### PR TITLE
Add setting "strict" to CodePrinter

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -264,10 +264,11 @@ to introduce the names of user-defined functions in the Fortran expression.
           1 - mygamma(x)**2
 
 However, when the user_functions argument is not provided, ``fcode`` will
-generate code which assumes that a function of the same name will be provided
-by the user.  A comment will be added to inform the user of the issue:
+by default raise an Exception, but if the user intends to provide a function
+with the same name, code can still be generated, by passing the option
+``strict=False``. The code then contains a comment informing the user of the issue:
 
-    >>> print(fcode(1 - gamma(x)**2))
+    >>> print(fcode(1 - gamma(x)**2, strict=False))
     C     Not supported in Fortran:
     C     gamma
           1 - gamma(x)**2

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -151,18 +151,13 @@ class C89CodePrinter(CodePrinter):
     standard = "C89"
     reserved_words = set(reserved_words)
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 17,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
         'contract': True,
         'dereference': set(),
         'error_on_reserved': False,
-        'reserved_word_suffix': '_',
-    }
+    })
 
     type_aliases = {
         real: float64,

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -64,6 +64,7 @@ class CodePrinter(StrPrinter):
         'human': True,
         'inline': False,
         'allow_unknown_functions': False,
+        'strict': False
     }
 
     # Functions which are "simple" to rewrite to other functions that
@@ -171,6 +172,8 @@ class CodePrinter(StrPrinter):
                         "Not supported in {}:".format(self.language)))
                 for expr in sorted(self._not_supported, key=str):
                     frontlines.append(self._get_comment(type(expr).__name__))
+                if self._settings.get("strict", False):
+                    raise ValueError('\n'.join(frontlines))
             for name, value in sorted(self._number_symbols, key=str):
                 frontlines.append(self._declare_number_const(name, value))
             lines = frontlines + lines

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -64,7 +64,7 @@ class CodePrinter(StrPrinter):
         'human': True,
         'inline': False,
         'allow_unknown_functions': False,
-        'strict': False
+        'strict': None  # True or False; None => True if human == True
     }
 
     # Functions which are "simple" to rewrite to other functions that
@@ -109,8 +109,10 @@ class CodePrinter(StrPrinter):
     }
 
     def __init__(self, settings=None):
-
         super().__init__(settings=settings)
+        if self._settings.get('strict', True) == None:
+            # for backwards compatibility, human=False need not to throw:
+            self._settings['strict'] = self._settings.get('human', True) == True
         if not hasattr(self, 'reserved_words'):
             self.reserved_words = set()
 
@@ -572,7 +574,8 @@ class CodePrinter(StrPrinter):
 
     def _print_not_supported(self, expr):
         if self._settings.get('strict', False):
