### PR TITLE
Use dot, cross, outer as primary methods in Vector and Dyadic

### DIFF
--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -1,5 +1,5 @@
 from sympy import sympify
-from sympy.physics.vector import Point, Dyadic, ReferenceFrame
+from sympy.physics.vector import Point, Dyadic, ReferenceFrame, outer
 from collections import namedtuple
 
 __all__ = ['inertia', 'inertia_of_point_mass', 'Inertia']
@@ -46,11 +46,11 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
         raise TypeError('Need to define the inertia in a frame')
     ixx, iyy, izz = sympify(ixx), sympify(iyy), sympify(izz)
     ixy, iyz, izx = sympify(ixy), sympify(iyz), sympify(izx)
-    return (ixx * (frame.x | frame.x) + ixy * (frame.x | frame.y) +
-            izx * (frame.x | frame.z) + ixy * (frame.y | frame.x) +
-            iyy * (frame.y | frame.y) + iyz * (frame.y | frame.z) +
-            izx * (frame.z | frame.x) + iyz * (frame.z | frame.y) +
-            izz * (frame.z | frame.z))
+    return (ixx*outer(frame.x, frame.x) + ixy*outer(frame.x, frame.y) +
+            izx*outer(frame.x, frame.z) + ixy*outer(frame.y, frame.x) +
+            iyy*outer(frame.y, frame.y) + iyz*outer(frame.y, frame.z) +
+            izx*outer(frame.z, frame.x) + iyz*outer(frame.z, frame.y) +
+            izz*outer(frame.z, frame.z))
 
 
 def inertia_of_point_mass(mass, pos_vec, frame):
@@ -79,9 +79,11 @@ def inertia_of_point_mass(mass, pos_vec, frame):
 
     """
 
-    return mass * (
-        ((frame.x | frame.x) + (frame.y | frame.y) + (frame.z | frame.z)) *
-        (pos_vec & pos_vec) - (pos_vec | pos_vec))
+    return mass*(
+        (outer(frame.x, frame.x) +
+         outer(frame.y, frame.y) +
+         outer(frame.z, frame.z)) *
+        (pos_vec.dot(pos_vec)) - outer(pos_vec, pos_vec))
 
 
 class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -214,7 +214,7 @@ class LagrangesMethod(_Methods):
             self._term4 = zeros(n, 1)
             for i, qd in enumerate(qds):
                 flist = zip(*_f_list_parser(self.forcelist, N))
-                self._term4[i] = sum(v.diff(qd, N) & f for (v, f) in flist)
+                self._term4[i] = sum(v.diff(qd, N).dot(f) for (v, f) in flist)
         else:
             self._term4 = zeros(n, 1)
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -71,7 +71,37 @@ class Dyadic(Printable, EvalfMixin):
         other = _check_dyadic(other)
         return Dyadic(self.args + other.args)
 
-    def __and__(self, other):
+    __radd__ = __add__
+
+    def __mul__(self, other):
+        """Multiplies the Dyadic by a sympifyable expression.
+
+        Parameters
+        ==========
+
+        other : Sympafiable
+            The scalar to multiply this Dyadic with
+
+        Examples
+        ========
+
+        >>> from sympy.physics.vector import ReferenceFrame, outer
+        >>> N = ReferenceFrame('N')
+        >>> d = outer(N.x, N.x)
+        >>> 5 * d
+        5*(N.x|N.x)
+
+        """
+        newlist = list(self.args)
+        other = sympify(other)
+        for i, v in enumerate(newlist):
+            newlist[i] = (other * newlist[i][0], newlist[i][1],
+                          newlist[i][2])
+        return Dyadic(newlist)
+
+    __rmul__ = __mul__
+
+    def dot(self, other):
         """The inner product operator for a Dyadic and a Dyadic or Vector.
 
         Parameters
@@ -99,13 +129,16 @@ class Dyadic(Printable, EvalfMixin):
             ol = Dyadic(0)
             for i, v in enumerate(self.args):
                 for i2, v2 in enumerate(other.args):
-                    ol += v[0] * v2[0] * (v[2] & v2[1]) * (v[1] | v2[2])
+                    ol += v[0] * v2[0] * (v[2].dot(v2[1])) * (v[1].outer(v2[2]))
         else:
             other = _check_vector(other)
             ol = Vector(0)
             for i, v in enumerate(self.args):
-                ol += v[0] * v[1] * (v[2] & other)
+                ol += v[0] * v[1] * (v[2].dot(other))
         return ol
+
+    # NOTE : supports non-advertised Dyadic & Dyadic, Dyadic & Vector notation
+    __and__ = dot
 
     def __truediv__(self, other):
         """Divides the Dyadic by a sympifyable expression. """
@@ -126,33 +159,6 @@ class Dyadic(Printable, EvalfMixin):
         elif (self.args == []) or (other.args == []):
             return False
         return set(self.args) == set(other.args)
-
-    def __mul__(self, other):
-        """Multiplies the Dyadic by a sympifyable expression.
-
-        Parameters
-        ==========
-
-        other : Sympafiable
-            The scalar to multiply this Dyadic with
-
-        Examples
-        ========
-
-        >>> from sympy.physics.vector import ReferenceFrame, outer
-        >>> N = ReferenceFrame('N')
-        >>> d = outer(N.x, N.x)
-        >>> 5 * d
-        5*(N.x|N.x)
-
-        """
-
-        newlist = list(self.args)
-        other = sympify(other)
-        for i, v in enumerate(newlist):
-            newlist[i] = (other * newlist[i][0], newlist[i][1],
-                          newlist[i][2])
-        return Dyadic(newlist)
 
     def __ne__(self, other):
         return not self == other
@@ -250,64 +256,8 @@ class Dyadic(Printable, EvalfMixin):
                 return outstr
         return Fake()
 
-    def __rand__(self, other):
-        """The inner product operator for a Vector or Dyadic, and a Dyadic
-
-        This is for: Vector dot Dyadic
-
-        Parameters
-        ==========
-
-        other : Vector
-            The vector we are dotting with
-
-        Examples
-        ========
-
-        >>> from sympy.physics.vector import ReferenceFrame, dot, outer
-        >>> N = ReferenceFrame('N')
-        >>> d = outer(N.x, N.x)
-        >>> dot(N.x, d)
-        N.x
-
-        """
-
-        from sympy.physics.vector.vector import Vector, _check_vector
-        other = _check_vector(other)
-        ol = Vector(0)
-        for i, v in enumerate(self.args):
-            ol += v[0] * v[2] * (v[1] & other)
-        return ol
-
     def __rsub__(self, other):
         return (-1 * self) + other
-
-    def __rxor__(self, other):
-        """For a cross product in the form: Vector x Dyadic
-
-        Parameters
-        ==========
-
-        other : Vector
-            The Vector that we are crossing this Dyadic with
-
-        Examples
-        ========
-
-        >>> from sympy.physics.vector import ReferenceFrame, outer, cross
-        >>> N = ReferenceFrame('N')
-        >>> d = outer(N.x, N.x)
-        >>> cross(N.y, d)
-        - (N.z|N.x)
-
-        """
-
-        from sympy.physics.vector.vector import _check_vector
-        other = _check_vector(other)
-        ol = Dyadic(0)
-        for i, v in enumerate(self.args):
-            ol += v[0] * ((other ^ v[1]) | v[2])
-        return ol
 
     def _sympystr(self, printer):
         """Printing method. """
@@ -349,18 +299,17 @@ class Dyadic(Printable, EvalfMixin):
         """The subtraction operator. """
         return self.__add__(other * -1)
 
-    def __xor__(self, other):
-        """For a cross product in the form: Dyadic x Vector.
+    def cross(self, other):
+        """Returns the dyadic resulting from the dyadic vector cross product:
+        Dyadic x Vector.
 
         Parameters
         ==========
-
         other : Vector
-            The Vector that we are crossing this Dyadic with
+            Vector to cross with.
 
         Examples
         ========
-
         >>> from sympy.physics.vector import ReferenceFrame, outer, cross
         >>> N = ReferenceFrame('N')
         >>> d = outer(N.x, N.x)
@@ -368,16 +317,15 @@ class Dyadic(Printable, EvalfMixin):
         (N.x|N.z)
 
         """
-
         from sympy.physics.vector.vector import _check_vector
         other = _check_vector(other)
         ol = Dyadic(0)
         for i, v in enumerate(self.args):
-            ol += v[0] * (v[1] | (v[2] ^ other))
+            ol += v[0] * (v[1].outer((v[2].cross(other))))
         return ol
 
-    __radd__ = __add__
-    __rmul__ = __mul__
+    # NOTE : supports non-advertised Dyadic ^ Vector notation
+    __xor__ = cross
 
     def express(self, frame1, frame2=None):
         """Expresses this Dyadic in alternate frame(s)
