### PR TITLE
I**(p/q) -> (-1)**(p/(2*q))

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -639,17 +639,8 @@ class Mul(Expr, AssocOp):
             if q == 2:
                 c_part.append(S.ImaginaryUnit)
             elif p:
-                # see if there is any positive base this power of
-                # -1 can join
                 neg1e = Rational(p, q)
-                for e, b in pnew.items():
-                    if e == neg1e and b.is_positive:
-                        pnew[e] = -b
-                        break
-                else:
-                    # keep it separate; we've already evaluated it as
-                    # much as possible so evaluate=False
-                    c_part.append(Pow(S.NegativeOne, neg1e, evaluate=False))
+                c_part.append(Pow(S.NegativeOne, neg1e, evaluate=False))
 
         # add all the pnew powers
         c_part.extend([Pow(b, e) for e, b in pnew.items()])

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2028,9 +2028,9 @@ class Integer(Rational):
             return super()._eval_power(expt)
         if not isinstance(expt, Rational):
             return
-        if expt is S.Half and self.is_negative:
-            # we extract I for this special case since everyone is doing so
-            return S.ImaginaryUnit*Pow(-self, expt)
+        if self.is_negative:
+            # Extract rational powers of -1
+            return Pow(S.NegativeOne, expt) * Pow(-self, expt)
         if expt.is_negative:
             # invert base and change sign on exponent
             ne = -expt

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2907,14 +2907,16 @@ class NegativeOne(IntegerConstant, metaclass=Singleton):
                 return S.NaN
             if expt in (S.Infinity, S.NegativeInfinity):
                 return S.NaN
-            if expt is S.Half:
-                return S.ImaginaryUnit
             if isinstance(expt, Rational):
-                if expt.q == 2:
-                    return S.ImaginaryUnit**Integer(expt.p)
                 i, r = divmod(expt.p, expt.q)
-                if i:
-                    return self**i*self**Rational(r, expt.q)
+                expt2 = Rational(r, expt.q)
+                if expt2 is S.Half:
+                    rv = S.ImaginaryUnit
+                else:
+                    rv = Pow(S.NegativeOne, expt2, evaluate=False)
+                if i & 1:
+                    rv = Mul(S.NegativeOne, rv, evaluate=False)
+                return rv
         return
 
 
@@ -4117,11 +4119,7 @@ class ImaginaryUnit(AtomicExpr, metaclass=Singleton):
             elif expt == 3:
                 return -S.ImaginaryUnit
         if isinstance(expt, Rational):
-            i, r = divmod(expt, 2)
-            rv = Pow(S.ImaginaryUnit, r, evaluate=False)
-            if i % 2:
-                return Mul(S.NegativeOne, rv, evaluate=False)
-            return rv
+            return S.NegativeOne**(expt/2)
 
     def as_base_exp(self):
         return S.NegativeOne, S.Half

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -288,7 +288,6 @@ def test_pow_im():
     assert Mul(*args, evaluate=False)**e == ans
     assert Mul(*args)**e == ans
     assert Mul(Pow(-1, Rational(3, 2), evaluate=False), I, I) == I
-    assert Mul(I*Pow(I, S.Half, evaluate=False)) == sqrt(I)*I
 
 
 def test_real_mul():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -240,7 +240,7 @@ def test_AlgebraicNumber():
     a = AlgebraicNumber(sqrt(2))
     sT(a, "AlgebraicNumber(Pow(Integer(2), Rational(1, 2)), [Integer(1), Integer(0)])")
     a = AlgebraicNumber(root(-2, 3))
-    sT(a, "AlgebraicNumber(Pow(Integer(-2), Rational(1, 3)), [Integer(1), Integer(0)])")
+    sT(a, "AlgebraicNumber(Mul(Pow(Integer(-1), Rational(1, 3)), Pow(Integer(2), Rational(1, 3))), [Integer(1), Integer(0)])")
 
 
 def test_PolyRing():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See gh-26140

Alternative to gh-26141.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Rational powers of `I` now transform to rational powers of `-1`.
<!-- END RELEASE NOTES -->
