### PR TITLE
Numpy arrays are now supported with SOPform and POSform

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -16,7 +16,7 @@ from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
-from sympy.utilities.iterables import sift, ibin
+from sympy.utilities.iterables import sift, ibin,iterable
 from sympy.utilities.misc import filldedent
 
 
@@ -2308,9 +2308,7 @@ def _input_to_binlist(inputlist, variables):
     binlist = []
     bits = len(variables)
     for val in inputlist:
-        if isinstance(val, int):
-            binlist.append(ibin(val, bits))
-        elif isinstance(val, dict):
+        if isinstance(val, dict):
             nonspecvars = list(variables)
             for key in val.keys():
                 nonspecvars.remove(key)
@@ -2318,12 +2316,14 @@ def _input_to_binlist(inputlist, variables):
                 d = dict(zip(nonspecvars, t))
                 d.update(val)
                 binlist.append([d[v] for v in variables])
-        elif isinstance(val, (list, tuple)):
+        elif iterable(val):
             if len(val) != bits:
                 raise ValueError("Each term must contain {bits} bits as there are"
                                  "\n{bits} variables (or be an integer)."
                                  "".format(bits=bits))
             binlist.append(list(val))
+        elif not (val%1):
+            binlist.append(ibin(val, bits))
         else:
             raise TypeError("A term list can only contain lists,"
                             " ints or dicts.")
@@ -2390,7 +2390,7 @@ def SOPform(variables, minterms, dontcares=None):
     .. [2] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
-    if not minterms:
+    if not len(minterms):
         return false
 
     variables = tuple(map(sympify, variables))
@@ -2471,7 +2471,7 @@ def POSform(variables, minterms, dontcares=None):
     .. [2] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
-    if not minterms:
+    if not len(minterms):
         return false
 
     variables = tuple(map(sympify, variables))

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2390,13 +2390,10 @@ def SOPform(variables, minterms, dontcares=None):
     .. [2] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
-    if not len(minterms):
-        return false
-
     variables = tuple(map(sympify, variables))
-
-
     minterms = _input_to_binlist(minterms, variables)
+    if not minterms:
+        return false
     dontcares = _input_to_binlist((dontcares or []), variables)
     for d in dontcares:
         if d in minterms:
@@ -2471,11 +2468,10 @@ def POSform(variables, minterms, dontcares=None):
     .. [2] https://en.wikipedia.org/wiki/Don%27t-care_term
 
     """
-    if not len(minterms):
-        return false
-
     variables = tuple(map(sympify, variables))
     minterms = _input_to_binlist(minterms, variables)
+    if not len(minterms):
+        return false
     dontcares = _input_to_binlist((dontcares or []), variables)
     for d in dontcares:
         if d in minterms:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes Issue #26164 Numpy arrays supported now for minterms

#### Brief description of what is fixed or changed
Earlier it used to work only with python lists , tuples or dictionaries , now additional support for 1D and 2D numpy arrays is added.

#### Other comments
Changes made now require any individual element to also be passed inside a list or array .

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * Support for 1D and 2D numpy arrays added for minterms 
<!-- END RELEASE NOTES -->
