### PR TITLE
Make wigner function use raw python types

### DIFF
--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -107,21 +107,22 @@ def _calc_factlist(nn):
             _Factlist.append(_Factlist[ii - 1] * ii)
     return _Factlist[:int(nn) + 1]
 
-
 def _Integer_or_halfInteger(value):
-    if isinstance(value, int):
-        return Integer(value)
-    elif isinstance(value, (float, Float)):
-        if isinstance(value, float) and value.is_integer():
-            return Integer(int(value))
-        elif (equal_valued((v:=2*value), (i:=int(v)))):
-            return Rational(i, 2)
-    elif isinstance(value, Integer):
+    if isinstance(value,Rational):
+        if value.q == 2:
+            return value.p/value.q
+        elif value.q == 1:
+            return value.p
+    elif isinstance(value, int):
         return value
-    elif isinstance(value, Rational) and value.q == 2:
-        return value
+    elif isinstance(value, Float):
+        value = float(value)
+    if type(value) is float:
+            if value.is_integer():
+                return int(value)
+            if (2*value).is_integer():
+                return value
     raise ValueError("expecting integer or half-integer, got %s" % value)
-
 
 def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     r"""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Made changes mentioned in issue #26323

#### Brief description of what is fixed or changed
the spin values in wigner_3j function are now passed as raw python types

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
