### PR TITLE
u-substitution check/solve for trig functions added to _eval_integral method

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -448,6 +448,7 @@ Chris Tefer <ctefer@gmail.com>
 Chris Wu <chris.wu@gmail.com> Chris.Wu <devnull@localhost>
 Chris du Plessis <christopherjonduplessis@gmail.com> Chris du Plessis <45897212+Maelstrom6@users.noreply.github.com>
 Chris du Plessis <christopherjonduplessis@gmail.com> Maelstrom6 <christopherjonduplessis@gmail.com>
+Chris Lee <cylee@andrew.cmu.edu>
 Christian Bühler <christian@cbuehler.de>
 Christian Muise <christian.muise@gmail.com>
 Christian Schubert <chr.schubert@gmx.de>

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1015,7 +1015,7 @@ class Integral(AddWithLimits):
         if (i != u_sub_result):
             u = u_sub_result.limits[0][0]
             return u_sub_result.doit().subs(u, x_expr)
-        
+
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,
         # if `f` is not Add -- we only have one term

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1000,13 +1000,13 @@ class Integral(AddWithLimits):
                                 continue
                 return integral_obj, None
 
-            # don't attempt u-substitution if it is in the format: exp1 + exp2  
+            # don't attempt u-substitution if it is in the format: exp1 + exp2
             f = integral_obj.function
             args = Add.make_args(f)
             if len(args) > 1:
-                return integral_obj, None            
+                return integral_obj, None
             return perform_u_substitution_on_trig(integral_obj)
-        
+
         # Make it an integral Class
         i = Integral(f, x)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -979,8 +979,6 @@ class Integral(AddWithLimits):
         def u_substitution_if_possible(integral_obj) :
             from sympy import sin, cos, tan
             def perform_u_substitution_on_trig(integral_obj):
-                # Helper function to perform transform_2 and check if substitution was successful
-            
                 x = integral_obj.limits[0][0]  # Assuming x is the variable of integration
                 # Clause 1: Check for trigonometric functions
                 for trig_func in [sin, cos, tan]:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1017,6 +1017,7 @@ class Integral(AddWithLimits):
         if (i != u_sub_result):
             u = u_sub_result.limits[0][0]
             return u_sub_result.doit().subs(u, x_expr)
+        
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,
         # if `f` is not Add -- we only have one term


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Fixes #25877 


#### Brief description of what is fixed or changed

- Safe auto u-substitution check/solve for trig functions added to the _eval_integral method inside Integral class in sympy/sympy/integrals/integrals.py.
- It allows integrate() to be able to solve some indefinite integrals that are currently not solvable by the Full Risch algorithm or Meijer G-Function algorithm in the _eval_integral method.


#### Other comments

The following operation is an example of which the new codebase is now able to solve:
integrate(cos(x)/(1 - (b**2)*(sin(x - a))**2)**(S(3)/2), x)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug with integrate(). Formerly, complex integrations involving trig functions returned incorrect answers.
<!-- END RELEASE NOTES -->
