### PR TITLE
fix to speed up charpoly for large sparse matrices

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1471,6 +1471,7 @@ Vladimir Perić <vlada.peric@gmail.com>
 Vladimir Poluhsin <vovapolu@gmail.com>
 Waldir Pimenta <waldyrious@gmail.com>
 Wang Ran (汪然) <wangr@smail.nju.edu.cn>
+Warren Jacinto <warrenjacinto@gmail.com>
 Wes Galbraith <galbwe92@gmail.com>
 Wes Turner <50891+westurner@users.noreply.github.com>
 Willem Melching <willem.melching@gmail.com>

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -419,7 +419,7 @@ def _charpoly(M, x='lambda', simplify=_simplify):
 
     cp = dM.charpoly()
 
-    x = uniquely_named_symbol(x, M, modify=lambda s: '_' + s)
+    x = uniquely_named_symbol(x, [M], modify=lambda s: '_' + s)
 
     if K.is_EXRAW or simplify is not _simplify:
         # XXX: Converting back to Expr is expensive. We only do it if the

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -1262,10 +1262,12 @@ class MatrixBase(Printable):
         return klass._eval_wilkinson(n)
 
     def _eval_atoms(self, *types):
-        result = set()
-        for i in self:
-            result.update(i.atoms(*types))
-        return result
+        values = self.values()
+        if len(values) < self.rows * self.cols and isinstance(S.Zero, types):
+            s = {S.Zero}
+        else:
+            s = set()
+        return s.union(*[v.atoms(*types) for v in values])
 
     def _eval_free_symbols(self):
         return set().union(*(i.free_symbols for i in self if i))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26054 

#### Brief description of what is fixed or changed
```diff
diff --git a/sympy/matrices/determinant.py b/sympy/matrices/determinant.py
index 2738622406..90d319c5a3 100644
--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -419,7 +419,7 @@ def _charpoly(M, x='lambda', simplify=_simplify):
 
     cp = dM.charpoly()
 
-    x = uniquely_named_symbol(x, M, modify=lambda s: '_' + s)
+    x = uniquely_named_symbol(x, [M], modify=lambda s: '_' + s)
 
     if K.is_EXRAW or simplify is not _simplify:
         # XXX: Converting back to Expr is expensive. We only do it if the

diff --git a/sympy/matrices/matrixbase.py b/sympy/matrices/matrixbase.py
index 479a142362..f29276e390 100644
--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -1262,10 +1262,12 @@ def wilkinson(kls, n, **kwargs):
         return klass._eval_wilkinson(n)
 
     def _eval_atoms(self, *types):
-        result = set()
-        for i in self:
-            result.update(i.atoms(*types))
-        return result
+        values = self.values()
+        if len(values) < self.rows * self.cols and isinstance(S.Zero, types):
+            s = {S.Zero}
+        else:
+            s = set()
+        return s.union(*[v.atoms(*types) for v in values])
``` 


#### Other comments
Without fix
```python
from sympy import *
M = randMatrix(1000, percent=0.1)
```


```python
%time M.charpoly()
```

    CPU times: user 13.6 s, sys: 7.53 ms, total: 13.6 s
    Wall time: 13.6 s




```python
%prun -s cumulative M.charpoly()
```

     


             65304081 function calls (65287060 primitive calls) in 38.758 seconds
    
       Ordered by: cumulative time
    
       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.000    0.000   38.758   38.758 {built-in method builtins.exec}
            1    0.000    0.000   38.758   38.758 <string>:1(<module>)
            1    0.000    0.000   38.758   38.758 matrixbase.py:2972(charpoly)
            1    0.000    0.000   38.758   38.758 determinant.py:332(_charpoly)
            1    0.000    0.000   37.921   37.921 symbol.py:130(uniquely_named_symbol)
      2000002    1.357    0.000   20.297    0.000 repmatrix.py:314(__getitem__)
            1    1.184    1.184   19.266   19.266 symbol.py:197(<listcomp>)
      2000002    6.959    0.000   18.940    0.000 repmatrix.py:918(_getitem_RepMatrix)
            1    1.120    1.120   18.654   18.654 symbol.py:198(<listcomp>)
      



```python

```
With Fix
```python
from sympy import *
M = randMatrix(1000, percent=0.1)
```


```python
%time M.charpoly()
```

    CPU times: user 542 ms, sys: 0 ns, total: 542 ms
    Wall time: 544 ms





```python
%prun -s cumulative M.charpoly()
```

     


             1402136 function calls (1383764 primitive calls) in 1.010 seconds
    
       Ordered by: cumulative time
    
       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.000    0.000    1.010    1.010 {built-in method builtins.exec}
            1    0.000    0.000    1.010    1.010 <string>:1(<module>)
            1    0.000    0.000    1.010    1.010 matrixbase.py:2974(charpoly)
            1    0.000    0.000    1.010    1.010 determinant.py:332(_charpoly)
            1    0.004    0.004    0.984    0.984 domainmatrix.py:3273(charpoly)
    18370/1000    0.509    0.000    0.920    0.001 densearith.py:735(dup_mul)
        28950    0.024    0.000    0.116    0.000 densearith.py:513(dup_add)
       365980    0.087    0.000    0.087    0.000 {built-in method builtins.max}
       356569    0.083    0.000    0.083    0.000 {built-in method builtins.min}
            1    0.002    0.002    0.059    0.059 domainmatrix.py:3388(charpoly_factor_blocks)
       357051    0.038    0.000    0.038    0.000 {method 'append' of 'list' objects}
        23160    0.035    0.000    0.038    0.000 densebasic.py:1815(dup_slice)
         2911    0.037    0.000    0.037    0.000 densearith.py:536(<listcomp>)
         2879    0.036    0.000    0.036    0.000 densearith.py:545(<listcomp>)
         8052    0.034    0.000    0.034    0.000 densebasic.py:255(dup_strip)
         1000    0.002    0.000    0.029    0.000 domainmatrix.py:3464(charpoly_base)
         1000    0.001    0.000    0.023    0.000 domainmatrix.py:3528(charpoly_berk)
            1    0.000    0.000    0.023    0.023 symbol.py:130(uniquely_named_symbol)
         1000    0.002    0.000    0.022    0.000 sdm.py:1244(charpoly)
            2    0.000    0.000    0.022    0.011 matrixbase.py:1347(atoms)
            2    0.000    0.000    0.022    0.011 matrixbase.py:1264(_eval_atoms)



```python

```


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
