### PR TITLE
Replace lambdas with operator when appropiate

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -965,7 +965,7 @@ class Mul(Expr, AssocOp):
             if d:
                 # Note: reduce is used in step of Mul as Mul is unable to
                 # handle subtypes and operation priority:
-                terms.append(reduce(lambda x, y: x*y, (args[:i] + [d] + args[i + 1:]), S.One))
+                terms.append(reduce(operator.mul, (args[:i] + [d] + args[i + 1:]), S.One))
         return Add.fromiter(terms)
 
     @cacheit

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -32,6 +32,7 @@ from sympy.polys.domains import FF
 from sympy.polys.polytools import Poly
 from sympy.utilities.misc import as_int, filldedent, translate
 from sympy.utilities.iterables import uniq, multiset
+import math
 import operator
 
 
@@ -1540,7 +1541,7 @@ def _rsa_key(*args, public=True, private=True, totient='Euler', index=None, mult
             new_primes.extend(factorint(i, multiple=True))
         primes = new_primes
 
-    n = reduce(operator.mul, primes)
+    n = math.prod(primes)
 
     tally = multiset(primes)
     if all(v == 1 for v in tally.values()):

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -32,6 +32,7 @@ from sympy.polys.domains import FF
 from sympy.polys.polytools import Poly
 from sympy.utilities.misc import as_int, filldedent, translate
 from sympy.utilities.iterables import uniq, multiset
+import operator
 
 
 class NonInvertibleCipherWarning(RuntimeWarning):
@@ -1539,7 +1540,7 @@ def _rsa_key(*args, public=True, private=True, totient='Euler', index=None, mult
             new_primes.extend(factorint(i, multiple=True))
         primes = new_primes
 
-    n = reduce(lambda i, j: i*j, primes)
+    n = reduce(operator.mul, primes)
 
     tally = multiset(primes)
     if all(v == 1 for v in tally.values()):
@@ -1886,7 +1887,7 @@ def _encipher_decipher_rsa(i, key, factors=None):
                     break
         return is_coprime_set
 
-    prod = reduce(lambda i, j: i*j, factors)
+    prod = reduce(operator.mul, factors)
     if prod == n and _is_coprime_set(factors):
         return _decipher_rsa_crt(i, d, factors)
     return _encipher_decipher_rsa(i, key, factors=None)

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -23,6 +23,7 @@ from sympy.core.sympify import _sympify
 from sympy.geometry import Segment2D, Polygon, Point, Point2D
 from sympy.polys.polytools import LC, gcd_list, degree_list, Poly
 from sympy.simplify.simplify import nsimplify
+import operator
 
 
 def polytope_integrate(poly, expr=None, *, clockwise=False, max_degree=None):
@@ -550,7 +551,7 @@ def left_integral2D(m, index, facets, x0, expr, gens):
         if j in ((index - 1) % m, (index + 1) % m):
             intersect = intersection(facets[index], facets[j], "segment2D")
         if intersect:
-            distance_origin = norm(tuple(map(lambda x, y: x - y,
+            distance_origin = norm(tuple(map(operator.sub,
                                              intersect, x0)))
             if is_vertex(intersect):
                 if isinstance(expr, Expr):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -67,6 +67,7 @@ from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
+import operator
 
 
 @dataclass
@@ -1029,9 +1030,9 @@ def special_function_rule(integral):
             (Mul, _symbol**e*exp(a*_symbol, evaluate=False), None, UpperGammaRule),
             (Mul, polylog(b, a*_symbol, evaluate=False)/_symbol, None, PolylogRule),
             (Pow, 1/sqrt(a - d*sin(_symbol, evaluate=False)**2),
-                lambda a, d: a != d, EllipticFRule),
+                operator.ne, EllipticFRule),
             (Pow, sqrt(a - d*sin(_symbol, evaluate=False)**2),
-                lambda a, d: a != d, EllipticERule),
+                operator.ne, EllipticERule),
         ))
     _integrand = integrand.subs(symbol, _symbol)
     for type_, pattern, constraint, rule in _special_function_patterns:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -67,7 +67,6 @@ from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
-import operator
 
 
 @dataclass
@@ -1030,9 +1029,9 @@ def special_function_rule(integral):
             (Mul, _symbol**e*exp(a*_symbol, evaluate=False), None, UpperGammaRule),
             (Mul, polylog(b, a*_symbol, evaluate=False)/_symbol, None, PolylogRule),
             (Pow, 1/sqrt(a - d*sin(_symbol, evaluate=False)**2),
-                operator.ne, EllipticFRule),
+                lambda a, d: a != d, EllipticFRule),
             (Pow, sqrt(a - d*sin(_symbol, evaluate=False)**2),
-                operator.ne, EllipticERule),
+                lambda a, d: a != d, EllipticERule),
         ))
     _integrand = integrand.subs(symbol, _symbol)
     for type_, pattern, constraint, rule in _special_function_patterns:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -18,6 +18,7 @@ from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
