### PR TITLE
trigsimp can use custom measure function

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1598,6 +1598,7 @@ vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
+vitrun <vitrun@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -696,7 +696,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         expr = besselsimp(expr)
 
     if expr.has(TrigonometricFunction, HyperbolicFunction):
-        expr = trigsimp(expr, deep=True)
+        expr = trigsimp(expr, deep=True, measure=measure)
 
     if expr.has(log):
         expr = shorter(expand_log(expr, deep=True), logcombine(expr))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #25906 

#### Brief description of what is fixed or changed
`trigsimp` now accepts a `measure` argument and passes it along

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
  - `simplify` uses custom complexity measure function in a more thorough manner.
<!-- END RELEASE NOTES -->
