### PR TITLE
Add is_sympy to Relational

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -146,6 +146,7 @@ class Relational(Boolean, EvalfMixin):
     ValidRelationOperator: dict[str | None, type[Relational]] = {}
 
     is_Relational = True
+    is_sympy = True
 
     # ValidRelationOperator - Defined below, because the necessary classes
     #   have not yet been defined


### PR DESCRIPTION
Fixes error with calling "subs" on a Relational.

#### Brief description of what is fixed or changed
Adds `is_sympy = True` to Relational. This prevents errors when attempting to call `Relational#subs`, despite the functionality existing.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
    * Fixed false error when performing substitutions on relational objects such as Equalities.


