### PR TITLE
Replaced numpy.allclose() with all_close()

### DIFF
--- a/sympy/physics/control/tests/test_control_plots.py
+++ b/sympy/physics/control/tests/test_control_plots.py
@@ -1,5 +1,5 @@
 from math import isclose
-from sympy.core.numbers import I
+from sympy.core.numbers import I, all_close
 from sympy.core.symbol import Dummy
 from sympy.functions.elementary.complexes import (Abs, arg)
 from sympy.functions.elementary.exponential import log
@@ -102,8 +102,8 @@ def test_pole_zero():
 
     def pz_tester(sys, expected_value):
         z, p = pole_zero_numerical_data(sys)
-        z_check = numpy.allclose(z, expected_value[0])
-        p_check = numpy.allclose(p, expected_value[1])
+        z_check = all_close(z, expected_value[0])
+        p_check = all_close(p, expected_value[1])
         return p_check and z_check
 
     exp1 = [[], [-0.24999999999999994+1.3919410907075054j, -0.24999999999999994-1.3919410907075054j]]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26043 


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
