### PR TITLE
maint(ci): add a numpy nightly CI job

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -181,11 +181,11 @@ jobs:
                          'antlr4-python3-runtime==4.11.*'                 \
                          #
 
-      - run: pip install llvmlite gmpy2 symengine pymc
+      - run: pip install llvmlite gmpy2 symengine
 
       # Not available in CPython 3.12 (yet).
       - if: ${{ ! contains(matrix.python-version, '3.12') }}
-        run: pip install numba
+        run: pip install numba pymc
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -214,12 +214,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements-dev.txt
-      - run: pip install -U --pre --only-binary numpy -i \
-                  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-                  numpy
-      - run: pip install -U --pre --only-binary scipy -i \
-                  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-                  scipy
+      - run: pip install -i \
+          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+          numpy
+      - run: pip install -i \
+          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+          scipy
 
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -181,11 +181,11 @@ jobs:
                          'antlr4-python3-runtime==4.11.*'                 \
                          #
 
-      - run: pip install llvmlite symengine
+      - run: pip install symengine
 
       # Not available in CPython 3.12 (yet).
       - if: ${{ ! contains(matrix.python-version, '3.12') }}
-        run: pip install numba pymc gmpy2
+        run: pip install numba pymc gmpy2 llvmlite
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -215,9 +215,11 @@ jobs:
 
       - run: pip install -r requirements-dev.txt
       - run: pip install -U --pre --only-binary numpy -i \
-                  https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+                  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+                  numpy
       - run: pip install -U --pre --only-binary scipy -i \
-                  https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+                  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+                  scipy
 
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -214,9 +214,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements-dev.txt
-      - run: pip install -U --pre --only-binary :all: -i \
+      - run: pip install -U --pre --only-binary numpy -i \
                   https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-      - run: pip install -U --pre --only-binary :all: -i \
+      - run: pip install -U --pre --only-binary scipy -i \
                   https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
 
       # Test modules with specific dependencies

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -182,8 +182,7 @@ jobs:
                          #
 
       # Not available in CPython 3.12 (yet).
-      - if: ${{ ! contains(matrix.python-version, '3.12') }}
-        run: pip install llvmlite numba gmpy2 symengine pymc
+      - run: pip install llvmlite numba gmpy2 symengine pymc
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -195,7 +195,7 @@ jobs:
 
   # -------------------- NumPy 2.0 job ----------------------------- #
 
-  optional-dependencies:
+  numpy-nightly:
     needs: code-quality
 
     runs-on: ubuntu-20.04
@@ -205,7 +205,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
-    name: ${{ matrix.python-version }} Optional Dendendencies
+    name: ${{ matrix.python-version }} NumPy nightly
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -181,8 +181,11 @@ jobs:
                          'antlr4-python3-runtime==4.11.*'                 \
                          #
 
+      - run: pip install llvmlite gmpy2 symengine pymc
+
       # Not available in CPython 3.12 (yet).
-      - run: pip install llvmlite numba gmpy2 symengine pymc
+      - if: ${{ ! contains(matrix.python-version, '3.12') }}
+        run: pip install numba
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -181,11 +181,11 @@ jobs:
                          'antlr4-python3-runtime==4.11.*'                 \
                          #
 
-      - run: pip install llvmlite gmpy2 symengine
+      - run: pip install llvmlite symengine
 
       # Not available in CPython 3.12 (yet).
       - if: ${{ ! contains(matrix.python-version, '3.12') }}
-        run: pip install numba pymc
+        run: pip install numba pymc gmpy2
 
       # Test external imports
       - run: bin/test_external_imports.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test all modules are listed in setup.py
         run: bin/test_setup.py
 
-      - run: pip install slotscheck . 
+      - run: pip install slotscheck .
 
       - name: Check for incorrect use of ``__slots__`` using slotscheck
         run: python -m slotscheck --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra|sympy.plotting.pygletplot.*)" sympy
@@ -189,6 +189,35 @@ jobs:
       - run: bin/test_external_imports.py
       - run: bin/test_submodule_imports.py
       - run: bin/test_executable.py
+
+      # Test modules with specific dependencies
+      - run: bin/test_optional_dependencies.py
+
+  # -------------------- NumPy 2.0 job ----------------------------- #
+
+  optional-dependencies:
+    needs: code-quality
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    name: ${{ matrix.python-version }} Optional Dendendencies
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip install -r requirements-dev.txt
+      - run: pip install -U --pre --only-binary :all: -i \
+                  https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+      - run: pip install -U --pre --only-binary :all: -i \
+                  https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
 
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -213,12 +213,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements-dev.txt
-      - run: pip install -i \
-          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-          numpy
-      - run: pip install -i \
-          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-          scipy
+      - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+      - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
 
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

gh-26094

#### Brief description of what is fixed or changed

Add a CI job that tests with numpy and scipy nightly builds.

I'm not sure this is always needed but at least in preparation for numpy 2.0 it seems worthwhile.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
