### PR TITLE
TensMul: ensure that coeff*nocoeff == self

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3527,7 +3527,7 @@ class TensMul(TensExpr, AssocOp):
 
     @property
     def nocoeff(self):
-        return self.func(*[t for t in self.args if isinstance(t, TensExpr)]).doit()
+        return self.func(*self.args, 1/self.coeff).doit(deep=False)
 
     @property
     def dum_in_args(self):

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2059,3 +2059,16 @@ def test_postprocessor():
 
     assert isinstance((x*2).replace(x, K(i)), TensMul)
     assert isinstance((x+2).replace(x, K(i)*K(-i)), TensAdd)
+
+def test_TensMul_nocoeff():
+    """
+    Ensure that for any TensMul instance, self.coeff * self.nocoeff == self
+    """
+
+    R3 = TensorIndexType('R3', dim=3)
+    i, j = tensor_indices("i j", R3)
+    K = TensorHead("K", [R3])
+    P = TensorHead("P", [R3])
+
+    expr = TensMul(2, K(i), P(j))
+    assert expr.coeff * expr.nocoeff == expr


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs. -->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

Earlier, if `doit` had not been called on a TensMul, self.coeff would be set to 1, while self.nocoeff would unconditionally drop the non-tensor arguments. This PR ensures that even if doit has not been called, we have `self.coeff * self.nocoeff == self`

#### Other comments

I have added a test.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * For any TensMul instance `A`, ensure that `A.coeff*A.nocoeff == A` is always true.
<!-- END RELEASE NOTES -->
