### PR TITLE
maint(ci): add more tests for python-flint in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -239,7 +239,14 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint
       # Test the modules that most directly use python-flint
-      - run: pytest sympy/polys sympy/ntheory sympy/matrices
+      - run: pytest                    \
+                    sympy/crypto       \
+                    sympy/integrals    \
+                    sympy/holonomic    \
+                    sympy/matrices     \
+                    sympy/ntheory      \
+                    sympy/polys        \
+                    sympy/solvers      \
         env:
           SYMPY_GROUND_TYPES: flint
       - run: bin/doctest                                  \

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -250,20 +250,21 @@ jobs:
               sympy/solvers
         env:
           SYMPY_GROUND_TYPES: flint
-      - run: bin/doctest                                  \
-                    sympy/integrals                       \
-                    sympy/holonomic                       \
-                    sympy/matrices                        \
-                    sympy/ntheory                         \
-                    sympy/polys                           \
-                    sympy/printing                        \
-                    doc/src/modules/integrals             \
-                    doc/src/modules/holonomic             \
-                    doc/src/modules/matrices              \
-                    doc/src/modules/ntheory.rst           \
-                    doc/src/modules/polys                 \
-                    doc/src/modules/printing.rst          \
-                    doc/src/tutorials/intro-tutorial/     \
+      - run: >-
+          bin/doctest
+              sympy/integrals
+              sympy/holonomic
+              sympy/matrices
+              sympy/ntheory
+              sympy/polys
+              sympy/printing
+              doc/src/modules/integrals
+              doc/src/modules/holonomic
+              doc/src/modules/matrices
+              doc/src/modules/ntheory.rst
+              doc/src/modules/polys
+              doc/src/modules/printing.rst
+              doc/src/tutorials/intro-tutorial/
         env:
           SYMPY_GROUND_TYPES: flint
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -239,14 +239,15 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint
       # Test the modules that most directly use python-flint
-      - run: pytest                    \
-                    sympy/crypto       \
-                    sympy/integrals    \
-                    sympy/holonomic    \
-                    sympy/matrices     \
-                    sympy/ntheory      \
-                    sympy/polys        \
-                    sympy/solvers      \
+      - run: >-
+          pytest
+              sympy/crypto
+              sympy/integrals
+              sympy/holonomic
+              sympy/matrices
+              sympy/ntheory
+              sympy/polys
+              sympy/solvers
         env:
           SYMPY_GROUND_TYPES: flint
       - run: bin/doctest                                  \

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -241,30 +241,30 @@ jobs:
       # Test the modules that most directly use python-flint
       - run: >-
           pytest
-              sympy/crypto
-              sympy/integrals
-              sympy/holonomic
-              sympy/matrices
-              sympy/ntheory
-              sympy/polys
-              sympy/solvers
+          sympy/crypto
+          sympy/integrals
+          sympy/holonomic
+          sympy/matrices
+          sympy/ntheory
+          sympy/polys
+          sympy/solvers
         env:
           SYMPY_GROUND_TYPES: flint
       - run: >-
           bin/doctest
-              sympy/integrals
-              sympy/holonomic
-              sympy/matrices
-              sympy/ntheory
-              sympy/polys
-              sympy/printing
-              doc/src/modules/integrals
-              doc/src/modules/holonomic
-              doc/src/modules/matrices
-              doc/src/modules/ntheory.rst
-              doc/src/modules/polys
-              doc/src/modules/printing.rst
-              doc/src/tutorials/intro-tutorial/
+          sympy/integrals
+          sympy/holonomic
+          sympy/matrices
+          sympy/ntheory
+          sympy/polys
+          sympy/printing
+          doc/src/modules/integrals
+          doc/src/modules/holonomic
+          doc/src/modules/matrices
+          doc/src/modules/ntheory.rst
+          doc/src/modules/polys
+          doc/src/modules/printing.rst
+          doc/src/tutorials/intro-tutorial/
         env:
           SYMPY_GROUND_TYPES: flint
 

--- a/doc/src/modules/polys/domainsintro.rst
+++ b/doc/src/modules/polys/domainsintro.rst
@@ -300,7 +300,7 @@ might give a ``float`` which is not an element of :ref:`ZZ`::
 
 The behaviour of ``/`` for non-fields can also differ for different
 implementations of the ground types of the domain. For example with
-`SYMPY_GROUND_TYPES=flint` dividing two elements of :ref:`ZZ` will raise an
+``SYMPY_GROUND_TYPES=flint`` dividing two elements of :ref:`ZZ` will raise an
 error rather than return a float::
 
    >>> z1 / z1  # doctest: +SKIP
