### PR TITLE
functions: expand_trig no longer uses sqrt formulae

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -238,6 +238,8 @@ def test_sin_expansion():
     assert sin(2*x).expand(trig=True) == 2*sin(x)*cos(x)
     assert sin(3*x).expand(trig=True) == -4*sin(x)**3 + 3*sin(x)
     assert sin(4*x).expand(trig=True) == -8*sin(x)**3*cos(x) + 4*sin(x)*cos(x)
+    assert sin(2*pi/17).expand(trig=True) == sin(2*pi/17, evaluate=False)
+    assert sin(x+pi/17).expand(trig=True) == sin(pi/17)*cos(x) + cos(pi/17)*sin(x)
     _test_extrig(sin, 2, 2*sin(1)*cos(1))
     _test_extrig(sin, 3, -4*sin(1)**3 + 3*sin(1))
 
@@ -449,6 +451,8 @@ def test_cos_expansion():
     assert cos(2*x).expand(trig=True) == 2*cos(x)**2 - 1
     assert cos(3*x).expand(trig=True) == 4*cos(x)**3 - 3*cos(x)
     assert cos(4*x).expand(trig=True) == 8*cos(x)**4 - 8*cos(x)**2 + 1
+    assert cos(2*pi/17).expand(trig=True) == cos(2*pi/17, evaluate=False)
+    assert cos(x+pi/17).expand(trig=True) == cos(pi/17)*cos(x) - sin(pi/17)*sin(x)
     _test_extrig(cos, 2, 2*cos(1)**2 - 1)
     _test_extrig(cos, 3, 4*cos(1)**3 - 3*cos(1))
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -510,10 +510,6 @@ class sin(TrigonometricFunction):
                 else:
                     return expand_mul(S.NegativeOne**(n/2 - 1)*cos(x)*
                                       chebyshevu(n - 1, sin(x)), deep=False)
-            pi_coeff = _pi_coeff(arg)
-            if pi_coeff is not None:
-                if pi_coeff.is_Rational:
-                    return self.rewrite(sqrt)
         return sin(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
@@ -868,10 +864,6 @@ class cos(TrigonometricFunction):
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer:
                 return chebyshevt(coeff, cos(terms))
-            pi_coeff = _pi_coeff(arg)
-            if pi_coeff is not None:
-                if pi_coeff.is_Rational:
-                    return self.rewrite(sqrt)
         return cos(arg)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Removes a change that was made in bb735c0861c from gh-1503. There is some limited discussion there about the reason for the change but I think it should just be reverted.

#### Brief description of what is fixed or changed

On master we have:
```python
In [4]: expand_trig(cos(2*pi/17))
Out[4]: 
                                     ______________________________________________________________ ↪
                  __________        ╱          __________        __________         __________      ↪
  1    √17   √2⋅╲╱ 17 - √17    √2⋅╲╱  - 8⋅√2⋅╲╱ √17 + 17  - √2⋅╲╱ 17 - √17  + √34⋅╲╱ 17 - √17  + 6⋅ ↪
- ── + ─── + ─────────────── + ──────────────────────────────────────────────────────────────────── ↪
  16   16          16                                               16                              ↪

↪ _________
↪          
↪ √17 + 34 
↪ ─────────
↪    

In [5]: cos(x+pi/17).expand(trig=True)
Out[5]: 
        ___________________________________________________________________________________________ ↪
       ╱         _______________________________________________________________________            ↪
      ╱         ╱          __________        __________         __________                      ___ ↪
     ╱     √2⋅╲╱  - 8⋅√2⋅╲╱ √17 + 17  - √2⋅╲╱ 17 - √17  + √34⋅╲╱ 17 - √17  + 6⋅√17 + 34    √2⋅╲╱ 17 ↪
-   ╱    - ───────────────────────────────────────────────────────────────────────────── - ──────── ↪
  ╲╱                                            32                                               32 ↪

↪ ___________________                ______________________________________________________________ ↪
↪                                   ╱                               _______________________________ ↪
↪ _______                          ╱             __________        ╱          __________        ___ ↪
↪  - √17    √17   17              ╱   √17   √2⋅╲╱ 17 - √17    √2⋅╲╱  - 8⋅√2⋅╲╱ √17 + 17  - √2⋅╲╱ 17 ↪
↪ ─────── - ─── + ── ⋅sin(x) +   ╱    ─── + ─────────────── + ───────────────────────────────────── ↪
↪           32    32           ╲╱     32          32                                                ↪

↪ ______________________________________________       
↪ ________________________________________             
↪ _______         __________                           
↪  - √17  + √34⋅╲╱ 17 - √17  + 6⋅√17 + 34    15        
↪ ──────────────────────────────────────── + ── ⋅cos(x)
↪ 32                                         32 
```
I don't really see this as "expansion" in the normal sense. What I would actually want here is more like:
```python
In [6]: from sympy.simplify.fu import TR10

In [7]: TR10(cos(x+pi/17))
Out[7]: 
     ⎛π ⎞             ⎛π ⎞       
- sin⎜──⎟⋅sin(x) + cos⎜──⎟⋅cos(x)
     ⎝17⎠             ⎝17⎠ 
```
This is in keeping with the general idea of expand that it should place an expression into some kind of canonical expanded polynomial form. Introducing radicals is generally not helpful in contexts where expand is being used.

With the PR we instead have:
```python
In [1]: expand_trig(cos(2*pi/17))
Out[1]: 
   ⎛2⋅π⎞
cos⎜───⎟
   ⎝17 ⎠

In [2]: cos(x+pi/17).expand(trig=True)
Out[2]: 
     ⎛π ⎞             ⎛π ⎞       
- sin⎜──⎟⋅sin(x) + cos⎜──⎟⋅cos(x)
     ⎝17⎠             ⎝17⎠  
```
It is still possible to use `.rewrite(sqrt)` to obtain the previous behaviour but it no longer happens as part of `expand_trig`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * Expanding sin and cos no longer rewrites using radical formulae.
<!-- END RELEASE NOTES -->
