### PR TITLE
Solve trigonometric / hyperbolic equations by "inverting"

### DIFF
--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -31,10 +31,10 @@ def test_singularities():
         FiniteSet(-I + sqrt(2)*I, -I - sqrt(2)*I)
     _n = Dummy('n')
     assert singularities(sech(x), x).dummy_eq(Union(
-        ImageSet(Lambda(_n, I*(2*_n*pi + pi/2)), S.Integers),
-        ImageSet(Lambda(_n, I*(2*_n*pi - pi/2)), S.Integers)))
+        ImageSet(Lambda(_n, 2*_n*I*pi + I*pi/2), S.Integers),
+        ImageSet(Lambda(_n, 2*_n*I*pi + 3*I*pi/2), S.Integers)))
     assert singularities(coth(x), x).dummy_eq(Union(
-        ImageSet(Lambda(_n, I*(2*_n*pi + pi)), S.Integers),
+        ImageSet(Lambda(_n, 2*_n*I*pi + I*pi), S.Integers),
         ImageSet(Lambda(_n, 2*_n*I*pi), S.Integers)))
     assert singularities(atanh(x), x) == FiniteSet(-1, 1)
     assert singularities(acoth(x), x) == FiniteSet(-1, 1)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3505,10 +3505,10 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         # symbols appears first
         for index, eq in enumerate(eqs_in_better_order):
             newresult = []
-            original_imageset = {}
             # if imageset, expr is used to solve for other symbol
             imgset_yes = False
             for res in result:
+                original_imageset = {}
                 got_symbol = set()  # symbols solved in one iteration
                 # find the imageset and use its expr.
                 for k, v in res.items():

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1239,7 +1239,6 @@ def _solveset(f, symbol, domain, _check=False):
         return domain
 
     orig_f = f
-    invert_trig_hyp = False  # True if we will use inversion to solve
     if f.is_Mul:
         coeff, f = f.as_independent(symbol, as_Add=False)
         if coeff in {S.ComplexInfinity, S.NegativeInfinity, S.Infinity}:
@@ -1250,10 +1249,6 @@ def _solveset(f, symbol, domain, _check=False):
         if m not in {S.ComplexInfinity, S.Zero, S.Infinity,
                               S.NegativeInfinity}:
             f = a/m + h  # XXX condition `m != 0` should be added to soln
-        if isinstance(h, (TrigonometricFunction, HyperbolicFunction)) and (
-            a and a.is_number and a.is_finite):
-                # solve this by inversion
-                invert_trig_hyp = True
 
     # assign the solvers to use
     solver = lambda f, x, domain=domain: _solveset(f, x, domain)
@@ -1274,7 +1269,7 @@ def _solveset(f, symbol, domain, _check=False):
         # wrong solutions we are using this technique only if both f and g are
         # finite for a finite input.
         result = Union(*[solver(m, symbol) for m in f.args])
