### PR TITLE
[typoError] Update calculus.rst, a typo

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -216,6 +216,7 @@ Abhishek Garg <abhishekgarg119@gmail.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>
+Abhishek kumar <kumar325571@gmail.com>
 Achal Jain <2achaljain@gmail.com>
 Adam Bloomston <adam@glitterfram.es> <mail@adambloomston>
 Addison Cugini <ajcugini@gmail.com>

--- a/doc/src/tutorials/intro-tutorial/calculus.rst
+++ b/doc/src/tutorials/intro-tutorial/calculus.rst
@@ -222,7 +222,7 @@ definite integrals.  Here is a sampling of some of the power of ``integrate``.
     ⎩
 
 This last example returned a ``Piecewise`` expression because the integral
-does not converge unless `\Re(y) > 1.`
+does not converge unless `\Re(y) > -1.`
 
 Limits
 ======


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
 integral converges for values of y where the real part of y is greater than -1.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
