### PR TITLE
Raise ValueError if Symbol does not print to valid C variable name.

### DIFF
--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -13,6 +13,7 @@ source code files that are compilable without further modifications.
 
 from __future__ import annotations
 from typing import Any
+import re
 
 from functools import wraps
 from itertools import chain
@@ -87,6 +88,13 @@ reserved_words = [
 ]
 
 reserved_words_c99 = ['inline', 'restrict']
+
+
+def _is_valid_c_variable_name(var_name):
+    pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
+    if not pattern.search(var_name):
+        raise ValueError('SymPy symbol {} not printable in C.'.format(var_name))
+
 
 def get_math_macros():
     """ Returns a dictionary with math-related macros from math.h/cmath
@@ -387,6 +395,8 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
+        # if name is an indexed, e.g. a[0], only check the variable name
+        _is_valid_c_variable_name(name.split('[')[0])
         if expr in self._settings['dereference']:
             return '(*{})'.format(name)
         else:

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -90,12 +90,6 @@ reserved_words = [
 reserved_words_c99 = ['inline', 'restrict']
 
 
-def _is_valid_c_variable_name(var_name):
-    pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
-    if not pattern.search(var_name):
-        raise ValueError('SymPy symbol {} not printable in C.'.format(var_name))
-
-
 def get_math_macros():
     """ Returns a dictionary with math-related macros from math.h/cmath
 
@@ -275,6 +269,13 @@ class C89CodePrinter(CodePrinter):
         rows, cols = mat.shape
         return ((i, j) for i in range(rows) for j in range(cols))
 
+    @staticmethod
+    def _check_valid_c_variable_name(var_name):
+        pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
+        msg = 'SymPy symbol {} not printable in C.'
+        if not pattern.search(var_name):
+            raise ValueError(msg.format(var_name))
+
     @_as_macro_if_defined
     def _print_Mul(self, expr, **kwargs):
         return super()._print_Mul(expr, **kwargs)
@@ -396,7 +397,7 @@ class C89CodePrinter(CodePrinter):
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
         # if name is an indexed, e.g. a[0], only check the variable name
-        _is_valid_c_variable_name(name.split('[')[0])
+        self._check_valid_c_variable_name(name.split('[')[0])
         if expr in self._settings['dereference']:
             return '(*{})'.format(name)
         else:

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -26,8 +26,18 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.matrices import Matrix, MatrixSymbol, SparseMatrix
 
 from sympy.printing.codeprinter import ccode
+from sympy.printing.c import _is_valid_c_variable_name
 
 x, y, z = symbols('x,y,z')
+
+
+def test_invalid_variable_names():
+    long_var = 'w'*32
+    syms = symbols('I_{x}, a*, 9t, bus#, %s' % long_var)
+    for s in syms:
+        with raises(ValueError):
+            ccode(s)
+    ccode('w'*31)
 
 
 def test_printmethod():

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -38,7 +38,7 @@ def test_invalid_variable_names():
             ccode(s)
     # these should not raise
     short_var = 'w'*31
-    syms = symbols('my_funny_var[5], b[1][2], a[idx], %s' % short_var)
+    syms = symbols('funny_var[5], b[1][2], a[idx], out[i*N+j], %s' % short_var)
     for s in syms:
         ccode(s)
 

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -26,7 +26,6 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.matrices import Matrix, MatrixSymbol, SparseMatrix
 
 from sympy.printing.codeprinter import ccode
-from sympy.printing.c import _is_valid_c_variable_name
 
 x, y, z = symbols('x,y,z')
 

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -32,11 +32,15 @@ x, y, z = symbols('x,y,z')
 
 def test_invalid_variable_names():
     long_var = 'w'*32
-    syms = symbols('I_{x}, a*, 9t, bus#, %s' % long_var)
+    syms = symbols(r'a_{\delta}[0], I_{x}, a*, 9t, bus#, %s' % long_var)
     for s in syms:
         with raises(ValueError):
             ccode(s)
-    ccode('w'*31)
+    # these should not raise
+    short_var = 'w'*31
+    syms = symbols('my_funny_var[5], b[1][2], a[idx], %s' % short_var)
+    for s in syms:
+        ccode(s)
 
 
 def test_printmethod():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Brought up in opty at https://github.com/csu-hmc/opty/issues/139

This somewhat addresses:

https://github.com/sympy/sympy/issues/7767

#### Brief description of what is fixed or changed

In C code generation processes there can be compile errors because some SymPy symbols do not print to valid C variable names. By the time the C code is compiled the error may not be clearly propagated and explained to the user. One option is to tell people up front at code printing time that they have an invalid symbol name. This will at least give a clear error message instead of a possibly obfuscated or hidden compile error.

Maybe the desired solution is to convert a `Symbol.name` into a valid C variable name instead of raising an error. I suppose that people could be printing invalid C code and then fixing it post printing before they compile the C code. If so, this "fix" could break their code. I'll throw this out here to see what people think, but maybe it is not a good solution.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Raise ValueError if Symbol does not print to valid C variable name.

<!-- END RELEASE NOTES -->
