### PR TITLE
Adding rewrite(hyper) for sin, cos, sec, and csc

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -29,7 +29,6 @@ from sympy.core.relational import Ne, Eq
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.sets.setexpr import SetExpr
 from sympy.testing.pytest import XFAIL, slow, raises
-from sympy.integrals.meijerint import _rewrite_single
 from sympy.functions.special.hyper import (hyper, meijerg)
 from sympy.simplify.hyperexpand import hyperexpand
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -221,9 +221,9 @@ def test_sin_rewrite():
     assert sin(cos(x)).rewrite(Pow) == sin(cos(x))
     assert sin(x).rewrite(besselj) == sqrt(pi*x/2)*besselj(S.Half, x)
     assert sin(x).rewrite(besselj).subs(x, 0) == sin(0)
-    assert sin(x).rewrite(hyper) == meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
-    assert sin(x).rewrite(hyper).subs(x, 0) == meijerg(((), ()), ((S.Half,), (0,)), 0)
-    assert hyperexpand(sin(x).rewrite(hyper)) == sin(x)/sqrt(pi)
+    assert sin(x).rewrite(hyper) == sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
+    assert sin(x).rewrite(hyper).subs(x, 0) == sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), 0)
+    assert hyperexpand(sin(x).rewrite(hyper)) == sin(x)
 
 
 def _test_extrig(f, i, e):
@@ -452,9 +452,9 @@ def test_cos_rewrite():
                 (1, True)
             )
     assert cos(x).rewrite(besselj).subs(x, 0) == cos(0)
-    assert cos(x).rewrite(hyper) == meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
-    assert cos(x).rewrite(hyper).subs(x, 0) == meijerg(((), ()), ((0,), (S.Half,)), 0)
-    assert hyperexpand(cos(x).rewrite(hyper)) == cos(x)/sqrt(pi)
+    assert cos(x).rewrite(hyper) == sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
+    assert cos(x).rewrite(hyper).subs(x, 0) == sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), 0)
+    assert hyperexpand(cos(x).rewrite(hyper)) == cos(x)
 
 
 def test_cos_expansion():
@@ -1738,9 +1738,9 @@ def test_sec_rewrite():
                 (1, True)
             )
     assert sec(x).rewrite(besselj).subs(x, 0) == sec(0)
-    assert sec(x).rewrite(hyper) == 1/meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
-    assert sec(x).rewrite(hyper).subs(x, 0) == 1/meijerg(((), ()), ((0,), (S.Half,)), 0)
-    assert hyperexpand(sec(x).rewrite(hyper)) == sqrt(pi)/cos(x)
+    assert sec(x).rewrite(hyper) == 1/(sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), x**2/4))
+    assert sec(x).rewrite(hyper).subs(x, 0) == 1/(sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), 0))
+    assert hyperexpand(sec(x).rewrite(hyper)) == 1/cos(x)
 
 
 def test_sec_fdiff():
@@ -1935,9 +1935,9 @@ def test_csc_rewrite():
                   I*cos(-pi/2 + I*besselj(I, I), evaluate=False), evaluate=False)
     assert csc(x).rewrite(besselj) == sqrt(2)/(sqrt(pi*x)*besselj(S.Half, x))
     assert csc(x).rewrite(besselj).subs(x, 0) == csc(0)
-    assert csc(x).rewrite(hyper) == 1/meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
-    assert csc(x).rewrite(hyper).subs(x, 0) == 1/meijerg(((), ()), ((S.Half,), (0,)), 0)
-    assert hyperexpand(csc(x).rewrite(hyper)) == sqrt(pi)/sin(x)
+    assert csc(x).rewrite(hyper) == 1/(sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), x**2/4))
+    assert csc(x).rewrite(hyper).subs(x, 0) == 1/(sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), 0))
+    assert hyperexpand(csc(x).rewrite(hyper)) == 1/sin(x)
 
 def test_acsc_leading_term():
     assert acsc(1/x).as_leading_term(x) == x

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -29,6 +29,9 @@ from sympy.core.relational import Ne, Eq
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.sets.setexpr import SetExpr
 from sympy.testing.pytest import XFAIL, slow, raises
