### PR TITLE
fix(series): fix hyper.nseries for nontrivial argument

### DIFF
--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -274,8 +274,12 @@ class hyper(TupleParametersBase):
         ap = self.args[0]
         bq = self.args[1]
 
-        if x0 != 0:
-            return super()._eval_nseries(x, n, logx)
+        if not (arg == x and x0 == 0):
+            # It would be better to do something with arg.nseries here, rather
+            # than falling back on Function._eval_nseries. The code below
+            # though is not sufficient if arg is something like x/(x+1).
+            from sympy.simplify.hyperexpand import hyperexpand
+            return hyperexpand(super()._eval_nseries(x, n, logx))
 
         terms = []
 

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -117,6 +117,8 @@ def test_E():
         z + z**5*(-m**2/40 + m/30) - m*z**3/6 + O(z**6)
     assert E(z).series(z) == pi/2 - pi*z/8 - 3*pi*z**2/128 - \
         5*pi*z**3/512 - 175*pi*z**4/32768 - 441*pi*z**5/131072 + O(z**6)
+    assert E(4*z/(z+1)).series(z) == \
+        pi/2 - pi*z/2 + pi*z**2/8 - 3*pi*z**3/8 - 15*pi*z**4/128 - 93*pi*z**5/128 + O(z**6)
 
     assert E(z, m).rewrite(Integral).dummy_eq(
         Integral(sqrt(1 - m*sin(t)**2), (t, 0, z)))

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -391,6 +391,13 @@ def test_derivative_appellf1():
 
 def test_eval_nseries():
     a1, b1, a2, b2 = symbols('a1 b1 a2 b2')
-    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == 1 + x**2/3 + x**4/24 + x**6/360 + O(x**7)
-    assert exp(x)._eval_nseries(x,7,None) == hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
-    assert hyper((a1, a2), (b1, b2), x)._eval_nseries(z, 7, None) == hyper((a1, a2), (b1, b2), x) + O(z**7)
+    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == \
+        1 + x**2/3 + x**4/24 + x**6/360 + O(x**7)
+    assert exp(x)._eval_nseries(x,7,None) == \
+        hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
+    assert hyper((a1, a2), (b1, b2), x)._eval_nseries(z, 7, None) ==\
+        hyper((a1, a2), (b1, b2), x) + O(z**7)
+    assert hyper((-S(1)/2, S(1)/2), (1,), 4*x/(x + 1)).nseries(x) == \
+        1 - x + x**2/4 - 3*x**3/4 - 15*x**4/64 - 93*x**5/64 + O(x**6)
+    assert (pi/2*hyper((-S(1)/2, S(1)/2), (1,), 4*x/(x + 1))).nseries(x) == \
+        pi/2 - pi*x/2 + pi*x**2/8 - 3*pi*x**3/8 - 15*pi*x**4/128 - 93*pi*x**5/128 + O(x**6)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -32,6 +32,8 @@ from sympy.series.limits import heuristics
 from sympy.series.order import Order
 from sympy.testing.pytest import XFAIL, raises
 
+from sympy import elliptic_e, elliptic_k
+
 from sympy.abc import x, y, z, k
 n = Symbol('n', integer=True, positive=True)
 
@@ -1402,3 +1404,11 @@ def test_issue_25847():
 
 def test_issue_26040():
     assert limit(besseli(0, x + 1)/besseli(0, x), x, oo) == S.Exp1
+
+
+def test_issue_26250():
+    e = elliptic_e(4*x/(x**2 + 2*x + 1))
+    k = elliptic_k(4*x/(x**2 + 2*x + 1))
+    e1 = ((1-3*x**2)*e**2/2 - (x**2-2*x+1)*e*k/2)
+    e2 = pi**2*(x**8 - 2*x**7 - x**6 + 4*x**5 - x**4 - 2*x**3 + x**2)
+    assert limit(e1/e2, x, 0) == -S(1)/8


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-26250
Closes gh-26259

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * A bug in series involving hypergeometric functions of functions has been fixed. Previously incorrect series forms were returned in some cases leading to wrong results also for some limits involving hypergeometric functions.
<!-- END RELEASE NOTES -->
