### PR TITLE
Fixed two docstring style guide in dev documentation.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -213,7 +213,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
-Abhishek Kumar <abhishek.nitdelhi@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com> ABHISHEK KUMAR <140839576+abhiphile@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>

--- a/doc/src/contributing/docstring.rst
+++ b/doc/src/contributing/docstring.rst
@@ -1,8 +1,8 @@
 .. _style_guide_docstring_guidelines:
 
-===============================
-SymPy Docstrings Style Guide
-===============================
+=========================
+Docstrings Style Guide
+=========================
 
 General Guidelines
 --------------------

--- a/doc/src/contributing/documentation-style-guide.rst
+++ b/doc/src/contributing/documentation-style-guide.rst
@@ -1,6 +1,6 @@
-=====================
-Docstring Style Guide
-=====================
+============================
+Documentation Style Guide
+============================
 
 General Guidelines
 --------------------


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Renamed the index to "Docstrings Style Guide and Documentation Style Guide" for improved clarity

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26387

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
