### PR TITLE
Fix unicode NFKC normalization when parsing expressions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -381,6 +381,7 @@ BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
 Bastian Weber <bastian.weber@gmx-topmail.de>
 Bavish Kulur <bavishkulur@gmail.com> bavish2201 <bavishkulur@gmail.com>
 Ben Goodrich <goodrich.ben@gmail.com>
+Ben Gyori <ben.gyori@gmail.com>
 Ben Lucato <ben.lucato@gmail.com>
 Ben Oostendorp <oostben@umich.edu> oostben <oostben@umich.edu>
 Ben Payne <ben.is.located@gmail.com> Ben <ben.is.located@gmail.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1074,9 +1074,6 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
 
     code = stringify_expr(s, local_dict, global_dict, _transformations)
 
-    if not evaluate:
-        code = compile(evaluateFalse(code), '<string>', 'eval') # type: ignore
-
     # Make sure we apply NFKC normalization to the input string
     # as well as keys of local_dict to make sure Python's built
     # in NFKC normalization, done when calling eval on code doesn't
@@ -1084,6 +1081,10 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
     code = unicodedata.normalize('NFKC', code)
     local_dict_tmp = {unicodedata.normalize('NFKC', k): v
                       for k, v in local_dict.items()}
+
+    if not evaluate:
+        code = compile(evaluateFalse(code), '<string>', 'eval') # type: ignore
+
     try:
         rv = eval_expr(code, local_dict_tmp, global_dict)
         # restore neutral definitions for names

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -906,6 +906,13 @@ def eval_expr(code, local_dict: DICT, global_dict: DICT):
 
     Generally, ``parse_expr`` should be used.
     """
+    # Make sure we apply NFKC normalization to the input string
+    # as well as keys of local_dict to make sure Python's built
+    # in NFKC normalization, done when calling eval on code doesn't
+    # create a discrepancy between the code and local_dict keys.
+    code = unicodedata.normalize('NFKC', code)
+    local_dict = {unicodedata.normalize('NFKC', k): v
+                  for k, v in local_dict.items()}
     expr = eval(
         code, global_dict, local_dict)  # take local objects in preference
     return expr

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -906,13 +906,6 @@ def eval_expr(code, local_dict: DICT, global_dict: DICT):
 
     Generally, ``parse_expr`` should be used.
     """
-    # Make sure we apply NFKC normalization to the input string
-    # as well as keys of local_dict to make sure Python's built
-    # in NFKC normalization, done when calling eval on code doesn't
-    # create a discrepancy between the code and local_dict keys.
-    code = unicodedata.normalize('NFKC', code)
-    local_dict = {unicodedata.normalize('NFKC', k): v
-                  for k, v in local_dict.items()}
     expr = eval(
         code, global_dict, local_dict)  # take local objects in preference
     return expr
@@ -1084,8 +1077,15 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
     if not evaluate:
         code = compile(evaluateFalse(code), '<string>', 'eval') # type: ignore
 
+    # Make sure we apply NFKC normalization to the input string
+    # as well as keys of local_dict to make sure Python's built
+    # in NFKC normalization, done when calling eval on code doesn't
+    # create a discrepancy between the code and local_dict keys.
+    code = unicodedata.normalize('NFKC', code)
+    local_dict_tmp = {unicodedata.normalize('NFKC', k): v
+                      for k, v in local_dict.items()}
     try:
-        rv = eval_expr(code, local_dict, global_dict)
+        rv = eval_expr(code, local_dict_tmp, global_dict)
         # restore neutral definitions for names
         for i in local_dict.pop(null, ()):
             local_dict[i] = null

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -309,6 +309,10 @@ def test_unicode_names():
     assert parse_expr('α') == Symbol('α')
 
 
+def test_unicode_nfkc_names():
+    assert parse_expr('ϵ', {'ϵ': Symbol('ϵ')}) == Symbol('ϵ')
+
+
 def test_python3_features():
     # Make sure the tokenizer can handle Python 3-only features
     if sys.version_info < (3, 8):


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #26234

#### Brief description of what is fixed or changed
The `parse_expr` function calls Python built-in `eval` on the input string. Within `eval`, certain Unicode characters are mapped to normalized ones using the NFKC normalization. This can create a discrepancy between characters appearing in the input string and the `local_dict` passed in to `parse_expr`. This PR applies NFKC normalization before calling eval to avoid this discrepancy.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fix NFKC normalization of unicode characters when parsing expressions

<!-- END RELEASE NOTES -->
