### PR TITLE
Abs solved by enumerating signed args

### DIFF
--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -543,12 +543,22 @@ def test_separable():
 @slow
 def test_factorable():
     assert integrate(-asin(f(2*x)+pi), x) == -Integral(asin(pi + f(2*x)), x)
-    _ode_solver_test(_get_examples_ode_sol_factorable)
+    _ode_solver_test(_get_examples_ode_sol_factorable_1)
+
+
+@slow
+def test_factorable():
+    _ode_solver_test(_get_examples_ode_sol_factorable_11)
 
 
 @slow
 def test_slow_examples_factorable():
-    _ode_solver_test(_get_examples_ode_sol_factorable, run_slow_test=True)
+    _ode_solver_test(_get_examples_ode_sol_factorable_1, run_slow_test=True)
+
+
+@slow
+def test_slow_examples_factorable():
+    _ode_solver_test(_get_examples_ode_sol_factorable_11, run_slow_test=True)
 
 
 def test_Riccati_special_minus2():
@@ -907,7 +917,7 @@ def _get_examples_ode_sol_1st_linear():
 
 
 @_add_example_keys
-def _get_examples_ode_sol_factorable():
+def _get_examples_ode_sol_factorable_1():
     """ some hints are marked as xfail for examples because they missed additional algebraic solution
     which could be found by Factorable hint. Fact_01 raise exception for
     nth_linear_constant_coeff_undetermined_coefficients"""
@@ -992,7 +1002,22 @@ def _get_examples_ode_sol_factorable():
         ],
         'slow': True,
     },
+    }
+    }
 
