### PR TITLE
Bug Fix for #26305

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3504,7 +3504,10 @@ class Expr(Basic, EvalfMixin):
         c, p = s.as_coeff_mul(x)
         if len(p) == 1:
             b, e = p[0].as_base_exp()
-            if b == x:
+            if abs(b) == x:
+                if abs(b) in [x, 1/x]:
+                    if abs(b) == 1/x:
+                        e = -e
                 return c, e
         return s, S.Zero
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2286,3 +2286,11 @@ def test_format():
 
 def test_issue_24045():
     assert powsimp(exp(a)/((c*a - c*b)*(Float(1.0)*c*a - Float(1.0)*c*b)))  # doesn't raise
+    
+def test_issue_26305():
+    assert ((1/x)**(y)).as_coeff_exponent(x) == (1, -y)
+    assert (sqrt(1/x)).as_coeff_exponent(x) == (1, -S(1)/2)
+    assert ((1/x)**(S(1)/3)).as_coeff_exponent(x) == (1, -S(1)/3)
+    assert ((1/-x)**(y)).as_coeff_exponent(-x) == (1, -y)
+    assert (sqrt(1/-x)).as_coeff_exponent(-x) == (1, -S(1)/2)
+    assert ((1/-x)**(S(1)/3)).as_coeff_exponent(-x) == (1, -S(1)/3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
#### References to other Issues or PRs
- Fixes #26305 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
 - Updated coeff function to handle 1/x and also for negative bases

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
