### PR TITLE
Adding _eval_aseries method  for hyper

### DIFF
--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -308,7 +308,6 @@ class hyper(TupleParametersBase):
                 return super()._eval_aseries(n, args0, x, logx)
 
             from sympy.functions.special.gamma_functions import gamma
-            from sympy.series.order import Order
 
             z = unpolarify(self.args[2])
 
@@ -317,25 +316,24 @@ class hyper(TupleParametersBase):
 
             result = S.Zero
             for k in range(len(self.ap)):
-                term = gamma(ap[k])
-                num = Mul(*[gamma(a-ap[k]) for a in ap if a !=ap[k]])
-                den = Mul(*[gamma(b-ap[k]) for b in bq])
+                term = gamma(ap[k]) if ap[k]>0 else S.One
+                num = Mul(*[gamma(a-ap[k]) for a in ap if a>ap[k]])
+                den = Mul(*[gamma(b-ap[k]) for b in bq if b>ap[k]])
                 term *= (num/den)*(-z)**(-ap[k])
                 terms = [
-                    (Mul(*[RisingFactorial(ap[k] - b + 1, j) for b in bq]) /
+                    (Mul(*[RisingFactorial(ap[k] - b + 1, j) for b in bq if b != ap[k]]) /
                     Mul(*[RisingFactorial(ap[k] - a + 1, j) for a in ap if a != ap[k]]) *
                     (z ** -j) * RisingFactorial(ap[k], j) / factorial(j))
                     for j in range(n)
                 ]
-                terms.append(Order(z**(-n), x))
                 term *= Add(*terms)
                 result += term
 
-            num = Mul(*[gamma(b) for b in bq])
-            den = Mul(*[gamma(a) for a in ap])
+            num = Mul(*[gamma(b) for b in bq if b>0])
+            den = Mul(*[gamma(a) for a in ap if a>0])
             result *= num/den
 
-            return result
+            return result._eval_nseries(x, n, logx)
 
         return super()._eval_aseries(n, args0, x, logx)
 

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -401,3 +401,19 @@ def test_eval_nseries():
         1 - x + x**2/4 - 3*x**3/4 - 15*x**4/64 - 93*x**5/64 + O(x**6)
     assert (pi/2*hyper((-S(1)/2, S(1)/2), (1,), 4*x/(x + 1))).nseries(x) == \
         pi/2 - pi*x/2 + pi*x**2/8 - 3*pi*x**3/8 - 15*pi*x**4/128 - 93*pi*x**5/128 + O(x**6)
+
+
+def test_aseries():
+    a = symbols('a', positive=True, integer=False)
+    b = symbols('b', positive=True, integer=True)
+    c = symbols('c')
+    assert hyper((a,b),(c,), x).series(x, oo, 2) == \
+    ((1 + b*(b - c + 1)/(x*(-a + b + 1)) + O(x**(-2), (x, oo)))*gamma(b)*\
+    gamma(a - b)/((-x)**b*gamma(-b + c)) + (1 + a*(a - c + 1)/(x*(a - b + 1)) + \
+    O(x**(-2), (x, oo)))*gamma(a)*gamma(-a + b)/((-x)**a*gamma(-a + c)))*gamma(c)/(gamma(a)*gamma(b))
+    assert hyper((S(1)/3, S(1)/2), (S(4)/3,), -x**3).series(x, oo, 2) == \
+    (sqrt(pi)*(-1/(14*x**3) + 1 + O(x**(-6), (x, oo)))*(1/x)**(S(3)/2)*gamma(-S(1)/6)/gamma(S(5)/6) + \
+    (1 + O(x**(-6), (x, oo)))*gamma(S(1)/6)*gamma(S(1)/3)/x)*gamma(S(4)/3)/(sqrt(pi)*gamma(S(1)/3))
+    assert hyper((S(1)/4,S(1)/2),(S(5)/4,), -x**4).series(x, oo, 2) == \
+    ((1 + O(x**(-8), (x, oo)))*gamma(S(1)/4)**2/x + sqrt(pi)*(-1/(10*x**4) + 1 + \
+    O(x**(-8), (x, oo)))*gamma(-S(1)/4)/(x**2*gamma(S(3)/4)))*gamma(S(5)/4)/(sqrt(pi)*gamma(S(1)/4))

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -404,16 +404,11 @@ def test_eval_nseries():
 
 
 def test_aseries():
-    a = symbols('a', positive=True, integer=False)
-    b = symbols('b', positive=True, integer=True)
-    c = symbols('c')
-    assert hyper((a,b),(c,), x).series(x, oo, 2) == \
-    ((1 + b*(b - c + 1)/(x*(-a + b + 1)) + O(x**(-2), (x, oo)))*gamma(b)*\
-    gamma(a - b)/((-x)**b*gamma(-b + c)) + (1 + a*(a - c + 1)/(x*(a - b + 1)) + \
-    O(x**(-2), (x, oo)))*gamma(a)*gamma(-a + b)/((-x)**a*gamma(-a + c)))*gamma(c)/(gamma(a)*gamma(b))
-    assert hyper((S(1)/3, S(1)/2), (S(4)/3,), -x**3).series(x, oo, 2) == \
-    (sqrt(pi)*(-1/(14*x**3) + 1 + O(x**(-6), (x, oo)))*(1/x)**(S(3)/2)*gamma(-S(1)/6)/gamma(S(5)/6) + \
-    (1 + O(x**(-6), (x, oo)))*gamma(S(1)/6)*gamma(S(1)/3)/x)*gamma(S(4)/3)/(sqrt(pi)*gamma(S(1)/3))
-    assert hyper((S(1)/4,S(1)/2),(S(5)/4,), -x**4).series(x, oo, 2) == \
-    ((1 + O(x**(-8), (x, oo)))*gamma(S(1)/4)**2/x + sqrt(pi)*(-1/(10*x**4) + 1 + \
-    O(x**(-8), (x, oo)))*gamma(-S(1)/4)/(x**2*gamma(S(3)/4)))*gamma(S(5)/4)/(sqrt(pi)*gamma(S(1)/4))
+    assert hyper((S(1)/3, S(1)/2), (S(4)/3,), -x**3).series(x, oo) == \
+    gamma(S(1)/6)*gamma(S(4)/3)/(sqrt(pi)*x) + (1/x)**(S(3)/2)*gamma(S(4)/3)/(gamma(S(1)/3)*gamma(S(5)/6)) - \
+        (1/x)**(S(9)/2)*gamma(S(4)/3)/(14*gamma(S(1)/3)*gamma(S(5)/6)) + O(x**(-6), (x, oo))
+    assert hyper((S(1)/4,S(1)/2),(S(5)/4,), -x**4).series(x, oo) == \
+    gamma(S(5)/4)/(x**2*gamma(S(1)/4)*gamma(S(3)/4)) + gamma(S(1)/4)*gamma(S(5)/4)/(sqrt(pi)*x) + O(x**(-6), (x, oo))
+    assert hyper((-3, S(3)/2), (S(5)/2,), x).series(x, oo) == 1 + 3*I*sqrt(pi)*(1/x)**(S(3)/2)/4 - 9*x/5 + \
+        9*x**2/7 - x**3/3 + O(x**(-6), (x, oo))
+    assert hyper((-3, S(3)/2), (S(3)/2,), x).series(x, oo) == 1 - 3*x + 3*x**2 - x**3 + O(x**(-6), (x, oo))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2160,3 +2160,8 @@ def test_integral_issue_26566():
 
     # Assert that the symbolic result matches the correct value
     assert simplify(numeric_symbolic_result - numeric_correct_result) == 0
+
+
+def test_issue_24879():
+    assert integrate(1/sqrt(1+x**3),(x,-1,oo)) == gamma(S(1)/3)*hyper((S(1)/3, S(1)/2), (S(4)/3,), 1)/(3*gamma(S(4)/3)) + \
+        gamma(S(1)/6)*gamma(S(1)/3)/(3*sqrt(pi))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially fixes #24879 

#### Brief description of what is fixed or changed

Adding  `_eval_aseries` method for `hyper` class to handle expansions when the argument tends to infinity and also for integrals that involve `hyper`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->


* series
  * `_eval_aseries` method for `hyper` is added
<!-- END RELEASE NOTES -->
