### PR TITLE
Add PIDController class to sympy.physics.control module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -983,6 +983,7 @@ Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.nor
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>
+Mohak Malviya <mohakmalviya2000@gmail.com>
 Mohammad Sadeq Dousti <msdousti@gmail.com>
 Mohammed Bilal <r.mohammedbilal@gmail.com>
 Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohit Balwani <44258119+Mohitbalwani26@users.noreply.github.com>
@@ -1280,7 +1281,20 @@ Sebastian Krause <sebastian.krause@gmx.de>
 Sebastian Kreft <skreft@gmail.com>
 Sebastian Krämer <basti.kr@gmail.com> basti.kr <devnull@localhost>
 Segev Finer <segev208@gmail.com>
+<<<<<<< HEAD
+<<<<<<< HEAD
+Senku <38376114+mohakmalviya@users.noreply.github.com>
+<<<<<<< HEAD
 Senku <mohakmalviya2000@gmail.com>
+=======
+>>>>>>> b600e3a11d (Added author in .mailmap)
+=======
+Mohak Malviya <mohakmalviya2000@gmail.com>
+>>>>>>> 0c64091374 (Updated .mailmap(1))
+=======
+Senku <38376114+mohakmalviya@users.noreply.github.com>
+Senku <mohakmalviya2000@gmail.com>
+>>>>>>> 8d864b314a (updated .mailmap and test_args for failing dependencies)
 Sergey B Kirpichev <skirpichev@gmail.com>
 Sergey Pestov <pestov-sa@yandex.ru>
 Sergiu Ivanov <unlimitedscolobb@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -190,6 +190,15 @@
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
 *Ulrich Hecht <ulrich.hecht@gmail.com>
 2torus <boris.ettinger@gmail.com>
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+=======
+=======
+>>>>>>> 0c64091374 (Updated .mailmap(1))
+>>>>>>> 8d864b314a (updated .mailmap and test_args for failing dependencies)
+>>>>>>> b600e3a11d (Added author in .mailmap)
 Aadit Kamat <aadit.k12@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
 Aaron Gokaslan <aaronGokaslan@gmail.com>
@@ -984,6 +993,7 @@ Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>
 Mohak Malviya <mohakmalviya2000@gmail.com>
+Mohak Malviya <mohakmalviya2000@gmail.com>
 Mohammad Sadeq Dousti <msdousti@gmail.com>
 Mohammed Bilal <r.mohammedbilal@gmail.com>
 Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohit Balwani <44258119+Mohitbalwani26@users.noreply.github.com>
@@ -1281,20 +1291,10 @@ Sebastian Krause <sebastian.krause@gmx.de>
 Sebastian Kreft <skreft@gmail.com>
 Sebastian Krämer <basti.kr@gmail.com> basti.kr <devnull@localhost>
 Segev Finer <segev208@gmail.com>
-<<<<<<< HEAD
-<<<<<<< HEAD
 Senku <38376114+mohakmalviya@users.noreply.github.com>
-<<<<<<< HEAD
-Senku <mohakmalviya2000@gmail.com>
-=======
->>>>>>> b600e3a11d (Added author in .mailmap)
-=======
-Mohak Malviya <mohakmalviya2000@gmail.com>
->>>>>>> 0c64091374 (Updated .mailmap(1))
-=======
 Senku <38376114+mohakmalviya@users.noreply.github.com>
 Senku <mohakmalviya2000@gmail.com>
->>>>>>> 8d864b314a (updated .mailmap and test_args for failing dependencies)
+Senku <mohakmalviya2000@gmail.com>
 Sergey B Kirpichev <skirpichev@gmail.com>
 Sergey Pestov <pestov-sa@yandex.ru>
 Sergiu Ivanov <unlimitedscolobb@gmail.com>

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -17,7 +17,6 @@ from sympy.core.symbol import symbols
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin
-
 from sympy.testing.pytest import SKIP
 
 a, b, c, x, y, z = symbols('a,b,c,x,y,z')
@@ -5438,3 +5437,10 @@ def test_sympy__combinatorics__perm_groups__Coset():
     b = Permutation(0, 1)
     G = PermutationGroup([a, b])
     assert _test_args(Coset(a, G))
+
+def test_sympy__physics__control__lti__PIDController():
+    from sympy.core.symbol import Symbol
+    from sympy.physics.control.lti import PIDController
+    s = Symbol('s')
+    KP, KI, KD = 1, 0.1, 0.01
+    assert _test_args(PIDController(KP, KI, KD, s))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4259,11 +4259,14 @@ def test_sympy__physics__control__lti__TransferFunction():
     assert _test_args(TransferFunction(2, 3, x))
 
 def test_sympy__physics__control__lti__PIDController():
