### PR TITLE
Add printing options for adjoint symbol in latex

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -167,6 +167,7 @@ class LatexPrinter(Printer):
         "min": None,
         "max": None,
         "diff_operator": "d",
+        "adjoint_style": "dagger",
     }
 
     def __init__(self, settings=None):
@@ -1755,17 +1756,23 @@ class LatexPrinter(Printer):
         return r"\operatorname{tr}\left(%s \right)" % self._print(mat)
 
     def _print_Adjoint(self, expr):
+        style_to_latex = {
+            "dagger"   : r"\dagger",
+            "star"     : r"\ast",
+            "hermitian": r"\mathsf{H}"
+        }
+        adjoint_style = style_to_latex.get(self._settings["adjoint_style"], r"\dagger")
         mat = expr.arg
         from sympy.matrices import MatrixSymbol, BlockMatrix
         if (not isinstance(mat, MatrixSymbol) and
             not isinstance(mat, BlockMatrix) and mat.is_MatrixExpr):
-            return r"\left(%s\right)^{\dagger}" % self._print(mat)
+            return r"\left(%s\right)^{%s}" % (self._print(mat), adjoint_style)
         else:
             s = self.parenthesize(mat, precedence_traditional(expr), True)
             if '^' in s:
-                return r"\left(%s\right)^{\dagger}" % s
+                return r"\left(%s\right)^{%s}" % (s, adjoint_style)
             else:
-                return r"%s^{\dagger}" % s
+                return r"%s^{%s}" % (s, adjoint_style)
 
     def _print_MatMul(self, expr):
         from sympy import MatMul
@@ -3045,6 +3052,9 @@ def latex(expr, **settings):
     diff_operator: string, optional
         String to use for differential operator. Default is ``'d'``, to print in italic
         form. ``'rd'``, ``'td'`` are shortcuts for ``\mathrm{d}`` and ``\text{d}``.
+    adjoint_style: string, optional
+        String to use for the adjoint symbol. Defined options are ``'dagger'``
+        (default),``'star'``, and ``'hermitian'``.
 
     Notes
     =====

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2115,6 +2115,13 @@ def test_Adjoint():
     Mx = MatrixSymbol('M^x', 2, 2)
     assert latex(Adjoint(Mx)) == r'\left(M^{x}\right)^{\dagger}'
 
+    # adjoint style
+    assert latex(Adjoint(X), adjoint_style="star") == r'X^{\ast}'
+    assert latex(Adjoint(X + Y), adjoint_style="hermitian") == r'\left(X + Y\right)^{\mathsf{H}}'
+    assert latex(Adjoint(X) + Adjoint(Y), adjoint_style="dagger") == r'X^{\dagger} + Y^{\dagger}'
+    assert latex(Adjoint(Y)*Adjoint(X)) == r'Y^{\dagger} X^{\dagger}'
+    assert latex(Adjoint(X**2), adjoint_style="star") == r'\left(X^{2}\right)^{\ast}'
+    assert latex(Adjoint(X)**2, adjoint_style="hermitian") == r'\left(X^{\mathsf{H}}\right)^{2}'
 
 def test_Transpose():
     from sympy.matrices import Transpose, MatPow, HadamardPower


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23725

#### Brief description of what is fixed or changed
The notation used to represent adjoint in latex is hard-coded i.e. \dagger.
However, the aforementioned notation is used in quantum mechanics and quantum
field theory. Still there are other used notations like star and H
as pointed out in  issue description and here : https://en.wikipedia.org/wiki/Conjugate_transpose

**After the patch**

```python
In [1]: from sympy import *

In [2]: A = MatrixSymbol("A", 3,3)

In [3]: latex(Adjoint(A), adjoint_style="star")
Out[3]: 'A^{\\ast}'

In [4]: latex(Adjoint(A), adjoint_style="hermitian")
Out[4]: 'A^{\\mathsf{H}}'

In [5]: latex(Adjoint(A), adjoint_style="dagger")
Out[5]: 'A^{\\dagger}'

In [6]: latex(Adjoint(A))
Out[6]: 'A^{\\dagger}'
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Added options for printing adjoint symbol in latex.
<!-- END RELEASE NOTES -->
