### PR TITLE
Fixed incorrect limit of Fibonacci ratio to properly converge to the Golden Ratio

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -812,7 +812,7 @@ class Function(Application, Expr):
             raise NotImplementedError(
                 '%s has no _eval_as_leading_term routine' % self.func)
         else:
-            return self.func(*args)
+            return self
 
 
 class AppliedUndef(Function):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -261,6 +261,10 @@ class fibonacci(Function):
                        "only for positive integer indices.")
                 return cls._fibpoly(n).subs(_sym, sym)
 
+    def _eval_rewrite_as_tractable(self, n, **kwargs):
+        from sympy.functions import sqrt, cos
+        return (S.GoldenRatio**n - cos(S.Pi*n)/S.GoldenRatio**n)/sqrt(5)
+
     def _eval_rewrite_as_sqrt(self, n, **kwargs):
         from sympy.functions.elementary.miscellaneous import sqrt
         return 2**(-n)*sqrt(5)*((1 + sqrt(5))**n - (-sqrt(5) + 1)**n) / 5

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -2,11 +2,12 @@ from itertools import product
 
 from sympy.concrete.summations import Sum
 from sympy.core.function import (Function, diff)
-from sympy.core import EulerGamma
+from sympy.core import EulerGamma, GoldenRatio
 from sympy.core.mod import Mod
 from sympy.core.numbers import (E, I, Rational, oo, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
+from sympy.functions.combinatorial.numbers import fibonacci
 from sympy.functions.combinatorial.factorials import (binomial, factorial, subfactorial)
 from sympy.functions.elementary.complexes import (Abs, re, sign)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
@@ -1393,3 +1394,6 @@ def test_issue_25847():
     assert limit(acsch(sin(x)/x), x, 0, '+-') == log(1 + sqrt(2))
     assert limit(acsch(exp(1/x)), x, 0, '+') == 0
     assert limit(acsch(exp(1/x)), x, 0, '-') == oo
+
+def test_issue_26027():
+    assert limit(fibonacci(n + 1)/fibonacci(n), n, oo) == GoldenRatio

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -777,6 +777,10 @@ def test_issue_9471():
     assert limit(((27**(log(n,3)+1))/n**3),n,oo) == 27
 
 
+def test_issue_10382():
+    assert limit(fibonacci(n + 1)/fibonacci(n), n, oo) == GoldenRatio
+
+
 def test_issue_11496():
     assert limit(erfc(log(1/x)), x, oo) == 2
 
@@ -1394,6 +1398,3 @@ def test_issue_25847():
     assert limit(acsch(sin(x)/x), x, 0, '+-') == log(1 + sqrt(2))
     assert limit(acsch(exp(1/x)), x, 0, '+') == 0
     assert limit(acsch(exp(1/x)), x, 0, '-') == oo
-
-def test_issue_26027():
-    assert limit(fibonacci(n + 1)/fibonacci(n), n, oo) == GoldenRatio


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #10382

#### Brief description of what is fixed or changed
Based on the discussions under the issue #10382, I found that the problem can be solved by defining an `_eval_rewrite_as_tractable` method for the `fibonacci`  class.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- functions
  - Fixed incorrect limit of Fibonacci ratio to properly converge to the Golden Ratio

<!-- END RELEASE NOTES -->
