### PR TITLE
Fix latex printing of undefined functions raised to a power

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -982,7 +982,11 @@ class LatexPrinter(Printer):
             elif exp is not None:
                 func_tex = self._hprint_Function(func)
                 func_tex = self.parenthesize_super(func_tex)
-                name = r'%s^{%s}' % (func_tex, exp)
+                if func in accepted_latex_functions:
+                    name = r'%s^{%s}' % (func_tex, exp)
+                else:
+                    name = r'\left(%s %s\right)^{%s}' % (func_tex, r'%s', exp)
+
             else:
                 name = self._hprint_Function(func)
 
@@ -994,7 +998,10 @@ class LatexPrinter(Printer):
                 else:
                     name += r"%s"
             else:
-                name += r"{\left(%s \right)}"
+                if func in accepted_latex_functions or exp is None:
+                    name += r"{\left(%s \right)}"
+                else:
+                    name = name % r"{\left(%s \right)}"
 
             if inv_trig_power_case and exp is not None:
                 name += r"^{%s}" % exp

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -489,17 +489,17 @@ def test_latex_functions():
     #   does not work on functions without brackets
 
     # > with argument and power combined
-    assert latex(Function('ab')()**2) == r"\operatorname{ab}^{2}{\left( \right)}"
-    assert latex(Function('ab1')()**2) == r"\operatorname{ab}_{1}^{2}{\left( \right)}"
-    assert latex(Function('ab12')()**2) == r"\operatorname{ab}_{12}^{2}{\left( \right)}"
-    assert latex(Function('ab_1')()**2) == r"\operatorname{ab}_{1}^{2}{\left( \right)}"
-    assert latex(Function('ab_12')()**2) == r"\operatorname{ab}_{12}^{2}{\left( \right)}"
-    assert latex(Function('ab')(Symbol('x'))**2) == r"\operatorname{ab}^{2}{\left(x \right)}"
-    assert latex(Function('ab1')(Symbol('x'))**2) == r"\operatorname{ab}_{1}^{2}{\left(x \right)}"
-    assert latex(Function('ab12')(Symbol('x'))**2) == r"\operatorname{ab}_{12}^{2}{\left(x \right)}"
-    assert latex(Function('ab_1')(Symbol('x'))**2) == r"\operatorname{ab}_{1}^{2}{\left(x \right)}"
+    assert latex(Function('ab')()**2) == r"\left(\operatorname{ab} {\left( \right)}\right)^{2}"
+    assert latex(Function('ab1')()**2) == r"\left(\operatorname{ab}_{1} {\left( \right)}\right)^{2}"
+    assert latex(Function('ab12')()**2) == r"\left(\operatorname{ab}_{12} {\left( \right)}\right)^{2}"
+    assert latex(Function('ab_1')()**2) == r"\left(\operatorname{ab}_{1} {\left( \right)}\right)^{2}"
+    assert latex(Function('ab_12')()**2) == r"\left(\operatorname{ab}_{12} {\left( \right)}\right)^{2}"
+    assert latex(Function('ab')(Symbol('x'))**2) == r"\left(\operatorname{ab} {\left(x \right)}\right)^{2}"
+    assert latex(Function('ab1')(Symbol('x'))**2) == r"\left(\operatorname{ab}_{1} {\left(x \right)}\right)^{2}"
+    assert latex(Function('ab12')(Symbol('x'))**2) == r"\left(\operatorname{ab}_{12} {\left(x \right)}\right)^{2}"
+    assert latex(Function('ab_1')(Symbol('x'))**2) == r"\left(\operatorname{ab}_{1} {\left(x \right)}\right)^{2}"
     assert latex(Function('ab_12')(Symbol('x'))**2) == \
-        r"\operatorname{ab}_{12}^{2}{\left(x \right)}"
+        r"\left(\operatorname{ab}_{12} {\left(x \right)}\right)^{2}"
 
     # single letter function names
     # > simple