-            raise ValueError("Unsupported by %s: %s" % (str(type(self)), str(type(expr))))
+            raise ValueError("Unsupported by %s: %s" % (str(type(self)), str(type(expr))) + \
+                             "\nSet the printer option 'strict' to False in order to generate partially printed code.")
         try:
             self._not_supported.add(expr)
         except TypeError:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -34,6 +34,11 @@ class AssignmentError(Exception):
     """
     pass
 
+class PrintMethodNotImplementedError(NotImplementedError):
+    """
+    Raised if a _print_* method is missing in the Printer.
+    """
+    pass
 
 def _convert_python_lists(arg):
     if isinstance(arg, list):
@@ -574,7 +579,7 @@ class CodePrinter(StrPrinter):
 
     def _print_not_supported(self, expr):
         if self._settings.get('strict', False):
-            raise ValueError("Unsupported by %s: %s" % (str(type(self)), str(type(expr))) + \
+            raise PrintMethodNotImplementedError("Unsupported by %s: %s" % (str(type(self)), str(type(expr))) + \
                              "\nSet the printer option 'strict' to False in order to generate partially printed code.")
         try:
             self._not_supported.add(expr)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -172,8 +172,6 @@ class CodePrinter(StrPrinter):
                         "Not supported in {}:".format(self.language)))
                 for expr in sorted(self._not_supported, key=str):
                     frontlines.append(self._get_comment(type(expr).__name__))
-                if self._settings.get("strict", False):
-                    raise ValueError('\n'.join(frontlines))
             for name, value in sorted(self._number_symbols, key=str):
                 frontlines.append(self._declare_number_const(name, value))
             lines = frontlines + lines
@@ -573,6 +571,8 @@ class CodePrinter(StrPrinter):
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
     def _print_not_supported(self, expr):
+        if self._settings.get('strict', False):
+            raise ValueError("Unsupported by %s: %s" % (str(type(self)), str(type(expr))))
         try:
             self._not_supported.add(expr)
         except TypeError:

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -96,18 +96,14 @@ class FCodePrinter(CodePrinter):
         intc: {'iso_c_binding': 'c_int'}
     }
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 17,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
         'source_format': 'fixed',
         'contract': True,
         'standard': 77,
         'name_mangling': True,
-    }
+    })
 
     _operators = {
         'and': '.and.',

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -38,7 +38,7 @@ class GLSLPrinter(CodePrinter):
     printmethod = "_glsl"
     language = "GLSL"
 
-    _default_settings = {
+    _default_settings = dict(CodePrinter._default_settings, **{
         'use_operators': True,
         'zero': 0,
         'mat_nested': False,
@@ -47,16 +47,10 @@ class GLSLPrinter(CodePrinter):
         'array_type': 'float',
         'glsl_types': True,
 
-        'order': None,
-        'full_prec': 'auto',
         'precision': 9,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
         'contract': True,
-        'error_on_reserved': False,
-        'reserved_word_suffix': '_',
-    }
+    })
 
     def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -49,15 +49,11 @@ class JavascriptCodePrinter(CodePrinter):
     printmethod = '_javascript'
     language = 'JavaScript'
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 17,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
         'contract': True,
-    }
+    })
 
     def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -58,16 +58,12 @@ class JuliaCodePrinter(CodePrinter):
         'not': '!',
     }
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 17,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
         'contract': True,
         'inline': True,
-    }
+    })
     # Note: contract is for expressing tensors as loops (if True), or just
     # assignment (if False).  FIXME: this should be looked a more carefully
     # for Julia.

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -88,13 +88,10 @@ class MapleCodePrinter(CodePrinter):
     printmethod = "_maple"
     language = "maple"
 
-    _default_settings = {
-        'order': None,
-        'full_prec': 'auto',
-        'human': True,
+    _default_settings = dict(CodePrinter._default_settings, **{
         'inline': True,
         'allow_unknown_functions': True,
-    }
+    })
 
     def __init__(self, settings=None):
         if settings is None:

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -127,14 +127,10 @@ class MCodePrinter(CodePrinter):
     printmethod = "_mcode"
     language = "Wolfram Language"
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 15,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
-    }
+    })
 
     _number_symbols: set[tuple[Expr, Float]] = set()
     _not_supported: set[Basic] = set()

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -258,7 +258,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         if len(expr.shape) == 2:
             return self._print(expr.tomatrix())
         # Should be possible to extend to more dimensions
-        return CodePrinter._print_not_supported(self, expr)
+        return super()._print_not_supported(self, expr)
 
     _add = "add"
     _einsum = "einsum"

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -75,16 +75,12 @@ class OctaveCodePrinter(CodePrinter):
         'not': '~',
     }
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 17,
         'user_functions': {},
-        'human': True,
-        'allow_unknown_functions': False,
         'contract': True,
         'inline': True,
-    }
+    })
     # Note: contract is for expressing tensors as loops (if True), or just
     # assignment (if False).  FIXME: this should be looked a more carefully
     # for Octave.

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -558,6 +558,9 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         PREC = precedence(expr)
         return self._operators['not'] + self.parenthesize(expr.args[0], PREC)
 
+    def _print_IndexedBase(self, expr):
+        return expr.name
+
     def _print_Indexed(self, expr):
         base = expr.args[0]
         index = expr.args[1:]
@@ -754,6 +757,11 @@ for k in _known_constants_mpmath:
 class SymPyPrinter(AbstractPythonCodePrinter):
 
     language = "Python with SymPy"
+
+    _default_settings = dict(
+        AbstractPythonCodePrinter._default_settings,
+        strict=False   # any class name will per definition be what we target in SymPyPrinter.
+    )
 
     def _print_Function(self, expr):
         mod = expr.func.__module__ or ''

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -80,17 +80,12 @@ class RCodePrinter(CodePrinter):
     printmethod = "_rcode"
     language = "R"
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 15,
         'user_functions': {},
-        'human': True,
         'contract': True,
         'dereference': set(),
-        'error_on_reserved': False,
-        'reserved_word_suffix': '_',
-    }
+    })
     _operators = {
        'and': '&',
         'or': '|',

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -221,18 +221,12 @@ class RustCodePrinter(CodePrinter):
     printmethod = "_rust_code"
     language = "Rust"
 
-    _default_settings: dict[str, Any] = {
-        'order': None,
-        'full_prec': 'auto',
+    _default_settings: dict[str, Any] = dict(CodePrinter._default_settings, **{
         'precision': 17,
         'user_functions': {},
-        'human': True,
         'contract': True,
         'dereference': set(),
-        'error_on_reserved': False,
-        'reserved_word_suffix': '_',
-        'inline': False,
-    }
+    })
 
     def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -570,6 +570,10 @@ def test_sparse_matrix():
     # gh-15791
     assert 'Not supported in C' in ccode(SparseMatrix([[1, 2, 3]]))
 
+    with raises(ValueError):
+        p = C89CodePrinter({'strict': True}).doprint(SparseMatrix([[1, 2, 3]]))
+
+
 
 def test_ccode_reserved_words():
     x, y = symbols('x, if')

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -140,11 +140,11 @@ def test_ccode_inline_function():
 def test_ccode_exceptions():
     assert ccode(gamma(x), standard='C99') == "tgamma(x)"
     with raises(ValueError):
-        gamma_c89 = ccode(gamma(x), standard='C89')
+        ccode(gamma(x), standard='C89')
     with raises(ValueError):
-        gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=False)
+        ccode(gamma(x), standard='C89', allow_unknown_functions=False)
 
-    gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=True)
+    ccode(gamma(x), standard='C89', allow_unknown_functions=True)
 
 
 

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -139,12 +139,13 @@ def test_ccode_inline_function():
 
 def test_ccode_exceptions():
     assert ccode(gamma(x), standard='C99') == "tgamma(x)"
-    gamma_c89 = ccode(gamma(x), standard='C89')
-    assert 'not supported in c' in gamma_c89.lower()
-    gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=False)
-    assert 'not supported in c' in gamma_c89.lower()
+    with raises(ValueError):
+        gamma_c89 = ccode(gamma(x), standard='C89')
+    with raises(ValueError):
+        gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=False)
+
     gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=True)
-    assert 'not supported in c' not in gamma_c89.lower()
+
 
 
 def test_ccode_functions2():
@@ -568,10 +569,10 @@ def test_Matrix_printing():
 
 def test_sparse_matrix():
     # gh-15791
-    assert 'Not supported in C' in ccode(SparseMatrix([[1, 2, 3]]))
-
     with raises(ValueError):
-        C89CodePrinter({'strict': True}).doprint(SparseMatrix([[1, 2, 3]]))
+        ccode(SparseMatrix([[1, 2, 3]]))
+
+    assert 'Not supported in C' in C89CodePrinter({'strict': False}).doprint(SparseMatrix([[1, 2, 3]]))
 
 
 

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -12,6 +12,7 @@ from sympy.sets import Range
 from sympy.logic import ITE, Implies, Equivalent
 from sympy.codegen import For, aug_assign, Assignment
 from sympy.testing.pytest import raises, XFAIL
+from sympy.printing.codeprinter import PrintMethodNotImplementedError
 from sympy.printing.c import C89CodePrinter, C99CodePrinter, get_math_macros
 from sympy.codegen.ast import (
     AddAugmentedAssignment, Element, Type, FloatType, Declaration, Pointer, Variable, value_const, pointer_const,
@@ -139,9 +140,9 @@ def test_ccode_inline_function():
 
 def test_ccode_exceptions():
     assert ccode(gamma(x), standard='C99') == "tgamma(x)"
-    with raises(ValueError):
+    with raises(PrintMethodNotImplementedError):
         ccode(gamma(x), standard='C89')
-    with raises(ValueError):
+    with raises(PrintMethodNotImplementedError):
         ccode(gamma(x), standard='C89', allow_unknown_functions=False)
 
     ccode(gamma(x), standard='C89', allow_unknown_functions=True)
@@ -569,7 +570,7 @@ def test_Matrix_printing():
 
 def test_sparse_matrix():
     # gh-15791
-    with raises(ValueError):
+    with raises(PrintMethodNotImplementedError):
         ccode(SparseMatrix([[1, 2, 3]]))
 
     assert 'Not supported in C' in C89CodePrinter({'strict': False}).doprint(SparseMatrix([[1, 2, 3]]))

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -571,7 +571,7 @@ def test_sparse_matrix():
     assert 'Not supported in C' in ccode(SparseMatrix([[1, 2, 3]]))
 
     with raises(ValueError):
-        p = C89CodePrinter({'strict': True}).doprint(SparseMatrix([[1, 2, 3]]))
+        C89CodePrinter({'strict': True}).doprint(SparseMatrix([[1, 2, 3]]))
 
 
 

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -49,7 +49,7 @@ def test_issue_15791():
     c = CrashingCodePrinter()
 
     # these should not silently succeed
-    with raises(NotImplementedError):
+    with raises(ValueError):
         c.doprint(ImmutableSparseMatrix(2, 2, {}))
-    with raises(NotImplementedError):
+    with raises(ValueError):
         c.doprint(MutableSparseMatrix(2, 2, {}))

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -1,4 +1,4 @@
-from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.codeprinter import CodePrinter, PrintMethodNotImplementedError
 from sympy.core import symbols
 from sympy.core.symbol import Dummy
 from sympy.testing.pytest import raises
@@ -49,7 +49,7 @@ def test_issue_15791():
     c = CrashingCodePrinter()
 
     # these should not silently succeed
-    with raises(ValueError):
+    with raises(PrintMethodNotImplementedError):
         c.doprint(ImmutableSparseMatrix(2, 2, {}))
-    with raises(ValueError):
+    with raises(PrintMethodNotImplementedError):
         c.doprint(MutableSparseMatrix(2, 2, {}))

--- a/sympy/printing/tests/test_cupy.py
+++ b/sympy/printing/tests/test_cupy.py
@@ -6,7 +6,7 @@ from sympy.abc import x, i, a, b
 from sympy.codegen.numpy_nodes import logaddexp
 from sympy.printing.numpy import CuPyPrinter, _cupy_known_constants, _cupy_known_functions
 
-from sympy.testing.pytest import skip
+from sympy.testing.pytest import skip, raises
 from sympy.external import import_module
 
 cp = import_module('cupy')
@@ -22,7 +22,8 @@ def test_cupy_print():
 
 def test_not_cupy_print():
     prntr = CuPyPrinter()
-    assert "Not supported" in prntr.doprint("abcd(x)")
+    with raises(ValueError):
+        prntr.doprint("abcd(x)")
 
 def test_cupy_sum():
     if not cp:

--- a/sympy/printing/tests/test_cupy.py
+++ b/sympy/printing/tests/test_cupy.py
@@ -22,7 +22,7 @@ def test_cupy_print():
 
 def test_not_cupy_print():
     prntr = CuPyPrinter()
-    with raises(ValueError):
+    with raises(NotImplementedError):
         prntr.doprint("abcd(x)")
 
 def test_cupy_sum():

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -206,7 +206,7 @@ def test_not_fortran():
     x = symbols('x')
     g = Function('g')
     with raises(ValueError):
-        gamma_f = fcode(gamma(x))
+        fcode(gamma(x))
     assert fcode(Integral(sin(x)), strict=False) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
     with raises(ValueError):
         fcode(g(x))

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -205,10 +205,11 @@ def test_implicit():
 def test_not_fortran():
     x = symbols('x')
     g = Function('g')
-    gamma_f = fcode(gamma(x))
-    assert gamma_f == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
-    assert fcode(Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
-    assert fcode(g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
+    with raises(ValueError):
+        gamma_f = fcode(gamma(x))
+    assert fcode(Integral(sin(x)), strict=False) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
+    with raises(ValueError):
+        fcode(g(x))
 
 
 def test_user_functions():

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -205,10 +205,10 @@ def test_implicit():
 def test_not_fortran():
     x = symbols('x')
     g = Function('g')
-    with raises(ValueError):
+    with raises(NotImplementedError):
         fcode(gamma(x))
     assert fcode(Integral(sin(x)), strict=False) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
-    with raises(ValueError):
+    with raises(NotImplementedError):
         fcode(g(x))
 
 

--- a/sympy/printing/tests/test_julia.py
+++ b/sympy/printing/tests/test_julia.py
@@ -309,7 +309,7 @@ def test_julia_boolean():
 
 
 def test_julia_not_supported():
-    with raises(ValueError):
+    with raises(NotImplementedError):
         julia_code(S.ComplexInfinity)
 
     f = Function('f')

--- a/sympy/printing/tests/test_julia.py
+++ b/sympy/printing/tests/test_julia.py
@@ -309,13 +309,11 @@ def test_julia_boolean():
 
 
 def test_julia_not_supported():
-    assert julia_code(S.ComplexInfinity) == (
-        "# Not supported in Julia:\n"
-        "# ComplexInfinity\n"
-        "zoo"
-    )
+    with raises(ValueError):
+        julia_code(S.ComplexInfinity)
+
     f = Function('f')
-    assert julia_code(f(x).diff(x)) == (
+    assert julia_code(f(x).diff(x), strict=False) == (
         "# Not supported in Julia:\n"
         "# Derivative\n"
         "Derivative(f(x), x)"

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -303,11 +303,8 @@ def test_sparse():
 
 # Not an important point.
 def test_maple_not_supported():
-    assert maple_code(S.ComplexInfinity) == (
-        "# Not supported in maple:\n"
-        "# ComplexInfinity\n"
-        "zoo"
-    )  # PROBLEM
+    with raises(ValueError):
+        maple_code(S.ComplexInfinity)
 
 
 def test_MatrixElement_printing():

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -303,7 +303,7 @@ def test_sparse():
 
 # Not an important point.
 def test_maple_not_supported():
-    with raises(ValueError):
+    with raises(NotImplementedError):
         maple_code(S.ComplexInfinity)
 
 

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -378,13 +378,10 @@ def test_octave_boolean():
 
 
 def test_octave_not_supported():
-    assert mcode(S.ComplexInfinity) == (
-        "% Not supported in Octave:\n"
-        "% ComplexInfinity\n"
-        "zoo"
-    )
+    with raises(ValueError):
+        mcode(S.ComplexInfinity)
     f = Function('f')
-    assert mcode(f(x).diff(x)) == (
+    assert mcode(f(x).diff(x), strict=False) == (
         "% Not supported in Octave:\n"
         "% Derivative\n"
         "Derivative(f(x), x)"
@@ -393,21 +390,15 @@ def test_octave_not_supported():
 
 def test_octave_not_supported_not_on_whitelist():
     from sympy.functions.special.polynomials import assoc_laguerre
-    assert mcode(assoc_laguerre(x, y, z)) == (
-        "% Not supported in Octave:\n"
-        "% assoc_laguerre\n"
-        "assoc_laguerre(x, y, z)"
-    )
+    with raises(ValueError):
+        mcode(assoc_laguerre(x, y, z))
 
 
 def test_octave_expint():
     assert mcode(expint(1, x)) == "expint(x)"
-    assert mcode(expint(2, x)) == (
-        "% Not supported in Octave:\n"
-        "% expint\n"
-        "expint(2, x)"
-    )
-    assert mcode(expint(y, x)) == (
+    with raises(ValueError):
+        mcode(expint(2, x))
+    assert mcode(expint(y, x), strict=False) == (
         "% Not supported in Octave:\n"
         "% expint\n"
         "expint(y, x)"
@@ -515,7 +506,8 @@ def test_MatrixElement_printing():
 
 def test_zeta_printing_issue_14820():
     assert octave_code(zeta(x)) == 'zeta(x)'
-    assert octave_code(zeta(x, y)) == '% Not supported in Octave:\n% zeta\nzeta(x, y)'
+    with raises(ValueError):
+        octave_code(zeta(x, y))
 
 
 def test_automatic_rewrite():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -378,7 +378,7 @@ def test_octave_boolean():
 
 
 def test_octave_not_supported():
-    with raises(ValueError):
+    with raises(NotImplementedError):
         mcode(S.ComplexInfinity)
     f = Function('f')
     assert mcode(f(x).diff(x), strict=False) == (
@@ -390,13 +390,13 @@ def test_octave_not_supported():
 
 def test_octave_not_supported_not_on_whitelist():
     from sympy.functions.special.polynomials import assoc_laguerre
-    with raises(ValueError):
+    with raises(NotImplementedError):
         mcode(assoc_laguerre(x, y, z))
 
 
 def test_octave_expint():
     assert mcode(expint(1, x)) == "expint(x)"
-    with raises(ValueError):
+    with raises(NotImplementedError):
         mcode(expint(2, x))
     assert mcode(expint(y, x), strict=False) == (
         "% Not supported in Octave:\n"
@@ -506,7 +506,7 @@ def test_MatrixElement_printing():
 
 def test_zeta_printing_issue_14820():
     assert octave_code(zeta(x)) == 'zeta(x)'
-    with raises(ValueError):
+    with raises(NotImplementedError):
         octave_code(zeta(x, y))
 
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -290,7 +290,7 @@ def test_issue_16535_16536():
     p_pycode = PythonCodePrinter({'strict': False})
 
     for expr in [expr1, expr2]:
-        with raises(ValueError):
+        with raises(NotImplementedError):
             p_numpy.doprint(expr1)
         assert "Not supported" in p_pycode.doprint(expr)
 
@@ -331,9 +331,9 @@ def test_fresnel_integrals():
     p_pycode = PythonCodePrinter()
     p_mpmath = MpmathPrinter()
     for expr in [expr1, expr2]:
-        with raises(ValueError):
+        with raises(NotImplementedError):
             p_numpy.doprint(expr)
-        with raises(ValueError):
+        with raises(NotImplementedError):
             p_pycode.doprint(expr)
 
     assert p_mpmath.doprint(expr1) == 'mpmath.fresnelc(x)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -286,13 +286,13 @@ def test_issue_16535_16536():
     assert prntr.doprint(expr1) == 'scipy.special.gamma(a)*scipy.special.gammainc(a, x)'
     assert prntr.doprint(expr2) == 'scipy.special.gamma(a)*scipy.special.gammaincc(a, x)'
 
-    prntr = NumPyPrinter()
-    assert "Not supported" in prntr.doprint(expr1)
-    assert "Not supported" in prntr.doprint(expr2)
+    p_numpy = NumPyPrinter()
+    p_pycode = PythonCodePrinter(dict(strict=False))
 
-    prntr = PythonCodePrinter()
-    assert "Not supported" in prntr.doprint(expr1)
-    assert "Not supported" in prntr.doprint(expr2)
+    for expr in [expr1, expr2]:
+        with raises(ValueError):
+            p_numpy.doprint(expr1)
+        assert "Not supported" in p_pycode.doprint(expr)
 
 
 def test_Integral():
@@ -327,17 +327,17 @@ def test_fresnel_integrals():
     assert prntr.doprint(expr1) == 'scipy.special.fresnel(x)[1]'
     assert prntr.doprint(expr2) == 'scipy.special.fresnel(x)[0]'
 
-    prntr = NumPyPrinter()
-    assert "Not supported" in prntr.doprint(expr1)
-    assert "Not supported" in prntr.doprint(expr2)
+    p_numpy = NumPyPrinter()
+    p_pycode = PythonCodePrinter()
+    p_mpmath = MpmathPrinter()
+    for expr in [expr1, expr2]:
+        with raises(ValueError):
+            p_numpy.doprint(expr)
+        with raises(ValueError):
+            p_pycode.doprint(expr)
 
-    prntr = PythonCodePrinter()
-    assert "Not supported" in prntr.doprint(expr1)
-    assert "Not supported" in prntr.doprint(expr2)
-
-    prntr = MpmathPrinter()
-    assert prntr.doprint(expr1) == 'mpmath.fresnelc(x)'
-    assert prntr.doprint(expr2) == 'mpmath.fresnels(x)'
+    assert p_mpmath.doprint(expr1) == 'mpmath.fresnelc(x)'
+    assert p_mpmath.doprint(expr2) == 'mpmath.fresnels(x)'
 
 
 def test_beta():
@@ -370,11 +370,11 @@ def test_airy():
     assert prntr.doprint(expr1) == 'scipy.special.airy(x)[0]'
     assert prntr.doprint(expr2) == 'scipy.special.airy(x)[2]'
 
-    prntr = NumPyPrinter()
+    prntr = NumPyPrinter(dict(strict=False))
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 
-    prntr = PythonCodePrinter()
+    prntr = PythonCodePrinter(dict(strict=False))
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 
@@ -388,11 +388,11 @@ def test_airy_prime():
     assert prntr.doprint(expr1) == 'scipy.special.airy(x)[1]'
     assert prntr.doprint(expr2) == 'scipy.special.airy(x)[3]'
 
-    prntr = NumPyPrinter()
+    prntr = NumPyPrinter(dict(strict=False))
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 
-    prntr = PythonCodePrinter()
+    prntr = PythonCodePrinter(dict(strict=False))
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -287,7 +287,7 @@ def test_issue_16535_16536():
     assert prntr.doprint(expr2) == 'scipy.special.gamma(a)*scipy.special.gammaincc(a, x)'
 
     p_numpy = NumPyPrinter()
-    p_pycode = PythonCodePrinter(dict(strict=False))
+    p_pycode = PythonCodePrinter({'strict': False})
 
     for expr in [expr1, expr2]:
         with raises(ValueError):
@@ -370,11 +370,11 @@ def test_airy():
     assert prntr.doprint(expr1) == 'scipy.special.airy(x)[0]'
     assert prntr.doprint(expr2) == 'scipy.special.airy(x)[2]'
 
-    prntr = NumPyPrinter(dict(strict=False))
+    prntr = NumPyPrinter({'strict': False})
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 
-    prntr = PythonCodePrinter(dict(strict=False))
+    prntr = PythonCodePrinter({'strict': False})
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 
@@ -388,11 +388,11 @@ def test_airy_prime():
     assert prntr.doprint(expr1) == 'scipy.special.airy(x)[1]'
     assert prntr.doprint(expr2) == 'scipy.special.airy(x)[3]'
 
-    prntr = NumPyPrinter(dict(strict=False))
+    prntr = NumPyPrinter({'strict': False})
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 
-    prntr = PythonCodePrinter(dict(strict=False))
+    prntr = PythonCodePrinter({'strict': False})
     assert "Not supported" in prntr.doprint(expr1)
     assert "Not supported" in prntr.doprint(expr2)
 

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -356,5 +356,5 @@ def test_matrix():
 
 def test_sparse_matrix():
     # gh-15791
-    with raises(ValueError):
+    with raises(NotImplementedError):
         rust_code(SparseMatrix([[1, 2, 3]]))

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -356,4 +356,5 @@ def test_matrix():
 
 def test_sparse_matrix():
     # gh-15791
-    assert 'Not supported in Rust' in rust_code(SparseMatrix([[1, 2, 3]]))
+    with raises(ValueError):
+        rust_code(SparseMatrix([[1, 2, 3]]))

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -969,7 +969,7 @@ class CCodeGen(CodeGen):
                 prefix = "const {} ".format(t)
 
             constants, not_c, c_expr = self._printer_method_with_settings(
-                'doprint', {"human": False, "dereference": dereference},
+                'doprint', {"human": False, "dereference": dereference, "strict": False},
                 result.expr, assign_to=assign_to)
 
             for name, value in sorted(constants, key=str):
@@ -1002,14 +1002,14 @@ class CCodeGen(CodeGen):
 
             try:
                 constants, not_c, c_expr = self._printer_method_with_settings(
-                    'doprint', {"human": False, "dereference": dereference},
+                    'doprint', {"human": False, "dereference": dereference, "strict": False},
                     result.expr, assign_to=assign_to)
             except AssignmentError:
                 assign_to = result.result_var
                 code_lines.append(
                     "%s %s;\n" % (result.get_datatype('c'), str(assign_to)))
                 constants, not_c, c_expr = self._printer_method_with_settings(
-                    'doprint', {"human": False, "dereference": dereference},
+                    'doprint', {"human": False, "dereference": dereference, "strict": False},
                     result.expr, assign_to=assign_to)
 
             for name, value in sorted(constants, key=str):
@@ -1226,7 +1226,7 @@ class FCodeGen(CodeGen):
                 assign_to = result.result_var
 
             constants, not_fortran, f_expr = self._printer_method_with_settings(
-                'doprint', {"human": False, "source_format": 'free', "standard": 95},
+                'doprint', {"human": False, "source_format": 'free', "standard": 95, "strict": False},
                 result.expr, assign_to=assign_to)
 
             for obj, v in sorted(constants, key=str):
@@ -1246,7 +1246,7 @@ class FCodeGen(CodeGen):
 
     def _indent_code(self, codelines):
         return self._printer_method_with_settings(
-            'indent_code', {"human": False, "source_format": 'free'}, codelines)
+            'indent_code', {"human": False, "source_format": 'free', "strict": False}, codelines)
 
     def dump_f95(self, routines, f, prefix, header=True, empty=True):
         # check that symbols are unique with ignorecase
@@ -1472,7 +1472,7 @@ class JuliaCodeGen(CodeGen):
                 raise CodeGenError("unexpected object in Routine results")
 
             constants, not_supported, jl_expr = self._printer_method_with_settings(
-                'doprint', {"human": False}, result.expr, assign_to=assign_to)
+                'doprint', {"human": False, "strict": False}, result.expr, assign_to=assign_to)
 
             for obj, v in sorted(constants, key=str):
                 declarations.append(
@@ -1490,7 +1490,7 @@ class JuliaCodeGen(CodeGen):
     def _indent_code(self, codelines):
         # Note that indenting seems to happen twice, first
         # statement-by-statement by JuliaPrinter then again here.
-        p = JuliaCodePrinter({'human': False})
+        p = JuliaCodePrinter({'human': False, "strict": False})
         return p.indent_code(codelines)
 
     def dump_jl(self, routines, f, prefix, header=True, empty=True):
@@ -1690,7 +1690,7 @@ class OctaveCodeGen(CodeGen):
                 raise CodeGenError("unexpected object in Routine results")
 
             constants, not_supported, oct_expr = self._printer_method_with_settings(
-                'doprint', {"human": False}, result.expr, assign_to=assign_to)
+                'doprint', {"human": False, "strict": False}, result.expr, assign_to=assign_to)
 
             for obj, v in sorted(constants, key=str):
                 declarations.append(
@@ -1707,7 +1707,7 @@ class OctaveCodeGen(CodeGen):
 
     def _indent_code(self, codelines):
         return self._printer_method_with_settings(
-            'indent_code', {"human": False}, codelines)
+            'indent_code', {"human": False, "strict": False}, codelines)
 
     def dump_m(self, routines, f, prefix, header=True, empty=True, inline=True):
         # Note used to call self.dump_code() but we need more control for header
@@ -1930,7 +1930,7 @@ class RustCodeGen(CodeGen):
                 raise CodeGenError("unexpected object in Routine results")
 
             constants, not_supported, rs_expr = self._printer_method_with_settings(
-                'doprint', {"human": False}, result.expr, assign_to=assign_to)
+                'doprint', {"human": False, "strict": False}, result.expr, assign_to=assign_to)
 
             for name, value in sorted(constants, key=str):
                 declarations.append("const %s: f64 = %s;\n" % (name, value))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1241,7 +1241,7 @@ def test_lambdify_Derivative_arg_issue_16468():
     fx = f.diff()
     assert lambdify((f, fx), f + fx)(10, 5) == 15
     assert eval(lambdastr((f, fx), f/fx))(10, 5) == 2
-    raises(SyntaxError, lambda:
+    raises(Exception, lambda:
         eval(lambdastr((f, fx), f/fx, dummify=False)))
     assert eval(lambdastr((f, fx), f/fx, dummify=True))(10, 5) == 2
     assert eval(lambdastr((fx, f), f/fx, dummify=True))(S(10), 5) == S.Half


### PR DESCRIPTION
For the n'th time I'm debugging generated code containing:
```
# Not supported in Python with numpy:
# Derivative
# Derivative
# Derivative
...
```

This PR aims to introduce a printer option "strict" ~~so that those of us who prefer an exception upon codegen (*fail early*) can opt-in to that behavior~~. The default is now `True`.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`CodePrinter._default_settings` got a new entry: `strict=True`.

#### Other comments
Subclasses of `CodePrinter` now "inherits" the entries in `CodePrinter._default_settings`. This way, in the future, printer options may be introduced in `codeprinter.py` without touching the respective language's defaults.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * CodePrinter got a new option "strict" (default is generally "True") to raise an exception, instead of generating comments, upon encountering unsupported constructs in a target language.
<!-- END RELEASE NOTES -->