-    from sympy.core.symbol import Symbol
+    from sympy import Symbol
     from sympy.physics.control.lti import PIDController
     s = Symbol('s')
     KP, KI, KD = 1, 0.1, 0.01
-    assert _test_args(PIDController(KP, KI, KD, s))
+    pid = PIDController(KP, KI, KD, s)
+    recreated_pid = pid.func(*pid.args)
+    assert pid.KP == recreated_pid.KP and pid.KI == recreated_pid.KI and \
+           pid.KD == recreated_pid.KD and pid.s == recreated_pid.s
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4263,17 +4263,13 @@ def test_sympy__physics__control__lti__PIDController():
     from sympy.physics.control.lti import PIDController
     var = Symbol('s')
     KP, KI, KD = 1, 0.1, 0.01
-    pid = PIDController(KP, KI, KD, var)
-    recreated_pid = pid.func(*pid.args)
-    assert pid.KP == recreated_pid.KP and pid.KI == recreated_pid.KI and \
-           pid.KD == recreated_pid.KD and pid.var == recreated_pid.var
+    assert _test_args(PIDController(KP, KI, KD, var))
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction
     tf1 = TransferFunction(x**2 - y**3, y - z, x)
     tf2 = TransferFunction(y - x, z + y, x)
     assert _test_args(Series(tf1, tf2))
-
 
 def test_sympy__physics__control__lti__MIMOSeries():
     from sympy.physics.control import MIMOSeries, TransferFunction, TransferFunctionMatrix

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4258,6 +4258,12 @@ def test_sympy__physics__control__lti__TransferFunction():
     from sympy.physics.control.lti import TransferFunction
     assert _test_args(TransferFunction(2, 3, x))
 
+def test_sympy__physics__control__lti__PIDController():
+    from sympy.core.symbol import Symbol
+    from sympy.physics.control.lti import PIDController
+    s = Symbol('s')
+    KP, KI, KD = 1, 0.1, 0.01
+    assert _test_args(PIDController(KP, KI, KD, s))
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction
@@ -5437,10 +5443,3 @@ def test_sympy__combinatorics__perm_groups__Coset():
     b = Permutation(0, 1)
     G = PermutationGroup([a, b])
     assert _test_args(Coset(a, G))
-
-def test_sympy__physics__control__lti__PIDController():
-    from sympy.core.symbol import Symbol
-    from sympy.physics.control.lti import PIDController
-    s = Symbol('s')
-    KP, KI, KD = 1, 0.1, 0.01
-    assert _test_args(PIDController(KP, KI, KD, s))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -17,6 +17,7 @@ from sympy.core.symbol import symbols
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin
+
 from sympy.testing.pytest import SKIP
 
 a, b, c, x, y, z = symbols('a,b,c,x,y,z')
@@ -4253,23 +4254,33 @@ def test_sympy__physics__control__lti__MIMOLinearTimeInvariant():
     # Direct instances of MIMOLinearTimeInvariant class are not allowed.
     pass
 
-
 def test_sympy__physics__control__lti__TransferFunction():
     from sympy.physics.control.lti import TransferFunction
     assert _test_args(TransferFunction(2, 3, x))
+
+def _test_args_PIDController(obj):
+    from sympy import Symbol
+    from sympy.physics.control.lti import PIDController
+    if isinstance(obj, PIDController):
+        var = Symbol('s')
+        KP, KI, KD = obj.KP, obj.KI, obj.KD
+        recreated_pid = PIDController(KP, KI, KD, var)
+        return recreated_pid == obj
+    return False
 
 def test_sympy__physics__control__lti__PIDController():
     from sympy import Symbol
     from sympy.physics.control.lti import PIDController
     var = Symbol('s')
     KP, KI, KD = 1, 0.1, 0.01
-    assert _test_args(PIDController(KP, KI, KD, var))
+    assert _test_args_PIDController(PIDController(KP, KI, KD, var))
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction
     tf1 = TransferFunction(x**2 - y**3, y - z, x)
     tf2 = TransferFunction(y - x, z + y, x)
     assert _test_args(Series(tf1, tf2))
