### PR TITLE
Text backend plotting

### DIFF
--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -60,6 +60,13 @@ class DummyBackendOk(Plot):
     def close(self):
         pass
 
+def test_basic_plotting_backend():
+    x = Symbol('x')
+    try:
+        plot(x, (x, 0, 3), backend='text')
+        plot(x**2 + 1, (x, 0, 3), backend='text')
+    except TypeError as exc:
+        assert False, f"{exc}"
 
 @pytest.mark.parametrize("adaptive", [True, False])
 def test_plot_and_save_1(adaptive):

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -62,11 +62,8 @@ class DummyBackendOk(Plot):
 
 def test_basic_plotting_backend():
     x = Symbol('x')
-    try:
-        plot(x, (x, 0, 3), backend='text')
-        plot(x**2 + 1, (x, 0, 3), backend='text')
-    except TypeError as exc:
-        assert False, f"{exc}"
+    plot(x, (x, 0, 3), backend='text')
+    plot(x**2 + 1, (x, 0, 3), backend='text')
 
 @pytest.mark.parametrize("adaptive", [True, False])
 def test_plot_and_save_1(adaptive):

--- a/sympy/plotting/textplot.py
+++ b/sympy/plotting/textplot.py
@@ -50,6 +50,12 @@ def textplot_str(expr, a, b, W=55, H=21):
             .format(free))
     x = free.pop() if free else Dummy()
     f = lambdify([x], expr)
+    if isinstance(a, complex):
+        if a.imag == 0:
+            a = a.real
+    if isinstance(b, complex):
+        if b.imag == 0:
+            b = b.real
     a = float(a)
     b = float(b)
 


### PR DESCRIPTION
Fixes #26481.  For some reason, the bounds of the backend renderer became complex at some point.  I just check if they are complex and then convert them to real if the complex part is equal to 0.

This solution is kinda a hack and it might be good to investigate why the endpoints are becoming complex at some point, but this fixes the problem I was having.

Also, might still be a good idea to add in some message telling user that installing matplotlib would probably be a good idea. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
  * Fixed an issue which caused plotting using backend='text' to error.
<!-- END RELEASE NOTES -->