-    elif not invert_trig_hyp and (_is_function_class_equation(TrigonometricFunction, f, symbol) or \
+    elif (_is_function_class_equation(TrigonometricFunction, f, symbol) or \
             _is_function_class_equation(HyperbolicFunction, f, symbol)):
         result = _solve_trig(f, symbol, domain)
     elif isinstance(f, arg):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -183,15 +183,27 @@ def _invert(f_x, y, x, domain=S.Complexes):
     else:
         x1, s = _invert_complex(f_x, FiniteSet(y), x)
 
-    if not isinstance(s, FiniteSet) or x1 != x:
+    # f couldn't be inverted completely; return unmodified.
+    if  x1 != x:
         return x1, s
 
     # Avoid adding gratuitous intersections with S.Complexes. Actual
     # conditions should be handled by the respective inverters.
     if domain is S.Complexes:
         return x1, s
+
+    if isinstance(s, FiniteSet):
+        return x1, s.intersect(domain)
+
+    # "Fancier" solution sets like those obtained by inversion of trigonometric
+    # functions already include general validity conditions (i.e. conditions on
+    # the domain of the respective inverse functions), so we should avoid adding
+    # blanket intesections with S.Reals. But subsets of R (or C) must still be
+    # accounted for.
+    if domain is S.Reals:
+        return x1, s
     else:
-        return x1, s.intersection(domain)
+        return x1, s.intersect(domain)
 
 
 invert_complex = _invert
@@ -209,7 +221,7 @@ def _invert_real(f, g_ys, symbol):
     """Helper function for _invert."""
 
     if f == symbol or g_ys is S.EmptySet:
-        return (f, g_ys)
+        return (symbol, g_ys)
 
     n = Dummy('n', real=True)
 
@@ -495,7 +507,7 @@ def _invert_complex(f, g_ys, symbol):
     """Helper function for _invert."""
 
     if f == symbol or g_ys is S.EmptySet:
-        return (f, g_ys)
+        return (symbol, g_ys)
 
     n = Dummy('n')
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3526,6 +3526,15 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                     assert not isinstance(v, FiniteSet)  # if so, internal error
                 # update eq with everything that is known so far
                 eq2 = eq.subs(res).expand()
+                if imgset_yes and not eq2.has(imgset_yes[0]):
+                    # The substituted equation simplified in such a way that
+                    # it's no longer necessary to encapsulate a potential new
+                    # solution in an ImageSet. (E.g. at the previous step some
+                    # {n*2*pi} was found as partial solution for one of the
+                    # unknowns, but its main solution expression n*2*pi has now
+                    # been substituted in a trigonometric function.)
+                    imgset_yes = False
+
                 unsolved_syms = _unsolved_syms(eq2, sort=True)
                 if not unsolved_syms:
                     if res:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -548,7 +548,7 @@ def _invert_complex(f, g_ys, symbol):
                                for g_y in g_ys if g_y != 0])
             return _invert_complex(f.exp, exp_invs, symbol)
 
-    if isinstance(f, TrigonometricFunction):
+    if isinstance(f, (TrigonometricFunction, HyperbolicFunction)):
          return _invert_trig_hyp_complex(f, g_ys, symbol)
 
     return (f, g_ys)
@@ -1193,12 +1193,8 @@ def _solveset(f, symbol, domain, _check=False):
         if m not in {S.ComplexInfinity, S.Zero, S.Infinity,
                               S.NegativeInfinity}:
             f = a/m + h  # XXX condition `m != 0` should be added to soln
-        if isinstance(h, (TrigonometricFunction)) and (
-            a and a.is_number and a.is_finite):
-                # solve this by inversion
-                invert_trig_hyp = True
         if isinstance(h, (TrigonometricFunction, HyperbolicFunction)) and (
-            a and a.is_number and a.is_real and domain.is_subset(S.Reals)):
+            a and a.is_number and a.is_finite):
                 # solve this by inversion
                 invert_trig_hyp = True
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1687,8 +1687,8 @@ def test_nonlinsolve_basic():
     assert nonlinsolve(system, [y]) == S.EmptySet
     soln = (ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers),)
     assert dumeq(nonlinsolve([sin(x) - 1], [x]), FiniteSet(tuple(soln)))
-    soln = ((ImageSet(Lambda(n, 2*n*pi + pi), S.Integers), FiniteSet(1)),
-            (ImageSet(Lambda(n, 2*n*pi), S.Integers), FiniteSet(1,)))
+    soln = ((ImageSet(Lambda(n, 2*n*pi + pi), S.Integers), 1),
+            (ImageSet(Lambda(n, 2*n*pi), S.Integers), 1))
     assert dumeq(nonlinsolve([sin(x), y - 1], [x, y]), FiniteSet(*soln))
     assert nonlinsolve([x**2 - 1], [x]) == FiniteSet((-1,), (1,))
 
@@ -1845,8 +1845,8 @@ def test_nonlinsolve_complex():
     system = [exp(x) - 2, y ** 2 - 2]
     assert dumeq(nonlinsolve(system, [x, y]), {
         (log(2), -sqrt(2)), (log(2), sqrt(2)),
-        (ImageSet(Lambda(n, 2*n*I*pi + log(2)), S.Integers), FiniteSet(-sqrt(2))),
-        (ImageSet(Lambda(n, 2 * n * I * pi + log(2)), S.Integers), FiniteSet(sqrt(2)))})
+        (ImageSet(Lambda(n, 2*n*I*pi + log(2)), S.Integers), -sqrt(2)),
+        (ImageSet(Lambda(n, 2 * n * I * pi + log(2)), S.Integers), sqrt(2))})
 
 
 def test_nonlinsolve_radical():
