### PR TITLE
CodePrinter option: strict_names

### DIFF
--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -89,6 +89,8 @@ reserved_words = [
 
 reserved_words_c99 = ['inline', 'restrict']
 
+valid_var_name_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
+
 
 def get_math_macros():
     """ Returns a dictionary with math-related macros from math.h/cmath
@@ -271,9 +273,8 @@ class C89CodePrinter(CodePrinter):
 
     @staticmethod
     def _check_valid_c_variable_name(var_name):
-        pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
-        msg = 'SymPy symbol {} not printable in C.'
-        if not pattern.search(var_name):
+        msg = 'SymPy symbol {} not valid C code.'
+        if not valid_var_name_pattern.search(var_name):
             raise ValueError(msg.format(var_name))
 
     @_as_macro_if_defined
@@ -396,8 +397,11 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
-        # if name is an indexed, e.g. a[0], only check the variable name
-        self._check_valid_c_variable_name(name.split('[')[0])
+        if self._settings['strict'] is True:  # can be None
+            # if name is an accessor, e.g. a[0], a.b a->b, only check the first
+            # variable name
+            first = name.split('[')[0].split('.')[0].split('->')[0]
+            self._check_valid_c_variable_name(first)
         if expr in self._settings['dereference']:
             return '(*{})'.format(name)
         else:

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -397,7 +397,7 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super()._print_Symbol(expr)
-        if self._settings['strict'] is True:  # can be None
+        if self._settings['strict']:
             # if name is an accessor, e.g. a[0], a.b a->b, only check the first
             # variable name
             first = name.split('[')[0].split('.')[0].split('->')[0]

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from functools import wraps
 from itertools import chain
-import re
+import re as _re
 
 from sympy.core import S
 from sympy.core.numbers import equal_valued, Float
@@ -221,7 +221,8 @@ class C89CodePrinter(CodePrinter):
     # known_functions-dict to copy
     _kf: dict[str, Any] = known_functions_C89
 
-    _valid_var_name_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
+    # 31 characters guaranteed to be supported by all C89 compilers:
+    _valid_var_name_pattern = _re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$")
 
     def __init__(self, settings=None):
         settings = settings or {}

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -120,9 +120,8 @@ class CodePrinter(StrPrinter):
     }
 
     # These two fields are used by the method "_check_valid_symbol_name",
-    # they may optionally be a dict mapping standard to regular epxression.
     _valid_var_name_pattern = _re.compile('.+')  # should cover most targeted languages
-    _invalid_var_name_pattern = _re.compile('[+-/*^\'"]')  # should cover most targeted languages
+    _invalid_var_name_pattern = _re.compile('[+-/*^\'" #$]')  # non-exhaustive, decent start for most languages
 
     def __init__(self, settings=None):
         super().__init__(settings=settings)

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from collections import defaultdict
 from itertools import chain
+import re as _re
 import string
 
 from sympy.codegen.ast import (
@@ -116,6 +117,13 @@ class FCodePrinter(CodePrinter):
     _relationals = {
         '!=': '/=',
     }
+
+    @property
+    def _valid_var_name_pattern(self):
+        return {
+            77: _re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,5}$"),
+            90: _re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,30}$"),
+        }[77 if self._settings['standard'] <= 77 else 90]
 
     def __init__(self, settings=None):
         if not settings:

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -3,6 +3,7 @@ Python code printers
 
 This module contains Python code printers for plain Python as well as NumPy & SciPy enabled code.
 """
+import re as _re
 from collections import defaultdict
 from itertools import chain
 from sympy.core import S
@@ -96,6 +97,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         contract=False,
         standard='python3',
     )
+    _valid_var_name_pattern = _re.compile(r'[^\W0-9]\w*')  # somewhat wider than PEP 3131
 
     def __init__(self, settings=None):
         super().__init__(settings)

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -33,14 +33,17 @@ x, y, z = symbols('x,y,z')
 def test_invalid_variable_names():
     long_var = 'w'*32
     syms = symbols(r'a_{\delta}[0], I_{x}, a*, 9t, bus#, %s' % long_var)
