### PR TITLE
Fixes Xor simplification with simplify to be consistent with other boolean operators

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1045,11 +1045,13 @@ class Xor(BooleanFunction):
         # as standard simplify uses simplify_logic which writes things as
         # And and Or, we only simplify the partial expressions before using
         # patterns
-        rv = super()._eval_simplify(**kwargs)
         rv = self.func(*[a.simplify(**kwargs) for a in self.args])
+        rv = rv.to_anf()
         if not isinstance(rv, Xor):  # This shouldn't really happen here
             return rv
         patterns = _simplify_patterns_xor()
+        print(_apply_patternbased_simplification(rv, patterns,
+                                                  kwargs['measure'], None))
         return _apply_patternbased_simplification(rv, patterns,
                                                   kwargs['measure'], None)
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1045,6 +1045,7 @@ class Xor(BooleanFunction):
         # as standard simplify uses simplify_logic which writes things as
         # And and Or, we only simplify the partial expressions before using
         # patterns
+        rv = super()._eval_simplify(**kwargs)
         rv = self.func(*[a.simplify(**kwargs) for a in self.args])
         if not isinstance(rv, Xor):  # This shouldn't really happen here
             return rv

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1050,8 +1050,6 @@ class Xor(BooleanFunction):
         if not isinstance(rv, Xor):  # This shouldn't really happen here
             return rv
         patterns = _simplify_patterns_xor()
-        print(_apply_patternbased_simplification(rv, patterns,
-                                                  kwargs['measure'], None))
         return _apply_patternbased_simplification(rv, patterns,
                                                   kwargs['measure'], None)
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -355,6 +355,7 @@ def test_simplification_boolalg():
     assert And(Eq(x - 1, 0), Eq(x + 2, 2)).simplify() == False
     assert And(Ne(x - 1, 0), Ne(x + 2, 2)).simplify(
         ) == And(Ne(x, 1), Ne(x, 0))
+    assert simplify(Xor(x, ~x)) == True
 
 
 def test_bool_map():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #25827 
#### Brief description of what is fixed or changed

Changed Xor simplification to use .to_anf() so that simplify() works on it for simple simplifications.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
