### PR TITLE
perf(matrices): use DomainMatrix for inv_mod

### DIFF
--- a/sympy/matrices/inverse.py
+++ b/sympy/matrices/inverse.py
@@ -1,4 +1,3 @@
-from sympy.core.intfunc import mod_inverse
 from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
 from sympy.polys.domains import EX
 
@@ -137,53 +136,6 @@ def _pinv(M, method='RD'):
         return _pinv_diagonalization(M)
     else:
         raise ValueError('invalid pinv method %s' % repr(method))
-
-
-def _inv_mod(M, m):
-    r"""
-    Returns the inverse of the matrix `K` (mod `m`), if it exists.
-
-    Method to find the matrix inverse of `K` (mod `m`) implemented in this function:
-
-    * Compute `\mathrm{adj}(K) = \mathrm{cof}(K)^t`, the adjoint matrix of `K`.
-
-    * Compute `r = 1/\mathrm{det}(K) \pmod m`.
-
-    * `K^{-1} = r\cdot \mathrm{adj}(K) \pmod m`.
-
-    Examples
-    ========
-
-    >>> from sympy import Matrix
-    >>> A = Matrix(2, 2, [1, 2, 3, 4])
-    >>> A.inv_mod(5)
-    Matrix([
-    [3, 1],
-    [4, 2]])
-    >>> A.inv_mod(3)
-    Matrix([
-    [1, 1],
-    [0, 1]])
-
-    """
-
-    if not M.is_square:
-        raise NonSquareMatrixError()
-
-    N       = M.cols
-    det_K   = M.det()
-    det_inv = None
-
-    try:
-        det_inv = mod_inverse(det_K, m)
-    except ValueError:
-        raise NonInvertibleMatrixError('Matrix is not invertible (mod %d)' % m)
-
-    K_adj = M.adjugate()
-    K_inv = M.__class__(N, N,
-            [det_inv * K_adj[i, j] % m for i in range(N) for j in range(N)])
-
-    return K_inv
 
 
 def _verify_invertible(M, iszerofunc=_iszero):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -62,7 +62,7 @@ from .solvers import (
     _pinv_solve, _cramer_solve, _solve, _solve_least_squares)
 
 from .inverse import (
-    _pinv, _inv_mod, _inv_ADJ, _inv_GE, _inv_LU, _inv_CH, _inv_LDL, _inv_QR,
+    _pinv, _inv_ADJ, _inv_GE, _inv_LU, _inv_CH, _inv_LDL, _inv_QR,
     _inv, _inv_block)
 
 
