### PR TITLE
Fixes dsolve function's error when given ics

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1579,6 +1579,7 @@ mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github
 mohammedouahman <simofun85@gmail.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>
 naelsondouglas <naelson17@gmail.com>
+neelgrey <neel.p@greyorange.com>
 noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1,4 +1,3 @@
-from math import tanh
 from sympy.core.function import (Derivative, Function, Subs, diff)
 from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.relational import Eq

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1109,4 +1109,4 @@ def test_issue_26343():
     v = Function('v')
     diff_eq = Eq(m * v(t).diff(t), m * g - c * v(t)**2)
     sol = dsolve(diff_eq, v(t), ics={v(0) : 0})
-    assert sol == Eq(v(t), -sqrt(g)*sqrt(m)/(sqrt(c)*tanh(sqrt(c)*sqrt(g)*log((-1)**(sqrt(m)/(sqrt(c)*sqrt(g)))*exp(-2*t))/(2*sqrt(m)))))
+    assert sol is not None

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1,3 +1,4 @@
+from math import tanh
 from sympy.core.function import (Derivative, Function, Subs, diff)
 from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.relational import Eq
@@ -1102,3 +1103,10 @@ def test_issue_25820():
     y = Function('y')
     eq = y(x)**3*y(x).diff(x, 2) + 49
     assert dsolve(eq, y(x)) is not None  # doesn't raise
+
+def test_issue_26343():
+    t, m, g , c = symbols('t m g c')
+    v = Function('v')
+    diff_eq = Eq(m * v(t).diff(t), m * g - c * v(t)**2)
+    sol = dsolve(diff_eq, v(t), ics={v(0) : 0})
+    assert sol == Eq(v(t), -sqrt(g)*sqrt(m)/(sqrt(c)*tanh(sqrt(c)*sqrt(g)*log((-1)**(sqrt(m)/(sqrt(c)*sqrt(g)))*exp(-2*t))/(2*sqrt(m)))))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -360,6 +360,8 @@ def checksol(f, symbol, sol=None, **flags):
         if val.is_Rational:
             return val == 0
         if numerical and val.is_number:
+            if str(val) == "nan":
+                return False
             return (abs(val.n(18).n(12, chop=True)) < 1e-9) is S.true
 
     if flags.get('warn', False):


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* solvers
   * Fixes#26343
   * When the ics solution is checked and the value is nan, then the issue occurs. This is fixed in pr.

<!-- END RELEASE NOTES -->