### PR TITLE
keep signed_permutations unique

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2954,7 +2954,8 @@ def permute_signs(t):
 
 def signed_permutations(t):
     """Return iterator in which the signs of non-zero elements
-    of t and the order of the elements are permuted.
+    of t and the order of the elements are permuted and all
+    returned values are unique.
 
     Examples
     ========
@@ -2967,7 +2968,7 @@ def signed_permutations(t):
     (-1, -2, 0), (2, 0, 1), (-2, 0, 1), (2, 0, -1), (-2, 0, -1),
     (2, 1, 0), (-2, 1, 0), (2, -1, 0), (-2, -1, 0)]
     """
-    return (type(t)(i) for j in permutations(t)
+    return (type(t)(i) for j in multiset_permutations(t)
         for i in permute_signs(j))
 
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -19,7 +19,7 @@ from sympy.utilities.iterables import (
     prefixes, reshape, rotate_left, rotate_right, runs, sift,
     strongly_connected_components, subsets, take, topological_sort, unflatten,
     uniq, variations, ordered_partitions, rotations, is_palindromic, iterable,
-    NotIterable, multiset_derangements,
+    NotIterable, multiset_derangements, signed_permutations,
     sequence_partitions, sequence_partitions_empty)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
@@ -934,3 +934,12 @@ def test_sequence_partitions_empty():
     assert list(sequence_partitions([], 0)) == []
     assert list(sequence_partitions([1], 0)) == []
     assert list(sequence_partitions([1, 2], 0)) == []
+
+
+def test_signed_permutations():
+    ans = [(0, 1, 1), (0, -1, 1), (0, 1, -1), (0, -1, -1),
+    (1, 0, 1), (-1, 0, 1), (1, 0, -1), (-1, 0, -1),
+    (1, 1, 0), (-1, 1, 0), (1, -1, 0), (-1, -1, 0)]
+    assert list(signed_permutations((0, 1, 1))) == ans
+    assert list(signed_permutations((1, 0, 1))) == ans
+    assert list(signed_permutations((1, 1, 0))) == ans


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * return values are now unique for `signed_permutations` when elements are identical in passed arg
<!-- END RELEASE NOTES -->
