### PR TITLE
Fix solveset to return EmptySet for Mod that is not integral

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1304,6 +1304,9 @@ def _invert_modular(modterm, rhs, n, symbol):
     """
     a, m = modterm.args
 
+    if rhs.is_integer is False:
+        return symbol, S.EmptySet
+
     if rhs.is_real is False or any(term.is_real is False
             for term in list(_term_factors(a))):
         # Check for complex arguments

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2861,6 +2861,8 @@ def test_invert_modular():
     n = Dummy('n', integer=True)
     from sympy.solvers.solveset import _invert_modular as invert_modular
 
+    # no solutions
+    assert invert_modular(Mod(x, 12), S(1)/2, n, x) == (x, S.EmptySet)
     # non invertible cases
     assert invert_modular(Mod(sin(x), 7), S(5), n, x) == (Mod(sin(x), 7), 5)
     assert invert_modular(Mod(exp(x), 7), S(5), n, x) == (Mod(exp(x), 7), 5)


### PR DESCRIPTION
Previously there were results like

```py
>>> solveset(Eq(Mod(192*i0, 2304), 2), i0, Integers)
{12⋅n + 1/96 │ n ∊ ℤ}
```

which are wrong. solveset now returns EmptySet when the Mod value does not equal an integer.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - Fix some incorrect results from solveset solving equations with Mod.
<!-- END RELEASE NOTES -->