@@ -529,11 +477,8 @@ class Dyadic(Printable, EvalfMixin):
 
         out = Dyadic(0)
         for a, b, c in self.args:
-            out += f(a) * (b | c)
+            out += f(a) * (b.outer(c))
         return out
-
-    dot = __and__
-    cross = __xor__
 
     def _eval_evalf(self, prec):
         if not self.args:

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -224,7 +224,7 @@ def outer(vec1, vec2):
     """Outer product convenience wrapper for Vector.outer():\n"""
     if not isinstance(vec1, Vector):
         raise TypeError('Outer product is between two Vectors')
-    return vec1 | vec2
+    return vec1.outer(vec2)
 
 
 outer.__doc__ += Vector.outer.__doc__  # type: ignore

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -169,8 +169,8 @@ class Point:
         a2 = self.acc(interframe)
         omega = interframe.ang_vel_in(outframe)
         alpha = interframe.ang_acc_in(outframe)
-        self.set_acc(outframe, a2 + 2 * (omega ^ v) + a1 + (alpha ^ dist) +
-                     (omega ^ (omega ^ dist)))
+        self.set_acc(outframe, a2 + 2 * (omega.cross(v)) + a1 +
+                     (alpha.cross(dist)) + (omega.cross(omega.cross(dist))))
         return self.acc(outframe)
 
     def a2pt_theory(self, otherpoint, outframe, fixedframe):
@@ -218,7 +218,8 @@ class Point:
         a = otherpoint.acc(outframe)
         omega = fixedframe.ang_vel_in(outframe)
         alpha = fixedframe.ang_acc_in(outframe)
-        self.set_acc(outframe, a + (alpha ^ dist) + (omega ^ (omega ^ dist)))
+        self.set_acc(outframe, a + (alpha.cross(dist)) +
+                     (omega.cross(omega.cross(dist))))
         return self.acc(outframe)
 
     def acc(self, frame):
@@ -449,7 +450,7 @@ class Point:
         v1 = self.vel(interframe)
         v2 = otherpoint.vel(outframe)
         omega = interframe.ang_vel_in(outframe)
-        self.set_vel(outframe, v1 + v2 + (omega ^ dist))
+        self.set_vel(outframe, v1 + v2 + (omega.cross(dist)))
         return self.vel(outframe)
 
     def v2pt_theory(self, otherpoint, outframe, fixedframe):
@@ -496,7 +497,7 @@ class Point:
         dist = self.pos_from(otherpoint)
         v = otherpoint.vel(outframe)
         omega = fixedframe.ang_vel_in(outframe)
-        self.set_vel(outframe, v + (omega ^ dist))
+        self.set_vel(outframe, v + (omega.cross(dist)))
         return self.vel(outframe)
 
     def vel(self, frame):

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -259,3 +259,16 @@ def test_vector_outer():
                    [f*a, f*b, f*c]])
     assert v2.outer(v1).to_matrix(N) == v2v1
     assert (v2 | v1).to_matrix(N) == v2v1
+
+
+def test_overloaded_operators():
+    a, b, c, d, e, f = symbols('a, b, c, d, e, f')
+    N = ReferenceFrame('N')
+    v1 = a*N.x + b*N.y + c*N.z
+    v2 = d*N.x + e*N.y + f*N.z
+
+    assert v1 + v2 == v2 + v1
+    assert v1 - v2 == -v2 + v1
+    assert v1 & v2 == v2 & v1
+    assert v1 ^ v2 == v1.cross(v2)
+    assert v2 ^ v1 == v2.cross(v1)

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -242,3 +242,20 @@ def test_issue_23366():
     N = ReferenceFrame('N')
     N_v_A = u1*N.x
     raises(VectorTypeError, lambda: N_v_A.diff(N, u1))
