### PR TITLE
Reverse noncommutative differentiation element order

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -652,6 +652,7 @@ Hampus Malmberg <hampus.malmberg88@gmail.com>
 Han Wei Ang <ang.h.w@u.nus.edu>
 Hannah Kari <hannah.kari@marquette.edu> hannah-kari <42753364+hannah-kari@users.noreply.github.com>
 Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
+Hara Red <rtc6fg4.fejg2@gmail.com>
 Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
 Harold Erbin <harold.erbin@gmail.com>
 Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -604,7 +604,7 @@ class Function(Application, Expr):
                 df = self.fdiff(i)
             except ArgumentIndexError:
                 df = Function.fdiff(self, i)
-            l.append(df * da)
+            l.append(da * df)
         return Add(*l)
 
     def _eval_is_commutative(self):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1453,3 +1453,9 @@ def test_eval_classmethod_check():
         class F(Function):
             def eval(self, x):
                 pass
+
+def test_noncommutative_diff():
+    # Check that noncommutative differentiation is properly handled
+    n = Symbol('n', commutative=False)
+    t = Symbol('t')
+    assert exp(t*n).diff(t) == n*exp(t*n)


### PR DESCRIPTION
#### References to other Issues or PRs

No relevant issues or pull-requests found

#### Brief description of what is fixed or changed

Changed order of elements being multiplied during function differentiation.
Now `_eval_derivative` provides proper order of multiplied elements, which is important in case of noncommutative elements.

#### Other comments

When differentiating something like `exp(t*n)` by `t` with noncommutative `n` one expects to get `n*exp(t*n)`, now this behavior is implemented.
A specific use-case is quaternion in exponential form differentiation for angular velocity estimation via `w = 2 * q.diff(t) / q`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * Reverse order of elements during function differentiation

<!-- END RELEASE NOTES -->
