### PR TITLE
control: add order reduction for TransferFunction and feedback

### DIFF
--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,6 +1,6 @@
 from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
     Feedback, MIMOFeedback, TransferFunctionMatrix, StateSpace, gbt, bilinear, forward_diff,
-    backward_diff, phase_margin, gain_margin)
+    backward_diff, phase_margin, gain_margin, reduce_transfer_function_order)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
@@ -8,7 +8,7 @@ from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_respo
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
     'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'StateSpace',
-    'gbt', 'bilinear', 'forward_diff', 'backward_diff', 'phase_margin', 'gain_margin',
+    'gbt', 'bilinear', 'forward_diff', 'backward_diff', 'phase_margin', 'gain_margin','reduce_transfer_function_order',
     'pole_zero_numerical_data', 'pole_zero_plot', 'step_response_numerical_data',
     'step_response_plot', 'impulse_response_numerical_data', 'impulse_response_plot',
     'ramp_response_numerical_data', 'ramp_response_plot',


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #26160

#### Brief description of what is fixed or changed

Introduces `reduce_transfer_function_order` function to the `sympy.physics.control` module. The function aims to simplify the analysis of control systems by reducing the order of transfer functions and feedback systems. It achieves this by dynamically reducing the polynomial degree of the numerator and denominator in transfer functions, making high-order systems more manageable for analysis and simulation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added `reduce_transfer_function_order function` for simplifying high-order transfer functions and feedback systems.
<!-- END RELEASE NOTES -->
