### PR TITLE
[integrals] fix substitution formula in meijerint

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -945,6 +945,7 @@ Matthew Wardrop <matthew.wardrop@airbnb.com>
 Matthias Bussonnier <bussonniermatthias@gmail.com>
 Matthias Geier <Matthias.Geier@gmail.com>
 Matthias Köppe <mkoeppe@math.ucdavis.edu> Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Matthias Liesenfeld <116307294+maliesen@users.noreply.github.com>
 Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
 Matthias Toews <mat.toews@googlemail.com>
 Mauro Garavello <mauro.garavello@unimib.it>

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1706,8 +1706,8 @@ def _meijerint_indefinite_1(f, x):
         c += s
 
         # we do a substitution t=a*x**b, get integrand fac*t**rho*g
-        fac_ = fac * C / (b*a**((1 + c)/b))
-        rho = (c + 1)/b - 1
+        fac_ = fac * C * x**(1 + c) / b
+        rho = (c + 1)/b
 
         # we now use t**rho*G(params, t) = G(params + rho, t)
         # [L, page 150, equation (4)]
@@ -1720,13 +1720,13 @@ def _meijerint_indefinite_1(f, x):
         t = _dummy('t', 'meijerint-indefinite', S.One)
 
         def tr(p):
-            return [a + rho + 1 for a in p]
+            return [a + rho for a in p]
         if any(b.is_integer and (b <= 0) == True for b in tr(g.bm)):
             r = -meijerg(
-                tr(g.an), tr(g.aother) + [1], tr(g.bm) + [0], tr(g.bother), t)
+                list(g.an), list(g.aother) + [1-rho], list(g.bm) + [-rho], list(g.bother), t)
         else:
             r = meijerg(
-                tr(g.an) + [1], tr(g.aother), tr(g.bm), tr(g.bother) + [0], t)
+                list(g.an) + [1-rho], list(g.aother), list(g.bm), list(g.bother) + [-rho], t)
         # The antiderivative is most often expected to be defined
         # in the neighborhood of  x = 0.
         if b.is_extended_nonnegative and not f.subs(x, 0).has(S.NaN, S.ComplexInfinity):

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -4,7 +4,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
-from sympy.functions.elementary.hyperbolic import cosh, acosh
+from sympy.functions.elementary.hyperbolic import cosh, acosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
 from sympy.functions.elementary.trigonometric import (cos, sin, sinc, asin)
@@ -766,3 +766,9 @@ def test_pr_23583():
 # 25786
 def test_integrate_function_of_square_over_negatives():
     assert integrate(exp(-x**2), (x,-5,0), meijerg=True) == sqrt(pi)/2 * erf(5)
+
+
+def test_issue_25949():
+    from sympy.core.symbol import symbols
+    y = symbols("y", nonzero=True)
+    assert integrate(cosh(y*(x + 1)), (x, -1, -0.25), meijerg=True) == sinh(0.75*y)/y

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -754,8 +754,7 @@ def test_issue_6462():
 
 
 def test_indefinite_1_bug():
-    assert integrate((b + t)**(-a), t, meijerg=True
-        ).equals(-b**(1 - a)*(1 + t/b)**(1 - a)/(a - 1))
+    assert integrate((b + t)**(-a), t, meijerg=True) == -b*(1 + t/b)**(1 - a)/(a*b**a - b**a)
 
 
 def test_pr_23583():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -755,10 +755,15 @@ def test_issue_6462():
 
 def test_indefinite_1_bug():
     assert integrate((b + t)**(-a), t, meijerg=True
-        ) == -b**(1 - a)*(1 + t/b)**(1 - a)/(a - 1)
+        ).equals(-b**(1 - a)*(1 + t/b)**(1 - a)/(a - 1))
 
 
 def test_pr_23583():
     # This result is wrong. Check whether new result is correct when this test fail.
     assert integrate(1/sqrt((x - I)**2-1), meijerg=True) == \
            Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+
+
+# 25786
+def test_integrate_function_of_square_over_negatives():
+    assert integrate(exp(-x**2), (x,-5,0), meijerg=True) == sqrt(pi)/2 * erf(5)

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -336,7 +336,7 @@ def test_variable_moment():
     assert b.slope().expand() == ((10*x*SingularityFunction(x, 0, 0)
         - 10*(x - 4)*SingularityFunction(x, 4, 0))/E).expand()
     assert b.deflection().expand() == ((5*x**2*SingularityFunction(x, 0, 0)
-        - 10*Piecewise((0, Abs(x)/4 < 1), (16*meijerg(((3, 1), ()), ((), (2, 0)), x/4), True))
+        - 10*Piecewise((0, Abs(x)/4 < 1), (x**2*meijerg(((-1, 1), ()), ((), (-2, 0)), x/4), True))
         + 40*SingularityFunction(x, 4, 1))/E).expand()
 
     b = Beam(4, E - x, I)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25786 

#### Brief description of what is fixed or changed

fix substitution formula in meijerint


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


* integrals
  * Fixed a bug with integrating over negative real numbers using meijerint algorithm. Formerly, `integrate(exp(-x**2), (x,-5,0), meijerg=True)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a bug with integrating over negative real numbers using meijerint algorithm. Formerly, `integrate(exp(-x**2), (x,-5,0), meijerg=True)` incorrectly gave `-sqrt(pi)/2 * erf(5)` instead of `sqrt(pi)/2 * erf(5)`.
<!-- END RELEASE NOTES -->
