### PR TITLE
fix corner case handling in log_to_real (used by ratint)

### DIFF
--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -170,3 +170,14 @@ def test_log_to_atan():
     fg_ans = 2*atan(2*sqrt(3)*x/3 + sqrt(3)/3)
     assert log_to_atan(f, g) == fg_ans
     assert log_to_atan(g, f) == -fg_ans
+
+
+def test_issue_25896():
+    # for both tests, C = 0 in log_to_real
+    # but this only has a log result
+    e = (2*x + 1)/(x**2 + x + 1) + 1/x
+    assert ratint(e, x) == log(x**3 + x**2 + x)
+    # while this has more
+    assert ratint((4*x + 7)/(x**2 + 4*x + 6) + 2/x, x) == (
+        2*log(x) + 2*log(x**2 + 4*x + 6) - sqrt(2)*atan(
+        sqrt(2)*x/2 + sqrt(2))/2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fix #25896 for case when C=0

#### Brief description of what is fixed or changed


#### Other comments
@oscarbenjamin comments [here](https://github.com/sympy/sympy/issues/25896#issuecomment-1807191211) suggest that `groebner` rather than resultants may be a better way to handle rational polynomials. This PR is not changing the approach, just handling a corner case.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * fixed bug in log_to_real which caused only the log part to be returned
<!-- END RELEASE NOTES -->
