### PR TITLE
Resolve the bug when defining the eta and xi as independent variables of a PDE

### DIFF
--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -39,7 +39,7 @@ from sympy.simplify import simplify  # type: ignore
 from sympy.core import Add, S
 from sympy.core.function import Function, expand, AppliedUndef, Subs
 from sympy.core.relational import Equality, Eq
-from sympy.core.symbol import Symbol, Wild, symbols
+from sympy.core.symbol import Symbol, Wild, symbols, Dummy
 from sympy.functions import exp
 from sympy.integrals.integrals import Integral, integrate
 from sympy.utilities.iterables import has_dups, is_sequence
@@ -648,7 +648,9 @@ def pde_1st_linear_constant_coeff(eq, func, order, match, solvefun):
     # TODO : For now homogeneous first order linear PDE's having
     # two variables are implemented. Once there is support for
     # solving systems of ODE's, this can be extended to n variables.
-    xi, eta = symbols("xi eta")
+    # xi, eta = symbols("xi eta")
+    xi = Dummy("xi")
+    eta = Dummy("eta")
     f = func.func
     x = func.args[0]
     y = func.args[1]

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -237,3 +237,15 @@ def test_pdsolve_variable_coeff():
     eq = exp(2*x)*(u.diff(y)) + y*u - u
     sol = pdsolve(eq, hint='1st_linear_variable_coeff')
     assert sol == Eq(u, F(x)*exp(-y*(y - 2)*exp(-2*x)/2))
+
+def test_with_eta_xi_vaiables():
+    eta = Symbol("eta")
+    xi = Symbol("xi")
+
+    u = Function('U')(eta, xi)
+    eq = Eq(u.diff(eta) - sin(eta), 0)
+    sol = pdsolve(eq,hint='1st_linear_constant_coeff')
+    F = Function('F')
+
+    assert sol == Eq(u,F(-xi) - cos(eta))
+    assert checkpdesol(eq, sol)[0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25869 


#### Brief description of what is fixed or changed
Changed the `eta` and `xi` variable types to Dummy, in order to solve the collision of user defined type and variable defined internally.

#### Other comments
Added a simple test case to test the issue

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
