### PR TITLE
Fix incorrect output in utilities.iterables.ordered_partitions

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1848,18 +1848,18 @@ def ordered_partitions(n, m=None, sort=True):
             x = n - b*m
             if not x:
                 if sort:
-                    yield a
+                    yield a[:]
             elif not sort and x <= m:
                 for ax in ordered_partitions(x, sort=False):
                     mi = len(ax)
                     a[-mi:] = [i + b for i in ax]
-                    yield a
+                    yield a[:]
                     a[-mi:] = [b]*mi
             else:
                 for mi in range(1, m):
                     for ax in ordered_partitions(x, mi, sort=True):
                         a[-mi:] = [i + b for i in ax]
-                        yield a
+                        yield a[:]
                         a[-mi:] = [b]*mi
 
 


### PR DESCRIPTION
This change updates sympy.utilities.iterables.ordered_partitions to return a correctly copied list.

#### Brief description of what is fixed or changed

Previously, `list(sympy.utilities.iterables.ordered_partitions(6, 2))` returned incorrect partitions. Specifically, it resulted in:

```python
# this outputs incorrect partitions
list(sympy.utilities.iterables.ordered_partitions(6, 2))
>> [[1, 1], [2, 2], [3, 3]] 

# but, the following code works well
for p in sympy.utilities.iterables.ordered_partitions(6, 2):
    print(p)
>> [1, 5]
>> [2, 4]
>> [3, 3]    
```

With the proposed change, the function now correctly returns the intended output.

```python
list(sympy.utilities.iterables.ordered_partitions(6, 2))
>> [[1, 5], [2, 4], [3, 3]]
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fixed a bug with output of utilities.iterables.ordered_partitions. 
<!-- END RELEASE NOTES -->
