### PR TITLE
Fix the _array_ methods to avoid deprecation warnings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1137,6 +1137,7 @@ Raghav Jajodia <jajodia.raghav@gmail.com>
 Rahil Hastu <rahilhastu@gmail.com> rahil hastu <rahilhastu@gmail.com>
 Rahil Parikh <r.parikh@somaiya.edu> rprkh <r.parikh@somaiya.edu>
 Raj <raj454raj@gmail.com>
+Raj Sapale <raj4sapale4@gmail.com>
 Rajat Aggarwal <rajataggarwal1975@gmail.com>
 Rajat Thakur <rajatthakur1997@gmail.com>
 Rajat Thakur <rajatthakur1997@gmail.com> <Rajat Thakur>

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -196,7 +196,9 @@ def test_Matrix_mul():
 
 def test_Matrix_array():
     class matarray:
-        def __array__(self):
+        def __array__(self, dtype=object, copy=None):
+            if copy is not None and not copy:
+                raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
             from numpy import array
             return array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     matarr = matarray()

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -388,7 +388,9 @@ class MatrixExpr(Expr):
         """
         return self.as_explicit().as_mutable()
 
-    def __array__(self):
+    def __array__(self, dtype=object, copy=None):
+        if copy is not None and not copy:
+            raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
         from numpy import empty
         a = empty(self.shape, dtype=object)
         for i in range(self.rows):

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3562,7 +3562,9 @@ class MatrixBase(Printable):
     def flat(self):
         return [self[i, j] for i in range(self.rows) for j in range(self.cols)]
 
-    def __array__(self, dtype=object):
+    def __array__(self, dtype=object, copy=None):
+        if copy is not None and not copy:
+            raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
         from .dense import matrix2numpy
         return matrix2numpy(self, dtype=dtype)
 


### PR DESCRIPTION
fixed #26302 

The signature of _array_ methods is changed to:
   def __array__(self, dtype=object, copy=None):
        if copy is not None and not copy:
            raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
        ...

as it is changed in the issue #25916

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

