### PR TITLE
Improvements to `Rationals.__iter__`

### DIFF
--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1266,7 +1266,7 @@ def test_Rationals():
     it = iter(S.Rationals)
     assert [next(it) for i in range(12)] == [
         0, 1, -1, S.Half, 2, Rational(-1, 2), -2,
-        Rational(1, 3), 3, Rational(-1, 3), -3, Rational(2, 3)]
+        Rational(1, 3), 3, Rational(-1, 3), -3, Rational(3, 2)]
     assert Basic() not in S.Rationals
     assert S.Half in S.Rationals
     assert S.Rationals.contains(0.5) == Contains(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
According to [1], rational numbers can be enumerated by the following equation

```math
x \to \frac{1}{2\left\lfloor x \right\rfloor + 1 - x}$
```

This eliminates the need to find the greatest common divisor.

[1] https://doi.org/10.4169/amer.math.monthly.120.03.243

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
