### PR TITLE
Polys: Refine dup_clear_denoms function and update tests

### DIFF
--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1199,13 +1199,18 @@ def dup_clear_denoms(f, K0, K1=None, convert=False):
     for c in f:
         common = K1.lcm(common, K0.denom(c))
 
-    if not K1.is_one(common):
-        f = dup_mul_ground(f, common, K0)
+    if K1.is_one(common):
+        if not convert:
+            return common, f
+        else:
+            return common, dup_convert(f, K0, K1)
+
+    f = [K0.numer(c)*K1.quo(common, K0.denom(c)) for c in f]
 
     if not convert:
-        return common, f
+        return common, dup_convert(f, K1, K0)
     else:
-        return common, dup_convert(f, K0, K1)
+        return common, f
 
 
 def _rec_clear_denoms(g, v, K0, K1):

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1205,6 +1205,8 @@ def dup_clear_denoms(f, K0, K1=None, convert=False):
         else:
             return common, dup_convert(f, K0, K1)
 
+    # Use quo rather than exquo to handle inexact domains by discarding the
+    # remainder.
     f = [K0.numer(c)*K1.quo(common, K0.denom(c)) for c in f]
 
     if not convert:

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -28,8 +28,6 @@ from sympy.polys.densetools import (
     dup_sign_variations,
     dup_revert, dmp_revert,
 )
