### PR TITLE
alternate for #25957 (sum of three squares)

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -3674,11 +3674,13 @@ def sum_of_three_squares(n):
         ``sum_of_three_squares(n)`` is one of the solutions output by ``power_representation(n, 2, 3, zeros=True)``
 
     """
-    special = {1:(1, 0, 0), 2:(1, 1, 0), 3:(1, 1, 1), 10: (1, 3, 0), 34: (3, 3, 4), 58:(3, 7, 0),
-        85:(6, 7, 0), 130:(3, 11, 0), 214:(3, 6, 13), 226:(8, 9, 9), 370:(8, 9, 15),
-        526:(6, 7, 21), 706:(15, 15, 16), 730:(1, 27, 0), 1414:(6, 17, 33), 1906:(13, 21, 36),
-        2986: (21, 32, 39), 9634: (56, 57, 57)}
-
+    # https://math.stackexchange.com/questions/483101/rabin-and-shallit-algorithm/651425#651425
+    # discusses these numbers (except for 1, 2, 3) as the exceptions of H&L's conjecture that
+    # Every sufficiently large number n is either a square or the sum of a prime and a square.
+    special = {1: (0, 0, 1), 2: (0, 1, 1), 3: (1, 1, 1), 10: (0, 1, 3), 34: (3, 3, 4),
+               58: (0, 3, 7), 85: (0, 6, 7), 130: (0, 3, 11), 214: (3, 6, 13), 226: (8, 9, 9),
+               370: (8, 9, 15), 526: (6, 7, 21), 706: (15, 15, 16), 730: (0, 1, 27),
+               1414: (6, 17, 33), 1906: (13, 21, 36), 2986: (21, 32, 39), 9634: (56, 57, 57)}
     n = as_int(n)
     if n < 0:
         raise ValueError("n should be a non-negative integer")
@@ -3689,12 +3691,11 @@ def sum_of_three_squares(n):
     if n % 8 == 7:
         return
     if n in special:
-        x, y, z = special[n]
-        return tuple(sorted([v*x, v*y, v*z]))
+        return tuple([v*i for i in special[n]])
 
     s, _exact = integer_nthroot(n, 2)
     if _exact:
-        return tuple(sorted([v*s, 0, 0]))
+        return (0, 0, v*s)
     if n % 8 == 3:
         if not s % 2:
             s -= 1
@@ -3725,12 +3726,6 @@ def sum_of_four_squares(n):
     Returns a 4-tuple `(a, b, c, d)` such that `a^2 + b^2 + c^2 + d^2 = n`.
     Here `a, b, c, d \geq 0`.
 
-    Explanation
-    ===========
-
-    If there exists a 3-tuple `(a, b, c)` in `n` such that `n = a^2 + b^2 + c^2`, then return a 4-tuple `(0, a, b, c)`.
-    If there exists a 3-tuple `(a, b, c)` in `n-1` such that `n-1 = a^2 + b^2 + c^2`, then return a 4-tuple `(1, a, b, c)`.
-
     Parameters
     ==========
 
@@ -3754,7 +3749,7 @@ def sum_of_four_squares(n):
 
     >>> from sympy.solvers.diophantine.diophantine import sum_of_four_squares
     >>> sum_of_four_squares(3456)
-    (0, 8, 16, 56)
+    (8, 8, 32, 48)
     >>> sum_of_four_squares(1294585930293)
     (0, 1234, 2161, 1137796)
 
@@ -3778,8 +3773,15 @@ def sum_of_four_squares(n):
         return (0, 0, 0, 0)
     n, v = remove(n, 4)
     v = 1 << v
-    d = 1 if n % 8 == 7 else 0
-    x, y, z = sum_of_three_squares(n - d)
+    if n % 8 == 7:
+        d = 2
+        n = n - 4
+    elif n % 8 in (2, 6):
+        d = 1
+        n = n - 1
+    else:
+        d = 0
+    x, y, z = sum_of_three_squares(n)  # sorted
     return tuple(sorted([v*d, v*x, v*y, v*z]))
 
 
@@ -3864,14 +3866,29 @@ def power_representation(n, p, k, zeros=False):
         return
 
     if p == 2:
+        if k == 3:
+            n, v = remove(n, 4)
+            if v:
+                v = 1 << v
+                for t in power_representation(n, p, k, zeros):
+                    yield tuple(i*v for i in t)
+                return
         feasible = _can_do_sum_of_squares(n, k)
         if not feasible:
             return
-        if not zeros and n > 33 and k >= 5 and k <= n and n - k in (
+        if not zeros:
+            if n > 33 and k >= 5 and k <= n and n - k in (
                 13, 10, 7, 5, 4, 2, 1):
-            '''Todd G. Will, "When Is n^2 a Sum of k Squares?", [online].
+                '''Todd G. Will, "When Is n^2 a Sum of k Squares?", [online].
                 Available: https://www.maa.org/sites/default/files/Will-MMz-201037918.pdf'''
-            return
+                return
+            # quick tests since feasibility includes the possiblity of 0
+            if k == 4 and (n in (1, 3, 5, 9, 11, 17, 29, 41) or remove(n, 4)[0] in (2, 6, 14)):
+                # A000534
+                return
+            if k == 3 and n in (1, 2, 5, 10, 13, 25, 37, 58, 85, 130):  # or n = some number >= 5*10**10
+                # A051952
+                return
         if feasible is not True:  # it's prime and k == 2
             yield prime_as_sum_of_two_squares(n)
             return

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -3855,6 +3855,8 @@ def power_representation(n, p, k, zeros=False):
     if k == 1:
         if p == 1:
             yield (n,)
+        elif n == 1:
+            yield (1,)
         else:
             be = perfect_power(n)
             if be:

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -3771,6 +3771,9 @@ def sum_of_four_squares(n):
         raise ValueError("n should be a non-negative integer")
     if n == 0:
         return (0, 0, 0, 0)
+    # remove factors of 4 since a solution in terms of 3 squares is
+    # going to be returned; this is also done in sum_of_three_squares,
+    # but it needs to be done here to select d
     n, v = remove(n, 4)
     v = 1 << v
     if n % 8 == 7:

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -660,7 +660,6 @@ def test_sum_of_three_squares():
               800, 801, 802, 803, 804, 805, 806]:
         a, b, c = sum_of_three_squares(i)
         assert a**2 + b**2 + c**2 == i
-        assert [a, b, c] == sorted([a, b, c])
         assert a >= 0
 
     # error
@@ -668,8 +667,12 @@ def test_sum_of_three_squares():
 
     assert sum_of_three_squares(7) is None
     assert sum_of_three_squares((4**5)*15) is None
+    # if there are two zeros, there might be a solution
+    # with only one zero, e.g. 25 => (0, 3, 4) or
+    # with no zeros, e.g. 49 => (2, 3, 6)
     assert sum_of_three_squares(25) == (0, 0, 5)
     assert sum_of_three_squares(4) == (0, 0, 2)
+
 
 
 def test_sum_of_four_squares():

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -660,10 +660,15 @@ def test_sum_of_three_squares():
               800, 801, 802, 803, 804, 805, 806]:
         a, b, c = sum_of_three_squares(i)
         assert a**2 + b**2 + c**2 == i
+        assert [a, b, c] == sorted([a, b, c])
+        assert a >= 0
+
+    # error
+    raises(ValueError, lambda: sum_of_three_squares(-1))
 
     assert sum_of_three_squares(7) is None
     assert sum_of_three_squares((4**5)*15) is None
-    assert sum_of_three_squares(25) == (5, 0, 0)
+    assert sum_of_three_squares(25) == (0, 0, 5)
     assert sum_of_three_squares(4) == (0, 0, 2)
 
 
@@ -674,12 +679,15 @@ def test_sum_of_four_squares():
     n = randint(1, 100000000000000)
     assert sum(i**2 for i in sum_of_four_squares(n)) == n
 
-    assert sum_of_four_squares(0) == (0, 0, 0, 0)
-    assert sum_of_four_squares(14) == (0, 1, 2, 3)
-    assert sum_of_four_squares(15) == (1, 1, 2, 3)
-    assert sum_of_four_squares(18) == (1, 2, 2, 3)
-    assert sum_of_four_squares(19) == (0, 1, 3, 3)
-    assert sum_of_four_squares(48) == (0, 4, 4, 4)
+    # error
+    raises(ValueError, lambda: sum_of_four_squares(-1))
+
+    for n in range(1000):
+        result = sum_of_four_squares(n)
+        assert len(result) == 4
+        assert all(r >= 0 for r in result)
+        assert sum(r**2 for r in result) == n
+        assert list(result) == sorted(result)
 
 
 def test_power_representation():

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -674,7 +674,6 @@ def test_sum_of_three_squares():
     assert sum_of_three_squares(4) == (0, 0, 2)
 
 
-
 def test_sum_of_four_squares():
     from sympy.core.random import randint
 

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -882,6 +882,9 @@ def test_sum_of_squares_powers():
     assert ans == tru
 
     raises(ValueError, lambda: list(sum_of_squares(10, -1)))
+    assert list(sum_of_squares(1, 1)) == [(1,)]
+    assert list(sum_of_squares(1, 2)) == []
+    assert list(sum_of_squares(1, 2, True)) == [(0, 1)]
     assert list(sum_of_squares(-10, 2)) == []
     assert list(sum_of_squares(2, 3)) == []
     assert list(sum_of_squares(0, 3, True)) == [(0, 0, 0)]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

squashed alternate to #25957 on which was noted:

* Added docstring
* Return sorted tuples in all cases
* `sum_of_four_squares` has been simplified a bit
* `sum_of_three_squares` now always returns a sorted tuple, even when the number is a square e.g. 16->(0, 0, 4)

#### Brief description of what is fixed or changed

Some known quick exits were added to the `power_representation` which will speed up `sum_of_squares` when searching for 3 squares, e.g.
```
list(set(ss(3*2**20,3)))
[(1024, 1024, 1024)]
```
formerly took about 4 seconds (and time increases as the exponent increases) and now the return is basically instantaneous because this problem reduces to finding 3 squares that sum to 3 and multiplying each of them by `2**10`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * `sum_of_squares(n,k)` will exit more quickly when there are many factors of 4 in n and k is 3
    * other special cases (when `k==3` or `k==4`) will more also return None more quickly
<!-- END RELEASE NOTES -->
