### PR TITLE
Adding aseries for modified bessel functions

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -595,10 +595,10 @@ class besseli(BesselBase):
         from sympy.series.order import Order
         point = args0[1]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
             s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(Rational(2*nu + 1, 2), k))/\
-                 ((2)**(k)*z**(Rational(2*k+1, 2))*factorial(k)) for k in range(n)] + [Order(1/z**(Rational(2*n+1, 2)), x)]
+            ((2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] + [Order(1/z**(Rational(2*n + 1, 2)), x)]
             return exp(z)/sqrt(2*pi) * (Add(*s))
 
         return super()._eval_aseries(n, args0, x, logx)
@@ -764,10 +764,10 @@ class besselk(BesselBase):
         from sympy.series.order import Order
         point = args0[1]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
-            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
-                Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] +[Order(1/z**(Rational(2*n + 1, 2)), x)]
+            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(Rational(2*nu + 1, 2), k))/\
+            ((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] +[Order(1/z**(Rational(2*n + 1, 2)), x)]
             return (exp(-z)*sqrt(pi/2))*Add(*s)
 
         return super()._eval_aseries(n, args0, x, logx)
@@ -2132,8 +2132,9 @@ class _besseli(Function):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
+        point = args0[1]
 
-        if args0[1] == S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
             l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
                     Rational(2*nu + 1, 2), k))/((2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]
@@ -2162,8 +2163,9 @@ class _besselk(Function):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
+        point = args0[1]
 
-        if args0[1] is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
             l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
                     Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -586,6 +586,19 @@ class besseli(BesselBase):
 
         return super(besseli, self)._eval_nseries(x, n, logx, cdir)
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+        nu, z = self.args
+        point = args0[1]
+
+        if point is S.Infinity:
+            s = [(RisingFactorial(S.Half-nu,k)*RisingFactorial(
+                S.Half+nu,k))/((2)**(k)*z**((2*k+1)/2)*factorial(k)) for k in range(n)] + [Order(1/z**((2*n+1)/2), x)]
+            return (exp(z)/sqrt((2*pi))) * Add(*s)
+
+        return super()._eval_aseries(n, args0, x, logx)
+
 
 class besselk(BesselBase):
     r"""
@@ -737,6 +750,19 @@ class besselk(BesselBase):
             return a + Add(*b) + Add(*c) # Order term comes from a
 
         return super(besselk, self)._eval_nseries(x, n, logx, cdir)
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+        nu, z = self.args
+        point = args0[1]
+
+        if point is S.Infinity:
+            s = [((RisingFactorial(S.Half - nu, k)*RisingFactorial(
+                S.Half + nu, k))/((-2)**(k)*z**((2*k+1)/2)*factorial(k))) for k in range(n)] +[Order(1/z**((2*n+1)/2), x)]
+            return ((exp(-z)*sqrt(pi/(2))) * Add(*s))
+
+        return super()._eval_aseries(n, args0, x, logx)
 
 
 class hankel1(BesselBase):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -518,6 +518,10 @@ class besseli(BesselBase):
         if nu != nnu:
             return besseli(nnu, z)
 
+    def _eval_rewrite_as_tractable(self, nu, z, limitvar=None, **kwargs):
+        if z.is_extended_real:
+            return exp(z)*_besseli(nu, z)
+
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         return exp(-I*pi*nu/2)*besselj(nu, polar_lift(I)*z)
 
@@ -589,13 +593,13 @@ class besseli(BesselBase):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
-        nu, z = self.args
         point = args0[1]
 
         if point is S.Infinity:
-            s = [(RisingFactorial(S.Half-nu,k)*RisingFactorial(
-                S.Half+nu,k))/((2)**(k)*z**((2*k+1)/2)*factorial(k)) for k in range(n)] + [Order(1/z**((2*n+1)/2), x)]
-            return (exp(z)/sqrt((2*pi))) * Add(*s)
+            nu, z = self.args
+            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(Rational(2*nu + 1, 2), k))/\
+                 ((2)**(k)*z**(Rational(2*k+1, 2))*factorial(k)) for k in range(n)] + [Order(1/z**(Rational(2*n+1, 2)), x)]
+            return exp(z)/sqrt(2*pi) * (Add(*s))
 
         return super()._eval_aseries(n, args0, x, logx)
 
@@ -681,6 +685,10 @@ class besselk(BesselBase):
         if nu.is_integer and z.is_positive:
             return True
 
+    def _eval_rewrite_as_tractable(self, nu, z, limitvar=None, **kwargs):
+        if z.is_extended_real:
+            return exp(-z)*_besselk(nu, z)
+
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         nu, z = self.args
         try:
@@ -754,13 +762,13 @@ class besselk(BesselBase):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
-        nu, z = self.args
         point = args0[1]
 
         if point is S.Infinity:
-            s = [((RisingFactorial(S.Half - nu, k)*RisingFactorial(
-                S.Half + nu, k))/((-2)**(k)*z**((2*k+1)/2)*factorial(k))) for k in range(n)] +[Order(1/z**((2*n+1)/2), x)]
-            return ((exp(-z)*sqrt(pi/(2))) * Add(*s))
+            nu, z = self.args
+            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
+                Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] +[Order(1/z**(Rational(2*n + 1, 2)), x)]
+            return (exp(-z)*sqrt(pi/2))*Add(*s)
 
         return super()._eval_aseries(n, args0, x, logx)
 
@@ -2113,3 +2121,62 @@ class marcumq(Function):
     def _eval_is_zero(self):
         if all(arg.is_zero for arg in self.args):
             return True
+
+class _besseli(Function):
+    """
+    Helper function to make the $\\mathrm{besseli}(nu, z)$
+    function tractable for the Gruntz algorithm.
+
+    """
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+
+        if args0[1] == S.Infinity:
+            nu, z = self.args
+            l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
+                    Rational(2*nu + 1, 2), k))/((2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]
+            return sqrt(pi/(2))*(Add(*l)) + Order(1/z**(Rational(2*n + 1, 2)), x)
+
+        return super()._eval_aseries(n, args0, x, logx)
+
+    def _eval_rewrite_as_intractable(self, nu, z, **kwargs):
+        return exp(-z)*besseli(nu, z)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_intractable(*self.args)
+            return f._eval_nseries(x, n, logx)
+        return super()._eval_nseries(x, n, logx)
+
+
+class _besselk(Function):
+    """
+    Helper function to make the $\\mathrm{besselk}(nu, z)$
+    function tractable for the Gruntz algorithm.
+
+    """
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+
+        if args0[1] is S.Infinity:
+            nu, z = self.args
+            l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
+                    Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]
+            return sqrt(pi/(2))*(Add(*l)) + Order(1/z**(Rational(2*n + 1, 2)), x)
+
+        return super()._eval_aseries(n, args0, x, logx)
+
+    def _eval_rewrite_as_intractable(self,nu, z, **kwargs):
+        return exp(z)*besselk(nu, z)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_intractable(*self.args)
+            return f._eval_nseries(x, n, logx)
+        return super()._eval_nseries(x, n, logx)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -145,6 +145,8 @@ def test_besseli_series():
     #test for aseries
     assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(sqrt(1/x) - (1/x)**(S(3)/2)/8 - \
         3*(1/x)**(S(5)/2)/128 - 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(x)/(2*sqrt(pi))
+    assert besseli(0,x).series(x,-oo, n=4) == sqrt(2)*(sqrt(-1/x) - (-1/x)**(S(3)/2)/8 - 3*(-1/x)**(S(5)/2)/128 - \
+        15*(-1/x)**(S(7)/2)/1024 + O((-1/x)**(S(9)/2), (x, -oo)))*exp(-x)/(2*sqrt(pi))
 
 
 def test_besselk_series():
@@ -174,6 +176,9 @@ def test_besselk_series():
     #test for aseries
     assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(sqrt(1/x) + (1/x)**(S(3)/2)/8 - \
             3*(1/x)**(S(5)/2)/128 + 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(-x)/2
+    assert besselk(0,x).series(x, -oo, n=4) == sqrt(2)*sqrt(pi)*(-I*sqrt(-1/x) + I*(-1/x)**(S(3)/2)/8 + \
+            3*I*(-1/x)**(S(5)/2)/128 + 15*I*(-1/x)**(S(7)/2)/1024 + O((-1/x)**(S(9)/2), (x, -oo)))*exp(-x)/2
+
 
 
 def test_diff():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -142,6 +142,10 @@ def test_besseli_series():
         x**(S(7)/2)/144 + x**(S(9)/2)/2880 + x**(S(11)/2)/86400 + O(x**6)
     assert besseli(-2, sin(x)).series(x, n=4) == besseli(2, sin(x)).series(x, n=4)
 
+    #test for aseries
+    assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(75*(1/x)**3.5/1024 + 9*(1/x)**2.5/128 + \
+    (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(x)/(2*sqrt(pi))
+
 
 def test_besselk_series():
     const = log(2) - S.EulerGamma - log(x)
@@ -166,6 +170,10 @@ def test_besselk_series():
         sqrt(x)*(log(x)/2 - S(1)/2 + S.EulerGamma) + x**(S(3)/2)*(log(x)/4 - S(5)/8 + \
         S.EulerGamma/2) + x**(S(5)/2)*(log(x)/24 - S(5)/36 + S.EulerGamma/12) + O(x**3*log(x))
     assert besselk(-2, sin(x)).series(x, n=4) == besselk(2, sin(x)).series(x, n=4)
+
+    #test for aseries
+    assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(-75*(1/x)**3.5/1024 + \
+    9*(1/x)**2.5/128 - (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(-x)/2
 
 
 def test_diff():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -143,8 +143,8 @@ def test_besseli_series():
     assert besseli(-2, sin(x)).series(x, n=4) == besseli(2, sin(x)).series(x, n=4)
 
     #test for aseries
-    assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(75*(1/x)**3.5/1024 + 9*(1/x)**2.5/128 + \
-    (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(x)/(2*sqrt(pi))
+    assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(sqrt(1/x) - (1/x)**(S(3)/2)/8 - \
+        3*(1/x)**(S(5)/2)/128 - 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(x)/(2*sqrt(pi))
 
 
 def test_besselk_series():
@@ -172,8 +172,8 @@ def test_besselk_series():
     assert besselk(-2, sin(x)).series(x, n=4) == besselk(2, sin(x)).series(x, n=4)
 
     #test for aseries
-    assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(-75*(1/x)**3.5/1024 + \
-    9*(1/x)**2.5/128 - (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(-x)/2
+    assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(sqrt(1/x) + (1/x)**(S(3)/2)/8 - \
+            3*(1/x)**(S(5)/2)/128 + 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(-x)/2
 
 
 def test_diff():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #26210
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* series
  * `_eval_aseries` method  was added for modified bessel functions.

<!-- END RELEASE NOTES -->
