### PR TITLE
Modified Mul to perform unit conversions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1260,13 +1260,13 @@ Sam Magura <samtheman132@gmail.com>
 Sam Ritchie <sam@mentat.org> sritchie09 <sritchie09@gmail.com>
 Sam Sleight <samuel.sleight@gmail.com>
 Sam Tygier <sam.tygier@hep.manchester.ac.uk>
+SamLubelsky <78610785+SamLubelsky@users.noreply.github.com>
 Sambuddha Basu <sammygamer@live.com>
 Samesh <samesh.lakhotia@gmail.com> Samesh Lakhotia <43701530+sameshl@users.noreply.github.com>
 Samesh Lakhotia <samesh.lakhotia@gmail.com> Samesh Lakhotia <samesh.lakhotia@gmail.com>
 Samnan Rahee <namanush.rsr.16@gmail.com>
 Sampad Kumar Saha <sampadsaha5@gmail.com>
 Samyak Jain <samyak.jain2016a@vitstudent.ac.in> Samyak Jain <samtan106@gmail.com>
-SamLubelsky <78610785+SamLubelsky@users.noreply.github.com>
 Sandeep Murthy <smurthy@protonmail.ch>
 Sandeep Veethu <sandeep.veethu@gmail.com>
 Sanket Agarwal <sanket@sanketagarwal.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1263,10 +1263,10 @@ Sam Tygier <sam.tygier@hep.manchester.ac.uk>
 Sambuddha Basu <sammygamer@live.com>
 Samesh <samesh.lakhotia@gmail.com> Samesh Lakhotia <43701530+sameshl@users.noreply.github.com>
 Samesh Lakhotia <samesh.lakhotia@gmail.com> Samesh Lakhotia <samesh.lakhotia@gmail.com>
-SamLubelsky <78610785+SamLubelsky@users.noreply.github.com>
 Samnan Rahee <namanush.rsr.16@gmail.com>
 Sampad Kumar Saha <sampadsaha5@gmail.com>
 Samyak Jain <samyak.jain2016a@vitstudent.ac.in> Samyak Jain <samtan106@gmail.com>
+SamLubelsky <78610785+SamLubelsky@users.noreply.github.com>
 Sandeep Murthy <smurthy@protonmail.ch>
 Sandeep Veethu <sandeep.veethu@gmail.com>
 Sanket Agarwal <sanket@sanketagarwal.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1255,6 +1255,7 @@ Salil Vishnu Kapur <salilvishnukapur@gmail.com>
 Salmista-94 <alejandrogroso@hotmail.com> alejandrogroso@hotmail.com <Salmista-94>
 Saloni Jain <tosalonijain@gmail.com>
 Sam Brockie <sambrockie@icloud.com>
+Sam Lubelsky <sammy56lt@gmail.com>
 Sam Magura <samtheman132@gmail.com>
 Sam Ritchie <sam@mentat.org> sritchie09 <sritchie09@gmail.com>
 Sam Sleight <samuel.sleight@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1263,6 +1263,7 @@ Sam Tygier <sam.tygier@hep.manchester.ac.uk>
 Sambuddha Basu <sammygamer@live.com>
 Samesh <samesh.lakhotia@gmail.com> Samesh Lakhotia <43701530+sameshl@users.noreply.github.com>
 Samesh Lakhotia <samesh.lakhotia@gmail.com> Samesh Lakhotia <samesh.lakhotia@gmail.com>
+SamLubelsky <78610785+SamLubelsky@users.noreply.github.com>
 Samnan Rahee <namanush.rsr.16@gmail.com>
 Sampad Kumar Saha <sampadsaha5@gmail.com>
 Samyak Jain <samyak.jain2016a@vitstudent.ac.in> Samyak Jain <samtan106@gmail.com>

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -177,28 +177,6 @@ class Mul(Expr, AssocOp):
             return False  # e.g. zoo*x == -zoo*x
         c = self.args[0]
         return c.is_Number and c.is_extended_negative
