### PR TITLE
Fix heurisch integration giving wrong answers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1622,6 +1622,7 @@ vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
 w495 <w495@yandex-team.ru>
+wei yijun <2o18o424@gmail.com>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>
 ylemkimon <ylemkimon@naver.com> <mail@ylem.kim>

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -498,6 +498,9 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     # sort mapping expressions from largest to smallest (last is always x).
     mapping = list(reversed(list(zip(*ordered(                          #
         [(a[0].as_independent(x)[1], a) for a in zip(terms, V)])))[1])) #
+    mapping_subs = []
+    for k, v in mapping:
+        mapping_subs += [(1/k, 1/v), (k, v)]
     rev_mapping = {v: k for k, v in mapping}                            #
     if mappings is None:                                                #
         # optimizing the number of permutations of mapping              #
@@ -508,7 +511,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         unnecessary_permutations = unnecessary_permutations or []
 
     def _substitute(expr):
-        return expr.subs(mapping)
+        return expr.subs(mapping_subs)
 
     for mapping in mappings:
         mapping = list(mapping)
@@ -732,7 +735,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
             raise PolynomialError
         solution = solve_lin_sys(numer.coeffs(), coeff_ring, _raw=False)
 
-        if solution is None or any(s.has_free(*V) for s in solution.values()):
+        if solution is None:
             return None
         else:
             return candidate.xreplace(solution).xreplace(

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -732,7 +732,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
             raise PolynomialError
         solution = solve_lin_sys(numer.coeffs(), coeff_ring, _raw=False)
 
-        if solution is None:
+        if solution is None or any(s.has_free(*V) for s in solution.values()):
             return None
         else:
             return candidate.xreplace(solution).xreplace(

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -365,3 +365,10 @@ def test_issue_22527():
     Uz = integrate(f(z), z)
     Ut = integrate(f(t), t)
     assert Ut == Uz.subs(z, t)
+
+
+def test_heurisch_complex_erf():
+    # It should not be able to find a solution,
+    # rather than returning an incorrect solution.
+    r = symbols(r'r', real=True)
+    assert heurisch(exp(-r**2/(2*(2-I)**2)), r, hints=[]) is None

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1147,8 +1147,8 @@ def test_issue_3940():
     a, b, c, d = symbols('a:d', positive=True)
     assert integrate(exp(-x**2 + I*c*x), x) == \
         -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
-    assert integrate(exp(a*x**2 + b*x + c), x) == \
-        sqrt(pi)*exp(c)*exp(-b**2/(4*a))*erfi(sqrt(a)*x + b/(2*sqrt(a)))/(2*sqrt(a))
+    assert simplify(integrate(exp(a*x**2 + b*x + c), x)) == \
+        sqrt(pi)*exp(c - b**2/(4*a))*erfi((2*a*x + b)/(2*sqrt(a)))/(2*sqrt(a))
 
     from sympy.core.function import expand_mul
     from sympy.abc import k

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -443,7 +443,7 @@ def test_issue_21741():
     r = Piecewise((b*I*exp(-a*I*pi*t*y)*exp(-a*I*pi*x*z)/(pi*x), Ne(x, 0)),
                   (z*exp(-a*I*pi*t*y), True))
     fun = E**((-2*I*pi*(z*x+t*y))/(500*10**(-9)))
-    assert all_close(integrate(fun, z), r)
+    assert all_close(integrate(fun, z).simplify(), r.simplify())
 
 
 def test_matrices():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`sympy.integrate` is giving wrong answers for some integrals.

![2024-03-09 21-10-51屏幕截图](https://github.com/sympy/sympy/assets/44540759/429a463f-44cc-4bf4-b568-3f13a471b01e)

This is due to an implementation error in the Heurisch integration method. Disabling the Heurisch method will produce the correct results:

![2024-03-09 21-13-34屏幕截图](https://github.com/sympy/sympy/assets/44540759/360137ff-61ed-4682-90cf-0e7969bd5931)

Because this method of integration requires trying to solve the integral as a system of linear equations, the solution of the system of linear equations must be independent of the variable V produced after the substitution. It should have failed for this type of integration, but the current implementation finds a solution to the linear system of equations that is dependent of the variable V, thus producing incorrect integration results.

After the fix, Heurisch no longer produces wrong solutions, so it will fallback to other methods that can produce correct solutions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a bug with integrating `exp(-x**2/c)` using Heurisch algorithm, for some complex values of `c`.
<!-- END RELEASE NOTES -->
