### PR TITLE
Fix type error in stationary_points

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -69,6 +69,7 @@ class NonlinearError(ValueError):
     """Raised when unexpectedly encountering nonlinear equations"""
     pass
 
+
 def _masked(f, *atoms):
     """Return ``f``, with all objects given by ``atoms`` replaced with
     Dummy symbols, ``d``, and the list of replacements, ``(d, e)``,

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -69,10 +69,6 @@ class NonlinearError(ValueError):
     """Raised when unexpectedly encountering nonlinear equations"""
     pass
 
-
-_rc = Dummy("R", real=True), Dummy("C", complex=True)
-
-
 def _masked(f, *atoms):
     """Return ``f``, with all objects given by ``atoms`` replaced with
     Dummy symbols, ``d``, and the list of replacements, ``(d, e)``,
@@ -2484,12 +2480,19 @@ def solveset(f, symbol=None, domain=S.Complexes):
         return solveset(f[0], s[0], domain).xreplace(swap)
 
     # solveset should ignore assumptions on symbols
-    if symbol not in _rc:
-        x = _rc[0] if domain.is_subset(S.Reals) else _rc[1]
-        rv = solveset(f.xreplace({symbol: x}), x, domain)
+    newsym = None
+    if domain.is_subset(S.Reals):
+        if symbol._assumptions_orig != {'real': True}:
+            newsym = Dummy('R', real=True)
+    elif domain.is_subset(S.Complexes):
+        if symbol._assumptions_orig != {'complex': True}:
+            newsym = Dummy('C', complex=True)
+
+    if newsym is not None:
+        rv = solveset(f.xreplace({symbol: newsym}), newsym, domain)
         # try to use the original symbol if possible
         try:
-            _rv = rv.xreplace({x: symbol})
+            _rv = rv.xreplace({newsym: symbol})
         except TypeError:
             _rv = rv
         if rv.dummy_eq(_rv):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3530,3 +3530,11 @@ def test_issue_22628():
 
 def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
+
+def test_issue_26077():
+    _n = Symbol('_n')
+    function = x*cot(5*x)
+    critical_points = stationary_points(function, x, S.Reals)
+    excluded_points = Union(ImageSet(Lambda(_n, 2*_n*pi/5), S.Integers), ImageSet(Lambda(_n, 2*_n*pi/5 + pi/5), S.Integers))
+    solution = ConditionSet(x, Eq(x*(-5*cot(5*x)**2 - 5) + cot(5*x), 0), Complement(S.Reals, excluded_points))
+    assert solution.as_dummy() == critical_points.as_dummy()

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,5 +1,6 @@
 from math import isclose
 
+from sympy.calculus.util import stationary_points
 from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda, nfloat, diff)
 from sympy.core.mod import Mod

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3532,10 +3532,17 @@ def test_issue_22628():
 def test_issue_25781():
     assert solve(sqrt(x/2) - x) == [0, S.Half]
 
+
 def test_issue_26077():
     _n = Symbol('_n')
     function = x*cot(5*x)
     critical_points = stationary_points(function, x, S.Reals)
-    excluded_points = Union(ImageSet(Lambda(_n, 2*_n*pi/5), S.Integers), ImageSet(Lambda(_n, 2*_n*pi/5 + pi/5), S.Integers))
-    solution = ConditionSet(x, Eq(x*(-5*cot(5*x)**2 - 5) + cot(5*x), 0), Complement(S.Reals, excluded_points))
+    excluded_points = Union(
+        ImageSet(Lambda(_n, 2*_n*pi/5), S.Integers),
+        ImageSet(Lambda(_n, 2*_n*pi/5 + pi/5), S.Integers)
+    )
+    solution = ConditionSet(x,
+        Eq(x*(-5*cot(5*x)**2 - 5) + cot(5*x), 0),
+        Complement(S.Reals, excluded_points)
+    )
     assert solution.as_dummy() == critical_points.as_dummy()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes: https://github.com/sympy/sympy/issues/26077


#### Brief description of what is fixed or changed
Fix type error in `stationary_points`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * A bug in `solveset` due to incorrect handling of Dummy symbols was fixed. Previously the `stationary_points` function might return incorrect results or raise an error due to this bug.
<!-- END RELEASE NOTES -->
