### PR TITLE
polys: use Flint for polynomials and matrices over GF(p)

### DIFF
--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -170,7 +170,8 @@ class DFM:
                     else:
                         return _cls(*e, c)
             else:
-                _func = flint.fmpz_mod_mat
+                m = flint.fmpz_mod_ctx(c)
+                _func = lambda *e: flint.fmpz_mod_mat(*e, m)
             return _func
         else:
             raise NotImplementedError("Only ZZ and QQ are supported by DFM")

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -143,13 +143,15 @@ class DFM:
             raise RuntimeError("Rep is not a flint.fmpz_mat")
         elif domain == QQ and not isinstance(rep, flint.fmpq_mat):
             raise RuntimeError("Rep is not a flint.fmpq_mat")
-        elif domain not in (ZZ, QQ):
+        elif domain.is_FF and not isinstance(rep, (flint.fmpz_mod_mat, flint.nmod_mat)):
+            raise RuntimeError("Rep is not a flint.fmpz_mod_mat or flint.nmod_mat")
+        elif domain not in (ZZ, QQ) and not domain.is_FF:
             raise NotImplementedError("Only ZZ and QQ are supported by DFM")
 
     @classmethod
     def _supports_domain(cls, domain):
         """Return True if the given domain is supported by DFM."""
-        return domain in (ZZ, QQ)
+        return domain in (ZZ, QQ) or domain.is_FF
 
     @classmethod
     def _get_flint_func(cls, domain):
@@ -158,6 +160,18 @@ class DFM:
             return flint.fmpz_mat
         elif domain == QQ:
             return flint.fmpq_mat
+        elif domain.is_FF:
+            c = domain.characteristic()
+            if isinstance(domain.one, flint.nmod):
+                _cls = flint.nmod_mat
+                def _func(*e):
+                    if len(e) == 1 and isinstance(e[0], flint.nmod_mat):
+                        return _cls(e[0])
+                    else:
+                        return _cls(*e, c)
+            else:
+                _func = flint.fmpz_mod_mat
+            return _func
         else:
             raise NotImplementedError("Only ZZ and QQ are supported by DFM")
 
@@ -298,8 +312,8 @@ class DFM:
             return self.copy()
         elif domain == QQ and self.domain == ZZ:
             return self._new(flint.fmpq_mat(self.rep), self.shape, domain)
-        elif domain == ZZ and self.domain == QQ:
-            # XXX: python-flint has no fmpz_mat.from_fmpq_mat
+        elif self._supports_domain(domain):
+            # XXX: Use more efficient conversions when possible.
             return self.to_ddm().convert_to(domain).to_dfm()
         else:
             # It is the callers responsibility to convert to DDM before calling
@@ -664,7 +678,7 @@ class DFM:
 
         if K == ZZ:
             raise DMDomainError("field expected, got %s" % K)
-        elif K == QQ:
+        elif K == QQ or K.is_FF:
             try:
                 return self._new_rep(self.rep.inv())
             except ZeroDivisionError:

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -92,8 +92,10 @@ def test_DomainMatrix_from_list():
     dom = FF(7)
     ddm = DDM([[dom(1), dom(2)], [dom(3), dom(4)]], (2, 2), dom)
     A = DomainMatrix.from_list([[1, 2], [3, 4]], dom)
-    # Not a DFM because FF(7) is not supported by DFM
-    assert A.rep == ddm
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
     assert A.shape == (2, 2)
     assert A.domain == dom
 

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -99,6 +99,16 @@ def test_DomainMatrix_from_list():
     assert A.shape == (2, 2)
     assert A.domain == dom
 
+    dom = FF(2**127-1)
+    ddm = DDM([[dom(1), dom(2)], [dom(3), dom(4)]], (2, 2), dom)
+    A = DomainMatrix.from_list([[1, 2], [3, 4]], dom)
+    if GROUND_TYPES != 'flint':
+        assert A.rep == ddm
+    else:
+        assert A.rep == ddm.to_dfm()
+    assert A.shape == (2, 2)
+    assert A.domain == dom
+
     ddm = DDM([[QQ(1, 2), QQ(3, 1)], [QQ(1, 4), QQ(5, 1)]], (2, 2), QQ)
     A = DomainMatrix.from_list([[(1, 2), (3, 1)], [(1, 4), (5, 1)]], QQ)
     if GROUND_TYPES != 'flint':

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -239,10 +239,9 @@ def test_DFM_domains():
         flint_funcs = {
             ZZ: flint.fmpz_mat,
             QQ: flint.fmpq_mat,
+            GF(5): None,
         }
         not_supported = [
-            # This could be supported but not yet implemented in SymPy:
-            GF(5),
             # Other domains could be supported but not implemented as matrices
             # in python-flint:
             QQ[x],
@@ -257,7 +256,8 @@ def test_DFM_domains():
 
     for domain in supported:
         assert DFM._supports_domain(domain) is True
-        assert DFM._get_flint_func(domain) == flint_funcs[domain]
+        if flint_funcs[domain] is not None:
+            assert DFM._get_flint_func(domain) == flint_funcs[domain]
     for domain in not_supported:
         assert DFM._supports_domain(domain) is False
         raises(NotImplementedError, lambda: DFM._get_flint_func(domain))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This needs the next release of python-flint (> 0.5.0) because this PR is needed:
https://github.com/flintlib/python-flint/pull/106

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * Flint's univariate nmod_poly or fmpz_mod_poly types are used by Poly/DMP for polynomials over GF(p) when the ground types are set to `"flint"`. This makes many operations with univariate polynomials over GF(p) much faster.
* matrices
    * Flint's matrix types nmod_mat or fmpz_mod_mat are used by DomainMatrix for dense matrices over GF(p) when the ground types are set to `"flint"`. This makes many operations with matrices over GF(p) much faster.
<!-- END RELEASE NOTES -->
