### PR TITLE
segment and ray tangent when in tangent line

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -748,13 +748,13 @@ class Ellipse(GeometrySet):
                 return True
             # might return None if it can't decide
             return hit[0].equals(hit[1])
-        elif isinstance(o, Ray2D):
+        elif isinstance(o, (Segment2D, Ray2D)):
             intersect = self.intersection(o)
             if len(intersect) == 1:
-                return intersect[0] != o.source and not self.encloses_point(o.source)
+                return o in self.tangent_lines(intersect[0])[0]
             else:
                 return False
-        elif isinstance(o, (Segment2D, Polygon)):
+        elif isinstance(o, Polygon):
             all_tangents = False
             segments = o.sides if isinstance(o, Polygon) else [o]
             for segment in segments:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -755,20 +755,7 @@ class Ellipse(GeometrySet):
             else:
                 return False
         elif isinstance(o, Polygon):
-            all_tangents = False
-            segments = o.sides if isinstance(o, Polygon) else [o]
-            for segment in segments:
-                intersect = self.intersection(segment)
-                if len(intersect) == 1:
-                    if not any(intersect[0] in i for i in segment.points) \
-                        and not any(self.encloses_point(i) for i in segment.points):
-                        all_tangents = True
-                        continue
-                    else:
-                        return False
-                else:
-                    return False
-            return all_tangents
+            return all(self.is_tangent(s) for s in o.sides)
         elif isinstance(o, (LinearEntity3D, Point3D)):
             raise TypeError('Entity must be two dimensional, not three dimensional')
         else:

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -452,6 +452,7 @@ def test_is_tangent():
     assert c1.is_tangent(Ray((-3, -2), (-15, -20))) is False
     assert c1.is_tangent(Ray((-3, -22), (15, 20))) is False
     assert c1.is_tangent(Ray((9, 20), (9, -20))) is True
+    assert c1.is_tangent(Ray((2, 5), (9, 5))) is True
     assert e1.is_tangent(Segment((2, 2), (-7, 7))) is False
     assert e1.is_tangent(Segment((0, 0), (1, 2))) is False
     assert c1.is_tangent(Segment((0, 0), (-5, -2))) is False

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -453,6 +453,7 @@ def test_is_tangent():
     assert c1.is_tangent(Ray((-3, -22), (15, 20))) is False
     assert c1.is_tangent(Ray((9, 20), (9, -20))) is True
     assert c1.is_tangent(Ray((2, 5), (9, 5))) is True
+    assert c1.is_tangent(Segment((2, 5), (9, 5))) is True
     assert e1.is_tangent(Segment((2, 2), (-7, 7))) is False
     assert e1.is_tangent(Segment((0, 0), (1, 2))) is False
     assert c1.is_tangent(Segment((0, 0), (-5, -2))) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #13496 
closes #19471

#### Brief description of what is fixed or changed

If a segment or ray intersects an ellipse, and is contained in a line that is tangent to an ellipse, then it is considered to be tangent.

The convention that a polygon *as a whole* is considered tangent only if all sides are tangent is maintained. If the user wants to know if there is any side that is tangent, `any(ellipse.is_tangent(s) for s in poly.sides)` could be used

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * segments and rays touching an ellipse, contained in a line tangent to the ellipse are now considered as being tangents
<!-- END RELEASE NOTES -->
