### PR TITLE
combinatorics: improved the FpGroups.index() method

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1435,6 +1435,7 @@ Tom Fryers <61272761+TomFryers@users.noreply.github.com>
 Tom Gijselinck <tomgijselinck@gmail.com>
 Tomasz Buchert <thinred@gmail.com>
 Tomasz Pytel <tompytel@gmail.com>
+Tommy Ford <tommyford28@googlemail.com>
 Tommy Olofsson <tommy.olofsson.90@gmail.com>
 Tomo Lazovich <lazovich@gmail.com>
 Tomáš Bambas <tomas.bambas@gmail.com>

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -353,8 +353,10 @@ class FpGroup(DefaultPrinting):
         # TODO: use |G:H| = |G|/|H| (currently H can't be made into a group)
         # when we know |G| and |H|
 
-        if H == []:
-            return self.order()
+        # Lagrange's Theorem applies for finite groups, this should solve the above task and give a small optimisation
+        # for finite groups
+        if self.order(strategy) is not S.Infinity:
+            return self.order(strategy) / self.subgroup(H).order(strategy)
         else:
             C = self.coset_enumeration(H, strategy)
             return len(C.table)

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -255,3 +255,23 @@ def test_abelian_invariants():
     assert f.abelian_invariants() == [2]
     f = FpGroup(F, [x**4, y**2, x*y*x**-1*y])
     assert f.abelian_invariants() == [2, 4]
+
+
+def test_index():
+    F, x = free_group("x")
+    f = FpGroup(F, [x**8])
+    H1 = [[x**i] for i in range(1, 9)]
+    I1 = [1, 2, 1, 4, 1, 2, 1, 8]
+    for H, I in zip(H1, I1):
+        assert f.index(H) == I
+
+    F, x, y = free_group("x, y")
+    f = FpGroup(F, [x**3, y**2, (x*y)**4])
+    H2 = [f.identity, x, x**-1, y, x*y, x**2*y, y*x, y*x**2, x*y*x, x*y*x**2, x**2*y*x, x**2*y*x**2, y*x*y, y*x**2*y,
+          x*y*x*y, x*y*x**2*y, x**2*y*x*y, y*x*y*x, y*x*y*x**2, y*x**2*y*x, x*y*x**2*y*x, y*x*y*x**2*y, y*x**2*y*x*y,
+          x*y*x**2*y*x*y]
+    I2 = [24, 8, 8, 12, 6, 6, 6, 6, 6, 12, 12, 6, 8, 8, 12, 8, 8, 12, 8, 8, 12, 12, 12, 12]
+    for H, I in zip(H2, I2):
+        assert f.index([H]) == I
+
+    assert f.index(f.elements) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
combinatorics: FpGroup.index() optimisiation

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added the use of Lagrange's theorem to FpGroup.index() method so that it returns |G|/|H| when G has finite order, by using FpGroup.subgroup() and FpGroup.order() methods. 

#### Other comments
I think there is an issue with this method, if the FpGroup has infinite order, but is not picked up by FpGroup._is_infinite() method. I can create this issue with an example.
Added myself to .mailmap as I'm new contributor.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added a small optimisation to FpGroup.index() method to return |G|/|H| if G has finite order.
<!-- END RELEASE NOTES -->