+from sympy.integrals.meijerint import _rewrite_single
+from sympy.functions.special.hyper import (hyper, meijerg)
+from sympy.simplify.hyperexpand import hyperexpand
 
 
 x, y, z = symbols('x y z')
@@ -219,6 +222,9 @@ def test_sin_rewrite():
     assert sin(cos(x)).rewrite(Pow) == sin(cos(x))
     assert sin(x).rewrite(besselj) == sqrt(pi*x/2)*besselj(S.Half, x)
     assert sin(x).rewrite(besselj).subs(x, 0) == sin(0)
+    assert sin(x).rewrite(hyper) == meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
+    assert sin(x).rewrite(hyper).subs(x, 0) == meijerg(((), ()), ((S.Half,), (0,)), 0)
+    assert hyperexpand(sin(x).rewrite(hyper)) == sin(x)/sqrt(pi)
 
 
 def _test_extrig(f, i, e):
@@ -447,6 +453,9 @@ def test_cos_rewrite():
                 (1, True)
             )
     assert cos(x).rewrite(besselj).subs(x, 0) == cos(0)
+    assert cos(x).rewrite(hyper) == meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
+    assert cos(x).rewrite(hyper).subs(x, 0) == meijerg(((), ()), ((0,), (S.Half,)), 0)
+    assert hyperexpand(cos(x).rewrite(hyper)) == cos(x)/sqrt(pi)
 
 
 def test_cos_expansion():
@@ -1730,6 +1739,9 @@ def test_sec_rewrite():
                 (1, True)
             )
     assert sec(x).rewrite(besselj).subs(x, 0) == sec(0)
+    assert sec(x).rewrite(hyper) == 1/meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
+    assert sec(x).rewrite(hyper).subs(x, 0) == 1/meijerg(((), ()), ((0,), (S.Half,)), 0)
+    assert hyperexpand(sec(x).rewrite(hyper)) == sqrt(pi)/cos(x)
 
 
 def test_sec_fdiff():
@@ -1924,7 +1936,9 @@ def test_csc_rewrite():
                   I*cos(-pi/2 + I*besselj(I, I), evaluate=False), evaluate=False)
     assert csc(x).rewrite(besselj) == sqrt(2)/(sqrt(pi*x)*besselj(S.Half, x))
     assert csc(x).rewrite(besselj).subs(x, 0) == csc(0)
-
+    assert csc(x).rewrite(hyper) == 1/meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
+    assert csc(x).rewrite(hyper).subs(x, 0) == 1/meijerg(((), ()), ((S.Half,), (0,)), 0)
+    assert hyperexpand(csc(x).rewrite(hyper)) == sqrt(pi)/sin(x)
 
 def test_acsc_leading_term():
     assert acsc(1/x).as_leading_term(x) == x

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -221,9 +221,14 @@ def test_sin_rewrite():
     assert sin(cos(x)).rewrite(Pow) == sin(cos(x))
     assert sin(x).rewrite(besselj) == sqrt(pi*x/2)*besselj(S.Half, x)
     assert sin(x).rewrite(besselj).subs(x, 0) == sin(0)
-    assert sin(x).rewrite(hyper) == sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
-    assert sin(x).rewrite(hyper).subs(x, 0) == sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), 0)
-    assert hyperexpand(sin(x).rewrite(hyper)) == sin(x)
+    assert sin(x).rewrite(meijerg) == sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
+    assert sin(x).rewrite(meijerg).subs(x, 0) == sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), 0)
+    assert hyperexpand(sin(x).rewrite(meijerg)) == sin(x)
+    assert hyperexpand(sin(x).rewrite(meijerg)).subs(x, 0) == sin(0)
+    assert hyperexpand(sin(x).rewrite(meijerg)).subs(x, pi/2) == sin(pi/2)
+    assert hyperexpand(sin(x).rewrite(meijerg)).subs(x, -pi/2) == sin(-pi/2)
+    assert hyperexpand(sin(x).rewrite(meijerg)).subs(x, I*(-pi/2)) == -sin(I*(pi/2))
+    assert hyperexpand(sin(x).rewrite(meijerg)).subs(x, I*(pi/2)) == sin(I*(pi/2))
 
 
 def _test_extrig(f, i, e):
