### PR TITLE
watch for +/-oo in gruntz

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -275,11 +275,10 @@ def mrv(e, x):
         if b1 == 1:
             return SubsSet(), b1
         if e1.has(x):
-            base_lim = limitinf(b1, x)
-            exp_lim = limitinf(e1, x)
-            if base_lim is S.One and exp_lim is S.Infinity:
-                return mrv(exp(e1 * (b1 - 1)), x)
-            return mrv(exp(e1 * log(b1)), x)
+            if limitinf(b1, x) is S.One:
+                if limitinf(e1, x).is_infinite is False:
+                    return mrv(exp(e1*(b1 - 1)), x)
+            return mrv(exp(e1*log(b1)), x)
         else:
             s, expr = mrv(b1, x)
             return s, expr**e1

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -475,5 +475,8 @@ def test_issue_7096():
     from sympy.functions import sign
     assert gruntz(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
 
-def test_issue_24210():
-    assert gruntz(exp(x)/((1+1/x)**(x**2)),x,+oo) == sqrt(E)
+def test_issue_24210_25885():
+    eq = exp(x)/(1+1/x)**x**2
+    ans = sqrt(E)
+    assert gruntz(eq, x, oo) == ans
+    assert gruntz(1/eq, x, oo) == 1/ans


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #25885

#### Brief description of what is fixed or changed


#### Other comments

This checks for any infinite value for exponent, not only `+oo`

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
