### PR TITLE
Remove unused keyword arguments to ast types

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1138,9 +1138,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],
-                keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False, ctx=ast.Load()))],
-                starargs=None,
-                kwargs=None
+                keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
             )
             return new_node
         return node
@@ -1171,9 +1169,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),
                     args=[ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1)), right],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False, ctx=ast.Load()))],
-                    starargs=None,
-                    kwargs=None
+                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
                 )
             elif isinstance(node.op, ast.Div):
                 if isinstance(node.left, ast.UnaryOp):
@@ -1182,17 +1178,13 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     left = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[left, ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False, ctx=ast.Load()))],
-                    starargs=None,
-                    kwargs=None
+                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
                 )
                 else:
                     right = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[right, ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False, ctx=ast.Load()))],
-                    starargs=None,
-                    kwargs=None
+                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
                 )
 
             if rev:  # undo reversal
@@ -1200,9 +1192,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],
-                keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False, ctx=ast.Load()))],
-                starargs=None,
-                kwargs=None
+                keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
             )
 
             if sympy_class in ('Add', 'Mul'):
@@ -1215,7 +1205,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
     def visit_Call(self, node):
         new_node = self.generic_visit(node)
         if isinstance(node.func, ast.Name) and node.func.id in self.functions:
-            new_node.keywords.append(ast.keyword(arg='evaluate', value=ast.Constant(value=False, ctx=ast.Load())))
+            new_node.keywords.append(ast.keyword(arg='evaluate', value=ast.Constant(value=False)))
         return new_node
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed
The Fedora project is using a python 3.13 prerelease to find and fix problems before the 3.13 release takes place.  Sympy currently fails a test because the ast module in 3.13 now raises a DeprecationWarning if unexpected keywords are passed.  This PR makes two kinds of changes:
- Remove the starargs and kwargs arguments to ast.Call.  They were removed in python 3.5.
- Remove the ctx argument to ast.Constant.  It takes no such argument and, indeed, that argument doesn't even make sense for a constant.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Python 3.13 compatibility
<!-- END RELEASE NOTES -->
