### PR TITLE
Closes already solved Issues in calculation of integrals.

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2131,13 +2131,14 @@ def test_issue_25886():
     F = integrate(f, (x, y, 1.0))
     assert F.is_same(F_exp, math.isclose)
 
+
 def test_old_issues():
-    #issue 5212
+    # https://github.com/sympy/sympy/issues/5212
     I1 = integrate(cos(log(x**2))/x)
     assert I1 == sin(log(x**2))/2
-    #issue 5462
+    # https://github.com/sympy/sympy/issues/5462
     I2 = integrate(1/(x**2+y**2)**(Rational(3,2)),x)
     assert I2 == x/(y**3*sqrt(x**2/y**2 + 1))
-    #issue 6278
+    # https://github.com/sympy/sympy/issues/6278
     I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
     assert I3 == 2*sqrt(3)*pi/3

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2130,3 +2130,14 @@ def test_issue_25886():
             - 1.13875255748434*exp(0.937098661*I))
     F = integrate(f, (x, y, 1.0))
     assert F.is_same(F_exp, math.isclose)
+
+def test_old_issues():
+    #issue 5212
+    I1 = integrate(cos(log(x**2))/x)
+    assert I1 == sin(log(x**2))/2
+    #issue 5462
+    I2 = integrate(1/(x**2+y**2)**(Rational(3,2)),x)
+    assert I2 == x/(y**3*sqrt(x**2/y**2 + 1))
+    #issue 6278
+    I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
+    assert I3 == 2*sqrt(3)*pi/3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes https://github.com/sympy/sympy/issues/5212 , https://github.com/sympy/sympy/issues/5462 , https://github.com/sympy/sympy/issues/6278


#### Brief description of what is fixed or changed
```
#issue 5212
>>> integrate(cos(log(x**2))/x)
sin(log(x**2))/2
#issue5462
integrate(1/(x**2+y**2)**(Rational(3,2)),x)
x/(y**3*sqrt(x**2/y**2 + 1))
#issue6278
>>> integrate(1/(cos(x)+2),(x,0,2*pi))
2*sqrt(3)*pi/3
```
#### Other comments
This can close the old issues in integrals that are already solved.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added tests that could close the related issues.

<!-- END RELEASE NOTES -->
