### PR TITLE
Fix quaternion substitution issue and add additional tests

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1001,7 +1001,8 @@ class Quaternion(Expr):
     def _eval_subs(self, *args):
         elements = [i.subs(*args) for i in self.args]
         norm = self._norm
-        norm = norm.subs(*args)
+        if norm is not None:
+            norm = norm.subs(*args)
         _check_norm(elements, norm)
         return Quaternion(*elements, norm=norm)
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,3 +1,5 @@
+from sympy.testing.pytest import slow
+
 from sympy.core.function import diff
 from sympy.core.function import expand
 from sympy.core.numbers import (E, I, Rational, pi)
@@ -132,6 +134,11 @@ def test_quaternion_complex_real_addition():
     assert q1 + q0 == q1
     assert q1 - q0 == q1
     assert q1 - q1 == q0
+    
+    
+def test_quaterion_subs():
+    q = Quaternion.from_axis_angle((0, 0, 1), phi)
++   assert q.subs(phi, 0) == Quaternion(1, 0, 0, 0)
 
 
 def test_quaternion_evalf():
@@ -355,6 +362,7 @@ def test_issue_16318():
     assert (axis, angle) == q.to_axis_angle()
 
 
+@slow
 def test_to_euler():
     q = Quaternion(w, x, y, z)
     q_normalized = q.normalize()
@@ -396,6 +404,7 @@ def test_to_euler_numerical_singilarities():
     test_one_case((pi/2,  -pi/2, 0), 'ZYX')
 
 
+@slow
 def test_to_euler_options():
     def test_one_case(q):
         angles1 = Matrix(q.to_euler(seq, True, True))

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -134,8 +134,8 @@ def test_quaternion_complex_real_addition():
     assert q1 + q0 == q1
     assert q1 - q0 == q1
     assert q1 - q1 == q0
-    
-    
+
+
 def test_quaternion_subs():
     q = Quaternion.from_axis_angle((0, 0, 1), phi)
     assert q.subs(phi, 0) == Quaternion(1, 0, 0, 0)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,5 +1,4 @@
 from sympy.testing.pytest import slow
-
 from sympy.core.function import diff
 from sympy.core.function import expand
 from sympy.core.numbers import (E, I, Rational, pi)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -136,9 +136,9 @@ def test_quaternion_complex_real_addition():
     assert q1 - q1 == q0
     
     
-def test_quaterion_subs():
+def test_quaternion_subs():
     q = Quaternion.from_axis_angle((0, 0, 1), phi)
-+   assert q.subs(phi, 0) == Quaternion(1, 0, 0, 0)
+    assert q.subs(phi, 0) == Quaternion(1, 0, 0, 0)
 
 
 def test_quaternion_evalf():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #26425 
Fixed quaternion substitution issue.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Fixed unexpected errors for quaternion substitution.
<!-- END RELEASE NOTES -->
