### PR TITLE
logic: Make `satisfiable` return model when using Z3 algorithm

### DIFF
--- a/sympy/logic/algorithms/z3_wrapper.py
+++ b/sympy/logic/algorithms/z3_wrapper.py
@@ -29,9 +29,14 @@ def z3_satisfiable(expr, all_models=False):
     if res == "unsat":
         return False
     elif res == "sat":
-        return True
+        return z3_model_to_sympy_model(s.model(), expr)
     else:
         return None
+
+
+def z3_model_to_sympy_model(z3_model, enc_cnf):
+    rev_enc = {value : key for key, value in enc_cnf.encoding.items()}
+    return {rev_enc[int(var.name()[1:])] : bool(z3_model[var]) for var in z3_model}
 
 
 def clause_to_assertion(clause):

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -332,7 +332,10 @@ def test_z3():
     x, y, z = symbols('x,y,z')
     assert z3_satisfiable((x >= 2) & (x < 1)) is False
     assert z3_satisfiable( A & ~A ) is False
-    assert z3_satisfiable(A & (~A | B | C)) is True
+
+    model = z3_satisfiable(A & (~A | B | C))
+    assert bool(model) is True
+    assert model[A] is True
 
     # test nonlinear function
     assert z3_satisfiable((x ** 2 >= 2) & (x < 1) & (x > -1)) is False


### PR DESCRIPTION
Fixes #26320

Previously, instead of returning a model, `satisfiable` returned True when using the Z3 algorithm option.

Example:

In [1]: from sympy.logic import satisfiable

In [2]: satisfiable(x & y | z, algorithm="z3")

Out[2]: {z: True, x: True, y: True} # instead of True

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
