### PR TITLE
adding assoc_legendre: legenp in mpmath_translation in lambdify.py

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -67,6 +67,7 @@ MPMATH_TRANSLATIONS = {
     "ceiling": "ceil",
     "chebyshevt": "chebyt",
     "chebyshevu": "chebyu",
+    "assoc_legendre": "legenp",
     "E": "e",
     "I": "j",
     "ln": "log",

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -964,6 +964,8 @@ def _recursive_to_string(doprint, arg):
             left, right = "[", "]"
         elif isinstance(arg, tuple):
             left, right = "(", ",)"
+            if not arg:
+                return "()"
         else:
             raise NotImplementedError("unhandled type: %s, %s" % (type(arg), arg))
         return left +', '.join(_recursive_to_string(doprint, e) for e in arg) + right

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1880,3 +1880,20 @@ def test_lambdify_empty_tuple():
     f = lambdify(a, expr)
     result = f(1)
     assert result == ((), (1,)), "Lambdify did not handle the empty tuple correctly."
+
+
+def test_issue_15795():
+    from mpmath import mpc
+    assoc_legendre_evalf = -25.4558441227157*I
+    assoc_legendre_n = -0.474572528387641
+    tol = 1e-3
+    assert assoc_legendre(2, 1, 3) == -18*sqrt(2)*I
+    assert all_close(assoc_legendre(2, 1, 3).evalf(), assoc_legendre_evalf)
+    assert all_close(assoc_legendre(1, 1/2, 0.1).n(), assoc_legendre_n)
+    assert mpmath.legenp(2, 1, 3) == mpc(real='-8.2688999181462742e-24', imag='-25.45584412271571')
+    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
+    assert all_close(assoc_legendre(0.1, 1, 10).evalf(), mpmath.legenp(0.1, 1, 10))
+    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
+    assert abs(assoc_legendre(1, -0.1*I, 10).evalf() - mpmath.legenp(1, -0.1*I, 10)) < tol
+    assert all_close(assoc_legendre(1, 0.1*I, 10).evalf(), mpmath.legenp(1, 0.1*I, 10))
+    assert all_close(assoc_legendre(1, 22/7, 10).evalf(), mpmath.legenp(1, 22/7, 10))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -52,6 +52,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.exceptions import ignore_warnings
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import uppergamma, lowergamma
+from sympy.core.numbers import all_close
 
 
 import sympy
@@ -1877,12 +1878,14 @@ def test_issue_15795():
     from mpmath import mpc
     assoc_legendre_evalf = -25.4558441227157*I
     assoc_legendre_n = -0.474572528387641
+    tol = 1e-3
     assert assoc_legendre(2, 1, 3) == -18*sqrt(2)*I
-    assert abs(assoc_legendre(2, 1, 3).evalf()) - abs(assoc_legendre_evalf) < 1e-10
-    assert abs(assoc_legendre(1, 1/2, 0.1).n()) - abs(assoc_legendre_n) < 1e-10
+    assert all_close(assoc_legendre(2, 1, 3).evalf(), assoc_legendre_evalf)
+    assert all_close(assoc_legendre(1, 1/2, 0.1).n(), assoc_legendre_n)
     assert mpmath.legenp(2, 1, 3) == mpc(real='-8.2688999181462742e-24', imag='-25.45584412271571')
-    assert abs(assoc_legendre(1, -1, 10).evalf()) - abs(mpmath.legenp(1, -1, 10)) < 1e-10
-    assert abs(assoc_legendre(0.1, 1, 10).evalf()) - abs(mpmath.legenp(0.1, 1, 10)) < 1e-10
-    assert abs(assoc_legendre(1, -1, 10).evalf()) - abs(mpmath.legenp(1, -1, 10)) < 1e-10
-    assert abs(assoc_legendre(1, -0.1*I, 10).evalf()) - abs(mpmath.legenp(1, -0.1*I, 10)) < 1e-10
-    assert abs(assoc_legendre(1, 0.1*I, 10).evalf()) - abs(mpmath.legenp(1, 0.1*I, 10)) < 1e-10
+    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
+    assert all_close(assoc_legendre(0.1, 1, 10).evalf(), mpmath.legenp(0.1, 1, 10))
+    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
+    assert abs(assoc_legendre(1, -0.1*I, 10).evalf() - mpmath.legenp(1, -0.1*I, 10)) < tol
+    assert all_close(assoc_legendre(1, 0.1*I, 10).evalf(), mpmath.legenp(1, 0.1*I, 10))
+    assert all_close(assoc_legendre(1, 22/7, 10).evalf(), mpmath.legenp(1, 22/7, 10))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1881,3 +1881,8 @@ def test_issue_15795():
     assert abs(assoc_legendre(2, 1, 3).evalf()) - abs(assoc_legendre_evalf) < 1e-10
     assert abs(assoc_legendre(1, 1/2, 0.1).n()) - abs(assoc_legendre_n) < 1e-10
     assert mpmath.legenp(2, 1, 3) == mpc(real='-8.2688999181462742e-24', imag='-25.45584412271571')
+    assert abs(assoc_legendre(1, -1, 10).evalf()) - abs(mpmath.legenp(1, -1, 10)) < 1e-10
+    assert abs(assoc_legendre(0.1, 1, 10).evalf()) - abs(mpmath.legenp(0.1, 1, 10)) < 1e-10
+    assert abs(assoc_legendre(1, -1, 10).evalf()) - abs(mpmath.legenp(1, -1, 10)) < 1e-10
+    assert abs(assoc_legendre(1, -0.1*I, 10).evalf()) - abs(mpmath.legenp(1, -0.1*I, 10)) < 1e-10
+    assert abs(assoc_legendre(1, 0.1*I, 10).evalf()) - abs(mpmath.legenp(1, 0.1*I, 10)) < 1e-10

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1871,3 +1871,13 @@ def test_lambdify_docstring_size_limit_matrix():
             docstring_limit=test_case.docstring_limit,
         )
         assert lambdified_expr.__doc__ == test_case.expected_docstring
