### PR TITLE
bugfix in fp_groups.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -279,6 +279,7 @@ Alexandr Popov <alexandr.s.popov@gmail.com>
 Alexey Pakhocmhik <cool.Bakov@yandex.ru>
 Alexey Subach <alexey.subach@gmail.com>
 Alexey U. Gudchenko <proga@goodok.ru>
+Alexis Schotte <alexis.schotte@gmail.com> AlexisSchotte <32765319+AlexisSchotte@users.noreply.github.com>
 Ali Raza Syed <arsyed@gmail.com>
 Alistair Lynn <arplynn@gmail.com>
 Alkiviadis G. Akritas <akritas@uth.gr>

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -1005,7 +1005,7 @@ def _simplify_relators(rels):
     Simplifies a set of relators. All relators are checked to see if they are
     of the form `gen^n`. If any such relators are found then all other relators
     are processed for strings in the `gen` known order.
-    
+
     Examples
     ========
 
@@ -1033,7 +1033,7 @@ def _simplify_relators(rels):
 
     if not rels:
         return []
-    
+
     identity = rels[0].group.identity
 
     # build dictionary with "gen: n" where gen^n is one of the relators

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -1014,15 +1014,15 @@ def _simplify_relators(rels):
     >>> F, x, y = free_group("x, y")
     >>> w1 = [x**2*y**4, x**3]
     >>> _simplify_relators(w1)
-    [x**-1*y**4, x**3]
+    [x**3, x**-1*y**4]
 
     >>> w2 = [x**2*y**-4*x**5, x**3, x**2*y**8, y**5]
     >>> _simplify_relators(w2)
-    [x**-1*y*x**-1, x**3, x**-1*y**-2, y**5]
+    [x**-1*y**-2, x**-1*y*x**-1, x**3, y**5]
 
     >>> w3 = [x**6*y**4, x**4]
     >>> _simplify_relators(w3)
-    [x**2*y**4, x**4]
+    [x**4, x**2*y**4]
 
     >>> w4 = [x**2, x**5, y**3]
     >>> _simplify_relators(w4)

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -984,7 +984,7 @@ def simplify_presentation(*args, change_gens=False):
         while change_gens and not set(prev_gens) == set(gens):
             prev_gens = gens
             gens, rels = elimination_technique_1(gens, rels, identity)
-        rels = _simplify_relators(rels, identity)
+        rels = _simplify_relators(rels)
 
     if change_gens:
         syms = [g.array_form[0][0] for g in gens]
@@ -1010,7 +1010,7 @@ def _simplify_relators(rels):
     ========
 
     >>> from sympy.combinatorics import free_group
-    >>> from sympy.combinatorics.fp_groups import _simplfy_relators
+    >>> from sympy.combinatorics.fp_groups import _simplify_relators
     >>> F, x, y = free_group("x, y")
     >>> w1 = [x**2*y**4, x**3]
     >>> _simplify_relators(w1)
@@ -1069,8 +1069,8 @@ def _simplify_relators(rels):
 
     rels = [r.identity_cyclic_reduction() for r in rels]
 
-    # include one_syllable_words that are not yet in the list of relators
-    rels += [word for word in one_syllables_words if word not in rels]
+    rels += one_syllables_words # include one_syllable_words in the list of relators
+    rels = list(set(rels)) # get unique values in rels
     rels.sort()
 
     # remove <identity> entries in rels

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -1095,7 +1095,7 @@ def _simplification_technique_1(rels):
                 exp = gcd(exp, exps[g].array_form[0][1])
             exps[g] = g**exp
 
-    one_syllables_words = exps.values()
+    one_syllables_words = list(exps.values())
     # decrease some of the exponents in relators, making use of the single
     # syllable relators
     for i in range(len(rels)):
@@ -1113,6 +1113,8 @@ def _simplification_technique_1(rels):
                 rel = rel.eliminate_word(g**(-max_exp), g**(-(max_exp-exp)), _all = True)
         rels[i] = rel
     rels = [r.identity_cyclic_reduction() for r in rels]
+    # include one_syllable_words that are not yet in the list of relators
+    rels += [word for word in one_syllables_words if word not in rels] 
     return rels
 
 

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -1000,13 +1000,80 @@ def simplify_presentation(*args, change_gens=False):
             rels[j] = rel
     return gens, rels
 
