### PR TITLE
Corrected Limit involving elliptic functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -513,6 +513,7 @@ Dennis Sweeney <sweeney.427@osu.edu> sweeneyde <sweeney.427@osu.edu>
 Denys Rybalka <rybalka.denis@gmail.com>
 Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
 Devansh <be19b002@smail.iitm.ac.in> prototypevito <96943731+prototypevito@users.noreply.github.com>
+Devansh Jaiswal <jaiswaldevansh27@gmail.com>
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devesh47cool@gmail.com>
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devsaw115@gmail.com>
 Devyani Kota <devyanikota@gmail.com> <divs.passion.18@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -514,6 +514,7 @@ Denys Rybalka <rybalka.denis@gmail.com>
 Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
 Devansh <be19b002@smail.iitm.ac.in> prototypevito <96943731+prototypevito@users.noreply.github.com>
 Devansh Jaiswal <jaiswaldevansh27@gmail.com>
+Devansh Jaiswal <jaiswaldevansh27@gmail.com> devanshj27 <107506278+devanshj27@users.noreply.github.com>
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devesh47cool@gmail.com>
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devsaw115@gmail.com>
 Devyani Kota <devyanikota@gmail.com> <divs.passion.18@gmail.com>

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -282,8 +282,7 @@ class hyper(TupleParametersBase):
         for i in range(n):
             num = Mul(*[RisingFactorial(a, i) for a in ap])
             den = Mul(*[RisingFactorial(b, i) for b in bq])
-            terms.append(((num/den) * (arg**i)) / factorial(i))
-
+            terms.append(((num/den) * (arg**i).nseries()) / factorial(i))
         return (Add(*terms) + Order(x**n,x))
 
     @property

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -391,6 +391,6 @@ def test_derivative_appellf1():
 
 def test_eval_nseries():
     a1, b1, a2, b2 = symbols('a1 b1 a2 b2')
-    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == 1 + x**2/3 + x**4/24 + x**6/360 + O(x**7)
-    assert exp(x)._eval_nseries(x,7,None) == hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
+    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == 1 + x**2/3 + x**4/24 + O(x**6)
+    assert exp(x)._eval_nseries(x,6,None) == hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
     assert hyper((a1, a2), (b1, b2), x)._eval_nseries(z, 7, None) == hyper((a1, a2), (b1, b2), x) + O(z**7)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
 
Fixes #26250 

#### Brief description of what is fixed or changed
```
>>> from sympy import *
>>> x = Symbol('x')
>>> e = ((1 - 3*x**2)*elliptic_e(4*x/(x**2 + 2*x + 1))**2/2 - (x**2 - 2*x + 1)*elliptic_e(4*x/(x**2 + 2*x + 1))*elliptic_k(4*x/(x**2 + 2*x + 1))/2)/(pi**2*x**8 - 2*pi**2*x**7 - pi**2*x**6 + 4*pi**2*x**5 - pi**2*x**4 - 2*pi**2*x**3 + pi**2*x**2)
>>> e.subs(x, 0.01).n()
-0.125070333715528
>>> e.limit(x, 0)
-1/8
```






#### Other comments


#### Release Notes


<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY 
<!-- END RELEASE NOTES -->
