### PR TITLE
Fixes incorrect result while checking equals with tan(2x) and its expanded form.

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -715,9 +715,11 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.simplify.simplify import nsimplify, simplify
+        from sympy.simplify.trigsimp import trigsimp
         from sympy.solvers.solvers import solve
         from sympy.polys.polyerrors import NotAlgebraic
         from sympy.polys.numberfields import minimal_polynomial
+        from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
         other = sympify(other)
         if self == other:
@@ -727,7 +729,10 @@ class Expr(Basic, EvalfMixin):
         # don't worry about doing simplification steps one at a time
         # because if the expression ever goes to 0 then the subsequent
         # simplification steps that are done will be very fast.
-        diff = factor_terms(simplify(self - other), radical=True)
+        if self.has(TrigonometricFunction):
+            diff = factor_terms(trigsimp(self - other))
+        else:
+            diff = factor_terms(simplify(self - other), radical=True)
 
         if not diff:
             return True

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -715,7 +715,7 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.simplify.simplify import nsimplify, simplify
-        from sympy.simplify.trigsimp import trigsimp
+        from sympy.functions.elementary.exponential import exp
         from sympy.solvers.solvers import solve
         from sympy.polys.polyerrors import NotAlgebraic
         from sympy.polys.numberfields import minimal_polynomial
@@ -729,11 +729,12 @@ class Expr(Basic, EvalfMixin):
         # don't worry about doing simplification steps one at a time
         # because if the expression ever goes to 0 then the subsequent
         # simplification steps that are done will be very fast.
-        if self.has(TrigonometricFunction):
-            diff = factor_terms(trigsimp(self - other))
-        else:
-            diff = factor_terms(simplify(self - other), radical=True)
+        diff = self - other
 
+        if self.has(TrigonometricFunction):
+            diff = diff.replace(lambda x: isinstance(x, TrigonometricFunction), lambda x: x.rewrite(exp))
+
+        diff = factor_terms(simplify(diff), radical=True)
         if not diff:
             return True
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2286,3 +2286,10 @@ def test_format():
 
 def test_issue_24045():
     assert powsimp(exp(a)/((c*a - c*b)*(Float(1.0)*c*a - Float(1.0)*c*b)))  # doesn't raise
+
+
+def test_issue_26383():
+    a = tan(2*x)
+    b = 2*tan(x)/(1 - tan(x)**2)
+    assert a.equals(b) == True
+    assert b.equals(a) == True

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2291,5 +2291,13 @@ def test_issue_24045():
 def test_issue_26383():
     a = tan(2*x)
     b = 2*tan(x)/(1 - tan(x)**2)
-    assert a.equals(b) == True
-    assert b.equals(a) == True
+    c = tan(3*x)
+    d = (3*tan(x) - tan(x)**3)/(1 - 3*tan(x)**2)
+    assert a.equals(b)
+    assert b.equals(a)
+    assert (1/a).equals(1/b)
+    assert (1/b).equals(1/a)
+    assert c.equals(d)
+    assert d.equals(c)
+    assert (1/c).equals(1/d)
+    assert (1/d).equals(1/c)


### PR DESCRIPTION
Fixes incorrect result while checking equality with tan(2x) and its expanded form.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #26383
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixes incorrect result for equality of tan(2*x) and its expanded form.
<!-- END RELEASE NOTES -->
