### PR TITLE
Added `groups_count`

### DIFF
--- a/doc/src/modules/combinatorics/group_numbers.rst
+++ b/doc/src/modules/combinatorics/group_numbers.rst
@@ -1,7 +1,7 @@
 .. _combinatorics-group_numbers:
 
-Nilpotent, Abelian and Cyclic Numbers
-=====================================
+Number of groups
+================
 
 .. module:: sympy.combinatorics.group_numbers
 
@@ -10,3 +10,5 @@ Nilpotent, Abelian and Cyclic Numbers
 .. autofunction:: is_abelian_number
 
 .. autofunction:: is_cyclic_number
+
+.. autofunction:: groups_count

--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -1,3 +1,6 @@
+from itertools import chain, combinations
+
+from sympy.external.gmpy import gcd
 from sympy.ntheory.factor_ import factorint
 from sympy.utilities.misc import as_int
 
@@ -114,3 +117,174 @@ def is_cyclic_number(n) -> bool:
         raise ValueError("n must be a positive integer, not %i" % n)
     factors = factorint(n)
     return all(e == 1 for e in factors.values()) and _is_nilpotent_number(factors)
+
+
+def _holder_formula(prime_factors: set):
+    r""" Number of groups of order `n`.
+    where `n` is squarefree and its prime factors are ``prime_factors``.
+    i.e., ``n == math.prod(prime_factors)``
+
+    Explanation
+    ===========
+
+    When `n` is squarefree, the number of groups of order `n` is expressed by
+
+    .. math ::
+        \sum_{d \mid n} \prod_p \frac{p^{c(p, d)} - 1}{p - 1}
+
+    where `n=de`, `p` is the prime factor of `e`,
+    and `c(p, d)` is the number of prime factors `q` of `d` such that `q \equiv 1 \pmod{p}` [2]_.
+
+    The formula is elegant, but can be improved when implemented as an algorithm.
+    Since `n` is assumed to be squarefree, the divisor `d` of `n` can be identified with the power set of prime factors.
+    We let `N` be the set of prime factors of `n`.
+    `F = \{p \in N : \forall q \in N, q \not\equiv 1 \pmod{p} \}, M = N \setminus F`, we have the following.
+
+    .. math ::
+        \sum_{d \in 2^{M}} \prod_{p \in M \setminus d} \frac{p^{c(p, F \cup d)} - 1}{p - 1}
+
+    Practically, many prime factors are expected to be members of `F`, thus reducing computation time.
+
+    Parameters
+    ==========
+
+    prime_factors : set
+        The set of prime factors of ``n``. where `n` is squarefree.
+
+    Returns
+    =======
+
+    int : Number of groups of order ``n``
+
+    Examples
+    ========
+
+    >>> from sympy.combinatorics.group_numbers import _holder_formula
+    >>> _holder_formula({2}) # n = 2
+    1
+    >>> _holder_formula({2, 3}) # n = 2*3 = 6
+    2
+
+    See Also
+    ========
+
+    groups_count
+
+    References
+    ==========
+
+    .. [1] Otto Hölder, Die Gruppen der Ordnungen p^3, pq^2, pqr, p^4,
+           Math. Ann. 43 pp. 301-412 (1893).
+           http://dx.doi.org/10.1007/BF01443651
+    .. [2] John H. Conway, Heiko Dietrich and E.A. O'Brien,
+           Counting groups: gnus, moas and other exotica
+           The Mathematical Intelligencer 30, 6-15 (2008)
+           https://doi.org/10.1007/BF02985731
+
+    """
+    F = {p for p in prime_factors if all(q % p != 1 for q in prime_factors)}
+    M = prime_factors - F
+
+    s = 0
+    powerset = chain.from_iterable(combinations(M, r) for r in range(len(M)+1))
+    for ps in powerset:
+        ps = set(ps)
+        prod = 1
+        for p in M - ps:
+            c = len([q for q in F | ps if q % p == 1])
+            prod *= (p**c - 1) // (p - 1)
+            if not prod:
+                break
+        s += prod
+    return s
+
+
+def groups_count(n):
+    r""" Number of groups of order `n`.
+    In [1]_, ``gnu(n)`` is given, so we follow this notation here as well.
+
+    Parameters
+    ==========
+
+    n : Integer
+        ``n`` is a positive integer
+
+    Returns
+    =======
+
+    int : ``gnu(n)``
+
+    Raises
+    ======
+
+    ValueError
+        Number of groups of order ``n`` is unknown or not implemented.
+        For example, gnu(`2^{11}`) is not yet known.
+        On the other hand, gnu(12) is known to be 5,
+        but this has not yet been implemented in this function.
+
+    Examples
+    ========
+
+    >>> from sympy.combinatorics.group_numbers import number_of_groups
+    >>> number_of_groups(3) # There is only one cyclic group of order 3
+    1
+    >>> # There are two groups of order 10: the cyclic group and the dihedral group
+    >>> number_of_groups(10)
+    2
+
+    See Also
+    ========
+
+    is_cyclic_number
+        `n` is cyclic iff gnu(n) = 1
+
+    References
+    ==========
+
+    .. [1] John H. Conway, Heiko Dietrich and E.A. O'Brien,
+           Counting groups: gnus, moas and other exotica
+           The Mathematical Intelligencer 30, 6-15 (2008)
+           https://doi.org/10.1007/BF02985731
+    .. [2] https://oeis.org/A000001
+
+    """
+    n = as_int(n)
+    if n <= 0:
+        raise ValueError("n must be a positive integer, not %i" % n)
+    factors = factorint(n)
+    if len(factors) == 1:
+        (p, e) = list(factors.items())[0]
+        if p == 2:
+            A000679 = [1, 1, 2, 5, 14, 51, 267, 2328, 56092, 10494213, 49487367289]
+            if e < len(A000679):
+                return A000679[e]
+        if p == 3:
+            A090091 = [1, 1, 2, 5, 15, 67, 504, 9310, 1396077, 5937876645]
+            if e < len(A090091):
+                return A090091[e]
+        if e <= 2: # gnu(p) = 1, gnu(p**2) = 2
+            return e
+        if e == 3: # gnu(p**3) = 5
+            return 5
+        if e == 4: # if p is an odd prime, gnu(p**4) = 15
+            return 15
+        if e == 5: # if p >= 5, gnu(p**5) is expressed by the following equation
+            return 61 + 2*p + 2*gcd(p-1, 3) + gcd(p-1, 4)
+        if e == 6: # if p >= 6, gnu(p**6) is expressed by the following equation
+            return 3*p**2 + 39*p + 344 +\
+                  24*gcd(p-1, 3) + 11*gcd(p-1, 4) + 2*gcd(p-1, 5)
+        if e == 7: # if p >= 7, gnu(p**7) is expressed by the following equation
+            if p == 5:
+                return 34297
+            return 3*p**5 + 12*p**4 + 44*p**3 + 170*p**2 + 707*p + 2455 +\
+                  (4*p**2 + 44*p + 291)*gcd(p-1, 3) + (p**2 + 19*p + 135)*gcd(p-1, 4) + \
+                  (3*p + 31)*gcd(p-1, 5) + 4*gcd(p-1, 7) + 5*gcd(p-1, 8) + gcd(p-1, 9)
+    if any(e > 1 for e in factors.values()): # n is not squarefree
+        raise ValueError("Number of groups of order n is unknown or not implemented")
+    if len(factors) == 2: # n is squarefree semiprime
+        p, q = list(factors.keys())
+        if p > q:
+            p, q = q, p
+        return 2 if q % p == 1 else 1
+    return _holder_formula(set(factors.keys()))

