### PR TITLE
Modified the case of autolev parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -359,6 +359,7 @@ Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
+Assem Ali <assemali852654@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>

--- a/sympy/parsing/autolev/__init__.py
+++ b/sympy/parsing/autolev/__init__.py
@@ -2,7 +2,7 @@ from sympy.external import import_module
 from sympy.utilities.decorator import doctest_depends_on
 
 @doctest_depends_on(modules=('antlr4',))
-def parse_autolev(autolev_code, include_numeric=False):
+def parse_autolev(autolev_code, include_numeric=False, lower_case=True):
     """Parses Autolev code (version 4.1) to SymPy code.
 
     Parameters
@@ -94,4 +94,4 @@ def parse_autolev(autolev_code, include_numeric=False):
         import_kwargs={'fromlist': ['X']})
 
     if _autolev is not None:
-        return _autolev.parse_autolev(autolev_code, include_numeric)
+        return _autolev.parse_autolev(autolev_code, include_numeric, lower_case)

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -40,7 +40,7 @@ def declare_frames(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText()
+        name1 = ctx.ID().getText().lower()
     name2 = "frame_" + name1
     if self.getValue(ctx.parentCtx.varType()) == "newtonian":
         self.newtonian = name2
@@ -61,7 +61,7 @@ def declare_points(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText()
+        name1 = ctx.ID().getText().lower()
 
     name2 = "point_" + name1
 
@@ -76,7 +76,7 @@ def declare_particles(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText()
+        name1 = ctx.ID().getText().lower()
 
     name2 = "particle_" + name1
 
@@ -93,7 +93,7 @@ def declare_bodies(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText()
+        name1 = ctx.ID().getText().lower()
 
     name2 = "body_" + name1
     self.bodies.update({name1: name2})
@@ -1447,7 +1447,7 @@ if AutolevListener:
                 elif ctx.equals().getText() == "^=":
                     equals = "**="
 
-                text = ctx.ID().getText()
+                text = ctx.ID().getText().lower()
                 self.type.update({text: "matrix"})
                 # Handle assignments of type ID[2] = expr
                 if ctx.index().getChildCount() == 1:

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -40,7 +40,7 @@ def declare_frames(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText().lower()
+        name1 = ctx.ID().getText()
     name2 = "frame_" + name1
     if self.getValue(ctx.parentCtx.varType()) == "newtonian":
         self.newtonian = name2
@@ -61,7 +61,7 @@ def declare_points(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText().lower()
+        name1 = ctx.ID().getText()
 
     name2 = "point_" + name1
 
@@ -76,7 +76,7 @@ def declare_particles(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText().lower()
+        name1 = ctx.ID().getText()
 
     name2 = "particle_" + name1
 
@@ -93,7 +93,7 @@ def declare_bodies(self, ctx, i, j=None):
         else:
             name1 = ctx.ID().getText().lower() + str(i)
     else:
-        name1 = ctx.ID().getText().lower()
+        name1 = ctx.ID().getText()
 
     name2 = "body_" + name1
     self.bodies.update({name1: name2})
@@ -266,7 +266,7 @@ def writeConstants(self, ctx):
 
 def processVariables(self, ctx):
     # Specified F = x*N1> + y*N2>
-    name = ctx.ID().getText().lower()
+    name = ctx.ID().getText()
     if "=" in ctx.getText():
         text = name + "'"*(ctx.getChildCount()-3)
         self.write(text + " = " + self.getValue(ctx.expr()) + "\n")
@@ -1447,7 +1447,7 @@ if AutolevListener:
                 elif ctx.equals().getText() == "^=":
                     equals = "**="
 
-                text = ctx.ID().getText().lower()
+                text = ctx.ID().getText()
                 self.type.update({text: "matrix"})
                 # Handle assignments of type ID[2] = expr
                 if ctx.index().getChildCount() == 1:
@@ -1533,11 +1533,11 @@ if AutolevListener:
                             ", " + self.symbol_table2[v3] + ")\n")
                             self.inertia_point.update({v2: v3})
                         elif v2 in self.type2.keys() and self.type2[v2] == "particle":
-                            self.write(ch.ID().getText().lower() + " = " + self.getValue(ctx.expr()) + "\n")
+                            self.write(ch.ID().getText() + " = " + self.getValue(ctx.expr()) + "\n")
                         else:
-                            self.write(ch.ID().getText().lower() + " = " + self.getValue(ctx.expr()) + "\n")
+                            self.write(ch.ID().getText() + " = " + self.getValue(ctx.expr()) + "\n")
                     else:
-                        self.write(ch.ID().getText().lower() + " = " + self.getValue(ctx.expr()) + "\n")
+                        self.write(ch.ID().getText() + " = " + self.getValue(ctx.expr()) + "\n")
 
                 elif num == 1:
                     v1, v2 = ch.ID().getText().lower().split('_')
@@ -1553,12 +1553,12 @@ if AutolevListener:
                             self.forces[e2] = self.forces[e2] + " + " + self.getValue(ctx.expr())
                         else:
                             self.forces.update({e2: self.getValue(ctx.expr())})
-                        self.write(ch.ID().getText().lower() + " = " + self.forces[e2] + "\n")
+                        self.write(ch.ID().getText() + " = " + self.forces[e2] + "\n")
 
                     else:
                         name = ch.ID().getText().lower()
                         self.symbol_table.update({vec_text: name})
-                        self.write(ch.ID().getText().lower() + " = " + self.getValue(ctx.expr()) + "\n")
+                        self.write(ch.ID().getText() + " = " + self.getValue(ctx.expr()) + "\n")
                 else:
                     name = ch.ID().getText().lower()
                     self.symbol_table.update({vec_text: name})
@@ -1813,11 +1813,11 @@ if AutolevListener:
                     self.symbol_table.update({ctx.expr(1).getText().lower(): ctx.expr(1).getText().lower()})
                     self.symbol_table.update({ctx.expr(2).getText().lower(): ctx.expr(2).getText().lower()})
                     # _sm.Matrix([i.evalf() for i in (i_s_so).eigenvals().keys()])
-                    self.write(ctx.expr(1).getText().lower() + " = " +
+                    self.write(ctx.expr(1).getText()+ " = " +
                                "_sm.Matrix([i.evalf() for i in " +
                                "(" + self.getValue(ctx.expr(0)) + ")" + ".eigenvals().keys()])\n")
                     # _sm.Matrix([i[2][0].evalf() for i in (i_s_o).eigenvects()]).reshape(i_s_o.shape[0], i_s_o.shape[1])
-                    self.write(ctx.expr(2).getText().lower() + " = " +
+                    self.write(ctx.expr(2).getText() + " = " +
                                "_sm.Matrix([i[2][0].evalf() for i in " + "(" + self.getValue(ctx.expr(0)) + ")" +
                                ".eigenvects()]).reshape(" + self.getValue(ctx.expr(0)) + ".shape[0], " +
                                self.getValue(ctx.expr(0)) + ".shape[1])\n")
@@ -2025,7 +2025,7 @@ if AutolevListener:
                 else:
                     e = self.getValue(ctx.expr().expr(1))
                 self.symbol_table.update({ctx.expr().expr(0).getText().lower(): ctx.expr().expr(0).getText().lower()})
-                self.write(ctx.expr().expr(0).getText().lower() + " = " + e + "\n")
+                self.write(ctx.expr().expr(0).getText() + " = " + e + "\n")
                 mass = ctx.expr().expr(0).getText().lower()
             else:
                 try:

--- a/sympy/parsing/autolev/_parse_autolev_antlr.py
+++ b/sympy/parsing/autolev/_parse_autolev_antlr.py
@@ -14,7 +14,7 @@ AutolevLexer = getattr(autolevlexer, 'AutolevLexer', None)
 AutolevListener = getattr(autolevlistener, 'AutolevListener', None)
 
 
-def parse_autolev(autolev_code, include_numeric):
+def parse_autolev(autolev_code, include_numeric, lower_case=True):
     antlr4 = import_module('antlr4')
     if not antlr4 or not version('antlr4-python3-runtime').startswith('4.11'):
         raise ImportError("Autolev parsing requires the antlr4 Python package,"

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -21,7 +21,7 @@ def _test_examples(in_filename, out_filename, test_name=""):
     correct_file_path = os.path.join(FILE_DIR, 'autolev', 'test-examples',
                                      out_filename)
     with open(in_file_path) as f:
-        generated_code = parse_autolev(f, include_numeric=True)
+        generated_code = parse_autolev(f, include_numeric=True, lower_case=True)
 
     with open(correct_file_path) as f:
         for idx, line1 in enumerate(f):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes [#15166](https://github.com/sympy/sympy/issues/15166) & [#16580 ](https://github.com/sympy/sympy/pull/16580)
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

- Added the parameter `lower_case` to the `parse_autolev()` function in the files: `__init__.py`, `_parse_autolev_antlr.py`, and `test_autolev.py`.
- Removed the .lower() function from the `_listener_autolev_antlr.py` file as much as I could. Some `.lower()` functions had to stay there because they were either a key or a value in dictionaries. 

#### Other comments
Can someone guide me to how to run the tests please

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
     * added `lower_case` paramter to `parse_autolev()`
<!-- END RELEASE NOTES -->
Thanks @NikhilPappu for the given tips previously.
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:



