### PR TITLE
Fix markdown issue in docstring

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -859,6 +859,7 @@ Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
 Laura Domine <temigo@gmx.com>
 Lauren Glattly <laurenglattly@gmail.com>
+Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
 Laurence Warne <laurencewarne@gmail.com>
 Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
 Lee Johnston <lee.johnston.100@gmail.com>

--- a/sympy/series/series.py
+++ b/sympy/series/series.py
@@ -22,7 +22,7 @@ def series(expr, x=None, x0=0, n=6, dir="+"):
 
     dir : String, optional
           The series-expansion can be bi-directional. If ``dir="+"``,
-          then (x->x0+). If ``dir="-", then (x->x0-). For infinite
+          then (x->x0+). If ``dir="-"``, then (x->x0-). For infinite
           ``x0`` (``oo`` or ``-oo``), the ``dir`` argument is determined
           from the direction of the infinity (i.e., ``dir="-"`` for
           ``oo``).


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Fixed the docstring of the `series` function.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
