### PR TITLE
Deprecation warning `ntheory` examples

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -88,14 +88,14 @@ class carmichael(Function):
     Examples
     ========
 
-    >>> from sympy import carmichael
-    >>> carmichael.find_first_n_carmichaels(5)
+    >>> from sympy.ntheory.factor_ import find_first_n_carmichaels, find_carmichael_numbers_in_range
+    >>> find_first_n_carmichaels(5)
     [561, 1105, 1729, 2465, 2821]
-    >>> carmichael.find_carmichael_numbers_in_range(0, 562)
+    >>> find_carmichael_numbers_in_range(0, 562)
     [561]
-    >>> carmichael.find_carmichael_numbers_in_range(0,1000)
+    >>> find_carmichael_numbers_in_range(0,1000)
     [561]
-    >>> carmichael.find_carmichael_numbers_in_range(0,2000)
+    >>> find_carmichael_numbers_in_range(0,2000)
     [561, 1105, 1729]
 
     References

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1967,7 +1967,7 @@ def totient(n):
     Examples
     ========
 
-    >>> from sympy.ntheory import totient
+    >>> from sympy.functions.combinatorial.numbers import totient
     >>> totient(1)
     1
     >>> totient(25)
@@ -2011,7 +2011,7 @@ def reduced_totient(n):
     Examples
     ========
 
-    >>> from sympy.ntheory import reduced_totient
+    >>> from sympy.functions.combinatorial.numbers import reduced_totient
     >>> reduced_totient(1)
     1
     >>> reduced_totient(8)
@@ -2079,7 +2079,7 @@ def divisor_sigma(n, k=1):
     Examples
     ========
 
-    >>> from sympy.ntheory import divisor_sigma
+    >>> from sympy.functions.combinatorial.numbers import divisor_sigma
     >>> divisor_sigma(18, 0)
     6
     >>> divisor_sigma(39, 1)
@@ -2233,7 +2233,7 @@ def udivisor_sigma(n, k=1):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import udivisor_sigma
+    >>> from sympy.functions.combinatorial.numbers import udivisor_sigma
     >>> udivisor_sigma(18, 0)
     4
     >>> udivisor_sigma(74, 1)
@@ -2286,7 +2286,7 @@ def primenu(n):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import primenu
+    >>> from sympy.functions.combinatorial.numbers import primenu
     >>> primenu(1)
     0
     >>> primenu(30)
@@ -2335,7 +2335,7 @@ def primeomega(n):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import primeomega
+    >>> from sympy.functions.combinatorial.numbers import primeomega
     >>> primeomega(1)
     0
     >>> primeomega(20)

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -264,8 +264,8 @@ def npartitions(n, verbose=False):
     Examples
     ========
 
-    >>> from sympy.ntheory import npartitions
-    >>> npartitions(25)
+    >>> from sympy.functions.combinatorial.numbers import partition
+    >>> partition(25)
     1958
 
     References

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1106,7 +1106,7 @@ def legendre_symbol(a, p):
     Examples
     ========
 
-    >>> from sympy.ntheory import legendre_symbol
+    >>> from sympy.functions.combinatorial.numbers import legendre_symbol
     >>> [legendre_symbol(i, 7) for i in range(7)]
     [0, 1, 1, -1, 1, -1, -1]
     >>> sorted(set([i**2 % 7 for i in range(7)]))
@@ -1168,7 +1168,7 @@ def jacobi_symbol(m, n):
     Examples
     ========
 
-    >>> from sympy.ntheory import jacobi_symbol, legendre_symbol
+    >>> from sympy.functions.combinatorial.numbers import jacobi_symbol, legendre_symbol
     >>> from sympy import S
     >>> jacobi_symbol(45, 77)
     -1
@@ -1226,7 +1226,7 @@ def mobius(n):
     Examples
     ========
 
-    >>> from sympy.ntheory import mobius
+    >>> from sympy.functions.combinatorial.numbers import mobius
     >>> mobius(13*7)
     1
     >>> mobius(1)


### PR DESCRIPTION
Fixed docstring examples that resulted in a deprecation warning.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#26319

related
- #26034
- #26042
- #26050

#### Brief description of what is fixed or changed

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
