### PR TITLE
Patched Wigner3j not working with float that were half integers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1378,6 +1378,7 @@ Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>
+T-vaccari <05-gesto-follemente@icloud.com>
 Takafumi Arakaki <aka.tkf@gmail.com>
 Takumasa Nakamura <n.takumasa@gmail.com>
 Tanay Agrawal <tanay_agrawal@hotmail.com>

--- a/sympy/physics/quantum/tests/test_cg.py
+++ b/sympy/physics/quantum/tests/test_cg.py
@@ -171,6 +171,8 @@ def test_cg_simp_sum():
 
 def test_doit():
     assert Wigner3j(S.Half, Rational(-1, 2), S.Half, S.Half, 0, 0).doit() == -sqrt(2)/2
+    assert Wigner3j(1/2,1/2,1/2,1/2,1/2,1/2).doit() == 0
+    assert Wigner3j(9/2,9/2,9/2,9/2,9/2,9/2).doit() ==  0
     assert Wigner6j(1, 2, 3, 2, 1, 2).doit() == sqrt(21)/105
     assert Wigner6j(3, 1, 2, 2, 2, 1).doit() == sqrt(21) / 105
     assert Wigner9j(

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -69,7 +69,7 @@ from sympy.functions.special.spherical_harmonics import Ynm
 from sympy.matrices.dense import zeros
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.utilities.misc import as_int
-from sympy import Rational
+from sympy.core.numbers import Rational, Integer, equal_valued
 # This list of precomputed factorials is needed to massively
 # accelerate future calculations of the various coefficients
 _Factlist = [1]
@@ -197,7 +197,7 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     def convert_float_to_rational_if_half_integer(value):
         if isinstance(value, float):
             if (value.is_integer()):
-                return Rational(int(value))
+                return Integer(int(value))
             elif (equal_valued((v:=2*value), (i:=int(v)))):
                 return Rational(i, 2)
         return value

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -56,7 +56,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.add import Add
 from sympy.core.numbers import int_valued
 from sympy.core.function import Function
-from sympy.core.numbers import (I, Integer, pi, Rational, equal_valued)
+from sympy.core.numbers import (Float, I, Integer, pi, Rational, equal_valued)
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -56,7 +56,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.add import Add
 from sympy.core.numbers import int_valued
 from sympy.core.function import Function
-from sympy.core.numbers import (I, Integer, pi)
+from sympy.core.numbers import (I, Integer, pi, Rational, equal_valued)
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
@@ -69,7 +69,7 @@ from sympy.functions.special.spherical_harmonics import Ynm
 from sympy.matrices.dense import zeros
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.utilities.misc import as_int
-from sympy.core.numbers import Rational, Integer, equal_valued
+
 # This list of precomputed factorials is needed to massively
 # accelerate future calculations of the various coefficients
 _Factlist = [1]

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -201,18 +201,10 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
             if fraction_value.denominator == 2:
                 return fraction_value
         return value
-
-    # Example list of values
     values = [j_1, j_2, j_3, m_1, m_2, m_3]
-
-    # Apply the conversion function to each value using a list comprehension
     converted_values = [convert_float_to_rational_if_half_integer(value) for value in values]
     j_1, j_2, j_3, m_1, m_2, m_3 = converted_values
-
-    # Define a tolerance for comparison
     tolerance = 1e-10
-
-    # Check if each value is either an integer or a half-integer
     if abs(j_1 * 2 - int(j_1 * 2)) > tolerance or \
             abs(j_2 * 2 - int(j_2 * 2)) > tolerance or \
             abs(j_3 * 2 - int(j_3 * 2)) > tolerance:
@@ -221,7 +213,6 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
             abs(m_2 * 2 - int(m_2 * 2)) > tolerance or \
             abs(m_3 * 2 - int(m_3 * 2)) > tolerance:
         raise ValueError("m values must be integer or half integer")
-
     if m_1 + m_2 + m_3 != 0:
         return S.Zero
     prefid = Integer((-1) ** int(j_1 - j_2 - m_3))

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -118,6 +118,8 @@ def _Integer_or_halfInteger(value):
             return Rational(i, 2)
     elif isinstance(value, Integer):
         return value
+    elif isinstance(value, Rational) and value.q == 2:
+        return value
     raise ValueError("expecting integer or half-integer, got %s" % value)
 
 

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -69,7 +69,7 @@ from sympy.functions.special.spherical_harmonics import Ynm
 from sympy.matrices.dense import zeros
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.utilities.misc import as_int
-from fractions import Fraction
+from sympy import Rational
 # This list of precomputed factorials is needed to massively
 # accelerate future calculations of the various coefficients
 _Factlist = [1]
@@ -195,15 +195,19 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     - Jens Rasch (2009-03-24): initial version
     """
 
+    
+
     def convert_float_to_rational_if_half_integer(value):
         if isinstance(value, float):
-            fraction_value = Fraction(value).limit_denominator()
+            fraction_value = Rational(value).limit_denominator()
             if fraction_value.denominator == 2:
                 return fraction_value
         return value
+
     values = [j_1, j_2, j_3, m_1, m_2, m_3]
     converted_values = [convert_float_to_rational_if_half_integer(value) for value in values]
     j_1, j_2, j_3, m_1, m_2, m_3 = converted_values
+
     tolerance = 1e-10
     if abs(j_1 * 2 - int(j_1 * 2)) > tolerance or \
             abs(j_2 * 2 - int(j_2 * 2)) > tolerance or \
@@ -213,6 +217,7 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
             abs(m_2 * 2 - int(m_2 * 2)) > tolerance or \
             abs(m_3 * 2 - int(m_3 * 2)) > tolerance:
         raise ValueError("m values must be integer or half integer")
+
     if m_1 + m_2 + m_3 != 0:
         return S.Zero
     prefid = Integer((-1) ** int(j_1 - j_2 - m_3))

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -197,10 +197,10 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     def convert_float_to_rational_if_half_integer(value):
         if isinstance(value, float):
-            if value.is_integer():  # Check if the float value is an integer
-                return Rational(int(value))  # Convert to a Rational if it's an integer
-            elif equal_valued((v:=2*value), (i:=int(v))):  # Check if the value is equivalent to a half
-                return Rational(i, 2)  # Return the value as a Rational with a denominator of 2
+            if value.is_integer():  
+                return Rational(int(value))  
+            elif equal_valued((v:=2*value), (i:=int(v))):  
+                return Rational(i, 2) 
         return value
 
     values = [j_1, j_2, j_3, m_1, m_2, m_3]

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -107,7 +107,7 @@ def _calc_factlist(nn):
             _Factlist.append(_Factlist[ii - 1] * ii)
     return _Factlist[:int(nn) + 1]
 
-
+from fractions import Fraction
 def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     r"""
     Calculate the Wigner 3j symbol `\operatorname{Wigner3j}(j_1,j_2,j_3,m_1,m_2,m_3)`.

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -195,8 +195,6 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     - Jens Rasch (2009-03-24): initial version
     """
 
-    
-
     def convert_float_to_rational_if_half_integer(value):
         if isinstance(value, float):
             fraction_value = Rational(value).limit_denominator()

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -69,7 +69,7 @@ from sympy.functions.special.spherical_harmonics import Ynm
 from sympy.matrices.dense import zeros
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.utilities.misc import as_int
-
+from fractions import Fraction
 # This list of precomputed factorials is needed to massively
 # accelerate future calculations of the various coefficients
 _Factlist = [1]
@@ -107,7 +107,7 @@ def _calc_factlist(nn):
             _Factlist.append(_Factlist[ii - 1] * ii)
     return _Factlist[:int(nn) + 1]
 
-from fractions import Fraction
+
 def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     r"""
     Calculate the Wigner 3j symbol `\operatorname{Wigner3j}(j_1,j_2,j_3,m_1,m_2,m_3)`.

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -194,13 +194,12 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-
     def convert_float_to_rational_if_half_integer(value):
         if isinstance(value, float):
-            if value.is_integer():  
-                return Rational(int(value))  
-            elif equal_valued((v:=2*value), (i:=int(v))):  
-                return Rational(i, 2) 
+            if (value.is_integer()):
+                return Rational(int(value))
+            elif (equal_valued((v:=2*value), (i:=int(v)))):
+                return Rational(i, 2)
         return value
 
     values = [j_1, j_2, j_3, m_1, m_2, m_3]

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -197,9 +197,10 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     def convert_float_to_rational_if_half_integer(value):
         if isinstance(value, float):
-            fraction_value = Rational(value).limit_denominator()
-            if fraction_value.denominator == 2:
-                return fraction_value
+            if value.is_integer():  # Check if the float value is an integer
+                return Rational(int(value))  # Convert to a Rational if it's an integer
+            elif equal_valued((v:=2*value), (i:=int(v))):  # Check if the value is equivalent to a half
+                return Rational(i, 2)  # Return the value as a Rational with a denominator of 2
         return value
 
     values = [j_1, j_2, j_3, m_1, m_2, m_3]

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -107,7 +107,7 @@ def _calc_factlist(nn):
             _Factlist.append(_Factlist[ii - 1] * ii)
     return _Factlist[:int(nn) + 1]
 
-
+from fractions import Fraction
 def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     r"""
     Calculate the Wigner 3j symbol `\operatorname{Wigner3j}(j_1,j_2,j_3,m_1,m_2,m_3)`.
@@ -194,12 +194,34 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-    if int(j_1 * 2) != j_1 * 2 or int(j_2 * 2) != j_2 * 2 or \
-            int(j_3 * 2) != j_3 * 2:
+
+    def convert_float_to_rational_if_half_integer(value):
+        if isinstance(value, float):
+            fraction_value = Fraction(value).limit_denominator()
+            if fraction_value.denominator == 2:
+                return fraction_value
+        return value
+
+    # Example list of values
+    values = [j_1, j_2, j_3, m_1, m_2, m_3]
+
+    # Apply the conversion function to each value using a list comprehension
+    converted_values = [convert_float_to_rational_if_half_integer(value) for value in values]
+    j_1, j_2, j_3, m_1, m_2, m_3 = converted_values
+
+    # Define a tolerance for comparison
+    tolerance = 1e-10
+
+    # Check if each value is either an integer or a half-integer
+    if abs(j_1 * 2 - int(j_1 * 2)) > tolerance or \
+            abs(j_2 * 2 - int(j_2 * 2)) > tolerance or \
+            abs(j_3 * 2 - int(j_3 * 2)) > tolerance:
         raise ValueError("j values must be integer or half integer")
-    if int(m_1 * 2) != m_1 * 2 or int(m_2 * 2) != m_2 * 2 or \
-            int(m_3 * 2) != m_3 * 2:
+    if abs(m_1 * 2 - int(m_1 * 2)) > tolerance or \
+            abs(m_2 * 2 - int(m_2 * 2)) > tolerance or \
+            abs(m_3 * 2 - int(m_3 * 2)) > tolerance:
         raise ValueError("m values must be integer or half integer")
+
     if m_1 + m_2 + m_3 != 0:
         return S.Zero
     prefid = Integer((-1) ** int(j_1 - j_2 - m_3))

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -107,7 +107,7 @@ def _calc_factlist(nn):
             _Factlist.append(_Factlist[ii - 1] * ii)
     return _Factlist[:int(nn) + 1]
 
-from fractions import Fraction
+
 def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     r"""
     Calculate the Wigner 3j symbol `\operatorname{Wigner3j}(j_1,j_2,j_3,m_1,m_2,m_3)`.


### PR DESCRIPTION
This pull request addresses an issue where the Wigner3j function would raise a ValueError when encountering half-integer inputs recognized as floats. The problem stemmed from incomplete validation checks, which failed to properly handle such inputs.

#### References to other Issues or PRs
Fixed #26219


#### Brief description of what is fixed or changed
To resolve this issue, I implemented enhanced validation checks within the function. Now, all inputs are meticulously validated to ensure they are either integers or half-integers. This modification ensures robustness and prevents the function from failing due to invalid input types.


<!-- BEGIN RELEASE NOTES -->

NO ENTRY


<!-- END RELEASE NOTES -->

  