@@ -520,55 +520,55 @@ def test_latex_functions():
     #   does not work on functions without brackets
 
     # > with argument and power combined
-    assert latex(Function('a')()**2) == r"a^{2}{\left( \right)}"
-    assert latex(Function('a1')()**2) == r"a_{1}^{2}{\left( \right)}"
-    assert latex(Function('a12')()**2) == r"a_{12}^{2}{\left( \right)}"
-    assert latex(Function('a_1')()**2) == r"a_{1}^{2}{\left( \right)}"
-    assert latex(Function('a_12')()**2) == r"a_{12}^{2}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**2) == r"a^{2}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**2) == r"a_{1}^{2}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**2) == r"a_{12}^{2}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**2) == r"a_{1}^{2}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**2) == r"a_{12}^{2}{\left(x \right)}"
+    assert latex(Function('a')()**2) == r"\left(a {\left( \right)}\right)^{2}"
+    assert latex(Function('a1')()**2) == r"\left(a_{1} {\left( \right)}\right)^{2}"
+    assert latex(Function('a12')()**2) == r"\left(a_{12} {\left( \right)}\right)^{2}"
+    assert latex(Function('a_1')()**2) == r"\left(a_{1} {\left( \right)}\right)^{2}"
+    assert latex(Function('a_12')()**2) == r"\left(a_{12} {\left( \right)}\right)^{2}"
+    assert latex(Function('a')(Symbol('x'))**2) == r"\left(a {\left(x \right)}\right)^{2}"
+    assert latex(Function('a1')(Symbol('x'))**2) == r"\left(a_{1} {\left(x \right)}\right)^{2}"
+    assert latex(Function('a12')(Symbol('x'))**2) == r"\left(a_{12} {\left(x \right)}\right)^{2}"
+    assert latex(Function('a_1')(Symbol('x'))**2) == r"\left(a_{1} {\left(x \right)}\right)^{2}"
+    assert latex(Function('a_12')(Symbol('x'))**2) == r"\left(a_{12} {\left(x \right)}\right)^{2}"
 
-    assert latex(Function('a')()**32) == r"a^{32}{\left( \right)}"
-    assert latex(Function('a1')()**32) == r"a_{1}^{32}{\left( \right)}"
-    assert latex(Function('a12')()**32) == r"a_{12}^{32}{\left( \right)}"
-    assert latex(Function('a_1')()**32) == r"a_{1}^{32}{\left( \right)}"
-    assert latex(Function('a_12')()**32) == r"a_{12}^{32}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**32) == r"a^{32}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**32) == r"a_{1}^{32}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**32) == r"a_{12}^{32}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**32) == r"a_{1}^{32}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**32) == r"a_{12}^{32}{\left(x \right)}"
+    assert latex(Function('a')()**32) == r"\left(a {\left( \right)}\right)^{32}"
+    assert latex(Function('a1')()**32) == r"\left(a_{1} {\left( \right)}\right)^{32}"
+    assert latex(Function('a12')()**32) == r"\left(a_{12} {\left( \right)}\right)^{32}"
+    assert latex(Function('a_1')()**32) == r"\left(a_{1} {\left( \right)}\right)^{32}"
+    assert latex(Function('a_12')()**32) == r"\left(a_{12} {\left( \right)}\right)^{32}"
+    assert latex(Function('a')(Symbol('x'))**32) == r"\left(a {\left(x \right)}\right)^{32}"
+    assert latex(Function('a1')(Symbol('x'))**32) == r"\left(a_{1} {\left(x \right)}\right)^{32}"
+    assert latex(Function('a12')(Symbol('x'))**32) == r"\left(a_{12} {\left(x \right)}\right)^{32}"
+    assert latex(Function('a_1')(Symbol('x'))**32) == r"\left(a_{1} {\left(x \right)}\right)^{32}"
+    assert latex(Function('a_12')(Symbol('x'))**32) == r"\left(a_{12} {\left(x \right)}\right)^{32}"
 