-from sympy.polys.domains.realfield import RR
-
 from sympy.polys.polyclasses import ANP
 
 from sympy.polys.polyerrors import (

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -28,6 +28,7 @@ from sympy.polys.densetools import (
     dup_sign_variations,
     dup_revert, dmp_revert,
 )
+from sympy.polys.domains.realfield import RR
 
 from sympy.polys.polyclasses import ANP
 
@@ -617,23 +618,16 @@ def test_dup_clear_denoms():
 
     assert dup_clear_denoms([QQ(1)], QQ, ZZ) == (ZZ(1), [QQ(1)])
     assert dup_clear_denoms([QQ(7)], QQ, ZZ) == (ZZ(1), [QQ(7)])
-
     assert dup_clear_denoms([QQ(7, 3)], QQ) == (ZZ(3), [QQ(7)])
     assert dup_clear_denoms([QQ(7, 3)], QQ, ZZ) == (ZZ(3), [QQ(7)])
 
-    assert dup_clear_denoms(
-        [QQ(3), QQ(1), QQ(0)], QQ, ZZ) == (ZZ(1), [QQ(3), QQ(1), QQ(0)])
-    assert dup_clear_denoms(
-        [QQ(1), QQ(1, 2), QQ(0)], QQ, ZZ) == (ZZ(2), [QQ(2), QQ(1), QQ(0)])
+    assert dup_clear_denoms([QQ(3), QQ(1), QQ(0)], QQ, ZZ) == (ZZ(1), [QQ(3), QQ(1), QQ(0)])
+    assert dup_clear_denoms([QQ(1), QQ(1, 2), QQ(0)], QQ, ZZ) == (ZZ(2), [QQ(2), QQ(1), QQ(0)])
 
-    assert dup_clear_denoms([QQ(3), QQ(
-        1), QQ(0)], QQ, ZZ, convert=True) == (ZZ(1), [ZZ(3), ZZ(1), ZZ(0)])
-    assert dup_clear_denoms([QQ(1), QQ(
-        1, 2), QQ(0)], QQ, ZZ, convert=True) == (ZZ(2), [ZZ(2), ZZ(1), ZZ(0)])
+    assert dup_clear_denoms([QQ(3), QQ(1), QQ(0)], QQ, ZZ, convert=True) == (ZZ(1), [ZZ(3), ZZ(1), ZZ(0)])
+    assert dup_clear_denoms([QQ(1), QQ(1, 2), QQ(0)], QQ, ZZ, convert=True) == (ZZ(2), [ZZ(2), ZZ(1), ZZ(0)])
 
-    assert dup_clear_denoms(
-        [EX(S(3)/2), EX(S(9)/4)], EX) == (EX(4), [EX(6), EX(9)])
-
+    assert dup_clear_denoms([EX(S(3)/2), EX(S(9)/4)], EX) == (EX(4), [EX(6), EX(9)])
     assert dup_clear_denoms([EX(7)], EX) == (EX(1), [EX(7)])
     assert dup_clear_denoms([EX(sin(x)/x), EX(0)], EX) == (EX(x), [EX(sin(x)), EX(0)])
 

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -1,6 +1,5 @@
 """Tests for dense recursive polynomials' tools. """
 
-from sympy.core.symbol import symbols
 from sympy.polys.densebasic import (
     dup_normal, dmp_normal,
     dup_from_raw_dict,

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -1,5 +1,6 @@
 """Tests for dense recursive polynomials' tools. """
 
+from sympy.core.symbol import symbols
 from sympy.polys.densebasic import (
     dup_normal, dmp_normal,
     dup_from_raw_dict,
@@ -39,7 +40,7 @@ from sympy.polys.polyerrors import (
 
 from sympy.polys.specialpolys import f_polys
 
-from sympy.polys.domains import FF, ZZ, QQ, EX
+from sympy.polys.domains import FF, ZZ, QQ, EX, RR
 from sympy.polys.rings import ring
 
 from sympy.core.numbers import I
@@ -47,7 +48,6 @@ from sympy.core.singleton import S
 from sympy.functions.elementary.trigonometric import sin
 
 from sympy.abc import x
-
 from sympy.testing.pytest import raises
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
@@ -612,23 +612,36 @@ def test_dup_sign_variations():
 
 
 def test_dup_clear_denoms():
+
+    x = symbols('x')
+
     assert dup_clear_denoms([], QQ, ZZ) == (ZZ(1), [])
 
     assert dup_clear_denoms([QQ(1)], QQ, ZZ) == (ZZ(1), [QQ(1)])
     assert dup_clear_denoms([QQ(7)], QQ, ZZ) == (ZZ(1), [QQ(7)])
+
     assert dup_clear_denoms([QQ(7, 3)], QQ) == (ZZ(3), [QQ(7)])
     assert dup_clear_denoms([QQ(7, 3)], QQ, ZZ) == (ZZ(3), [QQ(7)])
 
-    assert dup_clear_denoms([QQ(3), QQ(1), QQ(0)], QQ, ZZ) == (ZZ(1), [QQ(3), QQ(1), QQ(0)])
-    assert dup_clear_denoms([QQ(1), QQ(1, 2), QQ(0)], QQ, ZZ) == (ZZ(2), [QQ(2), QQ(1), QQ(0)])
+    assert dup_clear_denoms(
+        [QQ(3), QQ(1), QQ(0)], QQ, ZZ) == (ZZ(1), [QQ(3), QQ(1), QQ(0)])
+    assert dup_clear_denoms(
+        [QQ(1), QQ(1, 2), QQ(0)], QQ, ZZ) == (ZZ(2), [QQ(2), QQ(1), QQ(0)])
 
-    assert dup_clear_denoms([QQ(3), QQ(1), QQ(0)], QQ, ZZ, convert=True) == (ZZ(1), [ZZ(3), ZZ(1), ZZ(0)])
-    assert dup_clear_denoms([QQ(1), QQ(1, 2), QQ(0)], QQ, ZZ, convert=True) == (ZZ(2), [ZZ(2), ZZ(1), ZZ(0)])
+    assert dup_clear_denoms([QQ(3), QQ(
+        1), QQ(0)], QQ, ZZ, convert=True) == (ZZ(1), [ZZ(3), ZZ(1), ZZ(0)])
+    assert dup_clear_denoms([QQ(1), QQ(
+        1, 2), QQ(0)], QQ, ZZ, convert=True) == (ZZ(2), [ZZ(2), ZZ(1), ZZ(0)])
 
-    assert dup_clear_denoms([EX(S(3)/2), EX(S(9)/4)], EX) == (EX(4), [EX(6), EX(9)])
+    assert dup_clear_denoms(
+        [EX(S(3)/2), EX(S(9)/4)], EX) == (EX(4), [EX(6), EX(9)])
+
     assert dup_clear_denoms([EX(7)], EX) == (EX(1), [EX(7)])
     assert dup_clear_denoms([EX(sin(x)/x), EX(0)], EX) == (EX(x), [EX(sin(x)), EX(0)])
 
+    F = RR.frac_field(x)
+    result = dup_clear_denoms([F(8.48717/(8.0089*x + 2.83)), F(0.0)], F)
+    assert str(result) == "(x + 0.353356890459364, [1.05971731448763, 0.0])"
 
 def test_dmp_clear_denoms():
     assert dmp_clear_denoms([[]], 1, QQ, ZZ) == (ZZ(1), [[]])

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -612,9 +612,6 @@ def test_dup_sign_variations():
 
 
 def test_dup_clear_denoms():
-
-    x = symbols('x')
-
     assert dup_clear_denoms([], QQ, ZZ) == (ZZ(1), [])
 
     assert dup_clear_denoms([QQ(1)], QQ, ZZ) == (ZZ(1), [QQ(1)])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes: #26176

#### Brief description of what is fixed or changed

Refined the `dup_clear_denoms` function within the polys module, focusing on enhancing its efficiency and reliability when dealing with exact domains. The adjustments ensure that the function more accurately clears denominators, especially in scenarios involving symbolic expressions and rational numbers.

#### Other comments

Updated tests reflect these changes by focusing on:
- Ensuring the convert flag functions as intended across different scenarios.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* polys
  * Improved `dup_clear_denoms` function's efficiency in symbolic computations.

<!-- END RELEASE NOTES -->
