### PR TITLE
Add extra check for singular points in ``match_2nd_2F1_hypergeometric``

### DIFF
--- a/sympy/solvers/ode/hypergeometric.py
+++ b/sympy/solvers/ode/hypergeometric.py
@@ -146,7 +146,7 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func):
     delta = Wild("delta")
     # I0 of the standerd 2F1 equation.
     I0 = ((a-b+1)*(a-b-1)*x**2 + 2*((1-a-b)*c + 2*a*b)*x + c*(c-2))/(4*x**2*(x-1)**2)
-    if sing_point != [0, 1]:
+    if len(sing_point) >= 2 and sing_point != [0, 1]:
         # If singular point is [0, 1] then we have standerd equation.
         eqs = []
         sing_eqs = [-beta/alpha, -delta/gamma, (delta-beta)/(alpha-gamma)]

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -324,6 +324,14 @@ def test_classify_ode():
         'lie_group', 'separable_Integral',
         '1st_exact_Integral')
 
+    # test issue 25882
+    a = classify_ode((x - 1)*Derivative(f(x), (x, 2)) - Derivative(f(x), x), f(x))
+    assert a == ('factorable',
+        'Liouville', '2nd_hypergeometric',
+        '2nd_hypergeometric_Integral',
+        'nth_order_reducible',
+        '2nd_power_series_ordinary',
+        'Liouville_Integral')
 
 def test_classify_ode_ics():
     # Dummy


### PR DESCRIPTION
Adding extra check on the number of singular points in 2f1 hypergeometric function, and adding the corresponding tests.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes  #25882

#### Brief description of what is fixed or changed
Adding extra check on the number of singular points in ``match_2nd_2F1_hypergeometric``
function, and adding the corresponding tests.

**After the Patch**
```python
from sympy import classify_ode, Derivative, Function, Symbol
y = Function('y')
x = Symbol('x')
eq = (x - 1)*Derivative(y(x), (x,2)) - Derivative(y(x), x)
print(classify_ode(eq, y(x)))
```
Output:
```python
('factorable', 'Liouville', '2nd_hypergeometric', '2nd_hypergeometric_Integral', 'nth_order_reducible', '2nd_power_series_ordinary', 'Liouville_Integral')
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