@@ -573,11 +573,11 @@ finite field of prime order `p` can be constructed with :ref:`GF(p)`::
   >>> from sympy import GF
   >>> K = GF(5)
   >>> two = K(2)
-  >>> two
+  >>> two #doctest: +SKIP
   2 mod 5
-  >>> two ** 2
+  >>> two ** 2A #doctest: +SKIP
   4 mod 5
-  >>> two ** 3
+  >>> two ** 3 #doctest: +SKIP
   3 mod 5
 
 There is also ``FF`` as an alias for ``GF`` (standing for "finite field" and
@@ -593,7 +593,7 @@ a field. It is just the integers modulo ``6`` or ``9`` and therefore has zero
 divisors and non-invertible elements::
 
   >>> K = GF(6)
-  >>> K(3) * K(2)
+  >>> K(3) * K(2) #doctest: +SKIP
   0 mod 6
 
 It would be good to have a proper implementation of prime-power order finite

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2373,7 +2373,7 @@ def lfsr_sequence(key, fill, n):
         raise TypeError("key must be a list")
     if not isinstance(fill, list):
         raise TypeError("fill must be a list")
-    p = key[0].mod
+    p = key[0].modulus()
     F = FF(p)
     s = fill
     k = len(fill)
@@ -2494,7 +2494,7 @@ def lfsr_connection_polynomial(s):
 
     """
     # Initialization:
-    p = s[0].mod
+    p = s[0].modulus()
     x = Symbol("x")
     C = 1*x**0
     B = 1*x**0

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -32,6 +32,7 @@ from sympy.polys.domains import FF
 from sympy.polys.polytools import Poly
 from sympy.utilities.misc import as_int, filldedent, translate
 from sympy.utilities.iterables import uniq, multiset
+from sympy.utilities.decorator import doctest_depends_on
 
 
 class NonInvertibleCipherWarning(RuntimeWarning):
@@ -2284,6 +2285,7 @@ def decode_morse(msg, sep='|', mapping=None):
 #################### LFSRs  ##########################################
 
 
+@doctest_depends_on(ground_types=['python', 'gmpy'])
 def lfsr_sequence(key, fill, n):
     r"""
     This function creates an LFSR sequence.

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -860,26 +860,18 @@ def as_poly_1t(p, t, z):
         # Either way, if you see this (from the Risch Algorithm) it indicates
         # a bug.
         raise PolynomialError("%s is not an element of K[%s, 1/%s]." % (p, t, t))
-    d = pd.degree(t)
-    one_t_part = pa.slice(0, d + 1)
-    r = pd.degree() - pa.degree()
-    t_part = pa - one_t_part
-    try:
-        t_part = t_part.to_field().exquo(pd)
-    except DomainError as e:
-        # issue 4950
-        raise NotImplementedError(e)
-    # Compute the negative degree parts.
-    one_t_part = Poly.from_list(reversed(one_t_part.rep.to_list()), *one_t_part.gens,
-        domain=one_t_part.domain)
-    if 0 < r < oo:
-        one_t_part *= Poly(t**r, t)
 
-    one_t_part = one_t_part.replace(t, z)  # z will be 1/t
-    if pd.nth(d):
-        one_t_part *= Poly(1/pd.nth(d), z, expand=False)
-    ans = t_part.as_poly(t, z, expand=False) + one_t_part.as_poly(t, z,
-        expand=False)
+    t_part, remainder = pa.div(pd)
+
+    ans = t_part.as_poly(t, z, expand=False)
+
+    if remainder:
+        one = remainder.one
+        tp = t*one
+        r = pd.degree() - remainder.degree()
+        z_part = remainder.transform(one, tp) * tp**r
+        z_part = z_part.replace(t, z).to_field().quo_ground(pd.LC())
+        ans += z_part.as_poly(t, z, expand=False)
 
     return ans
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -29,7 +29,7 @@ from functools import reduce
 from sympy.core.function import Lambda
 from sympy.core.mul import Mul
 from sympy.core.intfunc import ilcm
-from sympy.core.numbers import I, oo
+from sympy.core.numbers import I
 from sympy.core.power import Pow
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
@@ -43,7 +43,7 @@ from sympy.functions.elementary.trigonometric import (atan, sin, cos,
     tan, acot, cot, asin, acos)
 from .integrals import integrate, Integral
 from .heurisch import _symbols
-from sympy.polys.polyerrors import DomainError, PolynomialError
+from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
     reduced)
 from sympy.polys.rootoftools import RootSum

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1827,6 +1827,9 @@ def dup_slice(f, m, n, K):
 
     f = f[N:M]
 