-    for s in syms:
+    for sym in syms:
         with raises(ValueError):
-            ccode(s)
+            ccode(sym, strict=True)
+        ccode(sym, strict=False)
     # these should not raise
     short_var = 'w'*31
-    syms = symbols('funny_var[5], b[1][2], a[idx], out[i*N+j], %s' % short_var)
-    for s in syms:
-        ccode(s)
+    stm = 'a.b.c, a.b->c, a->c, funny_var[5], b[1][2], a[idx], out[i*N+j], %s'
+    syms = symbols(stm % short_var)
+    for sym in syms:
+        ccode(sym, strict=False)
+        ccode(sym, strict=True)
 
 
 def test_printmethod():
@@ -587,7 +590,6 @@ def test_sparse_matrix():
         ccode(SparseMatrix([[1, 2, 3]]))
 
     assert 'Not supported in C' in C89CodePrinter({'strict': False}).doprint(SparseMatrix([[1, 2, 3]]))
-
 
 
 def test_ccode_reserved_words():

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -39,7 +39,7 @@ def test_invalid_variable_names():
         ccode(sym, strict_names=False)
     # these should not raise
     short_var = 'w'*31
-    stm = 'a.b.c, a.b->c, a->c, funny_var[5], b[1][2], a[idx], out[i*N+j], %s'
+    stm = '_, _0, %s'
     syms = symbols(stm % short_var)
     for sym in syms:
         ccode(sym, strict_names=False)

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -1,4 +1,4 @@
-from sympy.printing.codeprinter import CodePrinter, PrintMethodNotImplementedError
+from sympy.printing.codeprinter import CodePrinter, PrintMethodNotImplementedError, InvalidVariableNameError
 from sympy.core import symbols
 from sympy.core.symbol import Dummy
 from sympy.testing.pytest import raises
@@ -35,6 +35,13 @@ def test_print_Symbol():
     p = setup_test_printer(reserved_word_suffix='_He_Man')
     p.reserved_words.update(['if'])
     assert p._print(y) == 'if_He_Man'
+
+    invalid_symbol_name = symbols("f'(x)")
+    assert p._print(invalid_symbol_name) == invalid_symbol_name.name
+    p = setup_test_printer(strict_names=True)
+    with raises(InvalidVariableNameError):
+        p._print(invalid_symbol_name)
+
 
 def test_issue_15791():
     class CrashingCodePrinter(CodePrinter):

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -1,6 +1,6 @@
 from sympy.printing.codeprinter import CodePrinter, PrintMethodNotImplementedError, InvalidVariableNameError
 from sympy.core import symbols
-from sympy.core.symbol import Dummy
+from sympy.core.symbol import Symbol, Dummy
 from sympy.testing.pytest import raises
 
 
@@ -36,11 +36,13 @@ def test_print_Symbol():
     p.reserved_words.update(['if'])
     assert p._print(y) == 'if_He_Man'
 
-    invalid_symbol_name = symbols("f'(x)")
-    assert p._print(invalid_symbol_name) == invalid_symbol_name.name
-    p = setup_test_printer(strict_names=True)
-    with raises(InvalidVariableNameError):
-        p._print(invalid_symbol_name)
+
+    p2 = setup_test_printer(strict_names=True)
+    for invalid_name in ["f'(x)", "a b", "a+b", "#error", "", "$_"]:
+        invalid_symbol = Symbol(invalid_name)
+        assert p._print(invalid_symbol) == invalid_symbol.name
+        with raises(InvalidVariableNameError):
+            p2._print(invalid_symbol)
 
 
 def test_issue_15791():

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -25,6 +25,7 @@ from sympy.core.expr import UnevaluatedExpr
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or, Not, Equivalent, Xor
 from sympy.matrices import Matrix, MatrixSymbol