-def _simplify_relators(rels, identity):
-    """Relies upon ``_simplification_technique_1`` for its functioning. """
+def _simplify_relators(rels):
+    """
+    Simplifies a set of relators. All relators are checked to see if they are
+    of the form `gen^n`. If any such relators are found then all other relators
+    are processed for strings in the `gen` known order.
+    
+    Examples
+    ========
+
+    >>> from sympy.combinatorics import free_group
+    >>> from sympy.combinatorics.fp_groups import _simplfy_relators
+    >>> F, x, y = free_group("x, y")
+    >>> w1 = [x**2*y**4, x**3]
+    >>> _simplify_relators(w1)
+    [x**-1*y**4, x**3]
+
+    >>> w2 = [x**2*y**-4*x**5, x**3, x**2*y**8, y**5]
+    >>> _simplify_relators(w2)
+    [x**-1*y*x**-1, x**3, x**-1*y**-2, y**5]
+
+    >>> w3 = [x**6*y**4, x**4]
+    >>> _simplify_relators(w3)
+    [x**2*y**4, x**4]
+
+    >>> w4 = [x**2, x**5, y**3]
+    >>> _simplify_relators(w4)
+    [x, y**3]
+
+    """
     rels = rels[:]
 
-    rels = list(set(_simplification_technique_1(rels)))
-    rels.sort()
+    if not rels:
+        return []
+    
+    identity = rels[0].group.identity
+
+    # build dictionary with "gen: n" where gen^n is one of the relators
+    exps = {}
+    for i in range(len(rels)):
+        rel = rels[i]
+        if rel.number_syllables() == 1:
+            g = rel[0]
+            exp = abs(rel.array_form[0][1])
+            if rel.array_form[0][1] < 0:
+                rels[i] = rels[i]**-1
+                g = g**-1
+            if g in exps:
+                exp = gcd(exp, exps[g].array_form[0][1])
+            exps[g] = g**exp
+
+    one_syllables_words = list(exps.values())
+    # decrease some of the exponents in relators, making use of the single
+    # syllable relators
+    for i, rel in enumerate(rels):
+        if rel in one_syllables_words:
+            continue
+        rel = rel.eliminate_words(one_syllables_words, _all = True)
+        # if rels[i] contains g**n where abs(n) is greater than half of the power p
+        # of g in exps, g**n can be replaced by g**(n-p) (or g**(p-n) if n<0)
+        for g in rel.contains_generators():
+            if g in exps:
+                exp = exps[g].array_form[0][1]
+                max_exp = (exp + 1)//2
+                rel = rel.eliminate_word(g**(max_exp), g**(max_exp-exp), _all = True)
+                rel = rel.eliminate_word(g**(-max_exp), g**(-(max_exp-exp)), _all = True)
+        rels[i] = rel
+
     rels = [r.identity_cyclic_reduction() for r in rels]
+
+    # include one_syllable_words that are not yet in the list of relators
+    rels += [word for word in one_syllables_words if word not in rels]
+    rels.sort()
+
+    # remove <identity> entries in rels
     try:
         rels.remove(identity)
     except ValueError:
@@ -1054,69 +1121,6 @@ def elimination_technique_1(gens, rels, identity):
         pass
     gens = [g for g in gens if g not in redundant_gens]
     return gens, rels