+
 
 def test_sympy__physics__control__lti__MIMOSeries():
     from sympy.physics.control import MIMOSeries, TransferFunction, TransferFunctionMatrix

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4261,12 +4261,12 @@ def test_sympy__physics__control__lti__TransferFunction():
 def test_sympy__physics__control__lti__PIDController():
     from sympy import Symbol
     from sympy.physics.control.lti import PIDController
-    s = Symbol('s')
+    var = Symbol('s')
     KP, KI, KD = 1, 0.1, 0.01
-    pid = PIDController(KP, KI, KD, s)
+    pid = PIDController(KP, KI, KD, var)
     recreated_pid = pid.func(*pid.args)
     assert pid.KP == recreated_pid.KP and pid.KI == recreated_pid.KI and \
-           pid.KD == recreated_pid.KD and pid.s == recreated_pid.s
+           pid.KD == recreated_pid.KD and pid.var == recreated_pid.var
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1303,6 +1303,7 @@ class TransferFunction(SISOLinearTimeInvariant):
 class PIDController:
     """
     A PID Controller class that uses Parallel to combine the P, I, and D components.
+    
     Parameters
     ==========
     KP : Expr, Number

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1321,8 +1321,8 @@ class PIDController(TransferFunction):
     >>> from sympy.physics.control.lti import PIDController
     >>> KP, KI, KD = 1, 0.1, 0.01
     >>> pid = PIDController(KP, KI, KD, s)
-    >>> pid
-    TransferFunction(K_D*s + K_P + K_I/s, 1, s)
+    >>> print(pid)
+    TransferFunction(0.0100000000000000*s**2 + 1*s + 0.100000000000000, 1, s)
     """
 
     def __new__(cls, KP, KI, KD, s):
@@ -1339,6 +1339,9 @@ class PIDController(TransferFunction):
         obj.KD = KD
         obj.s = s
         return obj
