### PR TITLE
Change default role of single backticks from `math` to `code`

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -382,7 +382,6 @@ latex_show_pagerefs = True
 # We use False otherwise the module index gets generated twice.
 latex_use_modindex = False
 
-default_role = 'math'
 pngmath_divpng_args = ['-gamma 1.5', '-D 110']
 # Note, this is ignored by the mathjax extension
 # Any \newcommand should be defined in the file

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -382,6 +382,7 @@ latex_show_pagerefs = True
 # We use False otherwise the module index gets generated twice.
 latex_use_modindex = False
 
+default_role = 'code'
 pngmath_divpng_args = ['-gamma 1.5', '-D 110']
 # Note, this is ignored by the mathjax extension
 # Any \newcommand should be defined in the file


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/13519

#### Brief description of what is fixed or changed

This is a fix of an old issue, (that may not have been concluded well)
However, I'd like to try building the docs and see if we can just merge this, and avoid postponing that decision

The major rationale behind I bring up the PR is that

- We have 10 years passed, and established style guide about LaTeX formatting. So I expect a lot of things should have been corrected for now. 
  If we didn't clean some dusty corners, or have mistakes, people will anyway discover that bring up with issue. A lot of people are using SymPy anyway.
- It is not much ugly to display LaTeX as code plaintext. (`\frac{1}{2}` vs $\frac{1}{2}$) despite it may be slightly incorrect. However, displaying snakecased python code as LaTeX is much more worse (`default_role` vs $default_role$). So this is the main reason I find using `code` as default directive as okay idea. (even if it is not the ideal idea, that we have never got any success)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
