### PR TITLE
Support expint rewrite as integral

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1,7 +1,7 @@
 """ This module contains various functions that are special cases
     of incomplete gamma functions. It should probably be renamed. """
 
-from sympy.core import EulerGamma, oo  # Must be imported from core, not core.numbers
+from sympy.core import EulerGamma # Must be imported from core, not core.numbers
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.function import Function, ArgumentIndexError, expand_mul
@@ -1437,7 +1437,7 @@ class expint(Function):
         from sympy.integrals.integrals import Integral
         n, x = self.args
         t = Dummy('t')
-        return Integral((t**-n) * (exp(-t*x)), (t, 1, oo))
+        return Integral((t**-n) * (exp(-t*x)), (t, 1, S.Infinity))
 
 
 def E1(z):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1,7 +1,7 @@
 """ This module contains various functions that are special cases
     of incomplete gamma functions. It should probably be renamed. """
 
-from sympy.core import EulerGamma  # Must be imported from core, not core.numbers
+from sympy.core import EulerGamma, oo  # Must be imported from core, not core.numbers
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.function import Function, ArgumentIndexError, expand_mul
@@ -9,7 +9,7 @@ from sympy.core.numbers import I, pi, Rational
 from sympy.core.relational import is_eq
 from sympy.core.power import Pow
 from sympy.core.singleton import S
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Symbol, Dummy
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import factorial, factorial2, RisingFactorial
 from sympy.functions.elementary.complexes import  polar_lift, re, unpolarify
@@ -1432,6 +1432,12 @@ class expint(Function):
             return (exp(-z)/z) * Add(*s)
 
         return super(expint, self)._eval_aseries(n, args0, x, logx)
+
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
+        from sympy.integrals.integrals import Integral
+        n, x = self.args
+        t = Dummy('t')
+        return Integral((t**-n) * (exp(-t*x)), (t, 1, oo))
 
 
 def E1(z):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1437,7 +1437,7 @@ class expint(Function):
         from sympy.integrals.integrals import Integral
         n, x = self.args
         t = Dummy('t')
-        return Integral((t**-n) * (exp(-t*x)), (t, 1, S.Infinity))
+        return Integral(t**-n * exp(-t*x), (t, 1, S.Infinity))
 
 
 def E1(z):

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -818,4 +818,4 @@ def test_fresnel_series():
 
 
 def test_issue_26134():
-    assert expint(n, x).rewrite(Integral).dummy_eq(Integral((t**-n) * (exp(-t*x)), (t, 1, oo)))
+    assert expint(n, x).rewrite(Integral).dummy_eq(Integral(t**-n * exp(-t*x), (t, 1, oo)))

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -2,7 +2,7 @@ from sympy.core.function import (diff, expand, expand_func)
 from sympy.core import EulerGamma
 from sympy.core.numbers import (E, Float, I, Rational, nan, oo, pi)
 from sympy.core.singleton import S
-from sympy.core.symbol import (Symbol, symbols)
+from sympy.core.symbol import (Symbol, symbols, Dummy)
 from sympy.functions.elementary.complexes import (conjugate, im, polar_lift, re)
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (cosh, sinh)
@@ -23,6 +23,7 @@ from sympy.testing.pytest import raises
 x, y, z = symbols('x,y,z')
 w = Symbol("w", real=True)
 n = Symbol("n", integer=True)
+t = Dummy('t')
 
 
 def test_erf():
@@ -814,3 +815,7 @@ def test_fresnel_series():
     assert (fresnelc(1/z).series(z) - fc.subs(z, 1/z)).expand().is_Order
     assert ((2*fresnels(3*z)).series(z, oo) - 2*fs.subs(z, 3*z)).expand().is_Order
     assert ((3*fresnelc(2*z)).series(z, oo) - 3*fc.subs(z, 2*z)).expand().is_Order
+
+
+def test_issue_26134():
+    assert expint(n, x).rewrite(Integral).dummy_eq(Integral((t**-n) * (exp(-t*x)), (t, 1, oo)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes: https://github.com/sympy/sympy/issues/26134

#### Brief description of what is fixed or changed
Support rewrite as integral for expint

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * support expint rewrite as integral.
<!-- END RELEASE NOTES -->
