### PR TITLE
PID controller was added to physics.control

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -405,8 +405,22 @@ jobs:
 
   # -------------------- Test with mpmath master ------------------- #
 
+<<<<<<< HEAD
+<<<<<<< HEAD
   tests-mpmath-master:
     needs: [doctests-latest, tests-latest]
+=======
+  tests-mpmath-master
+  #needs: [doctests-latest, tests-latest]
+>>>>>>> 73c18c518e (maint(ci): add CI tests for mpmath master branch)
+=======
+  tests-mpmath-master:
+<<<<<<< HEAD
+    #needs: [doctests-latest, tests-latest]
+>>>>>>> a3415a176f (Fix yml syntax)
+=======
+    needs: [doctests-latest, tests-latest]
+>>>>>>> 50217bbe18 (maint(ci): make mpmath CI job run after main tests)
 
     runs-on: ubuntu-20.04
 
@@ -421,7 +435,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+<<<<<<< HEAD
+<<<<<<< HEAD
           python-version: '3.12'
+=======
+          python-version: ${{ matrix.python-version }}
+>>>>>>> 73c18c518e (maint(ci): add CI tests for mpmath master branch)
+=======
+          python-version: '3.12'
+>>>>>>> bae2acf5b6 (fix python version)
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Basic code quality tests
         run: bin/test quality
 
-      - name: Run flake8 on the sympy package
-        run: flake8 sympy
-
       - name: Run Ruff on the sympy package
         run: ruff check .
+
+      - name: Run flake8 on the sympy package
+        run: flake8 sympy
 
       - name: Detect invalid escapes like '\e'
         run: python -We:invalid -We::SyntaxWarning -m compileall -f -q sympy/

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -421,7 +421,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -406,7 +406,7 @@ jobs:
   # -------------------- Test with mpmath master ------------------- #
 
   tests-mpmath-master:
-    #needs: [doctests-latest, tests-latest]
+    needs: [doctests-latest, tests-latest]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -405,8 +405,8 @@ jobs:
 
   # -------------------- Test with mpmath master ------------------- #
 
-  tests-mpmath-master
-  #needs: [doctests-latest, tests-latest]
+  tests-mpmath-master:
+    #needs: [doctests-latest, tests-latest]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -403,6 +403,30 @@ jobs:
       - run: bin/doctest --force-colors
       - run: examples/all.py -q
 
