### PR TITLE
Improve automatic evaluation of arg(exp())

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -758,9 +758,17 @@ class arg(Function):
                 break
         else:
             return S.NaN
-        from sympy.functions.elementary.exponential import exp_polar
+        from sympy.functions.elementary.exponential import exp, exp_polar
         if isinstance(arg, exp_polar):
             return periodic_argument(arg, oo)
+        elif isinstance(arg, exp):
+            i_ = im(arg.args[0])
+            if i_.is_comparable:
+                i_ %= 2*S.Pi
+                if i_ > S.Pi:
+                    i_ -= 2*S.Pi
+                return i_
+
         if not arg.is_Atom:
             c, arg_ = factor_terms(arg).as_coeff_Mul()
             if arg_.is_Mul:

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, atan, atan2, cos, sin)
+from sympy.functions.elementary.hyperbolic import sinh
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
 from sympy.integrals.integrals import Integral
 from sympy.matrices.dense import Matrix
@@ -605,6 +606,15 @@ def test_arg():
     assert arg(exp_polar(4*pi*I)) == 4*pi
     assert arg(exp_polar(-7*pi*I)) == -7*pi
     assert arg(exp_polar(5 - 3*pi*I/4)) == pi*Rational(-3, 4)
+
+    assert arg(exp(I*pi/7)) == pi/7     # issue 17300
+    assert arg(exp(16*I)) == 16 - 6*pi
+    assert arg(exp(13*I*pi/12)) == -11*pi/12
+    assert arg(exp(123 - 5*I)) == -5 + 2*pi
+    assert arg(exp(sin(1 + 3*I))) == -2*pi + cos(1)*sinh(3)
+    r = Symbol('r', real=True)
+    assert arg(exp(r - 2*I)) == -2
+
     f = Function('f')
     assert not arg(f(0) + I*f(1)).atoms(re)
 


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17300

#### Brief description of what is fixed or changed

Before this commit, expressions of the form `arg(exp())` are not special cased and the argument to `arg()`, including `exp()`, ends up being split apart by `.as_real_imag()`. The real and imaginary parts are then passed to `atan2`. This often leads to poor results. See issue #17300 for examples.

This commit adds a special case for `arg(exp())` to better handle these expressions.

BEFORE:
```
>>> arg(exp(1 + 5*I))
atan(sin(5)/cos(5))
>>> arg(exp(1 + I*pi/8))
atan(sqrt(1/2 - sqrt(2)/4)/sqrt(sqrt(2)/4 + 1/2))
```
AFTER:
```
>>> arg(exp(1 + 5*I))
5 - 2⋅π
>>> arg(exp(1 + I*pi/8))
π
-
8
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Improved automatic evaluation of `arg(exp())`.

<!-- END RELEASE NOTES -->