+import operator
 
 
 def as_Boolean(e):
@@ -2603,7 +2604,7 @@ def anf_coeffs(truthvalues):
         tmp = []
         for j in range(2 ** (n-i-1)):
             tmp.append(coeffs[2*j] +
-                list(map(lambda x, y: x^y, coeffs[2*j], coeffs[2*j+1])))
+                list(map(operator.xor, coeffs[2*j], coeffs[2*j+1])))
         coeffs = tmp
 
     return coeffs[0]

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -42,6 +42,7 @@ from .exceptions import ( # noqa: F401
     MatrixError, ShapeError, NonSquareMatrixError, NonInvertibleMatrixError,
     NonPositiveDefiniteMatrixError
 )
+import operator
 
 
 _DEPRECATED_MIXINS = (
@@ -2649,7 +2650,7 @@ class MatrixArithmetic(MatrixRequired):
                 # Some matrices don't work with `sum` or `Add`
                 # They don't work with `sum` because `sum` tries to add `0`
                 # Fall back to a safe way to multiply if the `Add` fails.
-                return reduce(lambda a, b: a + b, vec)
+                return reduce(operator.add, vec)
 
         return self._new(self.rows, other.cols, entry)
 

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -4,6 +4,7 @@ from sympy.functions import KroneckerDelta
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import FunctionMatrix, MatrixExpr, Identity
 from sympy.testing.pytest import raises
+import operator
 
 
 def test_funcmatrix_creation():
@@ -45,7 +46,7 @@ def test_funcmatrix():
     assert X[1, 2] == -1
     assert X.shape == (3, 3)
     assert X.rows == X.cols == 3
-    assert Matrix(X) == Matrix(3, 3, lambda i, j: i - j)
+    assert Matrix(X) == Matrix(3, 3, operator.sub)
     assert isinstance(X*X + X, MatrixExpr)
 
 

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -84,6 +84,7 @@ from .decompositions import (
 from .graph import (
     _connected_components, _connected_components_decomposition,
     _strongly_connected_components, _strongly_connected_components_decomposition)
+import operator
 
 
 class MatrixBase(Printable):
@@ -2577,7 +2578,7 @@ class MatrixBase(Printable):
                 # Some matrices don't work with `sum` or `Add`
                 # They don't work with `sum` because `sum` tries to add `0`
                 # Fall back to a safe way to multiply if the `Add` fails.
-                return reduce(lambda a, b: a + b, vec)
+                return reduce(operator.add, vec)
 
         return self._new(self.rows, other.cols, entry)
 

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -11,6 +11,7 @@ from sympy.matrices.immutable import \
     ImmutableDenseMatrix, ImmutableSparseMatrix
 from sympy.abc import x, y
 from sympy.testing.pytest import raises
+import operator
 
 IM = ImmutableDenseMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 ISM = ImmutableSparseMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -110,7 +111,7 @@ def test_immutable_evaluation():
 
 
 def test_deterimant():
-    assert ImmutableMatrix(4, 4, lambda i, j: i + j).det() == 0
+    assert ImmutableMatrix(4, 4, operator.add).det() == 0
 
 
 def test_Equality():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -61,6 +61,7 @@ classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
 # Test the deprecated matrixmixins
 from sympy.matrices.common import _MinimalMatrix, _CastableMatrix
 from sympy.matrices.matrices import MatrixSubspaces, MatrixReductions
+import operator
 
 
 with warns_deprecated_sympy():
@@ -820,7 +821,7 @@ def test_slicing():
     assert m0[:3, :3] == eye(3)
     assert m0[2:4, 0:2] == zeros(2)
 
-    m1 = Matrix(3, 3, lambda i, j: i + j)
+    m1 = Matrix(3, 3, operator.add)
     assert m1[0, :] == Matrix(1, 3, (0, 1, 2))
     assert m1[1:3, 1] == Matrix(2, 1, (2, 3))
 
@@ -869,7 +870,7 @@ def test_extract():
 def test_reshape():
     m0 = eye(3)
     assert m0.reshape(1, 9) == Matrix(1, 9, (1, 0, 0, 0, 1, 0, 0, 0, 1))
-    m1 = Matrix(3, 4, lambda i, j: i + j)
+    m1 = Matrix(3, 4, operator.add)
     assert m1.reshape(
         4, 3) == Matrix(((0, 1, 2), (3, 1, 2), (3, 4, 2), (3, 4, 5)))
     assert m1.reshape(2, 6) == Matrix(((0, 1, 2, 3, 1, 2), (3, 4, 2, 3, 4, 5)))

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -25,6 +25,7 @@ from sympy.testing.pytest import (
     ignore_warnings, raises, skip, skip_under_pyodide, slow,
     warns_deprecated_sympy)
 from sympy.utilities.iterables import capture, iterable
+import operator
 
 all_classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
 mutable_classes = (Matrix, SparseMatrix)
@@ -1580,7 +1581,7 @@ def test_slicing():
     assert m0[:3, :3] == eye(3)
     assert m0[2:4, 0:2] == zeros(2)
 
-    m1 = Matrix(3, 3, lambda i, j: i + j)
+    m1 = Matrix(3, 3, operator.add)
     assert m1[0, :] == Matrix(1, 3, (0, 1, 2))
     assert m1[1:3, 1] == Matrix(2, 1, (2, 3))
 
@@ -1620,7 +1621,7 @@ def test_submatrix_assignment():
 def test_reshape():
     m0 = eye(3)
     assert m0.reshape(1, 9) == Matrix(1, 9, (1, 0, 0, 0, 1, 0, 0, 0, 1))
-    m1 = Matrix(3, 4, lambda i, j: i + j)
+    m1 = Matrix(3, 4, operator.add)
     assert m1.reshape(
         4, 3) == Matrix(((0, 1, 2), (3, 1, 2), (3, 4, 2), (3, 4, 5)))
     assert m1.reshape(2, 6) == Matrix(((0, 1, 2, 3, 1, 2), (3, 4, 2, 3, 4, 5)))

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -7,6 +7,7 @@ from sympy.matrices import \
     Matrix, MutableSparseMatrix, ImmutableSparseMatrix, SparseMatrix, eye, \
     ones, zeros, ShapeError, NonSquareMatrixError
 from sympy.testing.pytest import raises
+import operator
 
 
 def test_sparse_creation():
@@ -269,7 +270,7 @@ def test_sparse_matrix():
     assert m0[:3, :3] == sparse_eye(3)
     assert m0[2:4, 0:2] == sparse_zeros(2)
 
-    m1 = SparseMatrix(3, 3, lambda i, j: i + j)
+    m1 = SparseMatrix(3, 3, operator.add)
     assert m1[0, :] == SparseMatrix(1, 3, (0, 1, 2))
     assert m1[1:3, 1] == SparseMatrix(2, 1, (2, 3))
 
@@ -311,7 +312,7 @@ def test_sparse_matrix():
     # test_reshape
     m0 = sparse_eye(3)
     assert m0.reshape(1, 9) == SparseMatrix(1, 9, (1, 0, 0, 0, 1, 0, 0, 0, 1))
-    m1 = SparseMatrix(3, 4, lambda i, j: i + j)
+    m1 = SparseMatrix(3, 4, operator.add)
     assert m1.reshape(4, 3) == \
         SparseMatrix([(0, 1, 2), (3, 1, 2), (3, 4, 2), (3, 4, 5)])
     assert m1.reshape(2, 6) == \

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -7,7 +7,6 @@ from sympy.matrices import \
     Matrix, MutableSparseMatrix, ImmutableSparseMatrix, SparseMatrix, eye, \
     ones, zeros, ShapeError, NonSquareMatrixError
 from sympy.testing.pytest import raises
-import operator
 
 
 def test_sparse_creation():
@@ -270,7 +269,7 @@ def test_sparse_matrix():
     assert m0[:3, :3] == sparse_eye(3)
     assert m0[2:4, 0:2] == sparse_zeros(2)
 
-    m1 = SparseMatrix(3, 3, operator.add)
+    m1 = SparseMatrix(3, 3, lambda i, j: i + j)
     assert m1[0, :] == SparseMatrix(1, 3, (0, 1, 2))
     assert m1[1:3, 1] == SparseMatrix(2, 1, (2, 3))
 
@@ -312,7 +311,7 @@ def test_sparse_matrix():
     # test_reshape
     m0 = sparse_eye(3)
     assert m0.reshape(1, 9) == SparseMatrix(1, 9, (1, 0, 0, 0, 1, 0, 0, 0, 1))
-    m1 = SparseMatrix(3, 4, operator.add)
+    m1 = SparseMatrix(3, 4, lambda i, j: i + j)
     assert m1.reshape(4, 3) == \
         SparseMatrix([(0, 1, 2), (3, 1, 2), (3, 4, 2), (3, 4, 5)])
     assert m1.reshape(2, 6) == \

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -13,6 +13,7 @@ from sympy.core.sympify import sympify
 from sympy.sets.sets import Interval
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.qexpr import QuantumError
+import operator
 
 
 __all__ = [
@@ -383,7 +384,7 @@ class TensorProductHilbertSpace(HilbertSpace):
         if S.Infinity in arg_list:
             return S.Infinity
         else:
-            return reduce(lambda x, y: x*y, arg_list)
+            return reduce(operator.mul, arg_list)
 
     @property
     def spaces(self):
@@ -502,7 +503,7 @@ class DirectSumHilbertSpace(HilbertSpace):
         if S.Infinity in arg_list:
             return S.Infinity
         else:
-            return reduce(lambda x, y: x + y, arg_list)
+            return reduce(operator.add, arg_list)
 
     @property
     def spaces(self):

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -25,6 +25,7 @@ from sympy.matrices.dense import Matrix
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.core.expr import Expr
 from sympy.core.power import Pow
+import operator
 
 
 class _QuantityMapper:
@@ -261,7 +262,7 @@ class Dimension(Expr):
 
     @classmethod
     def _from_dimensional_dependencies(cls, dependencies):
-        return reduce(lambda x, y: x * y, (
+        return reduce(operator.mul, (
             d**e for d, e in dependencies.items()
         ), 1)
 

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -18,6 +18,7 @@ from sympy.physics.units.prefixes import Prefix
 from sympy.physics.units.quantities import Quantity
 from sympy.physics.units.unitsystem import UnitSystem
 from sympy.utilities.iterables import sift
+import operator
 
 
 def _get_conversion_matrix_for_expr(expr, target_units, unit_system):
@@ -111,7 +112,7 @@ def convert_to(expr, target_units, unit_system="SI"):
 
     def get_total_scale_factor(expr):
         if isinstance(expr, Mul):
-            return reduce(lambda x, y: x * y,
+            return reduce(operator.mul,
                 [get_total_scale_factor(i) for i in expr.args])
         elif isinstance(expr, Pow):
             return get_total_scale_factor(expr.base) ** expr.exp

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -74,6 +74,7 @@ from sympy.utilities.iterables import numbered_symbols
 
 from sympy.external import import_module
 import warnings
+import operator
 
 #TODO debugging output
 
@@ -242,8 +243,8 @@ class Lambdifier:
         # and sympy_expression_namespace can not catch it.
         from sympy.functions.elementary.miscellaneous import sqrt
         namespace.update({'sqrt': sqrt})
-        namespace.update({'Eq': lambda x, y: x == y})
-        namespace.update({'Ne': lambda x, y: x != y})
+        namespace.update({'Eq': operator.eq})
+        namespace.update({'Ne': operator.ne})
         # End workaround.
         if use_python_math:
             namespace.update({'math': __import__('math')})

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -28,6 +28,7 @@ from sympy.polys.rationaltools import together
 from sympy.polys.specialpolys import cyclotomic_poly
 from sympy.utilities import public
 from sympy.utilities.misc import filldedent
+import operator
 
 
 
@@ -1218,7 +1219,7 @@ def root_factors(f, *gens, filter=None, **args):
             factors, N = factors + [Poly(x - r, x)]*n, N + n
 
         if N < F.degree():
-            G = reduce(lambda p, q: p*q, factors)
+            G = reduce(operator.mul, factors)
             factors.append(F.quo(G))
 
     if not isinstance(f, Poly):

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -45,6 +45,7 @@ from sympy.core.singleton import S
 from sympy.testing.pytest import raises
 
 from sympy.core.numbers import oo
+import operator
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
 
@@ -667,7 +668,7 @@ def test_dmp_list_terms():
 
 
 def test_dmp_apply_pairs():
-    h = lambda a, b: a*b
+    h = operator.mul
 
     assert dmp_apply_pairs([1, 2, 3], [4, 5, 6], h, [], 0, ZZ) == [4, 10, 18]
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -130,6 +130,7 @@ from sympy.series.order import Order
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import debug_decorator as debug
 from sympy.utilities.timeutils import timethis
+import operator
 
 timeit = timethis('gruntz')
 
@@ -595,7 +596,7 @@ def build_expression_tree(Omega, rewrites):
             self.expr = None
             self.var = None
         def ht(self):
-            return reduce(lambda x, y: x + y,
+            return reduce(operator.add,
                           [x.ht() for x in self.before], 1)
     nodes = {}
     for expr, v in Omega:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -32,6 +32,7 @@ from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
 
 from mpmath.libmp.libmpf import prec_to_dps
+import operator
 
 
 tfn = defaultdict(lambda: None, {
@@ -991,7 +992,7 @@ ProductSet(iterable) is deprecated. Use ProductSet(*iterable) instead.
         return SetKind(TupleKind(*(i.kind.element_kind for i in self.args)))
 
     def __len__(self):
-        return reduce(lambda a, b: a*b, (len(s) for s in self.args))
+        return reduce(operator.mul, (len(s) for s in self.args))
 
     def __bool__(self):
         return all(self.sets)
@@ -1596,7 +1597,7 @@ class Intersection(Set, LatticeOp):
 
         # Convert to Python sets and build the set of all elements
         fs_sets = [set(fs) for fs in fs_args]
-        all_elements = reduce(lambda a, b: a | b, fs_sets, set())
+        all_elements = reduce(operator.or_, fs_sets, set())
 
         # Extract elements that are definitely in or definitely not in the
         # intersection. Here we check contains for all of args.
@@ -1619,7 +1620,7 @@ class Intersection(Set, LatticeOp):
         # sets iteratively until we end up with {n}, {}. At that point if we
         # get any empty set all remaining elements are discarded.
 
-        fs_elements = reduce(lambda a, b: a | b, fs_sets, set())
+        fs_elements = reduce(operator.or_, fs_sets, set())
 
         # Need fuzzy containment testing
         fs_symsets = [FiniteSet(*s) for s in fs_sets]
@@ -1661,7 +1662,7 @@ class Intersection(Set, LatticeOp):
 
         # Any set in others is redundant if it contains all the elements that
         # are in the finite sets so we don't need it in the Intersection
-        all_elements = reduce(lambda a, b: a | b, fs_sets, set())
+        all_elements = reduce(operator.or_, fs_sets, set())
         is_redundant = lambda o: all(fuzzy_bool(o.contains(e)) for e in all_elements)
         others = [o for o in others if not is_redundant(o)]
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable
-from functools import reduce
 from collections import defaultdict
 import inspect
+import math
 
 from sympy.core.kind import Kind, UndefinedKind, NumberKind
 from sympy.core.basic import Basic
@@ -32,7 +32,6 @@ from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
 
 from mpmath.libmp.libmpf import prec_to_dps
-import operator
 
 
 tfn = defaultdict(lambda: None, {
@@ -992,7 +991,7 @@ ProductSet(iterable) is deprecated. Use ProductSet(*iterable) instead.
         return SetKind(TupleKind(*(i.kind.element_kind for i in self.args)))
 
     def __len__(self):
-        return reduce(operator.mul, (len(s) for s in self.args))
+        return math.prod(len(s) for s in self.args)
 
     def __bool__(self):
         return all(self.sets)
@@ -1597,7 +1596,7 @@ class Intersection(Set, LatticeOp):
 
         # Convert to Python sets and build the set of all elements
         fs_sets = [set(fs) for fs in fs_args]
-        all_elements = reduce(operator.or_, fs_sets, set())
+        all_elements = set().union(*fs_sets)
 
         # Extract elements that are definitely in or definitely not in the
         # intersection. Here we check contains for all of args.
@@ -1620,7 +1619,7 @@ class Intersection(Set, LatticeOp):
         # sets iteratively until we end up with {n}, {}. At that point if we
         # get any empty set all remaining elements are discarded.
 
-        fs_elements = reduce(operator.or_, fs_sets, set())
+        fs_elements = set().union(*fs_sets)
 
         # Need fuzzy containment testing
         fs_symsets = [FiniteSet(*s) for s in fs_sets]
@@ -1662,7 +1661,7 @@ class Intersection(Set, LatticeOp):
 
         # Any set in others is redundant if it contains all the elements that
         # are in the finite sets so we don't need it in the Intersection
-        all_elements = reduce(operator.or_, fs_sets, set())
+        all_elements = set().union(*fs_sets)
         is_redundant = lambda o: all(fuzzy_bool(o.contains(e)) for e in all_elements)
         others = [o for o in others if not is_redundant(o)]
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -27,6 +27,7 @@ from sympy.abc import x, y, t, z
 from sympy.core.mod import Mod
 
 import itertools
+import operator
 
 
 def test_naturals():
@@ -140,7 +141,7 @@ def test_ImageSet():
     assert 2/S(100) not in ImageSet(Lambda(((x, y),), 2/x), c)
     assert Rational(2, 3) in ImageSet(Lambda(((x, y),), 2/x), c)
 
-    S1 = imageset(lambda x, y: x + y, S.Integers, S.Naturals)
+    S1 = imageset(operator.add, S.Integers, S.Naturals)
     assert S1.base_pset == ProductSet(S.Integers, S.Naturals)
     assert S1.base_sets == (S.Integers, S.Naturals)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -27,6 +27,7 @@ from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 from sympy.utilities.iterables import cartes
 
 from sympy.abc import x, y, z, m, n
+import operator
 
 EmptySet = S.EmptySet
 
@@ -355,14 +356,14 @@ def test_Complement():
 def test_set_operations_nonsets():
     '''Tests that e.g. FiniteSet(1) * 2 raises TypeError'''
     ops = [
-        lambda a, b: a + b,
-        lambda a, b: a - b,
-        lambda a, b: a * b,
-        lambda a, b: a / b,
-        lambda a, b: a // b,
-        lambda a, b: a | b,
-        lambda a, b: a & b,
-        lambda a, b: a ^ b,
+        operator.add,
+        operator.sub,
+        operator.mul,
+        operator.truediv,
+        operator.floordiv,
+        operator.or_,
+        operator.and_,
+        operator.xor,
         # FiniteSet(1) ** 2 gives a ProductSet
         #lambda a, b: a ** b,
     ]

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -32,6 +32,7 @@ from sympy.solvers.solvers import solve
 
 from sympy.testing.pytest import XFAIL, slow, _both_exp_pow
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, n
+import operator
 
 
 def test_issue_7263():
@@ -825,7 +826,7 @@ def test_nc_simplify():
     C = MatrixSymbol("C", x, x)
     D = MatrixSymbol("D", x, x)
     subst = {a: A, b: B, c: C, d:D}
-    funcs = {Add: lambda x,y: x+y, Mul: lambda x,y: x*y }
+    funcs = {Add: operator.add, Mul: operator.mul }
 
     def _to_matrix(expr):
         if expr in subst:

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -24,6 +24,7 @@ from sympy.strategies.core import identity
 from sympy.strategies.tree import greedy
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
+import operator
 
 def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
                       polynomial=False):
@@ -939,7 +940,7 @@ def _replace_mul_fpowxgpow(expr, f, g, rexp, h, rexph):
 
 
 _idn = lambda x: x
-_midn = lambda x: -x
+_midn = operator.neg
 _one = lambda x: S.One
 
 def _match_div_rewrite(expr, i):

--- a/sympy/strategies/tests/test_tree.py
+++ b/sympy/strategies/tests/test_tree.py
@@ -1,5 +1,6 @@
 from sympy.strategies.tree import treeapply, greedy, allresults, brute
 from functools import partial, reduce
+import operator
 
 
 def inc(x):
@@ -23,7 +24,7 @@ def add(*args):
 
 
 def mul(*args):
-    return reduce(lambda a, b: a * b, args, 1)
+    return reduce(operator.mul, args, 1)
 
 
 def test_treeapply():
@@ -51,7 +52,7 @@ def test_treeapply_strategies():
     assert treeapply(tree, join)(5) == 6
     assert treeapply(tree, join)(1) == 0
 
-    maximize = partial(minimize, objective=lambda x: -x)
+    maximize = partial(minimize, objective=operator.neg)
     join = {list: chain, tuple: maximize}
     fn = treeapply(tree, join)
     assert fn(4) == 6  # highest value comes from the dec then double
@@ -61,7 +62,7 @@ def test_treeapply_strategies():
 def test_greedy():
     tree = [inc, (dec, double)]  # either inc or dec-then-double
 
-    fn = greedy(tree, objective=lambda x: -x)
+    fn = greedy(tree, objective=operator.neg)
     assert fn(4) == 6  # highest value comes from the dec then double
     assert fn(1) == 2  # highest value comes from the inc
 
@@ -69,7 +70,7 @@ def test_greedy():
     lowest = greedy(tree)
     assert lowest(10) == 8
 
-    highest = greedy(tree, objective=lambda x: -x)
+    highest = greedy(tree, objective=operator.neg)
     assert highest(10) == 12
 
 
@@ -84,7 +85,7 @@ def test_allresults():
 
 def test_brute():
     tree = ([inc, dec], square)
-    fn = brute(tree, lambda x: -x)
+    fn = brute(tree, operator.neg)
 
     assert fn(2) == (2 + 1)**2
     assert fn(-2) == (-2 - 1)**2

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -8,6 +8,7 @@ from sympy.core.sympify import _sympify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray, ArrayKind
 from sympy.utilities.iterables import flatten
+import operator
 
 
 class DenseNDimArray(NDimArray):
@@ -71,7 +72,7 @@ class DenseNDimArray(NDimArray):
 
     @classmethod
     def zeros(cls, *shape):
-        list_length = functools.reduce(lambda x, y: x*y, shape, S.One)
+        list_length = functools.reduce(operator.mul, shape, S.One)
         return cls._new(([0]*list_length,), shape)
 
     def tomatrix(self):
@@ -120,7 +121,7 @@ class DenseNDimArray(NDimArray):
         [[1, 2], [3, 4], [5, 6]]
 
         """
-        new_total_size = functools.reduce(lambda x,y: x*y, newshape)
+        new_total_size = functools.reduce(operator.mul, newshape)
         if new_total_size != self._loop_size:
             raise ValueError('Expecting reshape size to %d but got prod(%s) = %d' % (
                 self._loop_size, str(newshape), new_total_size))
@@ -144,7 +145,7 @@ class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray): # type: ignor
         self._shape = shape
         self._array = list(flat_list)
         self._rank = len(shape)
-        self._loop_size = functools.reduce(lambda x,y: x*y, shape, 1)
+        self._loop_size = functools.reduce(operator.mul, shape, 1)
         return self
 
     def __setitem__(self, index, value):
@@ -170,7 +171,7 @@ class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
         self._shape = shape
         self._array = list(flat_list)
         self._rank = len(shape)
-        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
+        self._loop_size = functools.reduce(operator.mul, shape) if shape else len(flat_list)
         return self
 
     def __setitem__(self, index, value):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -7,6 +7,7 @@ from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray
 from sympy.utilities.iterables import flatten
 
 import functools
+import operator
 
 class SparseNDimArray(NDimArray):
 
@@ -95,7 +96,7 @@ class SparseNDimArray(NDimArray):
         return SparseMatrix(self.shape[0], self.shape[1], mat_sparse)
 
     def reshape(self, *newshape):
-        new_total_size = functools.reduce(lambda x,y: x*y, newshape)
+        new_total_size = functools.reduce(operator.mul, newshape)
         if new_total_size != self._loop_size:
             raise ValueError("Invalid reshape parameters " + newshape)
 
@@ -107,7 +108,7 @@ class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray): # type: ign
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         shape = Tuple(*map(_sympify, shape))
         cls._check_special_bounds(flat_list, shape)
-        loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
+        loop_size = functools.reduce(operator.mul, shape) if shape else len(flat_list)
 
         # Sparse array:
         if isinstance(flat_list, (dict, Dict)):
@@ -142,7 +143,7 @@ class MutableSparseNDimArray(MutableNDimArray, SparseNDimArray):
         self = object.__new__(cls)
         self._shape = shape
         self._rank = len(shape)
-        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
+        self._loop_size = functools.reduce(operator.mul, shape) if shape else len(flat_list)
 
         # Sparse array:
         if isinstance(flat_list, (dict, Dict)):

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -18,6 +18,7 @@ from sympy.tensor.indexed import Idx, Indexed
 from sympy.utilities import sift
 
 from collections import OrderedDict
+import operator
 
 class IndexConformanceException(Exception):
     pass
@@ -84,7 +85,7 @@ def _get_indices_Mul(expr, return_dummies=False):
     inds, syms = list(zip(*inds))
 
     inds = list(map(list, inds))
-    inds = list(reduce(lambda x, y: x + y, inds))
+    inds = list(reduce(operator.add, inds))
     inds, dummies = _remove_repeated(inds)
 
     symmetry = {}

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -525,7 +525,7 @@ class _TensorDataLazyEvaluator(CantSympify):
                     free_args_pos = {y: x for x, y in enumerate(free_args)}
                     axes = [free_args_pos[arg] for arg in key.free_args]
                     sum_list.append(permutedims(data, axes))
-            return reduce(lambda x, y: x+y, sum_list)
+            return reduce(operator.add, sum_list)
 
         return None
 
@@ -3422,7 +3422,7 @@ class TensMul(TensExpr, AssocOp):
         args = [arg for arg in args if arg != self.identity]
 
         # Extract non-tensor coefficients:
-        coeff = reduce(lambda a, b: a*b, [arg for arg in args if not isinstance(arg, TensExpr)], S.One)
+        coeff = reduce(operator.mul, [arg for arg in args if not isinstance(arg, TensExpr)], S.One)
         args = [arg for arg in args if isinstance(arg, TensExpr)]
 
         if len(args) == 0:

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -26,6 +26,7 @@ from sympy.utilities.enumerative import (
 
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises, warns_deprecated_sympy
+import operator
 
 w, x, y, z = symbols('w,x,y,z')
 
@@ -262,7 +263,7 @@ def test_topological_sort():
          (11, 9), (11, 10), (8, 9)]
 
     assert topological_sort((V, E)) == [3, 5, 7, 8, 11, 2, 9, 10]
-    assert topological_sort((V, E), key=lambda v: -v) == \
+    assert topological_sort((V, E), key=operator.neg) == \
         [7, 5, 11, 3, 10, 8, 9, 2]
 
     raises(ValueError, lambda: topological_sort((V, E + [(10, 7)])))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* This replaces all lambdas that implement an operator to use the implemented operator directly
* This is arguably more readable, and way more efficient since Python has a fast dispatch path for these calls and will use the c implementation of these operators when appropriate / possible (ie. do addition / multiplication in c float type)
* This is a non-functional change / optimization and was done with an automated tool.

#### Other comments


#### Release Notes


NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
