### PR TITLE
Float(0).is_integer is True, Float(1.1).is_integer is False, Float(1) is None

### DIFF
--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -5,7 +5,7 @@ Handlers for keys related to number theory: prime, even, odd, etc.
 from sympy.assumptions import Q, ask
 from sympy.core import Add, Basic, Expr, Float, Mul, Pow, S
 from sympy.core.numbers import (ImaginaryUnit, Infinity, Integer, NaN,
-    NegativeInfinity, NumberSymbol, Rational)
+    NegativeInfinity, NumberSymbol, Rational, int_valued)
 from sympy.functions import Abs, im, re
 from sympy.ntheory import isprime
 
@@ -119,14 +119,16 @@ def _(expr, assumptions):
 
 def _EvenPredicate_number(expr, assumptions):
     # helper method
+    if isinstance(expr, (float, Float)):
+        if int_valued(expr):
+            return None
+        return False
     try:
         i = int(expr.round())
-        if not (expr - i).equals(0):
-            raise TypeError
     except TypeError:
         return False
-    if isinstance(expr, (float, Float)):
-        return False
+    if not (expr - i).equals(0):
+        raise False
     return i % 2 == 0
 
 @EvenPredicate.register(Expr)

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -128,7 +128,7 @@ def _EvenPredicate_number(expr, assumptions):
     except TypeError:
         return False
     if not (expr - i).equals(0):
-        raise False
+        return False
     return i % 2 == 0
 
 @EvenPredicate.register(Expr)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2310,7 +2310,7 @@ def test_issue_9636():
     assert ask(Q.integer(1.0)) is None
     assert ask(Q.prime(3.0)) is None
     assert ask(Q.composite(4.0)) is None