@@ -452,9 +457,14 @@ def test_cos_rewrite():
                 (1, True)
             )
     assert cos(x).rewrite(besselj).subs(x, 0) == cos(0)
-    assert cos(x).rewrite(hyper) == sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
-    assert cos(x).rewrite(hyper).subs(x, 0) == sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), 0)
-    assert hyperexpand(cos(x).rewrite(hyper)) == cos(x)
+    assert cos(x).rewrite(meijerg) == sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), x**2/4)
+    assert cos(x).rewrite(meijerg).subs(x, 0) == sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), 0)
+    assert hyperexpand(cos(x).rewrite(meijerg)) == cos(x)
+    assert hyperexpand(cos(x).rewrite(meijerg)).subs(x, 0) == cos(0)
+    assert hyperexpand(cos(x).rewrite(meijerg)).subs(x, pi/2) == cos(pi/2)
+    assert hyperexpand(cos(x).rewrite(meijerg)).subs(x, -pi/2) == cos(-pi/2)
+    assert hyperexpand(cos(x).rewrite(meijerg)).subs(x, I*(-pi/2)) == cos(I*(-pi/2))
+    assert hyperexpand(cos(x).rewrite(meijerg)).subs(x, I*(pi/2)) == cos(I*(pi/2))
 
 
 def test_cos_expansion():
@@ -1738,9 +1748,14 @@ def test_sec_rewrite():
                 (1, True)
             )
     assert sec(x).rewrite(besselj).subs(x, 0) == sec(0)
-    assert sec(x).rewrite(hyper) == 1/(sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), x**2/4))
-    assert sec(x).rewrite(hyper).subs(x, 0) == 1/(sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), 0))
-    assert hyperexpand(sec(x).rewrite(hyper)) == 1/cos(x)
+    assert sec(x).rewrite(meijerg) == 1/(sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), x**2/4))
+    assert sec(x).rewrite(meijerg).subs(x, 0) == 1/(sqrt(pi)*meijerg(((), ()), ((0,), (S.Half,)), 0))
+    assert hyperexpand(sec(x).rewrite(meijerg)) == 1/cos(x)
+    assert hyperexpand(sec(x).rewrite(meijerg)).subs(x, 0) == 1/cos(0)
+    assert hyperexpand(sec(x).rewrite(meijerg)).subs(x, pi/2) == 1/cos(pi/2)
+    assert hyperexpand(sec(x).rewrite(meijerg)).subs(x, -pi/2) == 1/cos(-pi/2)
+    assert hyperexpand(sec(x).rewrite(meijerg)).subs(x, I*(-pi/2)) == 1/cos(I*(-pi/2))
+    assert hyperexpand(sec(x).rewrite(meijerg)).subs(x, I*(pi/2)) == 1/cos(I*(pi/2))
 
 
 def test_sec_fdiff():
@@ -1935,9 +1950,14 @@ def test_csc_rewrite():
                   I*cos(-pi/2 + I*besselj(I, I), evaluate=False), evaluate=False)
     assert csc(x).rewrite(besselj) == sqrt(2)/(sqrt(pi*x)*besselj(S.Half, x))
     assert csc(x).rewrite(besselj).subs(x, 0) == csc(0)
