### PR TITLE
added node for the 'Rational' function to Mathematica parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1255,6 +1255,7 @@ Salil Vishnu Kapur <salilvishnukapur@gmail.com>
 Salmista-94 <alejandrogroso@hotmail.com> alejandrogroso@hotmail.com <Salmista-94>
 Saloni Jain <tosalonijain@gmail.com>
 Sam Brockie <sambrockie@icloud.com>
+Sam Lubelsky <sammy56lt@gmail.com>
 Sam Magura <samtheman132@gmail.com>
 Sam Ritchie <sam@mentat.org> sritchie09 <sritchie09@gmail.com>
 Sam Sleight <samuel.sleight@gmail.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -980,6 +980,7 @@ class MathematicaParser:
         "Log": lambda *a: log(*reversed(a)),
         "Log2": lambda x: log(x, 2),
         "Log10": lambda x: log(x, 10),
+        "Rational": Rational,
         "Exp": exp,
         "Sqrt": sqrt,
 

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -264,10 +264,12 @@ def test_parser_mathematica_exp_alt():
     full_form1 = "Sin[Times[x, y]]"
     full_form2 = "Plus[Times[x, y], z]"
     full_form3 = "Sin[Times[x, Plus[y, z], Power[w, n]]]]"
+    full_form4 = "Rational[Rational[x, y], z]"
 
     assert parser._from_fullform_to_fullformlist(full_form1) == ["Sin", ["Times", "x", "y"]]
     assert parser._from_fullform_to_fullformlist(full_form2) == ["Plus", ["Times", "x", "y"], "z"]
     assert parser._from_fullform_to_fullformlist(full_form3) == ["Sin", ["Times", "x", ["Plus", "y", "z"], ["Power", "w", "n"]]]
+    assert parser._from_fullform_to_fullformlist(full_form4) == ["Rational", ["Rational", "x", "y"], "z"]
 
     assert convert_chain2(full_form1) == Sin(Times(x, y))
     assert convert_chain2(full_form2) == Plus(Times(x, y), z)


### PR DESCRIPTION
Before, there was no node that allowed a Rational node to be parsed and converted to a sympy node, now there is. Also added regression testing. Fixes #25404

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
