### PR TITLE
`limit` in `factorint` is now immutable

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -901,14 +901,12 @@ def _trial(factors, n, candidates, verbose=False):
     return int(n), len(factors) != nfactors
 
 
-def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
+def _check_termination(factors, n, limit, use_trial, use_rho, use_pm1,
                        verbose, next_p):
     """
     Helper function for integer factorization. Checks if ``n``
-    is a prime or a perfect power, and in those cases updates
-    the factorization and raises ``StopIteration``.
+    is a prime or a perfect power, and in those cases updates the factorization.
     """
-
     if verbose:
         print('Check for termination')
     if n == 1:
@@ -930,10 +928,6 @@ def _check_termination(factors, n, limitp1, use_trial, use_rho, use_pm1,
     if base < next_p**2 or isprime(base):
         factors[base] = exp
     else:
-        if limitp1:
-            limit = limitp1 - 1
-        else:
-            limit = limitp1
         facs = factorint(base, limit, use_trial, use_rho, use_pm1,
                          verbose=False)
         for b, e in facs.items():
@@ -1365,8 +1359,6 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         if not fermat:
             if verbose:
                 print(fermat_msg)
-            if limit:
-                limit -= 1
             for r in [a - b, a + b]:
                 facs = factorint(r, limit=limit, use_trial=use_trial,
                                  use_rho=use_rho, use_pm1=use_pm1,
@@ -1383,14 +1375,13 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     # be attempted in parallel with pollard methods
     low, high = next_p, 2*next_p
 
-    limit = limit or sqrt_n
     # add 1 to make sure limit is reached in primerange calls
-    limit += 1
+    _limit = (limit or sqrt_n) + 1
     iteration = 0
     while 1:
         high_ = high
-        if limit < high_:
-            high_ = limit
+        if _limit < high_:
+            high_ = _limit
 
         # Trial division
         if use_trial:
@@ -1405,9 +1396,9 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         else:
             found_trial = False
 
-        if high > limit:
+        if high > _limit:
             if verbose:
-                print('Exceeded limit:', limit)
+                print('Exceeded limit:', _limit)
             if n > 1:
                 factors[int(n)] = 1
             if verbose:
@@ -1425,7 +1416,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
                 c = pollard_pm1(n, B=high_root, seed=high_)
                 if c:
                     # factor it and let _trial do the update
-                    ps = factorint(c, limit=limit - 1,
+                    ps = factorint(c, limit=limit,
                                    use_trial=use_trial,
                                    use_rho=use_rho,
                                    use_pm1=use_pm1,
@@ -1444,7 +1435,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
                 c = pollard_rho(n, retries=1, max_steps=max_steps, seed=high_)
                 if c:
                     # factor it and let _trial do the update
-                    ps = factorint(c, limit=limit - 1,
+                    ps = factorint(c, limit=limit,
                                    use_trial=use_trial,
                                    use_rho=use_rho,
                                    use_pm1=use_pm1,
@@ -1470,7 +1461,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
             print(ecm_msg % (B1, B2, num_curves))
         factor = _ecm_one_factor(n, B1, B2, num_curves, seed=B1)
         if factor:
-            ps = factorint(factor, limit=limit - 1,
+            ps = factorint(factor, limit=limit,
                        use_trial=use_trial,
                        use_rho=use_rho,
                        use_pm1=use_pm1,


### PR DESCRIPTION
The variable `limit` in `factorint` is a variable that sets the limit of prime factorization. The handling of this variable was complicated by the fact that it is changed in the function. Therefore, it has been fixed so that it is not changed.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
