### PR TITLE
Replace list comprehension with generator for min/max/sum

### DIFF
--- a/.ci/parse_durations_log.py
+++ b/.ci/parse_durations_log.py
@@ -57,7 +57,7 @@ def slow_function():
     t = time.time()
     a = 0
     for i in range(5):
-        a += sum([x**.3 - x**i for x in range(1000000) if x % 3 == 0])
+        a += sum(x**.3 - x**i for x in range(1000000) if x % 3 == 0)
     return time.time() - t
 
 

--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -129,7 +129,7 @@ class SphinxDocString(NumpyDocString):
             #     out += [''] + autosum
 
             if others:
-                maxlen_0 = max(3, max([len(x[0]) for x in others]))
+                maxlen_0 = max(3, max(len(x[0]) for x in others))
                 hdr = "="*maxlen_0 + "  " + "="*10
                 fmt = '%%%ds  %%s  ' % (maxlen_0,)
                 out += ['', '', hdr]

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -325,7 +325,7 @@ class FpGroup(DefaultPrinting):
     def most_frequent_generator(self):
         gens = self.generators
         rels = self.relators
-        freqs = [sum([r.generator_count(g) for r in rels]) for g in gens]
+        freqs = [sum(r.generator_count(g) for r in rels) for g in gens]
         return gens[freqs.index(max(freqs))]
 
     def random(self):

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -841,7 +841,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         if len(gen) != 1:
             raise ValueError("gen must be a generator or inverse of a generator")
         s = gen.array_form[0]
-        return s[1]*sum([i[1] for i in self.array_form if i[0] == s[0]])
+        return s[1]*sum(i[1] for i in self.array_form if i[0] == s[0])
 
     def generator_count(self, gen):
         """
@@ -870,7 +870,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         if len(gen) != 1 or gen.array_form[0][1] < 0:
             raise ValueError("gen must be a generator")
         s = gen.array_form[0]
-        return s[1]*sum([abs(i[1]) for i in self.array_form if i[0] == s[0]])
+        return s[1]*sum(abs(i[1]) for i in self.array_form if i[0] == s[0])
 
     def subword(self, from_i, to_j, strict=True):
         """

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -2430,7 +2430,7 @@ class Permutation(Atom):
         """
         a = self.array_form
 
-        return sum([j for j in range(len(a) - 1) if a[j] > a[j + 1]])
+        return sum(j for j in range(len(a) - 1) if a[j] > a[j + 1])
 
     def runs(self):
         """
@@ -2829,7 +2829,7 @@ class Permutation(Atom):
         b = other.array_form
         if len(a) != len(b):
             raise ValueError("The permutations must be of the same size.")
-        return sum([abs(a[i] - b[i]) for i in range(len(a))])
+        return sum(abs(a[i] - b[i]) for i in range(len(a)))
 
     @classmethod
     def josephus(cls, m, n, s=1):

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -259,7 +259,7 @@ class RewritingSystem:
                     added = 0
                     if r:
                         # reset i since some elements were removed
-                        i = min([lhs.index(s) for s in r])
+                        i = min(lhs.index(s) for s in r)
                     lhs = [l for l in lhs if l not in r]
                     lhs.extend(a)
                     if r1 in r:

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -431,7 +431,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
             md = [min(_orbit(size, [_af_new(
                 ddx) for ddx in dsgsx], ii)) for ii in range(size - 2)]
 
-        p_i = min([min([md[h[x]] for x in deltab]) for s, d, h in TAB])
+        p_i = min(min(md[h[x]] for x in deltab) for s, d, h in TAB)
         dsgsx1 = [_af_new(_) for _ in dsgsx]
         Dxtrav = _orbit_transversal(size, dsgsx1, p_i, False, af=True) \
             if dsgsx else None
@@ -454,7 +454,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         TAB1 = []
         while TAB:
             s, d, h = TAB.pop()
-            if min([md[h[x]] for x in deltab]) != p_i:
+            if min(md[h[x]] for x in deltab) != p_i:
                 continue
             deltab1 = [x for x in deltab if md[h[x]] == p_i]
             # NEXT = s*deltab1 intersection (d*g)**-1*deltap

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -195,10 +195,9 @@ def deltaproduct(f, limit):
         newexpr = f.func(*terms)
         k = Dummy("kprime", integer=True)
         if isinstance(limit[1], int) and isinstance(limit[2], int):
