### PR TITLE
Beta functions will now use visually distinct symbols

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -213,6 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -1,6 +1,6 @@
 from sympy.core import S
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.symbol import Dummy
+from sympy.core.symbol import Dummy, uniquely_named_symbol
 from sympy.functions.special.gamma_functions import gamma, digamma
 from sympy.functions.combinatorial.numbers import catalan
 from sympy.functions.elementary.complexes import conjugate
@@ -163,7 +163,7 @@ class beta(Function):
 
     def _eval_rewrite_as_Integral(self, x, y, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy('t')
+        t = uniquely_named_symbol('t').as_dummy()
         return Integral(t**(x - 1)*(1 - t)**(y - 1), (t, 0, 1))
 
 ###############################################################################
@@ -268,7 +268,7 @@ class betainc(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy('t')
+        t = uniquely_named_symbol('t').as_dummy()
         return Integral(t**(a - 1)*(1 - t)**(b - 1), (t, x1, x2))
 
     def _eval_rewrite_as_hyper(self, a, b, x1, x2, **kwargs):
@@ -378,7 +378,7 @@ class betainc_regularized(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy('t')
+        t = uniquely_named_symbol('t').as_dummy()
         integrand = t**(a - 1)*(1 - t)**(b - 1)
         expr = Integral(integrand, (t, x1, x2))
         return expr / Integral(integrand, (t, 0, 1))

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -163,7 +163,7 @@ class beta(Function):
 
     def _eval_rewrite_as_Integral(self, x, y, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy(uniquely_named_symbol('t').name)
+        t = uniquely_named_symbol('t').as_dummy()
         return Integral(t**(x - 1)*(1 - t)**(y - 1), (t, 0, 1))
 
 ###############################################################################
@@ -268,7 +268,7 @@ class betainc(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy(uniquely_named_symbol('t').name)
+        t = uniquely_named_symbol('t').as_dummy()
         return Integral(t**(a - 1)*(1 - t)**(b - 1), (t, x1, x2))
 
     def _eval_rewrite_as_hyper(self, a, b, x1, x2, **kwargs):
@@ -378,7 +378,7 @@ class betainc_regularized(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = Dummy(uniquely_named_symbol('t').name)
+        t = uniquely_named_symbol('t').as_dummy()
         integrand = t**(a - 1)*(1 - t)**(b - 1)
         expr = Integral(integrand, (t, x1, x2))
         return expr / Integral(integrand, (t, 0, 1))

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -1,6 +1,6 @@
 from sympy.core import S
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.symbol import Dummy, uniquely_named_symbol
+from sympy.core.symbol import uniquely_named_symbol
 from sympy.functions.special.gamma_functions import gamma, digamma
 from sympy.functions.combinatorial.numbers import catalan
 from sympy.functions.elementary.complexes import conjugate
@@ -163,7 +163,7 @@ class beta(Function):
 
     def _eval_rewrite_as_Integral(self, x, y, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = uniquely_named_symbol('t').as_dummy()
+        t = Dummy(uniquely_named_symbol('t').name)
         return Integral(t**(x - 1)*(1 - t)**(y - 1), (t, 0, 1))
 
 ###############################################################################
@@ -268,7 +268,7 @@ class betainc(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = uniquely_named_symbol('t').as_dummy()
+        t = Dummy(uniquely_named_symbol('t').name)
         return Integral(t**(a - 1)*(1 - t)**(b - 1), (t, x1, x2))
 
     def _eval_rewrite_as_hyper(self, a, b, x1, x2, **kwargs):
@@ -378,7 +378,7 @@ class betainc_regularized(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = uniquely_named_symbol('t').as_dummy()
+        t = Dummy(uniquely_named_symbol('t').name)
         integrand = t**(a - 1)*(1 - t)**(b - 1)
         expr = Integral(integrand, (t, x1, x2))
         return expr / Integral(integrand, (t, 0, 1))

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -1,6 +1,6 @@
 from sympy.core import S
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.symbol import uniquely_named_symbol
+from sympy.core.symbol import Dummy, uniquely_named_symbol
 from sympy.functions.special.gamma_functions import gamma, digamma
 from sympy.functions.combinatorial.numbers import catalan
 from sympy.functions.elementary.complexes import conjugate
@@ -163,7 +163,7 @@ class beta(Function):
 
     def _eval_rewrite_as_Integral(self, x, y, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = uniquely_named_symbol('t').as_dummy()
+        t = Dummy(uniquely_named_symbol('t', [x, y]).name)
         return Integral(t**(x - 1)*(1 - t)**(y - 1), (t, 0, 1))
 
 ###############################################################################
@@ -268,7 +268,7 @@ class betainc(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = uniquely_named_symbol('t').as_dummy()
+        t = Dummy(uniquely_named_symbol('t', [a, b, x1, x2]).name)
         return Integral(t**(a - 1)*(1 - t)**(b - 1), (t, x1, x2))
 
     def _eval_rewrite_as_hyper(self, a, b, x1, x2, **kwargs):
@@ -378,7 +378,7 @@ class betainc_regularized(Function):
 
     def _eval_rewrite_as_Integral(self, a, b, x1, x2, **kwargs):
         from sympy.integrals.integrals import Integral
-        t = uniquely_named_symbol('t').as_dummy()
+        t = Dummy(uniquely_named_symbol('t', [a, b, x1, x2]).name)
         integrand = t**(a - 1)*(1 - t)**(b - 1)
         expr = Integral(integrand, (t, x1, x2))
         return expr / Integral(integrand, (t, 0, 1))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
solves issue https://github.com/sympy/sympy/issues/26143

#### Brief description of what is fixed or changed
The beta functions in special functions module now use visually different variables that used to earlier use same variable if given inside the function .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed usage of visually same variable when converting to integral in beta functions.
<!-- END RELEASE NOTES -->
