### PR TITLE
ruff - FURB142: Optimize inplace set modifications

### DIFF
--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -332,8 +332,7 @@ class CNF:
         clauses = set()
         for a, b in product(self.clauses, cnf.clauses):
             tmp = set(a)
-            for t in b:
-                tmp.add(t)
+            tmp.update(b)
             clauses.add(frozenset(tmp))
         return CNF(clauses)
 
@@ -343,15 +342,11 @@ class CNF:
 
     def _not(self):
         clss = list(self.clauses)
-        ll = set()
-        for x in clss[-1]:
-            ll.add(frozenset((~x,)))
+        ll = {frozenset((~x,)) for x in clss[-1]}
         ll = CNF(ll)
 
         for rest in clss[:-1]:
-            p = set()
-            for x in rest:
-                p.add(frozenset((~x,)))
+            p = {frozenset((~x,)) for x in rest}
             ll = ll._or(CNF(p))
         return ll
 

--- a/sympy/assumptions/facts.py
+++ b/sympy/assumptions/facts.py
@@ -230,10 +230,8 @@ def get_known_facts_keys():
     ``generate_known_facts_dict``.
 
     """
-    exclude = set()
-    for pred in [Q.eq, Q.ne, Q.gt, Q.lt, Q.ge, Q.le]:
-        # exclude polyadic predicates
-        exclude.add(pred)
+    # exclude polyadic predicates
+    exclude = {Q.eq, Q.ne, Q.gt, Q.lt, Q.ge, Q.le}
 
     result = []
     for attr in Q.__class__.__dict__:

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -219,8 +219,7 @@ def get_all_pred_and_expr_from_enc_cnf(enc_cnf):
     for pred in enc_cnf.encoding.keys():
         if isinstance(pred, AppliedPredicate):
             all_pred.add(pred)
-            for expr in pred.arguments:
-                all_exprs.add(expr)
+            all_exprs.update(pred.arguments)
 
     return all_pred, all_exprs
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -184,8 +184,7 @@ class ClassFactRegistry:
 
         handlers1, handlers2 = self[type(expr)]
 
-        for h in handlers1:
-            ret.add(h(expr))
+        ret.update(h(expr) for h in handlers1)
         for h in handlers2:
             ret.update(h(expr))
         return ret

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2167,8 +2167,7 @@ def test_known_facts_consistent():
     # test cnf clauses of fact between unary predicates
     cnf = CNF.to_CNF(fact)
     clauses = set()
-    for cl in cnf.clauses:
-        clauses.add(frozenset(Literal(lit.arg.function, lit.is_Not) for lit in sorted(cl, key=str)))
+    clauses.update(frozenset(Literal(lit.arg.function, lit.is_Not) for lit in sorted(cl, key=str)) for cl in cnf.clauses)
     assert get_all_known_facts() == clauses
     # test dictionary of fact between unary predicates
     keys = [pred(x) for pred in get_known_facts_keys()]

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -350,8 +350,7 @@ class AccumulationBounds(Expr):
                 v = set()
                 for a in self.args:
                     vi = other*a
-                    for i in vi.args or (vi,):
-                        v.add(i)
+                    v.update(vi.args or (vi,))
                 return AccumBounds(Min(*v), Max(*v))
             if other is S.Infinity:
                 if self.min.is_zero:

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -985,10 +985,8 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
 
         """
         group = self.group
-        gens = set()
-        for syllable in self.array_form:
-            gens.add(group.dtype(((syllable[0], 1),)))
-        return set(gens)
+        gens = {group.dtype(((syllable[0], 1),)) for syllable in self.array_form}
+        return gens
 
     def cyclic_subword(self, from_i, to_j):
         group = self.group

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -272,8 +272,7 @@ class Prufer(Basic):
         got = set()
         nmin = nmax = None
         for ei in e:
-            for i in ei:
-                got.add(i)
+            got.update(ei)
             nmin = min(ei[0], nmin) if nmin is not None else ei[0]
             nmax = max(ei[1], nmax) if nmax is not None else ei[1]
             rv.append(list(ei))

--- a/sympy/combinatorics/testutil.py
+++ b/sympy/combinatorics/testutil.py
@@ -193,8 +193,7 @@ def _verify_normal_closure(group, arg, closure=None):
     elif hasattr(arg, 'array_form'):
         subgr_gens = [arg]
     for el in group.generate_dimino():
-        for gen in subgr_gens:
-            conjugates.add(gen ^ el)
+        conjugates.update(gen ^ el for gen in subgr_gens)
     naive_closure = PermutationGroup(list(conjugates))
     return closure.is_subgroup(naive_closure)
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1122,10 +1122,7 @@ class BaseVectorField(Expr):
 def _find_coords(expr):
     # Finds CoordinateSystems existing in expr
     fields = expr.atoms(BaseScalarField, BaseVectorField)