@@ -2313,9 +2313,6 @@ class MatrixBase(MatrixDeprecated,
     def pinv(self, method='RD'):
         return _pinv(self, method=method)
 
-    def inv_mod(self, m):
-        return _inv_mod(self, m)
-
     def inverse_ADJ(self, iszerofunc=_iszero):
         return _inv_ADJ(self, iszerofunc=iszerofunc)
 
@@ -2379,7 +2376,6 @@ class MatrixBase(MatrixDeprecated,
     solve_least_squares.__doc__    = _solve_least_squares.__doc__
 
     pinv.__doc__                   = _pinv.__doc__
-    inv_mod.__doc__                = _inv_mod.__doc__
     inverse_ADJ.__doc__            = _inv_ADJ.__doc__
     inverse_GE.__doc__             = _inv_GE.__doc__
     inverse_LU.__doc__             = _inv_LU.__doc__

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -967,29 +967,6 @@ def test_inverse():
     assert all(type(m.inv(s)) is cls for s in 'GE ADJ LU CH LDL QR'.split())
 
 
-def test_matrix_inverse_mod():
-    A = Matrix(2, 1, [1, 0])
-    raises(NonSquareMatrixError, lambda: A.inv_mod(2))
-    A = Matrix(2, 2, [1, 0, 0, 0])
-    raises(ValueError, lambda: A.inv_mod(2))
-    A = Matrix(2, 2, [1, 2, 3, 4])
-    Ai = Matrix(2, 2, [1, 1, 0, 1])
-    assert A.inv_mod(3) == Ai
-    A = Matrix(2, 2, [1, 0, 0, 1])
-    assert A.inv_mod(2) == A
-    A = Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
-    raises(ValueError, lambda: A.inv_mod(5))
-    A = Matrix(3, 3, [5, 1, 3, 2, 6, 0, 2, 1, 1])
-    Ai = Matrix(3, 3, [6, 8, 0, 1, 5, 6, 5, 6, 4])
-    assert A.inv_mod(9) == Ai
-    A = Matrix(3, 3, [1, 6, -3, 4, 1, -5, 3, -5, 5])
-    Ai = Matrix(3, 3, [4, 3, 3, 1, 2, 5, 1, 5, 1])
-    assert A.inv_mod(6) == Ai
-    A = Matrix(3, 3, [1, 6, 1, 4, 1, 5, 3, 2, 5])
-    Ai = Matrix(3, 3, [6, 0, 3, 6, 6, 4, 1, 6, 1])
-    assert A.inv_mod(7) == Ai
-
-
 def test_jacobian_hessian():
     L = Matrix(1, 2, [x**2*y, 2*y**2 + x*y])
     syms = [x, y]

--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -1,4 +1,7 @@
-from sympy import Matrix
+from sympy.testing.pytest import raises
+from sympy.matrices.common import NonSquareMatrixError, NonInvertibleMatrixError
+
+from sympy import Matrix, Rational
 
 
 def test_lll():
@@ -17,3 +20,30 @@ def test_lll():
     assert A.lll() == L
     assert A.lll_transform() == (L, T)
     assert T * A == L
+
+
+def test_matrix_inv_mod():
+    A = Matrix(2, 1, [1, 0])
+    raises(NonSquareMatrixError, lambda: A.inv_mod(2))
+    A = Matrix(2, 2, [1, 0, 0, 0])
+    raises(NonInvertibleMatrixError, lambda: A.inv_mod(2))
+    A = Matrix(2, 2, [1, 2, 3, 4])
+    Ai = Matrix(2, 2, [1, 1, 0, 1])
+    assert A.inv_mod(3) == Ai
+    A = Matrix(2, 2, [1, 0, 0, 1])
+    assert A.inv_mod(2) == A
+    A = Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    raises(NonInvertibleMatrixError, lambda: A.inv_mod(5))
+    A = Matrix(3, 3, [5, 1, 3, 2, 6, 0, 2, 1, 1])
+    Ai = Matrix(3, 3, [6, 8, 0, 1, 5, 6, 5, 6, 4])
+    assert A.inv_mod(9) == Ai
+    A = Matrix(3, 3, [1, 6, -3, 4, 1, -5, 3, -5, 5])
+    Ai = Matrix(3, 3, [4, 3, 3, 1, 2, 5, 1, 5, 1])
+    assert A.inv_mod(6) == Ai
+    A = Matrix(3, 3, [1, 6, 1, 4, 1, 5, 3, 2, 5])
+    Ai = Matrix(3, 3, [6, 0, 3, 6, 6, 4, 1, 6, 1])
+    assert A.inv_mod(7) == Ai
+    A = Matrix([[1, 2], [3, Rational(3,4)]])
+    raises(ValueError, lambda: A.inv_mod(2))
+    A = Matrix([[1, 2], [3, 4]])
+    raises(TypeError, lambda: A.inv_mod(Rational(1, 2)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Use DomainMatrix over GF(p) for the Matrix.inv_mod method. This makes inv_mod significantly faster:
```
In [1]: M = randMatrix(20)

In [2]: %time ok = M.inv_mod(163)
CPU times: user 70.8 ms, sys: 0 ns, total: 70.8 ms
Wall time: 69.3 ms
```
That takes 30 seconds with master so this is 500x faster but the difference increases for larger matrices because the algorithm used on master is like `O(2^n)` rather than `O(n^3)` for DomainMatrix.

#### Other comments

I'm a little unsure really where these matrix methods belong any more. I've moved this method to RepMatrix because it uses DomainMatrix and RepMatrix is the Matrix class that is based on DomainMatrix.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * The Matrix.inv_mod method was made significantly faster by using DomainMatrix and the GF(p) domain.
<!-- END RELEASE NOTES -->
