### PR TITLE
Fixed link for gmpy2 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1613,3 +1613,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sophia Pustova <tripplezzed@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1324,6 +1324,7 @@ Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit-create <55887635+Smit-cr
 Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit-create <smitlunagariya.mat18@itbhu.ac.in>
 Sneha Goddu <s.goddu@wustl.edu>
 Soniya Nayak <soniyanayak51@gmail.com> Soniyanayak51 <39791511+Soniyanayak51@users.noreply.github.com>
+Sophia Pustova <tripplezzed@gmail.com>
 Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
 Soumya Dipta Biswas <sdb1323@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
@@ -1613,4 +1614,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sophia Pustova <tripplezzed@gmail.com>

--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -69,7 +69,7 @@ These dependencies are not required for SymPy to function, but it is
 recommended that all users install them if they can, as they will improve the
 general performance of SymPy.
 
-- **gmpy2**: [gmpy2](https://gmpy2.readthedocs.io/en/latest/intro.html) is a
+- **gmpy2**: [gmpy2](https://gmpy2.readthedocs.io/en/latest/) is a
   Python wrapper for the [GMP multiple-precision
   library](https://gmplib.org/). It provides large integers that are faster
   than the built-in Python `int`. When gmpy2 is installed, it is used


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#24140

#### Brief description of what is fixed or changed
Corrected link for gmpy2 documentation since the previous one gives a 404 error

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
