### PR TITLE
Make NDimArray TYPE_CHECKING import only

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -621,6 +621,7 @@ Geetika Vadali <geetika.vadali4@gmail.com> Geetika V <geetika047btcsai21@igdtuw.
 Geetika Vadali <geetika.vadali4@gmail.com> Geetika Vadali <123307246+geetHonve@users.noreply.github.com>
 Geoffry Song <goffrie@gmail.com>
 George Korepanov <gkorepanov.gk@gmail.com>
+George Pittock <gpittock4@gmail.com>
 George Waksman <waksman@gwax.com>
 Georges Khaznadar <georgesk@debian.org>
 Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -15,7 +15,7 @@ from sympy.core.power import Pow
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import SympifyError
 from sympy.logic.boolalg import true, BooleanTrue, BooleanFalse
-from sympy.tensor.array import NDimArray
+
 
 # sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
@@ -30,6 +30,7 @@ from sympy.utilities.iterables import has_variety, sift
 import re
 
 if TYPE_CHECKING:
+    from sympy.tensor.array import NDimArray
     from sympy.vector.basisdependent import BasisDependent
 
 # Hand-picked functions which can be used directly in both LaTeX and MathJax


### PR DESCRIPTION
Make ``NDimArray`` a TYPE_CHECKING import only, aligns with ``BasisDependent``

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

I don't believe this needs release notes as I doubt anyone is importing NDimArray from here.