### PR TITLE
units: fixed convert_to() bug and added some tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -675,6 +675,7 @@ Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.
 Haruki Moriguchi <harukimoriguchi@gmail.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
 Henrik Johansson <henjo2006@gmail.com>
+Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
 Henry Gebhardt <hsggebhardt@gmail.com>
 Henry Metlov <genrih.metlov@gmail.com>
 Himanshu <hs80941@gmail.com>

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -11,6 +11,7 @@ from sympy.physics.units import (
     second, speed_of_light, steradian, time, km)
 from sympy.physics.units.util import convert_to, check_dimensions
 from sympy.testing.pytest import raises
+from sympy.functions.elementary.miscellaneous import sqrt
 
 
 def NS(e, n=15, **options):
@@ -69,6 +70,10 @@ def test_convert_to_quantities():
     assert convert_to(pi*radians, degree) == 180*degree
     assert convert_to(pi, degree) == 180*degree
 
+    # https://github.com/sympy/sympy/issues/26263
+    assert convert_to(sqrt(meter**2 + meter**2.0), meter) == sqrt(meter**2 + meter**2.0)
+    assert convert_to((meter**2 + meter**2.0)**2, meter) == (meter**2 + meter**2.0)**2
+
 
 def test_convert_to_tuples_of_quantities():
     assert convert_to(speed_of_light, [meter, second]) == 299792458 * meter / second
@@ -88,6 +93,10 @@ def test_convert_to_tuples_of_quantities():
     assert NS(convert_to(planck_time, second), n=6) == '5.39125e-44*second'
     assert NS(convert_to(planck_temperature, kelvin), n=7) == '1.416784e+32*kelvin'
     assert NS(convert_to(convert_to(meter, [G, speed_of_light, planck]), meter), n=10) == '1.000000000*meter'
+
+    # similar to https://github.com/sympy/sympy/issues/26263
+    assert convert_to(sqrt(meter**2 + second**2.0), [meter, second]) == sqrt(meter**2 + second**2.0)
+    assert convert_to((meter**2 + second**2.0)**2, [meter, second]) == (meter**2 + second**2.0)**2
 
 
 def test_eval_simplify():

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -98,9 +98,14 @@ def convert_to(expr, target_units, unit_system="SI"):
     if not isinstance(target_units, (Iterable, Tuple)):
         target_units = [target_units]
 
-    if isinstance(expr, Add):
+    def handle_Adds(expr):
         return Add.fromiter(convert_to(i, target_units, unit_system)
             for i in expr.args)
+
+    if isinstance(expr, Add):
+        return handle_Adds(expr)
+    elif isinstance(expr, Pow) and isinstance(expr.base, Add):
+        return handle_Adds(expr.base) ** expr.exp
 
     expr = sympify(expr)
     target_units = sympify(target_units)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #26263.

#### Brief description of what is fixed or changed

Fixed a convert_to() function bug where an inconsistent handling of Adds would cause some factors to be duplicated. Found that the inconsistency occured when the first argument of convert_to() was a Pow expression whose base was an Add expression, so added a verification to get this cases and call a function that handles them correctly.
Added some tests to verify this.

Example:

- Before

In [1]: convert_to(sqrt(meter ** 2 + meter ** 2.0), [meter])
Out [1]: meter * sqrt(meter ** 2 + meter ** 2.0)

- After

In [2]: convert_to(sqrt(meter ** 2 + meter ** 2.0), [meter])
Out [2]: sqrt(meter ** 2 + meter ** 2.0)

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Fixed a bug with convert_to function.
<!-- END RELEASE NOTES -->
