### PR TITLE
Simplify unnecessary dict iterators

### DIFF
--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -342,7 +342,7 @@ def test_lookup_table():
     from sympy.integrals.meijerint import z as z_dummy
     table = {}
     _create_lookup_table(table)
-    for _, l in table.items():
+    for l in table.values():
         for formula, terms, cond, hint in sorted(l, key=default_sort_key):
             subs = {}
             for ai in list(formula.free_symbols) + [z_dummy]:

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -140,7 +140,7 @@ def prefix_unit(unit, prefixes):
 
     prefixed_units = []
 
-    for prefix_abbr, prefix in prefixes.items():
+    for prefix in prefixes.values():
         quantity = Quantity(
                 "%s%s" % (prefix.name, unit.name),
                 abbrev=("%s%s" % (prefix.abbrev, unit.abbrev)),

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -152,7 +152,7 @@ class Options(dict):
 
         preprocess_options(args)
 
-        for key, value in dict(defaults).items():
+        for key in dict(defaults).keys():
             if key in self:
                 del defaults[key]
             else:

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -152,7 +152,7 @@ class Options(dict):
 
         preprocess_options(args)
 
-        for key in dict(defaults).keys():
+        for key in dict(defaults):
             if key in self:
                 del defaults[key]
             else:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -279,7 +279,7 @@ class PolyRing(DefaultPrinting, IPolys):
         state = self.__dict__.copy()
         del state["leading_expv"]
 
-        for key in state.keys():
+        for key in state:
             if key.startswith("monomial_"):
                 del state[key]
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -279,7 +279,7 @@ class PolyRing(DefaultPrinting, IPolys):
         state = self.__dict__.copy()
         del state["leading_expv"]
 
-        for key, value in state.items():
+        for key in state.keys():
             if key.startswith("monomial_"):
                 del state[key]
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1615,7 +1615,7 @@ def devise_plan(target, origin, z):
             l = []
             for k in dic:
                 if k != key:
-                    l += list(dic[k])
+                    l.extend(dic[k])
             return l
         aother = others(nabuckets, r)
         bother = others(nbbuckets, r)

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1613,7 +1613,7 @@ def devise_plan(target, origin, z):
 
         def others(dic, key):
             l = []
-            for k, value in dic.items():
+            for k in dic.keys():
                 if k != key:
                     l += list(dic[k])
             return l

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1613,7 +1613,7 @@ def devise_plan(target, origin, z):
 
         def others(dic, key):
             l = []
-            for k in dic.keys():
+            for k in dic:
                 if k != key:
                     l += list(dic[k])
             return l

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -736,7 +736,7 @@ def trigsimp_old(expr, *, first=True, **opts):
                 d = separatevars(d, dict=True) or d
             if isinstance(d, dict):
                 expr = 1
-                for k, v in d.items():
+                for v in d.values():
                     # remove hollow factoring
                     was = v
                     v = expand_mul(v)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -243,7 +243,7 @@ class NDimArray(Printable):
 
         if isinstance(iterable, (Dict, dict)) and shape is not None:
             new_dict = iterable.copy()
-            for k, v in new_dict.items():
+            for k in new_dict.keys():
                 if isinstance(k, (tuple, Tuple)):
                     new_key = 0
                     for i, idx in enumerate(k):

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -243,7 +243,7 @@ class NDimArray(Printable):
 
         if isinstance(iterable, (Dict, dict)) and shape is not None:
             new_dict = iterable.copy()
-            for k in new_dict.keys():
+            for k in new_dict:
                 if isinstance(k, (tuple, Tuple)):
                     new_key = 0
                     for i, idx in enumerate(k):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Removes unnecessary dict item iterators and simplifies them with keys() or values() iterators

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
