### PR TITLE
fixed factoring of sums/integrals in factor_terms

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1104,6 +1104,7 @@ def gcd_terms(terms, isprimitive=False, clear=True, fraction=True):
         return Dict(*[(k, handle(v)) for k, v in terms.args])
     return terms.func(*[handle(i) for i in terms.args])
 
+
 def _factor_sum_int(expr, **kwargs):
     """Return Sum or Integral object with factors that are not
     in the wrt variables removed. In cases where there are additive
@@ -1142,6 +1143,7 @@ def _factor_sum_int(expr, **kwargs):
 
     # get the wrt variables
     wrt = {i.args[0] for i in limits}
+
     # factor out any common terms that are independent of wrt
     f = factor_terms(result, **kwargs)
     i, d = f.as_independent(*wrt)

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1104,7 +1104,6 @@ def gcd_terms(terms, isprimitive=False, clear=True, fraction=True):
         return Dict(*[(k, handle(v)) for k, v in terms.args])
     return terms.func(*[handle(i) for i in terms.args])
 
-
 def _factor_sum_int(expr, **kwargs):
     """Return Sum or Integral object with factors that are not
     in the wrt variables removed. In cases where there are additive
@@ -1143,12 +1142,13 @@ def _factor_sum_int(expr, **kwargs):
 
     # get the wrt variables
     wrt = {i.args[0] for i in limits}
-
     # factor out any common terms that are independent of wrt
     f = factor_terms(result, **kwargs)
     i, d = f.as_independent(*wrt)
     if isinstance(f, Add):
-        return i * expr.func(1, *limits) + expr.func(d, *limits)
+        q = factor_terms(d, **kwargs)
+        a, y = q.as_independent(*wrt)
+        return i * expr.func(1, *limits) + a * expr.func(y, *limits)
     else:
         return i * expr.func(d, *limits)
 

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -282,7 +282,9 @@ def test_factor_terms():
     assert factor_terms(eq, radical=True) == sqrt(2)*(1 + sqrt(5))
     eq = root(-6, 3) + root(6, 3)
     assert factor_terms(eq, radical=True) == 6**(S.One/3)*(1 + (-1)**(S.One/3))
-    assert factor_terms(Sum(5 * x **2  * y ** 2 + 4, (x, 1, 5),(y,1,3))) == 4*Sum(1, (x, 1, 5), (y, 1, 3)) + 5*Sum(x**2*y**2, (x, 1, 5), (y, 1, 3))
+    assert factor_terms(Sum(5*x**2*y**2 + 4, (x, 1, 5), (y, 1, 3))
+        ) == 4*Sum(1, (x, 1, 5), (y, 1, 3)
+        ) + 5*Sum(x**2*y**2, (x, 1, 5), (y, 1, 3))
     eq = [x + x*y]
     ans = [x*(y + 1)]
     for c in [list, tuple, set]:

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -282,7 +282,7 @@ def test_factor_terms():
     assert factor_terms(eq, radical=True) == sqrt(2)*(1 + sqrt(5))
     eq = root(-6, 3) + root(6, 3)
     assert factor_terms(eq, radical=True) == 6**(S.One/3)*(1 + (-1)**(S.One/3))
-
+    assert factor_terms(Sum(5 * x **2  * y ** 2 + 4, (x, 1, 5),(y,1,3))) == 4*Sum(1, (x, 1, 5), (y, 1, 3)) + 5*Sum(x**2*y**2, (x, 1, 5), (y, 1, 3))
     eq = [x + x*y]
     ans = [x*(y + 1)]
     for c in [list, tuple, set]:


### PR DESCRIPTION
before Sum(2 * x) was correctly factored to 2 * Sum(x), but something like Sum(y + 2 * x) would get factored to Sum(y) + Sum(2 * x).  i.e. When there was multiple terms the constant was not being pulled out properly.

This has been fixed and a regression test has been added.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug with factoring of sums/integrals.  Before Sum(y + 2 * x) would factor to Sum(y) + Sum(2x) instead of  
   Sum(y) + 2 * Sum(x)
<!-- END RELEASE NOTES -->
