### PR TITLE
Prevent calls to uniquely_named_symbols() from iterating over zeroes of large sparse matrices

### DIFF
--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -145,7 +145,7 @@ class Trace(Expr):
 
     def _eval_rewrite_as_Sum(self, expr, **kwargs):
         from sympy.concrete.summations import Sum
-        i = uniquely_named_symbol('i', expr)
+        i = uniquely_named_symbol('i', [expr])
         s = Sum(self.arg[i, i], (i, 0, self.arg.rows - 1))
         return s.doit()
 

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -590,7 +590,7 @@ def _gauss_jordan_solve(M, B, freevar=False):
 
     # Free parameters
     # what are current unnumbered free symbol names?
-    name = uniquely_named_symbol('tau', aug,
+    name = uniquely_named_symbol('tau', [aug],
             compare=lambda i: str(i).rstrip('1234567890'),
             modify=lambda s: '_' + s).name
     gen  = numbered_symbols(name)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
modify calls to `uniquely_named_symbols()` to prevent iteration over zeroes of large sparse matrices
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
refers to #26054
also see #26057 

#### Brief description of what is fixed or changed
```diff
diff --git a/sympy/matrices/expressions/trace.py b/sympy/matrices/expressions/trace.py
index 6c9a1232ce..b5f9f94ea7 100644
--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -145,7 +145,7 @@ def get_arg_key(x):
 
     def _eval_rewrite_as_Sum(self, expr, **kwargs):
         from sympy.concrete.summations import Sum
-        i = uniquely_named_symbol('i', expr)
+        i = uniquely_named_symbol('i', [expr])
         s = Sum(self.arg[i, i], (i, 0, self.arg.rows - 1))
         return s.doit()
 
diff --git a/sympy/matrices/solvers.py b/sympy/matrices/solvers.py
index 76e47bb3d5..01a85b29be 100644
--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -590,7 +590,7 @@ def _gauss_jordan_solve(M, B, freevar=False):
 
     # Free parameters
     # what are current unnumbered free symbol names?
-    name = uniquely_named_symbol('tau', aug,
+    name = uniquely_named_symbol('tau', [aug],
             compare=lambda i: str(i).rstrip('1234567890'),
             modify=lambda s: '_' + s).name

```

#### Other comments
performance changes
Before
```python
from sympy import *
```


```python
%time sol = eye(1000).solve(ones(1000, 1))
```

    CPU times: user 14.1 s, sys: 14.6 ms, total: 14.1 s
    Wall time: 14.1 s



```python
%prun -s cumulative eye(1000).solve(ones(1000, 1))
```

     


             64468451 function calls (64466449 primitive calls) in 36.987 seconds
    
       Ordered by: cumulative time
    
       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.000    0.000   36.987   36.987 {built-in method builtins.exec}
            1    0.000    0.000   36.987   36.987 <string>:1(<module>)
            1    0.000    0.000   36.968   36.968 matrixbase.py:5075(solve)
            1    0.000    0.000   36.968   36.968 solvers.py:778(_solve)
            1    0.000    0.000   36.968   36.968 matrixbase.py:5066(gauss_jordan_solve)
            1    0.003    0.003   36.968   36.968 solvers.py:437(_gauss_jordan_solve)
            1    0.000    0.000   36.717   36.717 symbol.py:130(uniquely_named_symbol)
      2005010    1.197    0.000   20.035    0.000 repmatrix.py:314(__getitem__)

After
```python
from sympy import *
```


```python
%time sol = eye(1000).solve(ones(1000, 1))
```

    CPU times: user 143 ms, sys: 3.9 ms, total: 147 ms
    Wall time: 146 ms



```python
%prun -s cumulative eye(1000).solve(ones(1000, 1))
```

     


             494510 function calls (492508 primitive calls) in 0.339 seconds
    
       Ordered by: cumulative time
    
       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.000    0.000    0.339    0.339 {built-in method builtins.exec}
            1    0.000    0.000    0.339    0.339 <string>:1(<module>)
            1    0.000    0.000    0.318    0.318 matrixbase.py:5075(solve)
            1    0.000    0.000    0.318    0.318 solvers.py:778(_solve)
            1    0.001    0.001    0.318    0.318 matrixbase.py:5066(gauss_jordan_solve)
            1    0.004    0.004    0.317    0.317 solvers.py:437(_gauss_jordan_solve)
         3008    0.002    0.000    0.132    0.000 repmatrix.py:314(__getitem__)
         3008    0.012    0.000    0.129    0.000 repmatrix.py:918(_getitem_RepMatrix)
         1006    0.006    0.000    0.099    0.000 matrixbase.py:366(extract)
         1006    0.001    0.000    0.077    0.000 repmatrix.py:311(_eval_extract)
         1006    0.002    0.000    0.074    0.000 domainmatrix.py:206(extract)
         1006    0.055    0.000    0.070    0.000 sdm.py:131(extract)
    2000/1000    0.004    0.000    0.069    0.000 repmatrix.py:568(__setitem__)
    2000/1000    0.012    0.000    0.068    0.000 matrixbase.py:3907(_setitem)
         1000    0.004    0.000    0.050    0.000 repmatrix.py:832(copyin_matrix)
            6    0.000    0.000    0.045    0.007 repmatrix.py:539(_new)
            1    0.000    0.000    0.042    0.042 symbol.py:130(uniquely_named_symbol)
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
