### PR TITLE
Fix geometric distribution pdf

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -529,6 +529,7 @@ Dmitry Batkovich <batya239@gmail.com>
 Dmitry Savransky <dsavransky@gmail.com>
 Dominik Stańczak <stanczakdominik@gmail.com>
 Donald Wilson <donwilson1029@gmail.com> wilds-23 <wilds-23@rhodes.edu>
+Donaldson Tan <geodome@gmail.com>
 Duane Nykamp <nykamp@umn.edu>
 Duc-Minh Phan <alephvn@gmail.com>
 Dustin Gadal <Dustin.Gadal@gmail.com> <dustin.gadal@gmail.com>

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -34,6 +34,7 @@ from sympy.functions.special.hyper import hyper
 from sympy.functions.special.zeta_functions import (polylog, zeta)
 from sympy.stats.drv import SingleDiscreteDistribution, SingleDiscretePSpace
 from sympy.stats.rv import _value_check, is_random
+from sympy import And
 
 
 __all__ = ['FlorySchulz',
@@ -207,7 +208,7 @@ class GeometricDistribution(SingleDiscreteDistribution):
         _value_check((0 < p, p <= 1), "p must be between 0 and 1")
 
     def pdf(self, k):
-        return (1 - self.p)**(k - 1) * self.p
+        return Piecewise(((1 - self.p)**(k - 1) * self.p, And(k > 0, k <= floor(k))), (0, True))
 
     def _characteristic_function(self, t):
         p = self.p

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -253,7 +253,7 @@ def Geometric(name, p):
     >>> X = Geometric("x", p)
 
     >>> density(X)(z)
-    (5/4)**(1 - z)/5
+     Piecewise(((5/4)**(1 - z)/5, (z > 0) & (z <= floor(z))), (0, True))
 
     >>> E(X)
     5


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes https://github.com/sympy/sympy/issues/20031


#### Brief description of what is fixed or changed
* Replaced naive form of pdf  formula with piecewise form that validates the input parameter k such that k is a positive integer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* stats
  * GeometricDistribution.pdf(k) calculates the probability mass function if k is a positive integer, returns 0 if otherwise.

<!-- END RELEASE NOTES -->