+  # -------------------- Test with mpmath master ------------------- #
+
+  tests-mpmath-master
+  #needs: [doctests-latest, tests-latest]
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+
+    name: mpmath-master ${{ matrix.group }}/4 Tests
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install git+https://github.com/mpmath/mpmath.git@master
+      - run: pip install -r requirements-dev.txt
+      - run: bin/test --split ${{ matrix.group }}/4
+
   # -------------------- Build the html/latex docs ----------------- #
 
   sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ select = [
     "C419",
     "E",
     "F",
+    "LOG",
     "PIE810",
     "PLE",
     "SIM101",

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -927,9 +927,11 @@ class Float(Number):
         obj._prec = _prec
         return obj
 
-    # mpz can't be pickled
     def __getnewargs_ex__(self):
-        return ((mlib.to_pickable(self._mpf_),), {'precision': self._prec})
+        sign, man, exp, bc = self._mpf_
+        arg = (sign, hex(man)[2:], exp, bc)
+        kwargs = {'precision': self._prec}
+        return ((arg,), kwargs)
 
     def _hashable_content(self):
         return (self._mpf_, self._prec)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4330,13 +4330,6 @@ if flint is not None:
     _sympy_converter[type(flint.fmpq(1, 2))] = sympify_fmpq
 
 
-def sympify_mpmath_mpq(x):
-    p, q = x._mpq_
-    return Rational(p, q, 1)
-
-_sympy_converter[type(mpmath.rational.mpq(1, 2))] = sympify_mpmath_mpq
-
-
 def sympify_mpmath(x):
     return Expr._from_mpmath(x, x.context.prec)
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -20,7 +20,7 @@ from sympy.functions.elementary.trigonometric import sin
 
 from sympy.testing.pytest import SKIP
 
-a, b, c, x, y, z = symbols('a,b,c,x,y,z')
+a, b, c, x, y, z, s  = symbols('a,b,c,x,y,z,s')
 
 
 whitelist = [
@@ -4259,6 +4259,17 @@ def test_sympy__physics__control__lti__TransferFunction():
     from sympy.physics.control.lti import TransferFunction
     assert _test_args(TransferFunction(2, 3, x))
 
+def _test_args_PIDController(obj):
+    from sympy.physics.control.lti import PIDController
+    if isinstance(obj, PIDController):
+        KP, KI, KD, TF = obj.KP, obj.KI, obj.KD, obj.TF
+        recreated_pid = PIDController(KP, KI, KD, 0, s)
+        return recreated_pid == obj
+    return False
+def test_sympy__physics__control__lti__PIDController():
+    from sympy.physics.control.lti import PIDController
+    KP, KI, KD = 1, 0.1, 0.01
+    assert _test_args_PIDController(PIDController(KP, KI, KD,0, s))
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4259,17 +4259,20 @@ def test_sympy__physics__control__lti__TransferFunction():
     from sympy.physics.control.lti import TransferFunction
     assert _test_args(TransferFunction(2, 3, x))
 
+
 def _test_args_PIDController(obj):
     from sympy.physics.control.lti import PIDController
     if isinstance(obj, PIDController):
         KP, KI, KD, TF = obj.KP, obj.KI, obj.KD, obj.TF
-        recreated_pid = PIDController(KP, KI, KD, 0, s)
+        recreated_pid = PIDController(KP, KI, KD, TF, s)
         return recreated_pid == obj
     return False
+
+
 def test_sympy__physics__control__lti__PIDController():
     from sympy.physics.control.lti import PIDController
-    KP, KI, KD = 1, 0.1, 0.01
-    assert _test_args_PIDController(PIDController(KP, KI, KD,0, s))
+    KP, KI, KD, TF = 1, 0.1, 0.01, 0
+    assert _test_args_PIDController(PIDController(KP, KI, KD, TF, s))
 
 def test_sympy__physics__control__lti__Series():
     from sympy.physics.control import Series, TransferFunction

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -274,8 +274,12 @@ class hyper(TupleParametersBase):
         ap = self.args[0]
         bq = self.args[1]
 
-        if x0 != 0:
-            return super()._eval_nseries(x, n, logx)
+        if not (arg == x and x0 == 0):
+            # It would be better to do something with arg.nseries here, rather
+            # than falling back on Function._eval_nseries. The code below
+            # though is not sufficient if arg is something like x/(x+1).
+            from sympy.simplify.hyperexpand import hyperexpand
+            return hyperexpand(super()._eval_nseries(x, n, logx))
 
         terms = []
 

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -117,6 +117,8 @@ def test_E():
         z + z**5*(-m**2/40 + m/30) - m*z**3/6 + O(z**6)
     assert E(z).series(z) == pi/2 - pi*z/8 - 3*pi*z**2/128 - \
         5*pi*z**3/512 - 175*pi*z**4/32768 - 441*pi*z**5/131072 + O(z**6)
+    assert E(4*z/(z+1)).series(z) == \
+        pi/2 - pi*z/2 + pi*z**2/8 - 3*pi*z**3/8 - 15*pi*z**4/128 - 93*pi*z**5/128 + O(z**6)
 
     assert E(z, m).rewrite(Integral).dummy_eq(
         Integral(sqrt(1 - m*sin(t)**2), (t, 0, z)))

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -391,6 +391,13 @@ def test_derivative_appellf1():
 
 def test_eval_nseries():
     a1, b1, a2, b2 = symbols('a1 b1 a2 b2')
-    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == 1 + x**2/3 + x**4/24 + x**6/360 + O(x**7)
-    assert exp(x)._eval_nseries(x,7,None) == hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
-    assert hyper((a1, a2), (b1, b2), x)._eval_nseries(z, 7, None) == hyper((a1, a2), (b1, b2), x) + O(z**7)
+    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == \
+        1 + x**2/3 + x**4/24 + x**6/360 + O(x**7)
+    assert exp(x)._eval_nseries(x,7,None) == \
+        hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
+    assert hyper((a1, a2), (b1, b2), x)._eval_nseries(z, 7, None) ==\
+        hyper((a1, a2), (b1, b2), x) + O(z**7)
+    assert hyper((-S(1)/2, S(1)/2), (1,), 4*x/(x + 1)).nseries(x) == \
+        1 - x + x**2/4 - 3*x**3/4 - 15*x**4/64 - 93*x**5/64 + O(x**6)
+    assert (pi/2*hyper((-S(1)/2, S(1)/2), (1,), 4*x/(x + 1))).nseries(x) == \
+        pi/2 - pi*x/2 + pi*x**2/8 - 3*pi*x**3/8 - 15*pi*x**4/128 - 93*pi*x**5/128 + O(x**6)

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,4 +1,4 @@
-from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
+from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel, PIDController,
     Feedback, MIMOFeedback, TransferFunctionMatrix, StateSpace, gbt, bilinear, forward_diff,
     backward_diff, phase_margin, gain_margin)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
@@ -7,7 +7,7 @@ from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_respo
     bode_phase_plot, bode_plot)
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
-    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'StateSpace',
+    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'PIDController', 'StateSpace',
     'gbt', 'bilinear', 'forward_diff', 'backward_diff', 'phase_margin', 'gain_margin',
     'pole_zero_numerical_data', 'pole_zero_plot', 'step_response_numerical_data',
     'step_response_plot', 'impulse_response_numerical_data', 'impulse_response_plot',

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4263,3 +4263,141 @@ class StateSpace(LinearTimeInvariant):
 
         """
         return self.controllability_matrix().rank() == self.num_states
+
+class PIDController(TransferFunction):
+    """
+    A PID Controller class that uses Parallel connection to combine the P, I, and D components.
+
+    Parameters
+    ==========
+    KP : Expr, Number
+        Proportional gain.
+    KI : Expr, Number
+        Integral gain.
+    KD : Expr, Number
+        Derivative gain.
+    TP : Expr, Number
+        Derivative filter time constant
+    s : Symbol
+        The complex frequency variable.
+
+    Examples
+    ========
+    >>> from sympy.abc import s
+    >>> from sympy.physics.control.lti import PIDController
+    >>> KP, KI, KD, TF = 1, 0.1, 0.01, 0
+    >>> pid = PIDController(KP, KI, KD, s)
+    >>> pid
+    PIDController(1, 0.1, s, 0, s)
+    >>> pid.doit() #Converts PIDController into TransferFunction
+    TransferFunction(s*(0.01*s + 1) + 0.1, s, s)
+    >>> pid.var
+    s
+    >>> pid.KP
+    1
+    """
+    def __new__(cls, KP, KI, KD, TF, var):
+        if not isinstance(var, Symbol):
+            raise ValueError("var must be a Symbol")
+
+        if not (KP or KI or  KD):
+            raise ValueError("All KP, KI & KD should not be None")
+
+        if(TF is None):
+            TF = S.Zero
+        if(KP is None):
+            KP = S.Zero
+        if(KI is None):
+            KI = S.Zero
+        if (KD is None):
+            KD = S.Zero
+
+        KP = _sympify(KP)
+        KI = _sympify(KI)
+        KD = _sympify(KD)
+        TF = _sympify(TF)
+
+        P = TransferFunction(KP, 1, var)
+        I = TransferFunction(KI, var, var)
+        D = TransferFunction(KD * var, S.One+TF*var, var)
+
+        pid_controller = Parallel(P, I, D)
+
+        tf = pid_controller.doit()
+
+        numerator = tf.num
+        denominator = tf.den
+
+        instance = super(PIDController, cls).__new__(cls,numerator,denominator,var)
+        instance._num = tf.num
+        instance._den = tf.den
+
+        return instance
+    def __init__(self, KP, KI, KD, TF, var):
+        """
+        Initialise the PID instance
+        """
+        self._KP = KP
+        self._KI = KI
+        self._KD = KD
+        self._TF = TF
+
+    def __str__(self):
+        return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
+    def __repr__(self):
+        return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
+    @property
+    def KP(self):
+        """
+        Get the Proportional (KP) gain of the PIDController.
+
+        Returns
+        -------
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._KP
+
+    @property
+    def KI(self):
+        """
+        Get the Proportional Integral (KI) gain of the PIDController.
+
+        Returns
+        =======
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._KI
+    @property
+    def KD(self):
+        """
+        Get the Proportional Derivative(P) gain of the PIDController.
+
+        Returns
+        =======
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._KD
+    @property
+    def TF(self):
+        """
+        Get the Derivative filter time constant (TP) of the PIDController.
+
+        Returns
+        =======
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._TF
+    def doit(self):
+        """
+        Convert the PIDController into a TransferFunction.
+
+        Returns
+        =======
+        TransferFunction
+            A TransferFunction representing the PIDController.
+        """
+        return TransferFunction(self._num, self._den, self.var)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4286,9 +4286,9 @@ class PIDController(TransferFunction):
     >>> from sympy.abc import s
     >>> from sympy.physics.control.lti import PIDController
     >>> KP, KI, KD, TF = 1, 0.1, 0.01, 0
-    >>> pid = PIDController(KP, KI, KD, s)
-    >>> pid
-    PIDController(1, 0.1, s, 0, s)
+    >>> pid = PIDController(KP, KI, KD, TF, s)
+    >>> print(pid)
+    PIDController(1, 0.1, 0.01, 0, s)
     >>> pid.doit() #Converts PIDController into TransferFunction
     TransferFunction(s*(0.01*s + 1) + 0.1, s, s)
     >>> pid.var

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1682,7 +1682,6 @@ def test_StateSpace_functions():
 def test_PIDControl():
     kp, ki, kd = symbols(['kp','ki','kd'])
     p1 = PIDController(kp, ki, kd,0, s)
-    p2 = PIDController(kp, 0, kd, 1, s)
     # Type Checking
     assert isinstance(p1, PIDController)
     assert isinstance(p1, TransferFunction)
@@ -1709,5 +1708,3 @@ def test_PIDControl():
     assert per1 == Parallel(PIDController(kp, ki, kd,0, s), TransferFunction(s, 1, s))
     assert ser1.doit() == TransferFunction(s*(ki + s*(kd*s + kp)), s, s)
     assert per1.doit() == TransferFunction(ki + s**2 + s*(kd*s + kp), s, s)
-
-

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -671,8 +671,8 @@ def hyperfocal_distance(f, N, c):
 def transverse_magnification(si, so):
     """
 
