### PR TITLE
Solves compatibility issues in Min and Max (jax with tuples)  

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1625,3 +1625,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Viraj Vekaria <virajv5593@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1464,6 +1464,7 @@ Vincent Delecroix <vincent.delecroix@labri.fr>
 Vinit Ravishankar <vinit.ravishankar@gmail.com>
 Vinzent Steinberg <vinzent.steinberg@gmail.com> <Vinzent.Steinberg@gmail.com>
 Vinzent Steinberg <vinzent.steinberg@gmail.com> <vinzent.steinberg@googlemail.com>
+Viraj Vekaria <virajv5593@gmail.com>
 Vishal <vishalg2235@gmail.com>
 Vishesh Mangla <manglavishesh64@gmail.com>
 Vivek Soni <sonisheela1977@gmail.com>
@@ -1625,4 +1626,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Viraj Vekaria <virajv5593@gmail.com>

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -3,7 +3,6 @@ from sympy.core.function import Lambda
 from sympy.core.power import Pow
 from .pycode import PythonCodePrinter, _known_functions_math, _print_known_const, _print_known_func, _unpack_integral_limits, ArrayPrinter
 from .codeprinter import CodePrinter
-import jax
 
 
 _not_in_numpy = 'erf erfc factorial gamma loggamma'.split()

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -3,6 +3,7 @@ from sympy.core.function import Lambda
 from sympy.core.power import Pow
 from .pycode import PythonCodePrinter, _known_functions_math, _print_known_const, _print_known_func, _unpack_integral_limits, ArrayPrinter
 from .codeprinter import CodePrinter
+import jax
 
 
 _not_in_numpy = 'erf erfc factorial gamma loggamma'.split()
@@ -216,11 +217,10 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return self._hprint_Pow(expr, rational=rational, sqrt=self._module + '.sqrt')
 
     def _print_Min(self, expr):
-        return '{}(({}), axis=0)'.format(self._module_format(self._module + '.amin'), ','.join(self._print(i) for i in expr.args))
+        return '{}({}.asarray([{}]), axis=0)'.format(self._module_format(self._module + '.amin'), self._module_format(self._module), ','.join(self._print(i) for i in expr.args))
 
     def _print_Max(self, expr):
-        return '{}(({}), axis=0)'.format(self._module_format(self._module + '.amax'), ','.join(self._print(i) for i in expr.args))
-
+        return '{}({}.asarray([{}]), axis=0)'.format(self._module_format(self._module + '.amax'), self._module_format(self._module), ','.join(self._print(i) for i in expr.args))
     def _print_arg(self, expr):
         return "%s(%s)" % (self._module_format(self._module + '.angle'), self._print(expr.args[0]))
 

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -10,6 +10,8 @@ from sympy.matrices.expressions.blockmatrix import BlockMatrix
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
 from sympy.utilities.lambdify import lambdify
+from sympy import symbols, Min, Max
+from jax.numpy import asarray
 
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.core import Pow
@@ -313,6 +315,15 @@ def test_issue_17006():
     n = symbols('n', integer=True)
     N = MatrixSymbol("M", n, n)
     raises(NotImplementedError, lambda: lambdify(N, N + Identity(n)))
+
+def test_26139():
+    x, y, z = symbols('x y z')
+    expr = Max(x, y, z) + Min(x, y, z)
+    func = lambdify((x, y, z), expr, modules='jax')
+    input_tuple1, input_tuple2 = (1, 2, 3), (4, 5, 6)
+    input_array1, input_array2 = asarray(input_tuple1), asarray(input_tuple2)
+    assert np.allclose(func(*input_tuple1), func(*input_array1))
+    assert np.allclose(func(*input_tuple2), func(*input_array2))
 
 def test_numpy_array():
     assert NumPyPrinter().doprint(Array(((1, 2), (3, 5)))) == 'numpy.array([[1, 2], [3, 5]])'

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -11,7 +11,6 @@ from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
 from sympy.utilities.lambdify import lambdify
 from sympy import symbols, Min, Max
-from jax.numpy import asarray
 
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.core import Pow
@@ -29,6 +28,7 @@ from sympy.testing.pytest import skip, raises
 from sympy.external import import_module
 
 np = import_module('numpy')
+jax = import_module('jax')
 
 if np:
     deafult_float_info = np.finfo(np.array([]).dtype)

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -317,9 +317,12 @@ def test_issue_17006():
     raises(NotImplementedError, lambda: lambdify(N, N + Identity(n)))
 
 def test_jax_tuple_compatibility():
+    if not jax:
+        skip("Jax not installed")
+        
     x, y, z = symbols('x y z')
     expr = Max(x, y, z) + Min(x, y, z)
-    func = lambdify((x, y, z), expr)
+    func = lambdify((x, y, z), expr, 'jax')
     input_tuple1, input_tuple2 = (1, 2, 3), (4, 5, 6)
     input_array1, input_array2 = jax.numpy.asarray(input_tuple1), jax.numpy.asarray(input_tuple2)
     assert np.allclose(func(*input_tuple1), func(*input_array1))

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -319,7 +319,7 @@ def test_issue_17006():
 def test_jax_tuple_compatibility():
     x, y, z = symbols('x y z')
     expr = Max(x, y, z) + Min(x, y, z)
-    func = lambdify((x, y, z), expr, modules='jax')
+    func = lambdify((x, y, z), expr)
     input_tuple1, input_tuple2 = (1, 2, 3), (4, 5, 6)
     input_array1, input_array2 = jax.numpy.asarray(input_tuple1), jax.numpy.asarray(input_tuple2)
     assert np.allclose(func(*input_tuple1), func(*input_array1))

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -319,7 +319,7 @@ def test_issue_17006():
 def test_jax_tuple_compatibility():
     if not jax:
         skip("Jax not installed")
-        
+
     x, y, z = symbols('x y z')
     expr = Max(x, y, z) + Min(x, y, z)
     func = lambdify((x, y, z), expr, 'jax')

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -316,7 +316,7 @@ def test_issue_17006():
     N = MatrixSymbol("M", n, n)
     raises(NotImplementedError, lambda: lambdify(N, N + Identity(n)))
 
-def test_26139():
+def test_jax_tuple_compatibility():
     x, y, z = symbols('x y z')
     expr = Max(x, y, z) + Min(x, y, z)
     func = lambdify((x, y, z), expr, modules='jax')

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -321,7 +321,7 @@ def test_jax_tuple_compatibility():
     expr = Max(x, y, z) + Min(x, y, z)
     func = lambdify((x, y, z), expr, modules='jax')
     input_tuple1, input_tuple2 = (1, 2, 3), (4, 5, 6)
-    input_array1, input_array2 = asarray(input_tuple1), asarray(input_tuple2)
+    input_array1, input_array2 = jax.numpy.asarray(input_tuple1), jax.numpy.asarray(input_tuple2)
     assert np.allclose(func(*input_tuple1), func(*input_array1))
     assert np.allclose(func(*input_tuple2), func(*input_array2))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26139

#### Brief description of what is fixed or changed
Adding wrapper function to jax amin and amax, which converts incoming iterables to ndarrays

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  *  Fix issues of `Min` and `Max` generating wrong code for `jax`.
<!-- END RELEASE NOTES -->
