### PR TITLE
Replace dict comprehensions with fromkeys

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1510,7 +1510,7 @@ def sqrt_linear_rule(integral: IntegralInfo):
         step: Rule = URule(integrand, x, u, u_x, substep)
         generic_cond = Ne(b0, 0)
         if generic_cond is not S.true:  # possible degenerate case
-            simplified = integrand.subs({b: 0 for b in bs})
+            simplified = integrand.subs(dict.fromkeys(bs, 0))
             degenerate_step = integral_steps(simplified, x)
             step = PiecewiseRule(integrand, x, [(step, generic_cond), (degenerate_step, S.true)])
         return step

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -206,7 +206,7 @@ def pl_true(expr, model=None, deep=False):
     if result in boolean:
         return bool(result)
     if deep:
-        model = {k: True for k in result.atoms()}
+        model = dict.fromkeys(result.atoms(), True)
         if pl_true(result, model):
             if valid(result):
                 return True

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -911,7 +911,7 @@ class MutableRepMatrix(RepMatrix):
         if not value:
             self._rep = DomainMatrix.zeros(self.shape, EXRAW)
         else:
-            elements_dod = {i: {j: value for j in range(self.cols)} for i in range(self.rows)}
+            elements_dod = {i: dict.fromkeys(range(self.cols), value) for i in range(self.rows)}
             self._rep = DomainMatrix(elements_dod, self.shape, EXRAW)
 
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2190,7 +2190,7 @@ class Beam:
         if isinstance(self.length, Expr):
             l = list(self.length.atoms(Symbol))
             # assigning every Symbol a default value of 10
-            l = {i:10 for i in l}
+            l = dict.fromkeys(l, 10)
             length = self.length.subs(l)
         else:
             l = {}

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -290,8 +290,8 @@ class KanesMethod(_Methods):
             raise ValueError('There must be an equal number of dependent '
                              'speeds and acceleration constraints.')
         if vel:
-            u_zero = {i: 0 for i in self.u}
-            udot_zero = {i: 0 for i in self._udot}
+            u_zero = dict.fromkeys(self.u, 0)
+            udot_zero = dict.fromkeys(self._udot, 0)
 
             # When calling kanes_equations, another class instance will be
             # created if auxiliary u's are present. In this case, the
@@ -353,9 +353,9 @@ class KanesMethod(_Methods):
 
             kdeqs = Matrix(kdeqs)
 
-            u_zero = {ui: 0 for ui in u}
-            uaux_zero = {uai: 0 for uai in self._uaux}
-            qdot_zero = {qdi: 0 for qdi in qdot}
+            u_zero = dict.fromkeys(u, 0)
+            uaux_zero = dict.fromkeys(self._uaux, 0)
+            qdot_zero = dict.fromkeys(qdot, 0)
 
             # Extract the linear coefficient matrices as per the following
             # equation:
@@ -444,10 +444,10 @@ class KanesMethod(_Methods):
         t = dynamicsymbols._t
         N = self._inertial
         # Dicts setting things to zero
-        udot_zero = {i: 0 for i in self._udot}
-        uaux_zero = {i: 0 for i in self._uaux}
+        udot_zero = dict.fromkeys(self._udot, 0)
+        uaux_zero = dict.fromkeys(self._uaux, 0)
         uauxdot = [diff(i, t) for i in self._uaux]
-        uauxdot_zero = {i: 0 for i in uauxdot}
+        uauxdot_zero = dict.fromkeys(uauxdot, 0)
         # Dictionary of q' and q'' to u and u'
         q_ddot_u_map = {k.diff(t): v.diff(t).xreplace(
             self._qdot_u_map) for (k, v) in self._qdot_u_map.items()}
@@ -576,10 +576,10 @@ class KanesMethod(_Methods):
         else:
             f_a = Matrix()
         # Dicts to sub to zero, for splitting up expressions
-        u_zero = {i: 0 for i in self.u}
-        ud_zero = {i: 0 for i in self._udot}
-        qd_zero = {i: 0 for i in self._qdot}
-        qd_u_zero = {i: 0 for i in Matrix([self._qdot, self.u])}
+        u_zero = dict.fromkeys(self.u, 0)
+        ud_zero = dict.fromkeys(self._udot, 0)
+        qd_zero = dict.fromkeys(self._qdot, 0)
+        qd_u_zero = dict.fromkeys(Matrix([self._qdot, self.u]), 0)
         # Break the kinematic differential eqs apart into f_0 and f_1
         f_0 = msubs(self._f_k, u_zero) + self._k_kqdot*Matrix(self._qdot)
         f_1 = msubs(self._f_k, qd_zero) + self._k_ku*Matrix(self.u)
@@ -605,7 +605,7 @@ class KanesMethod(_Methods):
         # Form dictionary to set auxiliary speeds & their derivatives to 0.
         uaux = self._uaux
         uauxdot = uaux.diff(dynamicsymbols._t)
