### PR TITLE
Create removing numpy and math imports.py

### DIFF
--- a/removing numpy and math imports.py
+++ b/removing numpy and math imports.py
@@ -1,0 +1,19 @@
+import sympy.physics.mechanics as me
+import sympy as sm
+
+frame_c = me.ReferenceFrame('c')
+frame_d = me.ReferenceFrame('d')
+frame_f = me.ReferenceFrame('f')
+fd, dc = me.dynamicsymbols('fd dc')
+fdd, dcd = me.dynamicsymbols('fd dc', 1)
+fdd2, dcd2 = me.dynamicsymbols('fd dc', 2)
+r, l = sm.symbols('r l', real=True)
+point_o = me.Point('o')
+point_e = me.Point('e')
+frame_d.orient(frame_f, 'Axis', [fd, frame_f.x])
+frame_c.orient(frame_d, 'Axis', [dc, frame_d.y])
+frame_c.set_ang_vel(frame_f, (frame_c.ang_vel_in(frame_f)).express(frame_f))
+point_e.set_pos(point_o, r*frame_d.y-l*frame_c.x)
+point_e.set_pos(point_o, (point_e.pos_from(point_o)).express(frame_d))
+point_e.set_vel(frame_f, ((point_e.pos_from(point_o)).dt(frame_f)).express(frame_d))
+point_e.set_acc(frame_f, ((point_e.vel(frame_f)).dt(frame_f)).express(frame_d))


### PR DESCRIPTION
Removed numpy and math imports

Fixes  #15186

The code was required to remove the imports of NumPy and math from the code.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