-    assert latex(Function('a')()**a) == r"a^{a}{\left( \right)}"
-    assert latex(Function('a1')()**a) == r"a_{1}^{a}{\left( \right)}"
-    assert latex(Function('a12')()**a) == r"a_{12}^{a}{\left( \right)}"
-    assert latex(Function('a_1')()**a) == r"a_{1}^{a}{\left( \right)}"
-    assert latex(Function('a_12')()**a) == r"a_{12}^{a}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**a) == r"a^{a}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**a) == r"a_{1}^{a}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**a) == r"a_{12}^{a}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**a) == r"a_{1}^{a}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**a) == r"a_{12}^{a}{\left(x \right)}"
+    assert latex(Function('a')()**a) == r"\left(a {\left( \right)}\right)^{a}"
+    assert latex(Function('a1')()**a) == r"\left(a_{1} {\left( \right)}\right)^{a}"
+    assert latex(Function('a12')()**a) == r"\left(a_{12} {\left( \right)}\right)^{a}"
+    assert latex(Function('a_1')()**a) == r"\left(a_{1} {\left( \right)}\right)^{a}"
+    assert latex(Function('a_12')()**a) == r"\left(a_{12} {\left( \right)}\right)^{a}"
+    assert latex(Function('a')(Symbol('x'))**a) == r"\left(a {\left(x \right)}\right)^{a}"
+    assert latex(Function('a1')(Symbol('x'))**a) == r"\left(a_{1} {\left(x \right)}\right)^{a}"
+    assert latex(Function('a12')(Symbol('x'))**a) == r"\left(a_{12} {\left(x \right)}\right)^{a}"
+    assert latex(Function('a_1')(Symbol('x'))**a) == r"\left(a_{1} {\left(x \right)}\right)^{a}"
+    assert latex(Function('a_12')(Symbol('x'))**a) == r"\left(a_{12} {\left(x \right)}\right)^{a}"
 
     ab = Symbol('ab')
-    assert latex(Function('a')()**ab) == r"a^{ab}{\left( \right)}"
-    assert latex(Function('a1')()**ab) == r"a_{1}^{ab}{\left( \right)}"
-    assert latex(Function('a12')()**ab) == r"a_{12}^{ab}{\left( \right)}"
-    assert latex(Function('a_1')()**ab) == r"a_{1}^{ab}{\left( \right)}"
-    assert latex(Function('a_12')()**ab) == r"a_{12}^{ab}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**ab) == r"a^{ab}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**ab) == r"a_{1}^{ab}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**ab) == r"a_{12}^{ab}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**ab) == r"a_{1}^{ab}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**ab) == r"a_{12}^{ab}{\left(x \right)}"
+    assert latex(Function('a')()**ab) == r"\left(a {\left( \right)}\right)^{ab}"
+    assert latex(Function('a1')()**ab) == r"\left(a_{1} {\left( \right)}\right)^{ab}"
+    assert latex(Function('a12')()**ab) == r"\left(a_{12} {\left( \right)}\right)^{ab}"
+    assert latex(Function('a_1')()**ab) == r"\left(a_{1} {\left( \right)}\right)^{ab}"
+    assert latex(Function('a_12')()**ab) == r"\left(a_{12} {\left( \right)}\right)^{ab}"
+    assert latex(Function('a')(Symbol('x'))**ab) == r"\left(a {\left(x \right)}\right)^{ab}"
+    assert latex(Function('a1')(Symbol('x'))**ab) == r"\left(a_{1} {\left(x \right)}\right)^{ab}"
+    assert latex(Function('a12')(Symbol('x'))**ab) == r"\left(a_{12} {\left(x \right)}\right)^{ab}"
+    assert latex(Function('a_1')(Symbol('x'))**ab) == r"\left(a_{1} {\left(x \right)}\right)^{ab}"
+    assert latex(Function('a_12')(Symbol('x'))**ab) == r"\left(a_{12} {\left(x \right)}\right)^{ab}"
 
     assert latex(Function('a^12')(x)) == R"a^{12}{\left(x \right)}"
