### PR TITLE
Deprecation warning body examples

### DIFF
--- a/doc/src/modules/physics/mechanics/api/deprecated_classes.rst
+++ b/doc/src/modules/physics/mechanics/api/deprecated_classes.rst
@@ -1,0 +1,17 @@
+===============================
+Deprecated Classes (Docstrings)
+===============================
+
+.. deprecated:: 1.13
+    :class:`~.Body` and :class:`~.JointsMethod` have been deprecated. The
+    functionality of :class:`~.Body` is fully captured by :class:`~.RigidBody`
+    and :class:`~.Particle` and the functionality of :class:`~.JointsMethod` is
+    fully captured by :class:`~.System`.
+
+.. autoclass:: sympy.physics.mechanics.body.Body
+    :members:
+    :inherited-members:
+
+.. autoclass:: sympy.physics.mechanics.jointsmethod.JointsMethod
+    :members:
+    :inherited-members:

--- a/doc/src/modules/physics/mechanics/api/index.rst
+++ b/doc/src/modules/physics/mechanics/api/index.rst
@@ -14,3 +14,4 @@ Mechanics API Reference
    pathway.rst
    actuator.rst
    wrapping_geometry.rst
+   deprecated_classes.rst

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -70,9 +70,9 @@ class Body(RigidBody, Particle):  # type: ignore
     ========
 
     As Body has been deprecated, the following examples are for illustrative
-    purposes only. The functionality of Body is fully captured by RigidBody and
-    Particle. To ignore the deprecation warning we can use the ignore_warnings
-    context manager.
+    purposes only. The functionality of Body is fully captured by
+    :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+    warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
 
@@ -219,9 +219,9 @@ class Body(RigidBody, Particle):  # type: ignore
         ========
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, ReferenceFrame, Point
@@ -287,9 +287,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy import symbols
@@ -394,9 +394,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy import symbols
@@ -474,9 +474,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
@@ -511,9 +511,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, Point
@@ -559,9 +559,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
@@ -597,9 +597,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, ReferenceFrame
@@ -637,9 +637,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
@@ -689,9 +689,9 @@ class Body(RigidBody, Particle):  # type: ignore
         =======
 
         As Body has been deprecated, the following examples are for illustrative
-        purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning we can use the
-        ignore_warnings context manager.
+        purposes only. The functionality of Body is fully captured by
+        :class:`~.RigidBody` and :class:`~.Particle`. To ignore the deprecation
+        warning we can use the ignore_warnings context manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -67,17 +67,18 @@ class Body(RigidBody, Particle):  # type: ignore
 
     As Body has been deprecated, the following examples are for illustrative
     purposes only. The functionality of Body is fully captured by RigidBody and
-    Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+    Particle. To ignore the deprecation warning we can use the ignore_warnings
+    context manager.
+    
+        >>> from sympy.utilities.exceptions import ignore_warnings
 
     Default behaviour. This results in the creation of a RigidBody object for
     which the mass, mass center, frame and inertia attributes are given default
     values. ::
 
         >>> from sympy.physics.mechanics import Body
-        >>> body = Body('name_of_body')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     body = Body('name_of_body')
 
     This next example demonstrates the code required to specify all of the
     values of the Body object. Note this will also create a RigidBody version of
@@ -91,7 +92,8 @@ class Body(RigidBody, Particle):  # type: ignore
         >>> frame = ReferenceFrame('frame')
         >>> ixx = Symbol('ixx')
         >>> body_inertia = inertia(frame, ixx, 0, 0)
-        >>> body = Body('name_of_body', masscenter, mass, frame, body_inertia)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     body = Body('name_of_body', masscenter, mass, frame, body_inertia)
 
     The minimal code required to create a Particle version of the Body object
     involves simply passing in a name and a mass. ::
@@ -99,7 +101,8 @@ class Body(RigidBody, Particle):  # type: ignore
         >>> from sympy import Symbol
         >>> from sympy.physics.mechanics import Body
         >>> mass = Symbol('mass')
