### PR TITLE
changing orient_explicit method to orient_dcm method, also adding new method orient_explicit

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -654,6 +654,7 @@ Harold Erbin <harold.erbin@gmail.com>
 Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
 Harry Mountain <harrymountain1@icloud.com>
 Harry Zheng <harry@harryzheng.com>
+Harsh Kasat <hkasat@waymore.io>
 Harsh Agarwal <hagarwal9200@gmail.com>
 Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
 Harsh Jain <harshjniitr@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -654,10 +654,10 @@ Harold Erbin <harold.erbin@gmail.com>
 Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
 Harry Mountain <harrymountain1@icloud.com>
 Harry Zheng <harry@harryzheng.com>
-Harsh Kasat <hkasat@waymore.io>
 Harsh Agarwal <hagarwal9200@gmail.com>
 Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
 Harsh Jain <harshjniitr@gmail.com>
+Harsh Kasat <hkasat@waymore.io>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>

--- a/doc/src/modules/physics/vector/api/classes.rst
+++ b/doc/src/modules/physics/vector/api/classes.rst
@@ -7,6 +7,8 @@ Essential Classes
 
 .. autoclass:: sympy.physics.vector.frame.ReferenceFrame
    :members:
+   :exclude-members: orient_explicit
+   :exclude-members: orient_dcm
 
 .. autoclass:: sympy.physics.vector.vector.Vector
    :members:

--- a/doc/src/modules/physics/vector/api/classes.rst
+++ b/doc/src/modules/physics/vector/api/classes.rst
@@ -8,7 +8,6 @@ Essential Classes
 .. autoclass:: sympy.physics.vector.frame.ReferenceFrame
    :members:
    :exclude-members: orient_explicit
-   :exclude-members: orient_dcm
 
 .. autoclass:: sympy.physics.vector.vector.Vector
    :members:

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -728,7 +728,19 @@ class ReferenceFrame:
             If the orientation creates a kinematic loop.
 
         """
-        self.orient_dcm(parent = parent, dcm = dcm.T)
+
+        _check_frame(parent)
+        # amounts must be a Matrix type object
+        # (e.g. sympy.matrices.dense.MutableDenseMatrix).
+        if not isinstance(dcm, MatrixBase):
+            raise TypeError("Amounts must be a SymPy Matrix type object.")
+
+        self._dcm(parent, dcm)
+
+        wvec = self._w_diff_dcm(parent)
+        self._ang_vel_dict.update({parent: wvec})
+        parent._ang_vel_dict.update({self: -wvec})
+        self._var_dict = {}
 
     def orient_dcm(self, parent, dcm):
         """Sets the orientation of this reference frame relative to another (parent) reference frame
@@ -753,18 +765,7 @@ class ReferenceFrame:
 
         """
 
-        _check_frame(parent)
-        # amounts must be a Matrix type object
-        # (e.g. sympy.matrices.dense.MutableDenseMatrix).
-        if not isinstance(dcm, MatrixBase):
-            raise TypeError("Amounts must be a SymPy Matrix type object.")
-
-        self._dcm(parent, dcm.T)
-
-        wvec = self._w_diff_dcm(parent)
-        self._ang_vel_dict.update({parent: wvec})
-        parent._ang_vel_dict.update({self: -wvec})
-        self._var_dict = {}
+        self.orient_explicit(parent = parent, dcm = dcm.transpose())
 
     def _rot(self, axis, angle):
         """DCM for simple axis 1,2,or 3 rotations."""

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -722,7 +722,6 @@ class ReferenceFrame:
             between the two reference frames.
         rotation matrix : Matrix Rotation Direction
             The simple matrix rotation relative ``parent`` to ``dcm``.
-      
         Warns
         ======
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -730,7 +730,7 @@ class ReferenceFrame:
 
         """
         self.orient_dcm(parent = parent, dcm = dcm)
