### PR TITLE
Fix for bug in pow class

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1533,7 +1533,8 @@ class Pow(Expr):
                 return res
 
         f = b.as_leading_term(x, logx=logx)
-        g = (b/f - S.One).cancel(expand=False)
+        g = ((b.expand()-f).simplify())
+        g = g/f
         if not m.is_number:
             raise NotImplementedError()
         maxpow = n - m*e

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1584,7 +1584,7 @@ class Pow(Expr):
             # Convert floats like 0.5 to exact SymPy numbers like S.Half, to
             # prevent rounding errors which can induce wrong values of d leading
             # to a NotImplementedError being returned from the block below.
-            g.replace(lambda x: x.is_Float, lambda x: Rational(x))
+            g = g.replace(lambda x: x.is_Float, lambda x: Rational(x))
             _, d = g.leadterm(x, logx=logx)
         if not d.is_positive:
             g = g.simplify()

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1533,7 +1533,7 @@ class Pow(Expr):
                 return res
 
         f = b.as_leading_term(x, logx=logx)
-        g = ((b.expand()-f).simplify())
+        g = (b.expand() - f).cancel()
         g = g/f
         if not m.is_number:
             raise NotImplementedError()
@@ -1584,8 +1584,8 @@ class Pow(Expr):
             # Convert floats like 0.5 to exact SymPy numbers like S.Half, to
             # prevent rounding errors which can induce wrong values of d leading
             # to a NotImplementedError being returned from the block below.
-            from sympy.simplify.simplify import nsimplify
-            _, d = nsimplify(g).leadterm(x, logx=logx)
+            g.replace(lambda x: x.is_Float, lambda x: Rational(x))
+            _, d = g.leadterm(x, logx=logx)
         if not d.is_positive:
             g = g.simplify()
             if g.is_zero:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1533,7 +1533,7 @@ class Pow(Expr):
                 return res
 
         f = b.as_leading_term(x, logx=logx)
-        g = (b.expand() - f).cancel()
+        g = (_mexpand(b) - f).cancel()
         g = g/f
         if not m.is_number:
             raise NotImplementedError()

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -479,14 +479,13 @@ def test_as_leading_term():
     # https://github.com/sympy/sympy/issues/21177
     e = -3*x + (x + Rational(3, 2) - sqrt(3)*S.ImaginaryUnit/2)**2\
         - Rational(3, 2) + 3*sqrt(3)*S.ImaginaryUnit/2
-    assert e.as_leading_term(x) == \
-        (12*sqrt(3)*x - 12*S.ImaginaryUnit*x)/(4*sqrt(3) + 12*S.ImaginaryUnit)
+    assert e.as_leading_term(x) == -sqrt(3)*I*x
 
     # https://github.com/sympy/sympy/issues/21245
     e = 1 - x - x**2
     d = (1 + sqrt(5))/2
     assert e.subs(x, y + 1/d).as_leading_term(y) == \
-        (-576*sqrt(5)*y - 1280*y)/(256*sqrt(5) + 576)
+        (-40*y - 16*sqrt(5)*y)/(16 + 8*sqrt(5))
 
 
 def test_leadterm2():

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -18,6 +18,7 @@ from sympy.core.intfunc import integer_nthroot
 from sympy.testing.pytest import warns, _both_exp_pow
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.abc import a, b, c, x, y
+from sympy.core.numbers import all_close
 
 def test_rational():
     a = Rational(1, 5)
@@ -664,4 +665,6 @@ def test_issue_26546():
 
 
 def test_issue_25165():
-    assert (1/sqrt(( - x + 1)**2 + (x - 0.23)**4)).series(x, 0, 2) == 0.998603724830355 + 1.02004923189934*x + O(x**2)
+    e1 = (1/sqrt(( - x + 1)**2 + (x - 0.23)**4)).series(x, 0, 2)
+    e2 = 0.998603724830355 + 1.02004923189934*x + O(x**2)
+    assert all_close(e1, e2)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -661,3 +661,7 @@ def test_issue_26546():
     assert Pow(x+I, Rational(1,2)).is_extended_real is False
     assert Pow(x+I, Rational(1,13)).is_extended_real is False
     assert Pow(x+I, Rational(2,3)).is_extended_real is None
+
+
+def test_issue_25165():
+    assert (1/sqrt(( - x + 1)**2 + (x - 0.23)**4)).series(x, 0, 2) == 0.998603724830355 + 1.02004923189934*x + O(x**2)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -367,9 +367,9 @@ def test_issue_20697():
 def test_issue_21245():
     fi = (1 + sqrt(5))/2
     assert (1/(1 - x - x**2)).series(x, 1/fi, 1).factor() == \
-        (-4812 - 2152*sqrt(5) + 1686*x + 754*sqrt(5)*x\
-        + O((x - 2/(1 + sqrt(5)))**2, (x, 2/(1 + sqrt(5)))))/((1 + sqrt(5))\
-        *(20 + 9*sqrt(5))**2*(x + sqrt(5)*x - 2))
+        (-37*sqrt(5) - 83 + 13*sqrt(5)*x + 29*x + O((x - 2/(1 + sqrt(5)))**2, (x\
+            , 2/(1 + sqrt(5)))))/((2*sqrt(5) + 5)**2*(x + sqrt(5)*x - 2))
+
 
 
 def test_issue_21938():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25165 

#### Brief description of what is fixed or changed
Added fixes for better execution of thee operation to remove the constant term from an expression in _eval_nseries method in Pow class


#### Other comments
Changed some old tests, as the new implementation gives more simplified forms of the expected results.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug in _eval_nseries method of Pow class to better handle the operation of negating the constant term from the expression.
<!-- END RELEASE NOTES -->