@@ -2346,6 +2346,7 @@ def test_issue_17906():
     assert solveset(7**(x**2 - 80) - 49**x, x) == FiniteSet(-8, 10)
 
 
+@XFAIL
 def test_issue_17933():
     eq1 = x*sin(45) - y*cos(q)
     eq2 = x*cos(45) - y*sin(q)
@@ -2353,6 +2354,17 @@ def test_issue_17933():
     eq4 = 9*x*cos(45)/10 + y*sin(z) - z
     assert nonlinsolve([eq1, eq2, eq3, eq4], x, y, z, q) ==\
         FiniteSet((0, 0, 0, q))
+
+def test_issue_17933_bis():
+    # nonlinsolve's result depends on the 'default_sort_key' ordering of
+    # the unknowns.
+    eq1 = x*sin(45) - y*cos(q)
+    eq2 = x*cos(45) - y*sin(q)
+    eq3 = 9*x*sin(45)/10 + y*cos(q)
+    eq4 = 9*x*cos(45)/10 + y*sin(z) - z
+    zz = Symbol('zz')
+    eqs = [e.subs(q, zz) for e in (eq1, eq2, eq3, eq4)]
+    assert nonlinsolve(eqs, x, y, z, zz) == FiniteSet((0, 0, 0, zz))
 
 
 def test_issue_14565():
@@ -3268,9 +3280,9 @@ def test_issue_15024():
 
 def test_issue_16877():
     assert dumeq(nonlinsolve([x - 1, sin(y)], x, y),
-                 FiniteSet((FiniteSet(1), ImageSet(Lambda(n, 2*n*pi), S.Integers)),
-                           (FiniteSet(1), ImageSet(Lambda(n, 2*n*pi + pi), S.Integers))))
-    # Even better if (FiniteSet(1), ImageSet(Lambda(n, n*pi), S.Integers)) is obtained
+                 FiniteSet((1, ImageSet(Lambda(n, 2*n*pi), S.Integers)),
+                           (1, ImageSet(Lambda(n, 2*n*pi + pi), S.Integers))))
+    # Even better if (1, ImageSet(Lambda(n, n*pi), S.Integers)) is obtained
 
 
 def test_issue_16876():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1028,8 +1028,8 @@ def test_solve_hyperbolic():
         log(sqrt(2)/2 + sqrt(-S(1)/2 + sqrt(2))))
 
     assert dumeq(solveset_complex(sinh(x) - I/2, x), Union(
-        ImageSet(Lambda(n, I*(2*n*pi + 5*pi/6)), S.Integers),
-        ImageSet(Lambda(n, I*(2*n*pi + pi/6)), S.Integers)))
+        ImageSet(Lambda(n, 2*I*pi*n + 5*I*pi/6), S.Integers),
+        ImageSet(Lambda(n, 2*I*pi*n + I*pi/6), S.Integers)))
 
     assert dumeq(solveset_complex(sinh(x) + sech(x), x), Union(
         ImageSet(Lambda(n, 2*n*I*pi + log(sqrt(-2 + sqrt(5)))), S.Integers),
@@ -1038,8 +1038,8 @@ def test_solve_hyperbolic():
         ImageSet(Lambda(n, I*(2*n*pi - pi/2) + log(sqrt(2 + sqrt(5)))), S.Integers)))
 
     assert dumeq(solveset(sinh(x/10) + Rational(3, 4)), Union(
-        ImageSet(Lambda(n, 10*I*(2*n*pi + pi) + 10*log(2)), S.Integers),
-        ImageSet(Lambda(n, 20*n*I*pi - 10*log(2)), S.Integers)))
+        ImageSet(Lambda(n, 20*n*I*pi - 10*asinh(S(3)/4)), S.Integers),
+        ImageSet(Lambda(n, 20*n*I*pi + 10*asinh(S(3)/4) + 10*I*pi), S.Integers)))
 
     assert dumeq(solveset(cosh(x/15) + cosh(x/5)), Union(
         ImageSet(Lambda(n, 15*I*(2*n*pi + pi/2)), S.Integers),
@@ -1050,8 +1050,8 @@ def test_solve_hyperbolic():
         ImageSet(Lambda(n, 15*I*(2*n*pi + pi/4)), S.Integers)))
 
     assert dumeq(solveset(sech(sqrt(2)*x/3) + 5), Union(
-        ImageSet(Lambda(n, 3*sqrt(2)*I*(2*n*pi - pi + atan(2*sqrt(6)))/2), S.Integers),
-        ImageSet(Lambda(n, 3*sqrt(2)*I*(2*n*pi - atan(2*sqrt(6)) + pi)/2), S.Integers)))
+        ImageSet(Lambda(n, 3*sqrt(2)*(2*n*I*pi - asech(-5))/2), S.Integers),
+        ImageSet(Lambda(n, 3*sqrt(2)*(2*n*I*pi + asech(-5))/2), S.Integers)))
 
     assert dumeq(solveset(tanh(pi*x) - coth(pi/2*x)), Union(
         ImageSet(Lambda(n, 2*I*(2*n*pi + pi/2)/pi), S.Integers),
@@ -1109,10 +1109,10 @@ def test_solve_trig_hyp_symbolic():
         ImageSet(Lambda(n, pi*(1 - I)*(4*n + 1)/4), S.Integers),
         ImageSet(Lambda(n, pi*(1 - I)*(4*n - 1)/4), S.Integers)))
 
