### PR TITLE
PIDController class was added to physics.control.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -213,8 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
-Abhishek Kumar <abhishek.nitdelhi@gmail.com>
-ABHISHEK KUMAR <140839576+abhiphile@users.noreply.github.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com> ABHISHEK KUMAR <140839576+abhiphile@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -214,6 +214,7 @@ Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
 Abhishek Kumar <abhishek.nitdelhi@gmail.com>
+ABHISHEK KUMAR <140839576+abhiphile@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -20,7 +20,7 @@ from sympy.functions.elementary.trigonometric import sin
 
 from sympy.testing.pytest import SKIP
 
-a, b, c, x, y, z = symbols('a,b,c,x,y,z')
+a, b, c, x, y, z, s = symbols('a,b,c,x,y,z,s')
 
 
 whitelist = [
@@ -4265,6 +4265,21 @@ def test_sympy__physics__control__lti__Series():
     tf1 = TransferFunction(x**2 - y**3, y - z, x)
     tf2 = TransferFunction(y - x, z + y, x)
     assert _test_args(Series(tf1, tf2))
+
+
+def _test_args_PIDController(obj):
+    from sympy.physics.control.lti import PIDController
+    if isinstance(obj, PIDController):
+        KP, KI, KD, TF = obj.KP, obj.KI, obj.KD, obj.TF
+        recreated_pid = PIDController(KP, KI, KD, TF, s)
+        return recreated_pid == obj
+    return False
+
+
+def test_sympy__physics__control__lti__PIDController():
+    from sympy.physics.control.lti import PIDController
+    KP, KI, KD, TF = 1, 0.1, 0.01, 0
+    assert _test_args_PIDController(PIDController(KP, KI, KD, TF, s))
 
 
 def test_sympy__physics__control__lti__MIMOSeries():

--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -1,4 +1,4 @@
-from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
+from .lti import (TransferFunction, Series, MIMOSeries, Parallel, PIDController, MIMOParallel,
     Feedback, MIMOFeedback, TransferFunctionMatrix, StateSpace, gbt, bilinear, forward_diff,
     backward_diff, phase_margin, gain_margin)
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
@@ -6,8 +6,8 @@ from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_respo
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
     bode_phase_plot, bode_plot)
 
-__all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
-    'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'StateSpace',
+__all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel', 'MIMOParallel', 'Feedback',
+    'MIMOFeedback', 'TransferFunctionMatrix', 'StateSpace', 'PIDController',
     'gbt', 'bilinear', 'forward_diff', 'backward_diff', 'phase_margin', 'gain_margin',
     'pole_zero_numerical_data', 'pole_zero_plot', 'step_response_numerical_data',
     'step_response_plot', 'impulse_response_numerical_data', 'impulse_response_plot',

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4297,7 +4297,10 @@ class PIDController(TransferFunction):
     1
     """
 
-    def __new__(cls, KP = None, KI = None, KD = None, TF = None, var):
+    def __new__(cls, KP = None, KI = None, KD = None, TF = None, var = None):
+        if var is None:
+            raise ValueError("var should not be None")
+
         if not isinstance(var, Symbol):
             raise ValueError("var must be a Symbol")
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4263,3 +4263,134 @@ class StateSpace(LinearTimeInvariant):
 
         """
         return self.controllability_matrix().rank() == self.num_states
