### PR TITLE
Dummy variables in Integrals will be printed differently solves issue #26143

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -213,6 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -439,6 +439,8 @@ class PrettyPrinter(Printer):
         arg = prettyF
         for x in integral.limits:
             prettyArg = self._print(x[0])
+            if(x[0].is_Dummy):
+                prettyArg = prettyForm(*prettyArg.left('_'))
             # XXX qparens (parens if needs-parens)
             if prettyArg.width() > 1:
                 prettyArg = prettyForm(*prettyArg.parens())


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Solves Issue #26143 

#### Brief description of what is fixed or changed
Dummy variables in integration will be printed by a ` _ ` before it .


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * checked if the variable is a dummy variable then add a _ before it
<!-- END RELEASE NOTES -->
