### PR TITLE
1.12.1 backport

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ from setuptools.command.sdist import sdist
 
 
 min_mpmath_version = '0.19'
+max_mpmath_version = '1.4.0'
 
 # This directory
 dir_setup = os.path.dirname(os.path.realpath(__file__))
@@ -351,7 +352,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: Implementation :: PyPy',
             ],
           install_requires=[
-            'mpmath>=%s' % min_mpmath_version,
+            'mpmath>=%s,<%s' % (min_mpmath_version, max_mpmath_version),
             ],
           **extra_kwargs
           )


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is a backport release for SymPy 1.12.1. The only change in a pin to mpmath, which prevents a backwards compatibility with mpmath 1.4.0 (see https://github.com/sympy/sympy/issues/26273). 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
