### PR TITLE
maint(ci): add a numpy prerelease job to CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -207,7 +207,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
-    name: ${{ matrix.python-version }} NumPy nightly
+    name: ${{ matrix.python-version }} NumPy Prerelease
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -216,6 +216,32 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements-dev.txt
+      - run: pip install --pre numpy scipy
+
+      # Test modules with specific dependencies
+      - run: bin/test_optional_dependencies.py
+
+  # -------------------- NumPy nightly ----------------------------- #
+
+  numpy-nightly:
+    needs: code-quality
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    name: ${{ matrix.python-version }} NumPy nightly
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip install -r requirements-dev.txt
       - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
       - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -197,7 +197,7 @@ jobs:
 
   # -------------------- NumPy 2.0 job ----------------------------- #
 
-  numpy-nightly:
+  numpy-prerelease:
     needs: code-quality
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
