### PR TITLE
Use the strict setting for invalid name checks and deal with other C accessors.

### DIFF
--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -89,6 +89,8 @@ reserved_words = [
 
 reserved_words_c99 = ['inline', 'restrict']
 
+valid_var_name_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
+
 
 def get_math_macros():
     """ Returns a dictionary with math-related macros from math.h/cmath
@@ -271,9 +273,8 @@ class C89CodePrinter(CodePrinter):
 
     @staticmethod
     def _check_valid_c_variable_name(var_name):
-        pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
-        msg = 'SymPy symbol {} not printable in C.'
-        if not pattern.search(var_name):
+        msg = 'SymPy symbol {} not valid C code.'
+        if not valid_var_name_pattern.search(var_name):
             raise ValueError(msg.format(var_name))
 
     @_as_macro_if_defined
@@ -396,8 +397,11 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
-        # if name is an indexed, e.g. a[0], only check the variable name
-        self._check_valid_c_variable_name(name.split('[')[0])
+        if self._settings['strict'] is True:  # can be None
+            # if name is an accessor, e.g. a[0], a.b a->b, only check the first
+            # variable name
+            first = name.split('[')[0].split('.')[0].split('->')[0]
+            self._check_valid_c_variable_name(first)
         if expr in self._settings['dereference']:
             return '(*{})'.format(name)
         else:

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -397,7 +397,7 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
-        if self._settings['strict'] is True:  # can be None
+        if self._settings['strict']:
             # if name is an accessor, e.g. a[0], a.b a->b, only check the first
             # variable name
             first = name.split('[')[0].split('.')[0].split('->')[0]

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -33,14 +33,17 @@ x, y, z = symbols('x,y,z')
 def test_invalid_variable_names():
     long_var = 'w'*32
     syms = symbols(r'a_{\delta}[0], I_{x}, a*, 9t, bus#, %s' % long_var)
-    for s in syms:
+    for sym in syms:
         with raises(ValueError):
-            ccode(s)
+            ccode(sym, strict=True)
+        ccode(sym, strict=False)
     # these should not raise
     short_var = 'w'*31
-    syms = symbols('funny_var[5], b[1][2], a[idx], out[i*N+j], %s' % short_var)
-    for s in syms:
-        ccode(s)
+    stm = 'a.b.c, a.b->c, a->c, funny_var[5], b[1][2], a[idx], out[i*N+j], %s'
+    syms = symbols(stm % short_var)
+    for sym in syms:
+        ccode(sym, strict=False)
+        ccode(sym, strict=True)
 
 
 def test_printmethod():
@@ -587,7 +590,6 @@ def test_sparse_matrix():
         ccode(SparseMatrix([[1, 2, 3]]))
 
     assert 'Not supported in C' in C89CodePrinter({'strict': False}).doprint(SparseMatrix([[1, 2, 3]]))
-
 
 
 def test_ccode_reserved_words():


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Addition to #26360 


#### Brief description of what is fixed or changed

Fixed some issues raised in the original PR after merging.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
