### PR TITLE
maint(ci): add CI tests for mpmath master branch

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -421,7 +421,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -406,7 +406,7 @@ jobs:
   # -------------------- Test with mpmath master ------------------- #
 
   tests-mpmath-master:
-    #needs: [doctests-latest, tests-latest]
+    needs: [doctests-latest, tests-latest]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -405,8 +405,8 @@ jobs:
 
   # -------------------- Test with mpmath master ------------------- #
 
-  tests-mpmath-master
-  #needs: [doctests-latest, tests-latest]
+  tests-mpmath-master:
+    #needs: [doctests-latest, tests-latest]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -403,6 +403,30 @@ jobs:
       - run: bin/doctest --force-colors
       - run: examples/all.py -q
 
+  # -------------------- Test with mpmath master ------------------- #
+
+  tests-mpmath-master
+  #needs: [doctests-latest, tests-latest]
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+
+    name: mpmath-master ${{ matrix.group }}/4 Tests
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install git+https://github.com/mpmath/mpmath.git@master
+      - run: pip install -r requirements-dev.txt
+      - run: bin/test --split ${{ matrix.group }}/4
+
   # -------------------- Build the html/latex docs ----------------- #
 
   sphinx:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -927,9 +927,11 @@ class Float(Number):
         obj._prec = _prec
         return obj
 
-    # mpz can't be pickled
     def __getnewargs_ex__(self):
-        return ((mlib.to_pickable(self._mpf_),), {'precision': self._prec})
+        sign, man, exp, bc = self._mpf_
+        arg = (sign, hex(man)[2:], exp, bc)
+        kwargs = {'precision': self._prec}
+        return ((arg,), kwargs)
 
     def _hashable_content(self):
         return (self._mpf_, self._prec)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4330,13 +4330,6 @@ if flint is not None:
     _sympy_converter[type(flint.fmpq(1, 2))] = sympify_fmpq
 
 
-def sympify_mpmath_mpq(x):
-    p, q = x._mpq_
-    return Rational(p, q, 1)
-
-_sympy_converter[type(mpmath.rational.mpq(1, 2))] = sympify_mpmath_mpq
-
-
 def sympify_mpmath(x):
     return Expr._from_mpmath(x, x.context.prec)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See gh-26268 and https://github.com/mpmath/mpmath/issues/704

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
