### PR TITLE
Unify linear equation solvers

### DIFF
--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -247,6 +247,23 @@ class MatrixBase(Printable):
             out_flat[i * cols + j] = val
         return cls._new(rows, cols, out_flat)
 
+    def _eval_todod(self):
+        rowsdict = {}
+        Mlol = self.tolist()
+        for i, Mi in enumerate(Mlol):
+            row = {j: Mij for j, Mij in enumerate(Mi) if Mij}
+            if row:
+                rowsdict[i] = row
+        return rowsdict
+
+    @classmethod
+    def _eval_from_dod(cls, rows, cols, dod):
+        flat_list = [S.Zero]*(rows*cols)
+        for i, rowdict in dod.items():
+            for j, val in rowdict.items():
+                flat_list[i*cols + j] = val
+        return cls._new(rows, cols, flat_list)
+
     def _eval_vec(self):
         rows = self.rows
 
@@ -723,7 +740,7 @@ class MatrixBase(Printable):
             return [[] for i in range(self.rows)]
         return self._eval_tolist()
 
-    def todod(M):
+    def todod(self):
         """Returns matrix as dict of dicts containing non-zero elements of the Matrix
 
         Examples
@@ -738,15 +755,45 @@ class MatrixBase(Printable):
         >>> A.todod()
         {0: {1: 1}, 1: {1: 3}}
 
+        See Also
+        ========
 
+        todok
+        from_dod
         """
-        rowsdict = {}
-        Mlol = M.tolist()
-        for i, Mi in enumerate(Mlol):
-            row = {j: Mij for j, Mij in enumerate(Mi) if Mij}
-            if row:
-                rowsdict[i] = row
-        return rowsdict
+        return self._eval_todod()
+
+    @classmethod
+    def from_dod(cls, rows, cols, dod):
+        """Construct a matrix from a dict of dicts containing non-zero elements
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> A = Matrix([[0, 1],[0, 3]])
+        >>> A
+        Matrix([
+        [0, 1],
+        [0, 3]])
+        >>> dod = A.todod()
+        >>> dod
+        {0: {1: 1}, 1: {1: 3}}
+        >>> Matrix.from_dod(2, 2, dod) == A
+        True
+
+        See Also
+        ========
+
+        todod
+        """
+        dod_sym = {}
+        for i, row in dod.items():
+            dod_sym[i] = {j: cls._sympify(v) for j, v in row.items()}
+
+        rows, cols = as_int(rows), as_int(cols)
+
+        return cls._eval_from_dod(rows, cols, dod_sym)
 
     def vec(self):
         """Return the Matrix converted into a one column matrix by stacking columns

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -246,6 +246,15 @@ class RepMatrix(MatrixBase):
     def _eval_from_dok(cls, rows, cols, dok):
         return cls._fromrep(cls._smat_to_DomainMatrix(rows, cols, dok))
 
+    def _eval_todod(self):
+        return self._rep.to_sympy().to_dod()
+
+    @classmethod
+    def _eval_from_dod(cls, rows, cols, dod):
+        types = set().union(*[map(type, row.values()) for row in dod.values()])
+        rep = cls._dod_to_DomainMatrix(rows, cols, dod, types)
+        return cls._fromrep(rep)
+
     def _eval_values(self):
         return list(self._eval_iter_values())
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -924,6 +924,19 @@ class DDM(list):
 
         return (basis_ddm, nonpivots)
 
+    def particular_from_rref(A, pivots=None):
+        """Particular solution to Ax = 0 from rref of A.
+
+        The domain of the matrix can be any domain.
+
+        See Also
+        ========
+
+        sympy.polys.matrices.domainmatrix.DomainMatrix.particular
+            The higher level interface to this function.
+        """
+        return A.to_sdm().particular_from_rref(pivots).to_ddm()
+
     def particular(a):
         return a.to_sdm().particular().to_ddm()
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -932,7 +932,7 @@ class DDM(list):
         See Also
         ========
 
-        sympy.polys.matrices.domainmatrix.DomainMatrix.particular
+        sympy.polys.matrices.domainmatrix.DomainMatrix.particular_from_rref
             The higher level interface to this function.
         """
         return A.to_sdm().particular_from_rref(pivots).to_ddm()

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1637,7 +1637,7 @@ class DomainMatrix:
         if lamda.element == lamda.domain.one:
             return A
 
