### PR TITLE
pass hints to fraction

### DIFF
--- a/doc/src/modules/physics/vector/vectors.rst
+++ b/doc/src/modules/physics/vector/vectors.rst
@@ -607,18 +607,18 @@ relationship between the two frames has been defined. ::
   >>> A.x + N.x
   N.x + A.x
 
-If we want to do vector multiplication, first we have to define and
+If we want to do vector multiplication, first we have to define an
 orientation. The ``orient`` method of ``ReferenceFrame`` provides that
 functionality. ::
 
   >>> A.orient(N, 'Axis', [x, N.y])
 
-If we desire, we can view the DCM between these two frames at any time. This
-can be calculated with the ``dcm`` method. This code: ``N.dcm(A)`` gives the
-dcm :math:`^{\mathbf{A}} \mathbf{C} ^{\mathbf{N}}`.
-
 This orients the :math:`\mathbf{A}` frame relative to the :math:`\mathbf{N}`
-frame by a simple rotation around the Y axis, by an amount x. Other, more
+frame by a simple rotation, around the Y axis, by an amount x.
+The DCM between these two frames can be viewed at any time with the
+``dcm`` method: ``A.dcm(N)`` gives the dcm :math:`^{\mathbf{A}} \mathbf{C} ^{\mathbf{N}}`.
+
+Other, more
 complicated rotation types include Body rotations, Space rotations,
 quaternions, and arbitrary axis rotations. Body and space rotations are
 equivalent to doing 3 simple rotations in a row, each about a basis vector in

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3631,15 +3631,17 @@ class Expr(Basic, EvalfMixin):
            log=log, multinomial=multinomial, basic=basic)
 
         expr = self
+        # default matches fraction's default
+        _fraction = lambda x: fraction(x, hints.get('exact', False))
         if hints.pop('frac', False):
             n, d = [a.expand(deep=deep, modulus=modulus, **hints)
-                    for a in fraction(self)]
+                    for a in _fraction(self)]
             return n/d
         elif hints.pop('denom', False):
-            n, d = fraction(self)
+            n, d = _fraction(self)
             return n/d.expand(deep=deep, modulus=modulus, **hints)
         elif hints.pop('numer', False):
-            n, d = fraction(self)
+            n, d = _fraction(self)
             return n.expand(deep=deep, modulus=modulus, **hints)/d
 
         # Although the hints are sorted here, an earlier hint may get applied

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -920,7 +920,8 @@ class Mul(Expr, AssocOp):
         # Handle things like 1/(x*(x + 1)), which are automatically converted
         # to 1/x*1/(x + 1)
         expr = self
-        n, d = fraction(expr)
+        # default matches fraction's default
+        n, d = fraction(expr, hints.get('exact', False))
         if d.is_Mul:
             n, d = [i._eval_expand_mul(**hints) if i.is_Mul else i
                 for i in (n, d)]

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -137,6 +137,13 @@ def test_expand_frac():
         y*(x + y)/(x**2 + x)
     eq = (x + 1)**2/y
     assert expand_numer(eq, multinomial=False) == eq
+    # issue 26329
+    eq = (exp(x*z) - exp(y*z))/exp(z*(x + y))
+    ans = exp(-y*z) - exp(-x*z)
+    assert eq.expand(numer=True) != ans
+    assert eq.expand(numer=True, exact=True) == ans
+    assert expand_numer(eq) != ans
+    assert expand_numer(eq, exact=True) == ans
 
 
 def test_issue_6121():
@@ -245,7 +252,7 @@ def test_expand_mul():
     e = Mul(2, 3, evaluate=False)
     assert e.expand() == 6
 
-    e = Mul(2, 3, 1/x, evaluate = False)
+    e = Mul(2, 3, 1/x, evaluate=False)
     assert e.expand() == 6/x
     e = Mul(2, R(1, 3), evaluate=False)
     assert e.expand() == R(2, 3)

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1116,7 +1116,7 @@ def fraction(expr, exact=False):
             elif ex.is_positive:
                 numer.append(term)
             elif not exact and ex.is_Mul:
-                n, d = term.as_numer_denom()
+                n, d = term.as_numer_denom()  # this will cause evaluation
                 if n != 1:
                     numer.append(n)
                 denom.append(d)
@@ -1131,12 +1131,12 @@ def fraction(expr, exact=False):
     return Mul(*numer, evaluate=not exact), Mul(*denom, evaluate=not exact)
 
 
-def numer(expr):
-    return fraction(expr)[0]
+def numer(expr, exact=False):  # default matches fraction's default
+    return fraction(expr, exact=exact)[0]
 
 
-def denom(expr):
-    return fraction(expr)[1]
+def denom(expr, exact=False):  # default matches fraction's default
+    return fraction(expr, exact=exact)[1]
 
 
 def fraction_expand(expr, **hints):
@@ -1144,12 +1144,14 @@ def fraction_expand(expr, **hints):
 
 
 def numer_expand(expr, **hints):
-    a, b = fraction(expr)
+    # default matches fraction's default
+    a, b = fraction(expr, exact=hints.get('exact', False))
     return a.expand(numer=True, **hints) / b
 
 
 def denom_expand(expr, **hints):
-    a, b = fraction(expr)
+    # default matches fraction's default
+    a, b = fraction(expr, exact=hints.get('exact', False))
     return a / b.expand(denom=True, **hints)
 
 

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1074,7 +1074,7 @@ def fraction(expr, exact=False):
        (x, y**(-k))
 
        If we know nothing about sign of some exponent and ``exact``
-       flag is unset, then structure this exponent's structure will
+       flag is unset, then the exponent's structure will
        be analyzed and pretty fraction will be returned:
 
        >>> from sympy import exp, Mul

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1214,7 +1214,7 @@ def besselsimp(expr):
     works on the Bessel J and I functions, however. It works by looking at all
     such functions in turn, and eliminating factors of "I" and "-1" (actually
     their polar equivalents) in front of the argument. Then, functions of
-    half-integer order are rewritten using strigonometric functions and
+    half-integer order are rewritten using trigonometric functions and
     functions of integer order (> 1) are rewritten using functions
     of low order.  Finally, if the expression was changed, compute
     factorization of the result with factor().


### PR DESCRIPTION
Now `expand` will pass along hints to `fraction` to allow it to leave powers with negative leading coefficients in the numerator rather than the denominator. I don't think the same issue can apply to denominators since a power with a negative exponent is automatically associated with the numerator. i.e. exp(-x) can be interpreted as being in the numerator or denominator while 1/exp(-x) will be identified as exp(x) (for which there is no ambiguity).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #26329
#### Brief description of what is fixed or changed

From the added tests:
```python
    # issue 26329
    eq = (exp(x*z) - exp(y*z))/exp(z*(x + y))
    ans = exp(-y*z) - exp(-x*z)
    assert eq.expand(numer=True) != ans
    assert eq.expand(numer=True, exact=True) == ans
    assert expand_numer(eq) != ans
    assert expand_numer(eq, exact=True) == ans
```
#### Other comments

When SymPy works with factors that are powers with a leading negative coefficient, those are displayed in numerator instead of the denominator, but `fraction` (by default) puts them in the denominator. So `(exp(-x)/x+exp(-y)/x)` is treated like `1/(x*exp(x)) + 1/(x*exp(y))` when bringing the fraction together and a more complicated fraction results:
```python
>>> (exp(-x)/x+exp(-y)/x).normal()
(x*exp(x) + x*exp(y))*exp(-x)*exp(-y)/x**2
```
If, `factor_terms` is used instead, a more-expected form results:
```python
>>> factor_terms(exp(-x)/x+exp(-y)/x)
(exp(-y) + exp(-x))/x
```

Allowing `expand` to take the `exact` hint is something that is needed to complete the ability of using the "frac", "denom" and "numer" (which are all `fraction` related).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * expand will now accept the hint `exact` which  may be useful when trying to expand the numerator of a fraction having a power like `x**-y` which is to be kept in the numerator instead of defaulting to the denominator
* simplify
<!-- END RELEASE NOTES -->
