### PR TITLE
Fixed _eval_as_leading_term method of pow to handle limit anomalies

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1661,6 +1661,8 @@ class Pow(Expr):
             from sympy.functions.elementary.complexes import im
             try:
                 f = b.as_leading_term(x, logx=logx, cdir=cdir)
+                c, d = f.as_coeff_exponent(x)
+                lt=self.func(c, e)*self.func(x**d, e)
             except PoleError:
                 return self
             if not e.is_integer and f.is_negative and not f.has(x):
@@ -1669,12 +1671,14 @@ class Pow(Expr):
                     # Normally, f**e would evaluate to exp(e*log(f)) but on branch cuts
                     # an other value is expected through the following computation
                     # exp(e*(log(f) - 2*pi*I)) == f**e*exp(-2*e*pi*I) == f**e*(-1)**(-2*e).
-                    return self.func(f, e) * (-1)**(-2*e)
+                    return lt * (-1)**(-2*e)
                 elif im(ndir).is_zero:
                     log_leadterm = log(b)._eval_as_leading_term(x, logx=logx, cdir=cdir)
                     if log_leadterm.is_infinite is False:
-                        return exp(e*log_leadterm)
-            return self.func(f, e)
+                        return exp(e*log_leadterm)._eval_as_leading_term(x, logx=logx, cdir=cdir)
+            if(c.is_negative):
+                return self.func(f, e)
+            return lt
 
     @cacheit
     def _taylor_term(self, n, x, *previous_terms): # of (1 + x)**e

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1393,3 +1393,10 @@ def test_issue_25847():
     assert limit(acsch(sin(x)/x), x, 0, '+-') == log(1 + sqrt(2))
     assert limit(acsch(exp(1/x)), x, 0, '+') == 0
     assert limit(acsch(exp(1/x)), x, 0, '-') == oo
+
+
+def test_issue_24067():
+    n = symbols('n', positive=True, integer=True)
+    assert limit((5*x)**(n+2)/x**2, x, 0) == 0
+    assert limit((5*sin(x))**(n+2)/x**2, x, 0) == 0
+    assert limit((5*x*cos(x))**(n+2)/x**2, x, 0) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24067 


#### Brief description of what is fixed or changed
Added recommended diffs with minor changes along with relevant test cases

#### Other comments
Implemented the changes suggested in the issue, kept the return statement same for cases when the coefficient `c` is negative which causes problems at branch cuts for non-integer exponents.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.



* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Changes incorporated in '_eval_as_leading_term' method of Pow class to handle limit anomalies with constant coefficients.
<!-- END RELEASE NOTES -->