+
+
+def test_vector_outer():
+    a, b, c, d, e, f = symbols('a, b, c, d, e, f')
+    N = ReferenceFrame('N')
+    v1 = a*N.x + b*N.y + c*N.z
+    v2 = d*N.x + e*N.y + f*N.z
+    v1v2 = Matrix([[a*d, a*e, a*f],
+                   [b*d, b*e, b*f],
+                   [c*d, c*e, c*f]])
+    assert v1.outer(v2).to_matrix(N) == v1v2
+    assert (v1 | v2).to_matrix(N) == v1v2
+    v2v1 = Matrix([[d*a, d*b, d*c],
+                   [e*a, e*b, e*c],
+                   [f*a, f*b, f*c]])
+    assert v2.outer(v1).to_matrix(N) == v2v1
+    assert (v2 | v1).to_matrix(N) == v2v1

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -281,45 +281,6 @@ class Vector(Printable, EvalfMixin):
 
         return prettyForm.__add__(*terms)
 
-    def __ror__(self, other):
-        """Outer product between two Vectors.
-
-        A rank increasing operation, which returns a Dyadic from two Vectors
-
-        Parameters
-        ==========
-
-        other : Vector
-            The Vector to take the outer product with
-
-        Examples
-        ========
-
-        >>> from sympy.physics.vector import ReferenceFrame, outer
-        >>> N = ReferenceFrame('N')
-        >>> outer(N.x, N.x)
-        (N.x|N.x)
-
-        """
-        from sympy.physics.vector.dyadic import Dyadic
-        other = _check_vector(other)
-        ol = Dyadic(0)
-        for i, v in enumerate(other.args):
-            for i2, v2 in enumerate(self.args):
-                # it looks this way because if we are in the same frame and
-                # use the enumerate function on the same frame in a nested
-                # fashion, then bad things happen
-                ol += Dyadic([(v[0][0] * v2[0][0], v[1].x, v2[1].x)])
-                ol += Dyadic([(v[0][0] * v2[0][1], v[1].x, v2[1].y)])
-                ol += Dyadic([(v[0][0] * v2[0][2], v[1].x, v2[1].z)])
-                ol += Dyadic([(v[0][1] * v2[0][0], v[1].y, v2[1].x)])
-                ol += Dyadic([(v[0][1] * v2[0][1], v[1].y, v2[1].y)])
-                ol += Dyadic([(v[0][1] * v2[0][2], v[1].y, v2[1].z)])
-                ol += Dyadic([(v[0][2] * v2[0][0], v[1].z, v2[1].x)])
-                ol += Dyadic([(v[0][2] * v2[0][1], v[1].z, v2[1].y)])
-                ol += Dyadic([(v[0][2] * v2[0][2], v[1].z, v2[1].z)])
-        return ol
-
     def __rsub__(self, other):
         return (-1 * self) + other
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,5 +1,5 @@
 from sympy import (S, sympify, expand, sqrt, Add, zeros, acos,
-                                ImmutableMatrix as Matrix, simplify)
+                   ImmutableMatrix as Matrix, simplify)
 from sympy.simplify.trigsimp import trigsimp
 from sympy.printing.defaults import Printable
 from sympy.utilities.misc import filldedent
@@ -29,7 +29,7 @@ class Vector(Printable, EvalfMixin):
     is_number = False
 
     def __init__(self, inlist):
-        """This is the constructor for the Vector class.  You should not be
+        """This is the constructor for the Vector class. You should not be
         calling this, it should only be used by other functions. You should be
         treating Vectors like you would with if you were doing the math by
         hand, and getting the first 3 from the standard basis vectors from a
@@ -72,7 +72,7 @@ class Vector(Printable, EvalfMixin):
         other = _check_vector(other)
         return Vector(self.args + other.args)
 
-    def __and__(self, other):
+    def dot(self, other):
         """Dot product of two vectors.
 
         Returns a scalar, the dot product of the two Vectors
@@ -100,16 +100,18 @@ class Vector(Printable, EvalfMixin):
 
         """
 
-        from sympy.physics.vector.dyadic import Dyadic
+        from sympy.physics.vector.dyadic import Dyadic, _check_dyadic
         if isinstance(other, Dyadic):
-            return NotImplemented
+            other = _check_dyadic(other)
+            ol = Vector(0)
+            for i, v in enumerate(other.args):
+                ol += v[0] * v[2] * (v[1].dot(self))
+            return ol
         other = _check_vector(other)
         out = S.Zero
         for i, v1 in enumerate(self.args):
             for j, v2 in enumerate(other.args):
-                out += ((v2[0].T)
-                        * (v2[1].dcm(v1[1]))
-                        * (v1[0]))[0]
+                out += ((v2[0].T) * (v2[1].dcm(v1[1])) * (v1[0]))[0]
         if Vector.simp:
             return trigsimp(out, recursive=True)
         else:
@@ -144,7 +146,7 @@ class Vector(Printable, EvalfMixin):
 
         frame = self.args[0][1]
         for v in frame:
-            if expand((self - other) & v) != 0:
+            if expand((self - other).dot(v)) != 0:
                 return False
         return True
 
@@ -179,7 +181,7 @@ class Vector(Printable, EvalfMixin):
     def __neg__(self):
         return self * -1
 
-    def __or__(self, other):
+    def outer(self, other):
         """Outer product between two Vectors.
 
         A rank increasing operation, which returns a Dyadic from two Vectors
@@ -299,7 +301,6 @@ class Vector(Printable, EvalfMixin):
         (N.x|N.x)
 
         """
-
         from sympy.physics.vector.dyadic import Dyadic
         other = _check_vector(other)
         ol = Dyadic(0)
@@ -366,7 +367,7 @@ class Vector(Printable, EvalfMixin):
         """The subtraction operator. """
         return self.__add__(other * -1)
 
-    def __xor__(self, other):
+    def cross(self, other):
         """The cross product operator for two Vectors.
 
         Returns a Vector, expressed in the same ReferenceFrames as self.
@@ -395,9 +396,13 @@ class Vector(Printable, EvalfMixin):
 
         """
 
-        from sympy.physics.vector.dyadic import Dyadic
+        from sympy.physics.vector.dyadic import Dyadic, _check_dyadic
         if isinstance(other, Dyadic):
-            return NotImplemented
+            other = _check_dyadic(other)
+            ol = Dyadic(0)
+            for i, v in enumerate(other.args):
+                ol += v[0] * ((self.cross(v[1])).outer(v[2]))
+            return ol
         other = _check_vector(other)
         if other.args == []:
             return Vector(0)
@@ -422,14 +427,13 @@ class Vector(Printable, EvalfMixin):
             tempy = v[1].y
             tempz = v[1].z
             tempm = ([[tempx, tempy, tempz],
-                      [self & tempx, self & tempy, self & tempz],
-                      [Vector([ar[i]]) & tempx, Vector([ar[i]]) & tempy,
-                       Vector([ar[i]]) & tempz]])
+                      [self.dot(tempx), self.dot(tempy), self.dot(tempz)],
+                      [Vector([ar[i]]).dot(tempx), Vector([ar[i]]).dot(tempy),
+                       Vector([ar[i]]).dot(tempz)]])
             outlist += _det(tempm).args
         return Vector(outlist)
 
     __radd__ = __add__
-    __rand__ = __and__
     __rmul__ = __mul__
 
     def separate(self):
@@ -457,17 +461,18 @@ class Vector(Printable, EvalfMixin):
             components[x[1]] = Vector([x])
         return components
 
-    def dot(self, other):
-        return self & other
-    dot.__doc__ = __and__.__doc__
+    def __and__(self, other):
+        return self.dot(other)
+    __and__.__doc__ = dot.__doc__
+    __rand__ = __and__
 
-    def cross(self, other):
-        return self ^ other
-    cross.__doc__ = __xor__.__doc__
+    def __xor__(self, other):
+        return self.cross(other)
+    __xor__.__doc__ = cross.__doc__
 
-    def outer(self, other):
-        return self | other
-    outer.__doc__ = __or__.__doc__
+    def __or__(self, other):
+        return self.outer(other)
+    __or__.__doc__ = outer.__doc__
 
     def diff(self, var, frame, var_in_dcm=True):
         """Returns the partial derivative of the vector with respect to a
@@ -670,7 +675,7 @@ class Vector(Printable, EvalfMixin):
         instead of ``(-A.x).magnitude()``.
 
         """
-        return sqrt(self & self)
+        return sqrt(self.dot(self))
 
     def normalize(self):
         """Returns a Vector of magnitude 1, codirectional with self."""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related: https://github.com/sympy/sympy/pull/23095

#### Brief description of what is fixed or changed

Originally Vector and Dyadic were designed to use dot = `__and__`, cross = `__xor__`, and outer = `__or__` as well as the right side definitions of these builtin operators. We have stopped advertising the use of these methods in the documentation for users and this changes the Vector and Dyadic classes so that we could more easily deprecate them in the future. It also removes the use of the builtin operators within the code of the two classes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