+
+@_add_example_keys
+def _get_examples_ode_sol_factorable_11():
+    """ some hints are marked as xfail for examples because they missed additional algebraic solution
+    which could be found by Factorable hint. Fact_01 raise exception for
+    nth_linear_constant_coeff_undetermined_coefficients"""
+
+    y = Dummy('y')
+    a0,a1,a2,a3,a4 = symbols('a0, a1, a2, a3, a4')
+    return {
+            'hint': "factorable",
+            'func': f(x),
+            'examples':{
     'fact_11': {
         'eq': (f(x).diff(x, 2)-exp(f(x)))*(f(x).diff(x, 2)+exp(f(x))),
         'sol': [
@@ -2870,7 +2895,8 @@ def _get_all_examples():
     all_examples = _get_examples_ode_sol_euler_homogeneous + \
     _get_examples_ode_sol_euler_undetermined_coeff + \
     _get_examples_ode_sol_euler_var_para + \
-    _get_examples_ode_sol_factorable + \
+    _get_examples_ode_sol_factorable_1 + \
+    _get_examples_ode_sol_factorable_11 + \
     _get_examples_ode_sol_bernoulli + \
     _get_examples_ode_sol_nth_algebraic + \
     _get_examples_ode_sol_riccati + \

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -547,7 +547,7 @@ def test_factorable():
 
 
 @slow
-def test_factorable():
+def test_factorable_11():
     _ode_solver_test(_get_examples_ode_sol_factorable_11)
 
 
@@ -557,7 +557,7 @@ def test_slow_examples_factorable():
 
 
 @slow
-def test_slow_examples_factorable():
+def test_slow_examples_factorable_11():
     _ode_solver_test(_get_examples_ode_sol_factorable_11, run_slow_test=True)
 
 
@@ -922,7 +922,6 @@ def _get_examples_ode_sol_factorable_1():
     which could be found by Factorable hint. Fact_01 raise exception for
     nth_linear_constant_coeff_undetermined_coefficients"""
 
-    y = Dummy('y')
     a0,a1,a2,a3,a4 = symbols('a0, a1, a2, a3, a4')
     return {
             'hint': "factorable",

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1050,7 +1050,21 @@ def _get_examples_ode_sol_factorable_11():
         'eq': f(x).diff(x)**2 - f(x)**2,
         'sol': [Eq(f(x), C1*exp(x)), Eq(f(x), C1*exp(-x))]
     },
+    }
+    }
 
+
+@_add_example_keys
+def _get_examples_ode_sol_factorable_16():
+    """ some hints are marked as xfail for examples because they missed additional algebraic solution
+    which could be found by Factorable hint. Fact_01 raise exception for
+    nth_linear_constant_coeff_undetermined_coefficients"""
+
+    a0,a1,a2,a3,a4 = symbols('a0, a1, a2, a3, a4')
+    return {
+            'hint': "factorable",
+            'func': f(x),
+            'examples':{
     'fact_16': {
         'eq': f(x).diff(x)**2 - f(x)**3,
         'sol': [Eq(f(x), 4/(C1**2 - 2*C1*x + x**2))],
@@ -1082,7 +1096,6 @@ def _get_examples_ode_sol_factorable_11():
     },
     }
     }
-
 
 
 @_add_example_keys

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1351,8 +1351,9 @@ def _solve_abs(f, symbols, flags, bare_f, ordered_symbols, as_set):
                     ] + [j.subs(i, -abs_[i]) for j in b]
             signed.append(b)
         # capture and set flags
-        new_flags = flags.copy()
-        new_flags['check'] = False # we need to check in original f
+        check = flags.get('check', True)
+        as_dict = flags.get('dict', False)
+        new_flags = {**flags, 'check':False}
         # now start finding possible solutions
         sol = []
         linear = True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1351,17 +1351,15 @@ def _solve_abs(f, symbols, flags, bare_f, ordered_symbols, as_set):
                     ] + [j.subs(i, -abs_[i]) for j in b]
             signed.append(b)
         # capture and set flags
-        as_dict = flags.get('dict', None)
-        flags['dict'] = True  # to make work here easier
-        check = flags.get('check', True)
-        flags['check'] = False  # we need to check in original f
+        new_flags = flags.copy()
+        new_flags['check'] = False # we need to check in original f
         # now start finding possible solutions
         sol = []
         linear = True
         for v in product(*signed):
             reps = dict(zip(outer, v))
             fi = [_.xreplace(reps) for _ in f]
-            _linear, s = _get_solution(fi, bare_f, symbols, flags)
+            _linear, s = _get_solution(fi, bare_f, symbols, new_flags)
             if linear:
                 # it is possible that a nonlinear system
                 # will appear linear, e.g. the square terms
@@ -1380,13 +1378,10 @@ def _solve_abs(f, symbols, flags, bare_f, ordered_symbols, as_set):
             solution = []
             # don't force the solution because x in abs(x) will be
             # replaced with positive x and evaluate to x
-            force = flags.get('force', '')
-            flags['force'] = False
+            new_flags['force'] = False
             for si in sol:
-                if checksol(f, si, **flags) is not False:
+                if checksol(f, si, **new_flags) is not False:
                     solution.append(si)
-            if force != '':
-                flags['force'] = force
 
         return _legacy_output(solution, symbols, ordered_symbols, bare_f, linear, as_dict, as_set)
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -37,7 +37,6 @@ from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.integrals.integrals import Integral
-from sympy.ntheory.digits import digits
 from sympy.ntheory.factor_ import divisors
 from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     powdenest, nsimplify, denom, logcombine, sqrtdenest, fraction,
@@ -1011,46 +1010,65 @@ def solve(f, *symbols, **flags):
                 raise NotImplementedError('solving %s when the argument '
                 'is not real or imaginary.' % a)
             if 0 not in ri:
+                # if real, ri will be (a.args[0], 0)
+                # if imaginary, ri will be (0,I*a.args[0])
                 raise NotImplementedError('solving %s with real and '
                 'imag parts.' % a)
             abs_[a] = sum(ri)
 
     if abs_:
-        abs_, args = zip(*abs_.items())
+        abs_nodes, args = zip(*abs_.items())
+        # identify the outermost abs that appear
+        abs_nodes = list(ordered(abs_nodes))
+        outer = []
+        for i in range(len(abs_nodes)):
+            if not any(abs_nodes[j].has(abs_nodes[i]) for j in
+                    range(i + 1, len(abs_nodes))):
+                outer.append(abs_nodes[i])
+        # now figure out what values they can have while considering
+        # any nested abs within them
+        absset = set(abs_nodes)
+        del abs_nodes
+        signed = []
+        for o in outer:
+            a = list(reversed(list(ordered([i for i in o.atoms(Abs)
+                if i in absset]))))
+            b = [abs_[a.pop(0)]]
+            b.append(-b[0])
+            for i in a:
+                b = [j.subs(i, abs_[i]) for j in b
+                    ] + [j.subs(i, -abs_[i]) for j in b]
+            signed.append(b)
+        # now start finding possible solutions
         as_dict = flags.get('dict', None)
         flags['dict'] = True
         sol = []
         linear = False  # for abs equations to maintain backward compatibility
-        for i in range(2**len(abs_)):
-            signed_args = [i if j else -i for i, j in
-                zip(args, digits(i, 2, len(abs_))[1:])]
-            reps = dict(zip(abs_, signed_args))
+        for v in product(*signed):
+            reps = dict(zip(outer, v))
             fi = [_.xreplace(reps) for _ in f]
-            if any(a.has_free(*symbols) for v in reps.values() for a in v.atoms(Abs)):
-                # recurse
-                s = solve(fi, symbols, **flags)
+            if bare_f:
+                s = None
+                if len(symbols) != 1:
+                    s = _solve_undetermined(fi[0], symbols, flags)
+                if not s:
+                    s = _solve(fi[0], *symbols, **flags)
             else:
-                # base case
-                if bare_f:
-                    s = None
-                    if len(symbols) != 1:
-                        s = _solve_undetermined(fi[0], symbols, flags)
-                    if not s:
-                        s = _solve(fi[0], *symbols, **flags)
-                else:
-                    _, s = _solve_system(fi, symbols, **flags)
-            # need to check in the original equation
-            if flags.get('check', True):
-                for si in s:
-                    if checksol(f, si) is not False:
-                        sol.append(si)
-            else:
-                sol.extend(s)
-        solution = list(uniq(sol))
+                _, s = _solve_system(fi, symbols, **flags)
+            sol.extend(s)
 
-        # check assumptions
+        # remove redundant solutions before doing any checking
+        # since this is a costly step
+        solution = sol = list(uniq(sol))
+
         if flags.get('check', True):
-            solution = _check_assumptions(solution, flags.get('warn', False))
+            # check assumptions
+            sol = _check_assumptions(sol, flags.get('warn', False))
+            # need to check in the original equation
+            solution = []
+            for si in sol:
+                if checksol(f, si) is not False:
+                    solution.append(si)
 
         return _legacy_output(solution, symbols, ordered_symbols, bare_f, linear, as_dict, as_set)
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1332,15 +1332,14 @@ def _solve_abs(f, symbols, flags, bare_f, ordered_symbols, as_set):
         abs_nodes, args = zip(*abs_.items())
         abs_nodes = list(ordered(abs_nodes))
         # identify the outermost abs that appear
-        outer = []
-        for i in range(len(abs_nodes)):
-            if not any(abs_nodes[j].has(abs_nodes[i]) for j in
-                    range(i + 1, len(abs_nodes))):
-                outer.append(abs_nodes[i])
+        absset = set(abs_nodes)
+        outer = {a: Dummy() for a in abs_nodes[::-1]}
+        douter = set(outer.values())
+        _outer = {v: k for k, v in outer.items()}
+        outer = set().union(*[{_outer[i] for i in fi.xreplace(outer).free_symbols & douter} for fi in f])
+        del abs_nodes, _outer, douter
         # now figure out what values they can have while considering
         # any nested abs within them
-        absset = set(abs_nodes)
-        del abs_nodes
         signed = []
         for o in outer:
             a = list(reversed(list(ordered([i for i in o.atoms(Abs)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2481,11 +2481,15 @@ def test_abs_handling():
     assert solve([abs(x - 1) + x - 4], x) == {x: S(5)/2}
     assert solve([abs(x - 1) + x - 4], x, dict=True) == [{x: S(5)/2}]
     assert solve([abs(x**2 - 1) - x**2 + x - 4]) == [{x: 5}]
-    # only one solution is valid; if warn=True user will be
-    # warned. `solve` doesn't currently return conditions under
+    assert solve(abs(y) + abs(abs(abs(y) - 2) - 2)) == [0]
+    # When solutions are symbolic they need to be tested with
+    # actual values since all might not be valid.
+    # `solve` doesn't currently return conditions under
     # which solution is valid (though Piecewise could be used for
     # this purpose).
-    assert solve(abs(x) + y, x) == [-y, y]
+    assert solve(abs(x) + y, x) == [-y, y]  # if y < 0
+    eq = abs(abs(x + 1) - 2) + abs(y)
+    assert solve(eq, x) == [1 - abs(y), -abs(y) - 3, abs(y) - 3, abs(y) + 1]  # if y == 0
 
 
 def test_issue_7982():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1867,6 +1867,7 @@ def test_issues_6819_6820_6821_6248_8692_25777_25779_25895():
     assert solve((eq1, eq2), (x, y)) == [(S(1)/3, S(1)/2)]
     assert solve(abs(x - I) - 4) == [-sqrt(15), sqrt(15)]
     assert solve(abs(x + 1) - abs(1 - x) - 2) == [1]
+
     assert solve(abs(x)) == [0]
     assert solve(Eq(abs(x**2 - 2*x), 4), x) == [
         1 - sqrt(5), 1 + sqrt(5)]
@@ -2509,8 +2510,13 @@ def test_issue_17799():
 
 
 def test_issue_17650():
-    x = Symbol('x', real=True)
-    assert solve(abs(abs(x**2 - 1) - x) - x) == [1, -1 + sqrt(2), 1 + sqrt(2)]
+    x, y = symbols('x y', real=True)
+    assert solve(abs(abs(x**2 - 1) - x) - x) == [
+        1, -1 + sqrt(2), 1 + sqrt(2)]
+    nest = [-Abs(y) + Abs(3*x + Abs(Abs(x - 1) - 2) - 5),
+        x - Abs(y + Abs(x))]
+    assert solve(nest) == [{x: S(2)/3, y: -S(4)/3},
+        {x: 1, y: 0}, {x: 4, y: -8}]
 
 
 def test_issue_17882():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1794,12 +1794,12 @@ def test_issue_6528():
     assert len(solve(eqs, y, x, check=False)) == 4
 
 
-def test_overdetermined():
+def test_abs_overdetermined():
     x = symbols('x', real=True)
     eqs = [Abs(4*x - 7) - 5, Abs(3 - 8*x) - 1]
-    assert solve(eqs, x) == [(S.Half,)]
+    assert solve(eqs, x) == {x: S.Half}
     assert solve(eqs, x, manual=True) == [(S.Half,)]
-    assert solve(eqs, x, manual=True, check=False) == [(S.Half,), (S(3),)]
+    assert solve(eqs, x, manual=True, check=False) == [(S.Half,), (3,)]
 
 
 def test_issue_6605():
@@ -1838,7 +1838,7 @@ def test_issue_6792():
          CRootOf(x**6 - x + 1, 4), CRootOf(x**6 - x + 1, 5)]
 
 
-def test_issues_6819_6820_6821_6248_8692_25777_25779_25895():
+def test_abs_issues_6819_6820_6821_6248_8692_25777_25779_25895():
     # issue 6821
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
@@ -1864,7 +1864,7 @@ def test_issues_6819_6820_6821_6248_8692_25777_25779_25895():
         ) == [{x: 4, y: -1}, {x: 4, y: 1}]
     eq1 = Eq(abs(-S(1)/6 - x) - y, 0)
     eq2 = Eq(abs(S(5)/6 - x) - y, 0)
-    assert solve((eq1, eq2), (x, y)) == [(S(1)/3, S(1)/2)]
+    assert solve((eq1, eq2), (x, y)) == {x: S(1)/3, y: S(1)/2}
     assert solve(abs(x - I) - 4) == [-sqrt(15), sqrt(15)]
     assert solve(abs(x + 1) - abs(1 - x) - 2) == [1]
 
@@ -2412,7 +2412,7 @@ def test_issue_14721():
     assert solve((a + b**2 - 1, a + b**2 - 2)) == []
 
 
-def test_issue_14779():
+def test_abs_issue_14779():
     x = symbols('x', real=True)
     assert solve(sqrt(x**4 - 130*x**2 + 1089) + sqrt(x**4 - 130*x**2
                  + 3969) - 96*Abs(x)/x,x) == [sqrt(130)]
@@ -2475,9 +2475,12 @@ def test_issue_10933():
     assert solve(I*x**4 + x**3 + x**2 + 1.)  # doesn't fail
 
 
-def test_Abs_handling():
+def test_abs_handling():
     x = symbols('x', real=True)
     assert solve(abs(x/y), x) == [0]
+    assert solve([abs(x - 1) + x - 4], x) == {x: S(5)/2}
+    assert solve([abs(x - 1) + x - 4], x, dict=True) == [{x: S(5)/2}]
+    assert solve([abs(x**2 - 1) - x**2 + x - 4]) == [{x: 5}]
 
 
 def test_issue_7982():
@@ -2509,7 +2512,7 @@ def test_issue_17799():
     assert solve(-erf(x**(S(1)/3))**pi + I, x) == []
 
 
-def test_issue_17650():
+def test_abs_issue_17650():
     x, y = symbols('x y', real=True)
     assert solve(abs(abs(x**2 - 1) - x) - x) == [
         1, -1 + sqrt(2), 1 + sqrt(2)]
@@ -2633,10 +2636,19 @@ def test_issue_21942():
         d**(1 - e))/a)**(1/(1 - e))]
 
 
-def test_solver_flags():
+def test_solver_cubics_flags():
     root = solve(x**5 + x**2 - x - 1, cubics=False)
     rad = solve(x**5 + x**2 - x - 1, cubics=True)
     assert root != rad
+
+
+def test_solver_flags():
+    assert solve([x - 1]) == {x: 1}
+    # manual treats all equations as nonlinear; it could
+    # be otherwise, but rather than change, just use
+    # dict=True and avoid mutating output
+    assert solve([x - 1], manual=True) == [{x: 1}]
+    assert solve([x - 1], x, manual=True) == [(1,)]
 
 
 def test_issue_22768():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1035,6 +1035,7 @@ def test_issue_5767():
 
 
 def _make_example_24609():
+    # used by two tests below
     D, R, H, B_g, V, D_c = symbols("D, R, H, B_g, V, D_c", real=True, positive=True)
     Sigma_f, Sigma_a, nu = symbols("Sigma_f, Sigma_a, nu", real=True, positive=True)
     x = symbols("x", real=True, positive=True)
@@ -1048,7 +1049,6 @@ def _make_example_24609():
 
 
 def test_issue_24609():
-    # https://github.com/sympy/sympy/issues/24609
     eq, expected, x = _make_example_24609()
     assert solve(eq, x, simplify=True) == [expected]
     [solapprox] = solve(eq.n(), x)
@@ -1838,7 +1838,7 @@ def test_issue_6792():
          CRootOf(x**6 - x + 1, 4), CRootOf(x**6 - x + 1, 5)]
 
 
-def test_issues_6819_6820_6821_6248_8692_25777_25779():
+def test_issues_6819_6820_6821_6248_8692_25777_25779_25895():
     # issue 6821
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
@@ -1854,8 +1854,19 @@ def test_issues_6819_6820_6821_6248_8692_25777_25779():
 
     # 25777
     assert solve(abs(x**3 + x + 2)/(x + 1)) == []
+    # you can get an imaginary value for x, however:
+    v = symbols('v')
+    assert solve((abs(y)/(v + 1), v**3 + v + 2 - y)) == [
+        {v: S.Half - sqrt(7)*I/2, y: 0}, {v: S.Half + sqrt(7)*I/2, y: 0}]
 
-    # 25779
+    # issues 25779, 25895
+    assert solve([Eq(x - abs(y), 3), Eq(4*x + 5*abs(y), 21)]
+        ) == [{x: 4, y: -1}, {x: 4, y: 1}]
+    eq1 = Eq(abs(-S(1)/6 - x) - y, 0)
+    eq2 = Eq(abs(S(5)/6 - x) - y, 0)
+    assert solve((eq1, eq2), (x, y)) == [(S(1)/3, S(1)/2)]
+    assert solve(abs(x - I) - 4) == [-sqrt(15), sqrt(15)]
+    assert solve(abs(x + 1) - abs(1 - x) - 2) == [1]
     assert solve(abs(x)) == [0]
     assert solve(Eq(abs(x**2 - 2*x), 4), x) == [
         1 - sqrt(5), 1 + sqrt(5)]
@@ -1897,6 +1908,7 @@ def test_issues_6819_6820_6821_6248_8692_25777_25779():
 
     x = symbols('x')
     assert solve(2**x + 4**x) == [I*pi/log(2)]
+
 
 def test_issue_17638():
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2481,7 +2481,11 @@ def test_abs_handling():
     assert solve([abs(x - 1) + x - 4], x) == {x: S(5)/2}
     assert solve([abs(x - 1) + x - 4], x, dict=True) == [{x: S(5)/2}]
     assert solve([abs(x**2 - 1) - x**2 + x - 4]) == [{x: 5}]
-    assert solve(abs(x) + y, x) == []
+    # only one solution is valid; if warn=True user will be
+    # warned. `solve` doesn't currently return conditions under
+    # which solution is valid (though Piecewise could be used for
+    # this purpose).
+    assert solve(abs(x) + y, x) == [-y, y]
 
 
 def test_issue_7982():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2476,11 +2476,12 @@ def test_issue_10933():
 
 
 def test_abs_handling():
-    x = symbols('x', real=True)
+    x, y = symbols('x y', real=True)
     assert solve(abs(x/y), x) == [0]
     assert solve([abs(x - 1) + x - 4], x) == {x: S(5)/2}
     assert solve([abs(x - 1) + x - 4], x, dict=True) == [{x: S(5)/2}]
     assert solve([abs(x**2 - 1) - x**2 + x - 4]) == [{x: 5}]
+    assert solve(abs(x) + y, x) == []
 
 
 def test_issue_7982():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #25779 alternate to #25904

cf #25709 where abs and sign appear. Perhaps `sign` could be treated the same way as `abs`: replace real args with one of {-1,0,1} and imaginary args with {-I,I} and raise an error for non-real or imaginary args.

#### Brief description of what is fixed or changed


#### Other comments

Replacing `[abs(x) - c]` with `[sqrt(z**2) - c, x - z]` adds additional equations and requires solving higher-order expressions when `unrad` is used to remove the `sqrt` that appear.  (See [here](https://math.stackexchange.com/questions/98157/how-could-we-solve-x-in-x1-1-x-2#comment1591348_98160).)

The approach taken here is to to denest `abs` and successively use the Cartesian product of the possible values to replace the `abs` so a system of abs-free equations are solved. The solutions are collected and checked *in the original expressions* to see if they are solutions or not.

So for `abs(abs(x +1) - 2) + abs(y)` the following replacements are identified:
```python
{Abs(y): y, Abs(Abs(x + 1) - 2): x - 1}
{Abs(y): y, Abs(Abs(x + 1) - 2): 1 - x}
{Abs(y): y, Abs(Abs(x + 1) - 2): -x - 3}
{Abs(y): y, Abs(Abs(x + 1) - 2): x + 3}
{Abs(y): -y, Abs(Abs(x + 1) - 2): x - 1}
{Abs(y): -y, Abs(Abs(x + 1) - 2): 1 - x}
{Abs(y): -y, Abs(Abs(x + 1) - 2): -x - 3}
{Abs(y): -y, Abs(Abs(x + 1) - 2): x + 3}
```
There will be `2**n` replacements for `n` `abs` expressions.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * solve is more robust in handling of equations with `Abs`
<!-- END RELEASE NOTES -->
