### PR TITLE
Use raw python type in wigner_3j

### DIFF
--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -56,7 +56,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.add import Add
 from sympy.core.numbers import int_valued
 from sympy.core.function import Function
-from sympy.core.numbers import (Float, I, Integer, pi, Rational, equal_valued)
+from sympy.core.numbers import (Float, I, Integer, pi, Rational)
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
@@ -109,17 +109,20 @@ def _calc_factlist(nn):
 
 
 def _Integer_or_halfInteger(value):
-    if isinstance(value, int):
-        return Integer(value)
-    elif isinstance(value, (float, Float)):
-        if isinstance(value, float) and value.is_integer():
-            return Integer(int(value))
-        elif (equal_valued((v:=2*value), (i:=int(v)))):
-            return Rational(i, 2)
-    elif isinstance(value, Integer):
+    if isinstance(value,Rational):
+        if value.q == 2:
+            return value.p/value.q
+        elif value.q == 1:
+            return value.p
+    elif isinstance(value, int):
         return value
-    elif isinstance(value, Rational) and value.q == 2:
-        return value
+    elif isinstance(value, Float):
+        value = float(value)
+    if type(value) is float:
+            if value.is_integer():
+                return int(value)
+            if (2*value).is_integer():
+                return value
     raise ValueError("expecting integer or half-integer, got %s" % value)
 
 

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -231,8 +231,6 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     if (abs(m_1) > j_1) or (abs(m_2) > j_2) or (abs(m_3) > j_3):
         return S.Zero
 
-    prefid = Integer((-1) ** int(j_1 - j_2 - m_3))
-    m_3 = -m_3
     maxfact = max(j_1 + j_2 + j_3 + 1, j_1 + abs(m_1), j_2 + abs(m_2),
                   j_3 + abs(m_3))
     _calc_factlist(int(maxfact))
@@ -264,6 +262,7 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
             _Factlist[int(j_1 + j_2 - j_3 - ii)]
         sumres = sumres + Integer((-1) ** ii) / den
 
+    prefid = Integer((-1) ** int(j_1 - j_2 - m_3))
     res = ressqrt * sumres * prefid
     return res
 

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -108,21 +108,22 @@ def _calc_factlist(nn):
     return _Factlist[:int(nn) + 1]
 
 
-def _Integer_or_halfInteger(value):
-    if isinstance(value,Rational):
-        if value.q == 2:
-            return value.p/value.q
-        elif value.q == 1:
-            return value.p
-    elif isinstance(value, int):
+def _int_or_halfint(value):
+    """return Python int unless value is half-int (then return float)"""
+    if isinstance(value, int):
         return value
+    elif type(value) is float:
+        if value.is_integer():
+            return int(value)  # an int
+        if (2*value).is_integer():
+            return value  # a float
+    elif isinstance(value, Rational):
+        if value.q == 2:
+            return value.p/value.q  # a float
+        elif value.q == 1:
+            return value.p  # an int
     elif isinstance(value, Float):
-        value = float(value)
-    if type(value) is float:
-            if value.is_integer():
-                return int(value)
-            if (2*value).is_integer():
-                return value
+        return _int_or_halfint(float(value))
     raise ValueError("expecting integer or half-integer, got %s" % value)
 
 
@@ -213,7 +214,7 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     - Jens Rasch (2009-03-24): initial version
     """
 
-    j_1, j_2, j_3, m_1, m_2, m_3 = map(_Integer_or_halfInteger,
+    j_1, j_2, j_3, m_1, m_2, m_3 = map(_int_or_halfint,
                                        [j_1, j_2, j_3, m_1, m_2, m_3])
 
     if m_1 + m_2 + m_3 != 0:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #26323

#### Brief description of what is fixed or changed
Raw python types used in wigner_3j instead of Sympy types

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
