### PR TITLE
Fixed missing term in polylog expansion

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -284,3 +284,12 @@ def test_issue_14177():
     n = Symbol('n')
 
     assert zeta(2*n) == zeta(2*n) # As sign of z (= 2*n) is not determined
+
+
+def test_issue_25159():
+    assert polylog(Rational(3, 2), exp(-x)).series(x, 0, 2) == zeta(Rational(3, 2)) - x*zeta(Rational(1, 2)) -\
+          2*sqrt(pi)*sqrt(x) + O(x**2)
+    assert polylog(Rational(3, 2), (x-1)**2).series(x, 0, 2) == zeta(Rational(3, 2)) -\
+          2*sqrt(pi)*(sqrt(2)*sqrt(x) + sqrt(2)*x**(Rational(3, 2))/4 + O(x**2)) - 2*x*zeta(Rational(1, 2)) + O(x**2)
+    assert polylog(Rational(3, 2), (x+1)**2).series(x, 0, 2) == zeta(Rational(3, 2)) -\
+          2*sqrt(pi)*(sqrt(2)*I*sqrt(x) - sqrt(2)*I*x**(Rational(3, 2))/4 + O(x**2)) + 2*x*zeta(Rational(1, 2)) + O(x**2)

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -392,10 +392,10 @@ class polylog(Function):
                 return self
 
             if exp.is_nonnegative:
-                if (nu.is_integer and (1-nu).is_nonpositive) is not True:
+                if (nu.is_integer and (1-nu).is_nonpositive) is False:
                     self = self.expand()
-                    return gamma(1-nu)*(((log(1/z))**(nu-1))._eval_nseries(x, n, logx, cdir)) + \
-                        super()._eval_nseries(x, n, logx, cdir)
+                    f = gamma(1-nu)*(((log(1/z))**(nu-1))._eval_nseries(x, n, logx, cdir))
+                    return f + super()._eval_nseries(x, n, logx, cdir)
 
         return super()._eval_nseries(x, n, logx, cdir)
 

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -355,6 +355,7 @@ class polylog(Function):
             return True
 
     def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.functions.special.gamma_functions import gamma
         from sympy.series.order import Order
         nu, z = self.args
 
@@ -384,7 +385,19 @@ class polylog(Function):
                     s.append(term/k**nu)
                 return Add(*s) + o
 
-        return super(polylog, self)._eval_nseries(x, n, logx, cdir)
+        if z0 == S.One:
+            try:
+                _, exp = z.leadterm(x)
+            except (ValueError, NotImplementedError):
+                return self
+
+            if exp.is_nonnegative:
+                if (nu.is_integer and (1-nu).is_nonpositive) is not True:
+                    self = self.expand()
+                    return gamma(1-nu)*(((log(1/z))**(nu-1))._eval_nseries(x, n, logx, cdir)) + \
+                        super()._eval_nseries(x, n, logx, cdir)
+
+        return super()._eval_nseries(x, n, logx, cdir)
 
 ###############################################################################
 ###################### HURWITZ GENERALIZED ZETA FUNCTION ######################


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25159 


#### Brief description of what is fixed or changed
Added a missing term in series expansion of polylog 

#### Other comments
Added the missing term of  of gamma(1-s)*(log(1/z))**(s-1)) in the _eval_nseries method of polylog when expanding around z=1.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Added a missing term in _eval_nseries method of polylog .


<!-- END RELEASE NOTES -->
