### PR TITLE
Implement Duffing Spring Actuator.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1560,6 +1560,7 @@ dodo <palumbododo@gmail.com>
 dps7ud <dps7ud@virginia.edu>
 dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>
+eh111eh <hwayeonniii@gmail.com>
 elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -40,7 +40,7 @@ __all__ = [
     'PathwayBase', 'LinearPathway', 'ObstacleSetPathway', 'WrappingPathway',
 
     'ActuatorBase', 'ForceActuator', 'LinearDamper', 'LinearSpring',
-    'TorqueActuator',
+    'TorqueActuator', 'DuffingSpring'
 ]
 
 from sympy.physics import vector
@@ -87,4 +87,4 @@ from .pathway import (PathwayBase, LinearPathway, ObstacleSetPathway,
                       WrappingPathway)
 
 from .actuator import (ActuatorBase, ForceActuator, LinearDamper, LinearSpring,
-                       TorqueActuator)
+                       TorqueActuator, DuffingSpring)

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from sympy import S, sympify
+from sympy import S, simplify, sympify
 from sympy.physics.mechanics.joint import PinJoint
 from sympy.physics.mechanics.loads import Torque
 from sympy.physics.mechanics.pathway import PathwayBase
@@ -896,15 +896,15 @@ class DuffingSpring(ForceActuator):
     """
 
     def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):
-        self.linear_stiffness = linear_stiffness
-        self.nonlinear_stiffness = nonlinear_stiffness
+        self.linear_stiffness = sympify(linear_stiffness)
+        self.nonlinear_stiffness = sympify(nonlinear_stiffness)
+        self.equilibrium_length = sympify(equilibrium_length)
         self.pathway = pathway
-        self.equilibrium_length = equilibrium_length
 
     @property
     def force(self):
         """The force produced by the Duffing spring."""
-        displacement = self.pathway.length - self.equilibrium_length
+        displacement = simplify(self.pathway.length - self.equilibrium_length)
         return -self.linear_stiffness * displacement - self.nonlinear_stiffness * displacement**3
 
     @force.setter

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -881,18 +881,18 @@ class DuffingSpring(ForceActuator):
     Explanation
     ===========
     Here, ``DuffingSpring`` represents the force exerted by a nonlinear spring based on the Duffing equation:
-    F = -β*x-α*x**3, where x is the displacement from the equilibrium position, β is the linear spring constant,
-    and α is the coefficient for the nonlinear cubic term.
+    F = -beta*x-alpha*x**3, where x is the displacement from the equilibrium position, beta is the linear spring constant,
+    and alpha is the coefficient for the nonlinear cubic term.
     Parameters
     ==========
     linear_stiffness : Expr
-        The linear stiffness coefficient (k).
+        The linear stiffness coefficient (beta).
     nonlinear_stiffness : Expr
-        The nonlinear stiffness coefficient (beta).
+        The nonlinear stiffness coefficient (alpha).
     pathway : PathwayBase
         The pathway that the actuator follows.
     equilibrium_length : Expr, optional
-        The length at which the spring is in equilibrium.
+        The length at which the spring is in equilibrium (x).
     """
 
     def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -940,6 +940,22 @@ class DuffingSpring(ForceActuator):
     def pathway(self):
         return self._pathway
 
+    @pathway.setter
+    def pathway(self, pathway):
+        if hasattr(self, '_pathway'):
+            msg = (
+                f'Can\'t set attribute `pathway` to {repr(pathway)} as it is '
+                f'immutable.'
+            )
+            raise AttributeError(msg)
+        if not isinstance(pathway, PathwayBase):
+            msg = (
+                f'Value {repr(pathway)} passed to `pathway` was of type '
+                f'{type(pathway)}, must be {PathwayBase}.'
+            )
+            raise TypeError(msg)
+        self._pathway = pathway
+
     @property
     def equilibrium_length(self):
         return self._equilibrium_length
@@ -959,6 +975,16 @@ class DuffingSpring(ForceActuator):
         """The force produced by the Duffing spring."""
         displacement = self.pathway.length - self.equilibrium_length
         return -self.linear_stiffness * displacement - self.nonlinear_stiffness * displacement**3