--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -119,7 +119,7 @@ def is_cyclic_number(n) -> bool:
     return all(e == 1 for e in factors.values()) and _is_nilpotent_number(factors)
 
 
-def _holder_formula(prime_factors: set):
+def _holder_formula(prime_factors):
     r""" Number of groups of order `n`.
     where `n` is squarefree and its prime factors are ``prime_factors``.
     i.e., ``n == math.prod(prime_factors)``
@@ -226,11 +226,11 @@ def groups_count(n):
     Examples
     ========
 
-    >>> from sympy.combinatorics.group_numbers import number_of_groups
-    >>> number_of_groups(3) # There is only one cyclic group of order 3
+    >>> from sympy.combinatorics.group_numbers import groups_count
+    >>> groups_count(3) # There is only one cyclic group of order 3
     1
     >>> # There are two groups of order 10: the cyclic group and the dihedral group
-    >>> number_of_groups(10)
+    >>> groups_count(10)
     2
 
     See Also

--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -173,7 +173,7 @@ def _holder_formula(prime_factors: set):
     References
     ==========
 
-    .. [1] Otto Hölder, Die Gruppen der Ordnungen p^3, pq^2, pqr, p^4,
+    .. [1] Otto Holder, Die Gruppen der Ordnungen p^3, pq^2, pqr, p^4,
            Math. Ann. 43 pp. 301-412 (1893).
            http://dx.doi.org/10.1007/BF01443651
     .. [2] John H. Conway, Heiko Dietrich and E.A. O'Brien,

--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -281,6 +281,12 @@ def groups_count(n):
                   (4*p**2 + 44*p + 291)*gcd(p-1, 3) + (p**2 + 19*p + 135)*gcd(p-1, 4) + \
                   (3*p + 31)*gcd(p-1, 5) + 4*gcd(p-1, 7) + 5*gcd(p-1, 8) + gcd(p-1, 9)
     if any(e > 1 for e in factors.values()): # n is not squarefree
+        # some known values for small n that have more than 1 factor and are not square free (https://oeis.org/A000001)
+        small = {12: 5, 18: 5, 20: 5, 24: 15, 28: 4, 36: 14, 40: 14, 44: 4, 45: 2, 48: 52,
+                50: 5, 52: 5, 54: 15, 56: 13, 60: 13, 63: 4, 68: 5, 72: 50, 75: 3, 76: 4,
+                80: 52, 84: 15, 88: 12, 90: 10, 92: 4}
+        if n in small:
+            return small[n]
         raise ValueError("Number of groups of order n is unknown or not implemented")
     if len(factors) == 2: # n is squarefree semiprime
         p, q = list(factors.keys())

--- a/sympy/combinatorics/tests/test_group_numbers.py
+++ b/sympy/combinatorics/tests/test_group_numbers.py
@@ -1,5 +1,7 @@
 from sympy.combinatorics.group_numbers import (is_nilpotent_number,
-    is_abelian_number, is_cyclic_number)
+    is_abelian_number, is_cyclic_number, _holder_formula, groups_count)
+from sympy.ntheory.factor_ import factorint
+from sympy.ntheory.generate import prime
 from sympy.testing.pytest import raises
 from sympy import randprime
 
@@ -33,6 +35,12 @@ def test_is_abelian_number():
         assert is_abelian_number(n) == (n in A051532)
 
 
+A003277 = [1, 2, 3, 5, 7, 11, 13, 15, 17, 19, 23, 29,
+           31, 33, 35, 37, 41, 43, 47, 51, 53, 59, 61,
+           65, 67, 69, 71, 73, 77, 79, 83, 85, 87, 89,
+           91, 95, 97]
+
+
 def test_is_cyclic_number():
     assert is_cyclic_number(15) == True
     assert is_cyclic_number(randprime(1, 2000)**2) == False
@@ -40,9 +48,63 @@ def test_is_cyclic_number():
     assert is_cyclic_number(4) == False
     raises(ValueError, lambda: is_cyclic_number(-5))
 
-    A003277 = [1, 2, 3, 5, 7, 11, 13, 15, 17, 19, 23, 29,
-               31, 33, 35, 37, 41, 43, 47, 51, 53, 59, 61,
-               65, 67, 69, 71, 73, 77, 79, 83, 85, 87, 89,
-               91, 95, 97]
     for n in range(1, 100):
         assert is_cyclic_number(n) == (n in A003277)
+
+
+def test_holder_formula():
+    # semiprime
+    assert _holder_formula({3, 5}) == 1
+    assert _holder_formula({5, 11}) == 2
+    # n in A003277 is always 1
+    for n in A003277:
+        assert _holder_formula(set(factorint(n).keys())) == 1
+    # otherwise
+    assert _holder_formula({2, 3, 5, 7}) == 12
+
+
+def test_groups_count():
+    A000001 = [0, 1, 1, 1, 2, 1, 2, 1, 5, 2, 2, 1, 5, 1,
+               2, 1, 14, 1, 5, 1, 5, 2, 2, 1, 15, 2, 2,
+               5, 4, 1, 4, 1, 51, 1, 2, 1, 14, 1, 2, 2,
+               14, 1, 6, 1, 4, 2, 2, 1, 52, 2, 5, 1, 5,
+               1, 15, 2, 13, 2, 2, 1, 13, 1, 2, 4, 267,
+               1, 4, 1, 5, 1, 4, 1, 50, 1, 2, 3, 4, 1,
+               6, 1, 52, 15, 2, 1, 15, 1, 2, 1, 12, 1,
+               10, 1, 4, 2]
+    for n in range(1, len(A000001)):
+        try:
+            assert groups_count(n) == A000001[n]
+        except ValueError:
+            pass
+
+    A000679 = [1, 1, 2, 5, 14, 51, 267, 2328, 56092, 10494213, 49487367289]
+    for e in range(1, len(A000679)):
+        assert groups_count(2**e) == A000679[e]
+
+    A090091 = [1, 1, 2, 5, 15, 67, 504, 9310, 1396077, 5937876645]
+    for e in range(1, len(A090091)):
+        assert groups_count(3**e) == A090091[e]
+
+    A090130 = [1, 1, 2, 5, 15, 77, 684, 34297]
+    for e in range(1, len(A090130)):
+        assert groups_count(5**e) == A090130[e]
+
+    A090140 = [1, 1, 2, 5, 15, 83, 860, 113147]
+    for e in range(1, len(A090140)):
+        assert groups_count(7**e) == A090140[e]
+
+    A232105 = [51, 67, 77, 83, 87, 97, 101, 107, 111, 125, 131,
+               145, 149, 155, 159, 173, 183, 193, 203, 207, 217]
+    for i in range(len(A232105)):
+        assert groups_count(prime(i+1)**5) == A232105[i]
+
+    A232106 = [267, 504, 684, 860, 1192, 1476, 1944, 2264, 2876,
+               4068, 4540, 6012, 7064, 7664, 8852, 10908, 13136]
+    for i in range(len(A232106)):
+        assert groups_count(prime(i+1)**6) == A232106[i]
+
+    A232107 = [2328, 9310, 34297, 113147, 750735, 1600573,
+               5546909, 9380741, 23316851, 71271069, 98488755]
+    for i in range(len(A232107)):
+        assert groups_count(prime(i+1)**7) == A232107[i]


### PR DESCRIPTION
Added `groups_count` function to count the number of groups of order n

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added `groups_count` function to count the number of groups of order n
<!-- END RELEASE NOTES -->
