### PR TITLE
Revert "Raise ValueError if Symbol does not print to valid C variable name."

### DIFF
--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -13,7 +13,6 @@ source code files that are compilable without further modifications.
 
 from __future__ import annotations
 from typing import Any
-import re
 
 from functools import wraps
 from itertools import chain
@@ -88,7 +87,6 @@ reserved_words = [
 ]
 
 reserved_words_c99 = ['inline', 'restrict']
-
 
 def get_math_macros():
     """ Returns a dictionary with math-related macros from math.h/cmath
@@ -269,13 +267,6 @@ class C89CodePrinter(CodePrinter):
         rows, cols = mat.shape
         return ((i, j) for i in range(rows) for j in range(cols))
 
-    @staticmethod
-    def _check_valid_c_variable_name(var_name):
-        pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
-        msg = 'SymPy symbol {} not printable in C.'
-        if not pattern.search(var_name):
-            raise ValueError(msg.format(var_name))
-
     @_as_macro_if_defined
     def _print_Mul(self, expr, **kwargs):
         return super()._print_Mul(expr, **kwargs)
@@ -396,8 +387,6 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
-        # if name is an indexed, e.g. a[0], only check the variable name
-        self._check_valid_c_variable_name(name.split('[')[0])
         if expr in self._settings['dereference']:
             return '(*{})'.format(name)
         else:

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -30,19 +30,6 @@ from sympy.printing.codeprinter import ccode
 x, y, z = symbols('x,y,z')
 
 
-def test_invalid_variable_names():
-    long_var = 'w'*32
-    syms = symbols(r'a_{\delta}[0], I_{x}, a*, 9t, bus#, %s' % long_var)
-    for s in syms:
-        with raises(ValueError):
-            ccode(s)
-    # these should not raise
-    short_var = 'w'*31
-    syms = symbols('funny_var[5], b[1][2], a[idx], out[i*N+j], %s' % short_var)
-    for s in syms:
-        ccode(s)
-
-
 def test_printmethod():
     class fabs(Abs):
         def _ccode(self, printer):


### PR DESCRIPTION
Reverts sympy/sympy#26360