### PR TITLE
Add attribute to overwrite the velocity constraints

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
@@ -20,7 +20,7 @@ generalized speeds `u_1`, `u_2` and `u_3` represent the angular velocities
 between the links. We also create some :func:`~.symbols` to represent the
 lengths and density of the links. ::
 
-   >>> from sympy import symbols, simplify
+   >>> from sympy import Matrix, linear_eq_to_matrix, pi, simplify, symbols
    >>> from sympy.physics.mechanics import *
    >>> mechanics_printing(pretty_print=False)
    >>> q1, q2, q3, u1, u2, u3 = dynamicsymbols('q1:4, u1:4')
@@ -60,8 +60,9 @@ add them to the system. ::
 Now we can formulate the holonomic constraint that will close the kinematic
 loop. ::
 
-   >>> loop = (link4.masscenter.pos_from(link1.masscenter) +
-   ...         l1/2*link1.x +l4/2*link4.x)
+   >>> start_point = link1.masscenter.locatenew('start_point', -l1/2*link1.x)
+   >>> end_point = link4.masscenter.locatenew('end_point', l4/2*link4.x)
+   >>> loop = end_point.pos_from(start_point)
    >>> system.add_holonomic_constraints(loop.dot(link1.x), loop.dot(link1.y))
 
 Before generating the equations of motion we need to specify which generalized
@@ -80,3 +81,67 @@ using :class:`~.KanesMethod` as the backend. ::
    >>> simplify(system.form_eoms())
     Matrix([[l2*rho*(-2*l2**2*sin(q3)*u1' + 3*l2*l3*u1**2*sin(q2 + q3)*sin(q2) + 3*l2*l3*sin(q2)*cos(q2 + q3)*u1' - 3*l2*l3*sin(q3)*u1' + 3*l2*l4*u1**2*sin(q2 + q3)*sin(q2) + 3*l2*l4*sin(q2)*cos(q2 + q3)*u1' + 3*l3**2*u1**2*sin(q2)*sin(q3) + 6*l3**2*u1*u2*sin(q2)*sin(q3) + 3*l3**2*u2**2*sin(q2)*sin(q3) + 2*l3**2*sin(q2)*cos(q3)*u1' + 2*l3**2*sin(q2)*cos(q3)*u2' - l3**2*sin(q3)*cos(q2)*u1' - l3**2*sin(q3)*cos(q2)*u2' + 3*l3*l4*u1**2*sin(q2)*sin(q3) + 6*l3*l4*u1*u2*sin(q2)*sin(q3) + 3*l3*l4*u2**2*sin(q2)*sin(q3) + 3*l3*l4*sin(q2)*cos(q3)*u1' + 3*l3*l4*sin(q2)*cos(q3)*u2' + l4**2*sin(q2)*u1' + l4**2*sin(q2)*u2' + l4**2*sin(q2)*u3')/(6*sin(q3))]])
 
+Revealing noncontributing forces
+--------------------------------
+
+To reveal the noncontributing forces at the closing joint, we require to
+introduce auxiliary speeds in the x and y-direction at the endpoint.
+
+   >>> uaux1, uaux2 = dynamicsymbols('uaux1:3')
+   >>> end_point_aux = end_point.locatenew('end_point_aux', 0)
+   >>> end_point_aux.set_vel(N, end_point.vel(N) + uaux1*N.x + uaux2*N.y)
+
+To ensure that speeds are included in the velocity constraints, we must manually
+overwrite the velocity constraints because those are by default specified as the
+time derivatives of the holonomic constraints.
+
+   >>> system.velocity_constraints = [
+   ...    end_point_aux.vel(N).dot(N.x), end_point_aux.vel(N).dot(N.y)]
+
+When adding the noncontributing forces we need them to depend only on the
+auxiliary velocity and not the velocity that is eliminated by the constraints.
+This can be achieved by applying an equal and opposite force to the
+non-auxiliary endpoint.
+
+   >>> faux1, faux2 = dynamicsymbols('faux1:3')
+   >>> noncontributing_forces = [
+   ...   Force(end_point_aux, faux1*N.x + faux2*N.y),
+   ...   Force(end_point, -(faux1*N.x + faux2*N.y)),
+   ... ]
+
+Alternatively, we can specify a new point that already subtracts the velocity
+eliminated by the constraints.
+
+   >>> end_point_forces = end_point.locatenew('end_point_forces', 0)
+   >>> end_point_forces.set_vel(N, uaux1*N.x + uaux2*N.y)
+   >>> noncontributing_forces = [Force(end_point_forces, faux1*N.x + faux2*N.y)]
+
+Next, we can add the auxiliary speeds and noncontributing forces to the system.
+
+   >>> system.add_loads(*noncontributing_forces)
+   >>> system.u_aux = [uaux1, uaux2]
+
+To include the gravity we can use :meth:`~.System.apply_uniform_gravity` before
+validating the system and forming the equations of motion.
+
+   >>> g = symbols('g')
+   >>> system.apply_uniform_gravity(-g*N.y)
+   >>> system.validate_system()
+   >>> system.form_eoms();
+
+With the equations of motion formed we can solve the auxiliary equations for the
+noncontributing forces and compute their values for a simple configuration.
+
+   >>> auxiliary_eqs = system.eom_method.auxiliary_eqs
+   >>> forces_eqs = Matrix.LUsolve(
+   ...   *linear_eq_to_matrix(auxiliary_eqs, [faux1, faux2]))
+   >>> subs = {
+   ...   l1: 2, l2: 1, l3: 2, l4: 1,
+   ...   rho: 5, g: 9.81,
+   ...   q1: pi / 2, q2: pi / 2, q3: pi / 2,
+   ...   u1: 0, u2: 0, u3: 0, u1.diff(): 0, u2.diff(): 0, u3.diff(): 0,
+   ... }
+   >>> forces_eqs.xreplace(subs)
+   Matrix([
+   [    0],
+   [-98.1]])

--- a/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
@@ -138,7 +138,7 @@ noncontributing forces and compute their values for a simple configuration.
    >>> subs = {
    ...   l1: 2, l2: 1, l3: 2, l4: 1,
    ...   rho: 5, g: 9.81,
-   ...   q1: pi / 2, q2: pi / 2, q3: pi / 2,
+   ...   q1: pi/2, q2: pi/2, q3: pi/2,
    ...   u1: 0, u2: 0, u3: 0, u1.diff(): 0, u2.diff(): 0, u3.diff(): 0,
    ... }
    >>> forces_eqs.xreplace(subs)

--- a/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
@@ -127,7 +127,7 @@ validating the system and forming the equations of motion.
    >>> g = symbols('g')
    >>> system.apply_uniform_gravity(-g*N.y)
    >>> system.validate_system()
-   >>> system.form_eoms();
+   >>> eoms = system.form_eoms()
 
 With the equations of motion formed we can solve the auxiliary equations for the
 noncontributing forces and compute their values for a simple configuration.

--- a/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
@@ -84,8 +84,8 @@ using :class:`~.KanesMethod` as the backend. ::
 Revealing noncontributing forces
 --------------------------------
 
-To reveal the noncontributing forces at the closing joint, we require to
-introduce auxiliary speeds in the x and y-direction at the endpoint.
+To reveal the noncontributing forces at the closing joint, we must introduce
+auxiliary speeds in the x and y-direction at the endpoint.
 
    >>> uaux1, uaux2 = dynamicsymbols('uaux1:3')
    >>> end_point_aux = end_point.locatenew('end_point_aux', 0)
@@ -121,7 +121,7 @@ Next, we can add the auxiliary speeds and noncontributing forces to the system.
    >>> system.add_loads(*noncontributing_forces)
    >>> system.u_aux = [uaux1, uaux2]
 
-To include the gravity we can use :meth:`~.System.apply_uniform_gravity` before
+To include gravity we can use :meth:`~.System.apply_uniform_gravity` before
 validating the system and forming the equations of motion.
 
    >>> g = symbols('g')

--- a/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/four_bar_linkage_example.rst
@@ -20,7 +20,7 @@ generalized speeds `u_1`, `u_2` and `u_3` represent the angular velocities
 between the links. We also create some :func:`~.symbols` to represent the
 lengths and density of the links. ::
 
-   >>> from sympy import symbols, Matrix, solve, simplify
+   >>> from sympy import symbols, simplify
    >>> from sympy.physics.mechanics import *
    >>> mechanics_printing(pretty_print=False)
    >>> q1, q2, q3, u1, u2, u3 = dynamicsymbols('q1:4, u1:4')

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -91,6 +91,10 @@ class System(_Methods):
     nonholonomic_constraints : ImmutableMatrix
         Matrix with the nonholonomic constraints as expressions equated to the
         zero matrix.
+    velocity_constraints : ImmutableMatrix
+        Matrix with the velocity constraints as expressions equated to the zero
+        matrix. These are by default derived as the time derivatives of the
+        holonomic constraints extended with the nonholonomic constraints.
     eom_method : subclass of KanesMethod or LagrangesMethod
         Backend for forming the equations of motion.
 
@@ -260,6 +264,7 @@ class System(_Methods):
         self._kdes = ImmutableMatrix(1, 0, []).T
         self._hol_coneqs = ImmutableMatrix(1, 0, []).T
         self._nonhol_coneqs = ImmutableMatrix(1, 0, []).T
+        self._vel_constrs = None
         self._bodies = []
         self._joints = []
         self._loads = []
@@ -456,6 +461,27 @@ class System(_Methods):
         constraints = self._objects_to_list(constraints)
         self._nonhol_coneqs = self._parse_expressions(
             constraints, [], 'nonholonomic constraints')
+
+    @property
+    def velocity_constraints(self):
+        """Matrix with the velocity constraints as expressions equated to the
+        zero matrix. The velocity constraints are by default derived from the
+        holonomic and nonholonomic constraints unless they are explicitly set.
+        """
+        if self._vel_constrs is None:
+            return self.holonomic_constraints.diff(dynamicsymbols._t).col_join(
+                self.nonholonomic_constraints)
+        return self._vel_constrs
+
+    @velocity_constraints.setter
+    @_reset_eom_method
+    def velocity_constraints(self, constraints):
+        if constraints is None:
+            self._vel_constrs = None
+            return
+        constraints = self._objects_to_list(constraints)
+        self._vel_constrs = self._parse_expressions(
+            constraints, [], 'velocity constraints')
 
     @property
     def eom_method(self):
@@ -850,13 +876,11 @@ class System(_Methods):
                 raise ValueError(
                     f"The following keyword arguments are not allowed to be "
                     f"overwritten in {eom_method.__name__}: {wrong_kwargs}.")
-            velocity_constraints = self.holonomic_constraints.diff(
-                dynamicsymbols._t).col_join(self.nonholonomic_constraints)
             kwargs = {"frame": self.frame, "q_ind": self.q_ind,
                       "u_ind": self.u_ind, "kd_eqs": self.kdes,
                       "q_dependent": self.q_dep, "u_dependent": self.u_dep,
                       "configuration_constraints": self.holonomic_constraints,
-                      "velocity_constraints": velocity_constraints,
+                      "velocity_constraints": self.velocity_constraints,
                       "u_auxiliary": self.u_aux,
                       "forcelist": loads, "bodies": self.bodies,
                       "explicit_kinematics": False, **kwargs}
@@ -1009,7 +1033,7 @@ class System(_Methods):
         msgs = []
         # Save some data in variables
         n_hc = self.holonomic_constraints.shape[0]
-        n_nhc = self.nonholonomic_constraints.shape[0]
+        n_vc = self.velocity_constraints.shape[0]
         n_q_dep, n_u_dep = self.q_dep.shape[0], self.u_dep.shape[0]
         q_set, u_set = set(self.q), set(self.u)
         n_q, n_u = len(q_set), len(u_set)
@@ -1042,10 +1066,10 @@ class System(_Methods):
                 msgs.append(filldedent(f"""
                 The kinematic differential equations {missing_kdes} used in
                 joints are not added to the system."""))
-            if n_u_dep != n_hc + n_nhc:
+            if n_u_dep != n_vc:
                 msgs.append(filldedent(f"""
                 The number of dependent generalized speeds {n_u_dep} should be
-                equal to the number of velocity constraints {n_hc + n_nhc}."""))
+                equal to the number of velocity constraints {n_vc}."""))
             if n_q > n_u:
                 msgs.append(filldedent(f"""
                 The number of generalized coordinates {n_q} should be less than

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -72,6 +72,8 @@ class System(_Methods):
         Matrix of the independent generalized speeds.
     u_dep : ImmutableMatrix
         Matrix of the dependent generalized speeds.
+    u_aux : ImmutableMatrix
+        Matrix of auxiliary generalized speeds.
     kdes : ImmutableMatrix
         Matrix of the kinematical differential equations as expressions equated
         to the zero matrix.

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -375,6 +375,24 @@ class TestSystem(TestSystemBase):
             self.system.add_nonholonomic_constraints(*args, **kwargs)
         self._filled_system_check()
 
+    @pytest.mark.parametrize('constraints, expected', [
+        ([], []),
+        (qd[2] - qd[0] + qd[1], [qd[2] - qd[0] + qd[1]]),
+        ([qd[2] + qd[1], u[2] - u[1]], [qd[2] + qd[1], u[2] - u[1]]),
+    ])
+    def test_velocity_constraints_overwrite(self, _filled_system_setup,
+                                            constraints, expected):
+        self.system.velocity_constraints = constraints
+        self._filled_system_check(exclude=('velocity_constraints',))
+        assert self.system.velocity_constraints[:] == expected
+
+    def test_velocity_constraints_back_to_auto(self, _filled_system_setup):
+        self.system.velocity_constraints = qd[3] - qd[2]
+        self._filled_system_check(exclude=('velocity_constraints',))
+        assert self.system.velocity_constraints[:] == [qd[3] - qd[2]]
+        self.system.velocity_constraints = None
+        self._filled_system_check()
+
     def test_bodies(self, _filled_system_setup):
         rb1, rb2 = RigidBody('rb1'), RigidBody('rb2')
         p1, p2 = Particle('p1'), Particle('p2')

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -60,6 +60,7 @@ class TestSystemBase:
         self.u_ind, self.u_dep = self.system.u_ind[:], self.system.u_dep[:]
         self.kdes = self.system.kdes[:]
         self.hc = self.system.holonomic_constraints[:]
+        self.vc = self.system.velocity_constraints[:]
         self.nhc = self.system.nonholonomic_constraints[:]
 
     @pytest.fixture()
@@ -85,6 +86,9 @@ class TestSystemBase:
         assert ('nonholonomic_constraints' in exclude or
                 self.system.nonholonomic_constraints[:] == [u[3] - qd[1] + u[2]]
                 )
+        assert ('velocity_constraints' in exclude or
+                self.system.velocity_constraints[:] == [
+                    qd[2] - qd[0] + qd[1], u[3] - qd[1] + u[2]])
         assert ('bodies' in exclude or
                 self.system.bodies == tuple(self.bodies))
         assert ('joints' in exclude or
@@ -253,7 +257,10 @@ class TestSystem(TestSystemBase):
     def test_add_after_reset(self, _filled_system_setup, prop, add_func, args,
                              kwargs):
         setattr(self.system, prop, ())
-        self._filled_system_check(exclude=(prop, 'q', 'u'))
+        exclude = (prop, 'q', 'u')
+        if prop in ('holonomic_constraints', 'nonholonomic_constraints'):
+            exclude += ('velocity_constraints',)
+        self._filled_system_check(exclude=exclude)
         assert list(getattr(self.system, prop)[:]) == []
         getattr(self.system, add_func)(*args, **kwargs)
         assert list(getattr(self.system, prop)[:]) == list(args)
@@ -312,14 +319,18 @@ class TestSystem(TestSystemBase):
     ])
     def test_holonomic_constraints(self, _filled_system_setup, args, kwargs,
                                    exp_con):
+        exclude = ('holonomic_constraints', 'velocity_constraints')
+        exp_vel_con = [c.diff(t) for c in exp_con] + self.nhc
         # Test add_holonomic_constraints
         self.system.add_holonomic_constraints(*args, **kwargs)
-        self._filled_system_check(exclude=('holonomic_constraints',))
+        self._filled_system_check(exclude=exclude)
         assert self.system.holonomic_constraints[:] == exp_con
+        assert self.system.velocity_constraints[:] == exp_vel_con
         # Test setter for holonomic_constraints
         self.system.holonomic_constraints = exp_con
-        self._filled_system_check(exclude=('holonomic_constraints',))
+        self._filled_system_check(exclude=exclude)
         assert self.system.holonomic_constraints[:] == exp_con
+        assert self.system.velocity_constraints[:] == exp_vel_con
 
     @pytest.mark.parametrize('args, kwargs', [
         ((q[2] - q[0] + q[1], q[4] - q[3]), {}),
@@ -339,14 +350,18 @@ class TestSystem(TestSystemBase):
     ])
     def test_nonholonomic_constraints(self, _filled_system_setup, args, kwargs,
                                       exp_con):
+        exclude = ('nonholonomic_constraints', 'velocity_constraints')
+        exp_vel_con = self.vc[:len(self.hc)] + exp_con
         # Test add_nonholonomic_constraints
         self.system.add_nonholonomic_constraints(*args, **kwargs)
-        self._filled_system_check(exclude=('nonholonomic_constraints',))
+        self._filled_system_check(exclude=exclude)
         assert self.system.nonholonomic_constraints[:] == exp_con
+        assert self.system.velocity_constraints[:] == exp_vel_con
         # Test setter for nonholonomic_constraints
         self.system.nonholonomic_constraints = exp_con
-        self._filled_system_check(exclude=('nonholonomic_constraints',))
+        self._filled_system_check(exclude=exclude)
         assert self.system.nonholonomic_constraints[:] == exp_con
+        assert self.system.velocity_constraints[:] == exp_vel_con
 
     @pytest.mark.parametrize('args, kwargs', [
         ((u[3] - qd[1] + u[2], u[4] - u[3]), {}),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR adds the `velocity_constraints` attribute to `System` to allow users to overwrite the velocity constraints, which can be computed automatically in most cases. An example where one is required to overwrite the velocity constraints is when computing the noncontributing forces in the closing joint of a four-bar linkage.

#### Other comments
The velocity constraints are only stored directly when specifically set by the user. Otherwise, they are computed based on the holonomic and nonholonomic constraints. This is to prevent possible inconsistencies in the system as the same constraint can/should be stored as both a nonholonomic constraint as well as a velocity constraint.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Implemented System.velocity_constraints to allow overwriting the automatically computed velocity constraints.
<!-- END RELEASE NOTES -->
