### PR TITLE
fix missing special case in manualintegrate quadratic denom rule

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1430,7 +1430,12 @@ def quadratic_denom_rule(integral):
             if positive_cond is S.false:
                 return negative_step
             return PiecewiseRule(integrand, symbol, [(general_rule, positive_cond), (negative_step, S.true)])
-        return general_rule
+
+        power = PowerRule(integrand, symbol, symbol, -2)
+        if b != 1:
+            power = ConstantTimesRule(integrand, symbol, 1/b, symbol**-2, power)
+
+        return PiecewiseRule(integrand, symbol, [(general_rule, Ne(c, 0)), (power, True)])
 
     d = Wild('d', exclude=[symbol])
     match2 = integrand.match(a / (b * symbol ** 2 + c * symbol + d))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -8,7 +8,7 @@ from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, cos, cot, csc, sec, sin, tan)
 from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f)
@@ -155,7 +155,8 @@ def test_manualintegrate_inversetrig():
                   ((log(x - sqrt(-ra)/2) - log(x + sqrt(-ra)/2))/(4*sqrt(-ra)), True))
     assert manualintegrate(1/(4 + 4*x**2), x) == atan(x) / 4
 
-    assert manualintegrate(1/(a + b*x**2), x) == atan(x/sqrt(a/b))/(b*sqrt(a/b))
+    assert manualintegrate(1/(a + b*x**2), x) == Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), Ne(a, 0)),
+                                                           (-1/(b*x), True))
 
     # asin
     assert manualintegrate(1/sqrt(1-x**2), x) == asin(x)
@@ -464,7 +465,8 @@ def test_issue_10847_slow():
 @slow
 def test_issue_10847():
 
-    assert manualintegrate(x**2 / (x**2 - c), x) == c*atan(x/sqrt(-c))/sqrt(-c) + x
+    assert manualintegrate(x**2 / (x**2 - c), x) == \
+        c*Piecewise((atan(x/sqrt(-c))/sqrt(-c), Ne(c, 0)), (-1/x, True)) + x
 
     rc = Symbol('c', real=True)
     assert manualintegrate(x**2 / (x**2 - rc), x) == \
@@ -472,7 +474,8 @@ def test_issue_10847():
                      ((log(-sqrt(rc) + x) - log(sqrt(rc) + x))/(2*sqrt(rc)), True)) + x
 
     assert manualintegrate(sqrt(x - y) * log(z / x), x) == \
-        4*y**Rational(3, 2)*atan(sqrt(x - y)/sqrt(y))/3 - 4*y*sqrt(x - y)/3 +\
+        4*y**2*Piecewise((atan(sqrt(x - y)/sqrt(y))/sqrt(y), Ne(y, 0)),
+                         (-1/sqrt(x - y), True))/3 - 4*y*sqrt(x - y)/3 + \
         2*(x - y)**Rational(3, 2)*log(z/x)/3 + 4*(x - y)**Rational(3, 2)/9
     ry = Symbol('y', real=True)
     rz = Symbol('z', real=True)
@@ -483,8 +486,11 @@ def test_issue_10847():
                          + 4*(x - ry)**Rational(3, 2)/9
 
     assert manualintegrate(sqrt(x) * log(x), x) == 2*x**Rational(3, 2)*log(x)/3 - 4*x**Rational(3, 2)/9
