### PR TITLE
Changed dummy variables to be visually unique

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1597,6 +1597,7 @@ sevaader <sevaader@gmail.com>
 sfoo <sfoohei@gmail.com>
 sharma-kunal <kunalsharma6914@gmail.com>
 shiksha11 <shiksharawat01@gmail.com> shiksha11 <33157995+shiksha11@users.noreply.github.com>
+Shishir Kushwaha <kushwahashishir1112@gmail.com>
 shruti <shrutishrm512@gmail.com>
 shubhayu09 <guptashubhayu601@gmail.com> shubhayu09 <87441886+shubhayu09@users.noreply.github.com>
 sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -2,7 +2,7 @@
 
 from sympy.core import S, pi, I, Rational
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.symbol import Dummy
+from sympy.core.symbol import Dummy,uniquely_named_symbol
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.hyperbolic import atanh
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -95,7 +95,9 @@ class elliptic_k(Function):
 
     def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy('t')
+        # t = Dummy('t')
+        t = Dummy(uniquely_named_symbol('t', args).name)
+
         m = self.args[0]
         return Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, pi/2))
 
@@ -173,7 +175,8 @@ class elliptic_f(Function):
 
     def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy('t')
+        # t = Dummy('t')
+        t = Dummy(uniquely_named_symbol('t', args).name)
         z, m = self.args[0], self.args[1]
         return Integral(1/(sqrt(1 - m*sin(t)**2)), (t, 0, z))
 
@@ -303,7 +306,8 @@ class elliptic_e(Function):
     def _eval_rewrite_as_Integral(self, *args, **kwargs):
         from sympy.integrals.integrals import Integral
         z, m = (pi/2, self.args[0]) if len(self.args) == 1 else self.args
-        t = Dummy('t')
+        # t = Dummy('t')
+        t = Dummy(uniquely_named_symbol('t', args).name)
         return Integral(sqrt(1 - m*sin(t)**2), (t, 0, z))
 
 
@@ -441,5 +445,6 @@ class elliptic_pi(Function):
             n, m, z = self.args[0], self.args[1], pi/2
         else:
             n, z, m = self.args
-        t = Dummy('t')
+        # t = Dummy('t')
+        t = Dummy(uniquely_named_symbol('t', args).name)
         return Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z))

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -178,3 +178,4 @@ def test_P():
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
     assert P(n, m).rewrite(Integral).dummy_eq(
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))
+    

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -177,4 +177,3 @@ def test_P():
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
     assert P(n, m).rewrite(Integral).dummy_eq(
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))
-    

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -51,6 +51,7 @@ def test_K():
     assert K(m).rewrite(Integral).dummy_eq(
         Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, pi/2)))
 
+    # assert K(z).rewrite('Integral')
 def test_F():
     assert F(z, 0) == z
     assert F(0, m) == 0

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -51,7 +51,6 @@ def test_K():
     assert K(m).rewrite(Integral).dummy_eq(
         Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, pi/2)))
 
-    # assert K(z).rewrite('Integral')
 def test_F():
     assert F(z, 0) == z
     assert F(0, m) == 0
@@ -178,4 +177,3 @@ def test_P():
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
     assert P(n, m).rewrite(Integral).dummy_eq(
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))
-    

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -178,5 +178,3 @@ def test_P():
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
     assert P(n, m).rewrite(Integral).dummy_eq(
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))
-
-  

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -177,3 +177,4 @@ def test_P():
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
     assert P(n, m).rewrite(Integral).dummy_eq(
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))
+    

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -177,3 +177,5 @@ def test_P():
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
     assert P(n, m).rewrite(Integral).dummy_eq(
         Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))
+
+  


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Makes some of the required Changes in #26143

#### Brief description of what is fixed or changed
The elliptical functions in special functions module now use visually different variables that used to earlier use same variable if given inside the function .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

*  solvers
  *   Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* functions
   * Fixed usage of visually same variable when converting to integral in elliptical functions.

<!-- END RELEASE NOTES -->
