### PR TITLE
Fixed Maximum bending moment bug in physics beam

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1119,6 +1119,7 @@ Prateek Papriwal <papriwalprateek@gmail.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>
+Prey Patel <patel.prey@iitgn.ac.in>
 Priit Laes <plaes@plaes.org>
 Prince Gupta <codemastercpp@gmail.com> LAPTOP-AS1M2R8B\codem <codemastercpp@gmail.com>
 Prionti Nasir <pdn3628@rit.edu>

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1027,7 +1027,10 @@ class Beam:
             if s == 0:
                 continue
             try:
-                moment_slope = Piecewise((float("nan"), x<=singularity[i-1]),((self.shear_force().rewrite(Piecewise)), x<s), (float("nan"), True))
+                moment_slope = Piecewise(
+                    (float("nan"), x <= singularity[i - 1]),
+                    (self.shear_force().rewrite(Piecewise), x < s),
+                    (float("nan"), True))
                 points = solve(moment_slope, x)
                 val = []
                 for point in points:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -10,7 +10,6 @@ from sympy.core.function import (Derivative, Function)
 from sympy.core.mul import Mul
 from sympy.core.relational import Eq
 from sympy.core.sympify import sympify
-from sympy.simplify import simplify
 from sympy.solvers import linsolve
 from sympy.solvers.ode.ode import dsolve
 from sympy.solvers.solvers import solve
@@ -1028,8 +1027,7 @@ class Beam:
             if s == 0:
                 continue
             try:
-                moment_in_range = simplify(Piecewise((float("nan"), x<0),((self.shear_force().rewrite(Piecewise)), True),(float("nan"), x>self.length)))
-                moment_slope = Piecewise((float("nan"), x<=singularity[i-1]),(moment_in_range, x<s), (float("nan"), True))
+                moment_slope = Piecewise((float("nan"), x<=singularity[i-1]),((self.shear_force().rewrite(Piecewise)), x<s), (float("nan"), True))
                 points = solve(moment_slope, x)
                 val = []
                 for point in points:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -10,6 +10,7 @@ from sympy.core.function import (Derivative, Function)
 from sympy.core.mul import Mul
 from sympy.core.relational import Eq
 from sympy.core.sympify import sympify
+from sympy.simplify import simplify
 from sympy.solvers import linsolve
 from sympy.solvers.ode.ode import dsolve
 from sympy.solvers.solvers import solve
@@ -934,8 +935,8 @@ class Beam:
             if isinstance(term, Mul):
                 term = term.args[-1]    # SingularityFunction in the term
             singularity.append(term.args[1])
-        singularity.sort()
         singularity = list(set(singularity))
+        singularity.sort()
 
         intervals = []    # List of Intervals with discrete value of shear force
         shear_values = []   # List of values of shear force in each interval
@@ -1018,8 +1019,8 @@ class Beam:
             if isinstance(term, Mul):
                 term = term.args[-1]    # SingularityFunction in the term
             singularity.append(term.args[1])
-        singularity.sort()
         singularity = list(set(singularity))
+        singularity.sort()
 
         intervals = []    # List of Intervals with discrete value of bending moment
         moment_values = []   # List of values of bending moment in each interval
@@ -1027,7 +1028,8 @@ class Beam:
             if s == 0:
                 continue
             try:
-                moment_slope = Piecewise((float("nan"), x<=singularity[i-1]),(self.shear_force().rewrite(Piecewise), x<s), (float("nan"), True))
+                moment_in_range = simplify(Piecewise((float("nan"), x<0),((self.shear_force().rewrite(Piecewise)), True),(float("nan"), x>self.length)))
+                moment_slope = Piecewise((float("nan"), x<=singularity[i-1]),(moment_in_range, x<s), (float("nan"), True))
                 points = solve(moment_slope, x)
                 val = []
                 for point in points:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1039,6 +1039,7 @@ class Beam:
                 max_moment = max(val)
                 moment_values.append(max_moment)
                 intervals.append(points[val.index(max_moment)])
+
             # If bending moment in a particular Interval has zero or constant
             # slope, then above block gives NotImplementedError as solve
             # can't represent Interval solutions.

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -514,7 +514,9 @@ def test_max_shear_force():
     b.apply_load(R2, l, -1)
     b.apply_load(P, 0, 0, end=l)
     b.solve_for_reaction_loads(R1, R2)
-    assert b.max_shear_force() == (0, l*Abs(P)/2)
+    max_shear = b.max_shear_force()
+    assert max_shear[0] == 0
+    assert simplify(max_shear[1] - (l*Abs(P)/2)) == 0
 
 
 def test_max_bmoment():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1422,10 +1422,10 @@ def _solve(f, *symbols, **flags):
         for i, (expr, cnd) in enumerate(f.args):
             # the explicit condition for this expr is the current cond
             # and none of the previous conditions
-            cond = And(neg, cnd)
+            cond = And(neg, cnd).simplify()
             neg = And(neg, ~cond)
 
-            if expr.is_zero and (simplify(cond)!=False):
+            if expr.is_zero and cond != False:
                 raise NotImplementedError(filldedent('''
                     An expression is already zero when %s.
                     This means that in this *region* the solution

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1422,10 +1422,10 @@ def _solve(f, *symbols, **flags):
         for i, (expr, cnd) in enumerate(f.args):
             # the explicit condition for this expr is the current cond
             # and none of the previous conditions
-            cond = And(neg, cnd).simplify()
+            cond = And(neg, cnd)
             neg = And(neg, ~cond)
 
-            if expr.is_zero and cond != False:
+            if expr.is_zero and cond.simplify() != False:
                 raise NotImplementedError(filldedent('''
                     An expression is already zero when %s.
                     This means that in this *region* the solution


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24221

#### Brief description of what is fixed or changed
Simplification of shear force equation was required before converting it into Piecewise. Also corrected sorting singularity list which was causing issues with rational points. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
