### PR TITLE
Rewrite factor_nc to use published algorithm

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1501,6 +1501,7 @@ Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+c
 Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zachariah Carmichael <20629897+craymichael@users.noreply.github.com>
 Zach Raines <raineszm@gmail.com>
 Zachariah Etienne <zachetie@gmail.com>
+Zachary Hempstead <zhempstead@gmail.com>
 Zamrath Nizam <zamiguy_ni@yahoo.com> <zamiguy.ni@gmail.com>
 Zaz Brown <zazbrown@zazbrown.com>
 Zedmat <104870914+harshkasat@users.noreply.github.com>

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1372,7 +1372,7 @@ class _NCMonomial():
                 raise ValueError(f"Expected {expr.arg[0]} to be a generator")
             return ((generators.index(expr.args[0]), expr.args[1]),)
         raise ValueError(f"Can't convert {expr} to monomial")
-        
+
 
     @staticmethod
     def from_expr(coeff, expr, generators):
@@ -1419,7 +1419,7 @@ class _NCMonomial():
 
     def __repr__(self):
         return str(self)
-            
+
     def as_expr(self):
         """Convert to Expr"""
         out_terms = [self.generators[t]**pw for t, pw in self.term]
@@ -1443,7 +1443,7 @@ class _NCMonomial():
                 self,
                 _NCMonomial(Integer(1), (), self.generators, 0)
             )
-            
+
         if ldegree > self.degree:
             raise ValueError(f"Monomial {self} of degree {self.degree} can't be split with left term of degree {ldegree}")
         rdegree = self.degree - ldegree
@@ -1638,7 +1638,7 @@ class _NCPoly():
     def as_expr(self):
         """Convert to Expr"""
         return Add(*[monom.as_expr() for monom in self.monomials()])
-        
+
     def monomials(self, degree=None):
         """Return iterator of all monomials (with specified degree)"""
         if degree is None:
@@ -1659,7 +1659,7 @@ class _NCPoly():
             numerators.append(num)
             denominators.append(denom)
         return gcd(numerators) / lcm(denominators)
- 
+
     def add(self, monom):
         """Add a monomial to this polynomial, updating in-place"""
         degree = monom.degree
@@ -1736,7 +1736,7 @@ class _NCPoly():
 
         if ldegree == 0 or ldegree >= self.degree:
             return
-            
+
         G, H = self._factor_homogeneous(ldegree)
         if G is None:
             return
@@ -1747,7 +1747,7 @@ class _NCPoly():
         # Future optimization: select the monomials with the least overlap potential
         Ghat = next(G.monomials())
         Hhat = next(H.monomials())
-        
+
         dummies = []
         Fhat = self.copy()
 
@@ -1809,13 +1809,13 @@ class _NCPoly():
                     break
             if not ok:
                 continue
-                    
+
             substitutes = list(zip(dummies, soln))
             yield (
                 _NCPoly(Gexpr.subs(substitutes), self.generators, self.extensions),
                 _NCPoly(Hexpr.subs(substitutes), self.generators, self.extensions),
             )
-                    
+
     def _factor_recursive(self):
         """Return a generator that yields all unique, valid, irreducible factorizations.
         Does not fully simplify coefficients.

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -9,14 +9,12 @@ from .function import expand_power_exp
 from .sympify import sympify
 from .numbers import Rational, Integer, Number, I, equal_valued
 from .singleton import S
-from .sorting import default_sort_key, ordered
+from .sorting import ordered
 from .symbol import Dummy
-from .traversal import preorder_traversal
 from .coreerrors import NonCommutativeExpression
 from .containers import Tuple, Dict
 from sympy.external.gmpy import SYMPY_INTS
-from sympy.utilities.iterables import (common_prefix, common_suffix,
-        variations, iterable, is_sequence)
+from sympy.utilities.iterables import (iterable, is_sequence)
 
 from collections import defaultdict
 from typing import Tuple as tTuple
@@ -1442,7 +1440,7 @@ class _NCMonomial:
         The right monomial will always have a coefficient of 1.
         """
         if ldegree < 0:
-            raise ValueError(f"ldegree must be nonnegative")
+            raise ValueError("ldegree must be nonnegative")
         if ldegree == 0:
             return (
                 _NCMonomial(self.coeff, (), self.generators, 0),
@@ -1707,7 +1705,6 @@ class _NCPoly:
 
         Implementation based on Algorithm 1 from https://arxiv.org/abs/1002.3180
         """
-        rdegree = self.degree - ldegree
         terms = list(self.monomials(self.degree))
         Ghat, Hhat = terms[0].split(ldegree)
         G = _NCPoly(None, self.generators, self.extensions)

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1414,159 +1414,7 @@ def factor_nc(expr):
         return expr.func(*[factor_nc(a) for a in expr.args])
     expr = expr.func(*[expand_power_exp(i) for i in expr.args])
 
-    from sympy.polys.polytools import gcd, factor
-    expr, rep, nc_symbols = _mask_nc(expr)
-
-    if rep:
-        return factor(expr).subs(rep)
-    else:
-        args = [a.args_cnc() for a in Add.make_args(expr)]
-        c = g = l = r = S.One
-        hit = False
-        # find any commutative gcd term
-        for i, a in enumerate(args):
-            if i == 0:
-                c = Mul._from_args(a[0])
-            elif a[0]:
-                c = gcd(c, Mul._from_args(a[0]))
-            else:
-                c = S.One
-        if c is not S.One:
-            hit = True
-            c, g = c.as_coeff_Mul()
-            if g is not S.One:
-                for i, (cc, _) in enumerate(args):
-                    cc = list(Mul.make_args(Mul._from_args(list(cc))/g))
-                    args[i][0] = cc
-            for i, (cc, _) in enumerate(args):
-                if cc:
-                    cc[0] = cc[0]/c
-                else:
-                    cc = [1/c]
-                args[i][0] = cc
-        # find any noncommutative common prefix
-        for i, a in enumerate(args):
-            if i == 0:
-                n = a[1][:]
-            else:
-                n = common_prefix(n, a[1])
-            if not n:
-                # is there a power that can be extracted?
-                if not args[0][1]:
-                    break
-                b, e = args[0][1][0].as_base_exp()
-                ok = False
-                if e.is_Integer:
-                    for t in args:
-                        if not t[1]:
-                            break
-                        bt, et = t[1][0].as_base_exp()
-                        if et.is_Integer and bt == b:
-                            e = min(e, et)
-                        else:
-                            break
-                    else:
-                        ok = hit = True
-                        l = b**e
-                        il = b**-e
-                        for _ in args:
-                            _[1][0] = il*_[1][0]
-                        break
-                if not ok:
-                    break
-        else:
-            hit = True
-            lenn = len(n)
-            l = Mul(*n)
-            for _ in args:
-                _[1] = _[1][lenn:]
-        # find any noncommutative common suffix
-        for i, a in enumerate(args):
-            if i == 0:
-                n = a[1][:]
-            else:
-                n = common_suffix(n, a[1])
-            if not n:
-                # is there a power that can be extracted?
-                if not args[0][1]:
-                    break
-                b, e = args[0][1][-1].as_base_exp()
-                ok = False
-                if e.is_Integer:
-                    for t in args:
-                        if not t[1]:
-                            break
-                        bt, et = t[1][-1].as_base_exp()
-                        if et.is_Integer and bt == b:
-                            e = min(e, et)
-                        else:
-                            break
-                    else:
-                        ok = hit = True
-                        r = b**e
-                        il = b**-e
-                        for _ in args:
-                            _[1][-1] = _[1][-1]*il
-                        break
-                if not ok:
-                    break
-        else:
-            hit = True
-            lenn = len(n)
-            r = Mul(*n)
-            for _ in args:
-                _[1] = _[1][:len(_[1]) - lenn]
-        if hit:
-            mid = Add(*[Mul(*cc)*Mul(*nc) for cc, nc in args])
-        else:
-            mid = expr
-
-        from sympy.simplify.powsimp import powsimp
-
-        # sort the symbols so the Dummys would appear in the same
-        # order as the original symbols, otherwise you may introduce
-        # a factor of -1, e.g. A**2 - B**2) -- {A:y, B:x} --> y**2 - x**2
-        # and the former factors into two terms, (A - B)*(A + B) while the
-        # latter factors into 3 terms, (-1)*(x - y)*(x + y)
-        rep1 = [(n, Dummy()) for n in sorted(nc_symbols, key=default_sort_key)]
-        unrep1 = [(v, k) for k, v in rep1]
-        unrep1.reverse()
-        new_mid, r2, _ = _mask_nc(mid.subs(rep1))
-        new_mid = powsimp(factor(new_mid))
-
-        new_mid = new_mid.subs(r2).subs(unrep1)
-
-        if new_mid.is_Pow:
-            return _keep_coeff(c, g*l*new_mid*r)
-
-        if new_mid.is_Mul:
-            def _pemexpand(expr):
-                "Expand with the minimal set of hints necessary to check the result."
-                return expr.expand(deep=True, mul=True, power_exp=True,
-                    power_base=False, basic=False, multinomial=True, log=False)
-            # XXX TODO there should be a way to inspect what order the terms
-            # must be in and just select the plausible ordering without
-            # checking permutations
-            cfac = []
-            ncfac = []
-            for f in new_mid.args:
-                if f.is_commutative:
-                    cfac.append(f)
-                else:
-                    b, e = f.as_base_exp()
-                    if e.is_Integer:
-                        ncfac.extend([b]*e)
-                    else:
-                        ncfac.append(f)
-            pre_mid = g*Mul(*cfac)*l
-            target = _pemexpand(expr/c)
-            for s in variations(ncfac, len(ncfac)):
-                ok = pre_mid*Mul(*s)*r
-                if _pemexpand(ok) == target:
-                    return _keep_coeff(c, ok)
-
-        # mid was an Add that didn't factor successfully
-        return _keep_coeff(c, g*l*mid*r)
+    return _NCPoly(expr).factor_one()
 
 
 def _nc_generators(expr):
@@ -1697,7 +1545,7 @@ class _NCMonomial():
             return _NCMonomial(self.coeff * other.coeff, self.term * other.term, self.generators, self.degree + other.degree)
         if isinstance(other, _NCPoly):
             return NotImplemented
-        return _NCMonomial(self.coeff * other, self.term, self.generators, self.degree)
+        return _NCMonomial((self.coeff * other).cancel(), self.term, self.generators, self.degree)
 
     def __str__(self):
         return str(self.coeff * self.term)
@@ -1719,7 +1567,7 @@ class _NCPoly():
             self.generators = generators
             if generators is None:
                 self.generators = _nc_generators(expr)
-            coeffs_dict = expr.as_coefficients_dict(*self.generators)
+            coeffs_dict = expr.as_coefficients_dict(*(self.generators or [None]))
 
             # Representation: Dict[degree, Dict[term, _NCMonomial]]
             self.rep = {}
@@ -1880,7 +1728,6 @@ class _NCPoly():
         return factorizations
 
     def factor_one(self):
-        return next(self._factor_recursive())
         coeff_factor, F = self._factor_coeff()
         out = next(F._factor_recursive())
         if coeff_factor != 1:
@@ -1915,7 +1762,7 @@ class _NCPoly():
         coeff_factor = self.extract_coeff_factor()
         if coeff_factor == 1:
             return (Integer(1), self)
-        return (coeff_factor, self * (1/coeff_factor))
+        return (coeff_factor.factor(), self * (1/coeff_factor))
 
     def _factor_once(self, ldegree):
         """Factor into polynomials of degree ldegree and self.degree - ldegree, if possible.

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -389,11 +389,15 @@ def test_factor_nc():
 
     # issue 6701
     _n = symbols('nz', zero=False, commutative=False)
-    assert factor_nc(_n**k + _n**(k + 1)) == _n**k*(1 + _n)
+    assert factor_nc(_n**k + _n**(k + 1)) in [(1 + _n)*_n**k, _n**k*(1 + _n)]
     assert factor_nc((m*n)**k + (m*n)**(k + 1)) == (1 + m*n)*(m*n)**k
 
     # issue 6918
     assert factor_nc(-n*(2*x**2 + 2*x)) == -2*n*x*(x + 1)
+
+    # issue 26041
+    poly = m**2 + 2*m*n + n**2
+    assert factor_nc(poly) == poly
 
 
 def test_issue_6360():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -4,7 +4,6 @@ from sympy.concrete.summations import Sum
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.containers import (Dict, Tuple)
-from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Rational, oo)
 from sympy.core.singleton import S


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #26041

#### Brief description of what is fixed or changed
factor_nc was rewritten to use https://arxiv.org/pdf/1002.3180.pdf. Previously, it was not always respecting non-commutativity:
```
>>> from sympy import *
>>> x, y = symbols('x y', commutative=False)
>>> factor_nc(x**2 + 2*x*y + y**2)
(x + y)**2
```

In addition, a new function, `factor_nc_all` is added. It returns a generator which yields all unique, irreducible factors of an expression with non-commutative generators. (This is still a TODO)

#### Other comments
TODO

#### Release Notes
TODO

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