+    while f and f[0] == K.zero:
+        f.pop(0)
+
     if not f:
         return []
     else:

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -1,6 +1,7 @@
 """Implementation of :class:`FiniteField` class. """
 
 from sympy.external.gmpy import GROUND_TYPES
+from sympy.utilities.decorator import doctest_depends_on
 
 from sympy.core.numbers import int_valued
 from sympy.polys.domains.field import Field
@@ -50,6 +51,7 @@ def _modular_int_factory(mod, dom, symmetric, self):
 
 
 @public
+@doctest_depends_on(modules=['python', 'gmpy'])
 class FiniteField(Field, SimpleDomain):
     r"""Finite field of prime order :ref:`GF(p)`
 

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -29,6 +29,9 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         else:
             self.val = self.dom.convert(val) % self.mod
 
+    def modulus(self):
+        return self.mod
+
     def __hash__(self):
         return hash((self.val, self.mod))
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -674,7 +674,7 @@ def dup_zz_factor(f, K):
         f_flint = fmpz_poly(f[::-1])
         cont, factors = f_flint.factor()
         factors = [(fac.coeffs()[::-1], exp) for fac, exp in factors]
-        return cont, factors
+        return cont, _sort_factors(factors)
 
     cont, g = dup_primitive(f, K)
 

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -273,8 +273,8 @@ class DomainMatrix:
         self.domain = rep.domain
         return self
 
-    @doctest_depends_on(ground_types=['python', 'gmpy'])
     @classmethod
+    @doctest_depends_on(ground_types=['python', 'gmpy'])
     def from_list(cls, rows, domain):
         r"""
         Convert a list of lists into a DomainMatrix

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -273,6 +273,7 @@ class DomainMatrix:
         self.domain = rep.domain
         return self
 