-        return A.mul(1 / lamda.element)
+        return A.mul(A.domain.one / lamda.element)
 
     def pow(A, n):
         r"""
@@ -2499,7 +2499,7 @@ class DomainMatrix:
             if u != K.one:
                 A_rref *= u
 
-        A_null = A_rref.nullspace_from_rref(pivots)
+        A_null, free_vars = A_rref.nullspace_from_rref(pivots)
 
         return A_null
 
@@ -2523,7 +2523,7 @@ class DomainMatrix:
         sympy.polys.matrices.ddm.DDM.nullspace_from_rref
         """
         null_rep, nonpivots = self.rep.nullspace_from_rref(pivots)
-        return self.from_rep(null_rep)
+        return self.from_rep(null_rep), nonpivots
 
     def particular_from_rref(self, pivots=None):
         """
@@ -3082,13 +3082,15 @@ class DomainMatrix:
         ...         [ZZ(4), ZZ(5), ZZ(6)],
         ...         [ZZ(7), ZZ(8), ZZ(9)]], ZZ)
         >>> b = DM([[ZZ(1)], [ZZ(2)], [ZZ(3)]], ZZ)
-        >>> xpart, den, xnull = A.solve_den_general(b)
+        >>> xpart, den, xnull, free_vars = A.solve_den_general(b)
         >>> xpart
         DomainMatrix([[1], [-2], [0]], (3, 1), ZZ)
         >>> den
         -3
         >>> xnull
         DomainMatrix([[-3, 6, -3]], (1, 3), ZZ)
+        >>> free_vars
+        [2]
         >>> A * xpart == den * b
         True
         >>> A * xnull.transpose()
@@ -3114,8 +3116,9 @@ class DomainMatrix:
             raise DMNonInvertibleMatrixError("No solutions")
 
         particular = Aaug_rref.particular_from_rref(pivots)
-        nullspace = Aaug_rref[:,:-1].nullspace_from_rref(pivots)
-        return particular, denom, nullspace
+        nullspace, free_vars = Aaug_rref[:,:-1].nullspace_from_rref(pivots)
+
+        return particular, denom, nullspace, free_vars
 
     def adj_poly_det(self, cp=None):
         """

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -2538,7 +2538,6 @@ class DomainMatrix:
         See Also
         ========
 
-        particular
         rref
         rref_den
         solve_den_general

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -2525,6 +2525,29 @@ class DomainMatrix:
         null_rep, nonpivots = self.rep.nullspace_from_rref(pivots)
         return self.from_rep(null_rep)
 
