### PR TITLE
Fixes dsolve fail with the Bessel equation when division appears

### DIFF
--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -2753,7 +2753,7 @@ class SecondLinearBessel(SingleODESolver):
             # c3 maybe of very complex form so I am simply checking (a - b) form
             # if yes later I will match with the standerd form of bessel in a and b
             # a, b are wild variable defined above.
-            _coeff2 = r[c3].match(a - b)
+            _coeff2 = expand(r[c3]).match(a - b)
             if _coeff2 is None:
                 return False
             # matching with standerd form for c3

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -2101,6 +2101,10 @@ def _get_examples_ode_sol_2nd_linear_bessel():
         'eq': f(x).diff(x, x) + 2/x*f(x).diff(x) + f(x),
         'sol': [Eq(f(x), (C1*besselj(S(1)/2, x) + C2*bessely(S(1)/2, x))/sqrt(x))],
     },
+    '2nd_lin_bessel_12': {
+        'eq': x**2*f(x).diff(x, 2) + x*f(x).diff(x) + (10**2*x**2/5**2 - 6**2)*f(x),
+        'sol': [Eq(f(x), C1*besselj(6, 2*x) + C2*bessely(6, 2*x))],
+    },
     }
     }
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -70,6 +70,7 @@ y = Symbol('y')
 f = Function('f')
 g = Function('g')
 C1, C2, C3, C4, C5, C6, C7, C8, C9, C10  = symbols('C1:11')
+a, b, c = symbols('a b c')
 
 
 hint_message = """\
@@ -2102,8 +2103,8 @@ def _get_examples_ode_sol_2nd_linear_bessel():
         'sol': [Eq(f(x), (C1*besselj(S(1)/2, x) + C2*bessely(S(1)/2, x))/sqrt(x))],
     },
     '2nd_lin_bessel_12': {
-        'eq': x**2*f(x).diff(x, 2) + x*f(x).diff(x) + (10**2*x**2/5**2 - 6**2)*f(x),
-        'sol': [Eq(f(x), C1*besselj(6, 2*x) + C2*bessely(6, 2*x))],
+        'eq': x**2*f(x).diff(x, 2) + x*f(x).diff(x) + (a**2*x**2/c**2 - b**2)*f(x),
+        'sol': [Eq(f(x), C1*besselj(sqrt(b**2), x*sqrt(a**2/c**2)) + C2*bessely(sqrt(b**2), x*sqrt(a**2/c**2)))],
     },
     }
     }


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19317

#### Brief description of what is fixed or changed
`dsolve()` can solve the Bessel differential equation when division appears by the following change (see pic).
![Screenshot from 2024-01-25 22-05-21](https://github.com/sympy/sympy/assets/57264717/ec613608-5352-45a5-b370-214b499b9439)



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  -   `dsolve()` can solve BDE when division appears.
<!-- END RELEASE NOTES -->
