### PR TITLE
Improve continuous_domain() and singularities()

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -21,6 +21,8 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.trigonometric import sec, csc, cot, tan, cos
+from sympy.functions.elementary.hyperbolic import (
+    sech, csch, coth, tanh, cosh, asech, acsch, atanh, acoth)
 from sympy.utilities.misc import filldedent
 
 
@@ -90,13 +92,18 @@ def singularities(expression, symbol, domain=None):
         domain = S.Reals if symbol.is_real else S.Complexes
     try:
         sings = S.EmptySet
-        for i in expression.rewrite([sec, csc, cot, tan], cos).atoms(Pow):
+        e = expression.rewrite([sec, csc, cot, tan], cos)
+        e = e.rewrite([sech, csch, coth, tanh], cosh)
+        for i in e.atoms(Pow):
             if i.exp.is_infinite:
                 raise NotImplementedError
             if i.exp.is_negative:
                 sings += solveset(i.base, symbol, domain)
-        for i in expression.atoms(log):
+        for i in expression.atoms(log, asech, acsch):
             sings += solveset(i.args[0], symbol, domain)
+        for i in expression.atoms(atanh, acoth):
+            sings += solveset(i.args[0] - 1, symbol, domain)
+            sings += solveset(i.args[0] + 1, symbol, domain)
         return sings
     except NotImplementedError:
         raise NotImplementedError(filldedent('''

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -98,6 +98,7 @@ def singularities(expression, symbol, domain=None):
             if i.exp.is_infinite:
                 raise NotImplementedError
             if i.exp.is_negative:
+                # XXX: exponent of varying sign not handled
                 sings += solveset(i.base, symbol, domain)
         for i in expression.atoms(log, asech, acsch):
             sings += solveset(i.args[0], symbol, domain)

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -1,7 +1,11 @@
-from sympy.core.numbers import (I, Rational, oo)
+from sympy.core.numbers import (I, Rational, pi, oo)
 from sympy.core.singleton import S
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Symbol, Dummy
+from sympy.core.function import Lambda
 from sympy.functions.elementary.exponential import (exp, log)
+from sympy.functions.elementary.trigonometric import sec, csc
+from sympy.functions.elementary.hyperbolic import (coth, sech,
+                                                   atanh, asech, acoth, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.calculus.singularities import (
     singularities,
@@ -11,7 +15,7 @@ from sympy.calculus.singularities import (
     is_strictly_decreasing,
     is_monotonic
 )
-from sympy.sets import Interval, FiniteSet
+from sympy.sets import Interval, FiniteSet, Union, ImageSet
 from sympy.testing.pytest import raises
 from sympy.abc import x, y
 
@@ -25,6 +29,17 @@ def test_singularities():
         FiniteSet(-1, (1 - sqrt(3) * I) / 2, (1 + sqrt(3) * I) / 2)
     assert singularities(1/(y**2 + 2*I*y + 1), y) == \
         FiniteSet(-I + sqrt(2)*I, -I - sqrt(2)*I)
+    _n = Dummy('n')
+    assert singularities(sech(x), x).dummy_eq(Union(
+        ImageSet(Lambda(_n, I*(2*_n*pi + pi/2)), S.Integers),
+        ImageSet(Lambda(_n, I*(2*_n*pi - pi/2)), S.Integers)))
+    assert singularities(coth(x), x).dummy_eq(Union(
+        ImageSet(Lambda(_n, I*(2*_n*pi + pi)), S.Integers),
+        ImageSet(Lambda(_n, 2*_n*I*pi), S.Integers)))
+    assert singularities(atanh(x), x) == FiniteSet(-1, 1)
+    assert singularities(acoth(x), x) == FiniteSet(-1, 1)
+    assert singularities(asech(x), x) == FiniteSet(0)
+    assert singularities(acsch(x), x) == FiniteSet(0)
 
     x = Symbol('x', real=True)
     assert singularities(1/(x**2 + 1), x) == S.EmptySet
@@ -32,6 +47,10 @@ def test_singularities():
     assert singularities(exp(1/x), x, Interval(1, 2)) == S.EmptySet
     assert singularities(log((x - 2)**2), x, Interval(1, 3)) == FiniteSet(2)
     raises(NotImplementedError, lambda: singularities(x**-oo, x))
+    assert singularities(sec(x), x, Interval(0, 3*pi)) == FiniteSet(
+        pi/2, 3*pi/2, 5*pi/2)
+    assert singularities(csc(x), x, Interval(0, 3*pi)) == FiniteSet(
+        0, pi, 2*pi, 3*pi)
 
 
 def test_is_increasing():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -84,6 +84,11 @@ def test_continuous_domain():
         Union(Interval.open(-oo, 0), Interval.open(0, oo))
     assert continuous_domain(1/(x**2 - 4) + 2, x, S.Reals) == \
         Union(Interval.open(-oo, -2), Interval.open(-2, 2), Interval.open(2, oo))
+    assert continuous_domain((x+1)**pi, x, S.Reals) == Interval(-1, oo)
+    assert continuous_domain((x+1)**(pi/2), x, S.Reals) == Interval(-1, oo)
+    assert continuous_domain(x**x, x, S.Reals) == Interval(0, oo)
+    assert continuous_domain((x+1)**log(x**2), x, S.Reals) == Union(
+        Interval.Ropen(-1, 0), Interval.open(0, oo))
     domain = continuous_domain(log(tan(x)**2 + 1), x, S.Reals)
     assert not domain.contains(3*pi/2)
     assert domain.contains(5)
@@ -134,6 +139,10 @@ def test_continuous_domain_acot():
 @XFAIL
 def test_continuous_domain_gamma():
     assert continuous_domain(gamma(x), x, S.Reals).contains(-1) == False
+
+@XFAIL
+def test_continuous_domain_neg_power():
+    assert continuous_domain((x-2)**(1-x), x, S.Reals) == Interval.open(2, oo)
 
 
 def test_not_empty_in():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -7,9 +7,10 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
-    cos, cot, csc, sec, sin, tan, asin, acos, atan, asec, acsc)
-from sympy.functions.elementary.hyperbolic import (
-    sinh, cosh, tanh, sech, asinh, acosh, atanh, acoth, asech)
+    cos, cot, csc, sec, sin, tan, asin, acos, atan, acot, asec, acsc)
+from sympy.functions.elementary.hyperbolic import (sinh, cosh, tanh, coth,
+    sech, csch, asinh, acosh, atanh, acoth, asech, acsch)
+from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.error_functions import expint
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.simplify.simplify import simplify
@@ -105,6 +106,9 @@ def test_continuous_domain():
         Interval(-oo, -1), Interval(1, oo))
     assert continuous_domain(acsc(x), x, S.Reals) == Union(
         Interval(-oo, -1), Interval(1, oo))
+    for f in (coth, acsch, csch):
+        assert continuous_domain(f(x), x, S.Reals) == Union(
+            Interval.open(-oo, 0), Interval.open(0, oo))
 
 
 @XFAIL

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -5,7 +5,8 @@ from sympy.functions.elementary.complexes import (Abs, re)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (cos, cot, csc, sec, sin, tan)
+from sympy.functions.elementary.trigonometric import (
+    cos, cot, csc, sec, sin, tan, asin, acos)
 from sympy.functions.special.error_functions import expint
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.simplify.simplify import simplify
@@ -78,6 +79,8 @@ def test_continuous_domain():
     assert domain.contains(5)
     d = Symbol('d', even=True, zero=False)
     assert continuous_domain(x**(1/d), x, S.Reals) == Interval(0, oo)
+    assert continuous_domain(asin(x), x, S.Reals) == Interval(-1, 1) # issue #21786
+    assert continuous_domain(1/acos(log(x)), x, S.Reals) == Interval.Ropen(exp(-1), E)
 
 
 def test_not_empty_in():
@@ -329,3 +332,8 @@ def test_issue_16469():
 @_both_exp_pow
 def test_issue_18747():
     assert periodicity(exp(pi*I*(x/4+S.Half/2)), x) == 8
+
+
+def test_issue_25942():
+    x = Symbol("x")
+    assert (acos(x) > pi/3).as_set() == Interval.Ropen(-1, S(1)/2)

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -129,6 +129,7 @@ def test_continuous_domain():
         1/(x**2+1), x, S.Complexes))
     raises(NotImplementedError, lambda : continuous_domain(
         gamma(x), x, Interval(-5,0)))
+    assert continuous_domain(x + gamma(pi), x, S.Reals) == S.Reals
 
 
 @XFAIL

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -109,11 +109,11 @@ def test_continuous_domain():
     for f in (coth, acsch, csch):
         assert continuous_domain(f(x), x, S.Reals) == Union(
             Interval.open(-oo, 0), Interval.open(0, oo))
+    assert continuous_domain(acot(x), x, S.Reals).contains(0) == False
 
 
 @XFAIL
 def test_continuous_domain_acot():
-    assert continuous_domain(acot(x), x, S.Reals).contains(0) == False
     acot_cont = Piecewise((pi+acot(x), x<0), (acot(x), True))
     assert continuous_domain(acot_cont, x, S.Reals) == S.Reals
 

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -1,5 +1,6 @@
 from sympy.core.function import Lambda
 from sympy.core.numbers import (E, I, Rational, oo, pi)
+from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.complexes import (Abs, re)
@@ -19,6 +20,7 @@ from sympy.calculus.util import (function_range, continuous_domain, not_empty_in
                                  stationary_points, minimum, maximum)
 from sympy.sets.sets import (Interval, FiniteSet, Complement, Union)
 from sympy.sets.fancysets import ImageSet
+from sympy.sets.conditionset import ConditionSet
 from sympy.testing.pytest import XFAIL, raises, _both_exp_pow
 from sympy.abc import x
 
@@ -110,6 +112,12 @@ def test_continuous_domain():
         assert continuous_domain(f(x), x, S.Reals) == Union(
             Interval.open(-oo, 0), Interval.open(0, oo))
     assert continuous_domain(acot(x), x, S.Reals).contains(0) == False
+    assert continuous_domain(1/(exp(x) - x), x, S.Reals) == Complement(
+        S.Reals, ConditionSet(x, Eq(-x + exp(x), 0), S.Reals))
+    raises(NotImplementedError, lambda : continuous_domain(
+        1/(x**2+1), x, S.Complexes))
+    raises(NotImplementedError, lambda : continuous_domain(
+        gamma(x), x, Interval(-5,0)))
 
 
 @XFAIL

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -5,6 +5,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.complexes import (Abs, re)
 from sympy.functions.elementary.exponential import (exp, log)
+from sympy.functions.elementary.integers import frac
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
@@ -114,6 +115,11 @@ def test_continuous_domain():
     assert continuous_domain(acot(x), x, S.Reals).contains(0) == False
     assert continuous_domain(1/(exp(x) - x), x, S.Reals) == Complement(
         S.Reals, ConditionSet(x, Eq(-x + exp(x), 0), S.Reals))
+    assert continuous_domain(frac(x**2), x, Interval(-2,-1)) == Union(
+        Interval.open(-2, -sqrt(3)), Interval.open(-sqrt(2), -1),
+        Interval.open(-sqrt(3), -sqrt(2)))
+    assert continuous_domain(frac(x), x, S.Reals) == Complement(
+        S.Reals, S.Integers)
     raises(NotImplementedError, lambda : continuous_domain(
         1/(x**2+1), x, S.Complexes))
     raises(NotImplementedError, lambda : continuous_domain(

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -7,9 +7,9 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
-    cos, cot, csc, sec, sin, tan, asin, acos, atan)
+    cos, cot, csc, sec, sin, tan, asin, acos, atan, asec, acsc)
 from sympy.functions.elementary.hyperbolic import (
-    sinh, cosh, tanh, sech, asinh, acosh, atanh, asech)
+    sinh, cosh, tanh, sech, asinh, acosh, atanh, acoth, asech)
 from sympy.functions.special.error_functions import expint
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.simplify.simplify import simplify
@@ -99,6 +99,12 @@ def test_continuous_domain():
     assert continuous_domain(atanh(x), x, S.Reals) == Interval.open(-1, 1)
     assert continuous_domain(atanh(x)+acosh(x), x, S.Reals) == S.EmptySet
     assert continuous_domain(asech(x), x, S.Reals) == Interval.Lopen(0, 1)
+    assert continuous_domain(acoth(x), x, S.Reals) == Union(
+        Interval.open(-oo, -1), Interval.open(1, oo))
+    assert continuous_domain(asec(x), x, S.Reals) == Union(
+        Interval(-oo, -1), Interval(1, oo))
+    assert continuous_domain(acsc(x), x, S.Reals) == Union(
+        Interval(-oo, -1), Interval(1, oo))
 
 
 @XFAIL

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -16,7 +16,6 @@ from sympy.functions.elementary.trigonometric import (
     asin, acos, acot, atan, asec, acsc)
 from sympy.functions.elementary.hyperbolic import (sinh, cosh, tanh, coth,
     sech, csch, asinh, acosh, atanh, acoth, asech, acsch)
-from sympy.functions.elementary.hyperbolic import (acosh)
 from sympy.polys.polytools import degree, lcm_list
 from sympy.sets.sets import (Interval, Intersection, FiniteSet, Union,
                              Complement)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -12,7 +12,7 @@ from sympy.functions.elementary.complexes import Abs, im, re
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
-    TrigonometricFunction, sin, cos, csc, sec)
+    TrigonometricFunction, sin, cos, csc, sec, asin, acos)
 from sympy.polys.polytools import degree, lcm_list
 from sympy.sets.sets import (Interval, Intersection, FiniteSet, Union,
                              Complement)
@@ -85,6 +85,15 @@ def continuous_domain(f, symbol, domain):
             constrained_interval = Intersection(constraint,
                                                 constrained_interval)
 
+        for atom in f.atoms(asin, acos):
+            constraint = solve_univariate_inequality(atom.args[0] >= -1,
+                                                     symbol).as_set()
+            constrained_interval = Intersection(constraint,
+                                                constrained_interval)
+            constraint = solve_univariate_inequality(atom.args[0] <= 1,
+                                                     symbol).as_set()
+            constrained_interval = Intersection(constraint,
+                                                constrained_interval)
 
     return constrained_interval - singularities(f, symbol, domain)
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -109,7 +109,9 @@ def continuous_domain(f, symbol, domain):
     cont_domain = domain
     for atom in f.atoms(Pow):
         den = atom.exp.as_numer_denom()[1]
-        if den.is_even and den.is_nonzero:
+        if atom.exp.is_rational and den.is_odd:
+            pass    # 0**negative handled by singularities()
+        else:
             constraint = solve_univariate_inequality(atom.base >= 0,
                                                         symbol).as_set()
             cont_domain = Intersection(constraint, cont_domain)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -12,7 +12,7 @@ from sympy.functions.elementary.complexes import Abs, im, re
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
-    TrigonometricFunction, sin, cos, csc, sec, asin, acos, asec, acsc)
+    TrigonometricFunction, sin, cos, csc, sec, asin, acos, acot, asec, acsc)
 from sympy.functions.elementary.hyperbolic import (sinh, cosh, tanh, coth, sech, csch,
                    asinh, acosh, atanh, acoth, asech, acsch)
 from sympy.functions.elementary.hyperbolic import (acosh)
@@ -112,6 +112,13 @@ def continuous_domain(f, symbol, domain):
                     constraint_set += solve_univariate_inequality(
                         constraint_relational, symbol).as_set()
                 cont_domain = Intersection(constraint_set, cont_domain)
+            elif atom.func == acot:
+                from sympy.solvers.solveset import solveset_real
+                # Sympy's acot() has a step discontinuity at 0. Since it's
+                # neither an essential singularity nor a pole, singularities()
+                # will not report it. But it's still relevant for determining
+                # the continuity of the function f.
+                cont_domain -= solveset_real(atom.args[0], symbol)
 
     return cont_domain - singularities(f, symbol, domain)
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -85,7 +85,7 @@ def continuous_domain(f, symbol, domain):
                    asin, acos, atan, acot, asec, acsc,
                    sinh, cosh, tanh, coth, sech, csch,
                    asinh, acosh, atanh, acoth, asech, acsch]
-    used = [fct.func for fct in f.atoms(Function)]
+    used = [fct.func for fct in f.atoms(Function) if fct.has(symbol)]
     if any(func not in implemented for func in used):
         raise NotImplementedError(filldedent('''
             Unable to determine the domain of the given function.

--- a/sympy/plotting/tests/test_series.py
+++ b/sympy/plotting/tests/test_series.py
@@ -90,7 +90,8 @@ def test_detect_poles():
         assert not np.any(np.isnan(yy1))
         assert np.any(np.isnan(yy2)) and np.any(np.isnan(yy2))
         assert not np.allclose(yy1, yy2, equal_nan=True)
-        assert len(s3.poles_locations) == 0
+        # The poles below are actually step discontinuities.
+        assert len(s3.poles_locations) == 21
 
     s1 = LineOver1DRangeSeries(tan(u * x), (x, -pi, pi), params={u: 1},
         adaptive=False, n=1000, detect_poles=False)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21786
Fixes #25942
slightly related to: #20654, #18455

#### Brief description of what is fixed or changed
`continuous_domain()` and `singularities()` should now both be able to handle the 24 trigonometric/hyperbolic functions and their inverses.

#### Other comments
This PR also adds a whitelist to `continuous_domain()` in order to prevent further "surprises" where it just returns a plain wrong default answer of S.Reals.
Error checking has also been improved.

Support for `frac()` has also been added in order to make a plotting test pass. Unfortunately it still doesn't pass. The test expects zero singularities/poles, but `continuous_domain()` now returns the actual domain of continuity, excluding the 21 discontinuities. Should I just adapt the expected number in the test and add a comment? After all, the plot should be interrupted at any discontinuity, irrespective of the exact nature of the discontinuity (step continuity vs. pole or essential singularity).

I do think that (in a future PR) separate `discontinuities()` and `is_continuous_at()` functions could be introduced in the `calculus` module.

Any feedback is welcome.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Added support for trigonometric and hyperbolic functions and their inverses in `continuous_domain()` and `singularities()`.
  * Improve handling of powers in `continuous_domain()`.
<!-- END RELEASE NOTES -->