+
+class PIDController(TransferFunction):
+    """
+    A PID Controller class that uses Parallel connection to combine the P, I, and D components.
+    Parameters
+    ==========
+    KP : Expr, Number
+        Proportional gain.
+    KI : Expr, Number
+        Integral gain.
+    KD : Expr, Number
+        Derivative gain.
+    TP : Expr, Number
+        Derivative filter time constant
+    s : Symbol
+        The complex frequency variable.
+    Examples
+    ========
+    >>> from sympy.abc import s
+    >>> from sympy.physics.control.lti import PIDController
+    >>> KP, KI, KD, TF = 1, 0.1, 0.01, 0
+    >>> pid = PIDController(KP, KI, KD, TF, s)
+    >>> print(pid)
+    PIDController(1, 0.1, 0.01, 0, s)
+    >>> pid.doit() #Converts PIDController into TransferFunction
+    TransferFunction(s*(0.01*s + 1) + 0.1, s, s)
+    >>> pid.var
+    s
+    >>> pid.KP
+    1
+    """
+    def __new__(cls, KP, KI, KD, TF, var):
+        if not isinstance(var, Symbol):
+            raise ValueError("var must be a Symbol")
+
+        if not (KP or KI or  KD):
+            raise ValueError("All KP, KI & KD should not be None")
+
+        if(TF is None):
+            TF = S.Zero
+        if(KP is None):
+            KP = S.Zero
+        if(KI is None):
+            KI = S.Zero
+        if (KD is None):
+            KD = S.Zero
+
+        KP = _sympify(KP)
+        KI = _sympify(KI)
+        KD = _sympify(KD)
+        TF = _sympify(TF)
+
+        P = TransferFunction(KP, 1, var)
+        I = TransferFunction(KI, var, var)
+        D = TransferFunction(KD * var, S.One+TF*var, var)
+
+        pid_controller = Parallel(P, I, D)
+
+        tf = pid_controller.doit()
+
+        numerator = tf.num
+        denominator = tf.den
+
+        instance = super(PIDController, cls).__new__(cls,numerator,denominator,var)
+        instance._num = tf.num
+        instance._den = tf.den
+
+        return instance
+    def __init__(self, KP, KI, KD, TF, var):
+        """
+        Initialise the PID instance
+        """
+        self._KP = KP
+        self._KI = KI
+        self._KD = KD
+        self._TF = TF
+
+    def __str__(self):
+        return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
+    def __repr__(self):
+        return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
+    @property
+    def KP(self):
+        """
+        Get the Proportional (KP) gain of the PIDController.
+        Returns
+        -------
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._KP
+
+    @property
+    def KI(self):
+        """
+        Get the Proportional Integral (KI) gain of the PIDController.
+        Returns
+        =======
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._KI
+    @property
+    def KD(self):
+        """
+        Get the Proportional Derivative(P) gain of the PIDController.
+        Returns
+        =======
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._KD
+    @property
+    def TF(self):
+        """
+        Get the Derivative filter time constant (TP) of the PIDController.
+        Returns
+        =======
+        Expr, Number
+            The Proportional gain.
+        """
+        return self._TF
+    def doit(self):
+        """
+        Convert the PIDController into a TransferFunction.
+        Returns
+        =======
+        TransferFunction
+            A TransferFunction representing the PIDController.
+        """
+        return TransferFunction(self._num, self._den, self.var)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4267,6 +4267,7 @@ class StateSpace(LinearTimeInvariant):
 class PIDController(TransferFunction):
     """
     A PID Controller class that uses Parallel connection to combine the P, I, and D components.
+
     Parameters
     ==========
     KP : Expr, Number
@@ -4279,7 +4280,6 @@ class PIDController(TransferFunction):
         Derivative filter time constant
     s : Symbol
         The complex frequency variable.
-
 
     Examples
     ========

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4296,7 +4296,8 @@ class PIDController(TransferFunction):
     >>> pid.KP
     1
     """
-    def __new__(cls, KP, KI, KD, TF, var):
+
+    def __new__(cls, KP = None, KI = None, KD = None, TF = None, var):
         if not isinstance(var, Symbol):
             raise ValueError("var must be a Symbol")
 
@@ -4333,6 +4334,7 @@ class PIDController(TransferFunction):
         instance._den = tf.den
 
         return instance
+
     def __init__(self, KP, KI, KD, TF, var):
         """
         Initialise the PID instance
@@ -4344,8 +4346,10 @@ class PIDController(TransferFunction):
 
     def __str__(self):
         return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
+
     def __repr__(self):
         return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
+
     @property
     def KP(self):
         """
@@ -4367,6 +4371,7 @@ class PIDController(TransferFunction):
             The Proportional gain.
         """
         return self._KI
+
     @property
     def KD(self):
         """
@@ -4377,6 +4382,7 @@ class PIDController(TransferFunction):
             The Proportional gain.
         """
         return self._KD
