### PR TITLE
meijerint_indefinite should produce a Piecewise result conditional upon all 'splitting point' assumptions made to obtain the ultimate antiderivative

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1699,7 +1699,7 @@ def meijerint_indefinite(f, x):
 
     def _compare(item):
         r, c = item
-        if c is has_closed_form:
+        if c == has_closed_form:
             return 0
         elif c == True:
             return 1

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -705,9 +705,26 @@ def test_issue_26477():
     from sympy.core.symbol import Symbol
     x = Symbol("x", positive=True)
     z = Symbol("z", real=True)
+
     result = meijerint_indefinite(z**(x - Rational(1, 2))*sqrt(1 - z), z)
     assert result == sqrt(z)*z**x*gamma(x + S(1)/2)*hyper((-S(1)/2, x + S(1)/2), (x + S(3)/2,), z*exp_polar(2*I*pi))/gamma(x + S(3)/2)
     assert (result.subs(z, 1) - result.subs(z, 0)).simplify() == sqrt(pi)*gamma(x + S(1)/2)/(2*gamma(x + 2))
+
+
+@slow
+def test_issue_26477_higher_level():
+    from sympy.core.symbol import Symbol
+    x = Symbol("x", positive=True)
+    z = Symbol("z", real=True)
+    y = Symbol('y', positive=True)
+
+    result = Integral(z**(x - 1)*(1 - z)**(y - 1), (z, 0, 1)).doit()
+    assert result == gamma(x)*hyper((x, 1 - y), (x + 1,), 1)/gamma(x + 1)
+    assert result.simplify() == gamma(x)*gamma(y)/gamma(x + y)
+
+    result2 = Integral(z**(x - S(1)/2)*(1 - z)**(y - 1), (z, 0, 1)).doit()
+    assert result2 == gamma(x + S(1)/2)*hyper((x + S(1)/2, 1 - y), (x + S(3)/2,), 1)/gamma(x + S(3)/2)
+    assert result2.simplify() == gamma(x + S(1)/2)*gamma(y)/gamma(x + y + S(1)/2)
 
 
 def test_issue_6348():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -687,7 +687,7 @@ def test_issue_6252():
     expr = 1/x/(a + b*x)**Rational(1, 3)
     anti = integrate(expr, x, meijerg=True)
 
-    # Note upon more aggressive treatment of special conditions related to poles in the integrand (the inadequate treatment of which has been baked into the lookup table rules of meijerint, the following result is obtainable)
+    # Note upon more aggressive treatment of special conditions related to poles in the integration result (the inadequate treatment of which has been baked into the lookup table rules of meijerint, the following result is obtainable)
     # assert anti == sympify("Piecewise((2*log(1 - b**(1/3)*(a/b + x)**(1/3)/a**(1/3))*gamma(2/3)/(3*a**(1/3)*gamma(5/3)) + 2*exp(2*I*pi/3)*log(1 - b**(1/3)*(a/b + x)**(1/3) *exp_polar(2*I*pi/3)/a**(1/3))*gamma(2/3)/(3*a**(1/3)*gamma(5/3)) + 2*exp(-2*I*pi/3)*log(1 - b**(1/3)*(a/b + x)**(1/3)*exp_polar(4*I*pi/3)/a**(1/3))*gamma(2/3)/(3*a**(1/3)* gamma(5/3)), Ne(a/b, 0)), (-3/(b**(1/3)*x**(1/3)), Eq(a, 0)), (log(x)/a**(1/3), Eq(b, 0)), (-gamma(1/3)*hyper((1/3, 1/3), (4/3,), a*exp_polar(I*pi)/(b*x))/(b**(1/3)*x**(1/3)*gamma(4/3)), True))", locals={"a": a, "b": b, "x": x})
 
     # Just treating the special conditions related to splitting points (in meijerint_indefinite) results in the current behavior of


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #26477 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
  * meijerint_indefinite now produces a Piecewise result conditional upon all 'splitting point' assumptions made to obtain the ultimate antiderivative

<!-- END RELEASE NOTES -->
