### PR TITLE
Improved speed of partial_velocity()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1174,6 +1174,7 @@ Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redebo
 Renato Coutinho <renato.coutinho@gmail.com>
 Renato Orsino <renato.orsino@gmail.com>
 Rhea Parekh <rheaparekh12@gmail.com>
+Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
 Riccardo Gori <goriccardo@gmail.com>
 Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
 Rich LaSota <rjlasota@gmail.com>


### PR DESCRIPTION

#### References to other Issues or PRs
- Issue #25070: 
The issue highlights inefficiencies in the mechanics module, particularly where diff() and jacobian() are used to derive linear coefficients in expressions assumed to be linear.


#### Brief description of what is fixed or changed

The new partial_velocity() function leverages the linearity of velocities in the generalised coordinates to speed up the calculations. The two approaches can be observed in the summary image below, where the new one is the one at the right of the arrow.

![Screenshot 2024-03-18 at 12 31 25](https://github.com/sympy/sympy/assets/118138006/0aa03ed9-8a82-4c16-bd0f-b9ca8f50151a)

Benchmarking the two approaches function using `n_link_pendulum_on_cart(n=10, cart_force=True, joint_torques=False) `from `sympy.physics.mechanics.models` yields this difference in performance:

- The new approach takes 37.7 ms ± 1.92 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
- The old approach takes 226 ms ± 9.42 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Improved speed of partial_velocity()

<!-- END RELEASE NOTES -->