-    result = set()
-    for f in fields:
-        result.add(f._coord_sys)
-    return result
+    return {f._coord_sys for f in fields}
 
 
 class Commutator(Expr):

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -639,8 +639,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     for poly in ordered(polys):
         coeff, factors = factor_list(poly, *V)
         reducibles.add(coeff)
-        for fact, mul in factors:
-            reducibles.add(fact)
+        reducibles.update(fact for fact, mul in factors)
 
     def _integrate(field=None):
         atans = set()

--- a/sympy/ntheory/ecm.py
+++ b/sympy/ntheory/ecm.py
@@ -227,8 +227,7 @@ def _ecm_one_factor(n, B1=10000, B2=100000, max_curve=200, seed=None):
     deltas_list = []
     for r in range(B1 + 2*D, B2 + 2*D, 4*D):
         deltas = set()
-        for q in primerange(r - 2*D, r + 2*D):
-            deltas.add((abs(q - r) - 1) // 2)
+        deltas.update((abs(q - r) - 1) // 2 for q in primerange(r - 2*D, r + 2*D))
         # d in deltas iff r+(2d+1) and/or r-(2d+1) is prime
         deltas_list.append(list(deltas))
 

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -124,8 +124,7 @@ class EllipticCurve:
             for i in range(char):
                 congruence_eq = self._poly.subs({self.x: i, self.z: 1}).expr
                 sol = polynomial_congruence(congruence_eq, char)
-                for num in sol:
-                    all_pt.add((i, num))
+                all_pt.update((i, num) for num in sol)
             return all_pt
         else:
             raise ValueError("Infinitely many points")

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -188,11 +188,9 @@ class Options(dict):
             for name, option in cls.__options__.items():
                 vertices.append(name)
 
-                for _name in option.after:
-                    edges.add((_name, name))
+                edges.update((_name, name) for _name in option.after)
 
-                for _name in option.before:
-                    edges.add((name, _name))
+                edges.update((name, _name) for _name in option.before)
 
             try:
                 cls.__order__ = topological_sort((vertices, list(edges)))

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -630,8 +630,7 @@ class BinaryQuadratic(DiophantineEquationType):
                 # In this case equation can be transformed into a Pell equation
 
                 solns_pell = set(solns_pell)
-                for X, Y in list(solns_pell):
-                    solns_pell.add((-X, -Y))
+                solns_pell.update((-X, -Y) for X, Y in list(solns_pell))
 
                 a = diop_DN(D, 1)
                 T = a[0][0]
@@ -1480,8 +1479,7 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
                 GeneralSumOfSquares.name,
                 GeneralSumOfEvenPowers.name,
                 Univariate.name]:
-            for sol in solution:
-                sols.add(merge_solution(var, var_t, sol))
+            sols.update(merge_solution(var, var_t, sol) for sol in solution)
 
         else:
             raise NotImplementedError('unhandled type: %s' % eq_type)

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -396,10 +396,7 @@ def solve_triangulated(polys, *gens, **args):
     dom = f.get_domain()
 
     zeros = f.ground_roots()
-    solutions = set()
-
-    for zero in zeros:
-        solutions.add(((zero,), dom))
+    solutions = {((zero,), dom) for zero in zeros}
 
     var_seq = reversed(gens[:-1])
     vars_seq = postfixes(gens[1:])

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -174,8 +174,7 @@ def denoms(eq, *symbols):
         den = denom(p)
         if den is S.One:
             continue
-        for d in Mul.make_args(den):
-            dens.add(d)
+        dens.update(Mul.make_args(den))
     if not symbols:
         return dens
     elif len(symbols) == 1:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -216,10 +216,8 @@ class Routine:
 
         """
         v = set(self.local_vars)
-        for arg in self.arguments:
-            v.add(arg.name)
-        for res in self.results:
-            v.add(res.result_var)
+        v.update(arg.name for arg in self.arguments)
+        v.update(res.result_var for res in self.results)
         return v
 
     @property

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -855,8 +855,7 @@ def topological_sort(graph, key=None):
     S = set(V)
     E = list(E)
 
-    for v, u in E:
-        S.discard(u)
+    S.difference_update(u for v, u in E)
 
     if key is None:
         def key(value):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Optimizes previously verbose and inefficient set creations / updates with the proper method or set comprehensions when appropriate. Should be faster and more readable. Edits are automatically generated by ruff using the new FURB142 rule that was recently added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
