### PR TITLE
fix(matrices): fix Matrix inverse over RR[x]

### DIFF
--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1805,6 +1805,13 @@ def sdm_rref_den(A, K):
         Aij = Ai[j]
         return ({0: Ai.copy()}, Aij, [j])
 
+    # For inexact domains like RR[x] we use quo and discard the remainder.
+    # Maybe it would be better for K.exquo to do this automatically.
+    if K.is_Exact:
+        exquo = K.exquo
+    else:
+        exquo = K.quo
+
     # Make sure we have the rows in order to make this deterministic from the
     # outset.
     _, rows_in_order = zip(*sorted(A.items()))
@@ -1901,7 +1908,7 @@ def sdm_rref_den(A, K):
                 for l, Akl in Ak.items():
                     Akl = Akl * Aij
                     if divisor is not None:
-                        Akl = K.exquo(Akl, divisor)
+                        Akl = exquo(Akl, divisor)
                     Ak[l] = Akl
                 continue
 
@@ -1912,19 +1919,19 @@ def sdm_rref_den(A, K):
             for l in Ai_nz - Ak_nz:
                 Ak[l] = - Akj * Ai[l]
                 if divisor is not None:
-                    Ak[l] = K.exquo(Ak[l], divisor)
+                    Ak[l] = exquo(Ak[l], divisor)
 
             # This loop also not needed in sdm_irref.
             for l in Ak_nz - Ai_nz:
                 Ak[l] = Aij * Ak[l]
                 if divisor is not None:
-                    Ak[l] = K.exquo(Ak[l], divisor)
+                    Ak[l] = exquo(Ak[l], divisor)
 
             for l in Ai_nz & Ak_nz:
                 Akl = Aij * Ak[l] - Akj * Ai[l]
                 if Akl:
                     if divisor is not None:
-                        Akl = K.exquo(Akl, divisor)
+                        Akl = exquo(Akl, divisor)
                     Ak[l] = Akl
                 else:
                     Ak.pop(l)
@@ -1948,7 +1955,7 @@ def sdm_rref_den(A, K):
                 denom *= Aij
 
         if divisor is not None:
-            denom = K.exquo(denom, divisor)
+            denom = exquo(denom, divisor)
 
         # Update the divisor.
         divisor = denom

--- a/sympy/polys/matrices/tests/test_inverse.py
+++ b/sympy/polys/matrices/tests/test_inverse.py
@@ -1,4 +1,4 @@
-from sympy import ZZ
+from sympy import ZZ, Matrix
 from sympy.polys.matrices import DM, DomainMatrix
 from sympy.polys.matrices.dense import ddm_iinv
 from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
@@ -6,6 +6,9 @@ from sympy.matrices.exceptions import NonInvertibleMatrixError
 
 import pytest
 from sympy.testing.pytest import raises
+from sympy.core.numbers import all_close
+
+from sympy.abc import x
 
 
 # Examples are given as adjugate matrix and determinant adj_det should match
@@ -151,3 +154,40 @@ def test_Matrix_adjugate(name, A, A_inv, den):
 @pytest.mark.parametrize('name, A, A_inv, den', INVERSE_EXAMPLES)
 def test_dm_adj_det(name, A, A_inv, den):
     assert A.adj_det() == (A_inv, den)
+
+
+def test_inverse_inexact():
+
+    M = Matrix([[x-0.3, -0.06, -0.22],
+                [-0.46, x-0.48, -0.41],
+                [-0.14, -0.39, x-0.64]])
+
+    Mn = Matrix([[1.0*x**2 - 1.12*x + 0.1473, 0.06*x + 0.0474, 0.22*x - 0.081],
+                 [0.46*x - 0.237, 1.0*x**2 - 0.94*x + 0.1612, 0.41*x - 0.0218],
+                 [0.14*x + 0.1122, 0.39*x - 0.1086, 1.0*x**2 - 0.78*x + 0.1164]])
+
+    d = 1.0*x**3 - 1.42*x**2 + 0.4249*x - 0.0546540000000002
+
+    Mi = Mn / d
+
+    M_dm = M.to_DM()
+    M_dmd = M_dm.to_dense()
+    M_dm_num, M_dm_den = M_dm.inv_den()
+    M_dmd_num, M_dmd_den = M_dmd.inv_den()
+
+    # XXX: We don't check M_dm().to_field().inv() which currently uses division
+    # and produces a more complicate result from gcd cancellation failing.
+    # DomainMatrix.inv() over RR(x) should be changed to clear denominators and
+    # use DomainMatrix.inv_den().
+
+    Minvs = [
+        M.inv(),
+        (M_dm_num.to_field() / M_dm_den).to_Matrix(),
+        (M_dmd_num.to_field() / M_dmd_den).to_Matrix(),
+        M_dm_num.to_Matrix() / M_dm_den.as_expr(),
+        M_dmd_num.to_Matrix() / M_dmd_den.as_expr(),
+    ]
+
+    for Minv in Minvs:
+        for Mi1, Mi2 in zip(Minv.flat(), Mi.flat()):
+            assert all_close(Mi2, Mi1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-26271

This is fixing a regression since `Matrix.inv()` started using DomainMatrix in gh-25452.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