+
+    @force.setter
+    def force(self, force):
+        if hasattr(self, '_force'):
+            msg = (
+                f'Can\'t set attribute `force` to {repr(force)} as it is '
+                f'immutable.'
+            )
+            raise AttributeError(msg)
+        self._force = sympify(force, strict=True)
 
     def __repr__(self):
         return (f"{self.__class__.__name__}("

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -16,6 +16,7 @@ __all__ = [
     'LinearDamper',
     'LinearSpring',
     'TorqueActuator',
+    'DuffingSpring'
 ]
 
 
@@ -873,3 +874,44 @@ class TorqueActuator(ActuatorBase):
         else:
             string += ')'
         return string
+
+
+class DuffingSpring(ForceActuator):
+    """A nonlinear spring based on the Duffing equation.
+    Explanation
+    ===========
+    Here, ``DuffingSpring`` represents the force exerted by a nonlinear spring based on the Duffing equation:
+    F = -β*x-α*x**3, where x is the displacement from the equilibrium position, β is the linear spring constant,
+    and α is the coefficient for the nonlinear cubic term.
+    Parameters
+    ==========
+    linear_stiffness : Expr
+        The linear stiffness coefficient (k).
+    nonlinear_stiffness : Expr
+        The nonlinear stiffness coefficient (beta).
+    pathway : PathwayBase
+        The pathway that the actuator follows.
+    equilibrium_length : Expr, optional
+        The length at which the spring is in equilibrium.
+    """
+
+    def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):
+        self.linear_stiffness = linear_stiffness
+        self.nonlinear_stiffness = nonlinear_stiffness
+        self.pathway = pathway
+        self.equilibrium_length = equilibrium_length
+
+    @property
+    def force(self):
+        """The force produced by the Duffing spring."""
+        displacement = self.pathway.length - self.equilibrium_length
+        return -self.linear_stiffness * displacement - self.nonlinear_stiffness * displacement**3
+
+    @force.setter
+    def force(self, force):
+        raise AttributeError("Can't set computed attribute `force`.")
+
+    def __repr__(self):
+        return (f"{self.__class__.__name__}("
+                f"{self.linear_stiffness}, {self.nonlinear_stiffness}, {self.pathway}, "
+                f"equilibrium_length={self.equilibrium_length})")

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -879,13 +879,17 @@ class TorqueActuator(ActuatorBase):
 
 class DuffingSpring(ForceActuator):
     """A nonlinear spring based on the Duffing equation.
+    
     Explanation
     ===========
+    
     Here, ``DuffingSpring`` represents the force exerted by a nonlinear spring based on the Duffing equation:
     F = -beta*x-alpha*x**3, where x is the displacement from the equilibrium position, beta is the linear spring constant,
     and alpha is the coefficient for the nonlinear cubic term.
+    
     Parameters
     ==========
+    
     linear_stiffness : Expr
         The linear stiffness coefficient (beta).
     nonlinear_stiffness : Expr
@@ -897,12 +901,9 @@ class DuffingSpring(ForceActuator):
     """
 
     def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):
-        try:
-            self._linear_stiffness = sympify(linear_stiffness)
-            self._nonlinear_stiffness = sympify(nonlinear_stiffness)
-            self._equilibrium_length = sympify(equilibrium_length)
-        except SympifyError:
-            raise SympifyError("Input arguments could not be sympified.")
+        self._linear_stiffness = sympify(linear_stiffness, strict=True)
+        self._nonlinear_stiffness = sympify(nonlinear_stiffness, strict=True)
+        self._equilibrium_length = sympify(equilibrium_length, strict=True)
 
         if not isinstance(pathway, PathwayBase):
             raise TypeError("pathway must be an instance of PathwayBase.")
@@ -911,44 +912,54 @@ class DuffingSpring(ForceActuator):
     @property
     def linear_stiffness(self):
         return self._linear_stiffness
-
+    
     @linear_stiffness.setter