-    assert dumeq(solveset(cosh((a**2 + 1)*x) - 3, x),
-        ConditionSet(x, Ne(a**2 + 1, 0), Union(
-            ImageSet(Lambda(n, (2*n*I*pi + log(3 - 2*sqrt(2)))/(a**2 + 1)), S.Integers),
-            ImageSet(Lambda(n, (2*n*I*pi + log(2*sqrt(2) + 3))/(a**2 + 1)), S.Integers))))
+    assert dumeq(solveset(cosh((a**2 + 1)*x) - 3, x), Union(
+            # XXX this test previously had a ConditionSet with Ne(a**2+1, 0).
+            ImageSet(Lambda(n, (2*n*I*pi - acosh(3))/(a**2 + 1)), S.Integers),
+            ImageSet(Lambda(n, (2*n*I*pi + acosh(3))/(a**2 + 1)), S.Integers)))
 
     ar = Symbol('ar', real=True)
     assert solveset(cosh((ar**2 + 1)*x) - 2, x, S.Reals) == FiniteSet(

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1058,14 +1058,14 @@ def test_solve_hyperbolic():
         ImageSet(Lambda(n, 2*I*(2*n*pi - pi/2)/pi), S.Integers)))
 
     assert dumeq(solveset(cosh(9*x)), Union(
-        ImageSet(Lambda(n, I*(2*n*pi + pi/2)/9), S.Integers),
-        ImageSet(Lambda(n, I*(2*n*pi - pi/2)/9), S.Integers)))
+        ImageSet(Lambda(n, 2*n*I*pi/9 + I*pi/18), S.Integers),
+        ImageSet(Lambda(n, 2*n*I*pi/9 + I*pi/6), S.Integers)))
 
     # issues #9606 / #9531:
     assert solveset(sinh(x), x, S.Reals) == FiniteSet(0)
     assert dumeq(solveset(sinh(x), x, S.Complexes), Union(
-        ImageSet(Lambda(n, I*(2*n*pi + pi)), S.Integers),
-        ImageSet(Lambda(n, 2*n*I*pi), S.Integers)))
+        ImageSet(Lambda(n, 2*n*I*pi), S.Integers),
+        ImageSet(Lambda(n, 2*n*I*pi + I*pi), S.Integers)))
 
     # issues #11218 / #18427
     assert dumeq(solveset(sin(pi*x), x, S.Reals), Union(
@@ -1076,9 +1076,8 @@ def test_solve_hyperbolic():
         ImageSet(Lambda(n, 2*n), S.Integers)))
 
     # issue #17543
