### PR TITLE
Avoid incompatible pointer type error with GCC 14

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -714,7 +714,11 @@ static PyMethodDef ${module}Methods[] = {
 _ufunc_outcalls = Template("*((double *)out${outnum}) = ${funcname}(${call_args});")
 
 _ufunc_body = Template("""\
+#ifdef NPY_1_19_API_VERSION
+static void ${funcname}_ufunc(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data)
+#else
 static void ${funcname}_ufunc(char **args, npy_intp *dimensions, npy_intp* steps, void* data)
+#endif
 {
     npy_intp i;
     npy_intp n = dimensions[0];

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -284,7 +284,11 @@ static PyMethodDef wrapper_module_%(num)sMethods[] = {
         {NULL, NULL, 0, NULL}
 };
 
+#ifdef NPY_1_19_API_VERSION
+static void test_ufunc(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data)
+#else
 static void test_ufunc(char **args, npy_intp *dimensions, npy_intp* steps, void* data)
+#endif
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -378,7 +382,11 @@ static PyMethodDef wrapper_module_%(num)sMethods[] = {
         {NULL, NULL, 0, NULL}
 };
 
+#ifdef NPY_1_19_API_VERSION
+static void multitest_ufunc(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data)
+#else
 static void multitest_ufunc(char **args, npy_intp *dimensions, npy_intp* steps, void* data)
+#endif
 {
     npy_intp i;
     npy_intp n = dimensions[0];


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

None.

#### Brief description of what is fixed or changed
The GCC maintainers are proposing to make GCC 14 more strict with regards to things like implicit return types, implicit function declarations, and incompatible pointer types.  The Fedora project has begun doing test builds to find problems as early as possible.  See:
- https://fedoraproject.org/wiki/Changes/PortingToModernC
- https://fedoraproject.org/wiki/Toolchain/PortingToModernC

The sympy build fails in the autowrap tests, because numpy 1.19.0 and later have additional const keywords:
```
wrapper_module_15.c:32:60: error: initialization of ‘void (*)(char **, const npy_intp *, const npy_intp *, void *)’ {aka ‘void (*)(char **, const long int *, const long int *, void *)’} from incompatible pointer type ‘void (*)(char **, npy_intp *, npy_intp *, void *)’ {aka ‘void (*)(char **, long int *, long int *, void *)’}
   32 | PyUFuncGenericFunction wrapped_281000935073472_funcs[1] = {&wrapped_281000935073472_ufunc};
      |                                                            ^
error: command '/usr/bin/gcc' failed with exit code 1
```

This PR conditionalizes the changes on the numpy version, so it should continue to work with older versions of numpy.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
