### PR TITLE
Refactoring of `_special_diop_DN`

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2176,44 +2176,26 @@ def _special_diop_DN(D, N):
     #
     # assert (1 < N**2 < D) and (not integer_nthroot(D, 2)[1])
 
-    sqrt_D = sqrt(D)
-    F = [(N, 1)]
-    f = 2
-    while True:
-        f2 = f**2
-        if f2 > abs(N):
-            break
-        n, r = divmod(N, f2)
-        if r == 0:
-            F.append((n, f))
-        f += 1
-
+    sqrt_D = isqrt(D)
+    F = {N // f**2: f for f in divisors(square_factor(abs(N)), generator=True)}
     P = 0
     Q = 1
     G0, G1 = 0, 1
     B0, B1 = 1, 0
 
     solutions = []
-
-    i = 0
     while True:
-        a = floor((P + sqrt_D) / Q)
-        P = a*Q - P
-        Q = (D - P**2) // Q
-        G2 = a*G1 + G0
-        B2 = a*B1 + B0
-
-        for n, f in F:
-            if G2**2 - D*B2**2 == n:
-                solutions.append((f*G2, f*B2))
-
-        i += 1
-        if Q == 1 and i % 2 == 0:
+        for _ in range(2):
+            a = (P + sqrt_D) // Q
+            P = a*Q - P
+            Q = (D - P**2) // Q
+            G0, G1 = G1, a*G1 + G0
+            B0, B1 = B1, a*B1 + B0
+            if (s := G1**2 - D*B1**2) in F:
+                f = F[s]
+                solutions.append((f*G1, f*B1))
+        if Q == 1:
             break
-
-        G0, G1 = G1, G2
-        B0, B1 = B1, B2
-
     return solutions
 
 


### PR DESCRIPTION
The calculation of `F` has been changed to list comprehension and `factorint` is now used. Since prime factorization was being done by trial factoring, a speedup can be expected when `N` is large. Also, `F` was changed from list to dict. Obviously `N // f**2` will not overlap and there is no need to do a linear search.
The variable `i` has been removed; we only need to make a conditional decision on break once every two times, so we use a for statement.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