-            result = deltaproduct(newexpr, limit) + sum([
-                deltaproduct(newexpr, (limit[0], limit[1], ik - 1)) *
+            result = deltaproduct(newexpr, limit) + sum(deltaproduct(newexpr, (limit[0], limit[1], ik - 1)) *
                 delta.subs(limit[0], ik) *
-                deltaproduct(newexpr, (limit[0], ik + 1, limit[2])) for ik in range(int(limit[1]), int(limit[2] + 1))]
+                deltaproduct(newexpr, (limit[0], ik + 1, limit[2])) for ik in range(int(limit[1]), int(limit[2] + 1))
             )
         else:
             result = deltaproduct(newexpr, limit) + deltasummation(

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1027,16 +1027,16 @@ def test_failing_matrix_sum():
 def test_indexed_idx_sum():
     i = symbols('i', cls=Idx)
     r = Indexed('r', i)
-    assert Sum(r, (i, 0, 3)).doit() == sum([r.xreplace({i: j}) for j in range(4)])
+    assert Sum(r, (i, 0, 3)).doit() == sum(r.xreplace({i: j}) for j in range(4))
     assert Product(r, (i, 0, 3)).doit() == prod([r.xreplace({i: j}) for j in range(4)])
 
     j = symbols('j', integer=True)
-    assert Sum(r, (i, j, j+2)).doit() == sum([r.xreplace({i: j+k}) for k in range(3)])
+    assert Sum(r, (i, j, j+2)).doit() == sum(r.xreplace({i: j+k}) for k in range(3))
     assert Product(r, (i, j, j+2)).doit() == prod([r.xreplace({i: j+k}) for k in range(3)])
 
     k = Idx('k', range=(1, 3))
     A = IndexedBase('A')
-    assert Sum(A[k], k).doit() == sum([A[Idx(j, (1, 3))] for j in range(1, 4)])
+    assert Sum(A[k], k).doit() == sum(A[Idx(j, (1, 3))] for j in range(1, 4))
     assert Product(A[k], k).doit() == prod([A[Idx(j, (1, 3))] for j in range(1, 4)])
 
     raises(ValueError, lambda: Sum(A[k], (k, 1, 4)))

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -122,7 +122,7 @@ def comp(z1, z2, tol=None):
                 ca = pure_complex(a, or_real=True)
                 if not ca:
                     if fa:
-                        a = a.n(prec_to_dps(min([i._prec for i in fa])))
+                        a = a.n(prec_to_dps(min(i._prec for i in fa)))
                         ca = pure_complex(a, or_real=True)
                         break
                     else:
@@ -130,7 +130,7 @@ def comp(z1, z2, tol=None):
                         a, b = b, a
             cb = pure_complex(b)
             if not cb and fb:
-                b = b.n(prec_to_dps(min([i._prec for i in fb])))
+                b = b.n(prec_to_dps(min(i._prec for i in fb)))
                 cb = pure_complex(b, or_real=True)
             if ca and cb and (ca[1] or cb[1]):
                 return all(comp(i, j) for i, j in zip(ca, cb))
@@ -210,7 +210,7 @@ def _decimal_to_Rational_prec(dec):
         rv = Integer(int(dec))
     else:
         s = (-1)**s
-        d = sum([di*10**i for i, di in enumerate(reversed(d))])
+        d = sum(di*10**i for i, di in enumerate(reversed(d)))
         rv = Rational(s*d, 10**-e)
     return rv, prec
 

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2383,7 +2383,7 @@ def lfsr_sequence(key, fill, n):
         s0 = s[:]
         L.append(s[0])
         s = s[1:k]
-        x = sum([int(key[i]*s0[i]) for i in range(k)])
+        x = sum(int(key[i]*s0[i]) for i in range(k))
         s.append(F(x))
     return L       # use [int(x) for x in L] for int version
 
@@ -2509,8 +2509,8 @@ def lfsr_connection_polynomial(s):
             r = min(L + 1, dC + 1)
             coeffsC = [C.subs(x, 0)] + [C.coeff(x**i)
                 for i in range(1, dC + 1)]
-            d = (int(s[N]) + sum([coeffsC[i]*int(s[N - i])
-                for i in range(1, r)])) % p
+            d = (int(s[N]) + sum(coeffsC[i]*int(s[N - i])
+                for i in range(1, r))) % p
         if L == 0:
             d = int(s[N])*x**0
         if d == 0:
@@ -2531,8 +2531,8 @@ def lfsr_connection_polynomial(s):
                 N += 1
     dC = Poly(C).degree()
     coeffsC = [C.subs(x, 0)] + [C.coeff(x**i) for i in range(1, dC + 1)]
-    return sum([coeffsC[i] % p*x**i for i in range(dC + 1)
-        if coeffsC[i] is not None])
+    return sum(coeffsC[i] % p*x**i for i in range(dC + 1)
+        if coeffsC[i] is not None)
 
 
 #################### ElGamal  #############################

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -2081,7 +2081,7 @@ class marcumq(Function):
             if m == 1:
                 return (1 + exp(-a**2) * besseli(0, a**2)) / 2
             if m.is_Integer and m >= 2:
-                s = sum([besseli(i, a**2) for i in range(1, m)])
+                s = sum(besseli(i, a**2) for i in range(1, m))
                 return S.Half + exp(-a**2) * besseli(0, a**2) / 2 + exp(-a**2) * s
 
     def _eval_is_zero(self):

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -132,15 +132,15 @@ class Plane(GeometryEntity):
             a = Matrix(self.normal_vector)
             b = Matrix(o.direction_ratio)
             c = a.dot(b)
-            d = sqrt(sum([i**2 for i in self.normal_vector]))
-            e = sqrt(sum([i**2 for i in o.direction_ratio]))
+            d = sqrt(sum(i**2 for i in self.normal_vector))
+            e = sqrt(sum(i**2 for i in o.direction_ratio))
             return asin(c/(d*e))
         if isinstance(o, Plane):
             a = Matrix(self.normal_vector)
             b = Matrix(o.normal_vector)
             c = a.dot(b)
-            d = sqrt(sum([i**2 for i in self.normal_vector]))
-            e = sqrt(sum([i**2 for i in o.normal_vector]))
+            d = sqrt(sum(i**2 for i in self.normal_vector))
+            e = sqrt(sum(i**2 for i in o.normal_vector))
             return acos(c/(d*e))
 
 
@@ -490,7 +490,7 @@ class Plane(GeometryEntity):
         if isinstance(l, LinearEntity3D):
             a = l.direction_ratio
             b = self.normal_vector
-            c = sum([i*j for i, j in zip(a, b)])
+            c = sum(i*j for i, j in zip(a, b))
             if c == 0:
                 return True
             else:

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1541,8 +1541,8 @@ class HolonomicFunction:
             keylist = [i[0] for i in dict1]
             lower = min(keylist)
             upper = max(keylist)
-            degree = max([i[1] for i in dict1])
-            degree2 = min([i[1] for i in dict1])
+            degree = max(i[1] for i in dict1)
+            degree2 = min(i[1] for i in dict1)
 
             smallest_n = lower + degree
             dummys = {}

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -618,7 +618,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
             else:
                 return 1
         elif not g.is_Atom and g.args:
-            return max([ _exponent(h) for h in g.args ])
+            return max(_exponent(h) for h in g.args)
         else:
             return 1
 

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -406,7 +406,7 @@ def distance_to_side(point, line_seg, A):
 
     n_side = cross_product((0, 0, 0), rev_normal, vector)
     vectorx0 = [line_seg[0][i] - point[i] for i in range(0, 3)]
-    dot_product = sum([vectorx0[i] * n_side[i] for i in range(0, 3)])
+    dot_product = sum(vectorx0[i] * n_side[i] for i in range(0, 3))
 
     return dot_product
 
@@ -808,7 +808,7 @@ def hyperplane_parameters(poly, vertices=None):
         for i, polygon in enumerate(poly):
             v1, v2, v3 = [vertices[vertex] for vertex in polygon[:3]]
             normal = cross_product(v1, v2, v3)
-            b = sum([normal[j] * v1[j] for j in range(0, 3)])
+            b = sum(normal[j] * v1[j] for j in range(0, 3))
             fac = gcd_list(normal)
             if fac.is_zero:
                 fac = 1
@@ -1132,7 +1132,7 @@ def point_sort(poly, normal=None, clockwise=True):
 
     def compare3d(a, b):
         det = cross_product(center, a, b)
-        dot_product = sum([det[i] * normal[i] for i in range(0, 3)])
+        dot_product = sum(det[i] * normal[i] for i in range(0, 3))
         if dot_product < 0:
             return -order
         elif dot_product > 0:
@@ -1160,7 +1160,7 @@ def norm(point):
     """
     half = S.Half
     if isinstance(point, (list, tuple)):
-        return sum([coord ** 2 for coord in point]) ** half
+        return sum(coord ** 2 for coord in point) ** half
     elif isinstance(point, Point):
         if isinstance(point, Point2D):
             return (point.x ** 2 + point.y ** 2) ** half

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -754,7 +754,7 @@ def manual_diff(f, symbol):
         elif isinstance(f, csc):
             return -arg.diff(symbol) * csc(arg) * cot(arg)
         elif isinstance(f, Add):
-            return sum([manual_diff(arg, symbol) for arg in f.args])
+            return sum(manual_diff(arg, symbol) for arg in f.args)
         elif isinstance(f, Mul):
             if len(f.args) == 2 and isinstance(f.args[0], Number):
                 return f.args[0] * manual_diff(f.args[1], symbol)
@@ -810,8 +810,8 @@ def find_substitutions(integrand, symbol, u_var):
             return False
         # avoid increasing the degree of a rational function
         if integrand.is_rational_function(symbol) and substituted.is_rational_function(u_var):
-            deg_before = max([degree(t, symbol) for t in integrand.as_numer_denom()])
-            deg_after = max([degree(t, u_var) for t in substituted.as_numer_denom()])
+            deg_before = max(degree(t, symbol) for t in integrand.as_numer_denom())
+            deg_after = max(degree(t, u_var) for t in substituted.as_numer_denom())
             if deg_after > deg_before:
                 return False
         return substituted.as_independent(u_var, as_Add=False)

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -127,7 +127,7 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
             "'base'}, not %s." % case)
 
     nb = order_at(ba, p, DE.t) - order_at(bd, p, DE.t)
-    nc = min([order_at(Ga, p, DE.t) - order_at(Gd, p, DE.t) for Ga, Gd in G])
+    nc = min(order_at(Ga, p, DE.t) - order_at(Gd, p, DE.t) for Ga, Gd in G)
     n = min(0, nc - min(0, nb))
     if not nb:
         # Possible cancellation.
@@ -346,7 +346,7 @@ def prde_no_cancel_b_large(b, Q, n, DE):
     if all(qi.is_zero for qi in Q):
         dc = -1
     else:
-        dc = max([qi.degree(DE.t) for qi in Q])
+        dc = max(qi.degree(DE.t) for qi in Q)
     M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
     A, u = constant_system(M, zeros(dc + 1, 1, DE.t), DE)
     c = eye(m, DE.t)
@@ -386,7 +386,7 @@ def prde_no_cancel_b_small(b, Q, n, DE):
         if all(qi.is_zero for qi in Q):
             dc = -1
         else:
-            dc = max([qi.degree(DE.t) for qi in Q])
+            dc = max(qi.degree(DE.t) for qi in Q)
         M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
         A, u = constant_system(M, zeros(dc + 1, 1, DE.t), DE)
         c = eye(m, DE.t)
@@ -430,7 +430,7 @@ def prde_no_cancel_b_small(b, Q, n, DE):
         # There are no constraints on d1.
 
     # Coefficients of t^j (j > 0) in Sum(ci*qi) must be zero.
-    d = max([qi.degree(DE.t) for qi in Q])
+    d = max(qi.degree(DE.t) for qi in Q)
     if d > 0:
         M = Matrix(d, m, lambda i, j: Q[j].nth(i + 1), DE.t)
         A, _ = constant_system(M, zeros(d, 1, DE.t), DE)
@@ -524,7 +524,7 @@ def param_poly_rischDE(a, b, q, n, DE):
         if all(qi.is_zero for qi in q):
             return [], zeros(1, m, DE.t)  # No constraints.
 
-        N = max([qi.degree(DE.t) for qi in q])
+        N = max(qi.degree(DE.t) for qi in q)
         M = Matrix(N + 1, m, lambda i, j: q[j].nth(i), DE.t)
         A, _ = constant_system(M, zeros(M.rows, 1, DE.t), DE)
 
@@ -812,8 +812,8 @@ def limited_integrate_reduce(fa, fd, G, DE):
         hs = reduce(lambda i, j: i.lcm(j), (ds,) + Es)  # lcm(ds, es1, ..., esm)
         a = hn*hs
         b -= (hn*derivation(hs, DE)).quo(hs)
-        mu = min(order_at_oo(fa, fd, DE.t), min([order_at_oo(ga, gd, DE.t) for
-            ga, gd in G]))
+        mu = min(order_at_oo(fa, fd, DE.t), min(order_at_oo(ga, gd, DE.t) for
+            ga, gd in G))
         # So far, all the above are also nonlinear or Liouvillian, but if this
         # changes, then this will need to be updated to call bound_degree()
         # as per the docstring of this function (DE.case == 'other_linear').
@@ -849,8 +849,8 @@ def limited_integrate(fa, fd, G, DE):
         r = len(h)
         m = len(v) - r - 1
         C = list(v[1: m + 1])
-        y = -sum([v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr() \
-                for i in range(r)])
+        y = -sum(v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr() \
+                for i in range(r))
         y_num, y_den = y.as_numer_denom()
         Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
         Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -293,7 +293,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
 
     # The parametric and regular cases are identical, except for this part
     if parametric:
-        dc = max([i.degree(DE.t) for i in cQ])
+        dc = max(i.degree(DE.t) for i in cQ)
     else:
         dc = cQ.degree(DE.t)
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -547,7 +547,7 @@ def test_issue_9858():
     assert not res.has(Integral)
     assert res.diff(x) == exp(10*x)*sin(exp(x))
     # an example with many similar integrations by parts
-    assert manualintegrate(sum([x*exp(k*x) for k in range(1, 8)]), x) == (
+    assert manualintegrate(sum(x*exp(k*x) for k in range(1, 8)), x) == (
         x*exp(7*x)/7 + x*exp(6*x)/6 + x*exp(5*x)/5 + x*exp(4*x)/4 +
         x*exp(3*x)/3 + x*exp(2*x)/2 + x*exp(x) - exp(7*x)/49 -exp(6*x)/36 -
         exp(5*x)/25 - exp(4*x)/16 - exp(3*x)/9 - exp(2*x)/4 - exp(x))

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2172,7 +2172,7 @@ def _simplified_pairs(terms):
     # is at most a difference of a single one
     termdict = defaultdict(list)
     for n, term in enumerate(terms):
-        ones = sum([1 for t in term if t == 1])
+        ones = sum(1 for t in term if t == 1)
         termdict[ones].append(n)
 
     variables = len(terms[0])

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -555,7 +555,7 @@ def _per(M):
         prod = 1
         sub_len = len(subset)
         for i in range(m):
-             prod *= sum([M[i, j] for j in subset])
+             prod *= sum(M[i, j] for j in subset)
         perm += prod * S.NegativeOne**sub_len * nC(n - sub_len, m - sub_len)
     perm *= S.NegativeOne**m
     return perm.simplify()

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -25,7 +25,7 @@ def _eigenvals_eigenvects_mpmath(M):
     norm2 = lambda v: mp.sqrt(sum(i**2 for i in v))
 
     v1 = None
-    prec = max([x._prec for x in M.atoms(Float)])
+    prec = max(x._prec for x in M.atoms(Float))
     eps = 2**-prec
 
     while prec < DEFAULT_MAXPREC:

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -111,7 +111,7 @@ class BlockMatrix(MatrixExpr):
             if not ok:
                 # same total cols in each row
                 ok = len({
-                    sum([i.cols for i in r]) for r in rows}) == 1
+                    sum(i.cols for i in r) for r in rows}) == 1
                 if blocky and ok:
                     raise ValueError(filldedent('''
                         Although this matrix is comprised of blocks,

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -563,7 +563,7 @@ def _matrix_derivative_old_algorithm(expr, x):
         return 1, 1
 
     def get_rank(parts):
-        return sum([j not in (1, None) for i in parts for j in _get_shape(i)])
+        return sum(j not in (1, None) for i in parts for j in _get_shape(i))
 
     ranks = [get_rank(i) for i in parts]
     rank = ranks[0]
@@ -837,9 +837,9 @@ class _LeftRightArgs:
         """
         rank = 0
         if self.first != 1:
-            rank += sum([i != 1 for i in self.first.shape])
+            rank += sum(i != 1 for i in self.first.shape)
         if self.second != 1:
-            rank += sum([i != 1 for i in self.second.shape])
+            rank += sum(i != 1 for i in self.second.shape)
         if self.higher != 1:
             rank += 2
         return rank

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3649,7 +3649,7 @@ class MatrixBase(Printable):
       q = list(range(len(b)))
       dat = [i.rows for i in b]
       active = [q.pop(0) for _ in range(ntop)]
-      cols = sum([b[i].cols for i in active])
+      cols = sum(b[i].cols for i in active)
       rows = []
       while any(dat):
           r = []

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -193,8 +193,8 @@ class SparseRepMatrix(RepMatrix):
 
             if rows is None:  # autosizing
                 keys = smat.keys()
-                rows = max([r for r, _ in keys]) + 1 if keys else 0
-                cols = max([c for _, c in keys]) + 1 if keys else 0
+                rows = max(r for r, _ in keys) + 1 if keys else 0
+                cols = max(c for _, c in keys) + 1 if keys else 0
 
             else:
                 for i, j in smat.keys():

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -196,8 +196,8 @@ def refraction_angle(incident, medium1, medium2, normal=None, plane=None):
 
     eta = n1/n2  # Relative index of refraction
     # Calculating magnitude of the vectors
-    mag_incident = sqrt(sum([i**2 for i in _incident]))
-    mag_normal = sqrt(sum([i**2 for i in _normal]))
+    mag_incident = sqrt(sum(i**2 for i in _incident))
+    mag_normal = sqrt(sum(i**2 for i in _normal))
     # Converting vectors to unit vectors by dividing
     # them with their magnitudes
     _incident /= mag_incident
@@ -382,9 +382,9 @@ def deviation(incident, medium1, medium2, normal=None, plane=None):
         else:
             _normal = Matrix(plane.normal_vector)
 
-        mag_incident = sqrt(sum([i**2 for i in _incident]))
-        mag_normal = sqrt(sum([i**2 for i in _normal]))
-        mag_refracted = sqrt(sum([i**2 for i in refracted]))
+        mag_incident = sqrt(sum(i**2 for i in _incident))
+        mag_normal = sqrt(sum(i**2 for i in _normal))
+        mag_refracted = sqrt(sum(i**2 for i in refracted))
         _incident /= mag_incident
         _normal /= mag_normal
         refracted /= mag_refracted

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -119,7 +119,7 @@ class Wigner3j(Expr):
         vsep = 1
         maxw = [-1]*3
         for j in range(3):
-            maxw[j] = max([ m[j][i].width() for i in range(2) ])
+            maxw[j] = max(m[j][i].width() for i in range(2))
         D = None
         for i in range(2):
             D_row = None
@@ -294,7 +294,7 @@ class Wigner6j(Expr):
         vsep = 1
         maxw = [-1]*3
         for j in range(3):
-            maxw[j] = max([ m[j][i].width() for i in range(2) ])
+            maxw[j] = max(m[j][i].width() for i in range(2))
         D = None
         for i in range(2):
             D_row = None
@@ -398,7 +398,7 @@ class Wigner9j(Expr):
         vsep = 1
         maxw = [-1]*3
         for j in range(3):
-            maxw[j] = max([ m[j][i].width() for i in range(3) ])
+            maxw[j] = max(m[j][i].width() for i in range(3))
         D = None
         for i in range(3):
             D_row = None

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -57,7 +57,7 @@ def superposition_basis(nqubits):
     """
 
     amp = 1/sqrt(2**nqubits)
-    return sum([amp*IntQubit(n, nqubits=nqubits) for n in range(2**nqubits)])
+    return sum(amp*IntQubit(n, nqubits=nqubits) for n in range(2**nqubits))
 
 class OracleGateFunction(Atom):
     """Wrapper for python functions used in `OracleGate`s"""

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -18,7 +18,7 @@ class VectorStrPrinter(StrPrinter):
     def _print_Derivative(self, e):
         from sympy.physics.vector.functions import dynamicsymbols
         t = dynamicsymbols._t
-        if (bool(sum([i == t for i in e.variables])) &
+        if (bool(sum(i == t for i in e.variables)) &
                 isinstance(type(e.args[0]), UndefinedFunction)):
             ol = str(e.args[0].func)
             for i, v in enumerate(e.variables):

--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -103,7 +103,7 @@ def _construct_algebraic(coeffs, opt):
     exts = list(ordered(exts))
 
     g, span, H = primitive_element(exts, ex=True, polys=True)
-    root = sum([ s*ext for s, ext in zip(span, exts) ])
+    root = sum(s*ext for s, ext in zip(span, exts))
 
     domain, g = QQ.algebraic_field((g, root)), g.rep.to_list()
 

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -1741,7 +1741,7 @@ def dmp_max_norm(f, u, K):
 
     v = u - 1
 
-    return max([ dmp_max_norm(c, v, K) for c in f ])
+    return max(dmp_max_norm(c, v, K) for c in f)
 
 
 def dup_l1_norm(f, K):
@@ -1783,7 +1783,7 @@ def dmp_l1_norm(f, u, K):
 
     v = u - 1
 
-    return sum([ dmp_l1_norm(c, v, K) for c in f ])
+    return sum(dmp_l1_norm(c, v, K) for c in f)
 
 
 def dup_l2_norm_squared(f, K):
@@ -1822,7 +1822,7 @@ def dmp_l2_norm_squared(f, u, K):
 
     v = u - 1
 
-    return sum([ dmp_l2_norm_squared(c, v, K) for c in f ])
+    return sum(dmp_l2_norm_squared(c, v, K) for c in f)
 
 
 def dup_expand(polys, K):

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -191,7 +191,7 @@ def _rec_degree_in(g, v, i, j):
 
     v, i = v - 1, i + 1
 
-    return max([ _rec_degree_in(c, v, i, j) for c in g ])
+    return max(_rec_degree_in(c, v, i, j) for c in g)
 
 
 def dmp_degree_in(f, j, u):

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -176,7 +176,7 @@ def dup_zz_mignotte_bound(f, K):
     delta2 = _ceil(delta / 2)
 
     # euclidean-norm
-    eucl_norm = K.sqrt( sum( [cf**2 for cf in f] ) )
+    eucl_norm = K.sqrt( sum( cf**2 for cf in f ) )
 
     # biggest values of binomial coefficients (p. 538 of reference)
     t1 = binomial(delta - 1, delta2)

--- a/sympy/polys/fglmtools.py
+++ b/sympy/polys/fglmtools.py
@@ -81,14 +81,14 @@ def _identity_matrix(n, domain):
 
 
 def _matrix_mul(M, v):
-    return [sum([row[i] * v[i] for i in range(len(v))]) for row in M]
+    return [sum(row[i] * v[i] for i in range(len(v))) for row in M]
 
 
 def _update(s, _lambda, P):
     """
     Update ``P`` such that for the updated `P'` `P' v = e_{s}`.
     """
-    k = min([j for j in range(s, len(_lambda)) if _lambda[j] != 0])
+    k = min(j for j in range(s, len(_lambda)) if _lambda[j] != 0)
 
     for r in range(len(_lambda)):
         if r != k:

--- a/sympy/polys/matrices/lll.py
+++ b/sympy/polys/matrices/lll.py
@@ -34,7 +34,7 @@ def _ddm_lll(x, delta=QQ(3, 4), return_transform=False):
         return abs(mu[k][j]) <= half
 
     def dot_rows(x, y, rows: tuple[int, int]):
-        return sum([x[rows[0]][z] * y[rows[1]][z] for z in range(x.shape[1])])
+        return sum(x[rows[0]][z] * y[rows[1]][z] for z in range(x.shape[1]))
 
     def reduce_row(T, mu, y, rows: tuple[int, int]):
         r = closest_integer(mu[rows[0]][rows[1]])

--- a/sympy/polys/numberfields/subfield.py
+++ b/sympy/polys/numberfields/subfield.py
@@ -488,7 +488,7 @@ def to_number_field(extension, theta=None, *, gen=None, alias=None):
         return AlgebraicNumber(extension[0], alias=alias)
 
     minpoly, coeffs = primitive_element(extension, gen, polys=True)
-    root = sum([ coeff*ext for coeff, ext in zip(coeffs, extension) ])
+    root = sum(coeff*ext for coeff, ext in zip(coeffs, extension))
 
     if theta is None:
         return AlgebraicNumber((minpoly, root), alias=alias)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1638,7 +1638,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         elif i < 0:
             return 0
         else:
-            return max([ monom[i] for monom in f.itermonoms() ])
+            return max(monom[i] for monom in f.itermonoms())
 
     def degrees(f):
         """
@@ -1666,7 +1666,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         elif i < 0:
             return 0
         else:
-            return min([ monom[i] for monom in f.itermonoms() ])
+            return min(monom[i] for monom in f.itermonoms())
 
     def tail_degrees(f):
         """
@@ -2474,7 +2474,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
             for i, (monom, coeff) in enumerate(f.terms()):
                 if all(monom[i] >= monom[i + 1] for i in indices):
-                    height = max([n*m for n, m in zip(weights, monom)])
+                    height = max(n*m for n, m in zip(weights, monom))
 
                     if height > _height:
                         _height, _monom, _coeff = height, monom, coeff

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1271,7 +1271,7 @@ def _reverse_intervals(intervals):
 
 def _winding_number(T, field):
     """Compute the winding number of the input polynomial, i.e. the number of roots. """
-    return int(sum([ field(*_values[t][i]) for t, i in T ]) / field(2))
+    return int(sum(field(*_values[t][i]) for t, i in T) / field(2))
 
 def dup_count_complex_roots(f, K, inf=None, sup=None, exclude=None):
     """Count all roots in [u + v*I, s + t*I] rectangle using Collins-Krandick algorithm. """
@@ -1287,7 +1287,7 @@ def dup_count_complex_roots(f, K, inf=None, sup=None, exclude=None):
 
     if inf is None or sup is None:
         _, lc = dup_degree(f), abs(dup_LC(f, F))
-        B = 2*max([ F.quo(abs(c), lc) for c in f ])
+        B = 2*max(F.quo(abs(c), lc) for c in f)
 
     if inf is None:
         (u, v) = (-B, -B)
@@ -1596,7 +1596,7 @@ def dup_isolate_complex_roots_sqf(f, K, eps=None, inf=None, sup=None, blackbox=F
     f = dup_convert(f, K, F)
 
     lc = abs(dup_LC(f, F))
-    B = 2*max([ F.quo(abs(c), lc) for c in f ])
+    B = 2*max(F.quo(abs(c), lc) for c in f)
 
     (u, v), (s, t) = (-B, F.zero), (B, B)
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -635,7 +635,7 @@ class ComplexRootOf(RootOf):
     @classmethod
     def _count_roots(cls, roots):
         """Count the number of real or complex roots with multiplicities."""
-        return sum([k for _, _, k in roots])
+        return sum(k for _, _, k in roots)
 
     @classmethod
     def _indexed_root(cls, poly, index, lazy=False):

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -37,7 +37,7 @@ def _check(roots):
     # this is the desired invariant for roots returned
     # by all_roots. It is trivially true for linear
     # polynomials.
-    nreal = sum([1 if i.is_real else 0 for i in roots])
+    nreal = sum(1 if i.is_real else 0 for i in roots)
     assert sorted(roots[:nreal]) == list(roots[:nreal])
     for ix in range(nreal, len(roots), 2):
         if not (

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -533,8 +533,8 @@ def test_issue_8316():
 def test__imag_count():
     from sympy.polys.rootoftools import _imag_count_of_factor
     def imag_count(p):
-        return sum([_imag_count_of_factor(f)*m for f, m in
-        p.factor_list()[1]])
+        return sum(_imag_count_of_factor(f)*m for f, m in
+        p.factor_list()[1])
     assert imag_count(Poly(x**6 + 10*x**2 + 1)) == 2
     assert imag_count(Poly(x**2)) == 0
     assert imag_count(Poly([1]*3 + [-1], x)) == 0

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -327,7 +327,7 @@ class C89CodePrinter(CodePrinter):
                 temp += (shift,)
                 shift *= dims[i]
             strides = temp
-        flat_index = sum([x[0]*x[1] for x in zip(indices, strides)]) + offset
+        flat_index = sum(x[0]*x[1] for x in zip(indices, strides)) + offset
         return "%s[%s]" % (self._print(expr.base.label),
                            self._print(flat_index))
 
@@ -540,7 +540,7 @@ class C89CodePrinter(CodePrinter):
                 raise ValueError("Expected strides when offset is given")
             idxs = ']['.join((self._print(arg) for arg in elem.indices))
         else:
-            global_idx = sum([i*s for i, s in zip(elem.indices, elem.strides)])
+            global_idx = sum(i*s for i, s in zip(elem.indices, elem.strides))
             if elem.offset != None: # Must be "!= None", cannot be "is not None"
                 global_idx += elem.offset
             idxs = self._print(global_idx)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1187,7 +1187,7 @@ class PrettyPrinter(Printer):
                 o1[i] = tempstr
 
         o1 = [x.split('\n') for x in o1]
-        n_newlines = max([len(x) for x in o1])  # Width of part in its pretty form
+        n_newlines = max(len(x) for x in o1)  # Width of part in its pretty form
 
         if 1 in flag:                           # If there was a fractional scalar
             for i, parts in enumerate(o1):
@@ -1369,7 +1369,7 @@ class PrettyPrinter(Printer):
         len_args = len(pexpr.args)
 
         # max widths
-        maxw = [max([P[i, j].width() for i in range(len_args)])
+        maxw = [max(P[i, j].width() for i in range(len_args))
                 for j in range(2)]
 
         # FIXME: Refactor this code and matrix into some tabular environment.

--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -269,7 +269,7 @@ class TableForm:
         # Check heading:
         if self._headings[0]:
             self._headings[0] = [str(x) for x in self._headings[0]]
-            _head_width = max([len(x) for x in self._headings[0]])
+            _head_width = max(len(x) for x in self._headings[0])
 
         if self._headings[1]:
             new_line = []

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -141,8 +141,8 @@ def cse_release_variables(r, e):
     # sort e so those with most sub-expressions appear first
     e = [(e[i], syms[i]) for i in range(len(e))]
     e, syms = zip(*sorted(e,
-        key=lambda x: -sum([p[s.index(i)].count_ops()
-        for i in x[0].free_symbols & in_use])))
+        key=lambda x: -sum(p[s.index(i)].count_ops()
+        for i in x[0].free_symbols & in_use)))
     syms = list(syms)
     p += e
     rv = []

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -470,7 +470,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                     # return the number of terms of this expression
                     # when multiplied out -- assuming no joining of terms
                     if e.is_Add:
-                        return sum([_terms(ai) for ai in e.args])
+                        return sum(_terms(ai) for ai in e.args)
                     if e.is_Mul:
                         return prod([_terms(mi) for mi in e.args])
                     return 1

--- a/sympy/simplify/ratsimp.py
+++ b/sympy/simplify/ratsimp.py
@@ -152,9 +152,9 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
             ng = Cs + Ds
 
             c_hat = Poly(
-                sum([Cs[i] * M1[i] for i in range(len(M1))]), opt.gens + ng)
+                sum(Cs[i] * M1[i] for i in range(len(M1))), opt.gens + ng)
             d_hat = Poly(
-                sum([Ds[i] * M2[i] for i in range(len(M2))]), opt.gens + ng)
+                sum(Ds[i] * M2[i] for i in range(len(M2))), opt.gens + ng)
 
             r = reduced(a * d_hat - b * c_hat, G, opt.gens + ng,
                         order=opt.order, polys=True)[1]

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1733,7 +1733,7 @@ def nc_simplify(expr, deep=True):
         if isinstance(s, _Pow):
             return get_score(s.args[0])
         elif isinstance(s, (_Add, _Mul)):
-            return sum([get_score(a) for a in s.args])
+            return sum(get_score(a) for a in s.args)
         return 1
 
     def compare(s, alt_s):

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -503,7 +503,7 @@ def test_issue_11577():
     def check(eq):
         r, c = cse(eq)
         assert eq.count_ops() >= \
-            len(r) + sum([i[1].count_ops() for i in r]) + \
+            len(r) + sum(i[1].count_ops() for i in r) + \
             count_ops(c)
 
     eq = x**5*y**2 + x**5*y + x**5
@@ -574,7 +574,7 @@ def test_cse__performance():
 def test_issue_12070():
     exprs = [x + y, 2 + x + y, x + y + z, 3 + x + y + z]
     subst, red = cse(exprs)
-    assert 6 >= (len(subst) + sum([v.count_ops() for k, v in subst]) +
+    assert 6 >= (len(subst) + sum(v.count_ops() for k, v in subst) +
                  count_ops(red))
 
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2699,7 +2699,7 @@ def diop_ternary_quadratic(eq, parameterize=False):
 
 
 def _diop_ternary_quadratic(_var, coeff):
-    eq = sum([i*coeff[i] for i in coeff])
+    eq = sum(i*coeff[i] for i in coeff)
     if HomogeneousTernaryQuadratic(eq).matches():
         return HomogeneousTernaryQuadratic(eq, free_symbols=_var).solve()
     elif HomogeneousTernaryQuadraticNormal(eq).matches():
@@ -2952,7 +2952,7 @@ def diop_ternary_quadratic_normal(eq, parameterize=False):
 
 
 def _diop_ternary_quadratic_normal(var, coeff):
-    eq = sum([i * coeff[i] for i in coeff])
+    eq = sum(i * coeff[i] for i in coeff)
     return HomogeneousTernaryQuadraticNormal(eq, free_symbols=var).solve()
 
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2577,9 +2577,9 @@ def det_minor(M):
     if n == 2:
         return M[0, 0]*M[1, 1] - M[1, 0]*M[0, 1]
     else:
-        return sum([(1, -1)[i % 2]*Add(*[M[0, i]*d for d in
+        return sum((1, -1)[i % 2]*Add(*[M[0, i]*d for d in
             Add.make_args(det_minor(M.minor_submatrix(0, i)))])
-            if M[0, i] else S.Zero for i in range(n)])
+            if M[0, i] else S.Zero for i in range(n))
 
 
 def det_quick(M, method=None):

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -434,7 +434,7 @@ def test_linear_system_symbols_doesnt_hang_1():
         y1s = symbols('y1_:{}'.format(wy), real=True)
         c = symbols('c_:{}'.format(order+1), real=True)
 
-        expr = sum([coeff*x**o for o, coeff in enumerate(c)])
+        expr = sum(coeff*x**o for o, coeff in enumerate(c))
         eqs = []
         for i in range(wy):
             eqs.append(expr.diff(x, i).subs({x: x0}) - y0s[i])
@@ -2127,7 +2127,7 @@ def test_issue_5114_6611():
     ans = solve(list(eqs), list(v), simplify=False)
     # If time is taken to simplify then then 2617 below becomes
     # 1168 and the time is about 50 seconds instead of 2.
-    assert sum([s.count_ops() for s in ans.values()]) <= 3270
+    assert sum(s.count_ops() for s in ans.values()) <= 3270
 
 
 def test_det_quick():

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -314,8 +314,8 @@ class FinitePSpace(PSpace):
         else:
             parse_domain = [expr.xreplace(dict(elem)) for elem in self.domain]
             bools = [True for elem in self.domain]
-        return sum([Piecewise((prob * elem, blv), (S.Zero, True))
-                for prob, elem, blv in zip(probs, parse_domain, bools)])
+        return sum(Piecewise((prob * elem, blv), (S.Zero, True))
+                for prob, elem, blv in zip(probs, parse_domain, bools))
 
     def compute_quantile(self, expr):
         cdf = self.compute_cdf(expr)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -586,7 +586,7 @@ class MultivariateEwensDistribution(JointDistribution):
         if condi:
             term_2 = Mul.fromiter(theta**syms[j]/((j+1)**syms[j]*factorial(syms[j]))
                                     for j in range(n))
-            cond = Eq(sum([(k + 1)*syms[k] for k in range(n)]), n)
+            cond = Eq(sum((k + 1)*syms[k] for k in range(n)), n)
             return Piecewise((term_1 * term_2, cond), (0, True))
         syms = syms[0]
         j, k = symbols('j, k', positive=True, integer=True)
@@ -667,8 +667,8 @@ class GeneralizedMultivariateLogGammaDistribution(JointDistribution):
                 ((gamma(v + n)**(k - 1))*gamma(v)*gamma(n + 1))
         sterm2 = Mul.fromiter(mui*li**(-v - n) for mui, li in zip(mu, l))
         term1 = sterm1 * sterm2
-        sterm3 = (v + n) * sum([mui * yi for mui, yi in zip(mu, y)])
-        sterm4 = sum([exp(mui * yi)/li for (mui, yi, li) in zip(mu, y, l)])
+        sterm3 = (v + n) * sum(mui * yi for mui, yi in zip(mu, y))
+        sterm4 = sum(exp(mui * yi)/li for (mui, yi, li) in zip(mu, y, l))
         term2 = exp(sterm3 - sterm4)
         return Pow(d, v) * Sum(term1 * term2, (n, 0, S.Infinity))
 

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -141,7 +141,7 @@ def entropy(expr, condition=None, **kwargs):
     pdf = density(expr, condition, **kwargs)
     base = kwargs.get('b', exp(1))
     if isinstance(pdf, dict):
-            return sum([-prob*log(prob, base) for prob in pdf.values()])
+            return sum(-prob*log(prob, base) for prob in pdf.values())
     return expectation(-log(pdf(expr), base))
 
 def covariance(X, Y, condition=None, **kwargs):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -675,13 +675,13 @@ class MarkovProcess(StochasticProcess):
                 gprob = S.One
 
             if min_key_rv == rv:
-                return sum([prob[FiniteSet(state)] for state in states])
+                return sum(prob[FiniteSet(state)] for state in states)
             if isinstance(self, ContinuousMarkovChain):
-                return gprob * sum([trans_probs(rv.key - min_key_rv.key).__getitem__((gstate, state))
-                                    for state in states])
+                return gprob * sum(trans_probs(rv.key - min_key_rv.key).__getitem__((gstate, state))
+                                    for state in states)
             if isinstance(self, DiscreteMarkovChain):
-                return gprob * sum([(trans_probs**(rv.key - min_key_rv.key)).__getitem__((gstate, state))
-                                    for state in states])
+                return gprob * sum((trans_probs**(rv.key - min_key_rv.key)).__getitem__((gstate, state))
+                                    for state in states)
 
         if isinstance(condition, Not):
             expr = condition.args[0]
@@ -720,8 +720,8 @@ class MarkovProcess(StochasticProcess):
             return prod
 
         if isinstance(condition, Or):
-            return sum([self.probability(expr, given_condition, evaluate, **kwargs)
-                        for expr in condition.args])
+            return sum(self.probability(expr, given_condition, evaluate, **kwargs)
+                        for expr in condition.args)
 
         raise NotImplementedError("Mechanism for handling (%s, %s) queries hasn't been "
                                 "implemented yet."%(condition, given_condition))
@@ -816,7 +816,7 @@ class MarkovProcess(StochasticProcess):
             cond = condition & mat_of & \
                     StochasticStateSpaceOf(self, state_index)
             func = lambda s: self.probability(Eq(rv, s), cond) * expr.subs(rv, self._state_index[s])
-            return sum([func(s) for s in state_index])
+            return sum(func(s) for s in state_index)
 
         raise NotImplementedError("Mechanism for handling (%s, %s) queries hasn't been "
                                 "implemented yet."%(expr, condition))

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -129,7 +129,7 @@ def _util_contraction_diagonal(array, *contraction_or_diagonal_axes):
     for axes_group in contraction_or_diagonal_axes:
         lidx = []
         for js in range(array.shape[axes_group[0]]):
-            lidx.append(sum([cum_shape[ig] * js for ig in axes_group]))
+            lidx.append(sum(cum_shape[ig] * js for ig in axes_group))
         summed_deltas.append(lidx)
 
     return array, remaining_indices, remaining_shape, summed_deltas

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1860,7 +1860,7 @@ class _EditArrayContraction:
                 perm.append(counter)
                 counter += 1
             permutation.append(perm)
-        max_ind = max([max(i) if i else -1 for i in permutation]) if permutation else -1
+        max_ind = max(max(i) if i else -1 for i in permutation) if permutation else -1
         perm_diag = [max_ind - i for i in perm_diag]
         self._track_permutation = permutation + [perm_diag]
 

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -758,7 +758,7 @@ def identify_hadamard_products(expr: tUnion[ArrayContraction, ArrayDiagonal]):
     v: List[_ArgE]
     for k, v in map_contr_to_args.items():
         make_trace: bool = False
-        if len(k) == 1 and next(iter(k)) >= 0 and sum([next(iter(k)) in i for i in map_contr_to_args]) == 1:
+        if len(k) == 1 and next(iter(k)) >= 0 and sum(next(iter(k)) in i for i in map_contr_to_args) == 1:
             # This is a trace: the arguments are fully contracted with only one
             # index, and the index isn't used anywhere else:
             make_trace = True
@@ -870,7 +870,7 @@ def remove_identity_matrices(expr: ArrayContraction):
 
     permutation_map = {}
 
-    free_indices = list(accumulate([0] + [sum([i is None for i in arg.indices]) for arg in editor.args_with_ind]))
+    free_indices = list(accumulate([0] + [sum(i is None for i in arg.indices) for arg in editor.args_with_ind]))
     free_map = dict(zip(editor.args_with_ind, free_indices[:-1]))
 
     update_pairs = {}

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1295,7 +1295,7 @@ def multiset_permutations(m, size=None, g=None):
             g = [list(i) for i in group(m, multiple=False)]
         del m
     do = [gi for gi in g if gi[1] > 0]
-    SUM = sum([gi[1] for gi in do])
+    SUM = sum(gi[1] for gi in do)
     if not do or size is not None and (size > SUM or size < 1):
         if not do and size is None or size == 0:
             yield []

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -333,7 +333,7 @@ class ImplicitRegion(Basic):
 
         if len(modified_eq.args) != 0:
             terms = modified_eq.args
-            m = min([total_degree(term) for term in terms])
+            m = min(total_degree(term) for term in terms)
         else:
             terms = modified_eq
             m = total_degree(terms)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This optimizes a bunch of Python code that uses builtin max/min/sum. If the code previously relied on a list comprehension, it will now rely on a generator which should be semantically identical since it will be immediately consumed. This should reduce peak-memory in many of these operations by avoiding have to store all the outputs in an intermediate list. All fixes were done with automated ruff tooling.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