-    
+
     def orient_dcm(self, parent, dcm):
         """Sets the orientation of this reference frame relative to a parent
         reference frame by explicitly setting the direction cosine matrix.
@@ -746,7 +746,6 @@ class ReferenceFrame:
             between the two reference frames.
         rotation matrix : Matrix Rotation Direction
             The simple matrix rotation relative ``parent`` to ``dcm``.
-
         Warns
         ======
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -801,6 +801,40 @@ class ReferenceFrame:
         UserWarning
             If the orientation creates a kinematic loop.
 
+        Examples
+        ========
+        
+        Setup variables for the examples:
+        
+        >>> from sympy import symbols, Matrix, sin, cos
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> q1 = symbols('q1')
+        >>> A = ReferenceFrame('A')
+        >>> B = ReferenceFrame('B')
+        >>> N = ReferenceFrame('N')
+
+        A simple rotation of ``A`` relative to ``N`` about ``N.x`` is defined
+        by the following direction cosine matrix:
+
+        >>> dcm = Matrix([[1, 0, 0],
+        ...               [0,  cos(q1), sin(q1)],
+        ...               [0, -sin(q1), cos(q1)]])
+        >>> A.orient_dcm(N, dcm)
+        >>> A.dcm(N)
+        Matrix([
+        [1,       0,      0],
+        [0,  cos(q1), sin(q1)],
+        [0, -sin(q1), cos(q1)]])
+
+        This is equivalent to using ``orient_axis()``:
+
+        >>> B.orient_axis(N, N.x, q1)
+        >>> B.dcm(N)
+        Matrix([
+        [1,       0,      0],
+        [0,  cos(q1), sin(q1)],
+        [0, -sin(q1), cos(q1)]])
+
         """
 
         _check_frame(parent)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -728,19 +728,13 @@ class ReferenceFrame:
             If the orientation creates a kinematic loop.
 
         """
-
         _check_frame(parent)
         # amounts must be a Matrix type object
         # (e.g. sympy.matrices.dense.MutableDenseMatrix).
         if not isinstance(dcm, MatrixBase):
             raise TypeError("Amounts must be a SymPy Matrix type object.")
 
-        self._dcm(parent, dcm)
-
-        wvec = self._w_diff_dcm(parent)
-        self._ang_vel_dict.update({parent: wvec})
-        parent._ang_vel_dict.update({self: -wvec})
-        self._var_dict = {}
+        self.orient_dcm(parent, dcm.T)
 
     def orient_dcm(self, parent, dcm):
         """Sets the orientation of this reference frame relative to another (parent) reference frame
