### PR TITLE
Refactoring of `prime_as_sum_of_two_squares`

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -11,6 +11,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, symbols
 from sympy.core.sympify import _sympify
+from sympy.external.gmpy import jacobi
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -3602,6 +3603,24 @@ def prime_as_sum_of_two_squares(p):
     Represent a prime `p` as a unique sum of two squares; this can
     only be done if the prime is congruent to 1 mod 4.
 
+    Parameters
+    ==========
+
+    p : Integer
+        A prime is congruent to 1 mod 4
+
+    Returns
+    =======
+
+    (int, int) | None : Pair of positive integers ``(x, y)`` satisfying ``x**2 + y**2 = p``.
+                        None if ``p`` is not congruent to 1 mod 4.
+
+    Raises
+    ======
+
+    ValueError
+        If ``p`` is not prime number
+
     Examples
     ========
 
@@ -3614,29 +3633,38 @@ def prime_as_sum_of_two_squares(p):
     =========
 
     .. [1] Representing a number as a sum of four squares, [online],
-        Available: https://schorn.ch/lagrange.html
+           Available: https://schorn.ch/lagrange.html
 
     See Also
     ========
-    sum_of_squares()
+
+    sum_of_squares
+
     """
-    if not p % 4 == 1:
+    p = as_int(p)
+    if p % 4 != 1:
         return
+    if not isprime(p):
+        raise ValueError("p should be a prime number")
 
     if p % 8 == 5:
+        # Legendre symbol (2/p) == -1 if p % 8 in [3, 5]
         b = 2
-    else:
+    elif p % 12 == 5:
+        # Legendre symbol (3/p) == -1 if p % 12 in [5, 7]
         b = 3
-
-        while pow(b, (p - 1) // 2, p) == 1:
+    elif p % 5 in [2, 3]:
+        # Legendre symbol (5/p) == -1 if p % 5 in [2, 3]
+        b = 5
+    else:
+        b = 7
+        while jacobi(b, p) == 1:
             b = nextprime(b)
 
-    b = pow(b, (p - 1) // 4, p)
+    b = pow(b, p >> 2, p)
     a = p
-
     while b**2 > p:
         a, b = b, a % b
-
     return (int(a % b), int(b))  # convert from long
 
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -3607,7 +3607,7 @@ def prime_as_sum_of_two_squares(p):
     ==========
 
     p : Integer
-        A prime is congruent to 1 mod 4
+        A prime that is congruent to 1 mod 4
 
     Returns
     =======


### PR DESCRIPTION
* Added docstring
* We now check if it is prime or not
* When small b, we omitted the calculation of the Legendre symbol

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
