### PR TITLE
only unify trig gens if there is more than 1 eq with trig

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1137,27 +1137,28 @@ def solve(f, *symbols, **flags):
         if _has_piecewise(fi):
             f[i] = piecewise_fold(fi)
 
-    # expand double angles; in general, expand_trig will allow
+    # expand angles of sums; in general, expand_trig will allow
     # more roots to be found but this is not a great solultion
     # to not returning a parametric solution, otherwise
     # many values can be returned that have a simple
     # relationship between values
     targs = {t for fi in f for t in fi.atoms(TrigonometricFunction)}
-    add, other = sift(targs, lambda x: x.args[0].is_Add, binary=True)
-    add, other = [[i for i in l if i.has_free(*symbols)] for l in (add, other)]
-    trep = {}
-    for t in add:
-        a = t.args[0]
-        ind, dep = a.as_independent(*symbols)
-        if dep in symbols or -dep in symbols:
-            # don't let expansion expand wrt anything in ind
-            n = Dummy() if not ind.is_Number else ind
-            trep[t] = TR10(t.func(dep + n)).xreplace({n: ind})
-    if other and len(other) <= 2:
-        base = gcd(*[i.args[0] for i in other]) if len(other) > 1 else other[0].args[0]
-        for i in other:
-            trep[i] = TR11(i, base)
-    f = [fi.xreplace(trep) for fi in f]
+    if len(targs) > 1:
+        add, other = sift(targs, lambda x: x.args[0].is_Add, binary=True)
+        add, other = [[i for i in l if i.has_free(*symbols)] for l in (add, other)]
+        trep = {}
+        for t in add:
+            a = t.args[0]
+            ind, dep = a.as_independent(*symbols)
+            if dep in symbols or -dep in symbols:
+                # don't let expansion expand wrt anything in ind
+                n = Dummy() if not ind.is_Number else ind
+                trep[t] = TR10(t.func(dep + n)).xreplace({n: ind})
+        if other and len(other) <= 2:
+            base = gcd(*[i.args[0] for i in other]) if len(other) > 1 else other[0].args[0]
+            for i in other:
+                trep[i] = TR11(i, base)
+        f = [fi.xreplace(trep) for fi in f]
 
     #
     # try to get a solution

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -644,8 +644,11 @@ def test_solve_transcendental():
         assert (sol[0][y] + sol[1][y]).is_Rational, (yi,sol)
     # don't allow massive expansion
     assert solve(cos(1000*x) - S.Half) == [pi/3000, pi/600]
-    assert solve(cos(x - 1000*y) - 1, x) == [2*atan(tan(500*y))]
-    assert solve(cos(x + y + z) - 1, x) == [-2*atan(tan(y/2 + z/2))]
+    assert solve(cos(x - 1000*y) - 1, x) == [1000*y, 1000*y + 2*pi]
+    assert solve(cos(x + y + z) - 1, x) == [-y - z, -y - z + 2*pi]
+
+    # issue 26008
+    assert solve(sin(x + pi/6)) == [-pi/6, 5*pi/6]
 
 
 def test_solve_for_functions_derivatives():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #26008 

#### Brief description of what is fixed or changed

The expansion to try unify generators is now only attempted if there is more than 1 equation with a trig function of interest in it.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
