### PR TITLE
polys: fix denominators in DUP_flint.cancel()

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2116,11 +2116,11 @@ class DUP_Flint(DMP):
         assert f.dom == g.dom in (ZZ, QQ)
 
         if f.dom.is_QQ:
-            cF, F = f.clear_denoms()
-            cG, G = g.clear_denoms()
+            cG, F = f.clear_denoms()
+            cF, G = g.clear_denoms()
         else:
-            cF, F = f.dom.one, f
-            cG, G = g.dom.one, g
+            cG, F = f.dom.one, f
+            cF, G = g.dom.one, g
 
         cH = cF.gcd(cG)
         cF, cG = cF // cH, cG // cH

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -208,6 +208,20 @@ def test_DMP_functionality():
     assert (4*f).content() == ZZ(4)
     assert (4*f).primitive() == (ZZ(4), f)
 
+    f = DMP([QQ(1,3), QQ(1)], QQ)
+    g = DMP([QQ(1,7), QQ(1)], QQ)
+
+    assert f.cancel(g) == f.cancel(g, include=True) == (
+        DMP([QQ(7), QQ(21)], QQ),
+        DMP([QQ(3), QQ(21)], QQ)
+    )
+    assert f.cancel(g, include=False) == (
+        QQ(7),
+        QQ(3),
+        DMP([QQ(1), QQ(3)], QQ),
+        DMP([QQ(1), QQ(7)], QQ)
+    )
+
     f = DMP([[ZZ(1)], [ZZ(2)], [ZZ(3)], [ZZ(4)], [ZZ(5)], [ZZ(6)]], ZZ)
 
     assert f.trunc(3) == DMP([[ZZ(1)], [ZZ(-1)], [], [ZZ(1)], [ZZ(-1)], []], ZZ)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3145,6 +3145,16 @@ def test_cancel():
 
     assert cancel((f, g)) == (1, -f, -g)
 
+    f = Poly(x/3 + 1, x)
+    g = Poly(x/7 + 1, x)
+
+    assert f.cancel(g) == (S(7)/3,
+        Poly(x + 3, x, domain=QQ),
+        Poly(x + 7, x, domain=QQ))
+    assert f.cancel(g, include=True) == (
+        Poly(7*x + 21, x, domain=QQ),
+        Poly(3*x + 21, x, domain=QQ))
+
     f = Poly(y, y, domain='ZZ(x)')
     g = Poly(1, y, domain='ZZ[x]')
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes a bug in DUP_flint.cancel that swaps the denominators. The bug only shows when the ground types are set to flint.

On master without flint:
```
In [1]: Poly(x/3 + 1).cancel(Poly(x/7 + 1))
Out[1]: (7/3, Poly(x + 3, x, domain='QQ'), Poly(x + 7, x, domain='QQ'))
```
On master with flint:
```
In [1]: Poly(x/3 + 1).cancel(Poly(x/7 + 1))
Out[1]: (3/7, Poly(x + 3, x, domain='QQ'), Poly(x + 7, x, domain='QQ'))
```
Note 7/3 vs 3/7.

This PR fixes it so that the same correct result is seen with and without flint.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