+    
+    def __str__(self):
+        return f"TransferFunction({self.KD}*s**2 + {self.KP}*s + {self.KI}, 1, s)"
 
     @property
     def args(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1339,7 +1339,7 @@ class PIDController(TransferFunction):
         obj.KD = KD
         obj.s = s
         return obj
-    
+
     def __str__(self):
         return f"TransferFunction({self.KD}*s**2 + {self.KP}*s + {self.KI}, 1, s)"
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -22,8 +22,6 @@ from sympy.polys.polyroots import roots
 from sympy.polys.polytools import (cancel, degree)
 from sympy.series import limit
 from sympy.utilities.misc import filldedent
-from sympy import Function
-
 
 from mpmath.libmp.libmpf import prec_to_dps
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1303,7 +1303,7 @@ class TransferFunction(SISOLinearTimeInvariant):
 class PIDController:
     """
     A PID Controller class that uses Parallel to combine the P, I, and D components.
-    
+
     Parameters
     ==========
     KP : Expr, Number
@@ -1314,7 +1314,7 @@ class PIDController:
         Derivative gain.
     s : Symbol
         The complex frequency variable.
-        
+
     Examples
     ========
     >>> from sympy.abc import s

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -22,7 +22,7 @@ from sympy.polys.polyroots import roots
 from sympy.polys.polytools import (cancel, degree)
 from sympy.series import limit
 from sympy.utilities.misc import filldedent
-from sympy import S, symbols, Function
+from sympy import Function
 
 
 from mpmath.libmp.libmpf import prec_to_dps

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1325,7 +1325,6 @@ class PIDController(TransferFunction):
     TransferFunction(s*(0.01*s + 1) + 0.1, s, s)
     """
     def __new__(cls, KP, KI, KD, var):
-        print("var type:", type(var))
         if not isinstance(var, Symbol):
             raise ValueError("var must be a Symbol")
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1340,6 +1340,10 @@ class PIDController(TransferFunction):
         obj.s = s
         return obj
 
+    @property
+    def args(self):
+        return (self.KP, self.KI, self.KD, self.s)
+
 def _flatten_args(args, _cls):
     temp_args = []
     for arg in args:

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -22,6 +22,8 @@ from sympy.polys.polyroots import roots
 from sympy.polys.polytools import (cancel, degree)
 from sympy.series import limit
 from sympy.utilities.misc import filldedent
+from sympy import S, symbols, Function
+
 
 from mpmath.libmp.libmpf import prec_to_dps
 
@@ -1299,6 +1301,50 @@ class TransferFunction(SISOLinearTimeInvariant):
         else:
             return Pow(self.den, -1, evaluate=False)
 
+
+class PIDController(Function):
+    """
+    A PID Controller class.
+
+    Parameters
+    ==========
+    KP : Expr
+        Proportional gain
+    KI : Expr
+        Integral gain
+    KD : Expr
+        Derivative gain
+    s : Symbol
+        The complex frequency variable
+
+    Examples
+    ========
+    >>> from sympy.abc import s
+    >>> from sympy.physics.control.lti import PIDController
+    >>> KP, KI, KD = 1, 0.1, 0.01
+    >>> pid = PIDController(KP, KI, KD, s)
+    >>> pid.transfer_function
+    TransferFunction(s**2*0.01 + s*1 + 0.1, s, s)
+    """
+
+    def __new__(cls, KP, KI, KD, s):
+        if not s.is_Symbol:
+            raise ValueError("s must be a symbol")
+        cls.KP = KP
+        cls.KI = KI
+        cls.KD = KD
+        cls.s = s
+
+        tf = TransferFunction(s*KD + KP + KI/s, 1, s)
+
+        return super().__new__(cls, tf)
+
+    @property
+    def transfer_function(self):
+        """
+        Returns the transfer function of the PID controller.
+        """
+        return TransferFunction(self.s*self.KD + self.KP + self.KI/self.s, 1, self.s)
 
 def _flatten_args(args, _cls):
     temp_args = []

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1384,7 +1384,7 @@ class PIDController(TransferFunction):
 
     @property
     def args(self):
-        return (self.KP, self.KI, self.KD, self.s, self.Tf, self.Ts, self.InputName, self.OutputName)
+        return (self.KP, self.KI, self.KD, self.s)
 
     def to_PID_expr(self):
         numerator = self.KD * self.s**2 + self.KP * self.s + self.KI

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1301,18 +1301,39 @@ class TransferFunction(SISOLinearTimeInvariant):
 
 
 class PIDController:
-    def __init__(self, KP, KI, KD, s):
-        if not isinstance(s, Symbol):
-            raise ValueError("s must be a Symbol")
+    """
+    A PID Controller class that uses Parallel to combine the P, I, and D components.
+    Parameters
+    ==========
+    KP : Expr, Number
+        Proportional gain.
+    KI : Expr, Number
+        Integral gain.
+    KD : Expr, Number
+        Derivative gain.
+    s : Symbol
+        The complex frequency variable.
+    Examples
+    ========
+    >>> from sympy.abc import s
+    >>> from sympy.physics.control.lti import PIDController
+    >>> KP, KI, KD = 1, 0.1, 0.01
+    >>> pid = PIDController(KP, KI, KD, s)
+    >>> print(pid.to_PID_expr())
+    TransferFunction(s*(0.01*s + 1) + 0.1, s, s)
+    """
+    def __init__(self, KP, KI, KD, var):
+        if not isinstance(var, Symbol):
+            raise ValueError("var must be a Symbol")
 
         self.KP = sympify(KP)
         self.KI = sympify(KI)
         self.KD = sympify(KD)
-        self.s = s
+        self.var = var
 
-        P = TransferFunction(KP, 1, s)
-        I = TransferFunction(KI, s, s)
-        D = TransferFunction(KD * s, 1, s)
+        P = TransferFunction(KP, 1, var)
+        I = TransferFunction(KI, var, var)
+        D = TransferFunction(KD * var, 1, var)
 
         self.pid_controller = Parallel(P, I, D)
 
@@ -1321,7 +1342,7 @@ class PIDController:
 
     @property
     def args(self):
-        return (self.KP, self.KI, self.KD, self.s)
+        return (self.KP, self.KI, self.KD, self.var)
 
     @property
     def func(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1302,7 +1302,8 @@ class TransferFunction(SISOLinearTimeInvariant):
 
 class PIDController(TransferFunction):
     """
-    A PID Controller class that subclasses TransferFunction.
+    A PID Controller class that subclasses TransferFunction, extended to support
+    discrete-time controllers, derivative filter time constants, and named input/output channels and IFormula.
 
     Parameters
     ==========
@@ -1314,42 +1315,80 @@ class PIDController(TransferFunction):
         Derivative gain.
     s : Symbol
         The complex frequency variable.
+    Tf : Expr, Number, optional
+        Derivative filter time constant.
+    Ts : Expr, Number, optional
+        Sample time for discrete-time controllers.
+    InputName : str, optional
+        Name of the input channel.
+    OutputName : str, optional
+        Name of the output channel.
 
     Examples
     ========
+    Create a continuous-time PID controller:
+
     >>> from sympy.abc import s
     >>> from sympy.physics.control.lti import PIDController
     >>> KP, KI, KD = 1, 0.1, 0.01
     >>> pid = PIDController(KP, KI, KD, s)
     >>> print(pid)
-    TransferFunction(0.0100000000000000*s**2 + 1*s + 0.100000000000000, 1, s)
+    TransferFunction(KP=1, KI=0.100000000000000, KD=0.0100000000000000, s=s, Tf=0, Ts=None, InputName='', OutputName='')
+
+    Create a PID controller with a derivative filter time constant:
+
+    >>> Tf = 0.5
+    >>> pid_with_tf = PIDController(KP, KI, KD, s, Tf=Tf)
+    >>> print(pid_with_tf)
+    TransferFunction(KP=1, KI=0.100000000000000, KD=0.0100000000000000, s=s, Tf=0.500000000000000, Ts=None, InputName='', OutputName='')
+
+    Create a discrete-time PID controller with sample time and named channels:
+
+    >>> Ts = 0.1
+    >>> InputName = 'error'
+    >>> OutputName = 'control_signal'
+    >>> pid_discrete = PIDController(KP, KI, KD, s, Ts=Ts, InputName=InputName, OutputName=OutputName)
+    >>> print(f"InputName: {pid_discrete.InputName}, OutputName: {pid_discrete.OutputName}")
+    InputName: error, OutputName: control_signal
+
+    Create a PID controller specifying the integration method (IFormula):
+
+    >>> IFormula = 'Trapezoidal'
+    >>> pid_with_iformula = PIDController(KP, KI, KD, s, IFormula=IFormula)
+    >>> print(f"IFormula: {pid_with_iformula.IFormula}")
+    IFormula: Trapezoidal
     """
 
-    def __new__(cls, KP, KI, KD, s):
+    def __new__(cls, KP, KI, KD, s, Tf=0, Ts=None, InputName='', OutputName='', IFormula=None):
         if not isinstance(s, Symbol):
             raise ValueError("s must be a Symbol")
 
-        KP, KI, KD = sympify(KP), sympify(KI), sympify(KD)
+        KP, KI, KD, Tf = sympify(KP), sympify(KI), sympify(KD), sympify(Tf)
         numerator = KD*s**2 + KP*s + KI
-        denominator = s
+        denominator = s + Tf if Tf else s
 
         obj = TransferFunction.__new__(cls, numerator, denominator, s)
         obj.KP = KP
         obj.KI = KI
         obj.KD = KD
+        obj.Tf = Tf
+        obj.Ts = Ts
+        obj.InputName = InputName
+        obj.OutputName = OutputName
+        obj.IFormula = IFormula
         obj.s = s
         return obj
 
     def __str__(self):
-        return f"TransferFunction({self.KD}*s**2 + {self.KP}*s + {self.KI}, 1, s)"
+        return f"TransferFunction(KP={self.KP}, KI={self.KI}, KD={self.KD}, s={self.s}, Tf={self.Tf}, Ts={self.Ts}, InputName='{self.InputName}', OutputName='{self.OutputName}')"
 
     @property
     def args(self):
-        return (self.KP, self.KI, self.KD, self.s)
+        return (self.KP, self.KI, self.KD, self.s, self.Tf, self.Ts, self.InputName, self.OutputName)
 
     def to_PID_expr(self):
         numerator = self.KD * self.s**2 + self.KP * self.s + self.KI
-        denominator = self.s
+        denominator = self.s + self.Tf if self.Tf else self.s
         return numerator / denominator
 
 def _flatten_args(args, _cls):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1314,6 +1314,7 @@ class PIDController:
         Derivative gain.
     s : Symbol
         The complex frequency variable.
+        
     Examples
     ========
     >>> from sympy.abc import s

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1330,7 +1330,7 @@ class PIDController(TransferFunction):
             raise ValueError("s must be a Symbol")
 
         KP, KI, KD = sympify(KP), sympify(KI), sympify(KD)
-        numerator = KP*s + KI + KD*s**2
+        numerator = KD*s**2 + KP*s + KI
         denominator = s
 
         obj = TransferFunction.__new__(cls, numerator, denominator, s)
@@ -1343,6 +1343,11 @@ class PIDController(TransferFunction):
     @property
     def args(self):
         return (self.KP, self.KI, self.KD, self.s)
+
+    def to_PID_expr(self):
+        numerator = self.KD * self.s**2 + self.KP * self.s + self.KI
+        denominator = self.s
+        return numerator / denominator
 
 def _flatten_args(args, _cls):
     temp_args = []

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -508,7 +508,6 @@ def test_Series_construction():
 
 def test_PIDController_creation_and_properties():
     KP, KI, KD = symbols('KP KI KD', real=True)
-    s = Symbol('s')
     pid = PIDController(KP, KI, KD, s)
     assert isinstance(pid, PIDController)
     expected_expr = (KD*s**2 + KP*s + KI) / s

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -507,12 +507,6 @@ def test_Series_construction():
     raises(TypeError, lambda: Series(tf3, Matrix([1, 2, 3, 4])))
 
 
-def test_PIDController_instance():
-    KP, KI, KD = 1, 0.1, 0.01
-    pid = PIDController(KP, KI, KD, s)
-    assert isinstance(pid, PIDController), "The object should be an instance of PIDController."
-    assert isinstance(pid, TransferFunction), "PIDController should inherit from TransferFunction."
-
 def test_PIDController_properties():
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -20,6 +20,7 @@ from sympy.physics.control import (TransferFunction, Series, Parallel,
     StateSpace, gbt, bilinear, forward_diff, backward_diff, phase_margin, gain_margin)
 from sympy.testing.pytest import raises
 
+
 a, x, b, s, g, d, p, k, tau, zeta, wn, T = symbols('a, x, b, s, g, d, p, k,\
     tau, zeta, wn, T')
 a0, a1, a2, a3, b0, b1, b2, b3, c0, c1, c2, c3, d0, d1, d2, d3 = symbols('a0:4,\
@@ -506,21 +507,27 @@ def test_Series_construction():
     raises(TypeError, lambda: Series(tf3, Matrix([1, 2, 3, 4])))
 
 
-def test_PIDController_creation_and_properties():
-    KP, KI, KD = symbols('KP KI KD', real=True)
+def test_PIDController_instance():
+    KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, s)
-    assert isinstance(pid, PIDController)
-    expected_expr = (KD*s**2 + KP*s + KI) / s
-    pid_expr = expand(pid.to_expr())
-    assert simplify(pid_expr - expected_expr) == 0
+    assert isinstance(pid, PIDController), "The object should be an instance of PIDController."
+    assert isinstance(pid, TransferFunction), "PIDController should inherit from TransferFunction."
 
-def test_PIDController_errors():
-    KP, KI, KD = symbols('KP KI KD')
-    try:
-        PIDController(KP, KI, KD, "not a symbol")
-        assert False, "PIDController did not raise ValueError for non-Symbol 's'"
-    except ValueError:
-        pass
+def test_PIDController_properties():
+    KP, KI, KD = 1, 0.1, 0.01
+    pid = PIDController(KP, KI, KD, s)
+    assert pid.KP == 1, "Proportional gain KP should be 1."
+    assert pid.KI == 0.1, "Integral gain KI should be 0.1."
+    assert pid.KD == 0.01, "Derivative gain KD should be 0.01."
+    assert pid.s == s, "Symbol s should match the one provided."
+
+def test_PIDController_functionality():
+    KP, KI, KD = 1, 0.1, 0.01
+    pid = PIDController(KP, KI, KD, s)
+    expected_expr = (KD*s**2 + KP*s + KI) / s
+    pid_expr = pid.to_PID_expr()
+    assert simplify(pid_expr - expected_expr) == 0, "The expression should match the expected expression."
+
 
 def test_MIMOSeries_construction():
     tf_1 = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -510,18 +510,31 @@ def test_Series_construction():
 def test_PIDController_properties():
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, s)
-    assert pid.KP == 1, "Proportional gain KP should be 1."
-    assert pid.KI == 0.1, "Integral gain KI should be 0.1."
-    assert pid.KD == 0.01, "Derivative gain KD should be 0.01."
-    assert pid.s == s, "Symbol s should match the one provided."
+    assert pid.KP == 1
+    assert pid.KI == 0.1
+    assert pid.KD == 0.01
+    assert pid.s == s
 
 def test_PIDController_functionality():
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, s)
     expected_expr = (KD*s**2 + KP*s + KI) / s
     pid_expr = pid.to_PID_expr()