-        >>> body = Body('name_of_body', mass=mass)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     body = Body('name_of_body', mass=mass)
 
     The Particle version of the Body object can also receive a masscenter point
     and a reference frame, just not an inertia.
@@ -213,17 +216,17 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, ReferenceFrame, Point
         >>> from sympy import symbols
         >>> m, v, r, omega = symbols('m v r omega')
         >>> N = ReferenceFrame('N')
         >>> O = Point('O')
-        >>> P = Body('P', masscenter=O, mass=m)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     P = Body('P', masscenter=O, mass=m)
         >>> P.masscenter.set_vel(N, v * N.y)
         >>> P.kinetic_energy(N)
         m*v**2/2
@@ -233,7 +236,8 @@ class Body(RigidBody, Particle):  # type: ignore
         >>> b.set_ang_vel(N, omega * b.x)
         >>> P = Point('P')
         >>> P.set_vel(N, v * N.x)
-        >>> B = Body('B', masscenter=P, frame=b)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B = Body('B', masscenter=P, frame=b)
         >>> B.kinetic_energy(N)
         B_ixx*omega**2/2 + B_mass*v**2/2
 
@@ -280,15 +284,15 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Body, Point, dynamicsymbols
         >>> m, g = symbols('m g')
-        >>> B = Body('B')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B = Body('B')
         >>> force1 = m*g*B.z
         >>> B.apply_force(force1) #Applying force on B's masscenter
         >>> B.loads
@@ -313,10 +317,12 @@ class Body(RigidBody, Particle):  # type: ignore
         consider two bodies connected through a spring.
 
         >>> from sympy.physics.mechanics import Body, dynamicsymbols
-        >>> N = Body('N') #Newtonion Frame
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     N = Body('N') #Newtonion Frame
         >>> x = dynamicsymbols('x')
-        >>> B1 = Body('B1')
-        >>> B2 = Body('B2')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B1 = Body('B1')
+        ...     B2 = Body('B2')
         >>> spring_force = x*N.x
 
         Now let's apply equal and opposite spring force to the bodies.
@@ -385,15 +391,15 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Body, dynamicsymbols
         >>> t = symbols('t')
-        >>> B = Body('B')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B = Body('B')
         >>> torque1 = t*B.z
         >>> B.apply_torque(torque1)
         >>> B.loads
@@ -417,9 +423,10 @@ class Body(RigidBody, Particle):  # type: ignore
         a torque `T` is acting on one body, and `-T` on the other.
 
         >>> from sympy.physics.mechanics import Body, dynamicsymbols
-        >>> N = Body('N') #Newtonion frame
-        >>> B1 = Body('B1')
-        >>> B2 = Body('B2')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     N = Body('N') #Newtonion frame
+        ...     B1 = Body('B1')
+        ...     B2 = Body('B2')
         >>> v = dynamicsymbols('v')
         >>> T = v*N.y #Torque
 
@@ -464,13 +471,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
-        >>> B = Body('B')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B = Body('B')
         >>> force = B.x + B.y
         >>> B.apply_force(force)
         >>> B.loads
@@ -501,13 +508,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, Point
-        >>> B = Body('B')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B = Body('B')
         >>> P = Point('P')
         >>> f1 = B.x
         >>> f2 = B.y
@@ -549,14 +556,14 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
-        >>> A = Body('A')
-        >>> B = Body('B')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     A = Body('A')
+        ...     B = Body('B')
         >>> A.masscenter.set_vel(B.frame, 5*B.frame.x)
         >>> A.masscenter_vel(B)
         5*B_frame.x
@@ -587,15 +594,16 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, ReferenceFrame
-        >>> A = Body('A')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     A = Body('A')
         >>> N = ReferenceFrame('N')
-        >>> B = Body('B', frame=N)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     B = Body('B', frame=N)
         >>> A.frame.set_ang_vel(N, 5*N.x)
         >>> A.ang_vel_in(B)
         5*N.x
