### PR TITLE
Fixing the Tab indentation size and style in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ skip = .eggs
 # RST files (used by sphinx)
 [*.rst]
 indent_style = space
-indent_size = 4
+indent_size = 3
 
 # JSON, YML
 [*.{json,yml}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ skip = .eggs
 # RST files (used by sphinx)
 [*.rst]
 indent_style = space
-indent_size = 3
+indent_size = 4
 
 # JSON, YML
 [*.{json,yml}]
@@ -29,3 +29,4 @@ indent_size = 2
 # Tab indentation (no size specified)
 [Makefile]
 indent_type = tab
+indent_size = 8

--- a/.mailmap
+++ b/.mailmap
@@ -1229,6 +1229,7 @@ Rupesh Harode <rupeshharode@gmail.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
+Richard Samuel <samuelrichard214@gmail.com>
 S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1182,6 +1182,8 @@ Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
 Rich LaSota <rjlasota@gmail.com>
 Richard Otis <richard.otis@outlook.com> <ovolve@users.noreply.github.com>
 Richard Otis <richard.otis@outlook.com> <richard.otis@jpl.nasa.gov>
+Richard Samuel <98638849+samuelard7@users.noreply.github.com>
+Richard Samuel <samuelrichard214@gmail.com>
 Rick Muller <rpmuller@gmail.com>
 Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
 Riley Britten <nrb1324@hotmail.com>
@@ -1645,4 +1647,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Richard Samuel <98638849+samuelard7@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1229,7 +1229,7 @@ Rupesh Harode <rupeshharode@gmail.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
-Richard Samuel <samuelrichard214@gmail.com>
+Richard Samuel <98638849+samuelard7@users.noreply.github.com>
 S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1229,7 +1229,6 @@ Rupesh Harode <rupeshharode@gmail.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
-Richard Samuel <98638849+samuelard7@users.noreply.github.com>
 S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
@@ -1646,3 +1645,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Richard Samuel <98638849+samuelard7@users.noreply.github.com>


### PR DESCRIPTION
Tab Indentation size and style
adding one more line indent_size
it could be 8 or 4 depending on the project's requirements and conventions.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
An additional indent_size has been specified to ensure consistent formatting. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:



  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

<!-- END RELEASE NOTES -->
