### PR TITLE
printing: fix boolean operators in maple printing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1488,6 +1488,7 @@ Vlad Seghete <vlad.seghete@gmail.com>
 Vladimir Lagunov <werehuman@gmail.com>
 Vladimir Perić <vlada.peric@gmail.com>
 Vladimir Poluhsin <vovapolu@gmail.com>
+Vladimir Sereda <voffch@gmail.com>
 Waldir Pimenta <waldyrious@gmail.com>
 Wang Ran (汪然) <wangr@smail.nju.edu.cn>
 Warren Jacinto <warrenjacinto@gmail.com>

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -88,6 +88,12 @@ class MapleCodePrinter(CodePrinter):
     printmethod = "_maple"
     language = "maple"
 
+    _operators = {
+        'and': 'and',
+        'or': 'or',
+        'not': 'not ',
+    }
+
     _default_settings = dict(CodePrinter._default_settings, **{
         'inline': True,
         'allow_unknown_functions': True,

--- a/sympy/printing/tests/test_maple.py
+++ b/sympy/printing/tests/test_maple.py
@@ -142,13 +142,13 @@ def test_constants_other():
 
 
 def test_boolean():
-    assert maple_code(x & y) == "x && y"
-    assert maple_code(x | y) == "x || y"
-    assert maple_code(~x) == "!x"
-    assert maple_code(x & y & z) == "x && y && z"
-    assert maple_code(x | y | z) == "x || y || z"
-    assert maple_code((x & y) | z) == "z || x && y"
-    assert maple_code((x | y) & z) == "z && (x || y)"
+    assert maple_code(x & y) == "x and y"
+    assert maple_code(x | y) == "x or y"
+    assert maple_code(~x) == "not x"
+    assert maple_code(x & y & z) == "x and y and z"
+    assert maple_code(x | y | z) == "x or y or z"
+    assert maple_code((x & y) | z) == "z or x and y"
+    assert maple_code((x | y) & z) == "z and (x or y)"
 
 
 def test_Matrices():


### PR DESCRIPTION
Maplesoft Maple uses `and`,  `or`, `not` in its boolean expressions (see, e.g., its [online help](https://www.maplesoft.com/support/help/maple/view.aspx?path=boolean) on this topic). However, Sympy's maple code printer outputted the default (incorrect) operators (`&&`, `||`, `!`) from the base `CodePrinter` class. This simple fix overrides the operators in the `MapleCodePrinter` class with their correct values in accordance with the syntax of Maplesoft Maple. Now printing the boolean expressions and the Piecewise functions that include complex boolean expressions should produce correct Maple code.

#### Brief description of what is fixed or changed

The `_operators` dict with the correct boolean operators was added to the `MapleCodePrinter` class. The relevant tests were also corrected.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * fixed a bug in printing the boolean operators with the maple printer
<!-- END RELEASE NOTES -->