-    assert simplify(pid_expr - expected_expr) == 0, "The expression should match the expected expression."
+    assert simplify(pid_expr - expected_expr) == 0
 
+def test_discrete_time_PI_controller_creation():
+    KP, KI = 5, 2.4
+    Ts = 0.1
+    pid = PIDController(KP, KI, 0, s, Ts=Ts, IFormula='Trapezoidal')
+    assert pid.Ts == Ts
+    assert pid.IFormula == 'Trapezoidal'
+
+def test_PID_controller_with_named_input_and_output():
+    KP, KI, KD = 1, 2, 3
+    input_name, output_name = 'e', 'u'
+    pid = PIDController(KP, KI, KD, s, InputName=input_name, OutputName=output_name)
+    assert pid.InputName == input_name
+    assert pid.OutputName == output_name
 
 def test_MIMOSeries_construction():
     tf_1 = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -4,7 +4,7 @@ from sympy.core.mul import Mul
 from sympy.core.numbers import (I, pi, Rational, oo)
 from sympy.core.power import Pow
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols, Symbol
+from sympy.core.symbol import symbols
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import atan

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -506,9 +506,9 @@ def test_Series_construction():
     raises(TypeError, lambda: Series(s**2 + p*s, tf3, tf2))
     raises(TypeError, lambda: Series(tf3, Matrix([1, 2, 3, 4])))
 