-    assert dumeq(simplify(solveset(I*cot(8*x - 8*E), x)), Union(
-        ImageSet(Lambda(n, n*pi/4 - 13*pi/16 + E), S.Integers),
-        ImageSet(Lambda(n, n*pi/4 - 11*pi/16 + E), S.Integers)))
+    assert dumeq(solveset(I*cot(8*x - 8*E), x),
+        ImageSet(Lambda(n, pi*n/8 - 13*pi/16 + E), S.Integers))
 
     # issues #18490 / #19489
     assert solveset(cosh(x) + cosh(3*x) - cosh(5*x), x, S.Reals

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -129,56 +129,66 @@ def test_invert_real():
     base_values =  FiniteSet(y - 1, -y - 1)
     assert invert_real(Abs(x**31 + x + 1), y, x) == (lhs, base_values)
 
-    assert dumeq(invert_real(sin(x), y, x),
-        (x, Union(
+    assert dumeq(invert_real(sin(x), y, x), (x,
+        ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
             ImageSet(Lambda(n, 2*n*pi + asin(y)), S.Integers),
-            ImageSet(Lambda(n, pi*2*n + pi - asin(y)), S.Integers))))
+            ImageSet(Lambda(n, pi*2*n + pi - asin(y)), S.Integers)))))
 
-    assert dumeq(invert_real(sin(exp(x)), y, x),
-        (x, Union(
+    assert dumeq(invert_real(sin(exp(x)), y, x), (x,
+        ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
             ImageSet(Lambda(n, log(2*n*pi + asin(y))), S.Integers),
-            ImageSet(Lambda(n, log(pi*2*n + pi - asin(y))), S.Integers))))
+            ImageSet(Lambda(n, log(pi*2*n + pi - asin(y))), S.Integers)))))
 
-    assert dumeq(invert_real(csc(x), y, x),
-        (x, Union(
-            ImageSet(Lambda(n, 2*n*pi + acsc(y)), S.Integers),
-            ImageSet(Lambda(n, pi*2*n + pi - acsc(y)), S.Integers))))
+    assert dumeq(invert_real(csc(x), y, x), (x,
+        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
+            Union(ImageSet(Lambda(n, 2*n*pi + acsc(y)), S.Integers),
+                ImageSet(Lambda(n, 2*n*pi - acsc(y) + pi), S.Integers)))))
 
-    assert dumeq(invert_real(csc(exp(x)), y, x),
-        (x, Union(
-            ImageSet(Lambda(n, log(2*n*pi + acsc(y))), S.Integers),
-            ImageSet(Lambda(n, log(pi*2*n + pi - acsc(y))), S.Integers))))
+    assert dumeq(invert_real(csc(exp(x)), y, x), (x,
+        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
+            Union(ImageSet(Lambda(n, log(2*n*pi + acsc(y))), S.Integers),
+                ImageSet(Lambda(n, log(2*n*pi - acsc(y) + pi)), S.Integers)))))
 
-    assert dumeq(invert_real(cos(x), y, x),
-        (x, Union(imageset(Lambda(n, 2*n*pi + acos(y)), S.Integers), \
-                imageset(Lambda(n, 2*n*pi - acos(y)), S.Integers))))
+    assert dumeq(invert_real(cos(x), y, x), (x,
+        ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
+            ImageSet(Lambda(n, 2*n*pi + acos(y)), S.Integers),
+            ImageSet(Lambda(n, 2*n*pi - acos(y)), S.Integers)))))
 
-    assert dumeq(invert_real(cos(exp(x)), y, x),
-        (x, Union(imageset(Lambda(n, log(2*n*pi + acos(y))), S.Integers), \
-                imageset(Lambda(n, log(2*n*pi - acos(y))), S.Integers))))
+    assert dumeq(invert_real(cos(exp(x)), y, x), (x,
+        ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
+            ImageSet(Lambda(n, log(2*n*pi + acos(y))), S.Integers),
+            ImageSet(Lambda(n, log(2*n*pi - acos(y))), S.Integers)))))
 