+    def particular_from_rref(self, pivots=None):
+        """
+        Compute particular solution from rref and pivots.
+
+        The domain of the matrix can be any domain.
+
+        The matrix must be in reduced row echelon form already. Otherwise the
+        result will be incorrect. Use :meth:`rref` or :meth:`rref_den` first
+        to get the reduced row echelon form.
+
+        See Also
+        ========
+
+        particular
+        rref
+        rref_den
+        solve_den_general
+        sympy.polys.matrices.sdm.SDM.particular_from_rref
+        sympy.polys.matrices.ddm.DDM.particular_from_rref
+        """
+        part_rep = self.rep.particular_from_rref(pivots)
+        return self.from_rep(part_rep)
+
     def inv(self):
         r"""
         Finds the inverse of the DomainMatrix if exists
@@ -3024,6 +3047,75 @@ class DomainMatrix:
         adjA_b = self.eval_poly_mul(f, b)
 
         return (adjA_b, detA)
+
+    def solve_den_general(self, b):
+        """
+        Find the general solution of a matrix equation $Ax = b$.
+
+        This method finds the general solution of the matrix equation $Ax = b$
+        for $x$ and returns the solution as a particular solution and a basis
+        for the nullspace. The particular solution is returned as a numerator
+        and denominator pair.
+
+        Examples
+        ========
+
+        Solve an equation with a unique solution:
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DM
+        >>> A = DM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], ZZ)
+        >>> b = DM([[ZZ(5)], [ZZ(6)]], ZZ)
+        >>> xpart, den, xnull = A.solve_den_general(b)
+        >>> xpart
+        DomainMatrix([[8], [-9]], (2, 1), ZZ)
+        >>> den
+        -2
+        >>> xnull
+        DomainMatrix([], (0, 2), ZZ)
+        >>> A * xpart == den * b
+        True
+
+        Solve an equation with infinitely many solutions:
+
+        >>> A = DM([[ZZ(1), ZZ(2), ZZ(3)],
+        ...         [ZZ(4), ZZ(5), ZZ(6)],
+        ...         [ZZ(7), ZZ(8), ZZ(9)]], ZZ)
+        >>> b = DM([[ZZ(1)], [ZZ(2)], [ZZ(3)]], ZZ)
+        >>> xpart, den, xnull = A.solve_den_general(b)
+        >>> xpart
+        DomainMatrix([[1], [-2], [0]], (3, 1), ZZ)
+        >>> den
+        -3
+        >>> xnull
+        DomainMatrix([[-3, 6, -3]], (1, 3), ZZ)
+        >>> A * xpart == den * b
+        True
+        >>> A * xnull.transpose()
+        DomainMatrix([[0], [0], [0]], (3, 1), ZZ)
+        >>> A.rank() == A.shape[0] - xnull.shape[0]
+        True
+
+        See Also
+        ========
+
+        solve_den
+            Solve matrix equations that have a unique solution.
+        """
+        m, n = self.shape
+        assert b.shape == (m, 1)
+
+        A, b = self.unify(b)
+        Aaug = A.hstack(b)
+
+        Aaug_rref, denom, pivots = Aaug.rref_den()
+
+        if pivots and pivots[-1] >= n:
+            raise DMNonInvertibleMatrixError("No solutions")
+
+        particular = Aaug_rref.particular_from_rref(pivots)
+        nullspace = Aaug_rref[:,:-1].nullspace_from_rref(pivots)
+        return particular, denom, nullspace
 
     def adj_poly_det(self, cp=None):
         """

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -3066,13 +3066,15 @@ class DomainMatrix:
         >>> from sympy.polys.matrices import DM
         >>> A = DM([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], ZZ)
         >>> b = DM([[ZZ(5)], [ZZ(6)]], ZZ)
-        >>> xpart, den, xnull = A.solve_den_general(b)
+        >>> xpart, den, xnull, free_vars = A.solve_den_general(b)
         >>> xpart
         DomainMatrix([[8], [-9]], (2, 1), ZZ)
         >>> den
         -2
         >>> xnull
         DomainMatrix([], (0, 2), ZZ)
+        >>> free_vars
+        []
         >>> A * xpart == den * b
         True
 

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -35,6 +35,7 @@ from sympy.core.singleton import S
 from sympy.polys.constructor import construct_domain
 from sympy.polys.solvers import PolyNonlinearError
 