@@ -765,7 +759,18 @@ class ReferenceFrame:
 
         """
 
-        self.orient_explicit(parent = parent, dcm = dcm.transpose())
+        _check_frame(parent)
+        # amounts must be a Matrix type object
+        # (e.g. sympy.matrices.dense.MutableDenseMatrix).
+        if not isinstance(dcm, MatrixBase):
+            raise TypeError("Amounts must be a SymPy Matrix type object.")
+
+        self._dcm(parent, dcm.T)
+
+        wvec = self._w_diff_dcm(parent)
+        self._ang_vel_dict.update({parent: wvec})
+        parent._ang_vel_dict.update({self: -wvec})
+        self._var_dict = {}
 
     def _rot(self, axis, angle):
         """DCM for simple axis 1,2,or 3 rotations."""

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -720,8 +720,8 @@ class ReferenceFrame:
         dcm : Matrix, shape(3, 3)
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
-        rotation matrix :  Matrix Rotation Direction
-            the simple matrix rotation relative ``parent`` to ``dcm``.   
+        rotation matrix : Matrix Rotation Direction
+            The simple matrix rotation relative ``parent`` to ``dcm``.
         
         Warns
         ======
@@ -745,8 +745,8 @@ class ReferenceFrame:
         dcm : Matrix, shape(3, 3)
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
-        rotation matrix :  Matrix Rotation Direction
-            the simple matrix rotation relative ``parent`` to ``dcm``.   
+        rotation matrix : Matrix Rotation Direction
+            The simple matrix rotation relative ``parent`` to ``dcm``.
         
         Warns
         ======

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -727,6 +727,51 @@ class ReferenceFrame:
         UserWarning
             If the orientation creates a kinematic loop.
 
+        Examples
+        ========
+        
+        Setup variables for the examples:
+        
+        >>> from sympy import symbols, Matrix, sin, cos
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> q1 = symbols('q1')
+        >>> A = ReferenceFrame('A')
+        >>> B = ReferenceFrame('B')
+        >>> N = ReferenceFrame('N')
+
+        A simple rotation of ``A`` relative to ``N`` about ``N.x`` is defined
+        by the following direction cosine matrix:
+
+        >>> dcm = Matrix([[1, 0, 0],
+        ...               [0, cos(q1), -sin(q1)],
+        ...               [0, sin(q1), cos(q1)]])
+        >>> A.orient_explicit(N, dcm)
+        >>> A.dcm(N)
+        Matrix([
+        [1,       0,      0],
+        [0,  cos(q1), sin(q1)],
+        [0, -sin(q1), cos(q1)]])
+
+        This is equivalent to using ``orient_axis()``:
+
+        >>> B.orient_axis(N, N.x, q1)
+        >>> B.dcm(N)
+        Matrix([
+        [1,       0,      0],
+        [0,  cos(q1), sin(q1)],
+        [0, -sin(q1), cos(q1)]])
+
+        **Note carefully that** ``N.dcm(B)`` **(the transpose) would be passed
+        into** ``orient_explicit()`` **for** ``A.dcm(N)`` **to match**
+        ``B.dcm(N)``:
+
+        >>> A.orient_explicit(N, N.dcm(B))
+        >>> A.dcm(N)
+        Matrix([
+        [1,       0,      0],
+        [0,  cos(q1), sin(q1)],
+        [0, -sin(q1), cos(q1)]])
+
         """
         _check_frame(parent)
         # amounts must be a Matrix type object
@@ -755,7 +800,6 @@ class ReferenceFrame:
 
         UserWarning
             If the orientation creates a kinematic loop.
-
 
         """
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -708,8 +708,8 @@ class ReferenceFrame:
         self._var_dict = {}
 
     def orient_explicit(self, parent, dcm):
-        """Sets the orientation of this reference frame relative to a parent
-        reference frame by explicitly setting the direction cosine matrix.
+        """Sets the orientation of this reference frame relative to another (parent) reference frame
+        using a direction cosine matrix that describes the rotation from the parent to the child.
 
         Parameters
         ==========
@@ -720,8 +720,7 @@ class ReferenceFrame:
         dcm : Matrix, shape(3, 3)
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
-        rotation matrix : Matrix Rotation Direction
-            The simple matrix rotation relative ``parent`` to ``dcm``.
+
         Warns
         ======
 
@@ -729,11 +728,11 @@ class ReferenceFrame:
             If the orientation creates a kinematic loop.
 
         """
-        self.orient_dcm(parent = parent, dcm = dcm)
+        self.orient_dcm(parent = parent, dcm = dcm.T)
 
     def orient_dcm(self, parent, dcm):
-        """Sets the orientation of this reference frame relative to a parent
-        reference frame by explicitly setting the direction cosine matrix.
+        """Sets the orientation of this reference frame relative to another (parent) reference frame
+        using a direction cosine matrix that describes the rotation from the child to the parent.
 
         Parameters
         ==========
@@ -744,8 +743,7 @@ class ReferenceFrame:
         dcm : Matrix, shape(3, 3)
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
-        rotation matrix : Matrix Rotation Direction
-            The simple matrix rotation relative ``parent`` to ``dcm``.
+
         Warns
         ======
 
@@ -1181,7 +1179,7 @@ class ReferenceFrame:
             self.orient_axis(parent, amounts[1], amounts[0])
 
         elif rot_type == 'DCM':
