### PR TITLE
Feedback will now act like a TransferFunction

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2302,11 +2302,6 @@ class Feedback(TransferFunction):
         if not sys2:
             sys2 = TransferFunction(1, 1, sys1.var)
 
-        if isinstance(sys1, Feedback):
-            sys1 = sys1.doit()
-        if isinstance(sys2, Feedback):
-            sys2 = sys2.doit()
-
         if not (isinstance(sys1, (TransferFunction, Series))
             and isinstance(sys2, (TransferFunction, Series))):
             raise TypeError("Unsupported type for `sys1` or `sys2` of Feedback.")

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2361,7 +2361,7 @@ class Feedback(TransferFunction):
                 Both `sys1` and `sys2` should be using the
                 same complex variable."""))
 
-        return super(SISOLinearTimeInvariant, cls).__new__(cls, sys1, sys2, _sympify(sign))
+        return super(TransferFunction, cls).__new__(cls, sys1, sys2, _sympify(sign))
 
     @property
     def sys1(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1138,7 +1138,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
-        if(isinstance(other, Feedback)):
+        if isinstance(other, Feedback):
             other = other.doit()
         if isinstance(other, (TransferFunction, Parallel)):
             if not self.var == other.var:

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -827,8 +827,6 @@ class TransferFunction(SISOLinearTimeInvariant):
         (p - 3)*(p + 5)
 
         """
-        if isinstance(self.args[0], TransferFunction):
-            return self.args[0].num
         return self.args[0]
 
     @property
@@ -849,8 +847,6 @@ class TransferFunction(SISOLinearTimeInvariant):
         4
 
         """
-        if isinstance(self.args[1], TransferFunction):
-            return self.args[1].num
         return self.args[1]
 
     @property
@@ -2442,6 +2438,40 @@ class Feedback(TransferFunction):
 
         """
         return self.sys1.var
