### PR TITLE
Changes for _eval_nseries in exp class for wrong outputs

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -8,7 +8,7 @@ from sympy.core.function import (Function, ArgumentIndexError, expand_log,
     expand_mul, FunctionClass, PoleError, expand_multinomial, expand_complex)
 from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.core.mul import Mul
-from sympy.core.numbers import Integer, Rational, pi, I, ImaginaryUnit
+from sympy.core.numbers import Integer, Rational, pi, I
 from sympy.core.parameters import global_parameters
 from sympy.core.power import Pow
 from sympy.core.singleton import S
@@ -495,8 +495,10 @@ class exp(ExpBase, metaclass=ExpMeta):
             return Order(x**n, x)
         if arg0 is S.Infinity:
             return self
+        if arg0.is_infinite:
+            raise PoleError("Cannot expand %s around 0" % (self))
         # checking for indecisiveness/ sign terms in arg0
-        if any(isinstance(arg, (sign, ImaginaryUnit)) for arg in arg0.args):
+        if any(isinstance(arg, sign) for arg in arg0.args):
             return self
         t = Dummy("t")
         nterms = n

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -390,13 +390,15 @@ def test_issue_23727():
 
 def test_issue_24266():
     #type1: exp(f(x))
-    assert (exp(-I*pi*(2*x+1))).series(x,0,3) == -1 + 2*I*pi*x + 2*pi**2*x**2 + O(x**3)
-    assert (exp(-I*pi*(2*x+1))*gamma(1+x)).series(x,0,3) == -1 + x*(EulerGamma + 2*I*pi) + x**2*(-EulerGamma**2/2 + 23*pi**2/12 - 2*EulerGamma*I*pi) + O(x**3)
+    assert (exp(-I*pi*(2*x+1))).series(x, 0, 3) == -1 + 2*I*pi*x + 2*pi**2*x**2 + O(x**3)
+    assert (exp(-I*pi*(2*x+1))*gamma(1+x)).series(x, 0, 3) == -1 + x*(EulerGamma + 2*I*pi) + \
+        x**2*(-EulerGamma**2/2 + 23*pi**2/12 - 2*EulerGamma*I*pi) + O(x**3)
 
     #type2: c**f(x)
-    assert ((2*I)**(-I*pi*(2*x+1))).series(x,0,2) == exp(pi**2/2 - I*pi*log(2)) + x*(pi**2*exp(pi**2/2 - I*pi*log(2)) - 2*I*pi*exp(pi**2/2 - I*pi*log(2))*log(2)) + O(x**2)
-    assert ((2)**(-I*pi*(2*x+1))).series(x,0,2) == exp(-I*pi*log(2)) - 2*I*pi*x*exp(-I*pi*log(2))*log(2) + O(x**2)
+    assert ((2*I)**(-I*pi*(2*x+1))).series(x, 0, 2) == exp(pi**2/2 - I*pi*log(2)) + \
+          x*(pi**2*exp(pi**2/2 - I*pi*log(2)) - 2*I*pi*exp(pi**2/2 - I*pi*log(2))*log(2)) + O(x**2)
+    assert ((2)**(-I*pi*(2*x+1))).series(x, 0, 2) == exp(-I*pi*log(2)) - 2*I*pi*x*exp(-I*pi*log(2))*log(2) + O(x**2)
 
     #type3: f(y)**g(x)
-    assert ((y)**(I*pi*(2*x+1))).series(x,0,2) == exp(I*pi*log(y)) + 2*I*pi*x*exp(I*pi*log(y))*log(y) + O(x**2)
-    assert ((I*y)**(I*pi*(2*x+1))).series(x,0,2) == exp(I*pi*log(I*y)) + 2*I*pi*x*exp(I*pi*log(I*y))*log(I*y) + O(x**2)
+    assert ((y)**(I*pi*(2*x+1))).series(x, 0, 2) == exp(I*pi*log(y)) + 2*I*pi*x*exp(I*pi*log(y))*log(y) + O(x**2)
+    assert ((I*y)**(I*pi*(2*x+1))).series(x, 0, 2) == exp(I*pi*log(I*y)) + 2*I*pi*x*exp(I*pi*log(I*y))*log(I*y) + O(x**2)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -12,6 +12,7 @@ from sympy.series.order import O
 from sympy.series.series import series
 from sympy.abc import x, y, n, k
 from sympy.testing.pytest import raises
+from sympy.core import EulerGamma
 
 
 def test_sin():
@@ -247,9 +248,9 @@ def test_issue_14384():
     assert series(x**a, x) == x**a
     assert series(x**(-2*a), x) == x**(-2*a)
     assert series(exp(a*log(x)), x) == exp(a*log(x))
-    assert series(x**I, x) == x**I
-    assert series(x**(I + 1), x) == x**(1 + I)
-    assert series(exp(I*log(x)), x) == exp(I*log(x))
+    raises(PoleError, lambda: series(x**I, x))
+    raises(PoleError, lambda: series(x**(I + 1), x))
+    raises(PoleError, lambda: series(exp(I*log(x)), x))
 
 
 def test_issue_14885():
@@ -385,3 +386,17 @@ def test_issue_23432():
 def test_issue_23727():
     res = series(sqrt(1 - x**2), x, 0.1)
     assert res.is_Add == True
+
+
+def test_issue_24266():
+    #type1: exp(f(x))
+    assert (exp(-I*pi*(2*x+1))).series(x,0,3) == -1 + 2*I*pi*x + 2*pi**2*x**2 + O(x**3)
+    assert (exp(-I*pi*(2*x+1))*gamma(1+x)).series(x,0,3) == -1 + x*(EulerGamma + 2*I*pi) + x**2*(-EulerGamma**2/2 + 23*pi**2/12 - 2*EulerGamma*I*pi) + O(x**3)
+
+    #type2: c**f(x)
+    assert ((2*I)**(-I*pi*(2*x+1))).series(x,0,2) == exp(pi**2/2 - I*pi*log(2)) + x*(pi**2*exp(pi**2/2 - I*pi*log(2)) - 2*I*pi*exp(pi**2/2 - I*pi*log(2))*log(2)) + O(x**2)
+    assert ((2)**(-I*pi*(2*x+1))).series(x,0,2) == exp(-I*pi*log(2)) - 2*I*pi*x*exp(-I*pi*log(2))*log(2) + O(x**2)
+
+    #type3: f(y)**g(x)
+    assert ((y)**(I*pi*(2*x+1))).series(x,0,2) == exp(I*pi*log(y)) + 2*I*pi*x*exp(I*pi*log(y))*log(y) + O(x**2)
+    assert ((I*y)**(I*pi*(2*x+1))).series(x,0,2) == exp(I*pi*log(I*y)) + 2*I*pi*x*exp(I*pi*log(I*y))*log(I*y) + O(x**2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #24266 

#### Brief description of what is fixed or changed
Added conditions to handle the case of imaginary exponents along with their test cases 

#### Other comments
Changed code to accommodate cases for when exponential class is called for exponential as well as non exponential bases with imaginary powers and categorised tests as follows:
Type 1: exp(f(x)) 
Type 2: c**f(x)
Type 3: f(y)**g(x)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added conditions for correct handling of imaginary exponents for different bases in _eval_nseries method of Exponential class 


<!-- END RELEASE NOTES -->
