### PR TITLE
Use `recurrence_memo`

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -10,6 +10,7 @@ from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csol
 from .primetest import isprime
 from .factor_ import factorint, _perfect_power
 from .modular import crt
+from sympy.utilities.memoization import recurrence_memo
 from sympy.utilities.misc import as_int
 from sympy.utilities.iterables import iproduct
 from sympy.core.random import _randint, randint
@@ -1778,11 +1779,8 @@ def _binomial_mod_prime_power(n, m, p, q):
 
     def up_plus_v_binom(u, v):
         """Compute binomial(u*p + v, v)_p modulo p^q."""
-        prod = div = 1
-        for i in range(1, v + 1):
-            div *= i
-            div %= modulo
-        div = invert(div, modulo)
+        prod = 1
+        div = invert(factorial(v), modulo)
         for j in range(1, q):
             b = div
             for v_ in range(j*p + 1, j*p + v + 1):
@@ -1798,13 +1796,10 @@ def _binomial_mod_prime_power(n, m, p, q):
             prod %= modulo
         return prod
 
-    factorials = [1]
-    def factorial(v):
+    @recurrence_memo([1])
+    def factorial(v, prev):
         """Compute v! modulo p^q."""
-        if len(factorials) <= v:
-            for i in range(len(factorials), v + 1):
-                factorials.append(factorials[-1]*i % modulo)
-        return factorials[v]
+        return v*prev[-1] % modulo
 
     def factorial_p(n):
         """Compute n!_p modulo p^q."""

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -10,8 +10,8 @@ def recurrence_memo(initial):
 
     >>> from sympy.utilities.memoization import recurrence_memo
     >>> @recurrence_memo([1]) # 0! = 1
-    >>> def factorial(n, prev):
-    >>>     return n * prev[-1]
+    ... def factorial(n, prev):
+    ...     return n * prev[-1]
     >>> factorial(4)
     24
     >>> factorial(3) # use cache values

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -5,7 +5,18 @@ def recurrence_memo(initial):
     """
     Memo decorator for sequences defined by recurrence
 
-    See usage examples e.g. in the specfun/combinatorial module
+    Examples
+    ========
+
+    >>> from sympy.utilities.memoization import recurrence_memo
+    >>> @recurrence_memo([1]) # 0! = 1
+    >>> def factorial(n, prev):
+    >>>     return n * prev[-1]
+    >>> factorial(4)
+    24
+    >>> factorial(3) # use cache values
+    6
+
     """
     cache = initial
 
@@ -13,7 +24,7 @@ def recurrence_memo(initial):
         @wraps(f)
         def g(n):
             L = len(cache)
-            if n <= L - 1:
+            if n < L:
                 return cache[n]
             for i in range(L, n + 1):
                 cache.append(f(i, cache))


### PR DESCRIPTION
In `ntheory.residue_ntheory._binomial_mod_prime_power`, we have memoized the factorial by our own implementation, but now we use `recurrence_memo`. Also, added examples to `recurrence_memo`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