-            self.orient_dcm(parent, amounts)
+            self.orient_explicit(parent, amounts)
 
         elif rot_type == 'BODY':
             self.orient_body_fixed(parent, amounts, rot_order)
@@ -1292,7 +1290,7 @@ class ReferenceFrame:
             newframe.orient_axis(self, amounts[1], amounts[0])
 
         elif rot_type == 'DCM':
-            newframe.orient_dcm(self, amounts)
+            newframe.orient_explicit(self, amounts)
 
         elif rot_type == 'BODY':
             newframe.orient_body_fixed(self, amounts, rot_order)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -720,57 +720,40 @@ class ReferenceFrame:
         dcm : Matrix, shape(3, 3)
             Direction cosine matrix that specifies the relative rotation
             between the two reference frames.
-
+        rotation matrix :  Matrix Rotation Direction
+            the simple matrix rotation relative ``parent`` to ``dcm``.   
+        
         Warns
         ======
 
         UserWarning
             If the orientation creates a kinematic loop.
 
-        Examples
-        ========
+        """
+        self.orient_dcm(parent = parent, dcm = dcm)
+    
+    def orient_dcm(self, parent, dcm):
+        """Sets the orientation of this reference frame relative to a parent
+        reference frame by explicitly setting the direction cosine matrix.
 
-        Setup variables for the examples:
+        Parameters
+        ==========
 
-        >>> from sympy import symbols, Matrix, sin, cos
-        >>> from sympy.physics.vector import ReferenceFrame
-        >>> q1 = symbols('q1')
-        >>> A = ReferenceFrame('A')
-        >>> B = ReferenceFrame('B')
-        >>> N = ReferenceFrame('N')
+        parent : ReferenceFrame
+            Reference frame that this reference frame will be rotated relative
+            to.
+        dcm : Matrix, shape(3, 3)
+            Direction cosine matrix that specifies the relative rotation
+            between the two reference frames.
+        rotation matrix :  Matrix Rotation Direction
+            the simple matrix rotation relative ``parent`` to ``dcm``.   
+        
+        Warns
+        ======
 
-        A simple rotation of ``A`` relative to ``N`` about ``N.x`` is defined
-        by the following direction cosine matrix:
+        UserWarning
+            If the orientation creates a kinematic loop.
 
