### PR TITLE
Implement matrix truncation for latex to enhance the display of large matrices

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -984,6 +984,7 @@ Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.nor
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>
+Mohamed Rezk <mohrizq895@gmail.com>
 Mohammad Sadeq Dousti <msdousti@gmail.com>
 Mohammed Bilal <r.mohammedbilal@gmail.com>
 Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohit Balwani <44258119+Mohitbalwani26@users.noreply.github.com>


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16251 


#### Brief description of what is fixed or changed
The `_print_matrix_contents` method now includes options for compactifying and setting maximum visible rows and columns, providing a more readable representation. This improvement prevents printing slowdowns for large matrices and improves overall user experience. 
Basically, the method looks if the number of rows or number of columns exceeds certain thresholds, which are predefined in the `_settings`dictionary under the names `mat_visible_rows` and `mat_visible_cols` respectively, with `15` as a default value. If so, the method avoids iterating over all elements of the matrix and adds dots to imply compaction.

The compaction feature is also predefined in `_settings` dictionary with default value `True` to avoid large matrix printing slowdown.    

**Here is the behavior after enabling the compaction feature:**  
![image](https://github.com/sympy/sympy/assets/59314933/00021ae5-425e-4295-a450-a29fb14242a0)
**And here is the behavior with it:**
![image](https://github.com/sympy/sympy/assets/59314933/79be328d-d597-46f7-9b77-9c528f0d0d31)

**Also, compaction of rows and cols are independent based on the dimension of each. The following two examples illustrates this better:**

![image](https://github.com/sympy/sympy/assets/59314933/3b9fe932-d723-4cd9-870e-a787cef5691d)
![image](https://github.com/sympy/sympy/assets/59314933/b8c1fa3e-2fa0-4ef0-acb1-aa987088d9ef)

**Finally, if the matrix dimensions are small (below thresholds) in both axes then no compaction takes place like so :**
![image](https://github.com/sympy/sympy/assets/59314933/61cbeea8-27a0-4d01-a26c-46179cf01c64)



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Added a truncation feature to latex  for large matrices printing.


<!-- END RELEASE NOTES -->
