### PR TITLE
Obtaining reaction loads from apply_support

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1119,6 +1119,7 @@ Prateek Papriwal <papriwalprateek@gmail.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>
+Prey Patel <patel.prey@iitgn.ac.in>
 Priit Laes <plaes@plaes.org>
 Prince Gupta <codemastercpp@gmail.com> LAPTOP-AS1M2R8B\codem <codemastercpp@gmail.com>
 Prionti Nasir <pdn3628@rit.edu>

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -406,7 +406,7 @@ class Beam:
             new_beam._hinge_position = self.length
             return new_beam
 
-    def apply_support(self, loc, type="fixed"):
+    def apply_support(self, loc, type="fixed", return_ = False):
         """
         This method applies support to a particular beam object.
 
@@ -466,6 +466,9 @@ class Beam:
             self._support_as_loads.append((reaction_moment, loc, -2, None))
 
         self._support_as_loads.append((reaction_load, loc, -1, None))
+
+        if not return_:
+            return
 
         if type in ("pin", "roller"):
             return reaction_load

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -469,7 +469,6 @@ class Beam:
 
         if not return_:
             return
-
         if type in ("pin", "roller"):
             return reaction_load
         else:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -467,6 +467,11 @@ class Beam:
 
         self._support_as_loads.append((reaction_load, loc, -1, None))
 
+        if type in ("pin", "roller"):
+            return reaction_load
+        else:
+            return reaction_load, reaction_moment
+
     def apply_load(self, value, start, order, end=None):
         """
         This method adds up the loads given to a particular beam object.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #21660
Fixes #24322

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The `apply_support()` method will now return reaction loads which can letter be used for `solve_for_reaction_loads()`.

#### Other comments
Previous method to apply supports and solve for reaction forces.
```
from sympy.physics.continuum_mechanics.beam import Beam
from sympy import symbols
E, I = symbols('E, I')
b = Beam(20, E, I)
b.apply_support(5, 'roller')    #reaction load will be R_5
b.apply_support(20, 'fixed')    #reaction loads will be R_20 and reaction moment will be M_20
b.apply_support(7.5, 'pin')     #reaction load will be R_7.50000000000000
b.apply_load(-8, 0, -1)
b.apply_load(120, 10, -2)
R_5, R_20, M_20, R_loc = symbols('R_5, R_20, M_20, R_7.50000000000000')

b.solve_for_reaction_loads(R_5, R_20, M_20, R_loc)
print(b.reaction_loads)

>>{R_5: 13.5578947368421, R_20: 10.6913684210526, M_20: 39.7473684210527, R_7.50000000000000: -16.2492631578947}
```

Updated method to apply supports and solve for reaction forces.
```
from sympy.physics.continuum_mechanics.beam import Beam
from sympy import symbols
E, I = symbols('E, I')
b = Beam(20, E, I)
p0 = b.apply_support(5, 'roller', True)    # reaction load will be R_5 will be stored in p0
p1, m1 = b.apply_support(20, 'fixed', True)  # the `return_` argument specifies if reactions are required.
p2 = b.apply_support(7.5, 'pin', True)
b.apply_load(-8, 0, -1)
b.apply_load(120, 10, -2)

b.solve_for_reaction_loads(p0, p1, m1, p2)  # we don't need to initialize symbols for reactions
print(b.reaction_loads)
>>{R_5: 13.5578947368421, R_20: 10.6913684210526, M_20: 39.7473684210527, R_7.50000000000000: -16.2492631578947}

print(p0, b.reaction_loads[p0])
>>R_5 13.5578947368421
```

If the updated method is acceptable, we can simplify the process by no longer needing to create symbols for reactions. Instead, we can utilize a variable to store these reactions when apply_support() is called. I will proceed with modifying the docstring and removing the return_ argument if this approach aligns with the desired direction.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
