### PR TITLE
changing orient_explicit method to orient_dcm method, also adding new method orient_explicit

### DIFF
--- a/doc/src/modules/physics/vector/api/classes.rst
+++ b/doc/src/modules/physics/vector/api/classes.rst
@@ -7,6 +7,7 @@ Essential Classes
 
 .. autoclass:: sympy.physics.vector.frame.ReferenceFrame
    :members:
+   :exclude-members: orient_explicit
 
 .. autoclass:: sympy.physics.vector.vector.Vector
    :members:

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -721,7 +721,7 @@ class ReferenceFrame:
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
 
-        rotation matrix :  
+        rotation matrix :  Matrix Rotation Direction
             the simple matrix rotation ``parent`` relative to ``dcm``.          
         """
         self.orient_dcm(parent = parent, dcm = dcm)
@@ -741,7 +741,7 @@ class ReferenceFrame:
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
 
-        rotation matrix :  
+        rotation matrix :  Matrix Rotation Direction
             the simple matrix rotation ``parent`` relative to ``dcm``.          
         """
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -721,57 +721,28 @@ class ReferenceFrame:
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
 
-        Warns
-        ======
+        rotation matrix :  
+            the simple matrix rotation ``parent`` relative to ``dcm``.          
+        """
+        self.orient_dcm(parent = parent, dcm = dcm)
 
-        UserWarning
-            If the orientation creates a kinematic loop.
+    
+    def orient_dcm(self, parent, dcm):
+        """Sets the orientation of this reference frame relative to a parent
+        reference frame by explicitly setting the direction cosine matrix.
 
-        Examples
-        ========
+        Parameters
+        ==========
 
-        Setup variables for the examples:
+        parent : ReferenceFrame
+            Reference frame that this reference frame will be rotated relative
+            to.
+        dcm : Matrix, shape(3, 3)
+            Direction cosine matrix that specifies the relative rotation
+            between the two reference frames.
 
-        >>> from sympy import symbols, Matrix, sin, cos
-        >>> from sympy.physics.vector import ReferenceFrame
-        >>> q1 = symbols('q1')
-        >>> A = ReferenceFrame('A')
-        >>> B = ReferenceFrame('B')
-        >>> N = ReferenceFrame('N')
-
-        A simple rotation of ``A`` relative to ``N`` about ``N.x`` is defined
-        by the following direction cosine matrix:
-
-        >>> dcm = Matrix([[1, 0, 0],
-        ...               [0, cos(q1), -sin(q1)],
-        ...               [0, sin(q1), cos(q1)]])
-        >>> A.orient_explicit(N, dcm)
-        >>> A.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
-
-        This is equivalent to using ``orient_axis()``:
-
-        >>> B.orient_axis(N, N.x, q1)
-        >>> B.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
-
-        **Note carefully that** ``N.dcm(B)`` **(the transpose) would be passed
-        into** ``orient_explicit()`` **for** ``A.dcm(N)`` **to match**
-        ``B.dcm(N)``:
-
-        >>> A.orient_explicit(N, N.dcm(B))
-        >>> A.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
-
+        rotation matrix :  
+            the simple matrix rotation ``parent`` relative to ``dcm``.          
         """
 
         _check_frame(parent)
@@ -780,9 +751,8 @@ class ReferenceFrame:
         if not isinstance(dcm, MatrixBase):
             raise TypeError("Amounts must be a SymPy Matrix type object.")
 
-        parent_orient_dcm = dcm
 
-        self._dcm(parent, parent_orient_dcm)
+        self._dcm(parent, dcm.T)
 
         wvec = self._w_diff_dcm(parent)
         self._ang_vel_dict.update({parent: wvec})
@@ -1202,7 +1172,7 @@ class ReferenceFrame:
             self.orient_axis(parent, amounts[1], amounts[0])
 
         elif rot_type == 'DCM':
-            self.orient_explicit(parent, amounts)
+            self.orient_dcm(parent, amounts)
 
         elif rot_type == 'BODY':
             self.orient_body_fixed(parent, amounts, rot_order)
@@ -1313,7 +1283,7 @@ class ReferenceFrame:
             newframe.orient_axis(self, amounts[1], amounts[0])
 
         elif rot_type == 'DCM':
-            newframe.orient_explicit(self, amounts)
+            newframe.orient_dcm(self, amounts)
 
         elif rot_type == 'BODY':
             newframe.orient_body_fixed(self, amounts, rot_order)

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -451,10 +451,10 @@ def test_dcm_diff_16824():
     assert simplify(AwB.dot(A.y) - alpha2) == 0
     assert simplify(AwB.dot(B.y) - beta2) == 0
 
-def test_orient_explicit():
+def test_orient_dcm():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    A.orient_explicit(B, eye(3))
+    A.orient_dcm(B, eye(3))
     assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
 def test_orient_axis():


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24764   

#### Brief description of what is fixed or changed
Complete as you mention above :
- [x] change method name `orient_explicit` to `orient_dcm`
- [x] create another method `orient_explicit` for backward compatibility
- [x] mention about rotation matrix direction 
- [x] Also `exclude-members: orient_explicit `

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