-
-def _simplification_technique_1(rels):
-    """
-    All relators are checked to see if they are of the form `gen^n`. If any
-    such relators are found then all other relators are processed for strings
-    in the `gen` known order.
-
-    Examples
-    ========
-
-    >>> from sympy.combinatorics import free_group
-    >>> from sympy.combinatorics.fp_groups import _simplification_technique_1
-    >>> F, x, y = free_group("x, y")
-    >>> w1 = [x**2*y**4, x**3]
-    >>> _simplification_technique_1(w1)
-    [x**-1*y**4, x**3]
-
-    >>> w2 = [x**2*y**-4*x**5, x**3, x**2*y**8, y**5]
-    >>> _simplification_technique_1(w2)
-    [x**-1*y*x**-1, x**3, x**-1*y**-2, y**5]
-
-    >>> w3 = [x**6*y**4, x**4]
-    >>> _simplification_technique_1(w3)
-    [x**2*y**4, x**4]
-
-    """
-    rels = rels[:]
-    # dictionary with "gen: n" where gen^n is one of the relators
-    exps = {}
-    for i in range(len(rels)):
-        rel = rels[i]
-        if rel.number_syllables() == 1:
-            g = rel[0]
-            exp = abs(rel.array_form[0][1])
-            if rel.array_form[0][1] < 0:
-                rels[i] = rels[i]**-1
-                g = g**-1
-            if g in exps:
-                exp = gcd(exp, exps[g].array_form[0][1])
-            exps[g] = g**exp
-
-    one_syllables_words = list(exps.values())
-    # decrease some of the exponents in relators, making use of the single
-    # syllable relators
-    for i in range(len(rels)):
-        rel = rels[i]
-        if rel in one_syllables_words:
-            continue
-        rel = rel.eliminate_words(one_syllables_words, _all = True)
-        # if rels[i] contains g**n where abs(n) is greater than half of the power p
-        # of g in exps, g**n can be replaced by g**(n-p) (or g**(p-n) if n<0)
-        for g in rel.contains_generators():
-            if g in exps:
-                exp = exps[g].array_form[0][1]
-                max_exp = (exp + 1)//2
-                rel = rel.eliminate_word(g**(max_exp), g**(max_exp-exp), _all = True)
-                rel = rel.eliminate_word(g**(-max_exp), g**(-(max_exp-exp)), _all = True)
-        rels[i] = rel
-    rels = [r.identity_cyclic_reduction() for r in rels]
-    # include one_syllable_words that are not yet in the list of relators
-    rels += [word for word in one_syllables_words if word not in rels]
-    return rels
-
 
 ###############################################################################
 #                           SUBGROUP PRESENTATIONS                            #

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -1114,7 +1114,7 @@ def _simplification_technique_1(rels):
         rels[i] = rel
     rels = [r.identity_cyclic_reduction() for r in rels]
     # include one_syllable_words that are not yet in the list of relators
-    rels += [word for word in one_syllables_words if word not in rels] 
+    rels += [word for word in one_syllables_words if word not in rels]
     return rels
 
 

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -234,7 +234,7 @@ def test_simplify_presentation():
     # CyclicGroup(3)
     # The second generator in <x, y | x^2, x^5, y^3> is trivial due to relators {x^2, x^5}
     F, x, y = free_group("x, y")
-    G = simplify_presentation(FpGroup(F, [x**2, x**5, y**3])) 
+    G = simplify_presentation(FpGroup(F, [x**2, x**5, y**3]))
     assert x in G.relators
 
 def test_cyclic():

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -231,6 +231,11 @@ def test_simplify_presentation():
     assert not G.generators
     assert not G.relators
 
+    # CyclicGroup(3)
+    # The second generator in <x, y | x^2, x^5, y^3> is trivial due to relators {x^2, x^5}
+    F, x, y = free_group("x, y")
+    G = simplify_presentation(FpGroup(F, [x**2, x**5, y**3])) 
+    assert x in G.relators
 
 def test_cyclic():
     F, x, y = free_group("x, y")


### PR DESCRIPTION
Bugfix in `sympy.combinatorics.fp_groups._simplification_technique_1` function

#### Brief description of what is fixed or changed
`sympy.combinatorics.fp_groups` contained a bug causing the order of certain finite groups to be incorrectly reported as infinite.
For example:
```
from sympy.combinatorics.free_groups import vfree_group
from sympy.combinatorics.fp_groups import FpGroup

F = vfree_group("s,r")
G = FpGroup(F, [s**2, r**2, r**5])

print(G.order())
```
will return infinity, while the correct answer is two. 

The behavior was caused by a bug in `_simplification_technique_1`. 
For example, `_simplification_technique_1([r**2, r**5])` returns `[<identity>, <identity>]`, while it should be returning `[r]`
**The fix** consists of adding back all `one_syllable_words` to the list of relators `rels` (except those already present in the list).

The bug in `_simplification_technique_1`  caused issues with incorrect results for `group.order()`  (for certain groups) because of the following chain of functions:
`FpGroup.order > FpGroup.subgroup > reidemeister_presentation > simplify_presentation > _simplify_relators > _simplification_technique_1`

#### Other comments


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed a bug with the simplification of group presentations.
  * Removed `_simplification_technique_1` function and moved its content to `_simplify_relators`
<!-- END RELEASE NOTES -->