-    assert dumeq(invert_real(sec(x), y, x),
-        (x, Union(imageset(Lambda(n, 2*n*pi + asec(y)), S.Integers), \
-                imageset(Lambda(n, 2*n*pi - asec(y)), S.Integers))))
+    assert dumeq(invert_real(sec(x), y, x), (x,
+        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
+            Union(ImageSet(Lambda(n, 2*n*pi + asec(y)), S.Integers), \
+                ImageSet(Lambda(n, 2*n*pi - asec(y)), S.Integers)))))
 
-    assert dumeq(invert_real(sec(exp(x)), y, x),
-        (x, Union(imageset(Lambda(n, log(2*n*pi + asec(y))), S.Integers), \
-                imageset(Lambda(n, log(2*n*pi - asec(y))), S.Integers))))
+    assert dumeq(invert_real(sec(exp(x)), y, x), (x,
+        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
+            Union(ImageSet(Lambda(n, log(2*n*pi - asec(y))), S.Integers),
+                ImageSet(Lambda(n, log(2*n*pi + asec(y))), S.Integers)))))
 
-    assert dumeq(invert_real(tan(x), y, x),
-        (x, imageset(Lambda(n, n*pi + atan(y)), S.Integers)))
+    assert dumeq(invert_real(tan(x), y, x), (x,
+        ConditionSet(x, (-oo < y) & (y < oo),
+            ImageSet(Lambda(n, n*pi + atan(y)), S.Integers))))
 
-    assert dumeq(invert_real(tan(exp(x)), y, x),
-        (x, imageset(Lambda(n, log(n*pi + atan(y))), S.Integers)))
+    assert dumeq(invert_real(tan(exp(x)), y, x), (x,
+        ConditionSet(x, (-oo < y) & (y < oo),
+            ImageSet(Lambda(n, log(n*pi + atan(y))), S.Integers))))
 
-    assert dumeq(invert_real(cot(x), y, x),
-        (x, imageset(Lambda(n, n*pi + acot(y)), S.Integers)))
+    assert dumeq(invert_real(cot(x), y, x), (x,
+        ConditionSet(x, (-oo < y) & (y < oo),
+            ImageSet(Lambda(n, n*pi + acot(y)), S.Integers))))
 
-    assert dumeq(invert_real(cot(exp(x)), y, x),
-        (x, imageset(Lambda(n, log(n*pi + acot(y))), S.Integers)))
+    assert dumeq(invert_real(cot(exp(x)), y, x), (x,
+        ConditionSet(x, (-oo < y) & (y < oo),
+            ImageSet(Lambda(n, log(n*pi + acot(y))), S.Integers))))
 
     assert dumeq(invert_real(tan(tan(x)), y, x),
-        (tan(x), imageset(Lambda(n, n*pi + atan(y)), S.Integers)))
+        (x, ConditionSet(x, Eq(tan(tan(x)), y), S.Reals)))
+        # slight regression compared to previous result:
+        # (tan(x), imageset(Lambda(n, n*pi + atan(y)), S.Integers)))
 
     x = Symbol('x', positive=True)
     assert invert_real(x**pi, y, x) == (x, FiniteSet(y**(1/pi)))
@@ -199,9 +209,11 @@ def test_invert_real():
         FiniteSet(-asech(r), asech(r)), S.Reals))
     assert invert_real(csch(x), p, x) == (x, FiniteSet(acsch(p)))
 
-    assert dumeq(invert_real(tanh(sin(x)), r, x), (x, Union(
-        ImageSet(Lambda(n, 2*n*pi + asin(atanh(r))), S.Integers),
-        ImageSet(Lambda(n, 2*n*pi - asin(atanh(r)) + pi), S.Integers))))
+    assert dumeq(invert_real(tanh(sin(x)), r, x), (x,
+        ConditionSet(x, (S(-1) <= atanh(r)) & (atanh(r) <= S(1)), Union(
+            ImageSet(Lambda(n, 2*n*pi + asin(atanh(r))), S.Integers),
+            ImageSet(Lambda(n, 2*n*pi - asin(atanh(r)) + pi), S.Integers)))))
+
 
 def test_invert_trig_hyp_real():
     # check some codepaths that are not as easily reached otherwise
