### PR TITLE
Conversion to Algebraic Normal Form `to_anf` will now give correct results for a given logical expression.

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -521,15 +521,15 @@ class BooleanFunction(Application, Boolean):
     @classmethod
     def _to_anf(cls, *args, **kwargs):
         deep = kwargs.get('deep', True)
-        argset = set()
+        new_args = []
         for arg in args:
             if deep:
                 if not is_literal(arg) or isinstance(arg, Not):
                     arg = arg.to_anf(deep=deep)
-                argset.add(arg)
+                new_args.append(arg)
             else:
-                argset.add(arg)
-        return cls(*argset, remove_true=False)
+                new_args.append(arg)
+        return cls(*new_args, remove_true=False)
 
     # the diff method below is copied from Expr class
     def diff(self, *symbols, **assumptions):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -526,9 +526,7 @@ class BooleanFunction(Application, Boolean):
             if deep:
                 if not is_literal(arg) or isinstance(arg, Not):
                     arg = arg.to_anf(deep=deep)
-                new_args.append(arg)
-            else:
-                new_args.append(arg)
+            new_args.append(arg)
         return cls(*new_args, remove_true=False)
 
     # the diff method below is copied from Expr class

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -505,6 +505,7 @@ def test_to_anf():
             Xor(True, And(Or(x, y), Implies(x, y)), remove_true=False)
     assert to_anf(Nor(x ^ y, x & y), deep=False) == \
             Xor(True, Or(Xor(x, y), And(x, y)), remove_true=False)
+    # issue 25218
     assert to_anf(x ^ ~(x ^ y ^ ~y)) == False
 
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -505,6 +505,7 @@ def test_to_anf():
             Xor(True, And(Or(x, y), Implies(x, y)), remove_true=False)
     assert to_anf(Nor(x ^ y, x & y), deep=False) == \
             Xor(True, Or(Xor(x, y), And(x, y)), remove_true=False)
+    assert to_anf(x ^ ~(x ^ y ^ ~y)) == False
 
 
 def test_to_nnf():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Algebraic Normal form (ANF) will be calculated correctly for given expression .

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Solves Issue https://github.com/sympy/sympy/issues/25218


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * Fixed a bug which shows wrong result in computing anf.
<!-- END RELEASE NOTES -->
