### PR TITLE
Fixes Issue#24915

### DIFF
--- a/Density Stats.ipynb
+++ b/Density Stats.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f08fee1b-8114-4076-9d86-a47d7d157758",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sympy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bd4899c8-5528-4a0c-8301-5c3ee1116d78",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left( y \\mapsto \\frac{\\sqrt{2} e^{- \\frac{\\left(- \\frac{\\sqrt[3]{- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}}}{3} + \\frac{1}{\\sqrt[3]{- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}}}\\right)^{2}}{2 \\sigma^{4}}} \\left|{\\frac{\\frac{243 y}{2 \\sqrt{729 y^{2} + 108}} - \\frac{9}{2}}{3 \\left(- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}\\right)^{\\frac{2}{3}}} + \\frac{\\frac{243 y}{2 \\sqrt{729 y^{2} + 108}} - \\frac{9}{2}}{\\left(- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}\\right)^{\\frac{4}{3}}}}\\right|}{2 \\sqrt{\\pi} \\sigma^{2}} + \\frac{\\sqrt{2} e^{- \\frac{\\left(- \\frac{\\left(- \\frac{1}{2} + \\frac{\\sqrt{3} i}{2}\\right) \\sqrt[3]{- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}}}{3} + \\frac{1}{\\left(- \\frac{1}{2} + \\frac{\\sqrt{3} i}{2}\\right) \\sqrt[3]{- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}}}\\right)^{2}}{2 \\sigma^{4}}} \\left|{- \\frac{\\left(- \\frac{1}{2} + \\frac{\\sqrt{3} i}{2}\\right) \\left(\\frac{243 y}{2 \\sqrt{729 y^{2} + 108}} - \\frac{9}{2}\\right)}{3 \\left(- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}\\right)^{\\frac{2}{3}}} + \\frac{- \\frac{243 y}{2 \\sqrt{729 y^{2} + 108}} + \\frac{9}{2}}{\\left(- \\frac{1}{2} + \\frac{\\sqrt{3} i}{2}\\right) \\left(- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}\\right)^{\\frac{4}{3}}}}\\right|}{2 \\sqrt{\\pi} \\sigma^{2}} + \\frac{\\sqrt{2} e^{- \\frac{\\left(- \\frac{\\left(- \\frac{1}{2} - \\frac{\\sqrt{3} i}{2}\\right) \\sqrt[3]{- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}}}{3} + \\frac{1}{\\left(- \\frac{1}{2} - \\frac{\\sqrt{3} i}{2}\\right) \\sqrt[3]{- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}}}\\right)^{2}}{2 \\sigma^{4}}} \\left|{- \\frac{\\left(- \\frac{1}{2} - \\frac{\\sqrt{3} i}{2}\\right) \\left(\\frac{243 y}{2 \\sqrt{729 y^{2} + 108}} - \\frac{9}{2}\\right)}{3 \\left(- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}\\right)^{\\frac{2}{3}}} + \\frac{- \\frac{243 y}{2 \\sqrt{729 y^{2} + 108}} + \\frac{9}{2}}{\\left(- \\frac{1}{2} - \\frac{\\sqrt{3} i}{2}\\right) \\left(- \\frac{27 y}{2} + \\frac{\\sqrt{729 y^{2} + 108}}{2}\\right)^{\\frac{4}{3}}}}\\right|}{2 \\sqrt{\\pi} \\sigma^{2}} \\right)$"
+      ],
+      "text/plain": [
+       "Lambda(_y, sqrt(2)*exp(-(-(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(1/3)/3 + (-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(-1/3))**2/(2*sigma**4))*Abs((243*_y/(2*sqrt(729*_y**2 + 108)) - 9/2)/(3*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(2/3)) + (243*_y/(2*sqrt(729*_y**2 + 108)) - 9/2)/(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(4/3))/(2*sqrt(pi)*sigma**2) + sqrt(2)*exp(-(-(-1/2 + sqrt(3)*I/2)*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(1/3)/3 + 1/((-1/2 + sqrt(3)*I/2)*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(1/3)))**2/(2*sigma**4))*Abs(-(-1/2 + sqrt(3)*I/2)*(243*_y/(2*sqrt(729*_y**2 + 108)) - 9/2)/(3*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(2/3)) + (-243*_y/(2*sqrt(729*_y**2 + 108)) + 9/2)/((-1/2 + sqrt(3)*I/2)*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(4/3)))/(2*sqrt(pi)*sigma**2) + sqrt(2)*exp(-(-(-1/2 - sqrt(3)*I/2)*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(1/3)/3 + 1/((-1/2 - sqrt(3)*I/2)*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(1/3)))**2/(2*sigma**4))*Abs(-(-1/2 - sqrt(3)*I/2)*(243*_y/(2*sqrt(729*_y**2 + 108)) - 9/2)/(3*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(2/3)) + (-243*_y/(2*sqrt(729*_y**2 + 108)) + 9/2)/((-1/2 - sqrt(3)*I/2)*(-27*_y/2 + sqrt(729*_y**2 + 108)/2)**(4/3)))/(2*sqrt(pi)*sigma**2))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sympy.stats as stats\n",
+    "from sympy import Symbol\n",
+    "\n",
+    "# Define the symbol\n",
+    "sigma = Symbol(\"sigma\")\n",
+    "\n",
+    "# Create a normal random variable\n",
+    "X = stats.Normal('X', 0, sigma**2)\n",
+    "\n",
+    "# Define a new random variable representing the 5th power\n",
+    "Y = X**3 + X\n",
+    "\n",
+    "# Explicitly condition on the value of Y\n",
+    "stats.density(Y)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c459a2c9-9cf7-487b-ae51-5088b3343355",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sympy.stats as stats\n",
+    "from sympy import Symbol\n",
+    "\n",
+    "# Define the symbol\n",
+    "sigma = Symbol(\"sigma\")\n",
+    "\n",
+    "# Create a normal random variable\n",
+    "X = stats.Normal('X', 0, sigma**2)\n",
+    "\n",
+    "# Define a new random variable representing the 5th power\n",
+    "Y = X**5 + X\n",
+    "\n",
+    "# Explicitly condition on the value of Y\n",
+    "A=stats.density(Y,Y<0)\n",
+    "\n",
+    "\n",
+    "B=stats.density(Y,Y>0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a9556ee8-ecfb-4422-b47c-68768fa69692",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left( z \\mapsto \\int\\limits_{-\\infty}^{0} \\begin{cases} \\frac{\\sqrt{2} e^{- \\frac{X^{2}}{2 \\sigma^{4}}} \\delta\\left(- z + X^{5} + X\\right)}{\\sqrt{\\pi} \\sigma^{2}} & \\text{for}\\: \\left|{\\arg{\\left(\\sigma \\right)}}\\right| \\leq \\frac{\\pi}{8} \\\\\\frac{\\sqrt{2} e^{- \\frac{X^{2}}{2 \\sigma^{4}}} \\delta\\left(- z + X^{5} + X\\right)}{2 \\sqrt{\\pi} \\sigma^{2} \\int\\limits_{-\\infty}^{0} \\frac{\\sqrt{2} e^{- \\frac{X^{2}}{2 \\sigma^{4}}}}{2 \\sqrt{\\pi} \\sigma^{2}}\\, dX} & \\text{otherwise} \\end{cases}\\, dX \\right)$"
+      ],
+      "text/plain": [
+       "Lambda(_z, Integral(Piecewise((sqrt(2)*exp(-X**2/(2*sigma**4))*DiracDelta(-_z + X**5 + X)/(sqrt(pi)*sigma**2), Abs(arg(sigma)) <= pi/8), (sqrt(2)*exp(-X**2/(2*sigma**4))*DiracDelta(-_z + X**5 + X)/(2*sqrt(pi)*sigma**2*Integral(sqrt(2)*exp(-_X**2/(2*sigma**4))/(2*sqrt(pi)*sigma**2), (_X, -oo, 0))), True)), (X, -oo, 0)))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "84ebb1dc-6a16-48a2-9696-a35b7ab4e9ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left( z \\mapsto \\int\\limits_{0}^{\\infty} \\begin{cases} \\frac{\\sqrt{2} e^{- \\frac{X^{2}}{2 \\sigma^{4}}} \\delta\\left(- z + X^{5} + X\\right)}{\\sqrt{\\pi} \\sigma^{2}} & \\text{for}\\: \\left|{\\arg{\\left(\\sigma \\right)}}\\right| \\leq \\frac{\\pi}{8} \\\\\\frac{\\sqrt{2} e^{- \\frac{X^{2}}{2 \\sigma^{4}}} \\delta\\left(- z + X^{5} + X\\right)}{2 \\sqrt{\\pi} \\sigma^{2} \\int\\limits_{0}^{\\infty} \\frac{\\sqrt{2} e^{- \\frac{X^{2}}{2 \\sigma^{4}}}}{2 \\sqrt{\\pi} \\sigma^{2}}\\, dX} & \\text{otherwise} \\end{cases}\\, dX \\right)$"
+      ],
+      "text/plain": [
+       "Lambda(_z, Integral(Piecewise((sqrt(2)*exp(-X**2/(2*sigma**4))*DiracDelta(-_z + X**5 + X)/(sqrt(pi)*sigma**2), Abs(arg(sigma)) <= pi/8), (sqrt(2)*exp(-X**2/(2*sigma**4))*DiracDelta(-_z + X**5 + X)/(2*sqrt(pi)*sigma**2*Integral(sqrt(2)*exp(-_X**2/(2*sigma**4))/(2*sqrt(pi)*sigma**2), (_X, 0, oo))), True)), (X, 0, oo)))"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43e8167-0f49-4fdb-88c1-33fa54d86c90",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**Issue:**
Condition set object not iterable in SymPy when calculating normal density distribution for the 5th power of x.

**Proposed Solution:**
[vertopal.com_Density Stats.pdf](https://github.com/sympy/sympy/files/14037437/vertopal.com_Density.Stats.pdf)


**CODE :**
import sympy.stats as stats
from sympy import Symbol

# Define the symbol
sigma = Symbol("sigma")

# Create a normal random variable
X = stats.Normal('X', 0, sigma**2)

# Define a new random variable representing the 5th power
Y = X**5 + X

# Explicitly condition on the value of Y
A=stats.density(Y,Y<0)


B=stats.density(Y,Y>0)

# You can also use a different condition based on your requirements
# density_y = stats.density(Y, Y < some_value)

**Explanation:**
I encountered the "Condition set object not iterable" error when trying to calculate the density for the expression X**5 + X. To address this, I modified the code to use an explicit condition (Y > 0) in the stats.density call. This ensures that the calculation is performed without encountering the condition set error.

**Testing:**
I have tested this solution with various values of sigma, and it appears to provide the expected results. I encourage others to review and provide feedback.

But there are some problems also.In this approach,we are getting the piecewise solution,not the simplified solution.
If there are any alternative approaches that could be considered, please feel free to provide feedback. I don't know if my solution is correct