+var = symbols('s')
 
 def test_PIDController_properties():
-    var = symbols('s')
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, var)
     assert pid.KP == S(1)
@@ -517,25 +517,20 @@ def test_PIDController_properties():
     assert pid.var == var
 
 def test_PIDController_functionality():
-    var = symbols('s')
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, var)
-    pid_tf = pid.to_PID_expr()
-    expected_tf = TransferFunction(s*(KD*s + KP) + KI, var, var)
-    diff = simplify(pid_tf - expected_tf)
-    assert diff.num == 0
+    expected_tf = TransferFunction(var*(0.01*var + 1) + 0.1, var, var)
+    assert pid.to_expr() == expected_tf.to_expr()
 
 def test_PIDController_parallel_functionality():
-    var = symbols('s')
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, var)
-    parallel_tf = pid.pid_controller
-    expected_tf = Parallel(
-        TransferFunction(KP, 1, var),
-        TransferFunction(KI, var, var),
-        TransferFunction(KD * var, 1, var)).doit()
+    expected_tf = simplify(Parallel(
+        TransferFunction(1, 1, var),
+        TransferFunction(0.1, var, var),
+        TransferFunction(0.01 * var, 1, var)))
 
-    assert simplify(parallel_tf.to_expr() - expected_tf.to_expr()) == 0
+    assert pid.to_expr() == expected_tf.to_expr()
 
 def test_MIMOSeries_construction():
     tf_1 = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -510,31 +510,18 @@ def test_Series_construction():
 def test_PIDController_properties():
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, s)
-    assert pid.KP == 1
-    assert pid.KI == 0.1
-    assert pid.KD == 0.01
+    assert pid.KP == S(1)
+    assert pid.KI == S(0.1)
+    assert pid.KD == S(0.01)
     assert pid.s == s
 
 def test_PIDController_functionality():
     KP, KI, KD = 1, 0.1, 0.01
     pid = PIDController(KP, KI, KD, s)
