### PR TITLE
utilities._compilation: allow passing extra objects

### DIFF
--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -51,6 +51,9 @@ def compile_sources(files, Runner=None, destdir=None, cwd=None, keep_dir_struct=
     \\*\\*kwargs: dict
         Default keyword arguments to pass to ``Runner``.
 
+    Returns
+    =======
+    List of strings (paths of object files).
     """
     _per_file_kwargs = {}
 
@@ -112,7 +115,7 @@ def get_mixed_fort_c_linker(vendor=None, cplus=False, cwd=None):
 
 
 def link(obj_files, out_file=None, shared=False, Runner=None,
-         cwd=None, cplus=False, fort=False, **kwargs):
+         cwd=None, cplus=False, fort=False, extra_objs=None, **kwargs):
     """ Link object files.
 
     Parameters
@@ -134,6 +137,8 @@ def link(obj_files, out_file=None, shared=False, Runner=None,
         C++ objects? default: ``False``.
     fort: bool
         Fortran objects? default: ``False``.
+    extra_objs: list
+        List of paths to extra object files / static libraries.
     \\*\\*kwargs: dict
         Keyword arguments passed to ``Runner``.
 
@@ -176,13 +181,13 @@ def link(obj_files, out_file=None, shared=False, Runner=None,
         raise ValueError("run_linker was set to False (nonsensical).")
 
     out_file = get_abspath(out_file, cwd=cwd)
-    runner = Runner(obj_files, out_file, flags, cwd=cwd, **kwargs)
+    runner = Runner(obj_files+(extra_objs or []), out_file, flags, cwd=cwd, **kwargs)
     runner.run()
     return out_file
 
 
 def link_py_so(obj_files, so_file=None, cwd=None, libraries=None,
-               cplus=False, fort=False, **kwargs):
+               cplus=False, fort=False, extra_objs=None, **kwargs):
     """ Link Python extension module (shared object) for importing
 
     Parameters
@@ -202,6 +207,8 @@ def link_py_so(obj_files, so_file=None, cwd=None, libraries=None,
         Any C++ objects? default: ``False``.
     fort: bool
         Any Fortran objects? default: ``False``.
+    extra_objs: list
+        List of paths of extra object files / static libraries to link against.
     kwargs**: dict
         Keyword arguments passed to ``link(...)``.
 
@@ -261,9 +268,9 @@ def link_py_so(obj_files, so_file=None, cwd=None, libraries=None,
         if flag not in flags:
             flags.append(flag)
 
-    return link(obj_files, shared=True, flags=flags, cwd=cwd,
-                cplus=cplus, fort=fort, include_dirs=include_dirs,
-                libraries=libraries, library_dirs=library_dirs, **kwargs)
+    return link(obj_files, shared=True, flags=flags, cwd=cwd, cplus=cplus, fort=fort,
+                include_dirs=include_dirs, libraries=libraries,
+                library_dirs=library_dirs, extra_objs=extra_objs, **kwargs)
 
 
 def simple_cythonize(src, destdir=None, cwd=None, **cy_kwargs):
@@ -504,7 +511,7 @@ def any_cplus_src(srcs):
 
 
 def compile_link_import_py_ext(sources, extname=None, build_dir='.', compile_kwargs=None,
-                               link_kwargs=None):
+                               link_kwargs=None, extra_objs=None):
     """ Compiles sources to a shared object (Python extension) and imports it
 
     Sources in ``sources`` which is imported. If shared object is newer than the sources, they
@@ -513,7 +520,7 @@ def compile_link_import_py_ext(sources, extname=None, build_dir='.', compile_kwa
     Parameters
     ==========
 
-    sources : string
+    sources : list of strings
         List of paths to sources.
     extname : string
         Name of extension (default: ``None``).
@@ -524,6 +531,8 @@ def compile_link_import_py_ext(sources, extname=None, build_dir='.', compile_kwa
         keyword arguments passed to ``compile_sources``
     link_kwargs: dict
         keyword arguments passed to ``link_py_so``
+    extra_objs: list
+        List of paths to (prebuilt) object files / static libraries to link against.
 
     Returns
     =======
@@ -542,7 +551,7 @@ def compile_link_import_py_ext(sources, extname=None, build_dir='.', compile_kwa
         objs = compile_sources(list(map(get_abspath, sources)), destdir=build_dir,
                                cwd=build_dir, **compile_kwargs)
         so = link_py_so(objs, cwd=build_dir, fort=any_fortran_src(sources),
-                        cplus=any_cplus_src(sources), **link_kwargs)
+                        cplus=any_cplus_src(sources), extra_objs=extra_objs, **link_kwargs)
         mod = import_module_from_file(so)
     return mod
 

--- a/sympy/utilities/_compilation/tests/test_compilation.py
+++ b/sympy/utilities/_compilation/tests/test_compilation.py
@@ -1,3 +1,4 @@
+import atexit
 import shutil
 import os
 import subprocess
@@ -5,7 +6,7 @@ import tempfile
 from sympy.external import import_module
 from sympy.testing.pytest import skip
 
-from sympy.utilities._compilation.compilation import compile_link_import_strings, compile_sources, get_abspath
+from sympy.utilities._compilation.compilation import compile_link_import_py_ext, compile_link_import_strings, compile_sources, get_abspath
 
 numpy = import_module('numpy')
 cython = import_module('cython')
@@ -64,13 +65,30 @@ def test_compile_link_import_strings():
         if info and info['build_dir']:
             shutil.rmtree(info['build_dir'])
 
+class TemporaryDirectory:
+    """This is a variant of tempfile.TemporaryDirectory that works under pytest.
+    Running 'pytest --pdb' will cause tempfile.TemporaryDirectory to be deleted,
+    even when an assertion fails inside the with-block.
+    """
+    def __init__(self, suffix: str):
+        self.suffix = suffix
+
+    def __enter__(self):
+        self.temp_dir = tempfile.mkdtemp(self.suffix)
+        return self.temp_dir
+
+    def __exit__(self, *exc):
+        def _cleanup():
+            shutil.rmtree(self.temp_dir)
+        atexit.register(_cleanup)
+
 
 def test_compile_sources():
     from sympy.utilities._compilation import has_c
     if not has_c():
         skip("No C compiler found.")
 
-    with tempfile.TemporaryDirectory("sympy_test_compilation") as build_dir:
+    with TemporaryDirectory("sympy_test_compilation") as build_dir:
         _handle, file_path = tempfile.mkstemp('.c', dir=build_dir)
         with open(file_path, 'wt') as ofh:
             ofh.write("""
@@ -82,9 +100,20 @@ def test_compile_sources():
         obj_path = get_abspath(obj, cwd=build_dir)
         assert os.path.exists(obj_path)
         try:
-            subprocess.check_call(["nm", "--help"])
+            _ = subprocess.check_output(["nm", "--help"])
         except subprocess.CalledProcessError:
             pass  # we cannot test contents of object file
         else:
             nm_out = subprocess.check_output(["nm", obj_path])
             assert 'foo' in nm_out.decode('utf-8')
+
+        if not cython:
+            return  # the final (optional) part of the test below requires Cython.
+
+        _handle, pyx_path = tempfile.mkstemp('.pyx', dir=build_dir)
+        with open(pyx_path, 'wt') as ofh:
+            ofh.write(("cdef extern int foo(int)\n"
+                       "def _foo(arg):\n"
+                       "    return foo(arg)"))
+        mod = compile_link_import_py_ext([pyx_path], extra_objs=[obj_path], build_dir=build_dir)
+        assert mod._foo(21) == 42


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
In one way, this is a natural extension of gh-25735, there we tested that we could build object files, but there was no natural way to use those in our existing API.


#### Brief description of what is fixed or changed
A new keyword argument `extra_objs=None` is introduced in a few functions. This is somewhat awkward in `link(obj_files, ...)`, but currently the name of the generated file taken to be the last of the files among `obj_files` by default. This causes problems when, for example, building a Cython extension, since the name of the extension module (shared object file) must match the `PyInit_NAMEOFEXTENSION` symbol for python's loader to work.

#### Other comments
~~When developing this, I used pytest with the `--pdb` flag, for that workflow `tempfile.TemporaryDirectory` has the poor habit of deleting all the interesting files before entering the debugger. Therefore I include a variant here which postpones cleanup to end of process, cf. https://github.com/sympy/sympy/pull/25735#discussion_r1338913970 .~~

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