-    assert manualintegrate(sqrt(a*x + b) / x, x) == \
-        Piecewise((2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
+
+    result = manualintegrate(sqrt(a*x + b) / x, x)
+    assert result == Piecewise((-2*b*Piecewise((-atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b), Ne(b, 0)), (1/sqrt(a*x + b), True)) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
+    assert piecewise_fold(result) == Piecewise((2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0) & Ne(b, 0)), (-2*b/sqrt(a*x + b) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
+
     ra = Symbol('a', real=True)
     rb = Symbol('b', real=True)
     assert manualintegrate(sqrt(ra*x + rb) / x, x) == \

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -488,8 +488,14 @@ def test_issue_10847():
     assert manualintegrate(sqrt(x) * log(x), x) == 2*x**Rational(3, 2)*log(x)/3 - 4*x**Rational(3, 2)/9
 
     result = manualintegrate(sqrt(a*x + b) / x, x)
-    assert result == Piecewise((-2*b*Piecewise((-atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b), Ne(b, 0)), (1/sqrt(a*x + b), True)) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
-    assert piecewise_fold(result) == Piecewise((2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0) & Ne(b, 0)), (-2*b/sqrt(a*x + b) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
+    assert result == Piecewise((-2*b*Piecewise(
+        (-atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b), Ne(b, 0)),
+        (1/sqrt(a*x + b), True)) + 2*sqrt(a*x + b), Ne(a, 0)),
+        (sqrt(b)*log(x), True))
+    assert piecewise_fold(result) == Piecewise(
+        (2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0) & Ne(b, 0)),
+        (-2*b/sqrt(a*x + b) + 2*sqrt(a*x + b), Ne(a, 0)),
+        (sqrt(b)*log(x), True))
 
     ra = Symbol('a', real=True)
     rb = Symbol('b', real=True)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -235,7 +235,7 @@ from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
     expand, expand_mul, Subs)
 from sympy.core.multidimensional import vectorize
 from sympy.core.numbers import nan, zoo, Number
-from sympy.core.relational import Equality, Eq, Ne
+from sympy.core.relational import Equality, Eq
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.core.sympify import sympify

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -235,7 +235,7 @@ from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
     expand, expand_mul, Subs)
 from sympy.core.multidimensional import vectorize
 from sympy.core.numbers import nan, zoo, Number
-from sympy.core.relational import Equality, Eq
+from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.core.sympify import sympify
@@ -1638,6 +1638,34 @@ def odesimp(ode, eq, func, hint):
         eq = simplify(eq)
     if not isinstance(eq, Equality):
         raise TypeError("eq should be an instance of Equality")
+
+    if eq.lhs.is_Piecewise or eq.rhs.is_Piecewise:
+        # Ignore any simple constraints imposed on the arbitrary constants from evaluating
+        # the integral. While it might be nice to indicate that say Ne(C1, 0) in the
+        # ode solution (even if somewhat obvious due to C1 appearing in a denominator),
+        # the call to solve below won't handle a Piecewise very well (see issue #20269).
+        # For example, the integral evaluation above returns in one case:
+        # Eq(Piecewise((2*atan(sqrt(C1 + 2*exp(f(x)))/sqrt(-C1))/sqrt(-C1), Ne(C1, 0)),
+        #              (-2/sqrt(C1 + 2*exp(f(x))), True)), C2 + x)
+        # Below we look for a Piecewise result with two branches, a Ne(C1, k) for
+        # some is_Number k branch, and an otherwise branch (the otherwise branch
+        # and the condition Ne(C1, k) are ignored).
+        piecewise = [a for a in eq.args if a.is_Piecewise]
+        if len(piecewise) == 1:
+            piecewise_args = piecewise[0].args
+            # Ignore otherwise branch of Piecewise:
+            piecewise_args = [a for a in piecewise_args if a[1] != True]
+            if len(piecewise_args) == 1:
+                ne_branch = piecewise_args[0]
+                ne = ne_branch[1]
+                if isinstance(ne, Ne) and set(ne.args) & constants:
+                    ne = ne.canonical
+                    assert ne.lhs in constants
+                    if ne.rhs.is_Number:
+                        # Keep only the constrained branch (but ignore the Ne condition
+                        # imposed on one of the arbitrary constants):
+                        other_side = next(a for a in eq.args if not a.is_Piecewise)
+                        eq = Eq(ne_branch[0], other_side)
 
     # Second, clean up the arbitrary constants.
     # Right now, nth linear hints can put as many as 2*order constants in an

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1660,8 +1660,8 @@ def odesimp(ode, eq, func, hint):
                 ne = ne_branch[1]
                 if isinstance(ne, Ne) and set(ne.args) & constants:
                     ne = ne.canonical
-                    assert ne.lhs in constants
                     if ne.rhs.is_Number:
+                        assert ne.lhs in constants
                         # Keep only the constrained branch (but ignore the Ne condition
                         # imposed on one of the arbitrary constants):
                         other_side = next(a for a in eq.args if not a.is_Piecewise)

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -2864,7 +2864,7 @@ def _get_examples_ode_sol_1st_homogeneous_coeff_best():
 
     '1st_homogeneous_coeff_best_08': {
         'eq': f(x)**2 + (x*sqrt(f(x)**2 - x**2) - x*f(x))*f(x).diff(x),
-        'sol': [Eq(f(x), -sqrt(-x*exp(2*C1)/(x - 2*exp(C1)))), Eq(f(x), sqrt(-x*exp(2*C1)/(x - 2*exp(C1))))],
+        'sol': [Eq(f(x), -C1*sqrt(-x/(x - 2*C1))), Eq(f(x), C1*sqrt(-x/(x - 2*C1)))],
         'checkodesol_XFAIL': True  # solutions are valid in a range
     },
     }


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
    * Fix missing special case in manualintegrate quadratic denom rule 

<!-- END RELEASE NOTES -->
