### PR TITLE
Fix parsing and printing of numpy types for numpy 2.0

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 from typing import Any, Callable
 
+import mpmath.libmp as mlib
+
 from inspect import getmro
 import string
 from sympy.core.random import choice
@@ -88,8 +90,8 @@ def _convert_numpy_types(a, **sympify_args):
         prec = np.finfo(a).nmant + 1
         # E.g. double precision means prec=53 but nmant=52
         # Leading bit of mantissa is always 1, so is not stored
-        a = str(list(np.reshape(np.asarray(a),
-                                (1, np.size(a)))[0]))[1:-1]
+        p, q = a.as_integer_ratio()
+        a = mlib.from_rational(p, q, prec)
         return Float(a, precision=prec)
 
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -647,8 +647,8 @@ def test_sympify_numpy():
     assert equal(sympify(np.complex64(1 + 2j)), S(1.0 + 2.0*I))
     assert equal(sympify(np.complex128(1 + 2j)), S(1.0 + 2.0*I))
 
-    lcprec = np.finfo(np.longcomplex(1)).nmant + 1
-    assert equal(sympify(np.longcomplex(1 + 2j)),
+    lcprec = np.finfo(np.clongdouble(1)).nmant + 1
+    assert equal(sympify(np.clongdouble(1 + 2j)),
                 Float(1.0, precision=lcprec) + Float(2.0, precision=lcprec)*I)
 
     #float96 does not exist on all platforms

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -26,8 +26,7 @@ _known_constants_numpy = {
     'Pi': 'pi',
     'EulerGamma': 'euler_gamma',
     'NaN': 'nan',
-    'Infinity': 'PINF',
-    'NegativeInfinity': 'NINF'
+    'Infinity': 'inf',
 }
 
 _numpy_known_functions = {k: 'numpy.' + v for k, v in _known_functions_numpy.items()}
@@ -63,6 +62,9 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         #     tuples in nopython mode.
         delimiter=', '
         return '({},)'.format(delimiter.join(self._print(item) for item in seq))
+
+    def _print_NegativeInfinity(self, expr):
+        return '-' + self._print(S.Infinity)
 
     def _print_MatMul(self, expr):
         "Matrix multiplication printer"

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -138,8 +138,8 @@ def test_NumPyPrinter():
     assert p.doprint(S.Pi) == 'numpy.pi'
     assert p.doprint(S.EulerGamma) == 'numpy.euler_gamma'
     assert p.doprint(S.NaN) == 'numpy.nan'
-    assert p.doprint(S.Infinity) == 'numpy.PINF'
-    assert p.doprint(S.NegativeInfinity) == 'numpy.NINF'
+    assert p.doprint(S.Infinity) == 'numpy.inf'
+    assert p.doprint(S.NegativeInfinity) == '-numpy.inf'
 
     # Function rewriting operator precedence fix
     assert p.doprint(sec(x)**2) == '(numpy.cos(x)**(-1.0))**2'
@@ -305,7 +305,7 @@ def test_Integral():
     evaluateat = Integral(x**2, (x, 1))
 
     prntr = SciPyPrinter()
-    assert prntr.doprint(single) == 'scipy.integrate.quad(lambda x: numpy.exp(-x), 0, numpy.PINF)[0]'
+    assert prntr.doprint(single) == 'scipy.integrate.quad(lambda x: numpy.exp(-x), 0, numpy.inf)[0]'
     assert prntr.doprint(double) == 'scipy.integrate.nquad(lambda x, y: x**2*numpy.exp(x*y), ((-z, z), (0, z)))[0]'
     raises(NotImplementedError, lambda: prntr.doprint(indefinite))
     raises(NotImplementedError, lambda: prntr.doprint(evaluateat))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/26094

#### Brief description of what is fixed or changed

Changed conversion from numpy types to Float and printing of numpy types like `np.PINF` in preparation for numpy 2.0.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Conversion from numpy types like float64 has been changed for compatibility with numpy 2.0.
* printing
    * Code printers for numpy no longer use np.PINF or np.NINF which will be removed in numpy 2.0.
<!-- END RELEASE NOTES -->