+
+    @property
+    def num(self):
+        """
+        Returns the numerator of the Feedback equivalent Transfer Function.
+
+        Returns:
+        - Expression: Numerator expression of the Feedback Transfer Function.
+        """
+        arg_list = list(self.sys1.args) if isinstance(self.sys1, Series) else [self.sys1]
+        # F_n and F_d are resultant TFs of num and den of Feedback.
+        F_n, unit = self.sys1.doit(), TransferFunction(1, 1, self.sys1.var)
+        if self.sign == -1:
+            F_d = Parallel(unit, Series(self.sys2, *arg_list)).doit()
+        else:
+            F_d = Parallel(unit, -Series(self.sys2, *arg_list)).doit()
+        return F_n.num * F_d.den
+
+    @property
+    def den(self):
+        """
+        Returns the denominator of the Feedback equivalent Transfer Function.
+
+        Returns:
+        - Expression: Denominator expression of the Feedback Transfer Function.
+        """
+        arg_list = list(self.sys1.args) if isinstance(self.sys1, Series) else [self.sys1]
+        # F_n and F_d are resultant TFs of num and den of Feedback.
+        F_n, unit = self.sys1.doit(), TransferFunction(1, 1, self.sys1.var)
+        if self.sign == -1:
+            F_d = Parallel(unit, Series(self.sys2, *arg_list)).doit()
+        else:
+            F_d = Parallel(unit, -Series(self.sys2, *arg_list)).doit()
+        return F_n.den * F_d.num
 
     @property
     def sign(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2443,9 +2443,6 @@ class Feedback(TransferFunction):
     def num(self):
         """
         Returns the numerator of the Feedback equivalent Transfer Function.
-
-        Returns:
-        - Expression: Numerator expression of the Feedback Transfer Function.
         """
         arg_list = list(self.sys1.args) if isinstance(self.sys1, Series) else [self.sys1]
         # F_n and F_d are resultant TFs of num and den of Feedback.
@@ -2460,9 +2457,6 @@ class Feedback(TransferFunction):
     def den(self):
         """
         Returns the denominator of the Feedback equivalent Transfer Function.
-
-        Returns:
-        - Expression: Denominator expression of the Feedback Transfer Function.
         """
         arg_list = list(self.sys1.args) if isinstance(self.sys1, Series) else [self.sys1]
         # F_n and F_d are resultant TFs of num and den of Feedback.

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2325,7 +2325,7 @@ class Feedback(TransferFunction):
                 Both `sys1` and `sys2` should be using the
                 same complex variable."""))
 
-        return super(SISOLinearTimeInvariant, cls).__new__(cls, sys1, sys2, _sympify(sign))
+        return super(TransferFunction,cls).__new__(cls, sys1, sys2, _sympify(sign))
 
     @property
     def sys1(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -827,6 +827,8 @@ class TransferFunction(SISOLinearTimeInvariant):
         (p - 3)*(p + 5)
 
         """
+        if isinstance(self.args[0], TransferFunction):
+            return self.args[0].num
         return self.args[0]
 
     @property
@@ -847,6 +849,8 @@ class TransferFunction(SISOLinearTimeInvariant):
         4
 
         """
+        if isinstance(self.args[1], TransferFunction):
+            return self.args[1].num
         return self.args[1]
 
     @property

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1093,7 +1093,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __add__(self, other):
         if isinstance(other, Feedback):
-            other = other.doit()
+            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
+            if other.sign == -1:
+                F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
+            else:
+                F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
+
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1116,7 +1124,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __sub__(self, other):
         if isinstance(other, Feedback):
-            other = other.doit()
+            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
+            if other.sign == -1:
+                F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
+            else:
+                F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
+
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1139,7 +1155,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __mul__(self, other):
         if isinstance(other, Feedback):
-            other = other.doit()
+            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
+            if other.sign == -1:
+                F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
+            else:
+                F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
+
         if isinstance(other, (TransferFunction, Parallel)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1160,6 +1184,16 @@ class TransferFunction(SISOLinearTimeInvariant):
     __rmul__ = __mul__
 
     def __truediv__(self, other):
+        if isinstance(other, Feedback):
+            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
+            if other.sign == -1:
+                F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
+            else:
+                F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
+
         if isinstance(other, TransferFunction):
             if not self.var == other.var:
                 raise ValueError(filldedent("""

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2340,11 +2340,6 @@ class Feedback(TransferFunction):
         if not sys2:
             sys2 = TransferFunction(1, 1, sys1.var)
 
-        if isinstance(sys1, Feedback):
-            sys1 = sys1.doit()
-        if isinstance(sys2, Feedback):
-            sys2 = sys2.doit()
-
         if not (isinstance(sys1, (TransferFunction, Series))
             and isinstance(sys2, (TransferFunction, Series))):
             raise TypeError("Unsupported type for `sys1` or `sys2` of Feedback.")

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1092,6 +1092,8 @@ class TransferFunction(SISOLinearTimeInvariant):
         return fuzzy_and(pole.as_real_imag()[0].is_negative for pole in self.poles())
 
     def __add__(self, other):
+        if isinstance(other, Feedback):
+            other = other.doit()
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1113,6 +1115,8 @@ class TransferFunction(SISOLinearTimeInvariant):
         return self + other
 
     def __sub__(self, other):
+        if isinstance(other, Feedback):
+            other = other.doit()
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1134,6 +1138,8 @@ class TransferFunction(SISOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
+        if(isinstance(other, Feedback)):
+            other = other.doit()
         if isinstance(other, (TransferFunction, Parallel)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -2205,7 +2211,7 @@ class MIMOParallel(MIMOLinearTimeInvariant):
         return MIMOParallel(*arg_list)
 
 
-class Feedback(SISOLinearTimeInvariant):
+class Feedback(TransferFunction):
     r"""
     A class for representing closed-loop feedback interconnection between two
     SISO input/output systems.
@@ -2296,6 +2302,11 @@ class Feedback(SISOLinearTimeInvariant):
         if not sys2:
             sys2 = TransferFunction(1, 1, sys1.var)
 
+        if isinstance(sys1, Feedback):
+            sys1 = sys1.doit()
+        if isinstance(sys2, Feedback):
+            sys2 = sys2.doit()
+
         if not (isinstance(sys1, (TransferFunction, Series))
             and isinstance(sys2, (TransferFunction, Series))):
             raise TypeError("Unsupported type for `sys1` or `sys2` of Feedback.")
@@ -2314,7 +2325,7 @@ class Feedback(SISOLinearTimeInvariant):
                 Both `sys1` and `sys2` should be using the
                 same complex variable."""))
 
-        return super().__new__(cls, sys1, sys2, _sympify(sign))
+        return super(SISOLinearTimeInvariant, cls).__new__(cls, sys1, sys2, _sympify(sign))
 
     @property
     def sys1(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1093,14 +1093,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __add__(self, other):
         if isinstance(other, Feedback):
-            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            if isinstance(other.sys1, Series):
+                arg_list = list(other.sys1.args)
+            else:
+                arg_list = [other.sys1]
             F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
             if other.sign == -1:
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
-
-            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
@@ -1124,14 +1125,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __sub__(self, other):
         if isinstance(other, Feedback):
-            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            if isinstance(other.sys1, Series):
+                arg_list = list(other.sys1.args)
+            else:
+                arg_list = [other.sys1]
             F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
             if other.sign == -1:
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
-
-            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
@@ -1155,14 +1157,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __mul__(self, other):
         if isinstance(other, Feedback):
-            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            if isinstance(other.sys1, Series):
+                arg_list = list(other.sys1.args)
+            else:
+                arg_list = [other.sys1]
             F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
             if other.sign == -1:
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
-
-            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, (TransferFunction, Parallel)):
             if not self.var == other.var:
@@ -1185,14 +1188,15 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def __truediv__(self, other):
         if isinstance(other, Feedback):
-            arg_list = list(other.sys1.args) if isinstance(other.sys1, Series) else [other.sys1]
+            if isinstance(other.sys1, Series):
+                arg_list = list(other.sys1.args)
+            else:
+                arg_list = [other.sys1]
             F_n, unit = other.sys1.doit(), TransferFunction(1, 1, other.sys1.var)
             if other.sign == -1:
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
-
-            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, TransferFunction):
             if not self.var == other.var:
