### PR TITLE
Fixed a case where `ldescent` would raise an error

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -3150,10 +3150,18 @@ def ldescent(A, B):
     """
     Return a non-trivial solution to `w^2 = Ax^2 + By^2` using
     Lagrange's method; return None if there is no such solution.
-    .
 
-    Here, `A \\neq 0` and `B \\neq 0` and `A` and `B` are square free. Output a
-    tuple `(w_0, x_0, y_0)` which is a solution to the above equation.
+    Parameters
+    ==========
+
+    A : Integer
+    B : Integer
+        non-zero integer
+
+    Returns
+    =======
+
+    (int, int, int) | None : a tuple `(w_0, x_0, y_0)` which is a solution to the above equation.
 
     Examples
     ========
@@ -3180,39 +3188,30 @@ def ldescent(A, B):
            [online], Available:
            https://nottingham-repository.worktribe.com/output/1023265/efficient-solution-of-rational-conics
     """
+    if A == 0 or B == 0:
+        raise ValueError("A and B must be non-zero integers")
     if abs(A) > abs(B):
         w, y, x = ldescent(B, A)
         return w, x, y
-
     if A == 1:
         return (1, 1, 0)
-
     if B == 1:
         return (1, 0, 1)
-
     if B == -1:  # and A == -1
         return
 
     r = sqrt_mod(A, B)
-
+    if r is None:
+        return
     Q = (r**2 - A) // B
-
     if Q == 0:
-        B_0 = 1
-        d = 0
-    else:
-        div = divisors(Q)
-        B_0 = None
-
-        for i in div:
-            sQ, _exact = integer_nthroot(abs(Q) // i, 2)
-            if _exact:
-                B_0, d = sign(Q)*i, sQ
-                break
-
-    if B_0 is not None:
-        W, X, Y = ldescent(A, B_0)
-        return _remove_gcd((-A*X + r*W), (r*X - W), Y*(B_0*d))
+        return r, -1, 0
+    for i in divisors(Q):
+        d, _exact = integer_nthroot(abs(Q) // i, 2)
+        if _exact:
+            B_0 = sign(Q)*i
+            W, X, Y = ldescent(A, B_0)
+            return _remove_gcd(-A*X + r*W, r*X - W, Y*B_0*d)
 
 
 def descent(A, B):

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -356,6 +356,7 @@ def test_ldescent():
         w, x, y = ldescent(a, b)
         assert a*x**2 + b*y**2 == w**2
     assert ldescent(-1, -1) is None
+    assert ldescent(2, 6) is None
 
 
 def test_diop_ternary_quadratic_normal():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25955

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
