### PR TITLE
Square Free List for Polynomials will include factors with excluded symbols .

### DIFF
--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -398,8 +398,13 @@ def dmp_sqf_list(f, u, K, all=False):
             f = dmp_neg(f, u, K)
             coeff = -coeff
 
-    if dmp_degree(f, u) <= 0:
+    deg = dmp_degree(f, u)
+    if deg < 0:
         return coeff, []
+    elif deg == 0:
+        coeff2, factors = dmp_sqf_list(f[0], u-1, K, all=all)
+        factors = [([fac], exp) for fac, exp in factors]
+        return coeff*coeff2, factors
 
     result, i = [], 1
 

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -11,7 +11,7 @@ from sympy.polys.densebasic import (
     dup_strip,
     dup_LC, dmp_ground_LC,
     dmp_zero_p,
-    dmp_ground,
+    dmp_ground, dmp_LC,
     dup_degree, dmp_degree,
     dmp_raise, dmp_inject,
     dup_convert)
@@ -402,7 +402,7 @@ def dmp_sqf_list(f, u, K, all=False):
     if deg < 0:
         return coeff, []
     elif deg == 0:
-        coeff2, factors = dmp_sqf_list(f[0], u-1, K, all=all)
+        coeff2, factors = dmp_sqf_list(dmp_LC(f, u), u-1, K, all=all)
         factors = [([fac], exp) for fac, exp in factors]
         return coeff*coeff2, factors
 

--- a/sympy/polys/tests/test_sqfreetools.py
+++ b/sympy/polys/tests/test_sqfreetools.py
@@ -5,6 +5,7 @@ from sympy.polys.domains import FF, ZZ, QQ
 from sympy.polys.specialpolys import f_polys
 
 from sympy.testing.pytest import raises
+from sympy.external.gmpy import MPQ
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = f_polys()
 
@@ -147,3 +148,9 @@ def test_dup_gff_list():
     assert R.dup_gff_list(g) == [(x**2 - 5*x + 4, 1), (x**2 - 5*x + 4, 2), (x, 3)]
 
     raises(ValueError, lambda: R.dup_gff_list(0))
+
+def test_issue_26178():
+    R, x, y, z = ring(['x', 'y', 'z'], QQ)
+    assert (x**2 - 2*y**2 + 1).sqf_list() == (MPQ(1,1), [(x**2 - 2*y**2 + 1, 1)])
+    assert (x**2 - 2*z**2 + 1).sqf_list() == (MPQ(1,1), [(x**2 - 2*z**2 + 1, 1)])
+    assert (y**2 - 2*z**2 + 1).sqf_list() == (MPQ(1,1), [(y**2 - 2*z**2 + 1, 1)])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Solves Issue https://github.com/sympy/sympy/issues/26178


#### Brief description of what is fixed or changed
+ Added separate conditions for both when deg < 0 and deg == 0.
+ Added tests for the issue #26178

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a bug which gives incorrect results in finding sqf_list for polynomials.
<!-- END RELEASE NOTES -->
