### PR TITLE
Moved `is_mersenne_prime` from `factor_` to `primetest`

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -97,8 +97,6 @@ Ntheory Functions Reference
 
 .. autofunction:: is_perfect
 
-.. autofunction:: is_mersenne_prime
-
 .. autofunction:: abundance
 
 .. autofunction:: is_abundant
@@ -152,6 +150,8 @@ Ntheory Functions Reference
 .. autofunction:: is_extra_strong_lucas_prp
 
 .. autofunction:: proth_test
+
+.. autofunction:: is_mersenne_prime
 
 .. autofunction:: isprime
 

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -4,13 +4,13 @@ Number theory module (primes, etc)
 
 from .generate import nextprime, prevprime, prime, primepi, primerange, \
     randprime, Sieve, sieve, primorial, cycle_length, composite, compositepi
-from .primetest import isprime, is_gaussian_prime
+from .primetest import isprime, is_gaussian_prime, is_mersenne_prime
 from .factor_ import divisors, proper_divisors, factorint, multiplicity, \
     multiplicity_in_factorial, perfect_power, pollard_pm1, pollard_rho, \
     primefactors, totient, \
     divisor_count, proper_divisor_count, divisor_sigma, factorrat, \
     reduced_totient, primenu, primeomega, mersenne_prime_exponent, \
-    is_perfect, is_mersenne_prime, is_abundant, is_deficient, is_amicable, \
+    is_perfect, is_abundant, is_deficient, is_amicable, \
     abundance, dra, drm
 
 from .partitions_ import npartitions
