### PR TITLE
Let Equality objects be used as substitution arguments

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -420,6 +420,8 @@ Brian Stephanik <xoedusk@gmail.com>
 Buck Shlegeris <buck2@bruceh15.anu.edu.au>
 Buck Shlegeris <buck2@bruceh15.anu.edu.au> <buck2@Bucks-MacBook-Pro.local>
 Bulat <daianovich@mail.ru>
+ByThePowerOfScience <public.bythepowerofscience@gmail.com> bythepowerofscience <16433721+ByThePowerOfScience@users.noreply.github.com> 
+ByThePowerOfScience <public.bythepowerofscience@gmail.com> bythepowerofscience <public.bythepowerofscience+github@gmail.com> 
 CJ Carey <perimosocordiae@gmail.com>
 Caley Finn <caleyreuben@gmail.com>
 Calvin Jay Ross <calvinjayross@gmail.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -926,7 +926,7 @@ class Basic(Printable):
           - two arguments, e.g. foo.subs(old, new)
           - one Equality, e.g. foo.subs(Eq(old, new))
           - one iterable argument, e.g. foo.subs(iterable). The iterable may be
-             o an iterable container with (old, new) pairs. In this case the
+             o an iterable container with (old, new) pairs or Eq(old, new) objects;
                replacements are processed in the order given with successive
                patterns possibly affecting replacements already made.
              o a dict or set whose key/value items correspond to old/new pairs.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1074,10 +1074,7 @@ class Basic(Printable):
             else:
                 return sympify(new, strict=True)
 
-        for el in sequence:
-            if isinstance(el, Equality):
-                el = [el.args]
-        
+        sequence = [i.args if isinstance(i, Equality) else i for i in sequence]
         sequence = [(sympify_old(s1), sympify_new(s2)) for s1, s2 in sequence]
 
         # skip if there is no change

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -924,6 +924,7 @@ class Basic(Printable):
 
         `args` is either:
           - two arguments, e.g. foo.subs(old, new)
+          - one Equality, e.g. foo.subs(Eq(old, new))
           - one iterable argument, e.g. foo.subs(iterable). The iterable may be
              o an iterable container with (old, new) pairs. In this case the
                replacements are processed in the order given with successive
@@ -1045,14 +1046,7 @@ class Basic(Printable):
                 unordered = True
                 sequence = sequence.items()
             elif isinstance(sequence, Equality):
-                if isinstance(sequence.lhs, Symbol):
-                    sequence = sequence.args
-                else:
-                    raise ValueError(filldedent("""
-                        Any Equality passed to subs must have a single free symbol
-                        on the left-hand side representing the symbol to be replaced.
-                        Use solve() to solve the equality in terms of
-                        the desired variable before using."""))
+                sequence = [sequence.args]
             elif not iterable(sequence):
                 raise ValueError(filldedent("""
                    When a single argument is passed to subs

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1034,21 +1034,30 @@ class Basic(Printable):
         from .containers import Dict
         from .symbol import Dummy, Symbol
         from .numbers import _illegal
+        from .relational import 
 
         unordered = False
         if len(args) == 1:
-
             sequence = args[0]
             if isinstance(sequence, set):
                 unordered = True
             elif isinstance(sequence, (Dict, Mapping)):
                 unordered = True
                 sequence = sequence.items()
+            elif isinstance(sequence, Equality):
+                if isinstance(sequence.lhs, Symbol) and len(sequence.lhs.free_symbols) == 1:
+                    sequence = [[sequence.lhs, sequence.rhs]]
+                else:
+                    raise ValueError(filldedent("""
+                        Any Equality passed to subs must have a single free symbol
+                        on the left-hand side representing the symbol to be replaced.
+                        Use solve() to solve the equality in terms of
+                        the desired variable before using."""))
             elif not iterable(sequence):
                 raise ValueError(filldedent("""
                    When a single argument is passed to subs
-                   it should be a dictionary of old: new pairs or an iterable
-                   of (old, new) tuples."""))
+                   it should be either an Equality, a dictionary of old: new pairs,
+                   or an iterable of (old, new) tuples."""))
         elif len(args) == 2:
             sequence = [args]
         else:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1046,7 +1046,7 @@ class Basic(Printable):
                 unordered = True
                 sequence = sequence.items()
             elif isinstance(sequence, Equality):
-                sequence = [sequence.args]
+                sequence = sequence.args
             elif not iterable(sequence):
                 raise ValueError(filldedent("""
                    When a single argument is passed to subs

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1074,8 +1074,7 @@ class Basic(Printable):
             else:
                 return sympify(new, strict=True)
 
-        sequence = [i.args if isinstance(i, Equality) else i for i in sequence]
-        sequence = [(sympify_old(s1), sympify_new(s2)) for s1, s2 in sequence]
+        sequence = [i.args if isinstance(i, Equality) else tuple(map(sympify_old, i)) for i in sequence]
 
         # skip if there is no change
         sequence = [(s1, s2) for s1, s2 in sequence if not _aresame(s1, s2)]

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1051,7 +1051,7 @@ class Basic(Printable):
                 raise ValueError(filldedent("""
                    When a single argument is passed to subs
                    it should be either an Equality, a dictionary of old: new pairs,
-                   or an iterable of (old, new) tuples."""))
+                   or an iterable of (old, new) tuples or Equalities."""))
         elif len(args) == 2:
             sequence = [args]
         else:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1046,7 +1046,7 @@ class Basic(Printable):
                 unordered = True
                 sequence = sequence.items()
             elif isinstance(sequence, Equality):
-                sequence = sequence.args
+                sequence = [sequence]
             elif not iterable(sequence):
                 raise ValueError(filldedent("""
                    When a single argument is passed to subs

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1034,7 +1034,7 @@ class Basic(Printable):
         from .containers import Dict
         from .symbol import Dummy, Symbol
         from .numbers import _illegal
-        from .relational import 
+        from .relational import Equality
 
         unordered = False
         if len(args) == 1:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1074,6 +1074,10 @@ class Basic(Printable):
             else:
                 return sympify(new, strict=True)
 
+        for el in sequence:
+            if isinstance(el, Equality):
+                el = [el.args]
+        
         sequence = [(sympify_old(s1), sympify_new(s2)) for s1, s2 in sequence]
 
         # skip if there is no change

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1045,8 +1045,8 @@ class Basic(Printable):
                 unordered = True
                 sequence = sequence.items()
             elif isinstance(sequence, Equality):
-                if isinstance(sequence.lhs, Symbol) and len(sequence.lhs.free_symbols) == 1:
-                    sequence = [[sequence.lhs, sequence.rhs]]
+                if isinstance(sequence.lhs, Symbol):
+                    sequence = sequence.args
                 else:
                     raise ValueError(filldedent("""
                         Any Equality passed to subs must have a single free symbol


### PR DESCRIPTION
#### Brief description of what is fixed or changed

This PR lets `Equality` objects with a lone free `Symbol` on the left-hand side be used as an argument for `subs()`.  
```python
force = Eq(F, M*A)
angular_accel = Eq(A, v**2/R)
force.subs(angular_accel) # acts like .subs(A, v**2/R)
```
This is very useful for substituting the answer to a recently-`solve()`'d equation into another one.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    *  Allowed `Equality`s with a left-hand side consisting of a single free symbol to be used as an argument for the `subs` function. [e.g. `(m*a).subs(Eq(a, v**2/R))`]
<!-- END RELEASE NOTES -->