+    @doctest_depends_on(ground_types=['python', 'gmpy'])
     @classmethod
     def from_list(cls, rows, domain):
         r"""

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2136,7 +2136,7 @@ class DUP_Flint(DMP):
         elif f_neg:
             cF, F = -cF, F.neg()
         elif g_neg:
-            cG, G = -cG, G.neg()
+            cF, G = -cF, G.neg()
 
         return cF, cG, F, G
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2109,7 +2109,9 @@ class DUP_Flint(DMP):
 
         l = f._mul(g)._exquo(f._gcd(g))
 
-        if l.LC() < 0:
+        if l.dom.is_Field:
+            l = l.monic()
+        elif l.LC() < 0:
             l = l.neg()
 
         return l

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1949,9 +1949,9 @@ class DUP_Flint(DMP):
         """Polynomial exact pseudo-quotient of ``f`` and ``g``. """
         d = f.degree() - g.degree() + 1
         q, r = divmod(g.LC()**d * f._rep, g._rep)
-        if not r:
+        if r:
             raise ExactQuotientFailed(f, g)
-        return q
+        return f.from_rep(q, f.dom)
 
     def _div(f, g):
         """Polynomial division with remainder of ``f`` and ``g``. """

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1955,8 +1955,13 @@ class DUP_Flint(DMP):
 
     def _div(f, g):
         """Polynomial division with remainder of ``f`` and ``g``. """
-        q, r = divmod(f._rep, g._rep)
-        return f.from_rep(q, f.dom), f.from_rep(r, f.dom)
+        if f.dom.is_Field:
+            q, r = divmod(f._rep, g._rep)
+            return f.from_rep(q, f.dom), f.from_rep(r, f.dom)
+        else:
+            # XXX: python-flint defines division in ZZ[x] differently
+            q, r = f.to_DMP_Python()._div(g.to_DMP_Python())
+            return q.to_DUP_Flint(), r.to_DUP_Flint()
 
     def _rem(f, g):
         """Computes polynomial remainder of ``f`` and ``g``. """

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -703,6 +703,10 @@ def test_dup_slice():
 
     assert dup_slice([1, 2], 0, 3, ZZ) == [1, 2]
 
+    g = [1, 0, 0, 2]
+
+    assert dup_slice(g, 0, 3, ZZ) == [2]
+
 
 def test_dup_random():
     f = dup_random(0, -10, 10, ZZ)

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -162,6 +162,30 @@ def test_DMP_arithmetics():
 
     raises(ExactQuotientFailed, lambda: f.exquo(g))
 
+    f = DMP([ZZ(1), ZZ(0), ZZ(-1)], ZZ)
+    g = DMP([ZZ(2), ZZ(-2)], ZZ)
+
+    q = DMP([], ZZ)
+    r = f
+
+    pq = DMP([ZZ(2), ZZ(2)], ZZ)
+    pr = DMP([], ZZ)
+
+    assert f.div(g) == (q, r)
+    assert f.quo(g) == q
+    assert f.rem(g) == r
+
+    assert divmod(f, g) == (q, r)
+    assert f // g == q
+    assert f % g == r
+
+    raises(ExactQuotientFailed, lambda: f.exquo(g))
+
+    assert f.pdiv(g) == (pq, pr)
+    assert f.pquo(g) == pq
+    assert f.prem(g) == pr
+    assert f.pexquo(g) == pq
+
 
 def test_DMP_functionality():
     f = DMP([[ZZ(1)], [ZZ(2), ZZ(0)], [ZZ(1), ZZ(0), ZZ(0)]], ZZ)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1007,6 +1007,10 @@ def test_Poly_slice():
     assert f.slice(x, 0, 3) == Poly(2*x**2 + 3*x + 4, x)
     assert f.slice(x, 0, 4) == Poly(x**3 + 2*x**2 + 3*x + 4, x)
 
+    g = Poly(x**3 + 1)
+
+    assert g.slice(0, 3) == Poly(1, x)
+
 
 def test_Poly_coeffs():
     assert Poly(0, x).coeffs() == [0]

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3159,6 +3159,22 @@ def test_cancel():
         Poly(7*x + 21, x, domain=QQ),
         Poly(3*x + 21, x, domain=QQ))
 
+    pairs = [
+        (1 + x, 1 + x, 1, 1, 1),
+        (1 + x, 1 - x, -1, -1-x, -1+x),
+        (1 - x, 1 + x, -1, 1-x, 1+x),
+        (1 - x, 1 - x, 1, 1, 1),
+    ]
+    for f, g, c, p, q in pairs:
+        assert cancel((f, g)) == (1, p, q)
+        pf = Poly(f, x)
+        pg = Poly(g, x)
+        pp = Poly(p, x)
+        pq = Poly(q, x)
+        assert pf.cancel(pg) == (c, c*pp, pq)
+        assert pf.rep.cancel(pg.rep) == (pp.rep, pq.rep)
+        assert pf.rep.cancel(pg.rep, include=True) == (pp.rep, pq.rep)
+
     f = Poly(y, y, domain='ZZ(x)')
     g = Poly(1, y, domain='ZZ[x]')
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1843,6 +1843,10 @@ def test_div():
     assert p.div(q, auto=True) == \
         (Poly(-S(1)/2 + 5*I/2, x, domain='QQ_I'), Poly(0, x, domain='QQ_I'))
 
+    f = 5*x**2 + 10*x + 3
+    g = 2*x + 2
+    assert div(f, g, domain=ZZ) == (0, f)
+
 
 def test_issue_7864():
     q, r = div(a, .408248290463863*a)
@@ -3165,13 +3169,13 @@ def test_cancel():
         (1 - x, 1 + x, -1, 1-x, 1+x),
         (1 - x, 1 - x, 1, 1, 1),
     ]
-    for f, g, c, p, q in pairs:
+    for f, g, coeff, p, q in pairs:
         assert cancel((f, g)) == (1, p, q)
         pf = Poly(f, x)
         pg = Poly(g, x)
         pp = Poly(p, x)
         pq = Poly(q, x)
-        assert pf.cancel(pg) == (c, c*pp, pq)
+        assert pf.cancel(pg) == (coeff, coeff*pp, pq)
         assert pf.rep.cancel(pg.rep) == (pp.rep, pq.rep)
         assert pf.rep.cancel(pg.rep, include=True) == (pp.rep, pq.rep)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2122,6 +2122,19 @@ def test_gcd():
         assert lcm(i, f) == 0
         assert lcm(f, i) == 0
 
+    f = 4*x**2 + x + 2
+    pfz = Poly(f, domain=ZZ)
+    pfq = Poly(f, domain=QQ)
+
+    assert pfz.gcd(pfz) == pfz
+    assert pfz.lcm(pfz) == pfz
+    assert pfq.gcd(pfq) == pfq.monic()
+    assert pfq.lcm(pfq) == pfq.monic()
+    assert gcd(f, f) == f
+    assert lcm(f, f) == f
+    assert gcd(f, f, domain=QQ) == monic(f)
+    assert lcm(f, f, domain=QQ) == monic(f)
+
 
 def test_gcd_numbers_vs_polys():
     assert isinstance(gcd(3, 9), Integer)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Test more modules with ground types as flint.

Fix some regressions found because o increased testing.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