@@ -932,8 +944,9 @@ def test_solve_trig():
               imageset(Lambda(n, 2*n*pi + pi/3), S.Integers)))
 
     assert dumeq(solveset(sin(y + a) - sin(y), a, domain=S.Reals),
-        Union(ImageSet(Lambda(n, 2*n*pi - y + asin(sin(y))), S.Integers),
-              ImageSet(Lambda(n, 2*n*pi - y - asin(sin(y)) + pi), S.Integers)))
+        ConditionSet(a, (S(-1) <= sin(y)) & (sin(y) <= S(1)), Union(
+            ImageSet(Lambda(n, 2*n*pi - y + asin(sin(y))), S.Integers),
+            ImageSet(Lambda(n, 2*n*pi - y - asin(sin(y)) + pi), S.Integers))))
 
     assert dumeq(solveset_real(sin(2*x)*cos(x) + cos(2*x)*sin(x)-1, x),
         ImageSet(Lambda(n, n*pi*Rational(2, 3) + pi/6), S.Integers))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -906,8 +906,8 @@ def test_solve_trig():
               imageset(Lambda(n, 2*n*pi + pi/3), S.Integers)))
 
     assert dumeq(solveset(sin(y + a) - sin(y), a, domain=S.Reals),
-        Union(ImageSet(Lambda(n, 2*n*pi), S.Integers),
-        Intersection(ImageSet(Lambda(n, -I*(I*(2*n*pi + arg(-exp(-2*I*y))) + 2*im(y))), S.Integers), S.Reals)))
+        Union(ImageSet(Lambda(n, 2*n*pi - y + asin(sin(y))), S.Integers),
+              ImageSet(Lambda(n, 2*n*pi - y - asin(sin(y)) + pi), S.Integers)))
 
     assert dumeq(solveset_real(sin(2*x)*cos(x) + cos(2*x)*sin(x)-1, x),
         ImageSet(Lambda(n, n*pi*Rational(2, 3) + pi/6), S.Integers))
@@ -1095,8 +1095,8 @@ def test_solve_trig_hyp_symbolic():
         ImageSet(Lambda(n, 2*n*pi/a), S.Integers))))
 
     assert dumeq(solveset(cosh(x/a), x), ConditionSet(x, Ne(a, 0), Union(
-        ImageSet(Lambda(n, I*a*(2*n*pi + pi/2)), S.Integers),
-        ImageSet(Lambda(n, I*a*(2*n*pi - pi/2)), S.Integers))))
+        ImageSet(Lambda(n, a*(2*n*I*pi + I*pi/2)), S.Integers),
+        ImageSet(Lambda(n, a*(2*n*I*pi + 3*I*pi/2)), S.Integers))))
 
     assert dumeq(solveset(sin(2*sqrt(3)/3*a**2/(b*pi)*x)
         + cos(4*sqrt(3)/3*a**2/(b*pi)*x), x),

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1108,10 +1108,10 @@ def test_solve_trig_hyp_symbolic():
         ImageSet(Lambda(n, pi*(1 - I)*(4*n + 1)/4), S.Integers),
         ImageSet(Lambda(n, pi*(1 - I)*(4*n - 1)/4), S.Integers)))
 