+
+
+def test_issue_15795():
+    from mpmath import mpc
+    assoc_legendre_evalf = -25.4558441227157*I
+    assoc_legendre_n = -0.474572528387641
+    assert assoc_legendre(2, 1, 3) == -18*sqrt(2)*I
+    assert abs(assoc_legendre(2, 1, 3).evalf()) - abs(assoc_legendre_evalf) < 1e-10
+    assert abs(assoc_legendre(1, 1/2, 0.1).n()) - abs(assoc_legendre_n) < 1e-10
+    assert mpmath.legenp(2, 1, 3) == mpc(real='-8.2688999181462742e-24', imag='-25.45584412271571')

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -52,7 +52,6 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.exceptions import ignore_warnings
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import uppergamma, lowergamma
-from sympy.core.numbers import all_close
 
 
 import sympy
@@ -1881,19 +1880,3 @@ def test_lambdify_empty_tuple():
     result = f(1)
     assert result == ((), (1,)), "Lambdify did not handle the empty tuple correctly."
 
-
-def test_issue_15795():
-    from mpmath import mpc
-    assoc_legendre_evalf = -25.4558441227157*I
-    assoc_legendre_n = -0.474572528387641
-    tol = 1e-3
-    assert assoc_legendre(2, 1, 3) == -18*sqrt(2)*I
-    assert all_close(assoc_legendre(2, 1, 3).evalf(), assoc_legendre_evalf)
-    assert all_close(assoc_legendre(1, 1/2, 0.1).n(), assoc_legendre_n)
-    assert mpmath.legenp(2, 1, 3) == mpc(real='-8.2688999181462742e-24', imag='-25.45584412271571')
-    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
-    assert all_close(assoc_legendre(0.1, 1, 10).evalf(), mpmath.legenp(0.1, 1, 10))
-    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
-    assert abs(assoc_legendre(1, -0.1*I, 10).evalf() - mpmath.legenp(1, -0.1*I, 10)) < tol
-    assert all_close(assoc_legendre(1, 0.1*I, 10).evalf(), mpmath.legenp(1, 0.1*I, 10))
-    assert all_close(assoc_legendre(1, 22/7, 10).evalf(), mpmath.legenp(1, 22/7, 10))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1879,4 +1879,3 @@ def test_lambdify_empty_tuple():
     f = lambdify(a, expr)
     result = f(1)
     assert result == ((), (1,)), "Lambdify did not handle the empty tuple correctly."
-

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1880,20 +1880,3 @@ def test_lambdify_empty_tuple():
     f = lambdify(a, expr)
     result = f(1)
     assert result == ((), (1,)), "Lambdify did not handle the empty tuple correctly."
-
-
-def test_issue_15795():
-    from mpmath import mpc
-    assoc_legendre_evalf = -25.4558441227157*I
-    assoc_legendre_n = -0.474572528387641
-    tol = 1e-3
-    assert assoc_legendre(2, 1, 3) == -18*sqrt(2)*I
-    assert all_close(assoc_legendre(2, 1, 3).evalf(), assoc_legendre_evalf)
-    assert all_close(assoc_legendre(1, 1/2, 0.1).n(), assoc_legendre_n)
-    assert mpmath.legenp(2, 1, 3) == mpc(real='-8.2688999181462742e-24', imag='-25.45584412271571')
-    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
-    assert all_close(assoc_legendre(0.1, 1, 10).evalf(), mpmath.legenp(0.1, 1, 10))
-    assert all_close(assoc_legendre(1, -1, 10).evalf(), mpmath.legenp(1, -1, 10))
-    assert abs(assoc_legendre(1, -0.1*I, 10).evalf() - mpmath.legenp(1, -0.1*I, 10)) < tol
-    assert all_close(assoc_legendre(1, 0.1*I, 10).evalf(), mpmath.legenp(1, 0.1*I, 10))
-    assert all_close(assoc_legendre(1, 22/7, 10).evalf(), mpmath.legenp(1, 22/7, 10))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1874,6 +1874,14 @@ def test_lambdify_docstring_size_limit_matrix():
         assert lambdified_expr.__doc__ == test_case.expected_docstring
 
 
+def test_lambdify_empty_tuple():
+    a = symbols("a")
+    expr = ((), (a,))
+    f = lambdify(a, expr)
+    result = f(1)
+    assert result == ((), (1,)), "Lambdify did not handle the empty tuple correctly."
+
+
 def test_issue_15795():
     from mpmath import mpc
     assoc_legendre_evalf = -25.4558441227157*I


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for: #15795 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Added "assoc_legendre" ("legenp") support in lambdify.py mpmath translation. Included a required test case for robust functionality.
<!-- END RELEASE NOTES -->