+
     @property
     def TF(self):
         """
@@ -4387,6 +4393,7 @@ class PIDController(TransferFunction):
             The Proportional gain.
         """
         return self._TF
+
     def doit(self):
         """
         Convert the PIDController into a TransferFunction.

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4357,6 +4357,7 @@ class PIDController(TransferFunction):
     def KP(self):
         """
         Get the Proportional (KP) gain of the PIDController.
+
         Returns
         -------
         Expr, Number
@@ -4368,6 +4369,7 @@ class PIDController(TransferFunction):
     def KI(self):
         """
         Get the Proportional Integral (KI) gain of the PIDController.
+
         Returns
         =======
         Expr, Number
@@ -4379,6 +4381,7 @@ class PIDController(TransferFunction):
     def KD(self):
         """
         Get the Proportional Derivative(P) gain of the PIDController.
+
         Returns
         =======
         Expr, Number
@@ -4390,6 +4393,7 @@ class PIDController(TransferFunction):
     def TF(self):
         """
         Get the Derivative filter time constant (TP) of the PIDController.
+
         Returns
         =======
         Expr, Number
@@ -4400,6 +4404,7 @@ class PIDController(TransferFunction):
     def doit(self):
         """
         Convert the PIDController into a TransferFunction.
+
         Returns
         =======
         TransferFunction

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4332,7 +4332,7 @@ class PIDController(TransferFunction):
         numerator = tf.num
         denominator = tf.den
 
-        instance = super(PIDController, cls).__new__(cls,numerator,denominator,var)
+        instance = super(PIDController, cls).__new__(cls, numerator, denominator, var)
         instance._num = tf.num
         instance._den = tf.den
         instance._KP, instance._KI, instance._KD = KP, KI, KD
@@ -4350,11 +4350,6 @@ class PIDController(TransferFunction):
     def KP(self):
         """
         Get the Proportional (KP) gain of the PIDController.
-
-        Returns
-        =======
-        Expr, Number
-            The Proportional gain.
         """
         return self._KP
 
@@ -4362,11 +4357,6 @@ class PIDController(TransferFunction):
     def KI(self):
         """
         Get the Proportional Integral (KI) gain of the PIDController.
-
-        Returns
-        =======
-        Expr, Number
-            The Proportional gain.
         """
         return self._KI
 
@@ -4374,11 +4364,6 @@ class PIDController(TransferFunction):
     def KD(self):
         """
         Get the Proportional Derivative(P) gain of the PIDController.
-
-        Returns
-        =======
-        Expr, Number
-            The Proportional gain.
         """
         return self._KD
 
@@ -4386,21 +4371,11 @@ class PIDController(TransferFunction):
     def TF(self):
         """
         Get the Derivative filter time constant (TP) of the PIDController.
-
-        Returns
-        =======
-        Expr, Number
-            The Proportional gain.
         """
         return self._TF
 
     def doit(self):
         """
         Convert the PIDController into a TransferFunction.
-
-        Returns
-        =======
-        TransferFunction
-            A TransferFunction representing the PIDController.
         """
         return TransferFunction(self._num, self._den, self.var)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4279,6 +4279,8 @@ class PIDController(TransferFunction):
         Derivative filter time constant
     s : Symbol
         The complex frequency variable.
+
+
     Examples
     ========
     >>> from sympy.abc import s

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4335,17 +4335,10 @@ class PIDController(TransferFunction):
         instance = super(PIDController, cls).__new__(cls,numerator,denominator,var)
         instance._num = tf.num
         instance._den = tf.den
+        instance._KP, instance._KI, instance._KD = KP, KI, KD
+        instance._TF = TF
 
         return instance
-
-    def __init__(self, KP, KI, KD, TF, var):
-        """
-        Initialise the PID instance
-        """
-        self._KP = KP
-        self._KI = KI
-        self._KD = KD
-        self._TF = TF
 
     def __str__(self):
         return f'PIDController({self._KP}, {self._KI}, {self._KD}, {self._TF}, {self.var})'
@@ -4359,7 +4352,7 @@ class PIDController(TransferFunction):
         Get the Proportional (KP) gain of the PIDController.
 
         Returns
