### PR TITLE
maint(ci): multicore for pytest in GitHub Actions

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -143,7 +143,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n4
+      - run: pytest -n auto
 
   # -------------------- Optional dependency tests ----------------- #
 
@@ -376,8 +376,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        group: [1, 2, 3, 4]
 
     steps:
       - uses: actions/checkout@v3
@@ -386,7 +384,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: bin/test --slow --timeout 595 --split ${{ matrix.group }}/4
+      - run: pytest -m slow --timeout 595 -n auto
 
   # -------------------- Test older (and newer) Python --------------- #
 
@@ -399,9 +397,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.13-dev', 'pypy-3.9']
-        group: [1, 2, 3, 4]
 
-    name: ${{ matrix.python-version }} ${{ matrix.group }}/4 Tests
+    name: ${{ matrix.python-version }} Tests
 
     steps:
       - uses: actions/checkout@v3
@@ -410,7 +407,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: bin/test --split ${{ matrix.group }}/4
+      - run: pytest -n auto
 
   # -------------------- Doctests older (and newer) Python --------------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -145,7 +145,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: bin/test --split ${{ matrix.group }}/4 -n4
+      - run: pytest --splits 4 --group ${{ matrix.group }} -n4
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -133,10 +133,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        group: [1, 2, 3, 4]
 
-    name: Tests ${{ matrix.group }}/4
+    name: Tests
 
     steps:
       - uses: actions/checkout@v3
@@ -145,7 +143,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest --splits 4 --group ${{ matrix.group }} -n4
+      - run: pytest -n4
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -145,7 +145,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: bin/test --split ${{ matrix.group }}/4
+      - run: bin/test --split ${{ matrix.group }}/4 -n4
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -455,7 +455,7 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt
-      - run: bin/test --split ${{ matrix.group }}/4
+      - run: pytest -n auto
 
   # -------------------- Build the html/latex docs ----------------- #
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Use multiple cores when running pytest in CI. I think that GitHub actions has increased the number of available cores per worker from 2 to 4. Previously with 2 cores pytest -n2 did not give much speedup over single core but now, -n2, -n3 or -n4 might run faster.

Potentially this could make it possible to remove the test splits.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