-    def linear_stiffness(self, value):
-        raise AttributeError("Cannot modify linear_stiffness")
+    def linear_stiffness(self, linear_stiffness):
+        if hasattr(self, '_linear_stiffness'):
+            msg = (
+                f'Can\'t set attribute `linear_stiffness` to '
+                f'{repr(linear_stiffness)} as it is immutable.'
+            )
+            raise AttributeError(msg)
+        self._linear_stiffness = sympify(linear_stiffness, strict=True)
 
     @property
     def nonlinear_stiffness(self):
         return self._nonlinear_stiffness
 
     @nonlinear_stiffness.setter
-    def nonlinear_stiffness(self, value):
-        raise AttributeError("Cannot modify nonlinear_stiffness")
+    def nonlinear_stiffness(self, nonlinear_stiffness):
+        if hasattr(self, '_nonlinear_stiffness'):
+            msg = (
+                f'Can\'t set attribute `nonlinear_stiffness` to '
+                f'{repr(nonlinear_stiffness)} as it is immutable.'
+            )
+            raise AttributeError(msg)
+        self._nonlinear_stiffness = sympify(nonlinear_stiffness, strict=True)
 
     @property
     def pathway(self):
         return self._pathway
-
-    @pathway.setter
-    def pathway(self, value):
-        raise AttributeError("Cannot modify pathway")
 
     @property
     def equilibrium_length(self):
         return self._equilibrium_length
 
     @equilibrium_length.setter
-    def equilibrium_length(self, value):
-        raise AttributeError("Cannot modify equilibrium_length")
+    def equilibrium_length(self, equilibrium_length):
+        if hasattr(self, '_equilibrium_length'):
+            msg = (
+                f'Can\'t set attribute `equilibrium_length` to '
+                f'{repr(equilibrium_length)} as it is immutable.'
+            )
+            raise AttributeError(msg)
+        self._equilibrium_length = sympify(equilibrium_length, strict=True)
 
     @property
     def force(self):
         """The force produced by the Duffing spring."""
-        displacement = simplify(self.pathway.length - self.equilibrium_length)
+        displacement = self.pathway.length - self.equilibrium_length
         return -self.linear_stiffness * displacement - self.nonlinear_stiffness * displacement**3
-
-    @force.setter
-    def force(self, force):
-        raise AttributeError("Can't set computed attribute `force`.")
 
     def __repr__(self):
         return (f"{self.__class__.__name__}("

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -2,8 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from sympy import S, simplify, sympify
-from sympy.core.sympify import SympifyError
+from sympy import S, sympify
 from sympy.physics.mechanics.joint import PinJoint
 from sympy.physics.mechanics.loads import Torque
 from sympy.physics.mechanics.pathway import PathwayBase
@@ -901,9 +900,9 @@ class DuffingSpring(ForceActuator):
     """
 
     def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):
-        self._linear_stiffness = sympify(linear_stiffness, strict=True)
-        self._nonlinear_stiffness = sympify(nonlinear_stiffness, strict=True)
-        self._equilibrium_length = sympify(equilibrium_length, strict=True)
+        self.linear_stiffness = sympify(linear_stiffness, strict=True)
+        self.nonlinear_stiffness = sympify(nonlinear_stiffness, strict=True)
+        self.equilibrium_length = sympify(equilibrium_length, strict=True)
 
         if not isinstance(pathway, PathwayBase):
             raise TypeError("pathway must be an instance of PathwayBase.")

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -879,17 +879,17 @@ class TorqueActuator(ActuatorBase):
 
 class DuffingSpring(ForceActuator):
     """A nonlinear spring based on the Duffing equation.
-    
+
     Explanation
     ===========
-    
+
     Here, ``DuffingSpring`` represents the force exerted by a nonlinear spring based on the Duffing equation:
     F = -beta*x-alpha*x**3, where x is the displacement from the equilibrium position, beta is the linear spring constant,
     and alpha is the coefficient for the nonlinear cubic term.
-    
+
     Parameters
     ==========
-    
+
     linear_stiffness : Expr
         The linear stiffness coefficient (beta).
     nonlinear_stiffness : Expr
@@ -912,7 +912,7 @@ class DuffingSpring(ForceActuator):
     @property
     def linear_stiffness(self):
         return self._linear_stiffness
-    
+
     @linear_stiffness.setter
     def linear_stiffness(self, linear_stiffness):
         if hasattr(self, '_linear_stiffness'):

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -898,15 +898,47 @@ class DuffingSpring(ForceActuator):
 
     def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):
         try:
-            self.linear_stiffness = sympify(linear_stiffness)
-            self.nonlinear_stiffness = sympify(nonlinear_stiffness)
-            self.equilibrium_length = sympify(equilibrium_length)
+            self._linear_stiffness = sympify(linear_stiffness)
+            self._nonlinear_stiffness = sympify(nonlinear_stiffness)
+            self._equilibrium_length = sympify(equilibrium_length)
         except SympifyError:
             raise SympifyError("Input arguments could not be sympified.")
 
         if not isinstance(pathway, PathwayBase):
             raise TypeError("pathway must be an instance of PathwayBase.")
-        self.pathway = pathway
+        self._pathway = pathway
+
+    @property
+    def linear_stiffness(self):
+        return self._linear_stiffness
+
+    @linear_stiffness.setter
+    def linear_stiffness(self, value):
+        raise AttributeError("Cannot modify linear_stiffness")
+
+    @property
+    def nonlinear_stiffness(self):
+        return self._nonlinear_stiffness
+
+    @nonlinear_stiffness.setter
+    def nonlinear_stiffness(self, value):
+        raise AttributeError("Cannot modify nonlinear_stiffness")
+
+    @property
+    def pathway(self):
+        return self._pathway
+
+    @pathway.setter
+    def pathway(self, value):
+        raise AttributeError("Cannot modify pathway")
+
+    @property
+    def equilibrium_length(self):
+        return self._equilibrium_length
+
+    @equilibrium_length.setter
+    def equilibrium_length(self, value):
+        raise AttributeError("Cannot modify equilibrium_length")
 
     @property
     def force(self):

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 
 from sympy import S, simplify, sympify
+from sympy.core.sympify import SympifyError
 from sympy.physics.mechanics.joint import PinJoint
 from sympy.physics.mechanics.loads import Torque
 from sympy.physics.mechanics.pathway import PathwayBase
