### PR TITLE
Document how to solve physics vector equations

### DIFF
--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -198,3 +198,34 @@ so dynamic symbols created before or after will print the same way.
 Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
 ``dynamicsymbols``, along with a number of other important functions and
 methods. Don't mix and match symbols representing time.
+
+Solving Vector Equations
+========================
+
+To solve equations involving vectors, you cannot directly use the solve
+functions on a vector. Instead, you must convert the vector equation to a
+matrix.
+
+Suppose that we have two frames ``N`` and ``A``, where ``A`` is rotated 30
+degrees about the z-axis with respect to ``N``. ::
+
+  >>> from sympy import pi, symbols, solve
+  >>> from sympy.physics.vector import ReferenceFrame
+  >>> N = ReferenceFrame("N")
+  >>> A = ReferenceFrame("A")
+  >>> A.orient_axis(N, pi / 6, N.z)
+
+Suppose that we have two vectors ``v1`` and ``v2``, which represent the same
+vector using different symbols. ::
+
+  >>> v1x, v1y, v1z = symbols("v1x v1y v1z")
+  >>> v2x, v2y, v2z = symbols("v2x v2y v2z")
+  >>> v1 = v1x * N.x + v1y * N.y + v1z * N.z
+  >>> v2 = v2x * A.x + v2y * A.y + v2z * A.z
+
+Our goal is to find the relationship between the symbols used in ``v2`` and the
+symbols used in ``v1``. We can achieve this by converting the vector to a matrix
+and then solving the matrix using :meth:`sympy.solvers.solvers.solve`. ::
+
+  >>> solve((v1 - v2).to_matrix(N), [v2x, v2y, v2z])
+  {v2x: sqrt(3)*v1x/2 + v1y/2, v2y: -v1x/2 + sqrt(3)*v1y/2, v2z: v1z}

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -203,8 +203,8 @@ Solving Vector Equations
 ========================
 
 To solve equations involving vectors, you cannot directly use the solve
-functions on a vector. Instead, you must convert the vector equation to a
-matrix.
+functions on a vector. Instead, you must convert the vector to a set of scalar
+equations.
 
 Suppose that we have two frames ``N`` and ``A``, where ``A`` is rotated 30
 degrees about the z-axis with respect to ``N``. ::


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Replaces #24923

#### Brief description of what is fixed or changed
Document how to solve equations in the form of vectors in `sympy.physics.vector`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