-    expected_expr = (KD*s**2 + KP*s + KI) / s
-    pid_expr = pid.to_PID_expr()
-    assert simplify(pid_expr - expected_expr) == 0
-
-def test_discrete_time_PI_controller_creation():
-    KP, KI = 5, 2.4
-    Ts = 0.1
-    pid = PIDController(KP, KI, 0, s, Ts=Ts, IFormula='Trapezoidal')
-    assert pid.Ts == Ts
-    assert pid.IFormula == 'Trapezoidal'
-
-def test_PID_controller_with_named_input_and_output():
-    KP, KI, KD = 1, 2, 3
-    input_name, output_name = 'e', 'u'
-    pid = PIDController(KP, KI, KD, s, InputName=input_name, OutputName=output_name)
-    assert pid.InputName == input_name
-    assert pid.OutputName == output_name
+    pid_tf = pid.to_PID_expr()
+    expected_tf = TransferFunction(s*(KD*s + KP) + KI, s, s)
+    diff = simplify(pid_tf - expected_tf)
+    assert diff.num == 0
 
 def test_MIMOSeries_construction():
     tf_1 = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1,5 +1,5 @@
 from sympy.core.add import Add
-from sympy.core.function import Function, expand
+from sympy.core.function import Function
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, pi, Rational, oo)
 from sympy.core.power import Pow

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import atan
 from sympy.matrices.dense import eye
