### PR TITLE
Modify config file to exclude modules required 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ markers = [
 
 [tool.ruff]
 # Enable Pyflakes `E` and `F` codes by default.
-select = [
+lint.select = [
     "C40",
     "C416",
     "C419",
@@ -38,7 +38,7 @@ select = [
 ]
 
 # Ignore rules that currently fail on the SymPy codebase
-ignore = [
+lint.ignore = [
     "E401",  # Multiple imports on one line
     "E402",  # Module level import not at top of file
     "E501",  # Line too long (<LENGTH> > 88 characters)
@@ -79,10 +79,10 @@ exclude = [
 line-length = 88
 
 # Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Per-file ignores currently specified in the flake8 configuration
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "sympy/interactive/session.py" = ["F821"]
 
 # Global mypy settings:
@@ -135,3 +135,14 @@ module = [
     "pysat.*",
 ]
 ignore_missing_imports = true
+
+[tool.slotscheck]
+strict-imports = true
+exclude-modules = '''
+(
+    sympy.parsing.latex._antlr
+    |sympy.parsing.autolev._antlr
+    |sympy.galgebra
+    |sympy.plotting.pygletplot
+)
+'''


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes Issue #26205

#### Brief description of what is fixed or changed
Slotscheck needed to be run with extra arguements earlier to get the desired behaviour , changes in the toml exclude the excess modules to run the command without extra arguements .
Slotcheck can now be run with 
`python -m slotscheck sympy/`

#### Other comments
Deprecation warnings are still given but Error is not produced . End with 'All OK !'

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Slotscheck work fine without extra arguements
<!-- END RELEASE NOTES -->