-    Calculates the transverse magnification, which is the ratio of the
-    image size to the object size.
+    Calculates the transverse magnification upon reflection in a mirror,
+    which is the ratio of the image size to the object size.
 
     Parameters
     ==========

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1805,6 +1805,13 @@ def sdm_rref_den(A, K):
         Aij = Ai[j]
         return ({0: Ai.copy()}, Aij, [j])
 
+    # For inexact domains like RR[x] we use quo and discard the remainder.
+    # Maybe it would be better for K.exquo to do this automatically.
+    if K.is_Exact:
+        exquo = K.exquo
+    else:
+        exquo = K.quo
+
     # Make sure we have the rows in order to make this deterministic from the
     # outset.
     _, rows_in_order = zip(*sorted(A.items()))
@@ -1901,7 +1908,7 @@ def sdm_rref_den(A, K):
                 for l, Akl in Ak.items():
                     Akl = Akl * Aij
                     if divisor is not None:
-                        Akl = K.exquo(Akl, divisor)
+                        Akl = exquo(Akl, divisor)
                     Ak[l] = Akl
                 continue
 
@@ -1912,19 +1919,19 @@ def sdm_rref_den(A, K):
             for l in Ai_nz - Ak_nz:
                 Ak[l] = - Akj * Ai[l]
                 if divisor is not None:
-                    Ak[l] = K.exquo(Ak[l], divisor)
+                    Ak[l] = exquo(Ak[l], divisor)
 
             # This loop also not needed in sdm_irref.
             for l in Ak_nz - Ai_nz:
                 Ak[l] = Aij * Ak[l]
                 if divisor is not None:
-                    Ak[l] = K.exquo(Ak[l], divisor)
+                    Ak[l] = exquo(Ak[l], divisor)
 
             for l in Ai_nz & Ak_nz:
                 Akl = Aij * Ak[l] - Akj * Ai[l]
                 if Akl:
                     if divisor is not None:
-                        Akl = K.exquo(Akl, divisor)
+                        Akl = exquo(Akl, divisor)
                     Ak[l] = Akl
                 else:
                     Ak.pop(l)
@@ -1948,7 +1955,7 @@ def sdm_rref_den(A, K):
                 denom *= Aij
 
         if divisor is not None:
-            denom = K.exquo(denom, divisor)
+            denom = exquo(denom, divisor)
 
         # Update the divisor.
         divisor = denom

--- a/sympy/polys/matrices/tests/test_inverse.py
+++ b/sympy/polys/matrices/tests/test_inverse.py
@@ -1,4 +1,4 @@
-from sympy import ZZ
+from sympy import ZZ, Matrix
 from sympy.polys.matrices import DM, DomainMatrix
 from sympy.polys.matrices.dense import ddm_iinv
 from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
