### PR TITLE
fix rejection of negative args in ntheory

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2442,10 +2442,9 @@ def is_perfect(n):
     .. [2] https://en.wikipedia.org/wiki/Perfect_number
 
     """
-    _n = as_int(abs(n))
-    if _n < 6:  # no negatives or less than first perfect (which is 6)
+    n = as_int(n)
+    if n < 1:
         return False
-    n = _n
     if n % 2 == 0:
         m = (n.bit_length() + 1) >> 1
         if (1 << (m - 1)) * ((1 << m) - 1) != n:
@@ -2498,10 +2497,9 @@ def is_mersenne_prime(n):
     .. [1] https://mathworld.wolfram.com/MersennePrime.html
 
     """
-    _n = as_int(abs(n))
-    if _n < 3:  # negative or less than first Mersenne prime
+    n = as_int(n)
+    if n < 1:
         return False
-    n = _n
     if n & (n + 1):
         # n is not Mersenne number
         return False

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -641,6 +641,7 @@ def test_mersenne_prime_exponent():
 
 
 def test_is_perfect():
+    assert is_perfect(-6) is False
     assert is_perfect(6) is True
     assert is_perfect(15) is False
     assert is_perfect(28) is True
@@ -651,6 +652,8 @@ def test_is_perfect():
 
 
 def test_is_mersenne_prime():
+    assert is_mersenne_prime(-3) is False
+    assert is_mersenne_prime(3) is True
     assert is_mersenne_prime(10) is False
     assert is_mersenne_prime(127) is True
     assert is_mersenne_prime(511) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This correctly rejects negative arguments to `is_perfect` and `is_mersenne_prime`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
