### PR TITLE
Fixes for variation of gaussian integral

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -790,6 +790,7 @@ def _check_antecedents_1(g, x, helper=False):
                                             tr(g.an), tr(g.aother), x/eta),
                                     x)
 
+    eta=unpolarify(eta)
     tmp = [-re(b) < 1 for b in g.bm] + [1 < 1 - re(a) for a in g.an]
     cond_3 = And(*tmp)
 
@@ -2006,6 +2007,16 @@ def _my_unpolarify(f):
     return _eval_cond(unpolarify(f))
 
 
+def _alt_unpolarify(f):
+   if isinstance(f, Mul):
+       new=S.One
+       for terms in Mul.make_args(f):
+           if terms.is_Pow:
+               b ,e = terms.as_base_exp()
+               terms = unpolarify(b)**e
+           new *= terms
+       return new
+
 @timeit
 def _meijerint_definite_4(f, x, only_double=False):
     """
@@ -2039,6 +2050,8 @@ def _meijerint_definite_4(f, x, only_double=False):
                 if cond == False:
                     break
             cond = _my_unpolarify(cond)
+            if _alt_unpolarify(res):
+                res = _alt_unpolarify(res)
             if cond == False:
                 _debug('But cond is always False.')
             else:
@@ -2069,6 +2082,8 @@ def _meijerint_definite_4(f, x, only_double=False):
                     continue
                 break
             cond = _my_unpolarify(cond)
+            if _alt_unpolarify(res):
+                res = _alt_unpolarify(res)
             if cond == False:
                 _debugf('But cond is always False (full_pb=%s).', full_pb)
             else:

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -762,3 +762,13 @@ def test_pr_23583():
     # This result is wrong. Check whether new result is correct when this test fail.
     assert integrate(1/sqrt((x - I)**2-1), meijerg=True) == \
            Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+
+
+def test_issue_26102():
+    from sympy.core.symbol import Symbol
+    x = Symbol('x', real=True)
+    z = Symbol('z', real=True)
+    z0 = Symbol('z0', real=True)
+    zR = Symbol('z_R', positive=True)
+    assert(integrate(abs(exp(-I/2 * x**2 / (I*zR + (z-z0))))**2,(x,-oo,oo),meijerg=True) == \
+        sqrt(pi)*sqrt(zR**2 + (z - z0)**2)/sqrt(zR))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26102 

#### Brief description of what is fixed or changed

Better handling of results that have non-integral exponents by using a different method `_alt_unpolarify()`. Also simplified the coefficient eta in `_check_antecedents_1` before is used for determining conditions for different branches in integrals.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added a method `_alt_unpolarify()` in meijerint,.py that will help in better simplifying results with non-integer powers as `unpolarify()` by default do not handles such cases.

<!-- END RELEASE NOTES -->
