### PR TITLE
Exclude pyglet from being imported in slotscheck

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,11 +41,10 @@ jobs:
       - name: Test all modules are listed in setup.py
         run: bin/test_setup.py
 
-      - run: sudo apt install xorg-dev libglu1-mesa libgl1-mesa-dev xvfb libxinerama1 libxcursor1
-      - run: pip install slotscheck pyglet . 
+      - run: pip install slotscheck . 
 
       - name: Check for incorrect use of ``__slots__`` using slotscheck
-        run: xvfb-run -a -s "-screen 0 1400x900x24 +extension RANDR" -- python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra)" sympy
+        run: python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra|sympy.plotting.pygletplot.*)" sympy
 
       # -- temporarily disabled -- #
       # These checks were too difficult for new contributors. They will


### PR DESCRIPTION
Excludes pyglet modules from being checked in the slotscheck CI run, as discussed in #25890.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