+from sympy.printing.codeprinter import InvalidVariableNameError
 from sympy.printing.fortran import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.tensor.array.expressions import ArraySymbol, ArrayElement
@@ -210,6 +211,14 @@ def test_not_fortran():
     assert fcode(Integral(sin(x)), strict=False) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
     with raises(NotImplementedError):
         fcode(g(x))
+
+    too_long_name_77 = symbols('too_long_name_in_fortran_77')
+    with raises(InvalidVariableNameError):
+        fcode(too_long_name_77, strict_names=True)
+    fcode(too_long_name_77, strict_names=True, standard=90)
+    too_long_name_90 = symbols('too_long_name_in_fortran_90'*3)
+    with raises(InvalidVariableNameError):
+        fcode(too_long_name_90, strict_names=True, standard=90)
 
 
 def test_user_functions():

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -6,7 +6,7 @@ from sympy.core import (Catalan, EulerGamma, GoldenRatio)
 from sympy.core.numbers import (E, Float, I, Integer, Rational, pi)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
-from sympy.core.symbol import (Dummy, symbols)
+from sympy.core.symbol import Dummy, Symbol, symbols
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (conjugate, sign)
 from sympy.functions.elementary.exponential import (exp, log)
@@ -219,6 +219,16 @@ def test_not_fortran():
     too_long_name_90 = symbols('too_long_name_in_fortran_90'*3)
     with raises(InvalidVariableNameError):
         fcode(too_long_name_90, strict_names=True, standard=90)
+
+def test_fcode_strict_names():
+    for invalid in ["α", "å", "", "⋅", "±"]:
+        s = Symbol(invalid)
+        fcode(s)
+        with raises(InvalidVariableNameError):
+            fcode(s, strict_names=True)
+
+    for valid in ["a"*i for i in range(1,7)]:
+        fcode(Symbol(valid), strict_names=True)
 
 
 def test_user_functions():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -3,12 +3,13 @@ from sympy.codegen.ast import none
 from sympy.codegen.cfunctions import expm1, log1p
 from sympy.codegen.scipy_nodes import cosm1
 from sympy.codegen.matrix_nodes import MatrixSolve
-from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
+from sympy.core import Expr, Mod, Symbol, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
 from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth, sec
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
+from sympy.printing.codeprinter import InvalidVariableNameError
 from sympy.printing.pycode import (
     MpmathPrinter, PythonCodePrinter, pycode, SymPyPrinter
 )
@@ -186,6 +187,17 @@ def test_pycode_reserved_words():
     raises(ValueError, lambda: pycode(s1 + s2, error_on_reserved=True))
     py_str = pycode(s1 + s2)
     assert py_str in ('else_ + if_', 'if_ + else_')
+
+
+def test_pycode_strict_names():
+    for invalid in ["", "⋅", "±"]:
+        s = Symbol(invalid)
+        pycode(s)
+        with raises(InvalidVariableNameError):
+            pycode(s, strict_names=True)
+
+    for valid in ["α", "å"]:
+        pycode(Symbol(valid), strict_names=True)
 
 
 def test_issue_20762():


### PR DESCRIPTION
#### References to other Issues or PRs
Based upon gh-26395

cc @moorepants @zachetienne 

#### Brief description of what is fixed or changed
This is a draft for implementing a new printer option for `CodePrinter` which would allow a "fail early" mode for users who are generating code (and for libraries which generates code on the users behalf, and where the user may not be able to decipher compiler error messages at a later stage). That is, an invalid variable name causes `SymPy` to raise an exception already during code-generation. The down-side is that it may trigger false positives, and be overly restrictive for expert use of our code printers, where symbol names often contain extended syntax in the targeted language (e.g. accessing fields in a struct etc.).

#### Other comments
So far this is a draft, it needs, at least:
- [ ] documentation
- [ ] some more test cases

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * CodePrinter got a new option "strict_names" (default is "False") to raise an exception, upon encountering unsupported variable names in a target language.
<!-- END RELEASE NOTES -->
