### PR TITLE
Changed definition to match use of Transverse_magnification function 

### DIFF
--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -671,8 +671,8 @@ def hyperfocal_distance(f, N, c):
 def transverse_magnification(si, so):
     """
 
-    Calculates the transverse magnification, which is the ratio of the
-    image size to the object size.
+    Calculates the transverse magnification upon reflection in a mirror,
+    which is the ratio of the image size to the object size.
 
     Parameters
     ==========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Changes docstring and html as mentioned in issue #24438

#### Brief description of what is fixed or changed
Docstring changed to match the result given by the function . The function uses the forumla for mirror but could also be used for a lens since lack of clarification.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY 

<!-- END RELEASE NOTES -->