-    def convert_to(self, other, unit_system="SI"):
-        """
-        Convert the quantity to another quantity of same dimensions.
-
-
-        Examples
-        ========
-
-
-        >>> from sympy.physics.units import speed_of_light, meter, second
-        >>> speed_of_light
-        speed_of_light
-        >>> (3*speed_of_light).convert_to(meter/second)
-        899377374*meter/second
-
-
-        >>> from sympy.physics.units import liter
-        >>> (26*liter).convert_to(meter**3)
-        13*meter**3/500
-        """
-        from sympy.physics.units.util import convert_to
-        return convert_to(self, other, unit_system)
     def __neg__(self):
         c, args = self.as_coeff_mul()
         if args[0] is not S.ComplexInfinity:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -177,6 +177,7 @@ class Mul(Expr, AssocOp):
             return False  # e.g. zoo*x == -zoo*x
         c = self.args[0]
         return c.is_Number and c.is_extended_negative
+        
     def __neg__(self):
         c, args = self.as_coeff_mul()
         if args[0] is not S.ComplexInfinity:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -177,7 +177,28 @@ class Mul(Expr, AssocOp):
             return False  # e.g. zoo*x == -zoo*x
         c = self.args[0]
         return c.is_Number and c.is_extended_negative
+    def convert_to(self, other, unit_system="SI"):
+        """
+        Convert the quantity to another quantity of same dimensions.
 
+
+        Examples
+        ========
+
+
+        >>> from sympy.physics.units import speed_of_light, meter, second
+        >>> speed_of_light
+        speed_of_light
+        >>> (3*speed_of_light).convert_to(meter/second)
+        899377374*meter/second
+
+
+        >>> from sympy.physics.units import liter
+        >>> (26*liter).convert_to(meter**3)
+        13*meter**3/500
+        """
+        from sympy.physics.units.util import convert_to
+        return convert_to(self, other, unit_system)
     def __neg__(self):
         c, args = self.as_coeff_mul()
         if args[0] is not S.ComplexInfinity:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -177,7 +177,6 @@ class Mul(Expr, AssocOp):
             return False  # e.g. zoo*x == -zoo*x
         c = self.args[0]
         return c.is_Number and c.is_extended_negative
-        
     def __neg__(self):
         c, args = self.as_coeff_mul()
         if args[0] is not S.ComplexInfinity:

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -49,7 +49,6 @@ def test_convert_to():
     assert q.convert_to(m) == 5000*m
 
     assert speed_of_light.convert_to(m / s) == 299792458 * m / s
-    assert (2*speed_of_light).convert_to(m / s) == 2 * 299792458 * m / s
     assert day.convert_to(s) == 86400*s
 
     # Wrong dimension to convert:
@@ -136,12 +135,8 @@ def test_add_sub():
 
     assert isinstance(u + v, Add)
     assert (u + v.convert_to(u)) == (1 + S.Half)*u
-    # TODO: eventually add this:
-    # assert (u + v).convert_to(u) == (1 + S.Half)*u
     assert isinstance(u - v, Add)
     assert (u - v.convert_to(u)) == S.Half*u
-    # TODO: eventually add this:
-    # assert (u - v).convert_to(u) == S.Half*u
 
 
 def test_quantity_abs():

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -49,8 +49,7 @@ def test_convert_to():
     assert q.convert_to(m) == 5000*m
 
     assert speed_of_light.convert_to(m / s) == 299792458 * m / s
-    # TODO: eventually support this kind of conversion:
-    # assert (2*speed_of_light).convert_to(m / s) == 2 * 299792458 * m / s
+    assert (2*speed_of_light).convert_to(m / s) == 2 * 299792458 * m / s
     assert day.convert_to(s) == 86400*s
 
     # Wrong dimension to convert:


### PR DESCRIPTION
    This change was made to address a TODO line in
    sympy.physics.units which requested
    mul objects to have a convert_to method.
    previously convert_to(mul_expr, unit_to_convert_to)
    worked but mul_expr.convert_to(unit_to_convert_to)
    did not.

    Example:

    from sympy.physics.units import speed_of_light, meter, second
    (2*speed_of_light).convert_to(meter/second)

    The above statement runs now without error,
    previously it didn't.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