+from .domainmatrix import DomainMatrix
 from .sdm import (
     SDM,
     sdm_irref,
@@ -68,39 +69,44 @@ def _linsolve(eqs, syms):
     {x: -y, y: y}
 
     """
-    # Number of unknowns (columns in the non-augmented matrix)
-    nsyms = len(syms)
-
-    # Convert to sparse augmented matrix (len(eqs) x (nsyms+1))
+    # Convert to sparse augmented matrix (len(eqs) x (len(syms)+1))
     eqsdict, const = _linear_eq_to_dict(eqs, syms)
     Aaug = sympy_dict_to_dm(eqsdict, const, syms)
+    return _linsolve_aug(Aaug, syms)
+
+
+def _linsolve_aug(Aaug, syms):
+    """Solve linear system represented as an augmented DomainMatrix.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, Matrix, linear_eq_to_matrix
+    >>> from sympy.polys.matrices.linsolve import _linsolve_aug
+    >>> x, y = symbols('x, y')
+    >>> eqs = [x + y - 1, x - y - 2]
+    >>> A, b = linear_eq_to_matrix(eqs, [x, y])
+    >>> Aaug = Matrix.hstack(A, b).to_DM().to_sdm()
+    >>> Aaug
+    SDM({0: {0: 1, 1: 1, 2: -1}, 1: {0: 1, 1: -1, 2: -2}}, (2, 3), ZZ)
+    >>> _linsolve_aug(Aaug, [x, y])
+    {x: 3/2, y: -1/2}
+    """
+    Aaug = Aaug.to_field().to_sdm()
+
     K = Aaug.domain
 
-    # sdm_irref has issues with float matrices. This uses the ddm_rref()
-    # function. When sdm_rref() can handle float matrices reasonably this
-    # should be removed...
-    if K.is_RealField or K.is_ComplexField:
-        Aaug = Aaug.to_ddm().rref()[0].to_sdm()
-
-    # Compute reduced-row echelon form (RREF)
-    Arref, pivots, nzcols = sdm_irref(Aaug)
+    P, V, free_variables = _particular_nullspace(Aaug)
 
     # No solution:
-    if pivots and pivots[-1] == nsyms:
+    if P is None:
         return None
-
-    # Particular solution for non-homogeneous system:
-    P = sdm_particular_from_rref(Arref, nsyms+1, pivots)
-
-    # Nullspace - general solution to homogeneous system
-    # Note: using nsyms not nsyms+1 to ignore last column
-    V, nonpivots = sdm_nullspace_from_rref(Arref, K.one, nsyms, pivots, nzcols)
 
     # Collect together terms from particular and nullspace:
     sol = defaultdict(list)
     for i, v in P.items():
         sol[syms[i]].append(K.to_sympy(v))
-    for npi, Vi in zip(nonpivots, V):
+    for npi, Vi in zip(free_variables, V):
         sym = syms[npi]
         for i, v in Vi.items():
             sol[syms[i]].append(sym * K.to_sympy(v))
@@ -117,11 +123,47 @@ def _linsolve(eqs, syms):
     return sol
 
 
+def _particular_nullspace(Aaug):
+    """Return a particular solution and nullspace basis for the
+    augmented matrix ``Aaug``. The augmented matrix is assumed to
+    be in reduced row echelon form. The particular solution is
+    returned as a dictionary mapping column indices to the
+    corresponding values.
+    """
+    # Number of unknowns (columns in the non-augmented matrix)
+    nsyms = Aaug.shape[1] - 1
+
+    K = Aaug.domain
+
+    # sdm_irref has issues with float matrices. This uses the ddm_rref()
+    # function. When sdm_rref() can handle float matrices reasonably this
+    # should be removed...
+    if K.is_RealField or K.is_ComplexField:
+        Aaug = Aaug.to_ddm().rref()[0].to_sdm()
+
+    # Compute reduced-row echelon form (RREF)
+    Arref, pivots, nzcols = sdm_irref(Aaug)
+
+    # No solution:
+    if pivots and pivots[-1] == nsyms:
+        return None, None, None
+
+    # Particular solution for non-homogeneous system:
+    P = sdm_particular_from_rref(Arref, nsyms+1, pivots)
+
+    # Nullspace - general solution to homogeneous system
+    # Note: using nsyms not nsyms+1 to ignore last column
+    V, free_variables = sdm_nullspace_from_rref(Arref, K.one, nsyms, pivots, nzcols)
+
+    return P, V, free_variables
+
+
 def sympy_dict_to_dm(eqs_coeffs, eqs_rhs, syms):
     """Convert a system of dict equations to a sparse augmented matrix"""
     elems = set(eqs_rhs).union(*(e.values() for e in eqs_coeffs))
     K, elems_K = construct_domain(elems, field=True, extension=True)
     elem_map = dict(zip(elems, elems_K))
+
     neqs = len(eqs_coeffs)
     nsyms = len(syms)
     sym2index = dict(zip(syms, range(nsyms)))
@@ -132,8 +174,12 @@ def sympy_dict_to_dm(eqs_coeffs, eqs_rhs, syms):
             eqdict[nsyms] = -elem_map[rhs]
         if eqdict:
             eqsdict.append(eqdict)
-    sdm_aug = SDM(enumerate(eqsdict), (neqs, nsyms + 1), K)
-    return sdm_aug
+
+    dod = dict(enumerate(eqsdict))
+    shape = (neqs, nsyms + 1)
+    Aaug = DomainMatrix.from_dod(dod, shape, K)
+
+    return Aaug
 
 
 def _linear_eq_to_dict(eqs, syms):

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -37,7 +37,6 @@ from sympy.polys.solvers import PolyNonlinearError
 
 from .domainmatrix import DomainMatrix
 from .sdm import (
-    SDM,
     sdm_irref,
     sdm_particular_from_rref,
     sdm_nullspace_from_rref
@@ -86,9 +85,9 @@ def _linsolve_aug(Aaug, syms):
     >>> x, y = symbols('x, y')
     >>> eqs = [x + y - 1, x - y - 2]
     >>> A, b = linear_eq_to_matrix(eqs, [x, y])
-    >>> Aaug = Matrix.hstack(A, b).to_DM().to_sdm()
+    >>> Aaug = Matrix.hstack(A, b).to_DM()
     >>> Aaug
-    SDM({0: {0: 1, 1: 1, 2: -1}, 1: {0: 1, 1: -1, 2: -2}}, (2, 3), ZZ)
+    DomainMatrix({0: {0: 1, 1: 1, 2: 1}, 1: {0: 1, 1: -1, 2: 2}}, (2, 3), ZZ)
     >>> _linsolve_aug(Aaug, [x, y])
     {x: 3/2, y: -1/2}
     """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1204,12 +1204,72 @@ class SDM(dict):
 
         return (A_null, nonpivots)
 
-    def particular(A):
+    def particular_from_rref(A, pivots=None):
+        """
+        Returns a particular solution for a :py:class:`~.SDM` matrix ``A`` in RREF.
+
+        The domain of the matrix can be any domain.
+
+        The matrix must already be in reduced row echelon form (RREF).
+
+        Examples
+        ========
+
+        >>> from sympy import QQ
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> A = SDM({0:{0:QQ(1), 1:QQ(2)}, 1:{0: QQ(2), 1: QQ(4)}}, (2, 2), QQ)
+        >>> A_rref, pivots = A.rref()
+        >>> A_particular = A_rref.particular_from_rref(pivots)
+        >>> A_particular
+        {0: {0: 2}}
+
+        See Also
+        ========
+
+        sympy.polys.matrices.domainmatrix.DomainMatrix.particular_from_rref
+            The higher-level function that calls this one.
+        """
         ncols = A.shape[1]
-        B, pivots, nzcols = sdm_irref(A)
-        P = sdm_particular_from_rref(B, ncols, pivots)
+
+        if pivots is None:
+            pivots = sorted(map(min, A.values()))
+
+        P = {}
+        for i, j in enumerate(pivots):
+            Ain = A[i].get(ncols-1, None)
+            if Ain is not None:
+                P[j] = Ain
+
         rep = {0:P} if P else {}
-        return A.new(rep, (1, ncols-1), A.domain)
+        return A.new(rep, (1, ncols-1), A.domain).transpose()
+
+    def particular(A):
+        """
+        Compute particular solution for augmented matrix ``A`` in RREF.
+
+        The domain of the matrix can be any domain.
+
+        The matrix must already be in reduced row echelon form (RREF).
+
+        Examples
+        ========
+
+        >>> from sympy import QQ
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> A = SDM({0:{0:QQ(1), 1:QQ(2), 2:QQ(3)},
+        ...          1:{0: QQ(2), 1: QQ(4), 2: QQ(6)}}, (2, 3), QQ)
+        >>> A_particular = A.rref()[0].particular()
+        >>> A_particular
+        {0: {0: 3}}
+
+        See Also
+        ========
+
+        particular_from_rref
+        sympy.polys.matrices.domainmatrix.DomainMatrix.particular
+        """
+        Aaug, pivots = A.rref()
+        return Aaug.particular_from_rref(pivots).transpose()
 
     def hstack(A, *B):
         """Horizontally stacks :py:class:`~.SDM` matrices.

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1266,7 +1266,6 @@ class SDM(dict):
         ========
 
         particular_from_rref
-        sympy.polys.matrices.domainmatrix.DomainMatrix.particular
         """
         Aaug, pivots = A.rref()
         return Aaug.particular_from_rref(pivots).transpose()

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -752,10 +752,10 @@ def test_DomainMatrix_nullspace():
 
     Arref, den, pivots = A.rref_den()
     assert den == ZZ(2)
-    assert Arref.nullspace_from_rref() == Anull
-    assert Arref.nullspace_from_rref(pivots) == Anull
-    assert Arref.to_sparse().nullspace_from_rref() == Anull.to_sparse()
-    assert Arref.to_sparse().nullspace_from_rref(pivots) == Anull.to_sparse()
+    assert Arref.nullspace_from_rref() == (Anull, [1])
+    assert Arref.nullspace_from_rref(pivots) == (Anull, [1])
+    assert Arref.to_sparse().nullspace_from_rref() == (Anull.to_sparse(), [1])
+    assert Arref.to_sparse().nullspace_from_rref(pivots) == (Anull.to_sparse(), [1])
 
 
 def test_DomainMatrix_solve():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -47,7 +47,8 @@ from sympy.strategies.rl import rebuild
 from sympy.matrices.exceptions import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, factor, Poly
-from sympy.polys.solvers import sympy_eqs_to_ring, solve_lin_sys
+from sympy.polys.domains import EX
+from sympy.polys.matrices.linsolve import _linsolve_aug
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
 from sympy.polys.polytools import gcd
 from sympy.utilities.lambdify import lambdify
@@ -2349,12 +2350,15 @@ def solve_linear_system(system, *symbols, **flags):
     """
     assert system.shape[1] == len(symbols) + 1
 
-    # This is just a wrapper for solve_lin_sys
-    eqs = list(system * Matrix(symbols + (-1,)))
-    eqs, ring = sympy_eqs_to_ring(eqs, symbols)
-    sol = solve_lin_sys(eqs, ring, _raw=False)
+    Aaug = system.to_DM(extension=True)
+    if Aaug.domain.is_EXRAW:
+        Aaug = Aaug.convert_to(EX)
+
+    sol = _linsolve_aug(Aaug, symbols)
+
     if sol is not None:
         sol = {sym:val for sym, val in sol.items() if sym != val}
+
     return sol
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -43,7 +43,7 @@ from sympy.logic.boolalg import And, BooleanTrue
 from sympy.sets import (FiniteSet, imageset, Interval, Intersection,
                         Union, ConditionSet, ImageSet, Complement, Contains)
 from sympy.sets.sets import Set, ProductSet
-from sympy.matrices import zeros, Matrix, MatrixBase
+from sympy.matrices import Matrix, MatrixBase
 from sympy.ntheory.factor_ import divisors
 from sympy.ntheory.residue_ntheory import discrete_log, nthroot_mod
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
@@ -52,7 +52,6 @@ from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.polytools import invert, groebner, poly
 from sympy.polys.solvers import (sympy_eqs_to_ring, solve_lin_sys,
     PolyNonlinearError)
-from sympy.polys.matrices.linsolve import _linsolve
 from sympy.solvers.solvers import (checksol, denoms, unrad,
     _simple_dens, recast_to_symbols)
 from sympy.solvers.polysys import solve_poly_system
@@ -2883,7 +2882,7 @@ def linear_eq_to_matrix(equations, *symbols):
         raise NonlinearError(str(err))
 
     # prepare output matrices
-    m, n = shape = len(eqs), len(symbols)
+    m, n = len(eqs), len(symbols)
     ix = dict(zip(symbols, range(n)))
     eqs_ind = [{ix[s]: v for s, v in eq.items()} for eq in eqs]
     dod = dict(zip(range(m), eqs_ind))

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -48,6 +48,7 @@ from sympy.ntheory.factor_ import divisors
 from sympy.ntheory.residue_ntheory import discrete_log, nthroot_mod
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf, factor, lcm, gcd)
+from sympy.polys.domains import EX
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.polytools import invert, groebner, poly
 from sympy.polys.solvers import PolyNonlinearError
@@ -3138,9 +3139,9 @@ def linsolve(system, *symbols):
             '''))
 
     # Actually solve the equations:
-    Aaug = Matrix.hstack(A, b).to_DM()
+    Aaug = Matrix.hstack(A, b).to_DM(extension=True)
     if Aaug.domain.is_EXRAW:
-        Aaug = Aaug.convert_to('EX')
+        Aaug = Aaug.convert_to(EX)
     sol = _linsolve_aug(Aaug, symbols)
 
     if sol is None:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2878,18 +2878,18 @@ def linear_eq_to_matrix(equations, *symbols):
 
     # construct the dictionaries
     try:
-        eq, c = _linear_eq_to_dict(equations, symbols)
+        eqs, c = _linear_eq_to_dict(equations, symbols)
     except PolyNonlinearError as err:
         raise NonlinearError(str(err))
+
     # prepare output matrices
-    n, m = shape = len(eq), len(symbols)
-    ix = dict(zip(symbols, range(m)))
-    A = zeros(*shape)
-    for row, d in enumerate(eq):
-        for k in d:
-            col = ix[k]
-            A[row, col] = d[k]
-    b = Matrix(n, 1, [-i for i in c])
+    m, n = shape = len(eqs), len(symbols)
+    ix = dict(zip(symbols, range(n)))
+    eqs_ind = [{ix[s]: v for s, v in eq.items()} for eq in eqs]
+    dod = dict(zip(range(m), eqs_ind))
+
+    A = Matrix.from_dod(m, n, dod)
+    b = Matrix(m, 1, [-i for i in c])
     return A, b
 
 
@@ -3066,64 +3066,52 @@ def linsolve(system, *symbols):
     ...
     NonlinearError: nonlinear term: x**2
     """
+    def is_mat(eq):
+        return isinstance(eq, MatrixBase)
+    def is_eq(eq):
+        return isinstance(eq, (Expr, Eq)) and not is_mat(eq)
+
+    # XXX: This is mathematically incorrect if system is supposed to be a list
+    # of equations.
     if not system:
         return S.EmptySet
 
-    # If second argument is an iterable
-    if symbols and hasattr(symbols[0], '__iter__'):
+    sym_gen = False
+    if len(symbols) == 1 and iterable(symbols[0]):
         symbols = symbols[0]
-    sym_gen = isinstance(symbols, GeneratorType)
-    dup_msg = 'duplicate symbols given'
+        sym_gen = isinstance(symbols, GeneratorType)
+    elif symbols:
+        symbols = symbols
+    else:
+        symbols = None
 
+    no_symbols = '''
+    When passing a system of equations, the explicit
+    symbols for which a solution is being sought must
+    be given as a sequence, too.
+    '''
+    wrong_arguments = '''
+    Expected augmented matrix, list of equations or
+    (A, b) as input.
+    '''
 
-    b = None  # if we don't get b the input was bad
-    # unpack system
-
-    if hasattr(system, '__iter__'):
-
-        # 1). (A, b)
-        if len(system) == 2 and isinstance(system[0], MatrixBase):
-            A, b = system
-
-        # 2). (eq1, eq2, ...)
-        if not isinstance(system[0], MatrixBase):
+    if isinstance(system, MatrixBase):
+        A, b = system[:, :-1], system[:, -1]
+    elif is_sequence(system):
+        system = [sympify(eq) for eq in system]
+        if all(is_eq(eq) for eq in system):
             if sym_gen or not symbols:
-                raise ValueError(filldedent('''
-                    When passing a system of equations, the explicit
-                    symbols for which a solution is being sought must
-                    be given as a sequence, too.
-                '''))
+                raise ValueError(filldedent(no_symbols))
             if len(set(symbols)) != len(symbols):
-                raise ValueError(dup_msg)
+                raise ValueError('duplicate symbols given')
+            A, b = linear_eq_to_matrix(system, *symbols)
+        elif len(system) == 2 and is_mat(system[0]) and is_mat(system[1]):
+            A, b = system
+        else:
+            raise ValueError(filldedent(wrong_arguments))
+    else:
+        raise ValueError(filldedent(wrong_arguments))
 
-            #
-            # Pass to the sparse solver implemented in polys. It is important
-            # that we do not attempt to convert the equations to a matrix
-            # because that would be very inefficient for large sparse systems
-            # of equations.
-            #
-            eqs = system
-            eqs = [sympify(eq) for eq in eqs]
-            try:
-                sol = _linsolve(eqs, symbols)
-            except PolyNonlinearError as exc:
-                # e.g. cos(x) contains an element of the set of generators
-                raise NonlinearError(str(exc))
-
-            if sol is None:
-                return S.EmptySet
-
-            sol = FiniteSet(Tuple(*(sol.get(sym, sym) for sym in symbols)))
-            return sol
-
-    elif isinstance(system, MatrixBase) and not (
-            symbols and not isinstance(symbols, GeneratorType) and
-            isinstance(symbols[0], MatrixBase)):
-        # 3). A augmented with b
-        A, b = system[:, :-1], system[:, -1:]
-
-    if b is None:
-        raise ValueError("Invalid arguments")
     if sym_gen:
         symbols = [next(symbols) for i in range(A.cols)]
         symset = set(symbols)
@@ -3135,7 +3123,7 @@ def linsolve(system, *symbols):
                 the generator, e.g. numbered_symbols('%s', cls=Dummy)
             ''' % symbols[0].name.rstrip('1234567890')))
         elif len(symset) != len(symbols):
-            raise ValueError(dup_msg)
+            raise ValueError('duplicate symbols given')
 
     if not symbols:
         symbols = [Dummy() for _ in range(A.cols)]
@@ -3144,6 +3132,11 @@ def linsolve(system, *symbols):
         gen  = numbered_symbols(name)
     else:
         gen = None
+
+    if any(is_mat(s) for s in symbols):
+        raise ValueError(filldedent('''
+            Symbols must not be matrices.
+            '''))
 
     # This is just a wrapper for solve_lin_sys
     eqs = []


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Includes gh-25996.

#### Brief description of what is fixed or changed

Add a Matrix.from_dod method and improve the implementation of todod to use DomainMatrix.to_dod.

Use from_dod in linear_eq_to_matrix

Use linear_eq_to_matrix in linsolve since it has been made more efficient (in previous PRs).

Add new function `_linsolve_aug` to replacem `_linsolve` and `solve_linsys`.

Make all places that use linear equation solvers use `_linsolve_aug`:

1. linsolve
2. solve_linear_system
3. solve
4. heurisch

#### Other comments

The intention here is mostly just to unify the different codepaths that solve linear equations so that we end up with a single target for optimisation. The `solve_lin_sys` function predates `DomainMatrix` and the `_linsolve` predates other changes in `linear_eq_to_matrix` and `DomainMatrix`. It should be possible to implement this all in a cleaner way now and tidy up the code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * A Matrix.from_dod() method is added to reconstruct a matrix from a dict of dicts format.
<!-- END RELEASE NOTES -->