### PR TITLE
Numpy support for POSform and SOPform added

### DIFF
--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -26,10 +26,12 @@ from sympy.testing.pytest import raises, XFAIL, slow
 
 from itertools import combinations, permutations, product
 
+from sympy.external.importtools import import_module
 
 A, B, C, D = symbols('A:D')
 a, b, c, d, e, w, x, y, z = symbols('a:e w:z')
 
+np = import_module('numpy')
 
 def test_overloading():
     """Test that |, & are overloaded as expected"""
@@ -356,6 +358,22 @@ def test_simplification_boolalg():
     assert And(Eq(x - 1, 0), Eq(x + 2, 2)).simplify() == False
     assert And(Ne(x - 1, 0), Ne(x + 2, 2)).simplify(
         ) == And(Ne(x, 1), Ne(x, 0))
+
+    if np is not None:
+        minterms = np.array([[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1],
+                    [1, 1, 1, 1]])
+        dontcares = np.array([[0, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 1]])
+        assert (
+            SOPform([w, x, y, z], minterms, dontcares) ==
+            Or(And(y, z), And(Not(w), Not(x))))
+        assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
+
+        minterms = np.array([1, 3, 7, 11, 15])
+        dontcares = np.array([0, 2, 5])
+        assert (
+            SOPform([w, x, y, z], minterms, dontcares) ==
+            Or(And(y, z), And(Not(w), Not(x))))
+        assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
 
 
 def test_bool_map():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -26,6 +26,7 @@ from sympy.testing.pytest import raises, XFAIL, slow
 
 from itertools import combinations, permutations, product
 
+
 A, B, C, D = symbols('A:D')
 a, b, c, d, e, w, x, y, z = symbols('a:e w:z')
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes Issues #26164 . 

#### Brief description of what is fixed or changed
Support for numpy arrays is added for POSform and SOPform with tests checking the working of numpy arrays . 

#### Other comments
All prior tests are passing and new tests are also added for extensive reliability

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * SOPform and POSform (simplification function can now work with numpy array (integers) data as well .

<!-- END RELEASE NOTES -->