@@ -31,14 +31,14 @@ __all__ = [
     'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',
     'Sieve', 'sieve', 'primorial', 'cycle_length', 'composite', 'compositepi',
 
-    'isprime', 'is_gaussian_prime',
+    'isprime', 'is_gaussian_prime', 'is_mersenne_prime',
 
 
     'divisors', 'proper_divisors', 'factorint', 'multiplicity', 'perfect_power',
     'pollard_pm1', 'pollard_rho', 'primefactors', 'totient',
     'divisor_count', 'proper_divisor_count', 'divisor_sigma', 'factorrat',
     'reduced_totient', 'primenu', 'primeomega', 'mersenne_prime_exponent',
-    'is_perfect', 'is_mersenne_prime', 'is_abundant', 'is_deficient', 'is_amicable',
+    'is_perfect', 'is_abundant', 'is_deficient', 'is_amicable',
     'abundance', 'dra', 'drm', 'multiplicity_in_factorial',
 
     'npartitions',

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -19,19 +19,12 @@ from sympy.core.random import _randint
 from sympy.core.singleton import S
 from sympy.external.gmpy import (SYMPY_INTS, gcd, lcm, sqrt as isqrt,
                                  sqrtrem, iroot, bit_scan1, remove)
-from .primetest import isprime
+from .primetest import isprime, MERSENNE_PRIME_EXPONENTS, is_mersenne_prime
 from .generate import sieve, primerange, nextprime
 from .digits import digits
 from sympy.utilities.iterables import flatten
 from sympy.utilities.misc import as_int, filldedent
 from .ecm import _ecm_one_factor
-
-# Note: This list should be updated whenever new Mersenne primes are found.
-# Refer: https://www.mersenne.org/
-MERSENNE_PRIME_EXPONENTS = (2, 3, 5, 7, 13, 17, 19, 31, 61, 89, 107, 127, 521, 607, 1279, 2203,
- 2281, 3217, 4253, 4423, 9689, 9941, 11213, 19937, 21701, 23209, 44497, 86243, 110503, 132049,
- 216091, 756839, 859433, 1257787, 1398269, 2976221, 3021377, 6972593, 13466917, 20996011, 24036583,
- 25964951, 30402457, 32582657, 37156667, 42643801, 43112609, 57885161, 74207281, 77232917, 82589933)
 
 
 def smoothness(n):
@@ -2474,48 +2467,6 @@ def is_perfect(n):
             which hem it in on all sides -- would be little short of a
             miracle." I guess SymPy just found that miracle and it
             factors like this: %s''' % factorint(n)))
-    return result
-
-
-def is_mersenne_prime(n):
-    """Returns True if  ``n`` is a Mersenne prime, else False.
-
-    A Mersenne prime is a prime number having the form `2^i - 1`.
-
-    Examples
-    ========
-
-    >>> from sympy.ntheory.factor_ import is_mersenne_prime
-    >>> is_mersenne_prime(6)
-    False
-    >>> is_mersenne_prime(127)
-    True
-
-    References
-    ==========
-
-    .. [1] https://mathworld.wolfram.com/MersennePrime.html
-
-    """
-    n = as_int(n)
-    if n < 1:
-        return False
-    if n & (n + 1):
-        # n is not Mersenne number
-        return False
-    p = n.bit_length()
-    if p in MERSENNE_PRIME_EXPONENTS:
-        return True
-    if p < 65_000_000 or not isprime(p):
-        # According to GIMPS, verification was completed on September 19, 2023 for p less than 65 million.
-        # https://www.mersenne.org/report_milestones/
-        # If p is composite number, then n=2**p-1 is composite number.
-        return False
-    result = isprime(n)
-    if result:
-        raise ValueError(filldedent('''
-            This Mersenne Prime, 2^%s - 1, should
-            be added to SymPy's known values.''' % p))
     return result
 
 

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -16,7 +16,7 @@ from sympy.ntheory import (totient,
 from sympy.ntheory.factor_ import (smoothness, smoothness_p, proper_divisors,
     antidivisors, antidivisor_count, core, udivisors, udivisor_sigma,
     udivisor_count, proper_divisor_count, primenu, primeomega,
-    mersenne_prime_exponent, is_perfect, is_mersenne_prime, is_abundant,
+    mersenne_prime_exponent, is_perfect, is_abundant,
     is_deficient, is_amicable, dra, drm, _perfect_power)
 
 from sympy.testing.pytest import raises, slow
@@ -649,16 +649,6 @@ def test_is_perfect():
     assert is_perfect(496) is True
     assert is_perfect(8128) is True
     assert is_perfect(10000) is False
-
-
-def test_is_mersenne_prime():
-    assert is_mersenne_prime(-3) is False
-    assert is_mersenne_prime(3) is True
-    assert is_mersenne_prime(10) is False
-    assert is_mersenne_prime(127) is True
-    assert is_mersenne_prime(511) is False
-    assert is_mersenne_prime(131071) is True
-    assert is_mersenne_prime(2147483647) is True
 
 
 def test_is_abundant():

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -4,7 +4,9 @@ from sympy.ntheory.generate import Sieve, sieve
 from sympy.ntheory.primetest import (mr, _lucas_extrastrong_params, is_lucas_prp, is_square,
                                      is_strong_lucas_prp, is_extra_strong_lucas_prp,
                                      proth_test, isprime, is_euler_pseudoprime,
-                                     is_gaussian_prime, is_fermat_pseudoprime, is_euler_jacobi_pseudoprime)
+                                     is_gaussian_prime, is_fermat_pseudoprime, is_euler_jacobi_pseudoprime,
+                                     MERSENNE_PRIME_EXPONENTS, _lucas_lehmer_primality_test,
+                                     is_mersenne_prime)
 
 from sympy.testing.pytest import slow, raises
 from sympy.core.numbers import I
@@ -122,6 +124,21 @@ def test_proth_test():
             assert proth_test(n) == (n in A080076)
         else:
             raises(ValueError, lambda: proth_test(n))
+
+
+def test_lucas_lehmer_primality_test():
+    for p in sieve.primerange(3, 100):
+        assert _lucas_lehmer_primality_test(p) == (p in MERSENNE_PRIME_EXPONENTS)
+
+
+def test_is_mersenne_prime():
+    assert is_mersenne_prime(-3) is False
+    assert is_mersenne_prime(3) is True
+    assert is_mersenne_prime(10) is False
+    assert is_mersenne_prime(127) is True
+    assert is_mersenne_prime(511) is False
+    assert is_mersenne_prime(131071) is True
+    assert is_mersenne_prime(2147483647) is True
 
 
 def test_isprime():


### PR DESCRIPTION
The `is_mersenne_prime` is a function to test if a number is a Mersenne prime. It has been moved to `primetest` because it is more appropriate to have it in `primetest` rather than `factor_`. Also, the Lucas-Lehmer test, a Mersenne prime number test algorithm, has been implemented.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Moved `is_mersenne_prime` from `factor_` to `primetest`
<!-- END RELEASE NOTES -->