-    assert dumeq(solveset(cosh((a**2 + 1)*x) - 3, x), Union(
-            # XXX this test previously had a ConditionSet with Ne(a**2+1, 0).
+    assert dumeq(solveset(cosh((a**2 + 1)*x) - 3, x), ConditionSet(
+        x, Ne(a**2 + 1, 0), Union(
             ImageSet(Lambda(n, (2*n*I*pi - acosh(3))/(a**2 + 1)), S.Integers),
-            ImageSet(Lambda(n, (2*n*I*pi + acosh(3))/(a**2 + 1)), S.Integers)))
+            ImageSet(Lambda(n, (2*n*I*pi + acosh(3))/(a**2 + 1)), S.Integers))))
 
     ar = Symbol('ar', real=True)
     assert solveset(cosh((ar**2 + 1)*x) - 2, x, S.Reals) == FiniteSet(

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2115,9 +2115,11 @@ def test_issue_19050():
 
 
 def test_issue_16618():
-    # AttributeError is removed !
     eqn = [sin(x)*sin(y), cos(x)*cos(y) - 1]
-    ans = FiniteSet((x, 2*n*pi), (2*n*pi, y), (x, 2*n*pi + pi), (2*n*pi + pi, y))
+    # nonlinsolve's answer is still suspicious since it contains only three
+    # distinct Dummys instead of 4. (Both 'x' ImageSets share the same Dummy.)
+    ans = FiniteSet((ImageSet(Lambda(n, 2*n*pi), S.Integers), ImageSet(Lambda(n, 2*n*pi), S.Integers)),
+        (ImageSet(Lambda(n, 2*n*pi + pi), S.Integers), ImageSet(Lambda(n, 2*n*pi + pi), S.Integers)))
     sol = nonlinsolve(eqn, [x, y])
 
     for i0, j0 in zip(ordered(sol), ordered(ans)):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -922,8 +922,8 @@ def test_solve_trig():
                             ImageSet(Lambda(n, n*pi), S.Integers))
 
     assert dumeq(solveset(sin(x/10) + Rational(3, 4)), Union(
-        ImageSet(Lambda(n, 20*n*pi + 10*atan(3*sqrt(7)/7) + 10*pi), S.Integers),
-        ImageSet(Lambda(n, 20*n*pi - 10*atan(3*sqrt(7)/7) + 20*pi), S.Integers)))
+        ImageSet(Lambda(n, 20*n*pi - 10*asin(S(3)/4) + 20*pi), S.Integers),
+        ImageSet(Lambda(n, 20*n*pi + 10*asin(S(3)/4) + 10*pi), S.Integers)))
 
     assert dumeq(solveset(cos(x/15) + cos(x/5)), Union(
         ImageSet(Lambda(n, 30*n*pi + 15*pi/2), S.Integers),
@@ -934,8 +934,8 @@ def test_solve_trig():
         ImageSet(Lambda(n, 30*n*pi + 15*pi/4), S.Integers)))
 
     assert dumeq(solveset(sec(sqrt(2)*x/3) + 5), Union(
-        ImageSet(Lambda(n, 3*sqrt(2)*(2*n*pi - pi + atan(2*sqrt(6)))/2), S.Integers),
-        ImageSet(Lambda(n, 3*sqrt(2)*(2*n*pi - atan(2*sqrt(6)) + pi)/2), S.Integers)))
+        ImageSet(Lambda(n, 3*sqrt(2)*(2*n*pi - asec(-5))/2), S.Integers),
+        ImageSet(Lambda(n, 3*sqrt(2)*(2*n*pi + asec(-5))/2), S.Integers)))
 
     assert dumeq(simplify(solveset(tan(pi*x) - cot(pi/2*x))), Union(
         ImageSet(Lambda(n, 4*n + 1), S.Integers),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #21296
Improves #17667
Improves #17579
Fixes #17334
Related to #12340
Closes #20798
Fixes #9825

#### Brief description of what is fixed or changed
This PR adds
- inverting of complex trigonometric functions
- inverting of complex hyperbolic functions
- domain checking to the inverter for real-valued trig
- a lot of tests

It also improves `_solve_trig` by using the inverter for more types of equations. It adds a bit of domain checking.

#### Other comments
The downside of the more precise results with this PR is that there are now more `ConditionSet`s when symbols are involved.

In order to make the test suite pass, I also had to fix two bugs in `nonlinsolve`. Even with the debugger these were quite frustrating to track down. (See the relevant commits.)

I guess there's always more to be done, but at this point I'd just like to kindly request a review in order to get this merged. (I'll remove the draft status as soon as the tests have successfully completed.)

Further work that could be done: unify trig/hyp inverting a bit more, refactor that part a bit.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Implemented `invert`ing of complex-valued trigonometric or hyperbolic functions.
  * Improved `solveset` by using the inverter more often for trigonometric or hyperbolic equations.
  * Added domain checking to the real-valued trigonometric inverter used by `solveset`.
  * nonlinsolve: Fix two bugs related to solving systems involving trigonometric functions. (Wrong results fixed.)
<!-- END RELEASE NOTES -->