-        >>> dcm = Matrix([[1, 0, 0],
-        ...               [0, cos(q1), -sin(q1)],
-        ...               [0, sin(q1), cos(q1)]])
-        >>> A.orient_explicit(N, dcm)
-        >>> A.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
-
-        This is equivalent to using ``orient_axis()``:
-
-        >>> B.orient_axis(N, N.x, q1)
-        >>> B.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
-
-        **Note carefully that** ``N.dcm(B)`` **(the transpose) would be passed
-        into** ``orient_explicit()`` **for** ``A.dcm(N)`` **to match**
-        ``B.dcm(N)``:
-
-        >>> A.orient_explicit(N, N.dcm(B))
-        >>> A.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
 
         """
 
@@ -780,9 +763,7 @@ class ReferenceFrame:
         if not isinstance(dcm, MatrixBase):
             raise TypeError("Amounts must be a SymPy Matrix type object.")
 
-        parent_orient_dcm = dcm
-
-        self._dcm(parent, parent_orient_dcm)
+        self._dcm(parent, dcm.T)
 
         wvec = self._w_diff_dcm(parent)
         self._ang_vel_dict.update({parent: wvec})
@@ -1202,7 +1183,7 @@ class ReferenceFrame:
             self.orient_axis(parent, amounts[1], amounts[0])
 
         elif rot_type == 'DCM':
-            self.orient_explicit(parent, amounts)
+            self.orient_dcm(parent, amounts)
 
         elif rot_type == 'BODY':
             self.orient_body_fixed(parent, amounts, rot_order)
@@ -1313,7 +1294,7 @@ class ReferenceFrame:
             newframe.orient_axis(self, amounts[1], amounts[0])
 
         elif rot_type == 'DCM':
-            newframe.orient_explicit(self, amounts)
+            newframe.orient_dcm(self, amounts)
 
         elif rot_type == 'BODY':
             newframe.orient_body_fixed(self, amounts, rot_order)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -722,7 +722,7 @@ class ReferenceFrame:
             between the two reference frames.
         rotation matrix : Matrix Rotation Direction
             The simple matrix rotation relative ``parent`` to ``dcm``.
-        
+      
         Warns
         ======
 
@@ -747,7 +747,7 @@ class ReferenceFrame:
             between the two reference frames.
         rotation matrix : Matrix Rotation Direction
             The simple matrix rotation relative ``parent`` to ``dcm``.
-        
+
         Warns
         ======
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -729,9 +729,9 @@ class ReferenceFrame:
 
         Examples
         ========
-        
+
         Setup variables for the examples:
-        
+
         >>> from sympy import symbols, Matrix, sin, cos
         >>> from sympy.physics.vector import ReferenceFrame
         >>> q1 = symbols('q1')
@@ -803,9 +803,9 @@ class ReferenceFrame:
 
         Examples
         ========
-        
+
         Setup variables for the examples:
-        
+
         >>> from sympy import symbols, Matrix, sin, cos
         >>> from sympy.physics.vector import ReferenceFrame
         >>> q1 = symbols('q1')

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -451,11 +451,30 @@ def test_dcm_diff_16824():
     assert simplify(AwB.dot(A.y) - alpha2) == 0
     assert simplify(AwB.dot(B.y) - beta2) == 0
 
-def test_orient_dcm():
+def test_orient_explicit():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    A.orient_dcm(B, eye(3))
+    A.orient_explicit(B, eye(3))
     assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+def test_orient_dcm():
+    A = me.ReferenceFrame('A')
+    B = me.ReferenceFrame('B')
+    B.orient_dcm(A, eye(3))
+    assert B.dcm(A) == Matrix([[1, 0, 0],[0, 1, 0],[0, 0, 1]])
+
+    # cxx, cyy, czz = sympy.physics.mechanics.dynamicsymbols('c_{xx}, c_{yy}, c_{zz}')
+    # cxy, cxz, cyx = sympy.physics.mechanics.dynamicsymbols('c_{xy}, c_{xz}, c_{yx}')
+    # cyz, czx, czy = sympy.physics.mechanics.dynamicsymbols('c_{yz}, c_{zx}, c_{zy}')
+
+    # B_C_A = sympy.Matrix([[cxx, cxy, cxz],
+    #                 [cyx, cyy, cyz],
+    #                 [czx, czy, czz]])
+
+    # A = me.ReferenceFrame('A')
+    # B = me.ReferenceFrame('B')
+    # B.orient_explicit(A, B_C_A)
+    # assert B.dcm(A) == Matrix([[c_{xx}(t), c_{xy}(t), c_{xz}(t)],[c_{yx}(t), c_{yy}(t), c_{yz}(t)],[c_{zx}(t), c_{zy}(t), c_{zz}(t)]])
 
 def test_orient_axis():
     A = ReferenceFrame('A')

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -451,10 +451,10 @@ def test_dcm_diff_16824():
     assert simplify(AwB.dot(A.y) - alpha2) == 0
     assert simplify(AwB.dot(B.y) - beta2) == 0
 
-def test_orient_explicit():
+def test_orient_dcm():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    A.orient_explicit(B, eye(3))
+    A.orient_dcm(B, eye(3))
     assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
 def test_orient_axis():

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -458,23 +458,10 @@ def test_orient_explicit():
     assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
 def test_orient_dcm():
-    A = me.ReferenceFrame('A')
-    B = me.ReferenceFrame('B')
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
     B.orient_dcm(A, eye(3))
     assert B.dcm(A) == Matrix([[1, 0, 0],[0, 1, 0],[0, 0, 1]])
-
-    # cxx, cyy, czz = sympy.physics.mechanics.dynamicsymbols('c_{xx}, c_{yy}, c_{zz}')
-    # cxy, cxz, cyx = sympy.physics.mechanics.dynamicsymbols('c_{xy}, c_{xz}, c_{yx}')
-    # cyz, czx, czy = sympy.physics.mechanics.dynamicsymbols('c_{yz}, c_{zx}, c_{zy}')
-
-    # B_C_A = sympy.Matrix([[cxx, cxy, cxz],
-    #                 [cyx, cyy, cyz],
-    #                 [czx, czy, czz]])
-
-    # A = me.ReferenceFrame('A')
-    # B = me.ReferenceFrame('B')
-    # B.orient_explicit(A, B_C_A)
-    # assert B.dcm(A) == Matrix([[c_{xx}(t), c_{xy}(t), c_{xz}(t)],[c_{yx}(t), c_{yy}(t), c_{yz}(t)],[c_{zx}(t), c_{zy}(t), c_{zz}(t)]])
 
 def test_orient_axis():
     A = ReferenceFrame('A')

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -452,16 +452,38 @@ def test_dcm_diff_16824():
     assert simplify(AwB.dot(B.y) - beta2) == 0
 
 def test_orient_explicit():
+    cxx, cyy, czz = dynamicsymbols('c_{xx}, c_{yy}, c_{zz}')
+    cxy, cxz, cyx = dynamicsymbols('c_{xy}, c_{xz}, c_{yx}')
+    cyz, czx, czy = dynamicsymbols('c_{yz}, c_{zx}, c_{zy}')
+    dcxx, dcyy, dczz = dynamicsymbols('c_{xx}, c_{yy}, c_{zz}', 1)
+    dcxy, dcxz, dcyx = dynamicsymbols('c_{xy}, c_{xz}, c_{yx}', 1)
+    dcyz, dczx, dczy = dynamicsymbols('c_{yz}, c_{zx}, c_{zy}', 1)
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    A.orient_explicit(B, eye(3))
-    assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    B_C_A = Matrix([[cxx, cxy, cxz],
+                    [cyx, cyy, cyz],
+                    [czx, czy, czz]])
+    B_w_A = ((cyx*dczx + cyy*dczy + cyz*dczz)*B.x +
+            (czx*dcxx + czy*dcxy + czz*dcxz)*B.y +
+            (cxx*dcyx + cxy*dcyy + cxz*dcyz)*B.z)
+    A.orient_explicit(B, B_C_A)
+    assert B.dcm(A) == B_C_A
+    assert A.ang_vel_in(B) == B_w_A
+    assert B.ang_vel_in(A) == -B_w_A
 
 def test_orient_dcm():
+    cxx, cyy, czz = dynamicsymbols('c_{xx}, c_{yy}, c_{zz}')
+    cxy, cxz, cyx = dynamicsymbols('c_{xy}, c_{xz}, c_{yx}')
+    cyz, czx, czy = dynamicsymbols('c_{yz}, c_{zx}, c_{zy}')
+    B_C_A = Matrix([[cxx, cxy, cxz],
+                    [cyx, cyy, cyz],
+                    [czx, czy, czz]])
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
-    B.orient_dcm(A, eye(3))
-    assert B.dcm(A) == Matrix([[1, 0, 0],[0, 1, 0],[0, 0, 1]])
+    B.orient_dcm(A, B_C_A)
+    assert B.dcm(A) == Matrix([[cxx, cxy, cxz],
+                               [cyx, cyy, cyz],
+                               [czx, czy, czz]])
 
 def test_orient_axis():
     A = ReferenceFrame('A')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24764   

#### Brief description of what is fixed or changed
Complete as you mention above :
- [x] change method name `orient_explicit` to `orient_dcm`
- [x] create another method `orient_explicit` for backward compatibility
- [x] mention about rotation matrix direction 
- [x] Also `exclude-members: orient_explicit `

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

 

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Implemented `ReferenceFrame.orient_dcm` to match the direction `ReferenceFrame.dcm`.

<!-- END RELEASE NOTES -->
