### PR TITLE
fixed wigner_3j and added tests

### DIFF
--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -196,3 +196,13 @@ def test_wigner_d():
     w = wigner_d(1, -pi/2, pi/2, -pi/2)@v.subs({theta: pi/4, phi: pi})
     w_ = v.subs({theta: pi/2, phi: pi/4})
     assert w.expand(func=True).as_real_imag() == w_.expand(func=True).as_real_imag()
+
+def test_wigner_3j():
+    a = Rational(1, 2)
+    b = 0.5
+    c = 1
+    assert wigner_3j(a, a, a, a, a, a) == 0
+    assert wigner_3j(b, b, b, b, b, b) == 0
+    assert wigner_3j(c, c, c, c, c, c) == 0
+    assert wigner_3j(0, a, b, 0, b ,-a) == sqrt(2)/2
+    assert wigner_3j(2, 6, Rational(4,1), 0, 0, 0) == sqrt(715)/143

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -194,11 +194,11 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-    if int(j_1 * 2) != j_1 * 2 or int(j_2 * 2) != j_2 * 2 or \
-            int(j_3 * 2) != j_3 * 2:
+    if not(int_valued(j_1 * 2) and int_valued(j_2 * 2) and \
+            int_valued(j_3 * 2)):
         raise ValueError("j values must be integer or half integer")
-    if int(m_1 * 2) != m_1 * 2 or int(m_2 * 2) != m_2 * 2 or \
-            int(m_3 * 2) != m_3 * 2:
+    if not(int_valued(m_1 * 2) and int_valued(m_2 * 2) and \
+            int_valued(m_3 * 2)):
         raise ValueError("m values must be integer or half integer")
     if m_1 + m_2 + m_3 != 0:
         return S.Zero


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes issue #26219

#### Brief description of what is fixed or changed
The wigner_3j function showed anamolous behaviour deoending on what the type of half value used was . It now can work with any type of value .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
  * wigner_3j Works with all types of Half integer and integer values that produced error earlier.

<!-- END RELEASE NOTES -->
