### PR TITLE
fix(polys): add conversion CC -> EX

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2114,8 +2114,20 @@ def test_issue_19427():
     # Sum of the above, used to incorrectly return 0 for a while:
     assert integrate((x ** 4 - 2 * x ** 2 + 1) * sqrt(1 - x ** 2), (x, -1, 1)) == 5 * pi / 16
 
+
 def test_issue_23942():
     I1 = Integral(1/sqrt(a*(1 + x)**3 + (1 + x)**2), (x, 0, z))
     assert I1.series(a, 1, n=1) == Integral(1/sqrt(x**3 + 4*x**2 + 5*x + 2), (x, 0, z)) + O(a - 1, (a, 1))
     I2 = Integral(1/sqrt(a*(4 - x)**4 + (5 + x)**2), (x, 0, z))
     assert I2.series(a, 2, n=1) == Integral(1/sqrt(2*x**4 - 32*x**3 + 193*x**2 - 502*x + 537), (x, 0, z)) + O(a - 2, (a, 2))
+
+
+def test_issue_25886():
+    # https://github.com/sympy/sympy/issues/25886
+    f = (1-x)*exp(0.937098661j*x)
+    F_exp = (1.0*(-1.0671234968289*I*y
+             + 1.13875255748434
+             + 1.0671234968289*I)*exp(0.937098661*I*y)
+            - 1.13875255748434*exp(0.937098661*I))
+    F = integrate(f, (x, y, 1.0))
+    assert F.is_same(F_exp, math.isclose)

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -2,6 +2,7 @@
 
 
 from sympy.core import sympify, SympifyError
+from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -17,7 +18,7 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
 
     is_SymbolicDomain = is_EX = True
 
-    class Expression(PicklableWithSlots):
+    class Expression(DomainElement, PicklableWithSlots):
         """An arbitrary expression. """
 
         __slots__ = ('ex',)
@@ -36,6 +37,9 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
 
         def __hash__(self):
             return hash((self.__class__.__name__, self.ex))
+
+        def parent(self):
+            return EX
 
         def as_expr(f):
             return f.ex
@@ -208,8 +212,16 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         """Convert a ``GaussianRational`` object to ``dtype``. """
         return K1(K0.to_sympy(a))
 
+    def from_AlgebraicField(K1, a, K0):
+        """Convert an ``ANP`` object to ``dtype``. """
+        return K1(K0.to_sympy(a))
+
     def from_RealField(K1, a, K0):
         """Convert a mpmath ``mpf`` object to ``dtype``. """
+        return K1(K0.to_sympy(a))
+
+    def from_ComplexField(K1, a, K0):
+        """Convert a mpmath ``mpc`` object to ``dtype``. """
         return K1(K0.to_sympy(a))
 
     def from_PolynomialRing(K1, a, K0):

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -218,6 +218,11 @@ class IntegerRing(Ring, CharacteristicZero, SimpleDomain):
         if a.y == 0:
             return a.x
 
+    def from_EX(K1, a, K0):
+        """Convert ``Expression`` to GMPY's ``mpz``. """
+        if a.is_Integer:
+            return K1.from_sympy(a)
+
     def gcdex(self, a, b):
         """Compute extended GCD of ``a`` and ``b``. """
         h, s, t = gcdex(a, b)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -659,6 +659,27 @@ def test_Domain_convert():
     assert K2.convert_from(QQ(1, 2), QQ) == K2(QQ(1, 2))
 
 
+def test_EX_convert():
+
+    elements = [
+        (ZZ, ZZ(3)),
+        (QQ, QQ(1,2)),
+        (ZZ_I, ZZ_I(1,2)),
+        (QQ_I, QQ_I(1,2)),
+        (RR, RR(3)),
+        (CC, CC(1,2)),
+        (EX, EX(3)),
+        (EXRAW, EXRAW(3)),
+        (ALG, ALG.from_sympy(sqrt(2))),
+    ]
+
+    for R, e in elements:
+        for E in EX, EXRAW:
+            elem = E.from_sympy(R.to_sympy(e))
+            assert E.convert_from(e, R) == elem
+            assert R.convert_from(elem, E) == e
+
+
 def test_GlobalPolynomialRing_convert():
     K1 = QQ.old_poly_ring(x)
     K2 = QQ[x]

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -674,10 +674,10 @@ def test_EX_convert():
     ]
 
     for R, e in elements:
-        for E in EX, EXRAW:
-            elem = E.from_sympy(R.to_sympy(e))
-            assert E.convert_from(e, R) == elem
-            assert R.convert_from(elem, E) == e
+        for EE in EX, EXRAW:
+            elem = EE.from_sympy(R.to_sympy(e))
+            assert EE.convert_from(e, R) == elem
+            assert R.convert_from(elem, EE) == e
 
 
 def test_GlobalPolynomialRing_convert():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-25886

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * Missing conversion methods were added for the EX domain. This fixes a bug when integrating expressions involving complex numbers and floats.
<!-- END RELEASE NOTES -->
