### PR TITLE
matrices: deprecate mixins and merge tests

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,6 +76,11 @@ SymPy deprecation warnings.
 
 ## Version 1.13
 
+(deprecated-matrix-mixins)=
+### Deprecated matrix mixin classes
+
+The Matrix mixin classes are deprecated.
+
 (deprecated-sympify-string-fallback)=
 ### The string fallback in `sympify()`
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -79,7 +79,62 @@ SymPy deprecation warnings.
 (deprecated-matrix-mixins)=
 ### Deprecated matrix mixin classes
 
-The Matrix mixin classes are deprecated.
+The matrix mixin classes are deprecated. Previously the ``Matrix`` class (aka
+``MutableDenseMatrix``) created through an inheritance hierarchy that looked
+like:
+```py
+class MatrixRequired:
+class MatrixShaping(MatrixRequired):
+class MatrixSpecial(MatrixRequired):
+class MatrixProperties(MatrixRequired):
+class MatrixOperations(MatrixRequired):
+class MatrixArithmetic(MatrixRequired):
+class MatrixCommon(
+    MatrixArithmetic,
+    MatrixOperations,
+    MatrixProperties,
+    MatrixSpecial,
+    MatrixShaping):
+class MatrixDeterminant(MatrixCommon):
+class MatrixReductions(MatrixDeterminant):
+class MatrixSubspaces(MatrixReductions):
+class MatrixEigen(MatrixSubspaces)
+class MatrixCalculus(MatrixCommon):
+class MatrixDeprecated(MatrixCommon):
+class MatrixBase(MatrixDeprecated,
+   MatrixCalculus,
+   MatrixEigen,
+   MatrixCommon,
+   Printable):
+class RepMatrix(MatrixBase):
+class DenseMatrix(RepMatrix):
+class MutableRepMatrix(RepMatrix):
+class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
+```
+As of SymPy 1.13 this has been simplified and all classes above
+``MatrixBase``are merged together so the hierarchy looks like:
+```py
+class MatrixBase(Printable):
+class RepMatrix(MatrixBase):
+class DenseMatrix(RepMatrix):
+class MutableRepMatrix(RepMatrix):
+class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
+```
+The matrix mixin classes like ``MatrixRequired`` etc are still available
+because downstream code might be subclassing these classes but these are all
+deprecated and will be removed in a future version of SymPy. Subclassing these
+classes is deprecated as is importing anything from the
+``sympy.matrices.common`` or ``sympy.matrices.matrices`` modulew in which these
+classes are defined.
+
+The reason for this change is that the complicated inheritance hierarchy made
+it difficult to improve ``Matrix`` for the majority of users while still
+providing all of these classes that could be subclassed. Since these mixin
+classes are no longer used as part of ``Matrix`` they no longer serve any
+function within SymPy and the removal of this now unused code will simplify the
+codebase. Any downstream code that subclasses these classes should be changed
+not to subclass them and any code that uses e.g. ``isinstance(obj,
+MaatrixCommon)`` should be changed to use ``isinstance(obj, MatrixBase)``.
 
 (deprecated-sympify-string-fallback)=
 ### The string fallback in `sympify()`

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -80,8 +80,8 @@ SymPy deprecation warnings.
 ### Deprecated matrix mixin classes
 
 The matrix mixin classes are deprecated. Previously the ``Matrix`` class (aka
-``MutableDenseMatrix``) created through an inheritance hierarchy that looked
-like:
+``MutableDenseMatrix``) was created through an inheritance hierarchy that
+looked like:
 ```py
 class MatrixRequired:
 class MatrixShaping(MatrixRequired):
@@ -123,18 +123,23 @@ class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
 The matrix mixin classes like ``MatrixRequired`` etc are still available
 because downstream code might be subclassing these classes but these are all
 deprecated and will be removed in a future version of SymPy. Subclassing these
-classes is deprecated as is importing anything from the
-``sympy.matrices.common`` or ``sympy.matrices.matrices`` module in which these
-classes are defined.
+classes is deprecated and anycode that does that should be changed to not
+subclass them.
 
-The reason for this change is that the complicated inheritance hierarchy made
-it difficult to improve ``Matrix`` for the majority of users while still
-providing all of these classes that could be subclassed. Since these mixin
-classes are no longer used as part of ``Matrix`` they no longer serve any
-function within SymPy and the removal of this now unused code will simplify the
-codebase. Any downstream code that subclasses these classes should be changed
-not to subclass them and any code that uses e.g. ``isinstance(obj,
-MatrixCommon)`` should be changed to use ``isinstance(obj, MatrixBase)``.
+It is also deprecated to use these classes with ``isinstance`` like
+``isinstance(M, MatrixCommon)``. Any code doing this should be changed to use
+``isinstance(M, Matrixbase)`` instead which will also work with previous SymPy
+versions.
+
+More generally importing anything from the ``sympy.matrices.common`` or
+``sympy.matrices.matrices`` modules in which these classes are defined is
+deprecated. These modules will be removed in a future release of SymPy.
+
+The reason for this change is that the convoluted inheritance hierarchy made it
+difficult to improve ``Matrix`` for the majority of users while still providing
+all of these classes that could be subclassed. Since these mixin classes are no
+longer used as part of ``Matrix`` they no longer serve any function within
+SymPy and the removal of this now unused code will simplify the codebase.
 
 (deprecated-sympify-string-fallback)=
 ### The string fallback in `sympify()`

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -124,7 +124,7 @@ The matrix mixin classes like ``MatrixRequired`` etc are still available
 because downstream code might be subclassing these classes but these are all
 deprecated and will be removed in a future version of SymPy. Subclassing these
 classes is deprecated as is importing anything from the
-``sympy.matrices.common`` or ``sympy.matrices.matrices`` modulew in which these
+``sympy.matrices.common`` or ``sympy.matrices.matrices`` module in which these
 classes are defined.
 
 The reason for this change is that the complicated inheritance hierarchy made
@@ -134,7 +134,7 @@ classes are no longer used as part of ``Matrix`` they no longer serve any
 function within SymPy and the removal of this now unused code will simplify the
 codebase. Any downstream code that subclasses these classes should be changed
 not to subclass them and any code that uses e.g. ``isinstance(obj,
-MaatrixCommon)`` should be changed to use ``isinstance(obj, MatrixBase)``.
+MatrixCommon)`` should be changed to use ``isinstance(obj, MatrixBase)``.
 
 (deprecated-sympify-string-fallback)=
 ### The string fallback in `sympify()`

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1,7 +1,12 @@
 """
-Basic methods common to all matrices to be used
-when creating more advanced matrices (e.g., matrices over rings,
-etc.).
+A module contining deprecated matrix mixin classes.
+
+The classes in this module are deprecated and will be removed in a future
+release. They are kept here for backwards compatibility in case downstream
+code was subclassing them.
+
+Importing anything else from this module is deprecated so anything here
+should either not be used or should be imported from somewhere else.
 """
 
 from collections import defaultdict
@@ -20,6 +25,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.complexes import Abs, re, im
+from sympy.utilities.exceptions import sympy_deprecation_warning
 from .utilities import _dotprodsimp, _simplify
 from sympy.polys.polytools import Poly
 from sympy.utilities.iterables import flatten, is_sequence
@@ -38,12 +44,55 @@ from .exceptions import ( # noqa: F401
 )
 
 
+_DEPRECATED_MIXINS = (
+    'MatrixShaping',
+    'MatrixSpecial',
+    'MatrixProperties',
+    'MatrixOperations',
+    'MatrixArithmetic',
+    'MatrixCommon',
+    'MatrixDeterminant',
+    'MatrixReductions',
+    'MatrixSubspaces',
+    'MatrixEigen',
+    'MatrixCalculus',
+    'MatrixDeprecated',
+)
+
+
 class MatrixRequired:
-    """All subclasses of matrix objects must implement the
-    required matrix properties listed here."""
+    """Deprecated mixin class for making matrix classes."""
+
     rows = None  # type: int
     cols = None  # type: int
     _simplify = None
+
+    def __init_subclass__(cls, **kwargs):
+
+        # Warn if any downstream code is subclassing this class or any of the
+        # deprecated mixin classes that are all ultimately subclasses of this
+        # class.
+        #
+        # We don't want to warn about the deprecated mixins themselves being
+        # subclassed, only about the deprecated mixins being used as mixins.
+        # Otherwise just importing this module would trigger a warning.
+        # Ultimately the whole module should be deprecated and removed but for
+        # SymPy 1.13 it is premature to do that given that this module was the
+        # main way to import matrix exception types in all previous versions.
+
+        if cls.__name__ not in _DEPRECATED_MIXINS:
+            sympy_deprecation_warning(
+                f"""
+                Inheriting from the Matrix mixin classes is deprecated.
+
+                The class {cls.__name__} is subclassing a deprecated mixin.
+                """,
+                deprecated_since_version="1.13",
+                active_deprecations_target="deprecated-matrix-mixins",
+                stacklevel=3,
+            )
+
+        super().__init_subclass__(**kwargs)
 
     @classmethod
     def _new(cls, *args, **kwargs):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -74,7 +74,7 @@ class MatrixRequired:
         # class.
         #
         # We don't want to warn about the deprecated mixins themselves being
-        # subclassed, only about the deprecated mixins being used as mixins.
+        # created, but only about them being used as mixins by downstream code.
         # Otherwise just importing this module would trigger a warning.
         # Ultimately the whole module should be deprecated and removed but for
         # SymPy 1.13 it is premature to do that given that this module was the

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,3 +1,7 @@
+#
+# A module consisting of deprecated matrix classes. New code should not be
+# added here.
+#
 from sympy.core.basic import Basic
 from sympy.core.symbol import Dummy
 

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -2295,8 +2295,21 @@ class MatrixBase(Printable):
         [G(0), G(1)],
         [G(1), G(2)]])
         """
-        return self.applyfunc(
-            lambda x: x.replace(F, G, map=map, simultaneous=simultaneous, exact=exact))
+        kwargs = {'map': map, 'simultaneous': simultaneous, 'exact': exact}
+
+        if map:
+
+            d = {}
+            def func(eij):
+                eij, dij = eij.replace(F, G, **kwargs)
+                d.update(dij)
+                return eij
+
+            M = self.applyfunc(func)
+            return M, d
+
+        else:
+            return self.applyfunc(lambda i: i.replace(F, G, **kwargs))
 
     def rot90(self, k=1):
         """Rotates Matrix by 90 degrees

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1,3 +1,10 @@
+#
+# Code for testing deprecated matrix classes. New test code should not be added
+# here. Instead, add it to test_matrixbase.py.
+#
+# This entire test module and the corresponding sympy/matrices/common.py
+# module will be removed in a future release.
+#
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.assumptions import Q
@@ -27,6 +34,68 @@ from sympy.utilities.iterables import flatten
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray as Array
 
 from sympy.abc import x, y, z
+
+
+def test_matrix_deprecated_isinstance():
+
+    # Test that e.g. isinstance(M, MatrixCommon) still gives True when M is a
+    # Matrix for each of the deprecated matrix classes.
+
+    from sympy.matrices.common import (
+        MatrixRequired,
+        MatrixShaping,
+        MatrixSpecial,
+        MatrixProperties,
+        MatrixOperations,
+        MatrixArithmetic,
+        MatrixCommon
+    )
+    from sympy.matrices.matrices import (
+        MatrixDeterminant,
+        MatrixReductions,
+        MatrixSubspaces,
+        MatrixEigen,
+        MatrixCalculus,
+        MatrixDeprecated
+    )
+    from sympy import (
+        Matrix,
+        ImmutableMatrix,
+        SparseMatrix,
+        ImmutableSparseMatrix
+    )
+    all_mixins = (
+        MatrixRequired,
+        MatrixShaping,
+        MatrixSpecial,
+        MatrixProperties,
+        MatrixOperations,
+        MatrixArithmetic,
+        MatrixCommon,
+        MatrixDeterminant,
+        MatrixReductions,
+        MatrixSubspaces,
+        MatrixEigen,
+        MatrixCalculus,
+        MatrixDeprecated
+    )
+    all_matrices = (
+        Matrix,
+        ImmutableMatrix,
+        SparseMatrix,
+        ImmutableSparseMatrix
+    )
+
+    Ms = [M([[1, 2], [3, 4]]) for M in all_matrices]
+    t = ()
+
+    for mixin in all_mixins:
+        for M in Ms:
+            with warns_deprecated_sympy():
+                assert isinstance(M, mixin) is True
+        with warns_deprecated_sympy():
+            assert isinstance(t, mixin) is False
+
 
 # classes to test the deprecated matrix classes. We use warns_deprecated_sympy
 # to suppress the deprecation warnings because subclassing the deprecated

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1,3 +1,5 @@
+from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+
 from sympy.assumptions import Q
 from sympy.core.expr import Expr
 from sympy.core.add import Add
@@ -22,14 +24,17 @@ from sympy.matrices import (Matrix, diag, eye,
     ImmutableSparseMatrix)
 from sympy.polys.polytools import Poly
 from sympy.utilities.iterables import flatten
-from sympy.testing.pytest import raises, XFAIL
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray as Array
 
 from sympy.abc import x, y, z
 
-# classes to test the basic matrix classes
-class ShapingOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixShaping):
-    pass
+# classes to test the deprecated matrix classes. We use warns_deprecated_sympy
+# to suppress the deprecation warnings because subclassing the deprecated
+# classes causes a warning to be raised.
+
+with warns_deprecated_sympy():
+    class ShapingOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixShaping):
+        pass
 
 
 def eye_Shaping(n):
@@ -40,8 +45,9 @@ def zeros_Shaping(n):
     return ShapingOnlyMatrix(n, n, lambda i, j: 0)
 
 
-class PropertiesOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixProperties):
-    pass
+with warns_deprecated_sympy():
+    class PropertiesOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixProperties):
+        pass
 
 
 def eye_Properties(n):
@@ -52,8 +58,9 @@ def zeros_Properties(n):
     return PropertiesOnlyMatrix(n, n, lambda i, j: 0)
 
 
-class OperationsOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixOperations):
-    pass
+with warns_deprecated_sympy():
+    class OperationsOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixOperations):
+        pass
 
 
 def eye_Operations(n):
@@ -64,8 +71,9 @@ def zeros_Operations(n):
     return OperationsOnlyMatrix(n, n, lambda i, j: 0)
 
 
-class ArithmeticOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixArithmetic):
-    pass
+with warns_deprecated_sympy():
+    class ArithmeticOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixArithmetic):
+        pass
 
 
 def eye_Arithmetic(n):
@@ -76,12 +84,14 @@ def zeros_Arithmetic(n):
     return ArithmeticOnlyMatrix(n, n, lambda i, j: 0)
 
 
-class SpecialOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixSpecial):
-    pass
+with warns_deprecated_sympy():
+    class SpecialOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixSpecial):
+        pass
 
 
-class CalculusOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixCalculus):
-    pass
+with warns_deprecated_sympy():
+    class CalculusOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixCalculus):
+        pass
 
 
 def test__MinimalMatrix():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,3 +1,10 @@
+#
+# Code for testing deprecated matrix classes. New test code should not be added
+# here. Instead, add it to test_matrixbase.py.
+#
+# This entire test module and the corresponding sympy/matrices/matrices.py
+# module will be removed in a future release.
+#
 import random
 import concurrent.futures
 from collections.abc import Hashable

--- a/sympy/matrices/tests/test_reductions.py
+++ b/sympy/matrices/tests/test_reductions.py
@@ -1,9 +1,7 @@
 from sympy.core.numbers import I
 from sympy.core.symbol import symbols
-from sympy.matrices.common import _MinimalMatrix, _CastableMatrix
-from sympy.matrices.matrices import MatrixReductions
 from sympy.testing.pytest import raises
-from sympy.matrices import Matrix, zeros
+from sympy.matrices import Matrix, zeros, eye
 from sympy.core.symbol import Symbol
 from sympy.core.numbers import Rational
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -11,19 +9,9 @@ from sympy.simplify.simplify import simplify
 from sympy.abc import x
 
 
-class ReductionsOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixReductions):
-    pass
-
-def eye_Reductions(n):
-    return ReductionsOnlyMatrix(n, n, lambda i, j: int(i == j))
-
-
-def zeros_Reductions(n):
-    return ReductionsOnlyMatrix(n, n, lambda i, j: 0)
-
-# ReductionsOnlyMatrix tests
+# Matrix tests
 def test_row_op():
-    e = eye_Reductions(3)
+    e = eye(3)
 
     raises(ValueError, lambda: e.elementary_row_op("abc"))
     raises(ValueError, lambda: e.elementary_row_op())
@@ -52,14 +40,14 @@ def test_row_op():
     assert e.elementary_row_op("n->n+km", row1=0, k=5, row2=1) == Matrix([[1, 5, 0], [0, 1, 0], [0, 0, 1]])
 
     # make sure the matrix doesn't change size
-    a = ReductionsOnlyMatrix(2, 3, [0]*6)
+    a = Matrix(2, 3, [0]*6)
     assert a.elementary_row_op("n->kn", 1, 5) == Matrix(2, 3, [0]*6)
     assert a.elementary_row_op("n<->m", 0, 1) == Matrix(2, 3, [0]*6)
     assert a.elementary_row_op("n->n+km", 0, 5, 1) == Matrix(2, 3, [0]*6)
 
 
 def test_col_op():
-    e = eye_Reductions(3)
+    e = eye(3)
 
     raises(ValueError, lambda: e.elementary_col_op("abc"))
     raises(ValueError, lambda: e.elementary_col_op())
@@ -88,36 +76,36 @@ def test_col_op():
     assert e.elementary_col_op("n->n+km", col1=0, k=5, col2=1) == Matrix([[1, 0, 0], [5, 1, 0], [0, 0, 1]])
 
     # make sure the matrix doesn't change size
-    a = ReductionsOnlyMatrix(2, 3, [0]*6)
+    a = Matrix(2, 3, [0]*6)
     assert a.elementary_col_op("n->kn", 1, 5) == Matrix(2, 3, [0]*6)
     assert a.elementary_col_op("n<->m", 0, 1) == Matrix(2, 3, [0]*6)
     assert a.elementary_col_op("n->n+km", 0, 5, 1) == Matrix(2, 3, [0]*6)
 
 
 def test_is_echelon():
-    zro = zeros_Reductions(3)
-    ident = eye_Reductions(3)
+    zro = zeros(3)
+    ident = eye(3)
 
     assert zro.is_echelon
     assert ident.is_echelon
 
-    a = ReductionsOnlyMatrix(0, 0, [])
+    a = Matrix(0, 0, [])
     assert a.is_echelon
 
-    a = ReductionsOnlyMatrix(2, 3, [3, 2, 1, 0, 0, 6])
+    a = Matrix(2, 3, [3, 2, 1, 0, 0, 6])
     assert a.is_echelon
 
-    a = ReductionsOnlyMatrix(2, 3, [0, 0, 6, 3, 2, 1])
+    a = Matrix(2, 3, [0, 0, 6, 3, 2, 1])
     assert not a.is_echelon
 
     x = Symbol('x')
-    a = ReductionsOnlyMatrix(3, 1, [x, 0, 0])
+    a = Matrix(3, 1, [x, 0, 0])
     assert a.is_echelon
 
-    a = ReductionsOnlyMatrix(3, 1, [x, x, 0])
+    a = Matrix(3, 1, [x, x, 0])
     assert not a.is_echelon
 
-    a = ReductionsOnlyMatrix(3, 3, [0, 0, 0, 1, 2, 3, 0, 0, 0])
+    a = Matrix(3, 3, [0, 0, 0, 1, 2, 3, 0, 0, 0])
     assert not a.is_echelon
 
 
@@ -126,17 +114,17 @@ def test_echelon_form():
     # must be row-equivalent to the original matrix
     # and it must be in echelon form.
 
-    a = zeros_Reductions(3)
-    e = eye_Reductions(3)
+    a = zeros(3)
+    e = eye(3)
 
     # we can assume the zero matrix and the identity matrix shouldn't change
     assert a.echelon_form() == a
     assert e.echelon_form() == e
 
-    a = ReductionsOnlyMatrix(0, 0, [])
+    a = Matrix(0, 0, [])
     assert a.echelon_form() == a
 
-    a = ReductionsOnlyMatrix(1, 1, [5])
+    a = Matrix(1, 1, [5])
     assert a.echelon_form() == a
 
     # now we get to the real tests
@@ -148,7 +136,7 @@ def test_echelon_form():
             if not all(t.is_zero for t in v):
                 assert not all(t.is_zero for t in a_echelon*v.transpose())
 
-    a = ReductionsOnlyMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    a = Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     nulls = [Matrix([
                      [ 1],
                      [-2],
@@ -159,14 +147,14 @@ def test_echelon_form():
     verify_row_null_space(a, rows, nulls)
 
 
-    a = ReductionsOnlyMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 8])
+    a = Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 8])
     nulls = []
     rows = [a[i, :] for i in range(a.rows)]
     a_echelon = a.echelon_form()
     assert a_echelon.is_echelon
     verify_row_null_space(a, rows, nulls)
 
-    a = ReductionsOnlyMatrix(3, 3, [2, 1, 3, 0, 0, 0, 2, 1, 3])
+    a = Matrix(3, 3, [2, 1, 3, 0, 0, 0, 2, 1, 3])
     nulls = [Matrix([
              [Rational(-1, 2)],
              [   1],
@@ -181,7 +169,7 @@ def test_echelon_form():
     verify_row_null_space(a, rows, nulls)
 
     # this one requires a row swap
-    a = ReductionsOnlyMatrix(3, 3, [2, 1, 3, 0, 0, 0, 1, 1, 3])
+    a = Matrix(3, 3, [2, 1, 3, 0, 0, 0, 1, 1, 3])
     nulls = [Matrix([
              [   0],
              [  -3],
@@ -191,7 +179,7 @@ def test_echelon_form():
     assert a_echelon.is_echelon
     verify_row_null_space(a, rows, nulls)
 
-    a = ReductionsOnlyMatrix(3, 3, [0, 3, 3, 0, 2, 2, 0, 1, 1])
+    a = Matrix(3, 3, [0, 3, 3, 0, 2, 2, 0, 1, 1])
     nulls = [Matrix([
              [1],
              [0],
@@ -205,7 +193,7 @@ def test_echelon_form():
     assert a_echelon.is_echelon
     verify_row_null_space(a, rows, nulls)
 
-    a = ReductionsOnlyMatrix(2, 3, [2, 2, 3, 3, 3, 0])
+    a = Matrix(2, 3, [2, 2, 3, 3, 3, 0])
     nulls = [Matrix([
              [-1],
              [1],
@@ -217,40 +205,40 @@ def test_echelon_form():
 
 
 def test_rref():
-    e = ReductionsOnlyMatrix(0, 0, [])
+    e = Matrix(0, 0, [])
     assert e.rref(pivots=False) == e
 
-    e = ReductionsOnlyMatrix(1, 1, [1])
-    a = ReductionsOnlyMatrix(1, 1, [5])
+    e = Matrix(1, 1, [1])
+    a = Matrix(1, 1, [5])
     assert e.rref(pivots=False) == a.rref(pivots=False) == e
 
-    a = ReductionsOnlyMatrix(3, 1, [1, 2, 3])
+    a = Matrix(3, 1, [1, 2, 3])
     assert a.rref(pivots=False) == Matrix([[1], [0], [0]])
 
-    a = ReductionsOnlyMatrix(1, 3, [1, 2, 3])
+    a = Matrix(1, 3, [1, 2, 3])
     assert a.rref(pivots=False) == Matrix([[1, 2, 3]])
 
-    a = ReductionsOnlyMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    a = Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     assert a.rref(pivots=False) == Matrix([
                                      [1, 0, -1],
                                      [0, 1,  2],
                                      [0, 0,  0]])
 
-    a = ReductionsOnlyMatrix(3, 3, [1, 2, 3, 1, 2, 3, 1, 2, 3])
-    b = ReductionsOnlyMatrix(3, 3, [1, 2, 3, 0, 0, 0, 0, 0, 0])
-    c = ReductionsOnlyMatrix(3, 3, [0, 0, 0, 1, 2, 3, 0, 0, 0])
-    d = ReductionsOnlyMatrix(3, 3, [0, 0, 0, 0, 0, 0, 1, 2, 3])
+    a = Matrix(3, 3, [1, 2, 3, 1, 2, 3, 1, 2, 3])
+    b = Matrix(3, 3, [1, 2, 3, 0, 0, 0, 0, 0, 0])
+    c = Matrix(3, 3, [0, 0, 0, 1, 2, 3, 0, 0, 0])
+    d = Matrix(3, 3, [0, 0, 0, 0, 0, 0, 1, 2, 3])
     assert a.rref(pivots=False) == \
             b.rref(pivots=False) == \
             c.rref(pivots=False) == \
             d.rref(pivots=False) == b
 
-    e = eye_Reductions(3)
-    z = zeros_Reductions(3)
+    e = eye(3)
+    z = zeros(3)
     assert e.rref(pivots=False) == e
     assert z.rref(pivots=False) == z
 
-    a = ReductionsOnlyMatrix([
+    a = Matrix([
             [ 0, 0,  1,  2,  2, -5,  3],
             [-1, 5,  2,  2,  1, -7,  5],
             [ 0, 0, -2, -3, -3,  8, -5],
@@ -263,7 +251,7 @@ def test_rref():
                      [0,  0, 0, 0, 0,  0,  0]])
     assert pivot_offsets == (0, 2, 3)
 
-    a = ReductionsOnlyMatrix([[Rational(1, 19),  Rational(1, 5),    2,    3],
+    a = Matrix([[Rational(1, 19),  Rational(1, 5),    2,    3],
                         [   4,    5,    6,    7],
                         [   8,    9,   10,   11],
                         [  12,   13,   14,   15]])
@@ -274,7 +262,7 @@ def test_rref():
                                          [0, 0, 0,       0]])
 
     x = Symbol('x')
-    a = ReductionsOnlyMatrix(2, 3, [x, 1, 1, sqrt(x), x, 1])
+    a = Matrix(2, 3, [x, 1, 1, sqrt(x), x, 1])
     for i, j in zip(a.rref(pivots=False),
             [1, 0, sqrt(x)*(-x + 1)/(-x**Rational(5, 2) + x),
                 0, 1, 1/(sqrt(x) + x + 1)]):

--- a/sympy/matrices/tests/test_subspaces.py
+++ b/sympy/matrices/tests/test_subspaces.py
@@ -1,16 +1,11 @@
-from sympy.matrices.common import _MinimalMatrix, _CastableMatrix
-from sympy.matrices.matrices import MatrixSubspaces
 from sympy.matrices import Matrix
 from sympy.core.numbers import Rational
 from sympy.core.symbol import symbols
 from sympy.solvers import solve
 
-class SubspaceOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixSubspaces):
-    pass
 
-# SubspaceOnlyMatrix tests
 def test_columnspace_one():
-    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
+    m = Matrix([[ 1,  2,  0,  2,  5],
                             [-2, -5,  1, -1, -8],
                             [ 0, -3,  3,  4,  1],
                             [ 3,  6,  0, -7,  2]])
@@ -25,7 +20,7 @@ def test_columnspace_one():
 
 
 def test_rowspace():
-    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
+    m = Matrix([[ 1,  2,  0,  2,  5],
                             [-2, -5,  1, -1, -8],
                             [ 0, -3,  3,  4,  1],
                             [ 3,  6,  0, -7,  2]])
@@ -39,7 +34,7 @@ def test_rowspace():
 
 
 def test_nullspace_one():
-    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
+    m = Matrix([[ 1,  2,  0,  2,  5],
                             [-2, -5,  1, -1, -8],
                             [ 0, -3,  3,  4,  1],
                             [ 3,  6,  0, -7,  2]])

--- a/sympy/matrices/tests/test_subspaces.py
+++ b/sympy/matrices/tests/test_subspaces.py
@@ -6,9 +6,9 @@ from sympy.solvers import solve
 
 def test_columnspace_one():
     m = Matrix([[ 1,  2,  0,  2,  5],
-                            [-2, -5,  1, -1, -8],
-                            [ 0, -3,  3,  4,  1],
-                            [ 3,  6,  0, -7,  2]])
+                [-2, -5,  1, -1, -8],
+                [ 0, -3,  3,  4,  1],
+                [ 3,  6,  0, -7,  2]])
 
     basis = m.columnspace()
     assert basis[0] == Matrix([1, -2, 0, 3])
@@ -21,9 +21,9 @@ def test_columnspace_one():
 
 def test_rowspace():
     m = Matrix([[ 1,  2,  0,  2,  5],
-                            [-2, -5,  1, -1, -8],
-                            [ 0, -3,  3,  4,  1],
-                            [ 3,  6,  0, -7,  2]])
+                [-2, -5,  1, -1, -8],
+                [ 0, -3,  3,  4,  1],
+                [ 3,  6,  0, -7,  2]])
 
     basis = m.rowspace()
     assert basis[0] == Matrix([[1, 2, 0, 2, 5]])
@@ -35,9 +35,9 @@ def test_rowspace():
 
 def test_nullspace_one():
     m = Matrix([[ 1,  2,  0,  2,  5],
-                            [-2, -5,  1, -1, -8],
-                            [ 0, -3,  3,  4,  1],
-                            [ 3,  6,  0, -7,  2]])
+                [-2, -5,  1, -1, -8],
+                [ 0, -3,  3,  4,  1],
+                [ 3,  6,  0, -7,  2]])
 
     basis = m.nullspace()
     assert basis[0] == Matrix([-2, 1, 1, 0, 0])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follow on from gh-25911

#### Brief description of what is fixed or changed

Deprecated the matrix mixin classes.

Merge tests from `test_matrices.py` and `test_commonmatrix.py` into new tests in `test_matrixbase.py`. Some tests in other test files were moved into `test_matrices.py` so that any tests for the deprecated mixin classes are in the two files `test_matrices` and `test_commonmatrix` which can be removed when the deprecated mixin classes are removed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
