### PR TITLE
Update density.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
 Jurjen N.E. Bos <jnebos@gmail.com>
 Mateusz Paprocki <mattpap@gmail.com>
+Amisha Chhajed <amishhhaaaa@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
 Brian Jorgensen <brian.jorgensen@gmail.com>
 Jason Gedge <inferno1386@gmail.com>

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -14,7 +14,7 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.matrixutils import numpy_ndarray, scipy_sparse_matrix, to_numpy
 from sympy.physics.quantum.tensorproduct import TensorProduct, tensor_product_simp
 from sympy.physics.quantum.trace import Tr
-
+from sympy import conjugate 
 
 class Density(HermitianOperator):
     """Density operator for representing mixed states.

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -192,7 +192,7 @@ class Density(HermitianOperator):
         else:
             op = Mul(*nc_part1)*Dagger(Mul(*nc_part2))
 
-        return Mul(*c_part1)*Mul(*c_part2) * op
+        return Mul(*c_part1)*conjugate(Mul(*c_part2)) * op
 
     def _represent(self, **options):
         return represent(self.doit(), **options)

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -14,7 +14,7 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.matrixutils import numpy_ndarray, scipy_sparse_matrix, to_numpy
 from sympy.physics.quantum.tensorproduct import TensorProduct, tensor_product_simp
 from sympy.physics.quantum.trace import Tr
-from sympy import conjugate 
+from sympy import conjugate
 
 class Density(HermitianOperator):
     """Density operator for representing mixed states.


### PR DESCRIPTION
References to other issues
Fixes #25980

Calculation of density matrix using the density class was incorrect hence the code for returning the correct answer is implemented in this PR.
## Changes
Brief description of what is changed or fixed

In Density.doit() there is a mistake for the _generate_outer_prod() method when returning return Mul(*c_part1)*Mul(*c_part2) * op. The commutative part 2 should be the complex conjugate, so the return is replaced by Mul(*c_part1)*conjugate(Mul(*c_part2))*op.


Release notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug in the density class.
<!-- END RELEASE NOTES -->