-        -------
+        =======
         Expr, Number
             The Proportional gain.
         """

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4275,7 +4275,7 @@ class PIDController(TransferFunction):
         Integral gain.
     KD : Expr, Number
         Derivative gain.
-    TP : Expr, Number
+    TF : Expr, Number
         Derivative filter time constant
     s : Symbol
         The complex frequency variable.

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1682,7 +1682,7 @@ def test_StateSpace_functions():
 
 
 def test_PIDControl():
-    kp, ki, kd = symbols(['kp','ki','kd'])
+    kp, ki, kd = symbols(['kp', 'ki', 'kd'])
     p1 = PIDController(kp, ki, kd,0, s)
     # Type Checking
     assert isinstance(p1, PIDController)
@@ -1702,9 +1702,9 @@ def test_PIDControl():
     assert p1.to_expr().expand() == kd*s + ki/s + kp
 
     #Using PIDController with TransferFunctions
-    tf1 = TransferFunction(s,1,s)
+    tf1 = TransferFunction(s,1, s)
     #Series combination and Parallel combination with TransferFunction
-    ser1 = Series(p1,tf1)
+    ser1 = Series(p1, tf1)
     per1 = Parallel(p1, tf1)
     assert ser1 == Series(PIDController(kp, ki, kd,0, s), TransferFunction(s, 1, s))
     assert per1 == Parallel(PIDController(kp, ki, kd,0, s), TransferFunction(s, 1, s))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -15,7 +15,7 @@ from sympy.simplify.simplify import simplify
 from sympy.core.containers import Tuple
 from sympy.matrices import ImmutableMatrix, Matrix, ShapeError
 from sympy.physics.control import (TransferFunction, Series, Parallel,
-    Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback,
+    Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback, PIDController,
     StateSpace, gbt, bilinear, forward_diff, backward_diff, phase_margin, gain_margin)
 from sympy.testing.pytest import raises
 
@@ -1679,3 +1679,34 @@ def test_StateSpace_functions():
     assert ss3.input_matrix == Matrix([[0, 0], [1, 0], [0, 1], [0, 0]])
     assert ss3.output_matrix == Matrix([[0, 1, 0, 0], [0, 0, 1, 0]])
     assert ss3.feedforward_matrix == Matrix([[0, 0], [0, 1]])
+
+
+def test_PIDControl():
+    kp, ki, kd = symbols(['kp','ki','kd'])
+    p1 = PIDController(kp, ki, kd,0, s)
+    # Type Checking
+    assert isinstance(p1, PIDController)
+    assert isinstance(p1, TransferFunction)
+
+    # Properties checking
+    assert p1 == PIDController(kp, ki, kd, 0, s)
+    assert p1.var == s
+    assert p1.num == ki + s*(kd*s + kp)
+    assert p1.den == s
+    assert p1.KP == kp
+    assert p1.KI == ki
+    assert p1.KD == kd
+
+    #Functionality Checking
+    assert p1.doit() == TransferFunction(ki + s*(kd*s + kp), s, s)
+    assert p1.to_expr().expand() == kd*s + ki/s + kp
+
+    #Using PIDController with TransferFunctions
+    tf1 = TransferFunction(s,1,s)
+    #Series combination and Parallel combination with TransferFunction
+    ser1 = Series(p1,tf1)
+    per1 = Parallel(p1, tf1)
+    assert ser1 == Series(PIDController(kp, ki, kd,0, s), TransferFunction(s, 1, s))
+    assert per1 == Parallel(PIDController(kp, ki, kd,0, s), TransferFunction(s, 1, s))
+    assert ser1.doit() == TransferFunction(s*(ki + s*(kd*s + kp)), s, s)
+    assert per1.doit() == TransferFunction(ki + s**2 + s*(kd*s + kp), s, s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes: https://github.com/sympy/sympy/issues/26163
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Introduced a PIDController class in the control module to simplify the creation and manipulation of PID controllers in control systems. This class allows users to define PID controllers by specifying proportional (kp), integral (ki), derivative (kd) gains and Derivative filter time constant (td).


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Introduced the PIDController class in the control module.
<!-- END RELEASE NOTES -->