@@ -6,6 +6,9 @@ from sympy.matrices.exceptions import NonInvertibleMatrixError
 
 import pytest
 from sympy.testing.pytest import raises
+from sympy.core.numbers import all_close
+
+from sympy.abc import x
 
 
 # Examples are given as adjugate matrix and determinant adj_det should match
@@ -151,3 +154,40 @@ def test_Matrix_adjugate(name, A, A_inv, den):
 @pytest.mark.parametrize('name, A, A_inv, den', INVERSE_EXAMPLES)
 def test_dm_adj_det(name, A, A_inv, den):
     assert A.adj_det() == (A_inv, den)
+
+
+def test_inverse_inexact():
+
+    M = Matrix([[x-0.3, -0.06, -0.22],
+                [-0.46, x-0.48, -0.41],
+                [-0.14, -0.39, x-0.64]])
+
+    Mn = Matrix([[1.0*x**2 - 1.12*x + 0.1473, 0.06*x + 0.0474, 0.22*x - 0.081],
+                 [0.46*x - 0.237, 1.0*x**2 - 0.94*x + 0.1612, 0.41*x - 0.0218],
+                 [0.14*x + 0.1122, 0.39*x - 0.1086, 1.0*x**2 - 0.78*x + 0.1164]])
+
+    d = 1.0*x**3 - 1.42*x**2 + 0.4249*x - 0.0546540000000002
+
+    Mi = Mn / d
+
+    M_dm = M.to_DM()
+    M_dmd = M_dm.to_dense()
+    M_dm_num, M_dm_den = M_dm.inv_den()
+    M_dmd_num, M_dmd_den = M_dmd.inv_den()
+
+    # XXX: We don't check M_dm().to_field().inv() which currently uses division
+    # and produces a more complicate result from gcd cancellation failing.
+    # DomainMatrix.inv() over RR(x) should be changed to clear denominators and
+    # use DomainMatrix.inv_den().
+
+    Minvs = [
+        M.inv(),
+        (M_dm_num.to_field() / M_dm_den).to_Matrix(),
+        (M_dmd_num.to_field() / M_dmd_den).to_Matrix(),
+        M_dm_num.to_Matrix() / M_dm_den.as_expr(),
+        M_dmd_num.to_Matrix() / M_dmd_den.as_expr(),
+    ]
+
+    for Minv in Minvs:
+        for Mi1, Mi2 in zip(Minv.flat(), Mi.flat()):
+            assert all_close(Mi2, Mi1)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -32,6 +32,8 @@ from sympy.series.limits import heuristics
 from sympy.series.order import Order
 from sympy.testing.pytest import XFAIL, raises
 
+from sympy import elliptic_e, elliptic_k
+
 from sympy.abc import x, y, z, k
 n = Symbol('n', integer=True, positive=True)
 
@@ -1402,3 +1404,11 @@ def test_issue_25847():
 
 def test_issue_26040():
     assert limit(besseli(0, x + 1)/besseli(0, x), x, oo) == S.Exp1
+
+
+def test_issue_26250():
+    e = elliptic_e(4*x/(x**2 + 2*x + 1))
+    k = elliptic_k(4*x/(x**2 + 2*x + 1))
+    e1 = ((1-3*x**2)*e**2/2 - (x**2-2*x+1)*e*k/2)
+    e2 = pi**2*(x**8 - 2*x**7 - x**6 + 4*x**5 - x**4 - 2*x**3 + x**2)
+    assert limit(e1/e2, x, 0) == -S(1)/8


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes: https://github.com/sympy/sympy/issues/26163
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Introduced a PIDController class in the control module to simplify the creation and manipulation of PID controllers in control systems. This class allows users to define PID controllers by specifying proportional (KP), integral (KI), derivative (KD) gains and Derivative filter time constant (TD).


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Introduced the PIDController class in the control module.
<!-- END RELEASE NOTES -->