### PR TITLE
Remove `debug=True` option for lark parser

### DIFF
--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -56,7 +56,6 @@ class LarkLaTeXParser:
             start="latex_string",
             lexer="auto",
             ambiguity="explicit",
-            debug=True,
             propagate_positions=False,
             maybe_placeholders=False,
             keep_all_tokens=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/26098#discussion_r1468279205

#### Brief description of what is fixed or changed

- I think that `debug=True` option is embarassingly slowing down the performance. The reason is that it generates `sppf.png` with each run of parser. The problem depends on the environment, so if you have `pydot` installed, it spends so much time generating that image after parsing. (I'd note that technically, SPPF is not the diagram for the grammar, but diagram for the parsing result, similar as parsing tree. So we are just drawing parsing tree every time)
- Maybe we should have sorted out this in code review before. However, we may have not noticed this shameful mistake, or underestimated that this had impact on performance (because nobody was using `pydot`)

```python3
import time
from sympy.parsing.latex import parse_latex

expression = r"\int_0^{\infty} e^{-x}\,dx"
%timeit parse_latex(expression, backend="lark")
```
I test out this and I get the result
`32.9 ms ± 980 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)` (with this PR)
`1.66 s ± 21.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)` (without this PR)
If you are not getting same result, check if you really have `sppf.png` junk generated

- I am procrastinating to give play with performance with `antlr` again, because that may not be relevant to the issue fixed in this PR, however, after merging this PR, we can ask the author of https://github.com/sympy/sympy/pull/26098 to see if `lark` is tolerable in terms of performance, because we fix it
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