-        uaux_zero = {i: 0 for i in Matrix([uaux, uauxdot])}
+        uaux_zero = dict.fromkeys(Matrix([uaux, uauxdot]), 0)
 
         # Checking for dynamic symbols outside the dynamic differential
         # equations; throws error if there is.

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -179,7 +179,7 @@ class LagrangesMethod(_Methods):
         """
 
         qds = self._qdots
-        qdd_zero = {i: 0 for i in self._qdoubledots}
+        qdd_zero = dict.fromkeys(self._qdoubledots, 0)
         n = len(self.q)
 
         # Internally we represent the EOM as four terms:

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -120,7 +120,7 @@ def itermonomials(variables, max_degrees, min_degrees=None):
         if all(variable.is_commutative for variable in variables):
             monomials_list_comm = []
             for item in combinations_with_replacement(variables, max_degree):
-                powers = {variable: 0 for variable in variables}
+                powers = dict.fromkeys(variables, 0)
                 for variable in item:
                     if variable != 1:
                         powers[variable] += 1
@@ -130,7 +130,7 @@ def itermonomials(variables, max_degrees, min_degrees=None):
         else:
             monomials_list_non_comm = []
             for item in product(variables, repeat=max_degree):
-                powers = {variable: 0 for variable in variables}
+                powers = dict.fromkeys(variables, 0)
                 for variable in item:
                     if variable != 1:
                         powers[variable] += 1

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -387,7 +387,7 @@ def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
         values (tuple of ``bool``\ s).
     """
     if dim is not None:
-        return {s: (False,) * dim for s in inputs}
+        return dict.fromkeys(inputs, (False,) * dim)
 
     if dims is not None:
         maxdim = max(dims.values())

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -399,7 +399,7 @@ def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
         values (tuple of ``bool``\ s).
     """
     if dim is not None:
-        return {s: (False,) * dim for s in inputs}
+        return dict.fromkeys(inputs, (False,) * dim)
 
     if dims is not None:
         maxdim = max(dims.values())

--- a/sympy/solvers/ode/lie_group.py
+++ b/sympy/solvers/ode/lie_group.py
@@ -550,7 +550,7 @@ def lie_heuristic_bivariate(match, comp=False):
                     etared = etaeq.subs(soldict)
                     # Scaling is done by substituting one for the parameters
                     # This can be any number except zero.
-                    dict_ = {sym: 1 for sym in symset}
+                    dict_ = dict.fromkeys(symset, 1)
                     inf = {eta: etared.subs(dict_).subs(y, func),
                         xi: xired.subs(dict_).subs(y, func)}
                     return [inf]
@@ -613,7 +613,7 @@ def lie_heuristic_chi(match, comp=False):
                         soldict = soldict[0]
                     if any(soldict.values()):
                         chieq = chieq.subs(soldict)
-                        dict_ = {sym: 1 for sym in solsyms}
+                        dict_ = dict.fromkeys(solsyms, 1)
                         chieq = chieq.subs(dict_)
                         # After finding chi, the main aim is to find out
                         # eta, xi by the equation eta = xi*h + chi

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1830,20 +1830,20 @@ def _second_order_to_first_order(eqs, funcs, t, type="auto", A1=None,
         A1 = match.get("A1", None)
         A0 = match.get("A0", None)
 
-    sys_order = {func: 2 for func in funcs}
+    sys_order = dict.fromkeys(funcs, 2)
 
     if type == "type1":
         if b is None:
             b = zeros(len(eqs))
         eqs = _second_order_subs_type1(A1, b, funcs, t)
-        sys_order = {func: 1 for func in funcs}
+        sys_order = dict.fromkeys(funcs, 1)
 
     if type == "type2":
         if t_ is None:
             t_ = Symbol("{}_".format(t))
         t = t_
         eqs, funcs = _second_order_subs_type2(A0, funcs, t_)
-        sys_order = {func: 2 for func in funcs}
+        sys_order = dict.fromkeys(funcs, 2)
 
     return _higher_order_to_first_order(eqs, sys_order, t, funcs=funcs)
 

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -149,7 +149,7 @@ class DiscreteUniformDistribution(SingleFiniteDistribution):
     @property  # type: ignore
     @cacheit
     def dict(self):
-        return {k: self.p for k in self.set}
+        return dict.fromkeys(self.set, self.p)
 
     @property
     def set(self):

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -225,7 +225,7 @@ class ImplicitRegion(Basic):
             flag = False
             for sol in solutions:
                 syms = Tuple(*sol).free_symbols
-                rep = {s: 3 for s in syms}
+                rep = dict.fromkeys(syms, 3)
                 sol_z = sol[2]
 
                 if sol_z == 0:
@@ -418,7 +418,7 @@ class ImplicitRegion(Basic):
             singular_points = self.singular_points()
             for spoint in singular_points:
                 syms = Tuple(*spoint).free_symbols
-                rep = {s: 2 for s in syms}
+                rep = dict.fromkeys(syms, 2)
 
                 if len(syms) != 0:
                    spoint = tuple(s.subs(rep) for s in spoint)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Replaces dict comprehensions with dict.fromkeys. This is significantly more efficient than using a dict comprehension. It also can make certain bugs (like sharing the same mutable instance for all values in a dict) more apparent. They are otherwise semantically equivalent.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
