### PR TITLE
Fix Output for isprime

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -618,8 +618,6 @@ def isprime(n):
     >>> from sympy.ntheory import isprime
     >>> isprime(13)
     True
-    >>> isprime(13.0)  # limited precision
-    False
     >>> isprime(15)
     False
 
@@ -667,10 +665,7 @@ def isprime(n):
            http://mpqs.free.fr/LucasPseudoprimes.pdf
     .. [3] https://en.wikipedia.org/wiki/Baillie-PSW_primality_test
     """
-    try:
-        n = as_int(n)
-    except ValueError:
-        return False
+    n = as_int(n)
 
     # Step 1, do quick composite testing via trial division.  The individual
     # modulo tests benchmark faster than one or two primorial igcds for me.

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -9,7 +9,7 @@ from sympy.ntheory.primetest import (mr, _lucas_extrastrong_params, is_lucas_prp
                                      is_mersenne_prime)
 
 from sympy.testing.pytest import slow, raises
-from sympy.core.numbers import I
+from sympy.core.numbers import I, Float
 
 
 def test_is_fermat_pseudoprime():
@@ -209,7 +209,8 @@ def test_isprime():
     sieve.extend(3000)
     assert isprime(2819)
     assert not isprime(2931)
-    assert not isprime(2.0)
+    raises(ValueError, lambda: isprime(2.0))
+    raises(ValueError, lambda: isprime(Float(2)))
 
 
 def test_is_square():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes Issue #26489

#### Brief description of what is fixed or changed
isprime raises a value error when using floating point values instead of giving false.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed outputs for floating point number for isprime 

<!-- END RELEASE NOTES -->
