### PR TITLE
[GSoC 1.1]Fixes for _eval_nseries of Abs class

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -658,10 +658,13 @@ class Abs(Function):
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         from sympy.functions.elementary.exponential import log
+        from sympy.series.order import Order
         direction = self.args[0].leadterm(x)[0]
         if direction.has(log(x)):
             direction = direction.subs(log(x), logx)
         s = self.args[0]._eval_nseries(x, n=n, logx=logx)
+        if direction.is_extended_real is False:
+            return im(s.removeO()) + Order(x**n, x)
         return (sign(direction)*s).expand()
 
     def _eval_derivative(self, x):

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -335,6 +335,10 @@ def test_sign():
     d = p - q
     assert sign(d).func is sign or sign(d) == 0
 
+    # test leading term
+    assert sign(x).as_leading_term(x) == S.One
+    assert sign(-x).as_leading_term(x) == -S.One
+
 
 def test_as_real_imag():
     n = pi**1000

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -338,6 +338,10 @@ def test_sign():
     # test leading term
     assert sign(x).as_leading_term(x) == S.One
     assert sign(-x).as_leading_term(x) == -S.One
+    assert sign(sin(x)).as_leading_term(x) == S.One
+    assert sign(x + 2).as_leading_term(x) == S.One
+    assert sign(x + I).as_leading_term(x) == S.ImaginaryUnit
+    assert sign(x*I).as_leading_term(x) == S.ImaginaryUnit
 
 
 def test_as_real_imag():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1438,3 +1438,12 @@ def test_issue_22982_15323():
 
 def test_issue_26991():
     assert limit(x/((x - 6)*sinh(tanh(0.03*x)) + tanh(x) - 0.5), x, oo) == 1/sinh(1)
+
+
+def test_issue_25681():
+    x = Symbol('x')
+    expr = x/abs(sqrt(x**2 - 1))
+    assert limit(expr, x, 1, '+') == oo
+    assert limit(expr, x, -1, '-') == -oo
+    assert limit(expr, x, 1, '-') == oo
+    assert limit(expr, x, -1, '+') == -oo

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -406,3 +406,10 @@ def test_issue_24266():
 
 def test_issue_26856():
     raises(ValueError, lambda: (2**x).series(x, oo, -1))
+
+
+def test_issue_25682():
+    x = Symbol('x', negative=True)
+    y = Symbol('y', positive=True)
+    assert (1/abs(sqrt(1 - (-1 + 1/x)**2))).series(x) == -x - x**2 - 3*x**3/2 - 5*x**4/2 - 35*x**5/8 + O(x**6)
+    assert (1/abs(sqrt(1 - (-1 + 1/y)**2))).series(y) == y + y**2 + 3*y**3/2 + 5*y**4/2 + 35*y**5/8 + O(y**6)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -413,3 +413,5 @@ def test_issue_25682():
     y = Symbol('y', positive=True)
     assert (1/abs(sqrt(1 - (-1 + 1/x)**2))).series(x) == -x - x**2 - 3*x**3/2 - 5*x**4/2 - 35*x**5/8 + O(x**6)
     assert (1/abs(sqrt(1 - (-1 + 1/y)**2))).series(y) == y + y**2 + 3*y**3/2 + 5*y**4/2 + 35*y**5/8 + O(y**6)
+    assert abs(sqrt(sin(x))).series(x) == sqrt(-x) - (-x)**(S(5)/2)/12 + (-x)**(S(9)/2)/1440 + O(x**6)
+    assert abs(sqrt(sin(y))).series(y) == sqrt(y) - y**(S(5)/2)/12 + y**(S(9)/2)/1440 + O(y**6)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #25682 
Fixes #25681 
Closes #25756
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
[comment#25682](https://github.com/sympy/sympy/issues/25682#issuecomment-1988436674)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed bugs in `_eval_nseries` method of Abs class.

<!-- END RELEASE NOTES -->
