### PR TITLE
Fix the _array_ methods to avoid deprecation warnings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1137,6 +1137,7 @@ Raghav Jajodia <jajodia.raghav@gmail.com>
 Rahil Hastu <rahilhastu@gmail.com> rahil hastu <rahilhastu@gmail.com>
 Rahil Parikh <r.parikh@somaiya.edu> rprkh <r.parikh@somaiya.edu>
 Raj <raj454raj@gmail.com>
+Raj Sapale <raj4sapale4@gmail.com>
 Rajat Aggarwal <rajataggarwal1975@gmail.com>
 Rajat Thakur <rajatthakur1997@gmail.com>
 Rajat Thakur <rajatthakur1997@gmail.com> <Rajat Thakur>

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -196,7 +196,9 @@ def test_Matrix_mul():
 
 def test_Matrix_array():
     class matarray:
-        def __array__(self):
+        def __array__(self, dtype=object, copy=None):
+            if copy is not None and not copy:
+                raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
             from numpy import array
             return array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     matarr = matarray()

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -388,7 +388,9 @@ class MatrixExpr(Expr):
         """
         return self.as_explicit().as_mutable()
 
-    def __array__(self):
+    def __array__(self, dtype=object, copy=None):
+        if copy is not None and not copy:
+            raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
         from numpy import empty
         a = empty(self.shape, dtype=object)
         for i in range(self.rows):

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -381,7 +381,7 @@ def test_numpy_conversion():
     assert array_equal(array(A), np_array)
     assert array_equal(array(A, copy=True), np_array)
     if(int(version('numpy').split('.')[0]) >= 2): #run this test only if numpy is new enough that copy variable is passed properly.
-        raises(TypeError, lambda: array(A, copy=False)) 
+        raises(TypeError, lambda: array(A, copy=False))
 
 def test_issue_2749():
     A = MatrixSymbol("A", 5, 2)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -18,7 +18,7 @@ from sympy.matrices.exceptions import NonSquareMatrixError
 from sympy.matrices.expressions.determinant import Determinant, det
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.matrices.expressions.special import ZeroMatrix, Identity
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises, XFAIL, skip
 
 
 n, m, l, k, p = symbols('n m l k p', integer=True)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -382,7 +382,6 @@ def test_numpy_conversion():
     assert array_equal(array(A, copy=True), np_array)
     #raises(TypeError, lambda: array(A, copy=False)) TODO: Uncomment this whenever copy variable properly passes to __array__
 
-
 def test_issue_2749():
     A = MatrixSymbol("A", 5, 2)
     assert (A.T * A).I.as_explicit() == Matrix([[(A.T * A).I[0, 0], (A.T * A).I[0, 1]], \

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -376,8 +376,8 @@ def test_numpy_conversion():
     except ImportError:
         skip('NumPy must be available to test creating matrices from ndarrays')
     A = MatrixSymbol('A', 2, 2)
-    np_array = array([[MatrixElement(A, 0, 0), MatrixElement(A, 1, 0)], 
-                     [MatrixElement(A, 0, 1), MatrixElement(A, 1, 1)]])
+    np_array = array([[MatrixElement(A, 0, 0), MatrixElement(A, 1, 0)],
+    [MatrixElement(A, 0, 1), MatrixElement(A, 1, 1)]])
     assert array_equal(array(A), np_array)
     assert array_equal(array(A, copy=True), np_array)
     #raises(TypeError, lambda: array(A, copy=False)) TODO: Uncomment this whenever copy variable properly passes to __array__

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -19,7 +19,7 @@ from sympy.matrices.expressions.determinant import Determinant, det
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.matrices.expressions.special import ZeroMatrix, Identity
 from sympy.testing.pytest import raises, XFAIL, skip
-
+from importlib.metadata import version
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
 x = symbols('x')
@@ -376,11 +376,12 @@ def test_numpy_conversion():
     except ImportError:
         skip('NumPy must be available to test creating matrices from ndarrays')
     A = MatrixSymbol('A', 2, 2)
-    np_array = array([[MatrixElement(A, 0, 0), MatrixElement(A, 1, 0)],
-    [MatrixElement(A, 0, 1), MatrixElement(A, 1, 1)]])
+    np_array = array([[MatrixElement(A, 0, 0), MatrixElement(A, 0, 1)],
+    [MatrixElement(A, 1, 0), MatrixElement(A, 1, 1)]])
     assert array_equal(array(A), np_array)
     assert array_equal(array(A, copy=True), np_array)
-    #raises(TypeError, lambda: array(A, copy=False)) TODO: Uncomment this whenever copy variable properly passes to __array__
+    if(int(version('numpy').split('.')[0]) >= 2): #run this test only if numpy is new enough that copy variable is passed properly.
+        raises(TypeError, lambda: array(A, copy=False)) 
 
 def test_issue_2749():
     A = MatrixSymbol("A", 5, 2)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -370,6 +370,18 @@ def test_factor_expand():
     # Ideally we get the first, but we at least don't want a wrong answer
     assert factor(expr) in [I - C, B**-1*(A**-1*(I - C)*B**-1)**-1*A**-1]
 
+def test_numpy_conversion():
+    try:
+        from numpy import array, array_equal
+    except ImportError:
+        skip('NumPy must be available to test creating matrices from ndarrays')
+    A = MatrixSymbol('A', 2, 2)
+    np_array = array([[MatrixElement(A, 0, 0), MatrixElement(A, 1, 0)], 
+                     [MatrixElement(A, 0, 1), MatrixElement(A, 1, 1)]])
+    assert array_equal(array(A), np_array)
+    assert array_equal(array(A, copy=True), np_array)
+    #raises(TypeError, lambda: array(A, copy=False)) TODO: Uncomment this whenever copy variable properly passes to __array__
+
 
 def test_issue_2749():
     A = MatrixSymbol("A", 5, 2)

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3562,7 +3562,9 @@ class MatrixBase(Printable):
     def flat(self):
         return [self[i, j] for i in range(self.rows) for j in range(self.cols)]
 
-    def __array__(self, dtype=object):
+    def __array__(self, dtype=object, copy=None):
+        if copy is not None and not copy:
+            raise TypeError("Cannot implement copy=False when converting Matrix to ndarray")
         from .dense import matrix2numpy
         return matrix2numpy(self, dtype=dtype)
 

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -362,7 +362,7 @@ def test_numpy_conversion():
     assert array_equal(array(A), np_array)
     assert array_equal(array(A, copy=True), np_array)
     if(int(version('numpy').split('.')[0]) >= 2): #run this test only if numpy is new enough that copy variable is passed properly.
-        raises(TypeError, lambda: array(A, copy=False)) 
+        raises(TypeError, lambda: array(A, copy=False))
 
 def test_rot90():
     A = Matrix([[1, 2], [3, 4]])

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -25,6 +25,7 @@ from sympy.testing.pytest import (
     ignore_warnings, raises, skip, skip_under_pyodide, slow,
     warns_deprecated_sympy)
 from sympy.utilities.iterables import capture, iterable
+from importlib.metadata import version
 
 all_classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
 mutable_classes = (Matrix, SparseMatrix)
@@ -360,7 +361,8 @@ def test_numpy_conversion():
     np_array = array([[1,2], [3,4]])
     assert array_equal(array(A), np_array)
     assert array_equal(array(A, copy=True), np_array)
-    #raises(TypeError, lambda: array(A, copy=False)) TODO: Uncomment this whenever copy variable properly passes to __array__
+    if(int(version('numpy').split('.')[0]) >= 2): #run this test only if numpy is new enough that copy variable is passed properly.
+        raises(TypeError, lambda: array(A, copy=False)) 
 
 def test_rot90():
     A = Matrix([[1, 2], [3, 4]])

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -351,6 +351,16 @@ def test_replace_map():
     assert N == Matrix(2, 2, lambda i, j: G(i+j))
     assert d == {F(0): G(0), F(1): G(1), F(2): G(2)}
 
+def test_numpy_conversion():
+    try:
+        from numpy import array, array_equal
+    except ImportError:
+        skip('NumPy must be available to test creating matrices from ndarrays')
+    A = Matrix([[1,2], [3,4]])
+    np_array = array([[1,2], [3,4]])
+    assert array_equal(array(A), np_array)
+    assert array_equal(array(A, copy=True), np_array)
+    #raises(TypeError, lambda: array(A, copy=False)) TODO: Uncomment this whenever copy variable properly passes to __array__
 
 def test_rot90():
     A = Matrix([[1, 2], [3, 4]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes #26302

I finished the work started in PR #26303 by adding test cases for the __array__ methods.

Note: currently the tests with copy=False are commented out because there is an issue 
with numpy passing the copy argument into the __array__ function.  As a result, __array__ 
will not raise an error as it should, so this test must be commented out for now.

see this comment for confirmation:
 https://github.com/numpy/numpy/issues/25941#issuecomment-2010343170.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
