### PR TITLE
Added `proth_test`

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -151,6 +151,8 @@ Ntheory Functions Reference
 
 .. autofunction:: is_extra_strong_lucas_prp
 
+.. autofunction:: proth_test
+
 .. autofunction:: isprime
 
 .. autofunction:: is_gaussian_prime

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -482,6 +482,7 @@ def proth_test(n):
     .. [1] https://en.wikipedia.org/wiki/Proth_prime
 
     """
+    n = as_int(n)
     if n < 3:
         raise ValueError("n is not Proth number")
     m = bit_scan1(n - 1)

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -447,6 +447,64 @@ def is_extra_strong_lucas_prp(n):
     return False
 
 
+def proth_test(n):
+    r""" Test if the Proth number `n = k2^m + 1` is prime. where k is a positive odd number and `2^m > k`.
+
+    Parameters
+    ==========
+
+    n : Integer
+        ``n`` is Proth number
+
+    Returns
+    =======
+
+    bool : If ``True``, then ``n`` is the Proth prime
+
+    Raises
+    ======
+
+    ValueError
+        If ``n`` is not Proth number.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.primetest import proth_test
+    >>> proth_test(41)
+    True
+    >>> proth_test(57)
+    False
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Proth_prime
+
+    """
+    if n < 3:
+        raise ValueError("n is not Proth number")
+    m = bit_scan1(n - 1)
+    k = n >> m
+    if m < k.bit_length():
+        raise ValueError("n is not Proth number")
+    if n % 3 == 0:
+        return n == 3
+    if k % 3: # n % 12 == 5
+        return pow(3, n >> 1, n) == n - 1
+    # If `n` is a square number, then `jacobi(a, n) = 1` for any `a`
+    if gmpy_is_square(n):
+        return False
+    # `a` may be chosen at random.
+    # In any case, we want to find `a` such that `jacobi(a, n) = -1`.
+    for a in range(5, n):
+        j = jacobi(a, n)
+        if j == -1:
+            return pow(a, n >> 1, n) == n - 1
+        if j == 0:
+            return False
+
+
 def isprime(n):
     """
     Test if n is a prime number (True) or not (False). For n < 2^64 the

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -2,7 +2,8 @@ from math import gcd
 
 from sympy.ntheory.generate import Sieve, sieve
 from sympy.ntheory.primetest import (mr, _lucas_extrastrong_params, is_lucas_prp, is_square,
-                                     is_strong_lucas_prp, is_extra_strong_lucas_prp, isprime, is_euler_pseudoprime,
+                                     is_strong_lucas_prp, is_extra_strong_lucas_prp,
+                                     proth_test, isprime, is_euler_pseudoprime,
                                      is_gaussian_prime, is_fermat_pseudoprime, is_euler_jacobi_pseudoprime)
 
 from sympy.testing.pytest import slow, raises
@@ -107,6 +108,20 @@ def test_prps():
             ] == [
         989, 3239, 5777, 10877, 27971, 29681, 30739, 31631, 39059,
         72389, 73919, 75077]
+
+
+def test_proth_test():
+    # Proth number
+    A080075 = [3, 5, 9, 13, 17, 25, 33, 41, 49, 57, 65,
+               81, 97, 113, 129, 145, 161, 177, 193]
+    # Proth prime
+    A080076 = [3, 5, 13, 17, 41, 97, 113, 193]
+
+    for n in range(100):
+        if n in A080075:
+            assert proth_test(n) == (n in A080076)
+        else:
+            raises(ValueError, lambda: proth_test(n))
 
 
 def test_isprime():

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -117,7 +117,7 @@ def test_proth_test():
     # Proth prime
     A080076 = [3, 5, 13, 17, 41, 97, 113, 193]
 
-    for n in range(100):
+    for n in range(200):
         if n in A080075:
             assert proth_test(n) == (n in A080076)
         else:


### PR DESCRIPTION
Added function `proth_test` to `sympy.ntheory.primetest` to test if a Proth number is prime.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added `primetest.proth_test`
<!-- END RELEASE NOTES -->