-    assert csc(x).rewrite(hyper) == 1/(sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), x**2/4))
-    assert csc(x).rewrite(hyper).subs(x, 0) == 1/(sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), 0))
-    assert hyperexpand(csc(x).rewrite(hyper)) == 1/sin(x)
+    assert csc(x).rewrite(meijerg) == 1/(sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), x**2/4))
+    assert csc(x).rewrite(meijerg).subs(x, 0) == 1/(sqrt(pi)*meijerg(((), ()), ((S.Half,), (0,)), 0))
+    assert hyperexpand(csc(x).rewrite(meijerg)) == 1/sin(x)
+    assert hyperexpand(csc(x).rewrite(meijerg)).subs(x, 0) == 1/sin(0)
+    assert hyperexpand(csc(x).rewrite(meijerg)).subs(x, pi/2) == 1/sin(pi/2)
+    assert hyperexpand(csc(x).rewrite(meijerg)).subs(x, -pi/2) == 1/sin(-pi/2)
+    assert hyperexpand(csc(x).rewrite(meijerg)).subs(x, I*(-pi/2)) == 1/sin(I*(-pi/2))
+    assert hyperexpand(csc(x).rewrite(meijerg)).subs(x, I*(pi/2)) == 1/sin(I*(pi/2))
 
 def test_acsc_leading_term():
     assert acsc(1/x).as_leading_term(x) == x

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -29,7 +29,7 @@ from sympy.core.relational import Ne, Eq
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.sets.setexpr import SetExpr
 from sympy.testing.pytest import XFAIL, slow, raises
