### PR TITLE
Bessel functions now use visually distinct symbols

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -213,6 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -8,7 +8,7 @@ from sympy.core.function import Function, ArgumentIndexError, _mexpand
 from sympy.core.logic import fuzzy_or, fuzzy_not
 from sympy.core.numbers import Rational, pi, I
 from sympy.core.power import Pow
-from sympy.core.symbol import Dummy, Wild
+from sympy.core.symbol import Dummy, uniquely_named_symbol, Wild
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.trigonometric import sin, cos, csc, cot
@@ -2067,7 +2067,7 @@ class marcumq(Function):
 
     def _eval_rewrite_as_Integral(self, m, a, b, **kwargs):
         from sympy.integrals.integrals import Integral
-        x = kwargs.get('x', Dummy('x'))
+        x = kwargs.get('x', Dummy(uniquely_named_symbol('x').name))
         return a ** (1 - m) * \
                Integral(x**m * exp(-(x**2 + a**2)/2) * besseli(m-1, a*x), [x, b, S.Infinity])
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -761,4 +761,5 @@ def test_marcumq():
 
 def test_issue_26134():
     x = Symbol('x')
-    assert marcumq(2, 3, 4).rewrite(Integral, x=x).dummy_eq(Integral(x**2*exp(-x**2/2 - Rational(9, 2))*besseli(1, 3*x), (x, 4, oo))/3)
+    assert marcumq(2, 3, 4).rewrite(Integral, x=x).dummy_eq(
+        Integral(x**2*exp(-x**2/2 - Rational(9, 2))*besseli(1, 3*x), (x, 4, oo))/3)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -757,3 +757,7 @@ def test_marcumq():
 
     x = Symbol('x', integer=True)
     assert marcumq(x, a, a).rewrite(besseli) == marcumq(x, a, a)
+
+def test_issue_26134():
+    x = Symbol('x')
+    assert marcumq(2, 3, 4).rewrite(Integral, x=x).dummy_eq(Integral(x**2*exp(-x**2/2 - Rational(9, 2))*besseli(1, 3*x), (x, 4, oo))/3)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -758,6 +758,7 @@ def test_marcumq():
     x = Symbol('x', integer=True)
     assert marcumq(x, a, a).rewrite(besseli) == marcumq(x, a, a)
 
+
 def test_issue_26134():
     x = Symbol('x')
     assert marcumq(2, 3, 4).rewrite(Integral, x=x).dummy_eq(Integral(x**2*exp(-x**2/2 - Rational(9, 2))*besseli(1, 3*x), (x, 4, oo))/3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
solves #26143 


#### Brief description of what is fixed or changed
` x = kwargs.get('x', Dummy('x')) ` was changed to `x = kwargs.get('x', Dummy(uniquely_named_symbol('x').name))` for rewriting  as integral to ensure visually unique variable of integration . 


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:



or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Corrected the code for unique visibility of variable of integration.
<!-- END RELEASE NOTES -->
