### PR TITLE
Set LaTeX representation for several PhysicalConstant

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1175,6 +1175,7 @@ Rich LaSota <rjlasota@gmail.com>
 Richard Otis <richard.otis@outlook.com> <ovolve@users.noreply.github.com>
 Richard Otis <richard.otis@outlook.com> <richard.otis@jpl.nasa.gov>
 Rick Muller <rpmuller@gmail.com>
+Rickard Holmberg <rho@novatronfusion.com>
 Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
 Riley Britten <nrb1324@hotmail.com>
 Rimi <rimibis@umich.edu>

--- a/sympy/physics/units/definitions/unit_definitions.py
+++ b/sympy/physics/units/definitions/unit_definitions.py
@@ -257,43 +257,43 @@ elementary_charge = PhysicalConstant("elementary_charge", abbrev="e")
 planck = PhysicalConstant("planck", abbrev="h")
 
 # Reduced Planck constant
-hbar = PhysicalConstant("hbar", abbrev="hbar")
+hbar = PhysicalConstant("hbar", abbrev="hbar", latex_repr=r"\hbar")
 
 # Electronvolt
 eV = electronvolt = electronvolts = PhysicalConstant("electronvolt", abbrev="eV")
 
 # Avogadro number
-avogadro_number = PhysicalConstant("avogadro_number")
+avogadro_number = PhysicalConstant("avogadro_number", latex_repr="N_0")
 
 # Avogadro constant
-avogadro = avogadro_constant = PhysicalConstant("avogadro_constant")
+avogadro = avogadro_constant = PhysicalConstant("avogadro_constant", latex_repr="N_A")
 
 # Boltzmann constant
-boltzmann = boltzmann_constant = PhysicalConstant("boltzmann_constant")
+boltzmann = boltzmann_constant = PhysicalConstant("boltzmann_constant", latex_repr="k_B")
 
 # Stefan-Boltzmann constant
-stefan = stefan_boltzmann_constant = PhysicalConstant("stefan_boltzmann_constant")
+stefan = stefan_boltzmann_constant = PhysicalConstant("stefan_boltzmann_constant", latex_repr=r"\sigma")
 
 # Molar gas constant
 R = molar_gas_constant = PhysicalConstant("molar_gas_constant", abbrev="R")
 
 # Faraday constant
-faraday_constant = PhysicalConstant("faraday_constant")
+faraday_constant = PhysicalConstant("faraday_constant", latex_repr=r"\mathcal{F}")
 
 # Josephson constant
-josephson_constant = PhysicalConstant("josephson_constant", abbrev="K_j")
+josephson_constant = PhysicalConstant("josephson_constant", abbrev="K_j", latex_repr="K_j")
 
 # Von Klitzing constant
-von_klitzing_constant = PhysicalConstant("von_klitzing_constant", abbrev="R_k")
+von_klitzing_constant = PhysicalConstant("von_klitzing_constant", abbrev="R_k", latex_repr="R_k")
 
 # Acceleration due to gravity (on the Earth surface)
 gee = gees = acceleration_due_to_gravity = PhysicalConstant("acceleration_due_to_gravity", abbrev="g")
 
 # magnetic constant:
-u0 = magnetic_constant = vacuum_permeability = PhysicalConstant("magnetic_constant")
+u0 = magnetic_constant = vacuum_permeability = PhysicalConstant("magnetic_constant", latex_repr=r"\mu_0")
 
 # electric constat:
-e0 = electric_constant = vacuum_permittivity = PhysicalConstant("vacuum_permittivity")
+e0 = electric_constant = vacuum_permittivity = PhysicalConstant("vacuum_permittivity", latex_repr="\varepsilon_0")
 
 # vacuum impedance:
 Z0 = vacuum_impedance = PhysicalConstant("vacuum_impedance", abbrev='Z_0', latex_repr=r'Z_{0}')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #26309 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Several of the PhysicalConstants defined in sympy.physics.units.definitions.unit_definitions have very ugly default renderings in notebooks. This PR adds better default LaTeX representations for them.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
