### PR TITLE
allow TR3 and TR4 to work with unevaluated expr

### DIFF
--- a/doc/src/modules/simplify/fu.rst
+++ b/doc/src/modules/simplify/fu.rst
@@ -112,7 +112,7 @@ In the expanded state, there are nearly 1000 trig functions:
     >>> L(expr)
     932
 
-If the expression where factored first, this would take time but the
+If the expression were factored first, this would take time but the
 resulting expression would be transformed very quickly:
 
     >>> def clock(f, n=2):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -246,6 +246,13 @@ def TR3(rv):
             rv = fmap[type(rv)](S.Pi/2 - rv.args[0])
         return rv
 
+    # touch numbers iside of trig functions to let them automatically update
+    rv = rv.replace(
+        lambda x: isinstance(x, TrigonometricFunction),
+        lambda x: x.replace(
+            lambda n: n.is_number and n.is_Mul,
+            lambda n: n.func(*n.args)))
+
     return bottom_up(rv, f)
 
 
@@ -273,7 +280,12 @@ def TR4(rv):
     0 1 zoo 0
     """
     # special values at 0, pi/6, pi/4, pi/3, pi/2 already handled
-    return rv
+    return rv.replace(
+        lambda x:
+            isinstance(x, TrigonometricFunction) and
+            (r:=x.args[0]/pi).is_Rational and r.q in (1, 2, 3, 4, 6),
+        lambda x:
+            x.func(x.args[0].func(*x.args[0].args)))
 
 
 def _TR56(rv, f, g, h, max, pow):

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -1,6 +1,7 @@
 from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Rational, pi)
+from sympy.core.parameters import evaluate
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.hyperbolic import (cosh, coth, csch, sech, sinh, tanh)
@@ -9,7 +10,7 @@ from sympy.functions.elementary.trigonometric import (cos, cot, csc, sec, sin, t
 from sympy.simplify.powsimp import powsimp
 from sympy.simplify.fu import (
     L, TR1, TR10, TR10i, TR11, _TR11, TR12, TR12i, TR13, TR14, TR15, TR16,
-    TR111, TR2, TR2i, TR3, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
+    TR111, TR2, TR2i, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
     TRpower, hyper_as_trig, fu, process_common_addends, trig_split,
     as_f_sign_1)
 from sympy.core.random import verify_numerically
@@ -71,6 +72,17 @@ def test_TR3():
         i = f(pi*Rational(3, 7))
         j = TR3(i)
         assert verify_numerically(i, j) and i.func != j.func
+
+    with evaluate(False):
+        eq = cos(9*pi/22)
+    assert eq.has(9*pi) and TR3(eq) == sin(pi/11)
+
+
+def test_TR4():
+    for i in [0, pi/6, pi/4, pi/3, pi/2]:
+        with evaluate(False):
+            eq = cos(i)
+        assert isinstance(eq, cos) and TR4(eq) == cos(i)
 
 
 def test__TR56():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #26388 

#### Brief description of what is fixed or changed

TR3 and TR4 now touch numbers in all trig functions of an expressions to make sure they are evaluated so unevaluated expressions will be processed properly.

#### Other comments

```
>>> with evaluate(False):
...  eq = cos(31*pi/22)
...
>>> cos(31*pi/22)
-cos(9*pi/22)
>>> TR3(_)
-sin(pi/11)
>>> eq
cos((31*pi)/22)
>>> TR3(eq) <--- makes no change in master, but now gives the right answer
-sin(pi/11)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * TR3 and TR4 of fu will now work with unevaluated numbers in trig functions; previously such numbers were unchanged
<!-- END RELEASE NOTES -->
