### PR TITLE
Small improvement to _discrete_log_pohlig_hellman()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -634,6 +634,7 @@ George Waksman <waksman@gwax.com>
 Georges Khaznadar <georgesk@debian.org>
 Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
 Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
+Gerald Teschl <gerald.teschl@univie.ac.at>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>

--- a/.mailmap
+++ b/.mailmap
@@ -633,8 +633,8 @@ George Pittock <gpittock4@gmail.com>
 George Waksman <waksman@gwax.com>
 Georges Khaznadar <georgesk@debian.org>
 Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
-Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
 Gerald Teschl <gerald.teschl@univie.ac.at>
+Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1543,8 +1543,6 @@ def discrete_log(n, a, b, order=None, prime_order=None):
                     break
             if i<e:
                 order_factors[p] = e-i
-    else:
-        order_factors= factorint(order)
 
     if prime_order is None:
         prime_order = isprime(order)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1541,8 +1541,8 @@ def discrete_log(n, a, b, order=None, prime_order=None):
                    i += 1
                 else:
                     break
-            if i<e:
-                order_factors[p] = e-i
+            if i < e:
+                order_factors[p] = e - i
 
     if prime_order is None:
         prime_order = isprime(order)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1432,7 +1432,7 @@ def _discrete_log_pollard_rho(n, a, b, order=None, retries=10, rseed=None):
     raise ValueError("Pollard's Rho failed to find logarithm")
 
 
-def _discrete_log_pohlig_hellman(n, a, b, order=None):
+def _discrete_log_pohlig_hellman(n, a, b, order=None, order_factors=None):
     """
     Pohlig-Hellman algorithm for computing the discrete logarithm of ``a`` to
     the base ``b`` modulo ``n``.
@@ -1460,47 +1460,23 @@ def _discrete_log_pohlig_hellman(n, a, b, order=None):
         Vanstone, S. A. (1997).
     """
     from .modular import crt
-    from collections import defaultdict
     a %= n
     b %= n
 
     if order is None:
-        # Compute the order and its factoring in one pass
-        # order = totient(n), factors = factorint(order)
-        factors = defaultdict(int)
-        for px, kx in factorint(n).items():
-            if kx > 1:
-                factors[px] += kx - 1
-            for py, ky in factorint(px - 1).items():
-                factors[py] += ky
-        order = 1
-        for px, kx in factors.items():
-            order *= px**kx
-        # Now the `order` is the order of the group and factors = factorint(order)
-        # The order of `a` divides the order of the group.
-        f= defaultdict(int)
-        for p, e in factors.items():
-            i=0
-            for _ in range(e):
-                if pow(a, order // p, n) == 1:
-                   order //= p
-                   i+=1
-                else:
-                    break
-            if i<e:
-                f[p]=e-i
-    else:
-        f = factorint(order)
-    l = [0] * len(f)
+        order = n_order(b, n)
+    if order_factors is None:
+        order_factors = factorint(order)
+    l = [0] * len(order_factors)
 
-    for i, (pi, ri) in enumerate(f.items()):
+    for i, (pi, ri) in enumerate(order_factors.items()):
         for j in range(ri):
             aj = pow(a * pow(b, -l[i], n), order // pi**(j + 1), n)
             bj = pow(b, order // pi, n)
             cj = discrete_log(n, aj, bj, pi, True)
             l[i] += cj * pi**j
 
-    d, _ = crt([pi**ri for pi, ri in f.items()], l)
+    d, _ = crt([pi**ri for pi, ri in order_factors.items()], l)
     return d
 
 
@@ -1537,7 +1513,38 @@ def discrete_log(n, a, b, order=None, prime_order=None):
     """
     n, a, b = as_int(n), as_int(a), as_int(b)
     if order is None:
-        order = n_order(b, n)
+        # Compute the order and its factoring in one pass
+        # order = totient(n), factors = factorint(order)
+        factors = {}
+        for px, kx in factorint(n).items():
+            if kx > 1:
+                if px in factors:
+                    factors[px] += kx - 1
+                else:
+                    factors[px] = kx - 1
+            for py, ky in factorint(px - 1).items():
+                if py in factors:
+                    factors[py] += ky
+                else:
+                    factors[py] = ky
+        order = 1
+        for px, kx in factors.items():
+            order *= px**kx
+        # Now the `order` is the order of the group and factors = factorint(order)
+        # The order of `a` divides the order of the group.
+        order_factors = {}
+        for p, e in factors.items():
+            i = 0
+            for _ in range(e):
+                if pow(b, order // p, n) == 1:
+                   order //= p
+                   i += 1
+                else:
+                    break
+            if i<e:
+                order_factors[p] = e-i
+    else:
+        order_factors= factorint(order)
 
     if prime_order is None:
         prime_order = isprime(order)
@@ -1547,7 +1554,7 @@ def discrete_log(n, a, b, order=None, prime_order=None):
     elif prime_order:
         if order < 1000000000000:
             return _discrete_log_shanks_steps(n, a, b, order)
-        return _discrete_log_pollard_rho(n, a, b, order)
+        return _discrete_log_pollard_rho(n, a, b, order, order_factors)
 
     return _discrete_log_pohlig_hellman(n, a, b, order)
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1531,7 +1531,7 @@ def discrete_log(n, a, b, order=None, prime_order=None):
         for px, kx in factors.items():
             order *= px**kx
         # Now the `order` is the order of the group and factors = factorint(order)
-        # The order of `a` divides the order of the group.
+        # The order of `b` divides the order of the group.
         order_factors = {}
         for p, e in factors.items():
             i = 0


### PR DESCRIPTION
Compute order and its factoring in one pass

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

The function discrete_log_pohlig_hellman currently first computes the order of the
group element and then factors the result. Since computing the order is done
by factoring the group order, this can be done along the way eliminating the need
of another factorization. To this end, the code from n_order() is slightly adapted.

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * .discrete_log now computes the order and its factorization in one pass
<!-- END RELEASE NOTES -->
