### PR TITLE
u-substitution check/solve for trig functions added to _eval_integral method

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1008,7 +1008,6 @@ class Integral(AddWithLimits):
             args = Add.make_args(f)
             if len(args) > 1:
                 return integral_obj, None            
-            
             return perform_u_substitution_on_trig(integral_obj)
         
         # Make it an integral Class
@@ -1019,8 +1018,6 @@ class Integral(AddWithLimits):
         if (i != u_sub_result):
             u = u_sub_result.limits[0][0]
             return u_sub_result.doit().subs(u, x_expr)    
-
-
 
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -379,7 +379,7 @@ class Integral(AddWithLimits):
                 newlimits.append(xab)
 
         return self.func(newfunc, *newlimits)
-
+    
     def doit(self, **hints):
         """
         Perform the integration using any hints given.
@@ -976,6 +976,52 @@ class Integral(AddWithLimits):
                         return result + i.doit(risch=False)
                 else:
                     return result
+                
+        def u_substitution_if_possible(integral_obj) :
+            from sympy import sin, cos, tan
+    
+            def perform_u_substitution_on_trig(integral_obj):
+                # Helper function to perform transform_2 and check if substitution was successful
+            
+                x = integral_obj.limits[0][0]  # Assuming x is the variable of integration
+                # Clause 1: Check for trigonometric functions
+                for trig_func in [sin, cos, tan]:
+                    for trig_expr in integral_obj.function.atoms(trig_func):
+                        inside_trig = trig_expr.args[0]
+                        if inside_trig == x:
+                            try:
+                                result = integral_obj.transform(trig_expr, x)
+                                if integral_obj != result:
+                                    return result, trig_expr
+                            except ValueError:
+                                continue
+                        else:
+                            try:
+                                result = integral_obj.transform(inside_trig, x)
+                                if integral_obj != result:
+                                    return result, inside_trig
+                            except ValueError:
+                                continue
+                return integral_obj, None
+
+            # don't attempt u-substitution if it is in the format: exp1 + exp2  
+            f = integral_obj.function
+            args = Add.make_args(f)
+            if len(args) > 1:
+                return integral_obj, None            
+            
+            return perform_u_substitution_on_trig(integral_obj)
+        
+        # Make it an integral Class
+        i = Integral(f, x)
+
+        # If u-sub successful, solve it
+        u_sub_result, x_expr = u_substitution_if_possible(i)
+        if (i != u_sub_result):
+            u = u_sub_result.limits[0][0]
+            return u_sub_result.doit().subs(u, x_expr)    
+        
+            
 
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -979,7 +979,6 @@ class Integral(AddWithLimits):
                 
         def u_substitution_if_possible(integral_obj) :
             from sympy import sin, cos, tan
-    
             def perform_u_substitution_on_trig(integral_obj):
                 # Helper function to perform transform_2 and check if substitution was successful
             
@@ -1020,8 +1019,8 @@ class Integral(AddWithLimits):
         if (i != u_sub_result):
             u = u_sub_result.limits[0][0]
             return u_sub_result.doit().subs(u, x_expr)    
-        
-            
+
+
 
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Fixes #25877 


#### Brief description of what is fixed or changed

- Safe auto u-substitution check/solve for trig functions added to the _eval_integral method inside Integral class in sympy/sympy/integrals/integrals.py.
- It allows integrate() to be able to solve some indefinite integrals that are currently not solvable by the Full Risch algorithm or Meijer G-Function algorithm in the _eval_integral method.


#### Other comments

The following operation is an example of which the new codebase is now able to solve:
integrate(cos(x)/(1 - (b**2)*(sin(x - a))**2)**(S(3)/2), x)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug with integrate(). Formerly, complex integrations involving trig functions returned incorrect answers.
<!-- END RELEASE NOTES -->