@@ -896,9 +897,15 @@ class DuffingSpring(ForceActuator):
     """
 
     def __init__(self, linear_stiffness, nonlinear_stiffness, pathway, equilibrium_length=S.Zero):
-        self.linear_stiffness = sympify(linear_stiffness)
-        self.nonlinear_stiffness = sympify(nonlinear_stiffness)
-        self.equilibrium_length = sympify(equilibrium_length)
+        try:
+            self.linear_stiffness = sympify(linear_stiffness)
+            self.nonlinear_stiffness = sympify(nonlinear_stiffness)
+            self.equilibrium_length = sympify(equilibrium_length)
+        except SympifyError:
+            raise SympifyError("Input arguments could not be sympified.")
+
+        if not isinstance(pathway, PathwayBase):
+            raise TypeError("pathway must be an instance of PathwayBase.")
         self.pathway = pathway
 
     @property

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -7,7 +7,6 @@ from sympy import (
     Matrix,
     Symbol,
     SympifyError,
-    simplify,
     sqrt,
     Abs
 )

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -831,13 +831,13 @@ class TestDuffingSpring:
 
         # Calculate the displacement from the equilibrium length
         displacement = self.q - self.equilibrium_length
-    
+
         # Make sure this matches the computation in DuffingSpring class
         force = -self.linear_stiffness * displacement - self.nonlinear_stiffness * displacement**3
-    
+
         # The expected loads on pA and pB due to the spring
         expected_loads = [Force(self.pA, force * self.N.x), Force(self.pB, -force * self.N.x)]
-    
+
         # Compare expected loads to what is returned from DuffingSpring.to_loads()
         calculated_loads = spring.to_loads()
         for calculated, expected in zip(calculated_loads, expected_loads):

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -828,7 +828,7 @@ class TestDuffingSpring:
     def test_to_loads(self):
         self.pB.set_pos(self.pA, self.q*self.N.x)
         spring = DuffingSpring(self.linear_stiffness, self.nonlinear_stiffness, self.pathway, self.equilibrium_length)
-    
+
         # Calculate the displacement from the equilibrium length
         displacement = self.q - self.equilibrium_length
     

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -730,7 +730,7 @@ class TestDuffingSpring:
                 Symbol('alpha'),
                 Symbol('l'),
                 Symbol('l'),
-                -Symbol('beta')*(sqrt(dynamicsymbols('q')**2)-Symbol('l'))-Symbol('alpha')*((sqrt(dynamicsymbols('q')**2))**3-Symbol('l')),
+                -Symbol('beta') * (sqrt(dynamicsymbols('q')**2) - Symbol('l')) - Symbol('alpha') * (sqrt(dynamicsymbols('q')**2) - Symbol('l'))**3,
             ),
         ]
     )

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -776,12 +776,12 @@ class TestDuffingSpring:
         assert isinstance(spring.force, ExprType)
         assert spring.force == force
 
-    @pytest.mark.parametrize('linear_stiffness', [NonSympifyable(), [NonSympifyable()]])
+    @pytest.mark.parametrize('linear_stiffness', [None, NonSympifyable()])
     def test_invalid_constructor_linear_stiffness_not_sympifyable(self, linear_stiffness):
         with pytest.raises(SympifyError):
             _ = DuffingSpring(linear_stiffness, self.nonlinear_stiffness, self.pathway, self.equilibrium_length)
 
-    @pytest.mark.parametrize('nonlinear_stiffness', [NonSympifyable(), [NonSympifyable()]])
+    @pytest.mark.parametrize('nonlinear_stiffness', [None, NonSympifyable()])
     def test_invalid_constructor_nonlinear_stiffness_not_sympifyable(self, nonlinear_stiffness):
         with pytest.raises(SympifyError):
             _ = DuffingSpring(self.linear_stiffness, nonlinear_stiffness, self.pathway, self.equilibrium_length)
@@ -790,7 +790,7 @@ class TestDuffingSpring:
         with pytest.raises(TypeError):
             _ = DuffingSpring(self.linear_stiffness, self.nonlinear_stiffness, NonSympifyable(), self.equilibrium_length)
 
-    @pytest.mark.parametrize('equilibrium_length', [NonSympifyable(), [NonSympifyable()]])
+    @pytest.mark.parametrize('equilibrium_length', [None, NonSympifyable()])
     def test_invalid_constructor_equilibrium_length_not_sympifyable(self, equilibrium_length):
         with pytest.raises(SympifyError):
             _ = DuffingSpring(self.linear_stiffness, self.nonlinear_stiffness, self.pathway, equilibrium_length)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#26402 

#### Brief description of what is fixed or changed
The Duffing equation is a nonlinear second order differential equation used to model the dynamics of systems, damped and driven oscillators, with a cubic nonlinearity in the restoring force, which is given by $$\\ddot{x} + \delta\dot{x} + \beta x + \alpha x^3 = \gamma \cos(\omega t)\$$

However, as a full Duffing second order forced system will not work as an actuator, I modify the Duffing Spring to treat it as a non-second order system.
For $\beta>0$, the Duffing oscillator can be interpreted as a forced oscillator with a spring whose restoring force is written as $$F = -\beta x - \alpha x^3$$
Since the case  $\beta<0$ causes the chaotic motions, I will not consider this case for now. 

I Implemented a new class `DuffingSpring` to model the force exerted by a nonlinear spring, based on the Duffing equation: $F = -\beta x - \alpha x^3$
where $x$ is the displacement from the equilibrium position, $\beta$ is the linear spring constant, and $\alpha$ is the coefficient for the nonlinear cubic term.

#### Task
- [x] Add a unit test to verify the new class `DuffingSpring` works as expected. Refer to the existing unit tests for actuators as examples.
- [x] Demonstrate the force exerted by a nonlinear spring, based on the Duffing equation, as illustrated in the following example: https://pydy.readthedocs.io/en/latest/examples/mass-spring-damper.html

#### Other comments
Reference
- http://www.scholarpedia.org/article/Duffing_oscillator 
- https://www.cfm.brown.edu/people/dobrush/am34/Matlab/ch3/duffing.html
- https://www.cfm.brown.edu/people/dobrush/am34/Mathematica/ch3/duffing.html

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * implemented `DuffingSpring` to model the force exerted by a nonlinear spring, based on the Duffing equation
<!-- END RELEASE NOTES -->
