### PR TITLE
Deprecate JointsMethod and Body

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,6 +76,35 @@ SymPy deprecation warnings.
 
 ## Version 1.13
 
+(deprecated-mechanics-body-class)=
+### Deprecated mechanics Body class
+
+The ``Body`` class in the ``sympy.physics.mechanics`` module has been
+deprecated. It was introduced to support the joints framework. However, it
+causes several problems because it represents both rigid bodies and particles.
+``Body`` has now been fully replaced by ``RigidBody`` and ``Particle``.
+Previously, one could create a simple rigid body or particle using only the
+``Body`` class:
+
+```py
+>>> from sympy import symbols
+>>> from sympy.physics.mechanics import Body
+>>> Body("rb")  # Rigid body
+Body('rb', masscenter=rb_masscenter, frame=rb_frame, mass=rb_mass, inertia=...)
+>>> Body("pt")  # Particle
+Body('pt', masscenter=pt_masscenter, mass=m)
+```
+
+Now they should be created using the ``RigidBody`` and ``Particle`` class:
+
+```py
+>>> from sympy.physics.mechanics import RigidBody, Particle
+>>> RigidBody("rb")
+RigidBody('rb', masscenter=rb_masscenter, frame=rb_frame, mass=rb_mass, inertia= ...)
+>>> Particle("pt")
+Particle('pt', masscenter=pt_masscenter, mass=pt_mass)
+```
+
 (deprecated-matrix-mixins)=
 ### Deprecated matrix mixin classes
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -105,6 +105,60 @@ RigidBody('rb', masscenter=rb_masscenter, frame=rb_frame, mass=rb_mass, inertia=
 Particle('pt', masscenter=pt_masscenter, mass=pt_mass)
 ```
 
+(deprecated-mechanics-jointsmethod)=
+### Deprecated mechanics JointsMethod
+
+The ``JointsMethod`` class in the ``sympy.physics.mechanics`` module has been
+deprecated. It was introduced to support the joints framework, but it has been
+fully replaced due to limitations in its design. Previously, one could construct
+as system solely consisting out of bodies and joints, which were then parsed by
+``JointsMethod`` to a backend, like ``KanesMethod`` to form the equations of
+motion.
+
+```py
+>>> from sympy import symbols
+>>> from sympy.physics.mechanics import (
+...   Body, JointsMethod, PinJoint, PrismaticJoint)
+>>> g, l = symbols("g l")
+>>> wall = Body("wall")
+>>> cart = Body("cart")
+>>> pendulum = Body("Pendulum")
+>>> slider = PrismaticJoint("s", wall, cart, joint_axis=wall.x)
+>>> pin = PinJoint("j", cart, pendulum, joint_axis=cart.z,
+...                child_point=l * pendulum.y)
+>>> pendulum.masscenter.set_vel(pendulum.frame, 0)
+>>> cart.apply_force(-g * cart.mass * wall.y)
+>>> pendulum.apply_force(-g * pendulum.mass * wall.y)
+>>> method = JointsMethod(wall, slider, pin)
+>>> method.form_eoms()
+Matrix([
+[ Pendulum_mass*l*u_j(t)**2*sin(q_j(t)) - Pendulum_mass*l*cos(q_j(t))*Derivative(u_j(t), t) - (Pendulum_mass + cart_mass)*Derivative(u_s(t), t)],
+[-Pendulum_mass*g*l*sin(q_j(t)) - Pendulum_mass*l*cos(q_j(t))*Derivative(u_s(t), t) - (Pendulum_izz + Pendulum_mass*l**2)*Derivative(u_j(t), t)]])
+```
+
+The replacement of ``JointsMethod`` is ``System``, which can be used to form the
+equations of motion of the same cart pole as follows:
+
+```py
+>>> from sympy import symbols
+>>> from sympy.physics.mechanics import (
+...   Particle, PinJoint, PrismaticJoint, RigidBody, System)
+>>> g, l = symbols("g l")
+>>> wall = RigidBody("wall")
+>>> cart = RigidBody("cart")
+>>> pendulum = RigidBody("Pendulum")
+>>> slider = PrismaticJoint("s", wall, cart, joint_axis=wall.x)
+>>> pin = PinJoint("j", cart, pendulum, joint_axis=cart.z,
+...                child_point=l * pendulum.y)
+>>> system = System.from_newtonian(wall)
+>>> system.add_joints(slider, pin)
+>>> system.apply_uniform_gravity(-g * wall.y)
+>>> system.form_eoms()
+Matrix([
+[ Pendulum_mass*l*u_j(t)**2*sin(q_j(t)) - Pendulum_mass*l*cos(q_j(t))*Derivative(u_j(t), t) - (Pendulum_mass + cart_mass)*Derivative(u_s(t), t)],
+[-Pendulum_mass*g*l*sin(q_j(t)) - Pendulum_mass*l*cos(q_j(t))*Derivative(u_s(t), t) - (Pendulum_izz + Pendulum_mass*l**2)*Derivative(u_j(t), t)]])
+```
+
 (deprecated-matrix-mixins)=
 ### Deprecated matrix mixin classes
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -89,20 +89,20 @@ Previously, one could create a simple rigid body or particle using only the
 ```py
 >>> from sympy import symbols
 >>> from sympy.physics.mechanics import Body
->>> Body("rb")  # Rigid body
-Body('rb', masscenter=rb_masscenter, frame=rb_frame, mass=rb_mass, inertia=...)
->>> Body("pt")  # Particle
-Body('pt', masscenter=pt_masscenter, mass=m)
+>>> Body("rigid_body")  # doctest: +SKIP
+rigid_body
+>>> Body("particle", mass=symbols("m"))  # doctest: +SKIP
+particle
 ```
 
 Now they should be created using the ``RigidBody`` and ``Particle`` class:
 
 ```py
 >>> from sympy.physics.mechanics import RigidBody, Particle
->>> RigidBody("rb")
-RigidBody('rb', masscenter=rb_masscenter, frame=rb_frame, mass=rb_mass, inertia= ...)
->>> Particle("pt")
-Particle('pt', masscenter=pt_masscenter, mass=pt_mass)
+>>> RigidBody("rigid_body")
+rigid_body
+>>> Particle("particle")
+particle
 ```
 
 (deprecated-mechanics-jointsmethod)=
@@ -129,8 +129,8 @@ motion.
 >>> pendulum.masscenter.set_vel(pendulum.frame, 0)
 >>> cart.apply_force(-g * cart.mass * wall.y)
 >>> pendulum.apply_force(-g * pendulum.mass * wall.y)
->>> method = JointsMethod(wall, slider, pin)
->>> method.form_eoms()
+>>> method = JointsMethod(wall, slider, pin)  # doctest: +SKIP
+>>> method.form_eoms()  # doctest: +SKIP
 Matrix([
 [ Pendulum_mass*l*u_j(t)**2*sin(q_j(t)) - Pendulum_mass*l*cos(q_j(t))*Derivative(u_j(t), t) - (Pendulum_mass + cart_mass)*Derivative(u_s(t), t)],
 [-Pendulum_mass*g*l*sin(q_j(t)) - Pendulum_mass*l*cos(q_j(t))*Derivative(u_s(t), t) - (Pendulum_izz + Pendulum_mass*l**2)*Derivative(u_j(t), t)]])

--- a/doc/src/modules/physics/mechanics/api/body.rst
+++ b/doc/src/modules/physics/mechanics/api/body.rst
@@ -1,6 +1,0 @@
-=================
-Body (Docstrings)
-=================
-
-.. automodule:: sympy.physics.mechanics.body
-   :members:

--- a/doc/src/modules/physics/mechanics/api/index.rst
+++ b/doc/src/modules/physics/mechanics/api/index.rst
@@ -5,7 +5,6 @@ Mechanics API Reference
    :titlesonly:
 
    part_bod.rst
-   body.rst
    kane_lagrange.rst
    joint.rst
    system.rst

--- a/doc/src/modules/physics/mechanics/api/joint.rst
+++ b/doc/src/modules/physics/mechanics/api/joint.rst
@@ -27,6 +27,3 @@ Joint (Docstrings)
 
 .. autoclass:: WeldJoint
    :members:
-
-.. automodule:: sympy.physics.mechanics.jointsmethod
-   :members:

--- a/doc/src/modules/physics/mechanics/examples/multi_degree_freedom_holonomic_system.rst
+++ b/doc/src/modules/physics/mechanics/examples/multi_degree_freedom_holonomic_system.rst
@@ -3,75 +3,90 @@ Multi Degree of Freedom Holonomic System
 =========================================
 
 In this example we demonstrate the use of the functionality provided in
-:mod:`sympy.physics.mechanics` for deriving the equations of motion (EOM) of a holonomic
-system that includes both particles and rigid bodies with contributing forces and torques,
-some of which are specified forces and torques. The system is shown below:
+:mod:`sympy.physics.mechanics` for deriving the equations of motion (EOM) of a
+holonomic system that includes both particles and rigid bodies with contributing
+forces and torques, some of which are specified forces and torques. The system
+is shown below:
 
 .. image:: multidof-holonomic.*
    :align: center
 
-The system will be modeled using ``JointsMethod``. First we need to create the
-``dynamicsymbols`` needed to describe the system as shown in the above diagram.
-In this case, the generalized coordinates :math:`q_1` represent lateral distance of block from wall,
-:math:`q_2` represents angle of the compound pendulum from vertical, :math:`q_3`  represents angle of the simple
-pendulum from the compound pendulum. The generalized speeds :math:`u_1` represents lateral speed of block,
-:math:`u_2` represents lateral speed of compound pendulum and :math:`u_3` represents angular speed of C relative to B.
+The system will be modeled using :class:`~.System`. First we need to create the
+:func:`~.dynamicsymbols` needed to describe the system as shown in the above
+diagram. In this case, the generalized coordinates :math:`q_1` represent lateral
+distance of block from wall, :math:`q_2` represents angle of the compound
+pendulum from vertical, :math:`q_3`  represents angle of the simple pendulum
+from the compound pendulum. The generalized speeds :math:`u_1` represents
+lateral speed of block, :math:`u_2` represents lateral speed of compound
+pendulum and :math:`u_3` represents angular speed of C relative to B.
 
-We also create some ``symbols`` to represent the length and
-mass of the pendulum, as well as gravity and others. ::
+We also create some :func:`~.symbols` to represent the length and mass of the
+pendulum, as well as gravity and others. ::
 
     >>> from sympy import zeros, symbols
-    >>> from sympy.physics.mechanics import Body, PinJoint, PrismaticJoint, JointsMethod, inertia
-    >>> from sympy.physics.mechanics import dynamicsymbols
+    >>> from sympy.physics.mechanics import *
     >>> q1, q2, q3, u1, u2, u3 = dynamicsymbols('q1, q2, q3, u1, u2, u3')
+    >>> F, T = dynamicsymbols('F, T')
     >>> l, k, c, g, kT = symbols('l, k, c, g, kT')
     >>> ma, mb, mc, IBzz= symbols('ma, mb, mc, IBzz')
 
-Next, we create the bodies and connect them using joints to establish the
-kinematics. ::
+With all symbols defined, we can now define the bodies and initialize our
+instance of :class:`~.System`. ::
 
-    >>> wall = Body('N')
-    >>> block = Body('A', mass=ma)
-    >>> IB = inertia(block.frame, 0, 0, IBzz)
-    >>> compound_pend = Body('B', mass=mb, central_inertia=IB)
-    >>> simple_pend = Body('C', mass=mc)
+    >>> wall = RigidBody('N')
+    >>> block = Particle('A', mass=ma)
+    >>> compound_pend = RigidBody('B', mass=mb)
+    >>> compound_pend.central_inertia = inertia(compound_pend.frame, 0, 0, IBzz)
+    >>> simple_pend = Particle('C', mass=mc)
+    >>> system = System.from_newtonian(wall)
+    >>> system.add_bodies(block, compound_pend, simple_pend)
 
-    >>> bodies = (wall, block, compound_pend, simple_pend)
+Next, we connect the bodies using joints to establish the kinematics. Note that
+we specify the intermediate frames for both particles, as particles do not have
+an associated frame. ::
 
-    >>> slider = PrismaticJoint('J1', wall, block, coordinates=q1, speeds=u1)
+    >>> block_frame = ReferenceFrame('A')
+    >>> block.masscenter.set_vel(block_frame, 0)
+    >>> slider = PrismaticJoint('J1', wall, block, coordinates=q1, speeds=u1,
+    ...                         child_interframe=block_frame)
     >>> rev1 = PinJoint('J2', block, compound_pend, coordinates=q2, speeds=u2,
-    ...                 joint_axis=block.z, child_point=l*2/3*compound_pend.y)
-    >>> rev2 = PinJoint('J3', compound_pend, simple_pend, coordinates=q3, speeds=u3,
-    ...                 joint_axis=compound_pend.z, parent_point=-l/3*compound_pend.y,
-    ...                 child_point=l*simple_pend.y)
+    ...                 joint_axis=wall.z, child_point=l*2/3*compound_pend.y,
+    ...                 parent_interframe=block_frame)
+    >>> simple_pend_frame = ReferenceFrame('C')
+    >>> simple_pend.masscenter.set_vel(simple_pend_frame, 0)
+    >>> rev2 = PinJoint('J3', compound_pend, simple_pend, coordinates=q3,
+    ...                 speeds=u3, joint_axis=compound_pend.z,
+    ...                 parent_point=-l/3*compound_pend.y,
+    ...                 child_point=l*simple_pend_frame.y,
+    ...                 child_interframe=simple_pend_frame)
 
-    >>> joints = (slider, rev1, rev2)
+    >>> system.add_joints(slider, rev1, rev2)
 
-Now we can apply loads (forces and torques) to the bodies, gravity acts on all bodies,
-a linear spring and damper act on block and wall, a rotational linear spring acts on C relative to B
-specified torque T acts on compound_pend and block, specified force F acts on block. ::
+Now we can apply loads (forces and torques) to the bodies, gravity acts on all
+bodies, a linear spring and damper act on block and wall, a rotational linear
+spring acts on C relative to B specified torque T acts on compound_pend and
+block, specified force F acts on block. ::
 
-    >>> F, T = dynamicsymbols('F, T')
-    >>> block.apply_force(F*block.x)
-    >>> block.apply_force(-k*q1*block.x, reaction_body=wall)
-    >>> block.apply_force(-c*u1*block.x, reaction_body=wall)
-    >>> compound_pend.apply_torque(T*compound_pend.z, reaction_body=block)
-    >>> simple_pend.apply_torque(-kT*q3*simple_pend.z, reaction_body=compound_pend)
-    >>> block.apply_force(-wall.y*block.mass*g)
-    >>> compound_pend.apply_force(-wall.y*compound_pend.mass*g)
-    >>> simple_pend.apply_force(-wall.y*simple_pend.mass*g)
+    >>> system.apply_uniform_gravity(-g * wall.y)
+    >>> system.add_loads(Force(block, F * wall.x))
+    >>> spring_damper_path = LinearPathway(wall.masscenter, block.masscenter)
+    >>> system.add_actuators(
+    ...     LinearSpring(k, spring_damper_path),
+    ...     LinearDamper(c, spring_damper_path),
+    ...     TorqueActuator(T, wall.z, compound_pend, wall),
+    ...     TorqueActuator(kT * q3, wall.z, compound_pend, simple_pend_frame),
+    ... )
 
-With the problem setup, the equations of motion can be generated using the
-``JointsMethod`` class with KanesMethod in backend. ::
+With the system setup, we can now form the equations of motion with
+:class:`~.KanesMethod` in the backend. ::
 
-    >>> method = JointsMethod(wall, slider, rev1, rev2)
-    >>> method.form_eoms()
+    >>> system.form_eoms(explicit_kinematics=True)
     Matrix([
     [                                -c*u1(t) - k*q1(t) + 2*l*mb*u2(t)**2*sin(q2(t))/3 - l*mc*(-sin(q2(t))*sin(q3(t)) + cos(q2(t))*cos(q3(t)))*Derivative(u3(t), t) - l*mc*(-sin(q2(t))*cos(q3(t)) - sin(q3(t))*cos(q2(t)))*(u2(t) + u3(t))**2 + l*mc*u2(t)**2*sin(q2(t)) - (2*l*mb*cos(q2(t))/3 + mc*(l*(-sin(q2(t))*sin(q3(t)) + cos(q2(t))*cos(q3(t))) + l*cos(q2(t))))*Derivative(u2(t), t) - (ma + mb + mc)*Derivative(u1(t), t) + F(t)],
     [-2*g*l*mb*sin(q2(t))/3 - g*l*mc*(sin(q2(t))*cos(q3(t)) + sin(q3(t))*cos(q2(t))) - g*l*mc*sin(q2(t)) + l**2*mc*(u2(t) + u3(t))**2*sin(q3(t)) - l**2*mc*u2(t)**2*sin(q3(t)) - mc*(l**2*cos(q3(t)) + l**2)*Derivative(u3(t), t) - (2*l*mb*cos(q2(t))/3 + mc*(l*(-sin(q2(t))*sin(q3(t)) + cos(q2(t))*cos(q3(t))) + l*cos(q2(t))))*Derivative(u1(t), t) - (IBzz + 4*l**2*mb/9 + mc*(2*l**2*cos(q3(t)) + 2*l**2))*Derivative(u2(t), t) + T(t)],
     [                                                                                                                                                                        -g*l*mc*(sin(q2(t))*cos(q3(t)) + sin(q3(t))*cos(q2(t))) - kT*q3(t) - l**2*mc*u2(t)**2*sin(q3(t)) - l**2*mc*Derivative(u3(t), t) - l*mc*(-sin(q2(t))*sin(q3(t)) + cos(q2(t))*cos(q3(t)))*Derivative(u1(t), t) - mc*(l**2*cos(q3(t)) + l**2)*Derivative(u2(t), t)]])
 
-    >>> method.mass_matrix_full
+    >>> system.mass_matrix_full
     Matrix([
     [1, 0, 0,                                                                                            0,                                                                                            0,                                                     0],
     [0, 1, 0,                                                                                            0,                                                                                            0,                                                     0],
@@ -80,7 +95,7 @@ With the problem setup, the equations of motion can be generated using the
     [0, 0, 0, 2*l*mb*cos(q2(t))/3 + mc*(l*(-sin(q2(t))*sin(q3(t)) + cos(q2(t))*cos(q3(t))) + l*cos(q2(t))),                                         IBzz + 4*l**2*mb/9 + mc*(2*l**2*cos(q3(t)) + 2*l**2),                           mc*(l**2*cos(q3(t)) + l**2)],
     [0, 0, 0,                                        l*mc*(-sin(q2(t))*sin(q3(t)) + cos(q2(t))*cos(q3(t))),                                                                  mc*(l**2*cos(q3(t)) + l**2),                                               l**2*mc]])
 
-    >>> method.forcing_full
+    >>> system.forcing_full
     Matrix([
     [                                                                                                                                                                           u1(t)],
     [                                                                                                                                                                           u2(t)],

--- a/doc/src/modules/physics/mechanics/joints.rst
+++ b/doc/src/modules/physics/mechanics/joints.rst
@@ -7,18 +7,19 @@ Joints Framework in Physics/Mechanics
 :mod:`sympy.physics.mechanics` provides a joints framework. This system consists
 of two parts. The first are the :obj:`joints<sympy.physics.mechanics.joint>`
 themselves, which are used to create connections between
-:class:`bodies<sympy.physics.mechanics.body.RigidBody>`. The second part is the
+:class:`bodies<sympy.physics.mechanics.rigidbody.RigidBody>`. The second part is the
 :class:`~.System`, which is used to form the equations of motion. Both of these
 parts are doing what we can call "book-keeping": keeping track of the
-relationships between :class:`bodies<sympy.physics.mechanics.body.RigidBody>`.
+relationships between
+:class:`bodies<sympy.physics.mechanics.rigidbody.RigidBody>`.
 
 Joints in Physics/Mechanics
 ===========================
 
 The general task of the :mod:`joints<sympy.physics.mechanics.joint>` is creating
 kinematic relationships between
-:class:`bodies<sympy.physics.mechanics.body.RigidBody>`. A joint is generally
-described as shown in the image below.
+:class:`bodies<sympy.physics.mechanics.rigidbody.RigidBody>`. A joint is
+generally described as shown in the image below.
 
 .. image:: api/joint_explanation.svg
    :align: center

--- a/doc/src/modules/physics/mechanics/joints.rst
+++ b/doc/src/modules/physics/mechanics/joints.rst
@@ -7,17 +7,17 @@ Joints Framework in Physics/Mechanics
 :mod:`sympy.physics.mechanics` provides a joints framework. This system consists
 of two parts. The first are the :obj:`joints<sympy.physics.mechanics.joint>`
 themselves, which are used to create connections between
-:class:`bodies<sympy.physics.mechanics.body.Body>`. The second part is the
-:class:`~.JointsMethod`, which is used to form the equations of motion. Both of
-these parts are doing what we can call "book-keeping": keeping track of the
-relationships between :class:`bodies<sympy.physics.mechanics.body.Body>`.
+:class:`bodies<sympy.physics.mechanics.body.RigidBody>`. The second part is the
+:class:`~.System`, which is used to form the equations of motion. Both of these
+parts are doing what we can call "book-keeping": keeping track of the
+relationships between :class:`bodies<sympy.physics.mechanics.body.RigidBody>`.
 
 Joints in Physics/Mechanics
 ===========================
 
 The general task of the :mod:`joints<sympy.physics.mechanics.joint>` is creating
 kinematic relationships between
-:class:`bodies<sympy.physics.mechanics.body.Body>`. A joint is generally
+:class:`bodies<sympy.physics.mechanics.body.RigidBody>`. A joint is generally
 described as shown in the image below.
 
 .. image:: api/joint_explanation.svg
@@ -68,8 +68,8 @@ body's frame. ::
    >>> from sympy.physics.mechanics import *
    >>> mechanics_printing(pretty_print=False)
    >>> q, u = dynamicsymbols('q, u')
-   >>> parent = Body('parent')
-   >>> child = Body('child')
+   >>> parent = RigidBody('parent')
+   >>> child = RigidBody('child')
    >>> joint = PinJoint(
    ...     'hinge', parent, child, coordinates=q, speeds=u,
    ...     parent_point=3 * parent.frame.x,
@@ -88,19 +88,19 @@ body's frame. ::
    >>> child.masscenter.vel(parent.frame)
    3*u*child_frame.y
 
-JointsMethod in Physics/Mechanics
-=================================
-After defining the entire system you can use the :class:`~.JointsMethod` to
-parse the system and form the equations of motion. In this process the
-:class:`~.JointsMethod` only does the "book-keeping" of the joints. It uses
-another method, like the :class:`~.KanesMethod`, as its backend for forming the
-equations of motion.
+System in Physics/Mechanics
+===========================
+After defining the entire system you can use the :class:`~.System` to parse the
+system and form the equations of motion. In this process the :class:`~.System`
+only does the "book-keeping" of the joints. It uses another method, like the
+:class:`~.KanesMethod`, as its backend for forming the equations of motion.
 
 In the code below we form the equations of motion of the single
 :class:`~.PinJoint` shown previously. ::
 
-   >>> method = JointsMethod(parent, joint)
-   >>> method.form_eoms()
+   >>> system = System.from_newtonian(parent)
+   >>> system.add_joints(joint)
+   >>> system.form_eoms()
    Matrix([[-(child_izz + 9*child_mass)*u']])
-   >>> type(method.method)  # The method working in the backend
+   >>> type(system.eom_method)  # The method working in the backend
    <class 'sympy.physics.mechanics.kane.KanesMethod'>

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -2,6 +2,7 @@ from sympy import Symbol
 from sympy.physics.vector import Point, Vector, ReferenceFrame, Dyadic
 from sympy.physics.mechanics import RigidBody, Particle, Inertia
 from sympy.physics.mechanics.body_base import BodyBase
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['Body']
 
@@ -99,6 +100,14 @@ class Body(RigidBody, Particle):  # type: ignore
 
     def __init__(self, name, masscenter=None, mass=None, frame=None,
                  central_inertia=None):
+        sympy_deprecation_warning(
+            """
+            Support for the Body class has been removed, as its functionality is
+            fully captured by RigidBody and Particle.
+            """,
+            deprecated_since_version="1.13",
+            active_deprecations_target="deprecated-mechanics-body-class"
+        )
 
         self._loads = []
 

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -3,6 +3,7 @@ from sympy.physics.mechanics import (Body, Lagrangian, KanesMethod, LagrangesMet
 from sympy.physics.mechanics.body_base import BodyBase
 from sympy.physics.mechanics.method import _Methods
 from sympy import Matrix
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 __all__ = ['JointsMethod']
 
@@ -77,6 +78,14 @@ class JointsMethod(_Methods):
     """
 
     def __init__(self, newtonion, *joints):
+        sympy_deprecation_warning(
+            """
+            The JointsMethod class is deprecated.
+            Its functionality has been replaced by the new System class.
+            """,
+            deprecated_since_version="1.13",
+            active_deprecations_target="deprecated-mechanics-jointsmethod"
+        )
         if isinstance(newtonion, BodyBase):
             self.frame = newtonion.frame
         else:

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -74,7 +74,7 @@ class RigidBody(BodyBase):
     def __repr__(self):
         return (f'{self.__class__.__name__}({repr(self.name)}, masscenter='
                 f'{repr(self.masscenter)}, frame={repr(self.frame)}, mass='
-                f'{repr(self.mass)}), inertia={repr(self.inertia)}))')
+                f'{repr(self.mass)}, inertia={repr(self.inertia)})')
 
     @property
     def frame(self):

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -2,11 +2,12 @@ from sympy import (Symbol, symbols, sin, cos, Matrix, zeros,
                                 simplify)
 from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols, Dyadic
 from sympy.physics.mechanics import inertia, Body
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 def test_default():
-    body = Body('body')
+    with warns_deprecated_sympy():
+        body = Body('body')
     assert body.name == 'body'
     assert body.loads == []
     point = Point('body_masscenter')
@@ -27,8 +28,9 @@ def test_custom_rigid_body():
     rigidbody_mass = Symbol('rigidbody_mass')
     rigidbody_frame = ReferenceFrame('rigidbody_frame')
     body_inertia = inertia(rigidbody_frame, 1, 0, 0)
-    rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
-                      rigidbody_frame, body_inertia)
+    with warns_deprecated_sympy():
+        rigid_body = Body('rigidbody_body', rigidbody_masscenter,
+                          rigidbody_mass, rigidbody_frame, body_inertia)
     com = rigid_body.masscenter
     frame = rigid_body.frame
     rigidbody_masscenter.set_vel(rigidbody_frame, 0)
@@ -51,8 +53,9 @@ def test_particle_body():
     particle_masscenter = Point('particle_masscenter')
     particle_mass = Symbol('particle_mass')
     particle_frame = ReferenceFrame('particle_frame')
-    particle_body = Body('particle_body', particle_masscenter, particle_mass,
-                         particle_frame)
+    with warns_deprecated_sympy():
+        particle_body = Body('particle_body', particle_masscenter,
+                             particle_mass, particle_frame)
     com = particle_body.masscenter
     frame = particle_body.frame
     particle_masscenter.set_vel(particle_frame, 0)
@@ -72,7 +75,8 @@ def test_particle_body():
     assert particle_body.central_inertia == inertia(particle_frame, 1, 1, 1)
     assert particle_body.is_rigidbody
 
-    particle_body = Body('particle_body', mass=particle_mass)
+    with warns_deprecated_sympy():
+        particle_body = Body('particle_body', mass=particle_mass)
     assert not particle_body.is_rigidbody
     point = particle_body.masscenter.locatenew('point', particle_body.x)
     point_inertia = particle_mass * inertia(particle_body.frame, 0, 1, 1)
@@ -87,8 +91,9 @@ def test_particle_body_add_force():
     particle_masscenter = Point('particle_masscenter')
     particle_mass = Symbol('particle_mass')
     particle_frame = ReferenceFrame('particle_frame')
-    particle_body = Body('particle_body', particle_masscenter, particle_mass,
-                         particle_frame)
+    with warns_deprecated_sympy():
+        particle_body = Body('particle_body', particle_masscenter,
+                             particle_mass, particle_frame)
 
     a = Symbol('a')
     force_vector = a * particle_body.frame.x
@@ -112,8 +117,9 @@ def test_body_add_force():
     rigidbody_mass = Symbol('rigidbody_mass')
     rigidbody_frame = ReferenceFrame('rigidbody_frame')
     body_inertia = inertia(rigidbody_frame, 1, 0, 0)
-    rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
-                      rigidbody_frame, body_inertia)
+    with warns_deprecated_sympy():
+        rigid_body = Body('rigidbody_body', rigidbody_masscenter,
+                          rigidbody_mass, rigidbody_frame, body_inertia)
 
     l = Symbol('l')
     Fa = Symbol('Fa')
@@ -139,7 +145,8 @@ def test_body_add_force():
     raises(TypeError, lambda: rigid_body.apply_force(0))
 
 def test_body_add_torque():
-    body = Body('body')
+    with warns_deprecated_sympy():
+        body = Body('body')
     torque_vector = body.frame.x
     body.apply_torque(torque_vector)
 
@@ -148,32 +155,38 @@ def test_body_add_torque():
     raises(TypeError, lambda: body.apply_torque(0))
 
 def test_body_masscenter_vel():
-    A = Body('A')
+    with warns_deprecated_sympy():
+        A = Body('A')
     N = ReferenceFrame('N')
-    B = Body('B', frame=N)
+    with warns_deprecated_sympy():
+        B = Body('B', frame=N)
     A.masscenter.set_vel(N, N.z)
     assert A.masscenter_vel(B) == N.z
     assert A.masscenter_vel(N) == N.z
 
 def test_body_ang_vel():
-    A = Body('A')
+    with warns_deprecated_sympy():
+        A = Body('A')
     N = ReferenceFrame('N')
-    B = Body('B', frame=N)
+    with warns_deprecated_sympy():
+        B = Body('B', frame=N)
     A.frame.set_ang_vel(N, N.y)
     assert A.ang_vel_in(B) == N.y
     assert B.ang_vel_in(A) == -N.y
     assert A.ang_vel_in(N) == N.y
 
 def test_body_dcm():
-    A = Body('A')
-    B = Body('B')
+    with warns_deprecated_sympy():
+        A = Body('A')
+        B = Body('B')
     A.frame.orient_axis(B.frame, B.frame.z, 10)
     assert A.dcm(B) == Matrix([[cos(10), sin(10), 0], [-sin(10), cos(10), 0], [0, 0, 1]])
     assert A.dcm(B.frame) == Matrix([[cos(10), sin(10), 0], [-sin(10), cos(10), 0], [0, 0, 1]])
 
 def test_body_axis():
     N = ReferenceFrame('N')
-    B = Body('B', frame=N)
+    with warns_deprecated_sympy():
+        B = Body('B', frame=N)
     assert B.x == N.x
     assert B.y == N.y
     assert B.z == N.z
@@ -181,7 +194,8 @@ def test_body_axis():
 def test_apply_force_multiple_one_point():
     a, b = symbols('a b')
     P = Point('P')
-    B = Body('B')
+    with warns_deprecated_sympy():
+        B = Body('B')
     f1 = a*B.x
     f2 = b*B.y
     B.apply_force(f1, P)
@@ -194,8 +208,9 @@ def test_apply_force():
     q, x, v1, v2 = dynamicsymbols('q x v1 v2')
     P1 = Point('P1')
     P2 = Point('P2')
-    B1 = Body('B1')
-    B2 = Body('B2')
+    with warns_deprecated_sympy():
+        B1 = Body('B1')
+        B2 = Body('B2')
     N = ReferenceFrame('N')
 
     P1.set_vel(B1.frame, v1*B1.x)
@@ -225,8 +240,9 @@ def test_apply_force():
 def test_apply_torque():
     t = symbols('t')
     q = dynamicsymbols('q')
-    B1 = Body('B1')
-    B2 = Body('B2')
+    with warns_deprecated_sympy():
+        B1 = Body('B1')
+        B2 = Body('B2')
     N = ReferenceFrame('N')
     torque = t*q*N.x
 
@@ -241,7 +257,8 @@ def test_apply_torque():
 def test_clear_load():
     a = symbols('a')
     P = Point('P')
-    B = Body('B')
+    with warns_deprecated_sympy():
+        B = Body('B')
     force = a*B.z
     B.apply_force(force, P)
     assert B.loads == [(P, force)]
@@ -251,7 +268,8 @@ def test_clear_load():
 def test_remove_load():
     P1 = Point('P1')
     P2 = Point('P2')
-    B = Body('B')
+    with warns_deprecated_sympy():
+        B = Body('B')
     f1 = B.x
     f2 = B.y
     B.apply_force(f1, P1)
@@ -266,10 +284,11 @@ def test_remove_load():
 
 def test_apply_loads_on_multi_degree_freedom_holonomic_system():
     """Example based on: https://pydy.readthedocs.io/en/latest/examples/multidof-holonomic.html"""
-    W = Body('W') #Wall
-    B = Body('B') #Block
-    P = Body('P') #Pendulum
-    b = Body('b') #bob
+    with warns_deprecated_sympy():
+        W = Body('W') #Wall
+        B = Body('B') #Block
+        P = Body('P') #Pendulum
+        b = Body('b') #bob
     q1, q2 = dynamicsymbols('q1 q2') #generalized coordinates
     k, c, g, kT = symbols('k c g kT') #constants
     F, T = dynamicsymbols('F T') #Specified forces
@@ -298,7 +317,8 @@ def test_parallel_axis():
     # Test RigidBody
     o = Point('o')
     p = o.locatenew('p', a * N.x + b * N.y)
-    R = Body('R', masscenter=o, frame=N, mass=m, central_inertia=Io)
+    with warns_deprecated_sympy():
+        R = Body('R', masscenter=o, frame=N, mass=m, central_inertia=Io)
     Ip = R.parallel_axis(p)
     Ip_expected = inertia(N, Ix + m * b**2, Iy + m * a**2,
                           Iz + m * (a**2 + b**2), ixy=-m * a * b)
@@ -311,7 +331,8 @@ def test_parallel_axis():
     # Test Particle
     o = Point('o')
     p = o.locatenew('p', a * N.x + b * N.y)
-    P = Body('P', masscenter=o, mass=m, frame=N)
+    with warns_deprecated_sympy():
+        P = Body('P', masscenter=o, mass=m, frame=N)
     Ip = P.parallel_axis(p, N)
     Ip_expected = inertia(N, m * b ** 2, m * a ** 2, m * (a ** 2 + b ** 2),
                           ixy=-m * a * b)

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -1197,7 +1197,8 @@ def test_weld_joint():
     assert P.frame.ang_vel_in(C.frame) == 0
     assert P.x == A.z
 
-    JointsMethod(P, W)  # Tests #10770
+    with warns_deprecated_sympy():
+        JointsMethod(P, W)  # Tests #10770
 
 
 def test_deprecated_parent_child_axis():

--- a/sympy/physics/mechanics/tests/test_joint.py
+++ b/sympy/physics/mechanics/tests/test_joint.py
@@ -215,8 +215,9 @@ def test_particle_compatibility():
 def test_body_compatibility():
     m, l = symbols('m l')
     C_frame = ReferenceFrame('C')
-    P = Body('P')
-    C = Body('C', mass=m, frame=C_frame)
+    with warns_deprecated_sympy():
+        P = Body('P')
+        C = Body('C', mass=m, frame=C_frame)
     q, u = dynamicsymbols('q, u')
     PinJoint('J', P, C, q, u, child_point=l * C_frame.y)
     assert C.frame == C_frame

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -4,10 +4,10 @@ from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.dense import Matrix
 from sympy.simplify.trigsimp import trigsimp
 from sympy.physics.mechanics import (
-    PinJoint, JointsMethod, RigidBody, Particle,Body, KanesMethod,
+    PinJoint, JointsMethod, RigidBody, Particle, Body, KanesMethod,
     PrismaticJoint, LagrangesMethod, inertia)
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy import zeros
 from sympy.utilities.lambdify import lambdify
 from sympy.solvers.solvers import solve
@@ -17,8 +17,9 @@ t = dynamicsymbols._t # type: ignore
 
 
 def test_jointsmethod():
-    P = Body('P')
-    C = Body('C')
+    with warns_deprecated_sympy():
+        P = Body('P')
+        C = Body('C')
     Pin = PinJoint('P1', P, C)
     C_ixx, g = symbols('C_ixx g')
     q, u = dynamicsymbols('q_P1, u_P1')
@@ -53,9 +54,10 @@ def test_rigid_body_particle_compatibility():
 
 
 def test_jointmethod_duplicate_coordinates_speeds():
-    P = Body('P')
-    C = Body('C')
-    T = Body('T')
+    with warns_deprecated_sympy():
+        P = Body('P')
+        C = Body('C')
+        T = Body('T')
     q, u = dynamicsymbols('q u')
     P1 = PinJoint('P1', P, C, q)
     P2 = PrismaticJoint('P2', C, T, q)
@@ -73,9 +75,10 @@ def test_complete_simple_double_pendulum():
     q1, q2 = dynamicsymbols('q1 q2')
     u1, u2 = dynamicsymbols('u1 u2')
     m, l, g = symbols('m l g')
-    C = Body('C')  # ceiling
-    PartP = Body('P', mass=m)
-    PartR = Body('R', mass=m)
+    with warns_deprecated_sympy():
+        C = Body('C')  # ceiling
+        PartP = Body('P', mass=m)
+        PartR = Body('R', mass=m)
     J1 = PinJoint('J1', C, PartP, speeds=u1, coordinates=q1,
                   child_point=-l*PartP.x, joint_axis=C.z)
     J2 = PinJoint('J2', PartP, PartR, speeds=u2, coordinates=q2,
@@ -98,9 +101,10 @@ def test_complete_simple_double_pendulum():
 def test_two_dof_joints():
     q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')
     m, c1, c2, k1, k2 = symbols('m c1 c2 k1 k2')
-    W = Body('W')
-    B1 = Body('B1', mass=m)
-    B2 = Body('B2', mass=m)
+    with warns_deprecated_sympy():
+        W = Body('W')
+        B1 = Body('B1', mass=m)
+        B2 = Body('B2', mass=m)
     J1 = PrismaticJoint('J1', W, B1, coordinates=q1, speeds=u1)
     J2 = PrismaticJoint('J2', B1, B2, coordinates=q2, speeds=u2)
     W.apply_force(k1*q1*W.x, reaction_body=B1)
@@ -118,8 +122,9 @@ def test_two_dof_joints():
 
 def test_simple_pedulum():
     l, m, g = symbols('l m g')
-    C = Body('C')
-    b = Body('b', mass=m)
+    with warns_deprecated_sympy():
+        C = Body('C')
+        b = Body('b', mass=m)
     q = dynamicsymbols('q')
     P = PinJoint('P', C, b, speeds=q.diff(t), coordinates=q,
                  child_point=-l * b.x, joint_axis=C.z)
@@ -137,9 +142,12 @@ def test_chaos_pendulum():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
 
-    rod = Body('rod', mass=mA, frame=A, central_inertia=inertia(A, IAxx, IAxx, 0))
-    plate = Body('plate', mass=mB, frame=B, central_inertia=inertia(B, IBxx, IByy, IBzz))
-    C = Body('C')
+    with warns_deprecated_sympy():
+        rod = Body('rod', mass=mA, frame=A,
+                   central_inertia=inertia(A, IAxx, IAxx, 0))
+        plate = Body('plate', mass=mB, frame=B,
+                     central_inertia=inertia(B, IBxx, IByy, IBzz))
+        C = Body('C')
     J1 = PinJoint('J1', C, rod, coordinates=theta, speeds=omega,
                   child_point=-lA * rod.z, joint_axis=C.y)
     J2 = PinJoint('J2', rod, plate, coordinates=phi, speeds=alpha,
@@ -167,10 +175,12 @@ def test_four_bar_linkage_with_manual_constraints():
 
     N = ReferenceFrame('N')
     inertias = [inertia(N, 0, 0, rho * l ** 3 / 12) for l in (l1, l2, l3, l4)]
-    link1 = Body('Link1', frame=N, mass=rho * l1, central_inertia=inertias[0])
-    link2 = Body('Link2', mass=rho * l2, central_inertia=inertias[1])
-    link3 = Body('Link3', mass=rho * l3, central_inertia=inertias[2])
-    link4 = Body('Link4', mass=rho * l4, central_inertia=inertias[3])
+    with warns_deprecated_sympy():
+        link1 = Body('Link1', frame=N, mass=rho * l1,
+                     central_inertia=inertias[0])
+        link2 = Body('Link2', mass=rho * l2, central_inertia=inertias[1])
+        link3 = Body('Link3', mass=rho * l3, central_inertia=inertias[2])
+        link4 = Body('Link4', mass=rho * l4, central_inertia=inertias[3])
 
     joint1 = PinJoint(
         'J1', link1, link2, coordinates=q1, speeds=u1, joint_axis=link1.z,

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -24,7 +24,8 @@ def test_jointsmethod():
     C_ixx, g = symbols('C_ixx g')
     q, u = dynamicsymbols('q_P1, u_P1')
     P.apply_force(g*P.y)
-    method = JointsMethod(P, Pin)
+    with warns_deprecated_sympy():
+        method = JointsMethod(P, Pin)
     assert method.frame == P.frame
     assert method.bodies == [C, P]
     assert method.loads == [(P.masscenter, g*P.frame.y)]
@@ -46,7 +47,8 @@ def test_rigid_body_particle_compatibility():
     q, u = dynamicsymbols('q u')
     P = PinJoint('P', C, b, coordinates=q, speeds=u, child_interframe=b_frame,
                  child_point=-l * b_frame.x, joint_axis=C.z)
-    method = JointsMethod(C, P)
+    with warns_deprecated_sympy():
+        method = JointsMethod(C, P)
     method.loads.append((b.masscenter, m * g * C.x))
     method.form_eoms()
     rhs = method.rhs()
@@ -61,15 +63,18 @@ def test_jointmethod_duplicate_coordinates_speeds():
     q, u = dynamicsymbols('q u')
     P1 = PinJoint('P1', P, C, q)
     P2 = PrismaticJoint('P2', C, T, q)
-    raises(ValueError, lambda: JointsMethod(P, P1, P2))
+    with warns_deprecated_sympy():
+        raises(ValueError, lambda: JointsMethod(P, P1, P2))
 
     P1 = PinJoint('P1', P, C, speeds=u)
     P2 = PrismaticJoint('P2', C, T, speeds=u)
-    raises(ValueError, lambda: JointsMethod(P, P1, P2))
+    with warns_deprecated_sympy():
+        raises(ValueError, lambda: JointsMethod(P, P1, P2))
 
     P1 = PinJoint('P1', P, C, q, u)
     P2 = PrismaticJoint('P2', C, T, q, u)
-    raises(ValueError, lambda: JointsMethod(P, P1, P2))
+    with warns_deprecated_sympy():
+        raises(ValueError, lambda: JointsMethod(P, P1, P2))
 
 def test_complete_simple_double_pendulum():
     q1, q2 = dynamicsymbols('q1 q2')
@@ -87,7 +92,8 @@ def test_complete_simple_double_pendulum():
     PartP.apply_force(m*g*C.x)
     PartR.apply_force(m*g*C.x)
 
-    method = JointsMethod(C, J1, J2)
+    with warns_deprecated_sympy():
+        method = JointsMethod(C, J1, J2)
     method.form_eoms()
 
     assert expand(method.mass_matrix_full) == Matrix([[1, 0, 0, 0],
@@ -111,7 +117,8 @@ def test_two_dof_joints():
     W.apply_force(c1*u1*W.x, reaction_body=B1)
     B1.apply_force(k2*q2*W.x, reaction_body=B2)
     B1.apply_force(c2*u2*W.x, reaction_body=B2)
-    method = JointsMethod(W, J1, J2)
+    with warns_deprecated_sympy():
+        method = JointsMethod(W, J1, J2)
     method.form_eoms()
     MM = method.mass_matrix
     forcing = method.forcing
@@ -129,7 +136,8 @@ def test_simple_pedulum():
     P = PinJoint('P', C, b, speeds=q.diff(t), coordinates=q,
                  child_point=-l * b.x, joint_axis=C.z)
     b.potential_energy = - m * g * l * cos(q)
-    method = JointsMethod(C, P)
+    with warns_deprecated_sympy():
+        method = JointsMethod(C, P)
     method.form_eoms(LagrangesMethod)
     rhs = method.rhs()
     assert rhs[1] == -g*sin(q)/l
@@ -156,7 +164,8 @@ def test_chaos_pendulum():
     rod.apply_force(mA*g*C.z)
     plate.apply_force(mB*g*C.z)
 
-    method = JointsMethod(C, J1, J2)
+    with warns_deprecated_sympy():
+        method = JointsMethod(C, J1, J2)
     method.form_eoms()
 
     MM = method.mass_matrix
@@ -197,7 +206,8 @@ def test_four_bar_linkage_with_manual_constraints():
 
     fh = Matrix([loop.dot(link1.x), loop.dot(link1.y)])
 
-    method = JointsMethod(link1, joint1, joint2, joint3)
+    with warns_deprecated_sympy():
+        method = JointsMethod(link1, joint1, joint2, joint3)
 
     t = dynamicsymbols._t
     qdots = solve(method.kdes, [q1.diff(t), q2.diff(t), q3.diff(t)])

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -17,13 +17,13 @@ def test_rigidbody_default():
     assert b.frame.name == 'B_frame'
     assert b.__str__() == 'B'
     assert b.__repr__() == (
-        "RigidBody('B', masscenter=B_masscenter, frame=B_frame, mass=B_mass), "
+        "RigidBody('B', masscenter=B_masscenter, frame=B_frame, mass=B_mass, "
         "inertia=Inertia(dyadic=B_ixx*(B_frame.x|B_frame.x) + "
         "B_ixy*(B_frame.x|B_frame.y) + B_izx*(B_frame.x|B_frame.z) + "
         "B_ixy*(B_frame.y|B_frame.x) + B_iyy*(B_frame.y|B_frame.y) + "
         "B_iyz*(B_frame.y|B_frame.z) + B_izx*(B_frame.z|B_frame.x) + "
         "B_iyz*(B_frame.z|B_frame.y) + B_izz*(B_frame.z|B_frame.z), "
-        "point=B_masscenter)))")
+        "point=B_masscenter))")
 
 
 def test_rigidbody():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Deprecation has among other been discussed in #24256
Related issues to what is being deprecated #21964 #23269 #21965

#### Brief description of what is fixed or changed
This PR deprecates Body and JointsMethod as they have been fully replaced and are only causing issues.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * BREAKING CHANGE: Deprecate Body class
  * BREAKING CHANGE: Deprecate JointsMethod
<!-- END RELEASE NOTES -->
