### PR TITLE
Fix lambdify crash on empty tuple (#26119)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1474,6 +1474,7 @@ Wang Ran (汪然) <wangr@smail.nju.edu.cn>
 Warren Jacinto <warrenjacinto@gmail.com>
 Wes Galbraith <galbwe92@gmail.com>
 Wes Turner <50891+westurner@users.noreply.github.com>
+Senku <mohakmalviya2000@gmail.com>
 Willem Melching <willem.melching@gmail.com>
 Wolfgang Stöcher <wolfgang@stoecher.com> coproc <wolfgang@stoecher.com>
 Wyatt Peak <wyattpeak@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1276,6 +1276,7 @@ Sebastian Krause <sebastian.krause@gmx.de>
 Sebastian Kreft <skreft@gmail.com>
 Sebastian Krämer <basti.kr@gmail.com> basti.kr <devnull@localhost>
 Segev Finer <segev208@gmail.com>
+Senku <mohakmalviya2000@gmail.com>
 Sergey B Kirpichev <skirpichev@gmail.com>
 Sergey Pestov <pestov-sa@yandex.ru>
 Sergiu Ivanov <unlimitedscolobb@gmail.com>
@@ -1474,7 +1475,6 @@ Wang Ran (汪然) <wangr@smail.nju.edu.cn>
 Warren Jacinto <warrenjacinto@gmail.com>
 Wes Galbraith <galbwe92@gmail.com>
 Wes Turner <50891+westurner@users.noreply.github.com>
-Senku <mohakmalviya2000@gmail.com>
 Willem Melching <willem.melching@gmail.com>
 Wolfgang Stöcher <wolfgang@stoecher.com> coproc <wolfgang@stoecher.com>
 Wyatt Peak <wyattpeak@gmail.com>

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -963,6 +963,8 @@ def _recursive_to_string(doprint, arg):
             left, right = "[", "]"
         elif isinstance(arg, tuple):
             left, right = "(", ",)"
+            if not arg:
+                return "()"
         else:
             raise NotImplementedError("unhandled type: %s, %s" % (type(arg), arg))
         return left +', '.join(_recursive_to_string(doprint, e) for e in arg) + right

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1871,3 +1871,11 @@ def test_lambdify_docstring_size_limit_matrix():
             docstring_limit=test_case.docstring_limit,
         )
         assert lambdified_expr.__doc__ == test_case.expected_docstring
+
+
+def test_lambdify_empty_tuple():
+    a = symbols("a")
+    expr = ((), (a,))
+    f = lambdify(a, expr)
+    result = f(1)
+    assert result == ((), (1,)), "Lambdify did not handle the empty tuple correctly."


### PR DESCRIPTION
Resolve Lambdify Crash on Empty Tuple Input
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #26119

#### Brief description of what is fixed or changed

Resolved a bug in lambdify where it crashed when handling an empty tuple. This was caused by a syntax error during the compilation of the function string. The fix involves modifying _recursive_to_string in sympy.utilities.lambdify to correctly handle empty tuples, ensuring they are converted to an empty tuple string in Python.
#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fix bug that caused lambdify to crash on empty tuples.
<!-- END RELEASE NOTES -->
