### PR TITLE
ci: skip biomechanics doctests if matplotlib is not installed

### DIFF
--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -85,8 +85,6 @@ blacklist = [
 
 doctest_list = [
     # numpy
-    'doc/src/tutorials/biomechanics/biomechanical-model-example.rst',
-    'doc/src/tutorials/biomechanics/biomechanics.rst',
     'sympy/matrices/',
     'sympy/utilities/lambdify.py',
 
@@ -128,6 +126,18 @@ doctest_list = [
     # lxml
     "sympy/utilities/mathml/",
 ]
+
+
+# This is just needed for the numpy nightly job which does not have matplotlib
+# Otherwise these could be added to doctest_list above
+try:
+    import matplotlib
+    doctest_list.extend([
+        'doc/src/tutorials/biomechanics/biomechanical-model-example.rst',
+        'doc/src/tutorials/biomechanics/biomechanics.rst',
+    ])
+except ImportError:
+    pass
 
 
 print('Testing optional dependencies')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows gh-26107 and gh-26112

See e.g. https://github.com/sympy/sympy/pull/26095#issuecomment-1910040845


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
