### PR TITLE
Latex printer can shorten Dyadic expressions when needed

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -160,22 +160,32 @@ class Dyadic(Printable, EvalfMixin):
     def __neg__(self):
         return self * -1
 
-    def _latex(self, printer):
+    def _latex(self, printer, **kwargs):
         ar = self.args  # just to shorten things
+        shorten = kwargs.get('shorten', False)
         if len(ar) == 0:
             return str(0)
         ol = []  # output list, to be concatenated to a string
         for i, v in enumerate(ar):
             # if the coef of the dyadic is 1, we skip the 1
             if ar[i][0] == 1:
-                ol.append(' + ' + printer._print(ar[i][1]) + r"\otimes " +
-                          printer._print(ar[i][2]))
+                if not shorten:
+                    ol.append(' + ' + printer._print(ar[i][1]) + r"\otimes " +
+                              printer._print(ar[i][2]))
+                else:
+                    ol.append(' + ' + printer._print(ar[i][1]) +
+                              printer._print(ar[i][2]))                    
             # if the coef of the dyadic is -1, we skip the 1
             elif ar[i][0] == -1:
-                ol.append(' - ' +
-                          printer._print(ar[i][1]) +
-                          r"\otimes " +
-                          printer._print(ar[i][2]))
+                if not shorten:
+                    ol.append(' - ' +
+                              printer._print(ar[i][1]) +
+                              r"\otimes " +
+                              printer._print(ar[i][2]))
+                else:
+                    ol.append(' - ' +
+                              printer._print(ar[i][1]) +
+                              printer._print(ar[i][2]))
             # If the coefficient of the dyadic is not 1 or -1,
             # we might wrap it in parentheses, for readability.
             elif ar[i][0] != 0:
@@ -187,8 +197,13 @@ class Dyadic(Printable, EvalfMixin):
                     str_start = ' - '
                 else:
                     str_start = ' + '
-                ol.append(str_start + arg_str + printer._print(ar[i][1]) +
-                          r"\otimes " + printer._print(ar[i][2]))
+                
+                if not shorten:
+                    ol.append(str_start + arg_str + printer._print(ar[i][1]) +
+                              r"\otimes " + printer._print(ar[i][2]))
+                else:
+                    ol.append(str_start + arg_str + printer._print(ar[i][1]) +
+                              printer._print(ar[i][2]))
         outstr = ''.join(ol)
         if outstr.startswith(' + '):
             outstr = outstr[3:]

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -174,7 +174,7 @@ class Dyadic(Printable, EvalfMixin):
                               printer._print(ar[i][2]))
                 else:
                     ol.append(' + ' + printer._print(ar[i][1]) +
-                              printer._print(ar[i][2]))                    
+                              printer._print(ar[i][2]))
             # if the coef of the dyadic is -1, we skip the 1
             elif ar[i][0] == -1:
                 if not shorten:
@@ -197,7 +197,6 @@ class Dyadic(Printable, EvalfMixin):
                     str_start = ' - '
                 else:
                     str_start = ' + '
-                
                 if not shorten:
                     ol.append(str_start + arg_str + printer._print(ar[i][1]) +
                               r"\otimes " + printer._print(ar[i][2]))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26280

#### Brief description of what is fixed or changed
On use of shorten keyword inside ._latex() method , we can omitt the use of `\otimes` symbol .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Dyadic expressions can be used without \otimes symbol with use of shorten keyword

<!-- END RELEASE NOTES -->