-    assert ask(Q.even(2.0)) is False  # Float(2).is_even is None
+    assert ask(Q.even(2.0)) is None
     assert ask(Q.odd(3.0)) is None
 
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -97,7 +97,7 @@ def test_float_1():
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
-    assert ask(Q.even(z)) is False
+    assert ask(Q.even(z)) is None
     assert ask(Q.odd(z)) is None
     assert ask(Q.finite(z)) is True
     assert ask(Q.prime(z)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -89,7 +89,7 @@ def test_int_12():
 def test_float_1():
     z = 1.0
     assert ask(Q.commutative(z)) is True
-    assert ask(Q.integer(z)) is False
+    assert ask(Q.integer(z)) is None
     assert ask(Q.rational(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
@@ -98,10 +98,10 @@ def test_float_1():
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
     assert ask(Q.even(z)) is False
-    assert ask(Q.odd(z)) is False
+    assert ask(Q.odd(z)) is None
     assert ask(Q.finite(z)) is True
-    assert ask(Q.prime(z)) is False
-    assert ask(Q.composite(z)) is False
+    assert ask(Q.prime(z)) is None
+    assert ask(Q.composite(z)) is None
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False
 
@@ -2307,11 +2307,11 @@ def test_check_old_assumption():
 
 
 def test_issue_9636():
-    assert ask(Q.integer(1.0)) is False
-    assert ask(Q.prime(3.0)) is False
-    assert ask(Q.composite(4.0)) is False
-    assert ask(Q.even(2.0)) is False
-    assert ask(Q.odd(3.0)) is False
+    assert ask(Q.integer(1.0)) is None
+    assert ask(Q.prime(3.0)) is None
+    assert ask(Q.composite(4.0)) is None
+    assert ask(Q.even(2.0)) is False  # Float(2).is_even is None
+    assert ask(Q.odd(3.0)) is None
 
 
 def test_autosimp_used_to_fail():

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -749,8 +749,11 @@ class Float(Number):
 
     _mpf_: tuple[int, int, int, int]
 
-    # A Float represents many real numbers,
-    # both rational and irrational.
+    # A Float is a computationally efficient rational but does
+    # not behaves as such in all computations. Integers --
+    # as well all fractions with denominators that are powers
+    # of 2 -- are exact, but currently only the integer
+    # is can be identified with int_valued after instantiation.
     is_rational = None
     is_irrational = None
     is_number = True
@@ -969,7 +972,10 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_ == fzero
+        if self._mpf_ == fzero:
+            return True
+        if not int_valued(self):
+            return False
 
     def _eval_is_negative(self):
         if self._mpf_ in (_mpf_ninf, _mpf_inf):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -749,11 +749,11 @@ class Float(Number):
 
     _mpf_: tuple[int, int, int, int]
 
-    # A Float is a computationally efficient rational but does
-    # not behaves as such in all computations. Integers --
-    # as well all fractions with denominators that are powers
-    # of 2 -- are exact, but currently only the integer
-    # is can be identified with int_valued after instantiation.
+    # A Float, though rational in form, does not behave like
+    # a rational in all Python expressions so we deal with
+    # exceptions (where we want to deal with the rational
+    # form of the Float as a rational) at the source rather
+    # than assigning a mathematically loaded category of 'rational'
     is_rational = None
     is_irrational = None
     is_number = True

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -4,6 +4,7 @@ from .basic import Atom, Basic
 from .sorting import ordered
 from .evalf import EvalfMixin
 from .function import AppliedUndef
+from .numbers import int_valued
 from .singleton import S
 from .sympify import _sympify, SympifyError
 from .parameters import global_parameters
@@ -1570,6 +1571,15 @@ def is_eq(lhs, rhs, assumptions=None):
                 return False
             if z:
                 return True
+
+        # is_zero cannot help decide integer/rational with Float
+        c, t = dif.as_coeff_Add()
+        if c.is_Float:
+            if int_valued(c):
+                if t.is_integer is False:
+                    return False
+            elif t.is_rational is False:
+                return False
 
         n2 = _n2(lhs, rhs)
         if n2 is not None:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -504,7 +504,7 @@ def test_Float():
     # rationality properties
     # if the integer test fails then the use of intlike
     # should be removed from gamma_functions.py
-    assert Float(1).is_integer is False
+    assert Float(1).is_integer is None
     assert Float(1).is_rational is None
     assert Float(1).is_irrational is None
     assert sqrt(2).n(15).is_rational is None

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1260,16 +1260,7 @@ def test_issue_23731():
     ni = symbols('ni', integer=False)
     assert Eq(ni, 1) == False
     assert unchanged(Eq, ni, .1)
-
-
-@XFAIL
-def test_issue_23731b():
-    ni = symbols('ni', integer=False)
     assert Eq(ni, 1.0) == False
-
-
-@XFAIL
-def test_issue_23731c():
     nr = symbols('nr', rational=False)
     assert Eq(nr, .1) == False
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -5,7 +5,7 @@ from sympy.testing.pytest import XFAIL, raises
 from sympy.assumptions.ask import Q
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
+from sympy.core.expr import Expr, unchanged
 from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (Float, I, Rational, nan, oo, pi, zoo)
@@ -1251,6 +1251,28 @@ def test_weak_strict():
     eq = Le(x, 1)
     assert eq.strict == Lt(x, 1)
     assert eq.weak == eq
+
+
+def test_issue_23731():
+    i = symbols('i', integer=True)
+    assert unchanged(Eq, i, 1.0)
+    assert unchanged(Eq, i/2, 0.5)
+    ni = symbols('ni', integer=False)
+    assert Eq(ni, 1) == False
+    assert unchanged(Eq, ni, .1)
+
+
+@XFAIL
+def test_issue_23731b():
+    ni = symbols('ni', integer=False)
+    assert Eq(ni, 1.0) == False
+
+
+@XFAIL
+def test_issue_23731c():
+    nr = symbols('nr', rational=False)
+    assert Eq(nr, .1) == False
+
 
 def test_rewrite_Add():
     from sympy.testing.pytest import warns_deprecated_sympy

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -539,8 +539,8 @@ class bernoulli(Function):
 
     # We implement a specialized memoization scheme to handle each
     # case modulo 6 separately
-    _cache = {0: S.One, 2: Rational(1, 6), 4: Rational(-1, 30)}
-    _highest = {0: 0, 2: 2, 4: 4}
+    _cache = {0: S.One, 1: Rational(1, 2), 2: Rational(1, 6), 4: Rational(-1, 30)}
+    _highest = {0: 0, 1: 1, 2: 2, 4: 4}
 
     @classmethod
     def eval(cls, n, x=None):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -235,7 +235,8 @@ class MatrixExpr(Expr):
     @classmethod
     def _check_dim(cls, dim):
         """Helper function to check invalid matrix dimensions"""
-        ok = check_assumptions(dim, integer=True, nonnegative=True)
+        ok = not dim.is_Float and check_assumptions(
+            dim, integer=True, nonnegative=True)
         if ok is False:
             raise ValueError(
                 "The dimension specification {} should be "

--- a/sympy/matrices/expressions/sets.py
+++ b/sympy/matrices/expressions/sets.py
@@ -57,7 +57,8 @@ class MatrixSet(Set):
     @classmethod
     def _check_dim(cls, dim):
         """Helper function to check invalid matrix dimensions"""
-        ok = check_assumptions(dim, integer=True, nonnegative=True)
+        ok = not dim.is_Float and check_assumptions(
+            dim, integer=True, nonnegative=True)
         if ok is False:
             raise ValueError(
                 "The dimension specification {} should be "

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -114,7 +114,8 @@ def test_ImageSet():
     harmonics = ImageSet(Lambda(x, 1/x), S.Naturals)
     assert Rational(1, 5) in harmonics
     assert Rational(.25) in harmonics
-    assert 0.25 not in harmonics
+    assert harmonics.contains(.25) == Contains(
+        0.25, ImageSet(Lambda(x, 1/x), S.Naturals), evaluate=False)
     assert Rational(.3) not in harmonics
     assert (1, 2) not in harmonics
 
@@ -1268,7 +1269,8 @@ def test_Rationals():
         Rational(1, 3), 3, Rational(-1, 3), -3, Rational(2, 3)]
     assert Basic() not in S.Rationals
     assert S.Half in S.Rationals
-    assert S.Rationals.contains(0.5)
+    assert S.Rationals.contains(0.5) == Contains(
+        0.5, S.Rationals, evaluate=False)
     assert 2 in S.Rationals
     r = symbols('r', rational=True)
     assert r in S.Rationals

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1268,7 +1268,7 @@ def test_Rationals():
         Rational(1, 3), 3, Rational(-1, 3), -3, Rational(2, 3)]
     assert Basic() not in S.Rationals
     assert S.Half in S.Rationals
-    assert S.Rationals.contains(0.5) == Contains(0.5, S.Rationals, evaluate=False)
+    assert S.Rationals.contains(0.5)
     assert 2 in S.Rationals
     r = symbols('r', rational=True)
     assert r in S.Rationals

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1644,7 +1644,7 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     >>> B = BernoulliProcess("B", p=0.7, success=1, failure=0)
     >>> B.state_space
     {0, 1}
-    >>> (B.p).round(2)
+    >>> B.p.round(2)
     0.70
     >>> B.success
     1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

yet another attempt to fix #23731
alternate to #25865, #25864, #25856

#### Brief description of what is fixed or changed

```python
>>> Float(0).is_integer  # same as master
True
>>> print(Float(1).is_integer)  # False in master
None
>>> Float(1.5).is_integer  # same as master
False
```

#### Other comments

There was a long discussion of whether `Float` should be classified as `rational` [here](https://groups.google.com/g/sympy/c/RUYOxxwMgac/m/4-1JXtny32EJ). One major concern was that float/Float objects do not behave as Rationals in operations, e.g.
```python
>>> S(1e-16) + S(2) == 2.0
True
>>> (x+y).n(subs={x:1e-16,y:2}) == 2.
True
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - `Float.is_integer` is now `None` except for `0.0` and `Floats` with a non-zero fraction. Previously, only `Float(0)` was True
  - Fixed Eq incorrectly evaluating to `False` in some cases with floats.
<!-- END RELEASE NOTES -->
