### PR TITLE
Quarter wave plate equation added in polarization

### DIFF
--- a/sympy/physics/optics/polarization.py
+++ b/sympy/physics/optics/polarization.py
@@ -765,4 +765,3 @@ def quarter_wave_plate(delta=0):
     M = Matrix([[cos(delta), sin(delta)],
                 [sin(delta), -cos(delta)]])
     return M
-

--- a/sympy/physics/optics/polarization.py
+++ b/sympy/physics/optics/polarization.py
@@ -757,9 +757,9 @@ def quarter_wave_plate(delta=0):
     >>> delta = pi/4
     >>> J = quarter_wave_plate(delta)
     >>> pprint(J, use_unicode=True)
-    ⎡1   0⎤
-    ⎢     ⎥
-    ⎣0  -1⎦
+    ⎡ √2/2   √2/2 ⎤
+    ⎢             ⎥
+    ⎣ √2/2  -√2/2 ⎦
 
     """
     M = Matrix([[cos(delta), sin(delta)],

--- a/sympy/physics/optics/polarization.py
+++ b/sympy/physics/optics/polarization.py
@@ -752,6 +752,7 @@ def quarter_wave_plate(delta=0):
 
     A quarter-wave plate with a phase retardance of pi/4.
 
+    >>> from sympy import pprint, pi
     >>> from sympy.physics.optics.polarization import quarter_wave_plate
     >>> delta = pi/4
     >>> J = quarter_wave_plate(delta)

--- a/sympy/physics/optics/polarization.py
+++ b/sympy/physics/optics/polarization.py
@@ -730,3 +730,39 @@ def polarizing_beam_splitter(Tp=1, Rs=1, Ts=0, Rp=0, phia=0, phib=0):
                   [I*sqrt(Rp), 0, sqrt(Tp), 0],
                   [0, -I*sqrt(Rs)*exp(I*phib), 0, sqrt(Ts)]])
     return PBS
+
+
+def quarter_wave_plate(delta=0):
+    """A quarter-wave plate Jones matrix with phase retardance ``delta``.
+
+    Parameters
+    ==========
+
+    delta : numeric type or SymPy Symbol
+        The phase retardance of the quarter-wave plate in radians.
+
+    Returns
+    =======
+
+    SymPy Matrix
+        A Jones matrix representing the quarter-wave plate.
+
+    Examples
+    ========
+
+    A quarter-wave plate with a phase retardance of pi/4.
+
+    >>> from sympy import pprint, symbols, pi
+    >>> from sympy.physics.optics.polarization import quarter_wave_plate
+    >>> delta = pi/4
+    >>> J = quarter_wave_plate(delta)
+    >>> pprint(J, use_unicode=True)
+    ⎡1   0⎤
+    ⎢     ⎥
+    ⎣0  -1⎦
+
+    """
+    M = Matrix([[cos(delta), sin(delta)],
+                [sin(delta), -cos(delta)]])
+    return M
+

--- a/sympy/physics/optics/polarization.py
+++ b/sympy/physics/optics/polarization.py
@@ -752,7 +752,6 @@ def quarter_wave_plate(delta=0):
 
     A quarter-wave plate with a phase retardance of pi/4.
 
-    >>> from sympy import pprint, symbols, pi
     >>> from sympy.physics.optics.polarization import quarter_wave_plate
     >>> delta = pi/4
     >>> J = quarter_wave_plate(delta)

--- a/sympy/physics/optics/tests/test_polarization.py
+++ b/sympy/physics/optics/tests/test_polarization.py
@@ -1,7 +1,7 @@
 from sympy.physics.optics.polarization import (jones_vector, stokes_vector,
     jones_2_stokes, linear_polarizer, phase_retarder, half_wave_retarder,
     quarter_wave_retarder, transmissive_filter, reflective_filter,
-    mueller_matrix, polarizing_beam_splitter)
+    mueller_matrix, polarizing_beam_splitter, quarter_wave_plate)
 from sympy.core.numbers import (I, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
@@ -55,3 +55,6 @@ def test_polarization():
     #################################################################
     res = Matrix([[1, 0, 0, 0], [0, 0, 0, -I], [0, 0, 1, 0], [0, -I, 0, 0]])
     assert polarizing_beam_splitter() == res
+    #################################################################
+    res = Matrix([[1, 0], [0, -1]])
+    assert quarter_wave_plate(0) == res


### PR DESCRIPTION
## Quarter wave plate Optical Equation

<!-- #### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I have added Quarter wave plate equation which return the output in Jones Matrix.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:
-->

* physics.optics
  * Added the code of Quarter Wave Plate Equation which takes input of angle in radians and output a Jones Matrix.

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