@@ -626,14 +634,14 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
-        >>> A = Body('A')
-        >>> B = Body('B')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     A = Body('A')
+        ...     B = Body('B')
         >>> A.frame.orient_axis(B.frame, B.frame.x, 5)
         >>> A.dcm(B)
         Matrix([
@@ -678,13 +686,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         As Body has been deprecated, the following examples are for illustrative
         purposes only. The functionality of Body is fully captured by RigidBody
-        and Particle. To ignore the deprecation warning, use the following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+        and Particle. To ignore the deprecation warning we can use the
+        ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
-        >>> A = Body('A')
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     A = Body('A')
         >>> P = A.masscenter.locatenew('point', 3 * A.x + 5 * A.y)
         >>> A.parallel_axis(P).to_matrix(A.frame)
         Matrix([

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -65,6 +65,13 @@ class Body(RigidBody, Particle):  # type: ignore
     Examples
     ========
 
+    As Body has been deprecated, the following examples are for illustrative
+    purposes only. The functionality of Body is fully captured by RigidBody and
+    Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+
     Default behaviour. This results in the creation of a RigidBody object for
     which the mass, mass center, frame and inertia attributes are given default
     values. ::
@@ -204,6 +211,13 @@ class Body(RigidBody, Particle):  # type: ignore
         Examples
         ========
 
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+
         >>> from sympy.physics.mechanics import Body, ReferenceFrame, Point
         >>> from sympy import symbols
         >>> m, v, r, omega = symbols('m v r omega')
@@ -263,6 +277,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         Example
         =======
+
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Body, Point, dynamicsymbols
@@ -362,6 +383,13 @@ class Body(RigidBody, Particle):  # type: ignore
         Example
         =======
 
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+
         >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Body, dynamicsymbols
         >>> t = symbols('t')
@@ -434,6 +462,13 @@ class Body(RigidBody, Particle):  # type: ignore
         Example
         =======
 
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+
         >>> from sympy.physics.mechanics import Body
         >>> B = Body('B')
         >>> force = B.x + B.y
@@ -463,6 +498,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         Example
         =======
+
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         >>> from sympy.physics.mechanics import Body, Point
         >>> B = Body('B')
@@ -505,6 +547,13 @@ class Body(RigidBody, Particle):  # type: ignore
         Example
         =======
 
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+
         >>> from sympy.physics.mechanics import Body
         >>> A = Body('A')
         >>> B = Body('B')
@@ -535,6 +584,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         Example
         =======
+
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         >>> from sympy.physics.mechanics import Body, ReferenceFrame
         >>> A = Body('A')
@@ -567,6 +623,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         Example
         =======
+
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         >>> from sympy.physics.mechanics import Body
         >>> A = Body('A')
@@ -612,6 +675,13 @@ class Body(RigidBody, Particle):  # type: ignore
 
         Example
         =======
+
+        As Body has been deprecated, the following examples are for illustrative
+        purposes only. The functionality of Body is fully captured by RigidBody
+        and Particle. To ignore the deprecation warning, use the following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         >>> from sympy.physics.mechanics import Body
         >>> A = Body('A')

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -69,7 +69,7 @@ class Body(RigidBody, Particle):  # type: ignore
     purposes only. The functionality of Body is fully captured by RigidBody and
     Particle. To ignore the deprecation warning we can use the ignore_warnings
     context manager.
-    
+
         >>> from sympy.utilities.exceptions import ignore_warnings
 
     Default behaviour. This results in the creation of a RigidBody object for
@@ -218,7 +218,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, ReferenceFrame, Point
         >>> from sympy import symbols
@@ -286,7 +286,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Body, Point, dynamicsymbols
@@ -393,7 +393,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy import symbols
         >>> from sympy.physics.mechanics import Body, dynamicsymbols
@@ -473,7 +473,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
         >>> with ignore_warnings(DeprecationWarning):
@@ -510,7 +510,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, Point
         >>> with ignore_warnings(DeprecationWarning):
@@ -558,7 +558,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
         >>> with ignore_warnings(DeprecationWarning):
@@ -596,7 +596,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body, ReferenceFrame
         >>> with ignore_warnings(DeprecationWarning):
@@ -636,7 +636,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
         >>> with ignore_warnings(DeprecationWarning):
@@ -688,7 +688,7 @@ class Body(RigidBody, Particle):  # type: ignore
         purposes only. The functionality of Body is fully captured by RigidBody
         and Particle. To ignore the deprecation warning we can use the
         ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
         >>> from sympy.physics.mechanics import Body
         >>> with ignore_warnings(DeprecationWarning):

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -17,7 +17,7 @@ class Body(RigidBody, Particle):  # type: ignore
     created. Otherwise a RigidBody object will be created.
 
     .. deprecated:: 1.13
-        The Body class is deprecated. Its functionality is captured by 
+        The Body class is deprecated. Its functionality is captured by
         :class:`~.RigidBody` and :class:`~.Particle`.
 
     Explanation

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -16,6 +16,10 @@ class Body(RigidBody, Particle):  # type: ignore
     passed in and central_inertia is left as None, the Particle object is
     created. Otherwise a RigidBody object will be created.
 
+    .. deprecated:: 1.13
+        The Body class is deprecated. Its functionality is captured by 
+        :class:`~.RigidBody` and :class:`~.Particle`.
+
     Explanation
     ===========
 

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -11,6 +11,10 @@ __all__ = ['JointsMethod']
 class JointsMethod(_Methods):
     """Method for formulating the equations of motion using a set of interconnected bodies with joints.
 
+    .. deprecated:: 1.13
+        The JointsMethod class is deprecated. Its functionality has been
+        replaced by the new :class:`~.System` class.
+
     Parameters
     ==========
 

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -51,9 +51,9 @@ class JointsMethod(_Methods):
 
     As Body and JointsMethod have been deprecated, the following examples are
     for illustrative purposes only. The functionality of Body is fully captured
-    by RigidBody and Particle and the functionality of JointsMethod is fully
-    captured by System. To ignore the deprecation warning we can use the
-    ignore_warnings context manager.
+    by :class:`~.RigidBody` and :class:`~.Particle` and the functionality of
+    JointsMethod is fully captured by :class:`~.System`. To ignore the
+    deprecation warning we can use the ignore_warnings context manager.
 
     >>> from sympy.utilities.exceptions import ignore_warnings
 
@@ -242,9 +242,10 @@ class JointsMethod(_Methods):
 
         As Body and JointsMethod have been deprecated, the following examples
         are for illustrative purposes only. The functionality of Body is fully
-        captured by RigidBody and Particle and the functionality of JointsMethod
-        is fully captured by System. To ignore the deprecation warning we can
-        use the ignore_warnings context manager.
+        captured by :class:`~.RigidBody` and :class:`~.Particle` and the
+        functionality of JointsMethod is fully captured by :class:`~.System`. To
+        ignore the deprecation warning we can use the ignore_warnings context
+        manager.
 
         >>> from sympy.utilities.exceptions import ignore_warnings
 

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -48,10 +48,10 @@ class JointsMethod(_Methods):
     As Body and JointsMethod have been deprecated, the following examples are
     for illustrative purposes only. The functionality of Body is fully captured
     by RigidBody and Particle and the functionality of JointsMethod is fully
-    captured by System. To ignore the deprecation warnings, use the following:
-
-    >>> import warnings
-    >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+    captured by System. To ignore the deprecation warning we can use the
+    ignore_warnings context manager.
+    
+    >>> from sympy.utilities.exceptions import ignore_warnings
 
     This is a simple example for a one degree of freedom translational
     spring-mass-damper.
@@ -61,12 +61,14 @@ class JointsMethod(_Methods):
     >>> from sympy.physics.vector import dynamicsymbols
     >>> c, k = symbols('c k')
     >>> x, v = dynamicsymbols('x v')
-    >>> wall = Body('W')
-    >>> body = Body('B')
+    >>> with ignore_warnings(DeprecationWarning):
+    ...     wall = Body('W')
+    ...     body = Body('B')
     >>> J = PrismaticJoint('J', wall, body, coordinates=x, speeds=v)
     >>> wall.apply_force(c*v*wall.x, reaction_body=body)
     >>> wall.apply_force(k*x*wall.x, reaction_body=body)
-    >>> method = JointsMethod(wall, J)
+    >>> with ignore_warnings(DeprecationWarning):
+    ...     method = JointsMethod(wall, J)
     >>> method.form_eoms()
     Matrix([[-B_mass*Derivative(v(t), t) - c*v(t) - k*x(t)]])
     >>> M = method.mass_matrix_full
@@ -237,11 +239,10 @@ class JointsMethod(_Methods):
         As Body and JointsMethod have been deprecated, the following examples
         are for illustrative purposes only. The functionality of Body is fully
         captured by RigidBody and Particle and the functionality of JointsMethod
-        is fully captured by System. To ignore the deprecation warnings, use the
-        following:
-
-        >>> import warnings
-        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+        is fully captured by System. To ignore the deprecation warning we can
+        use the ignore_warnings context manager.
+        
+        >>> from sympy.utilities.exceptions import ignore_warnings
 
         This is a simple example for a one degree of freedom translational
         spring-mass-damper.
@@ -252,12 +253,14 @@ class JointsMethod(_Methods):
         >>> q = dynamicsymbols('q')
         >>> qd = dynamicsymbols('q', 1)
         >>> m, k, b = symbols('m k b')
-        >>> wall = Body('W')
-        >>> part = Body('P', mass=m)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     wall = Body('W')
+        ...     part = Body('P', mass=m)
         >>> part.potential_energy = k * q**2 / S(2)
         >>> J = PrismaticJoint('J', wall, part, coordinates=q, speeds=qd)
         >>> wall.apply_force(b * qd * wall.x, reaction_body=part)
-        >>> method = JointsMethod(wall, J)
+        >>> with ignore_warnings(DeprecationWarning):
+        ...     method = JointsMethod(wall, J)
         >>> method.form_eoms(LagrangesMethod)
         Matrix([[b*Derivative(q(t), t) + k*q(t) + m*Derivative(q(t), (t, 2))]])
 

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -50,7 +50,7 @@ class JointsMethod(_Methods):
     by RigidBody and Particle and the functionality of JointsMethod is fully
     captured by System. To ignore the deprecation warning we can use the
     ignore_warnings context manager.
-    
+
     >>> from sympy.utilities.exceptions import ignore_warnings
 
     This is a simple example for a one degree of freedom translational
@@ -241,7 +241,7 @@ class JointsMethod(_Methods):
         captured by RigidBody and Particle and the functionality of JointsMethod
         is fully captured by System. To ignore the deprecation warning we can
         use the ignore_warnings context manager.
-        
+
         >>> from sympy.utilities.exceptions import ignore_warnings
 
         This is a simple example for a one degree of freedom translational

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -45,6 +45,14 @@ class JointsMethod(_Methods):
     Examples
     ========
 
+    As Body and JointsMethod have been deprecated, the following examples are
+    for illustrative purposes only. The functionality of Body is fully captured
+    by RigidBody and Particle and the functionality of JointsMethod is fully
+    captured by System. To ignore the deprecation warnings, use the following:
+
+    >>> import warnings
+    >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
+
     This is a simple example for a one degree of freedom translational
     spring-mass-damper.
 
@@ -225,6 +233,15 @@ class JointsMethod(_Methods):
 
         Examples
         ========
+
+        As Body and JointsMethod have been deprecated, the following examples
+        are for illustrative purposes only. The functionality of Body is fully
+        captured by RigidBody and Particle and the functionality of JointsMethod
+        is fully captured by System. To ignore the deprecation warnings, use the
+        following:
+
+        >>> import warnings
+        >>> warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         This is a simple example for a one degree of freedom translational
         spring-mass-damper.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially fixes #26319

#### Brief description of what is fixed or changed
Ignore deprecation warnings in docstring examples of deprecated `Body` and `JointsMethod` classes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