+from sympy.physics.control.lti import PIDController
 from sympy.polys.polytools import factor
 from sympy.polys.rootoftools import CRootOf
 from sympy.simplify.simplify import simplify
@@ -18,7 +19,6 @@ from sympy.physics.control import (TransferFunction, Series, Parallel,
     Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback,
     StateSpace, gbt, bilinear, forward_diff, backward_diff, phase_margin, gain_margin)
 from sympy.testing.pytest import raises
-from sympy.physics.control.lti import PIDController
 
 a, x, b, s, g, d, p, k, tau, zeta, wn, T = symbols('a, x, b, s, g, d, p, k,\
     tau, zeta, wn, T')
@@ -521,7 +521,6 @@ def test_PIDController_errors():
         assert False, "PIDController did not raise ValueError for non-Symbol 's'"
     except ValueError:
         pass
-
 
 def test_MIMOSeries_construction():
     tf_1 = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -18,7 +18,7 @@ from sympy.physics.control import (TransferFunction, Series, Parallel,
     Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback,
     StateSpace, gbt, bilinear, forward_diff, backward_diff, phase_margin, gain_margin)
 from sympy.testing.pytest import raises
-from sympy.physics.control.lti import PIDController, TransferFunction
+from sympy.physics.control.lti import PIDController
 
 a, x, b, s, g, d, p, k, tau, zeta, wn, T = symbols('a, x, b, s, g, d, p, k,\
     tau, zeta, wn, T')
@@ -533,10 +533,10 @@ def test_PIDController_behavior():
 def test_PIDController_errors():
     KP, KI, KD = symbols('KP KI KD')
     try:
-        pid_error = PIDController(KP, KI, KD, "not a symbol")
-        assert False, "PIDController should raise a ValueError for non-symbol 's'"
-    except ValueError:
-        pass
+        PIDController(KP, KI, KD, "not a symbol")
+        assert False, "Expected ValueError was not raised"
+    except ValueError as e:
+        assert str(e) == "Expected error message", "The error message did not match the expected message"
 
 
 def test_MIMOSeries_construction():

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -508,18 +508,20 @@ def test_Series_construction():
 
 
 def test_PIDController_properties():
+    var = symbols('s')
     KP, KI, KD = 1, 0.1, 0.01
-    pid = PIDController(KP, KI, KD, s)
+    pid = PIDController(KP, KI, KD, var)
     assert pid.KP == S(1)
     assert pid.KI == S(0.1)
     assert pid.KD == S(0.01)
-    assert pid.s == s
+    assert pid.var == var
 
 def test_PIDController_functionality():
+    var = symbols('s')
     KP, KI, KD = 1, 0.1, 0.01
-    pid = PIDController(KP, KI, KD, s)
+    pid = PIDController(KP, KI, KD, var)
     pid_tf = pid.to_PID_expr()
-    expected_tf = TransferFunction(s*(KD*s + KP) + KI, s, s)
+    expected_tf = TransferFunction(s*(KD*s + KP) + KI, var, var)
     diff = simplify(pid_tf - expected_tf)
     assert diff.num == 0
 

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -525,6 +525,18 @@ def test_PIDController_functionality():
     diff = simplify(pid_tf - expected_tf)
     assert diff.num == 0
 
+def test_PIDController_parallel_functionality():
+    var = symbols('s')
+    KP, KI, KD = 1, 0.1, 0.01
+    pid = PIDController(KP, KI, KD, var)
+    parallel_tf = pid.pid_controller
+    expected_tf = Parallel(
+        TransferFunction(KP, 1, var),
+        TransferFunction(KI, var, var),
+        TransferFunction(KD * var, 1, var)).doit()
+
+    assert simplify(parallel_tf.to_expr() - expected_tf.to_expr()) == 0
+
 def test_MIMOSeries_construction():
     tf_1 = TransferFunction(a0*s**3 + a1*s**2 - a2*s, b0*p**4 + b1*p**3 - b2*s*p, s)
     tf_2 = TransferFunction(a2*p - s, a2*s + p, s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes: #26163

#### Brief description of what is fixed or changed

Introduced a PIDController class in the control module to simplify the creation and manipulation of PID controllers in control systems. This class allows users to define PID controllers by specifying proportional (KP), integral (KI), and derivative (KD) gains, and automatically constructs the corresponding transfer function.

This addition enhances the control module by providing a direct way to work with PID controller.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Introduced the PIDController class in the control module.
<!-- END RELEASE NOTES -->
