### PR TITLE
Raise ValueError for unsolvable density function in CRV

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -320,6 +320,7 @@ Animesh Sinha <animeshsinha1309@gmail.com>
 Anish Shah <shah.anish07@gmail.com>
 Anjul Kumar Tyagi <anjul.ten@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
+Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
 Ansh Mishra <anshmishra471@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -531,11 +531,16 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
 
         gs = solveset(expr - y, self.value, S.Reals)
 
-        if isinstance(gs, Intersection) and S.Reals in gs.args:
-            gs = list(gs.args[1])
-
-        if not gs:
-            raise ValueError("Can not solve %s for %s"%(expr, self.value))
+        if isinstance(gs, Intersection):
+            if len(gs.args) == 2:
+                if gs.args[0] is S.Reals:
+                    gs = gs.args[1]
+                else:
+                    raise NotImplementedError("Anticipating Intersection(Reals, Set)")
+            else:
+                raise NotImplementedError("Intersection length is not 2")
+        if not gs.is_FiniteSet:
+            raise ValueError("Can not solve %s for %s" % (expr, self.value))
         fx = self.compute_density(self.value)
         fy = sum(fx(g) * abs(g.diff(y)) for g in gs)
         return Lambda(y, fy)

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -537,8 +537,6 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
                     gs = gs.args[1]
                 else:
                     raise NotImplementedError("Anticipating Intersection(Reals, Set)")
-            else:
-                raise NotImplementedError("Intersection length is not 2")
         if not gs.is_FiniteSet:
             raise ValueError("Can not solve %s for %s" % (expr, self.value))
         fx = self.compute_density(self.value)

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -532,11 +532,8 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         gs = solveset(expr - y, self.value, S.Reals)
 
         if isinstance(gs, Intersection):
-            if len(gs.args) == 2:
-                if gs.args[0] is S.Reals:
-                    gs = gs.args[1]
-                else:
-                    raise NotImplementedError("Anticipating Intersection(Reals, Set)")
+            if len(gs.args) == 2 and gs.args[0] is S.Reals:
+                gs = gs.args[1]
         if not gs.is_FiniteSet:
             raise ValueError("Can not solve %s for %s" % (expr, self.value))
         fx = self.compute_density(self.value)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1577,3 +1577,7 @@ def test_issue_16318():
     # test compute_expectation function of the SingleContinuousDomain
     N = SingleContinuousDomain(x, Interval(0, 1))
     raises(ValueError, lambda: SingleContinuousDomain.compute_expectation(N, x+1, {x, y}))
+
+def test_compute_density():
+    X = Normal('X', 0, Symbol("sigma")**2)
+    raises(ValueError, lambda: density(X**5 + X))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24915 
Continuing the apparently stale pull request #25373, but applying the last review comments.
#### Brief description of what is fixed or changed
For the density of the sum of normal and normal to the 5th power or higher power, the ValueError exception is raised with informative messages instead of calculating it as per the Abel-Ruffini theorem.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
- stats 
  - The `compute_density` function adheres to the Abel-Ruffini theorem, raising a ValueError.
<!-- END RELEASE NOTES -->
