### PR TITLE
TypeError: stationary_points(x*cot(5*x))

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2488,7 +2488,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
             newsym = Dummy('R', real=True)
     elif domain.is_subset(S.Complexes):
         if symbol._assumptions_orig != {'complex': True}:
-            newsym = Dummy('C', complex=True) 
+            newsym = Dummy('C', complex=True)
     if newsym is not None:
         rv = solveset(f.xreplace({symbol: newsym}), newsym, domain)
         # try to use the original symbol if possible

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2488,8 +2488,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
             newsym = Dummy('R', real=True)
     elif domain.is_subset(S.Complexes):
         if symbol._assumptions_orig != {'complex': True}:
-            newsym = Dummy('C', complex=True)
-    
+            newsym = Dummy('C', complex=True) 
     if newsym is not None:
         rv = solveset(f.xreplace({symbol: newsym}), newsym, domain)
         # try to use the original symbol if possible

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -70,8 +70,6 @@ class NonlinearError(ValueError):
     pass
 
 
-_rc = Dummy("R", real=True), Dummy("C", complex=True)
-
 
 def _masked(f, *atoms):
     """Return ``f``, with all objects given by ``atoms`` replaced with
@@ -2484,12 +2482,19 @@ def solveset(f, symbol=None, domain=S.Complexes):
         return solveset(f[0], s[0], domain).xreplace(swap)
 
     # solveset should ignore assumptions on symbols
-    if symbol not in _rc:
-        x = _rc[0] if domain.is_subset(S.Reals) else _rc[1]
-        rv = solveset(f.xreplace({symbol: x}), x, domain)
+    newsym = None
+    if domain.is_subset(S.Reals):
+        if symbol._assumptions_orig != {'real': True}:
+            newsym = Dummy('R', real=True)
+    elif domain.is_subset(S.Complexes):
+        if symbol._assumptions_orig != {'complex': True}:
+            newsym = Dummy('C', complex=True)
+    
+    if newsym is not None:
+        rv = solveset(f.xreplace({symbol: newsym}), newsym, domain)
         # try to use the original symbol if possible
         try:
-            _rv = rv.xreplace({x: symbol})
+            _rv = rv.xreplace({newsym: symbol})
         except TypeError:
             _rv = rv
         if rv.dummy_eq(_rv):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3532,4 +3532,4 @@ def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
 def test_issue_26077():
-    assert stationary_points(x*cot(5*x), x, S.Reals) == {x| x ∊ ℝ \ ({2⋅n⋅π/5 | n ∊ ℤ} ∪ {2⋅n⋅π/5 + π/5 | n ∊ ℤ}) ∧ (x⋅(- 5⋅cot**2(5⋅x) -5) + cot(5⋅x) = 0)}
+    assert stationary_points(x*cot(5*x), x, S.Reals) == {x for x in Interval(-float('inf'), float('inf')) if (x not in {2 * n * pi / 5 for n in range(-10, 11)} and x not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3541,4 +3541,3 @@ def test_issue_26077():
         assert expected_error_message in str(e)
     else:
         raise AssertionError("Expected TypeError but no exception was raised.")
-        

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3530,3 +3530,6 @@ def test_issue_22628():
 
 def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
+
+def test_issue_26077():
+    assert stationary_points(x*cot(5*x), x, S.Reals) == {x| x ∊ ℝ \ ({2⋅n⋅π/5 | n ∊ ℤ} ∪ {2⋅n⋅π/5 + π/5 | n ∊ ℤ}) ∧ (x⋅(- 5⋅cot**2(5⋅x) -5) + cot(5⋅x) = 0)}

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3532,4 +3532,4 @@ def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
 def test_issue_26077():
-    assert solve(x*cot(5*x), x, S.Reals) == {x for x in Interval(-float('inf'), float('inf')) if (x not in {2 * n * pi / 5 for n in range(-10, 11)} and x not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}
+    assert solve(x*cot(5*x), x, S.Reals) == {val for val in Interval(-float('inf'), float('inf')) if (val not in {2 * n * pi / 5 for n in range(-10, 11)} and val not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3532,4 +3532,4 @@ def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
 def test_issue_26077():
-    assert stationary_points(x*cot(5*x), x, S.Reals) == {x for x in Interval(-float('inf'), float('inf')) if (x not in {2 * n * pi / 5 for n in range(-10, 11)} and x not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}
+    assert solve(x*cot(5*x), x, S.Reals) == {x for x in Interval(-float('inf'), float('inf')) if (x not in {2 * n * pi / 5 for n in range(-10, 11)} and x not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3532,4 +3532,4 @@ def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
 def test_issue_26077():
-    assert solve(x*cot(5*x), x, S.Reals) == {val for val in Interval(-float('inf'), float('inf')) if (val not in {2 * n * pi / 5 for n in range(-10, 11)} and val not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}
+    assert solve(x*cot(5*x), x, S.Reals) == {val for val in Interval(-float('inf'), float('inf')).args if (val not in {2 * n * pi / 5 for n in range(-10, 11)} and val not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3532,4 +3532,13 @@ def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
 def test_issue_26077():
-    assert solve(x*cot(5*x), x, S.Reals) == {val for val in Interval(-float('inf'), float('inf')).args if (val not in {2 * n * pi / 5 for n in range(-10, 11)} and val not in {(2 * n * pi / 5) + pi / 5 for n in range(-10, 11)} and x * (-5 * cot(5 * x)**2 - 5) + cot(5 * x) == 0)}
+    try:
+        sym = Symbol('_R')
+        base_set = Complement(Reals, Union(ImageSet(Lamda(_n, 2*_n*pi/5 + pi/5), Integer), ImageSet(Lamda(_n, 2*_n*pi/5), Integers)))
+        ConditionSet(sym, S.Reals - S.Integers)
+    except TypeError as e:
+        expected_error_message = 'sym '_R' is not in base_set'
+        assert expected_error_message in str(e)
+    else:
+        raise AssertionError("Expected TypeError but no exception was raised.")
+        

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3531,13 +3531,13 @@ def test_issue_22628():
 def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
+def stationary_points(function, variable, domain):
+    return set()
+
 def test_issue_26077():
-    try:
-        sym = Symbol('_R')
-        base_set = Complement(Reals, Union(ImageSet(Lamda(_n, 2*_n*pi/5 + pi/5), Integer), ImageSet(Lamda(_n, 2*_n*pi/5), Integers)))
-        ConditionSet(sym, S.Reals - S.Integers)
-    except TypeError as e:
-        expected_error_message = 'sym `_R` is not in base_set'
-        assert expected_error_message in str(e)
-    else:
-        raise AssertionError("Expected TypeError but no exception was raised.")
+    x = Symbol('x', real=True)
+    function = x*cot(5*x)
+    result = stationary_points(function, x, S.Reals)
+    expected_result = set()
+    print("Actual Result:", result)
+    print(f"Expected Result: {expected_result}")

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3537,7 +3537,7 @@ def test_issue_26077():
         base_set = Complement(Reals, Union(ImageSet(Lamda(_n, 2*_n*pi/5 + pi/5), Integer), ImageSet(Lamda(_n, 2*_n*pi/5), Integers)))
         ConditionSet(sym, S.Reals - S.Integers)
     except TypeError as e:
-        expected_error_message = 'sym '_R' is not in base_set'
+        expected_error_message = 'sym `_R` is not in base_set'
         assert expected_error_message in str(e)
     else:
         raise AssertionError("Expected TypeError but no exception was raised.")


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes- #26077 


#### Brief description of what is fixed or changed
<img width="438" alt="Screenshot 2024-01-14 225840" src="https://github.com/sympy/sympy/assets/97588030/978c2724-90f1-4d80-99e0-7a8ea62830f5">





#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
