### PR TITLE
Modifying `PermutationGroup.elements`

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -508,7 +508,7 @@ class FpGroup(DefaultPrinting):
 
         '''
         P, T = self._to_perm_group()
-        return T.invert(P._elements)
+        return T.invert(P.elements)
 
     @property
     def is_cyclic(self):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -149,7 +149,8 @@ class PermutationGroup(Basic):
     def __init__(self, *args, **kwargs):
         self._generators = list(self.args)
         self._order = None
-        self._center = []
+        self._elements = []
+        self._center = None
         self._is_abelian = None
         self._is_transitive = None
         self._is_sym = None
@@ -804,7 +805,7 @@ class PermutationGroup(Basic):
             raise ValueError("The argument must be a subgroup")
 
         if H.order() == 1:
-            return self._elements
+            return self.elements
 
         self._schreier_sims(base=H.base) # make G.base an extension of H.base
 
@@ -831,7 +832,7 @@ class PermutationGroup(Basic):
         # contains all the elements of G^(l) so we might just as well
         # start with l = len(h_stabs)-1
         if len(g_stabs) > len(h_stabs):
-            T = g_stabs[len(h_stabs)]._elements
+            T = g_stabs[len(h_stabs)].elements
         else:
             T = [identity]
         l = len(h_stabs)-1
@@ -962,7 +963,9 @@ class PermutationGroup(Basic):
         of ``.centralizer()``
 
         """
-        return self.centralizer(self)
+        if not self._center:
+            self._center = self.centralizer(self)
+        return self._center
 
     def centralizer(self, other):
         r"""
@@ -1376,21 +1379,6 @@ class PermutationGroup(Basic):
 
     @property
     def elements(self):
-        """Returns all the elements of the permutation group as a set
-
-        Examples
-        ========
-
-        >>> from sympy.combinatorics import Permutation, PermutationGroup
-        >>> p = PermutationGroup(Permutation(1, 3), Permutation(1, 2))
-        >>> p.elements
-        {(1 2 3), (1 3 2), (1 3), (2 3), (3), (3)(1 2)}
-
-        """
-        return set(self._elements)
-
-    @property
-    def _elements(self):
         """Returns all the elements of the permutation group as a list
 
         Examples
@@ -1398,11 +1386,14 @@ class PermutationGroup(Basic):
 
         >>> from sympy.combinatorics import Permutation, PermutationGroup
         >>> p = PermutationGroup(Permutation(1, 3), Permutation(1, 2))
-        >>> p._elements
+        >>> p.elements
         [(3), (3)(1 2), (1 3), (2 3), (1 2 3), (1 3 2)]
 
         """
-        return list(islice(self.generate(), None))
+        if not self._elements:
+            self._elements = list(islice(self.generate(), None))
+
+        return self._elements
 
     def derived_series(self):
         r"""Return the derived series for the group.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1391,7 +1391,7 @@ class PermutationGroup(Basic):
 
         """
         if not self._elements:
-            self._elements = list(islice(self.generate(), None))
+            self._elements = list(self.generate())
 
         return self._elements
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1,5 +1,5 @@
 from math import factorial as _factorial, log, prod
-from itertools import chain, islice, product
+from itertools import chain, product
 
 
 from sympy.combinatorics import Permutation

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -806,7 +806,7 @@ def test_elements():
     from sympy.sets.sets import FiniteSet
 
     p = Permutation(2, 3)
-    assert PermutationGroup(p).elements == {Permutation(3), Permutation(2, 3)}
+    assert set(PermutationGroup(p).elements) == {Permutation(3), Permutation(2, 3)}
     assert FiniteSet(*PermutationGroup(p).elements) \
         == FiniteSet(Permutation(2, 3), Permutation(3))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* `PermutationGroup._elements` is no longer a method. Instead a `PermutationGroup` instance will have an attribute `self._elements`, which is set to `[]` at initialization. 
* `PermutationGroup.elements` returns `self._elements` when it is not empty, and  computes the **list** of elements of the group (and stores the result in `self._elements`) when it is. Note that `PermutationGroup.elements` used to return the **set** of all elements rather than a list. 
* `PermutationGroup.center()` now acts as a getter for `self._center` when it is not `None`, and computes the center (and stores the outcome in `self._center`) when it is. 

#### Other comments
These modifications can greatly improve the speed in certain use cases, because the elements of a group are now cached after the first call of `PermutationGroup.elements` (rather than computed from scratch each time). Especially for large groups this makes a significant difference if `PermutationGroup.elements` is called repeatedly.

The changes introduced here can affect users in two ways:
* `PermutationGroup.elements` now outputs **a list instead of a set**. I still believe this change is warranted because the behavior was inconsistent with that of `FpGroup.elements` (which returns a list). 
* `PermutationGroup._elements` is now an attribute and it is **empty at initialization**. This means that calling `obj._elements` directly will now return an empty list instead of the list of all elements. However, since this was supposed to be a private property of the class, it should not be used by users directly anyway. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Changed the behavior of `PermutationGroup.elements` to output a list of all elements rather than a set. It now caches the result in the `self._elements` attribute. Note that `PermutationGroup._elements` is no longer a property but has been changed to an attribute (which is set to an empty list on initialization). 
  * `PermutationGroup.center()` now caches its result in `self._center` .
<!-- END RELEASE NOTES -->
