### PR TITLE
physics/vector: Improved speed of Point/Frame partial_velocity methods

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1558,8 +1558,10 @@ class ReferenceFrame:
 
         """
 
-        partials = [self.ang_vel_in(frame).diff(speed, frame, var_in_dcm=False)
-                    for speed in gen_speeds]
+        from sympy.physics.vector.functions import partial_velocity
+
+        vel = self.ang_vel_in(frame)
+        partials = partial_velocity([vel], gen_speeds, frame)[0]
 
         if len(partials) == 1:
             return partials[0]

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -622,8 +622,11 @@ class Point:
         (N.x, A.y)
 
         """
-        partials = [self.vel(frame).diff(speed, frame, var_in_dcm=False) for
-                    speed in gen_speeds]
+
+        from sympy.physics.vector.functions import partial_velocity
+
+        vel = self.vel(frame)
+        partials = partial_velocity([vel], gen_speeds, frame)[0]
 
         if len(partials) == 1:
             return partials[0]


### PR DESCRIPTION
#### References to other Issues or PRs
- Issue #25070: 
The issue highlights inefficiencies in the mechanics module, particularly where diff() and jacobian() are used to derive linear coefficients in expressions assumed to be linear.
- PR #26367: 
This PR introduced a speed improvement in the partial_velocity function in physics.vector


#### Brief description of what is fixed or changed

The optimised method to compute partial_velocity which leverages the linearity of velocities in the generalised coordinates, already discussed in #26367, has been now implemented in the partial_velocity method of Point and Frame classes.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Improved speed of Point/Frame partial_velocity methods

<!-- END RELEASE NOTES -->