### PR TITLE
Add slotscheck to CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Test all modules are listed in setup.py
         run: bin/test_setup.py
 
+      - run: sudo apt install xorg-dev libglu1-mesa libgl1-mesa-dev xvfb libxinerama1 libxcursor1
+      - run: pip install slotscheck pyglet . 
+
+      - name: Check for incorrect use of ``__slots__`` using slotscheck
+        run: xvfb-run -a -s "-screen 0 1400x900x24 +extension RANDR" -- python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra)" sympy -v
+
       # -- temporarily disabled -- #
       # These checks were too difficult for new contributors. They will
       # need to be made easier to work with before they are reenabled.

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -45,7 +45,7 @@ jobs:
       - run: pip install slotscheck pyglet . 
 
       - name: Check for incorrect use of ``__slots__`` using slotscheck
-        run: xvfb-run -a -s "-screen 0 1400x900x24 +extension RANDR" -- python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra)" sympy -v
+        run: xvfb-run -a -s "-screen 0 1400x900x24 +extension RANDR" -- python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra)" sympy
 
       # -- temporarily disabled -- #
       # These checks were too difficult for new contributors. They will

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Test all modules are listed in setup.py
         run: bin/test_setup.py
 
+      - run: sudo apt install xorg-dev libglu1-mesa libgl1-mesa-dev xvfb libxinerama1 libxcursor1
+      - run: pip install slotscheck pyglet . 
+
+      - name: Check for incorrect use of ``__slots__`` using slotscheck
+        run: xvfb-run -a -s "-screen 0 1400x900x24 +extension RANDR" -- python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra)" sympy
+
       # -- temporarily disabled -- #
       # These checks were too difficult for new contributors. They will
       # need to be made easier to work with before they are reenabled.

--- a/.mailmap
+++ b/.mailmap
@@ -650,6 +650,7 @@ Hannah Kari <hannah.kari@marquette.edu> hannah-kari <42753364+hannah-kari@users.
 Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
 Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
 Harold Erbin <harold.erbin@gmail.com>
+Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
 Harry Mountain <harrymountain1@icloud.com>
 Harry Zheng <harry@harryzheng.com>
 Harsh Agarwal <hagarwal9200@gmail.com>
@@ -1609,4 +1610,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1609,3 +1609,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>


### PR DESCRIPTION
Fixes #23030. Installs `slotscheck` and other dependencies, before running over the library. Galgebra and the auto-generated ANTLR4 code is excluded from this check by the `--exclude-modules` regex.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->