### PR TITLE
Fixed the style of `isprime` reference

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -475,6 +475,7 @@ Cristian Di Pietrantonio <cristiandipietrantonio@gmail.com>
 Cristóvão Sousa <crisjss@gmail.com>
 Cédric Travelletti <cedrictravelletti@gmail.com> Cedric <cedric@localhost.localdomain>
 Daan Koning (he/him) <daanolivierkoning@gmail.com>
+Daiki Takahashi <haru.td@gmail.com> haru-44 <36563693+haru-44@users.noreply.github.com>
 Dammina Sahabandu <dmsahabandu@gmail.com>
 Dana Jacobsen <dana@acm.org>
 Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
@@ -1537,7 +1538,6 @@ fazledyn-or <ataf@openrefactory.com>
 foice <foice.news@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
-haru-44 <36563693+haru-44@users.noreply.github.com>
 helo9 <helo9@users.noreply.github.com>
 hm <hacman0@gmail.com>
 immerrr <immerrr@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1200,7 +1200,7 @@ Michele Ceccacci <michelececcacci1@gmail.com>
 Ayush Aryan <ayush.aryan71@gmail.com>
 Kishore Gopalakrishnan <kishore96@gmail.com>
 Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com>
-haru-44 <36563693+haru-44@users.noreply.github.com>
+Daiki Takahashi <haru.td@gmail.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Aman Kumar Shukla <theprofessionalaman@gmail.com>
 Zoufiné Lauer-Baré <raszoufine@gmail.com>

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -660,10 +660,12 @@ def isprime(n):
 
     References
     ==========
-    - https://en.wikipedia.org/wiki/Strong_pseudoprime
-    - "Lucas Pseudoprimes", Baillie and Wagstaff, 1980.
-      http://mpqs.free.fr/LucasPseudoprimes.pdf
-    - https://en.wikipedia.org/wiki/Baillie-PSW_primality_test
+    .. [1] https://en.wikipedia.org/wiki/Strong_pseudoprime
+    .. [2] Robert Baillie, Samuel S. Wagstaff, Lucas Pseudoprimes,
+           Math. Comp. Vol 35, Number 152 (1980), pp. 1391-1417,
+           https://doi.org/10.1090%2FS0025-5718-1980-0583518-6
+           http://mpqs.free.fr/LucasPseudoprimes.pdf
+    .. [3] https://en.wikipedia.org/wiki/Baillie-PSW_primality_test
     """
     try:
         n = as_int(n)


### PR DESCRIPTION
Fixed references according to the [SymPy Docstrings Style Guide](https://docs.sympy.org/dev/contributing/docstring.html).

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
