### PR TITLE
Added a test Case for the recursion error in `function_range`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1587,6 +1587,7 @@ risubaba <risubhjain1010@gmail.com>
 ritikBhandari <ritikbhandari68@gmail.com>
 rushyam <rushyamsonu@gmail.com>
 sachinSingh16-09 <sachinishu02@gmail.com>
+samithkavishke <55777141+samithkavishke@users.noreply.github.com>
 sbt4104 <sthorat661@gmail.com>
 scimax <max.kellermeier@hotmail.de>
 seadavis <45022599+seadavis@users.noreply.github.com>

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -22,7 +22,7 @@ from sympy.calculus.util import (function_range, continuous_domain, not_empty_in
 from sympy.sets.sets import (Interval, FiniteSet, Complement, Union)
 from sympy.sets.fancysets import ImageSet
 from sympy.sets.conditionset import ConditionSet
-from sympy.testing.pytest import XFAIL, raises, _both_exp_pow
+from sympy.testing.pytest import XFAIL, raises, _both_exp_pow, slow
 from sympy.abc import x
 
 a = Symbol('a', real=True)
@@ -57,7 +57,6 @@ def test_function_range():
         ) == Interval(-1, 1)
     assert function_range(cos(x), x, S.EmptySet) == S.EmptySet
     assert function_range(x/sqrt(x**2+1), x, S.Reals) == Interval.open(-1,1)
-    assert function_range(tan(x)**2 + tan(3*x)**2 + 1, x, S.Reals) == Interval(1,oo)
     raises(NotImplementedError, lambda : function_range(
         exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
     raises(NotImplementedError, lambda : function_range(
@@ -66,6 +65,10 @@ def test_function_range():
         log(x), x, S.Integers))
     raises(NotImplementedError, lambda : function_range(
         sin(x)/2, x, S.Naturals))
+
+@slow
+def test_function_range1():
+    assert function_range(tan(x)**2 + tan(3*x)**2 + 1, x, S.Reals) == Interval(1,oo)
 
 
 def test_continuous_domain():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -57,6 +57,7 @@ def test_function_range():
         ) == Interval(-1, 1)
     assert function_range(cos(x), x, S.EmptySet) == S.EmptySet
     assert function_range(x/sqrt(x**2+1), x, S.Reals) == Interval.open(-1,1)
+    assert function_range(tan(x)**2 + tan(3*x)**2 + 1, x, S.Reals) == Interval(1,oo)
     raises(NotImplementedError, lambda : function_range(
         exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
     raises(NotImplementedError, lambda : function_range(

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -66,6 +66,7 @@ def test_function_range():
     raises(NotImplementedError, lambda : function_range(
         sin(x)/2, x, S.Naturals))
 
+
 @slow
 def test_function_range1():
     assert function_range(tan(x)**2 + tan(3*x)**2 + 1, x, S.Reals) == Interval(1,oo)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix for #26076 

#### Brief description of what is fixed or changed
I have added a simple test case to validate this case


#### Other comments
None

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