-    assert latex(Function('a^12')(x) ** ab) == R"\left(a^{12}\right)^{ab}{\left(x \right)}"
+    assert latex(Function('a^12')(x) ** ab) == R"\left(\left(a^{12}\right) {\left(x \right)}\right)^{ab}"
     assert latex(Function('a__12')(x)) == R"a^{12}{\left(x \right)}"
-    assert latex(Function('a__12')(x) ** ab) == R"\left(a^{12}\right)^{ab}{\left(x \right)}"
+    assert latex(Function('a__12')(x) ** ab) == R"\left(\left(a^{12}\right) {\left(x \right)}\right)^{ab}"
     assert latex(Function('a_1__1_2')(x)) == R"a^{1}_{1 2}{\left(x \right)}"
 
     # issue 5868
@@ -583,7 +583,7 @@ def test_latex_functions():
     assert latex(sin(x**2), fold_func_brackets=True) == \
         r"\sin {x^{2}}"
 
-    assert latex(asin(x)**2) == r"\operatorname{asin}^{2}{\left(x \right)}"
+    assert latex(asin(x)**2) == r"\left(\operatorname{asin} {\left(x \right)}\right)^{2}"
     assert latex(asin(x)**2, inv_trig_style="full") == \
         r"\arcsin^{2}{\left(x \right)}"
     assert latex(asin(x)**2, inv_trig_style="power") == \
@@ -692,12 +692,12 @@ def test_latex_functions():
     assert latex(elliptic_pi(x, y)**2) == r"\Pi^{2}\left(x\middle| y\right)"
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
-    assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'
+    assert latex(Ei(x)**2) == r'\left(\operatorname{Ei} {\left(x \right)}\right)^{2}'
     assert latex(expint(x, y)) == r'\operatorname{E}_{x}\left(y\right)'
     assert latex(expint(x, y)**2) == r'\operatorname{E}_{x}^{2}\left(y\right)'
-    assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left(x \right)}'
-    assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left(x \right)}'
-    assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left(x \right)}'
+    assert latex(Shi(x)**2) == r'\left(\operatorname{Shi} {\left(x \right)}\right)^{2}'
+    assert latex(Si(x)**2) == r'\left(\operatorname{Si} {\left(x \right)}\right)^{2}'
+    assert latex(Ci(x)**2) == r'\left(\operatorname{Ci} {\left(x \right)}\right)^{2}'
     assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}\left(x\right)'
     assert latex(Chi(x)) == r'\operatorname{Chi}\left(x\right)'
     assert latex(jacobi(n, a, b, x)) == \


### PR DESCRIPTION
The used notation to print functions raised to a power is standardized across all types of functions, the recognized and not recognized ones. The undefined functions raised to power should be wrapped between parenthesis. Also, corresponding tests have been modified.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes  #24596

#### Brief description of what is fixed or changed
The used notation to print functions raised to a power is standardized across
all types of functions, the recognized and not recognized ones. The undefined
functions raised to power should be wrapped between parenthesis.

So instead of ``func**2(x)`` it should be  ``(func(x))**2``
but for regular functions like trigonometric functions, they stay the same ``sin**2(x)``

**Before the patch**
![image](https://github.com/sympy/sympy/assets/59314933/6475e571-2896-419b-b345-c00bc243fc13)

**After the patch**
![image](https://github.com/sympy/sympy/assets/59314933/863b8467-e180-48dd-b84c-7ec9a91b3689)

Also, corresponding tests have been modified.


#### Other comments
<!-- @asmeurer  The tests are modified,  the bot will raise errors.-->

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug in latex printing for undefined functions raised to a power.  

<!-- END RELEASE NOTES -->