-from sympy.functions.special.hyper import (hyper, meijerg)
+from sympy.functions.special.hyper import ( meijerg)
 from sympy.simplify.hyperexpand import hyperexpand
 
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -485,7 +485,7 @@ class sin(TrigonometricFunction):
 
     def  _eval_rewrite_as_hyper(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return _rewrite_single(sin(arg), arg)[0][0][2]
+        return _rewrite_single(sin(arg), arg)[0][0][2]*sqrt(pi)
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -862,7 +862,7 @@ class cos(TrigonometricFunction):
 
     def  _eval_rewrite_as_hyper(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return _rewrite_single(cos(arg), arg)[0][0][2]
+        return _rewrite_single(cos(arg), arg)[0][0][2]*sqrt(pi)
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -1789,7 +1789,7 @@ class sec(ReciprocalTrigonometricFunction):
 
     def  _eval_rewrite_as_hyper(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return 1/(_rewrite_single(cos(arg), arg)[0][0][2])
+        return 1/(_rewrite_single(cos(arg), arg)[0][0][2]*sqrt(pi))
 
     def _eval_is_complex(self):
         arg = self.args[0]
@@ -1892,7 +1892,7 @@ class csc(ReciprocalTrigonometricFunction):
 
     def  _eval_rewrite_as_hyper(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return 1/(_rewrite_single(sin(arg), arg)[0][0][2])
+        return 1/(_rewrite_single(sin(arg), arg)[0][0][2]*sqrt(pi))
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -483,6 +483,10 @@ class sin(TrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return sqrt(pi*arg/2)*besselj(S.Half, arg)
 
+    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.integrals.meijerint import _rewrite_single
+        return _rewrite_single(sin(arg), arg)[0][0][2]
+
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
@@ -856,6 +860,10 @@ class cos(TrigonometricFunction):
                 (1, True)
             )
 
+    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.integrals.meijerint import _rewrite_single
+        return _rewrite_single(cos(arg), arg)[0][0][2]
+
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
@@ -1215,6 +1223,10 @@ class tan(TrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return besselj(S.Half, arg)/besselj(-S.Half, arg)
 
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.integrals.meijerint import _rewrite_single
+        return _rewrite_single(tan(arg), arg)[0][0][2]
+
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         from sympy.calculus.accumulationbounds import AccumBounds
         from sympy.functions.elementary.complexes import re
@@ -1503,6 +1515,10 @@ class cot(TrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return besselj(-S.Half, arg)/besselj(S.Half, arg)
 
+    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.integrals.meijerint import _rewrite_single
+        return _rewrite_single(cot(arg), arg)[0][0][2]
+
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         from sympy.calculus.accumulationbounds import AccumBounds
         from sympy.functions.elementary.complexes import re
@@ -1771,6 +1787,10 @@ class sec(ReciprocalTrigonometricFunction):
                 (1, True)
             )
 
+    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.integrals.meijerint import _rewrite_single
+        return 1/(_rewrite_single(cos(arg), arg)[0][0][2])
+
     def _eval_is_complex(self):
         arg = self.args[0]
 
@@ -1869,6 +1889,10 @@ class csc(ReciprocalTrigonometricFunction):
     def _eval_rewrite_as_besselj(self, arg, **kwargs):
         from sympy.functions.special.bessel import besselj
         return sqrt(2/pi)*(1/(sqrt(arg)*besselj(S.Half, arg)))
+
+    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+        from sympy.integrals.meijerint import _rewrite_single
+        return 1/(_rewrite_single(sin(arg), arg)[0][0][2])
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -483,9 +483,9 @@ class sin(TrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return sqrt(pi*arg/2)*besselj(S.Half, arg)
 
-    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+    def _eval_rewrite_as_meijerg(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return _rewrite_single(sin(arg), arg)[0][0][2]*sqrt(pi)
+        return _rewrite_single(sin(arg), arg)[0][0][2]*_rewrite_single(sin(arg), arg)[0][0][0]
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -860,9 +860,9 @@ class cos(TrigonometricFunction):
                 (1, True)
             )
 
-    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+    def _eval_rewrite_as_meijerg(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return _rewrite_single(cos(arg), arg)[0][0][2]*sqrt(pi)
+        return _rewrite_single(cos(arg), arg)[0][0][2]*_rewrite_single(cos(arg), arg)[0][0][0]
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -1223,7 +1223,7 @@ class tan(TrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return besselj(S.Half, arg)/besselj(-S.Half, arg)
 
-    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+    def _eval_rewrite_as_meijerg(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
         return _rewrite_single(tan(arg), arg)[0][0][2]
 
@@ -1515,7 +1515,7 @@ class cot(TrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return besselj(-S.Half, arg)/besselj(S.Half, arg)
 
-    def _eval_rewrite_as_hyper(self, arg, **kwargs):
+    def _eval_rewrite_as_meijerg(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
         return _rewrite_single(cot(arg), arg)[0][0][2]
 
@@ -1787,9 +1787,9 @@ class sec(ReciprocalTrigonometricFunction):
                 (1, True)
             )
 
-    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+    def _eval_rewrite_as_meijerg(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return 1/(_rewrite_single(cos(arg), arg)[0][0][2]*sqrt(pi))
+        return 1/(_rewrite_single(cos(arg), arg)[0][0][2]*_rewrite_single(cos(arg), arg)[0][0][0])
 
     def _eval_is_complex(self):
         arg = self.args[0]
@@ -1890,9 +1890,9 @@ class csc(ReciprocalTrigonometricFunction):
         from sympy.functions.special.bessel import besselj
         return sqrt(2/pi)*(1/(sqrt(arg)*besselj(S.Half, arg)))
 
-    def  _eval_rewrite_as_hyper(self, arg, **kwargs):
+    def _eval_rewrite_as_meijerg(self, arg, **kwargs):
         from sympy.integrals.meijerint import _rewrite_single
-        return 1/(_rewrite_single(sin(arg), arg)[0][0][2]*sqrt(pi))
+        return 1/(_rewrite_single(sin(arg), arg)[0][0][2]*_rewrite_single(sin(arg), arg)[0][0][0])
 
     def fdiff(self, argindex=1):
         if argindex == 1:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #24176 

#### Brief description of what is fixed or changed


#### Other comments
- [x] rewrite trigonometric hyper(meijeg G) of sin, cos, sec, csc
- [x] A test case has been added for the corresponding method.
- [ ] unable solve for tan and cot need help!

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Trigo functions can now rewrite to hyper e.g. `sin(x).rewrite(hyper)`
<!-- END RELEASE NOTES -->
