### PR TITLE
bug fix in _generate_outer_prod() as mention in issue

### DIFF
--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -14,6 +14,7 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.matrixutils import numpy_ndarray, scipy_sparse_matrix, to_numpy
 from sympy.physics.quantum.tensorproduct import TensorProduct, tensor_product_simp
 from sympy.physics.quantum.trace import Tr
+from sympy.functions.elementary.complexes import conjugate
 
 
 class Density(HermitianOperator):
@@ -192,7 +193,7 @@ class Density(HermitianOperator):
         else:
             op = Mul(*nc_part1)*Dagger(Mul(*nc_part2))
 
-        return Mul(*c_part1)*Mul(*c_part2) * op
+        return Mul(*c_part1)*conjugate(Mul(*c_part2)) * op
 
     def _represent(self, **options):
         return represent(self.doit(), **options)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25980 
#### Brief description of what is fixed or changed


#### Other comments

- [x] update _generate_outer_prod() as mention in issue
- [ ] test case needed?
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * adding conjugate

<!-- END RELEASE NOTES -->