@@ -2336,6 +2340,11 @@ class Feedback(TransferFunction):
         if not sys2:
             sys2 = TransferFunction(1, 1, sys1.var)
 
+        if isinstance(sys1, Feedback):
+            sys1 = sys1.doit()
+        if isinstance(sys2, Feedback):
+            sys2 = sys2.doit()
+
         if not (isinstance(sys1, (TransferFunction, Series))
             and isinstance(sys2, (TransferFunction, Series))):
             raise TypeError("Unsupported type for `sys1` or `sys2` of Feedback.")
@@ -2354,7 +2363,7 @@ class Feedback(TransferFunction):
                 Both `sys1` and `sys2` should be using the
                 same complex variable."""))
 
-        return super(TransferFunction,cls).__new__(cls, sys1, sys2, _sympify(sign))
+        return super(SISOLinearTimeInvariant, cls).__new__(cls, sys1, sys2, _sympify(sign))
 
     @property
     def sys1(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1102,7 +1102,7 @@ class TransferFunction(SISOLinearTimeInvariant):
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
-
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1134,6 +1134,7 @@ class TransferFunction(SISOLinearTimeInvariant):
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
@@ -1166,6 +1167,7 @@ class TransferFunction(SISOLinearTimeInvariant):
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, (TransferFunction, Parallel)):
             if not self.var == other.var:
@@ -1197,6 +1199,7 @@ class TransferFunction(SISOLinearTimeInvariant):
                 F_d = Parallel(unit, Series(other.sys2, *arg_list)).doit()
             else:
                 F_d = Parallel(unit, -Series(other.sys2, *arg_list)).doit()
+            other = TransferFunction(F_n.num * F_d.den, F_n.den * F_d.num, F_n.var)
 
         if isinstance(other, TransferFunction):
             if not self.var == other.var:

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1692,7 +1692,7 @@ def test_Feedback_as_TransferFunction(): #Solves https://github.com/sympy/sympy/
     # Operation checking
     num, den = fd1.num, fd1.den
     assert num == s + 1
-    assert den == s + 2
+    assert den == (s + 1)*(s + 2) + 1
     # Combining Operations of TransferFunction and Feedback
     fd2 = Feedback(tf1*fd1, tf2)
     assert fd2.doit().simplify() == TransferFunction(2*(s + 1)**2, 2*s + ((s + 1)*(s + 2) + 1)*(s**2 + 2*s + 1) + 2, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1697,13 +1697,10 @@ def test_Feedback_as_TransferFunction(): #Solves https://github.com/sympy/sympy/
     fd2 = Feedback(tf1*fd1, tf2)
     assert fd2.doit().simplify() == TransferFunction(2*(s + 1)**2, 2*s + ((s + 1)*(s + 2) + 1)*(s**2 + 2*s + 1) + 2, s)
     assert (tf1+fd1) == Parallel(TransferFunction(2*s + 2, s**2 + 2*s + 1, s),
-                                 Feedback(TransferFunction(s + 1, 1, s),
-                                          TransferFunction(s + 2, 1, s), -1))
+                                 TransferFunction(s + 1, (s + 1)*(s + 2) + 1, s))
     assert (fd1-tf1) == Parallel(Feedback(TransferFunction(s + 1, 1, s), TransferFunction(s + 2, 1, s), -1),
                                  TransferFunction(-2*s - 2, s**2 + 2*s + 1, s))
-    assert (fd1*tf1) == Series(Feedback(TransferFunction(s + 1, 1, s),
-                                        TransferFunction(s + 2, 1, s), -1),
+    assert (fd1*tf1) == Series(Feedback(TransferFunction(s + 1, 1, s), TransferFunction(s + 2, 1, s), -1),
                                TransferFunction(2*s + 2, s**2 + 2*s + 1, s))
-    assert (fd1/tf1) == Series(Feedback(TransferFunction(s + 1, 1, s),
-                                        TransferFunction(s + 2, 1, s), -1),
+    assert (fd1/tf1) == Series(Feedback(TransferFunction(s + 1, 1, s), TransferFunction(s + 2, 1, s), -1),
                                TransferFunction(s**2 + 2*s + 1, 2*s + 2, s))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1691,8 +1691,8 @@ def test_Feedback_as_TransferFunction(): #Solves https://github.com/sympy/sympy/
     assert not isinstance(tf1, Feedback)
     # Operation checking
     num, den = fd1.num, fd1.den
-    assert num == TransferFunction(s + 1, 1, s)
-    assert den == TransferFunction(s + 2, 1, s)
+    assert num == s + 1
+    assert den == s + 2
     # Combining Operations of TransferFunction and Feedback
     fd2 = Feedback(tf1*fd1, tf2)
     assert fd2.doit().simplify() == TransferFunction(2*(s + 1)**2, 2*s + ((s + 1)*(s + 2) + 1)*(s**2 + 2*s + 1) + 2, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1681,7 +1681,7 @@ def test_StateSpace_functions():
     assert ss3.feedforward_matrix == Matrix([[0, 0], [0, 1]])
 
 
-def test_Feedback_as_TransferFunction():
+def test_Feedback_as_TransferFunction(): #Solves https://github.com/sympy/sympy/issues/26161
     fd1 = Feedback(TransferFunction(s + 1, 1 , s), TransferFunction(s + 2, 1, s))
     tf1 = TransferFunction(2 * (s+1), s**2 + 2*s + 1, s)
     tf2 = TransferFunction(1, s + 1, s)
@@ -1696,3 +1696,14 @@ def test_Feedback_as_TransferFunction():
     # Combining Operations of TransferFunction and Feedback
     fd2 = Feedback(tf1*fd1, tf2)
     assert fd2.doit().simplify() == TransferFunction(2*(s + 1)**2, 2*s + ((s + 1)*(s + 2) + 1)*(s**2 + 2*s + 1) + 2, s)
+    assert (tf1+fd1) == Parallel(TransferFunction(2*s + 2, s**2 + 2*s + 1, s),
+                                 Feedback(TransferFunction(s + 1, 1, s),
+                                          TransferFunction(s + 2, 1, s), -1))
+    assert (fd1-tf1) == Parallel(Feedback(TransferFunction(s + 1, 1, s), TransferFunction(s + 2, 1, s), -1),
+                                 TransferFunction(-2*s - 2, s**2 + 2*s + 1, s))
+    assert (fd1*tf1) == Series(Feedback(TransferFunction(s + 1, 1, s),
+                                        TransferFunction(s + 2, 1, s), -1),
+                               TransferFunction(2*s + 2, s**2 + 2*s + 1, s))
+    assert (fd1/tf1) == Series(Feedback(TransferFunction(s + 1, 1, s),
+                                        TransferFunction(s + 2, 1, s), -1),
+                               TransferFunction(s**2 + 2*s + 1, 2*s + 2, s))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1679,3 +1679,20 @@ def test_StateSpace_functions():
     assert ss3.input_matrix == Matrix([[0, 0], [1, 0], [0, 1], [0, 0]])
     assert ss3.output_matrix == Matrix([[0, 1, 0, 0], [0, 0, 1, 0]])
     assert ss3.feedforward_matrix == Matrix([[0, 0], [0, 1]])
+
+
+def test_Feedback_as_TransferFunction():
+    fd1 = Feedback(TransferFunction(s + 1, 1 , s), TransferFunction(s + 2, 1, s))
+    tf1 = TransferFunction(2 * (s+1), s**2 + 2*s + 1, s)
+    tf2 = TransferFunction(1, s + 1, s)
+    # Type Checking
+    assert isinstance(fd1, TransferFunction)
+    assert isinstance(fd1, Feedback)
+    assert not isinstance(tf1, Feedback)
+    # Operation checking
+    num, den = fd1.num, fd1.den
+    assert num == TransferFunction(s + 1, 1, s)
+    assert den == TransferFunction(s + 2, 1, s)
+    # Combining Operations of TransferFunction and Feedback
+    fd2 = Feedback(tf1*fd1, tf2)
+    assert fd2.doit().simplify() == TransferFunction(2*(s + 1)**2, 2*s + ((s + 1)*(s + 2) + 1)*(s**2 + 2*s + 1) + 2, s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Feedback will now act like a TransferFunction.
Solves Issue https://github.com/sympy/sympy/issues/26161

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added support for using Feedback as a TransferFunction.
<!-- END RELEASE NOTES -->
