### PR TITLE
[ODE]: piecewise_fold'ed solution for an ODE

### DIFF
--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -625,8 +625,8 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             retdict['best'] = min(list(retdict.values()), key=lambda x:
                 ode_sol_simplicity(x, func, trysolving=not simplify))
             if given_hint == 'best':
-            	rv = retdict['best']
-            	if rv.has(Piecewise):
+                rv = retdict['best']
+                if rv.has(Piecewise):
                     rv = piecewise_fold(rv)            	
                 return rv
             for i in orderedhints:
@@ -637,8 +637,8 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             retdict['order'] = gethints['order']
             retdict.update(failed_hints)
             for value in retdict.values():
-            	if value.has(Piecewise):
-            	    value = piecewise_fold(value)
+                if value.has(Piecewise):
+                    value = piecewise_fold(value)
             return retdict
 
         else:
@@ -646,7 +646,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             hint = hints['hint']
             rv = _helper_simplify(eq, hint, hints, simplify, ics=ics)
             if rv.has(Piecewise):
-            	rv = piecewise_fold(rv)            	            	
+                rv = piecewise_fold(rv)
             return rv
 
 

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -245,6 +245,7 @@ from sympy.logic.boolalg import (BooleanAtom, BooleanTrue,
                                 BooleanFalse)
 from sympy.functions import exp, log, sqrt
 from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
 from sympy.integrals.integrals import Integral
 from sympy.polys import (Poly, terms_gcd, PolynomialError, lcm)
 from sympy.polys.polytools import cancel
@@ -624,7 +625,10 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             retdict['best'] = min(list(retdict.values()), key=lambda x:
                 ode_sol_simplicity(x, func, trysolving=not simplify))
             if given_hint == 'best':
-                return retdict['best']
+            	rv = retdict['best']
+            	if rv.has(Piecewise):
+                    rv = piecewise_fold(rv)            	
+                return rv
             for i in orderedhints:
                 if retdict['best'] == retdict.get(i, None):
                     retdict['best_hint'] = i
@@ -632,12 +636,18 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             retdict['default'] = gethints['default']
             retdict['order'] = gethints['order']
             retdict.update(failed_hints)
+            for value in retdict.values():
+            	if value.has(Piecewise):
+            	    value = piecewise_fold(value)
             return retdict
 
         else:
             # The key 'hint' stores the hint needed to be solved for.
             hint = hints['hint']
-            return _helper_simplify(eq, hint, hints, simplify, ics=ics)
+            rv = _helper_simplify(eq, hint, hints, simplify, ics=ics)
+            if rv.has(Piecewise):
+            	rv = piecewise_fold(rv)            	            	
+            return rv
 
 
 def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix: #12623 

#### Brief description of what is fixed or changed
For the case pointed out in the issue's discussion thread, the dsolve() function was modified appropriately to return a piecewise_folded solution, in case it has a Piecewise object.
This is done for single equation ODE systems while returning a solution when a hint is given by the user and also when the ODE is solved for all possible hints given by classify_ode, which is when a dictionary is returned.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* solvers
  * corrected the format of output solution of dsolve which needs to be folded piecewise

<!-- END RELEASE NOTES -->
