### PR TITLE
Added `next_p` argument to `_factorint_small` and `_check_termination`

### DIFF
--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -105,10 +105,10 @@ def test_private_perfect_power():
     for x in [2, 3, 5, 6, 7, 12, 15, 105, 100003]:
         for y in range(2, 100):
             assert _perfect_power(x**y) == (x, y)
-            if x != 2:
-                assert _perfect_power(x**y, k=3) == (x, y)
+            if x & 1:
+                assert _perfect_power(x**y, next_p=3) == (x, y)
             if x == 100003:
-                assert _perfect_power(x**y, k=100003) == (x, y)
+                assert _perfect_power(x**y, next_p=100003) == (x, y)
             assert _perfect_power(101*x**y) == False
             # Catalan's conjecture
             if x**y not in [8, 9]:


### PR DESCRIPTION
* Added `next_p` argument to `_factorint_small` and `_check_termination` to indicate that there is no smaller prime factor to avoid unnecessary trial division.
* Changed keyword name of `_perfect_power` to `next_p` for parity.
* fiexd an error in `test_private_perfect_power`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
