### PR TITLE
Add new java printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1373,6 +1373,7 @@ Stepan Roucka <stepan@roucka.eu>
 Stepan Simsa <simsa.st@gmail.com>
 Steph Papanik <spapanik21@gmail.com>
 Stephan Seitz <stephan.seitz@fau.de>
+Stephan Weissmann <stephweissm@gmail.com>
 Stephen Loo <shikil@yahoo.com>
 Steve Anton <anxuiz.nx@gmail.com>
 Steve Kieffer <sk@skieffer.info>

--- a/sympy/printing/java.py
+++ b/sympy/printing/java.py
@@ -6,7 +6,7 @@ _known_constants = {
 }
 
 class JavaPrinter(AbstractJavaFamilyPrinter):
-    
+
     printmethod = '_java'
     language = 'Java'
 
@@ -17,8 +17,7 @@ class JavaPrinter(AbstractJavaFamilyPrinter):
             'user_functions', {}))
         self.known_constants = dict(_known_constants, **(settings or {}).get(
             'user_constants', {}))
-        
-    
+
     def _print_isnan(self, e):
         arg, = e.args
         return f"Double.isNaN({self._print(arg)})"
@@ -33,3 +32,7 @@ class JavaPrinter(AbstractJavaFamilyPrinter):
     
     def _print_Print(self, e):
         return "System.out." + super()._print_Print(e)
+
+
+def javacode(expr, assign_to=None, **settings):
+    return JavaPrinter(settings).doprint(expr, assign_to)

--- a/sympy/printing/java.py
+++ b/sympy/printing/java.py
@@ -21,15 +21,15 @@ class JavaPrinter(AbstractJavaFamilyPrinter):
     def _print_isnan(self, e):
         arg, = e.args
         return f"Double.isNaN({self._print(arg)})"
-    
+
     def _print_Raise(self, e):
         arg, = e.args
         return f"throw new {self._print(arg)}"
-    
+
     def _print_RuntimeError_(self, e):
         arg, = e.args
         return f"Exception({self._print(arg)})"
-    
+
     def _print_Print(self, e):
         return "System.out." + super()._print_Print(e)
 

--- a/sympy/printing/java.py
+++ b/sympy/printing/java.py
@@ -1,4 +1,3 @@
-from .codeprinter import CodePrinter
 from .jscode import AbstractJavaFamilyPrinter, known_functions as _known_functions
 
 _known_constants = {

--- a/sympy/printing/java.py
+++ b/sympy/printing/java.py
@@ -1,0 +1,35 @@
+from .codeprinter import CodePrinter
+from .jscode import AbstractJavaFamilyPrinter, known_functions as _known_functions
+
+_known_constants = {
+    "Infinity": "Double.POSITIVE_INFINITY"
+}
+
+class JavaPrinter(AbstractJavaFamilyPrinter):
+    
+    printmethod = '_java'
+    language = 'Java'
+
+    def __init__(self, settings=None):
+        super().__init__(settings)
+        # Known functions and constants handler
+        self.known_functions = dict(_known_functions, **(settings or {}).get(
+            'user_functions', {}))
+        self.known_constants = dict(_known_constants, **(settings or {}).get(
+            'user_constants', {}))
+        
+    
+    def _print_isnan(self, e):
+        arg, = e.args
+        return f"Double.isNaN({self._print(arg)})"
+    
+    def _print_Raise(self, e):
+        arg, = e.args
+        return f"throw new {self._print(arg)}"
+    
+    def _print_RuntimeError_(self, e):
+        arg, = e.args
+        return f"Exception({self._print(arg)})"
+    
+    def _print_Print(self, e):
+        return "System.out." + super()._print_Print(e)

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -27,10 +27,12 @@ known_functions = {
     'atan': 'Math.atan',
     'atan2': 'Math.atan2',
     'atanh': 'Math.atanh',
+    'Cbrt': 'Math.cbrt',
     'ceiling': 'Math.ceil',
     'cos': 'Math.cos',
     'cosh': 'Math.cosh',
     'exp': 'Math.exp',
+    'expm1': 'Math.expm1',
     'floor': 'Math.floor',
     'log': 'Math.log',
     'Max': 'Math.max',
@@ -38,10 +40,26 @@ known_functions = {
     'sign': 'Math.sign',
     'sin': 'Math.sin',
     'sinh': 'Math.sinh',
+    'Sqrt': 'Math.sqrt',
     'tan': 'Math.tan',
     'tanh': 'Math.tanh',
 }
 
+
+class AbstractJavaFamilyPrinter(CodePrinter):
+
+    def _print_Pow(self, expr):
+        PREC = precedence(expr)
+        if equal_valued(expr.exp, -1):
+            return '1/%s' % (self.parenthesize(expr.base, PREC))
+        elif equal_valued(expr.exp, 0.5):
+            return 'Math.sqrt(%s)' % self._print(expr.base)
+        elif expr.exp == S.One/3:
+            return 'Math.cbrt(%s)' % self._print(expr.base)
+        else:
+            return 'Math.pow(%s, %s)' % (self._print(expr.base),
+                                 self._print(expr.exp))
+    
 
 class JavascriptCodePrinter(CodePrinter):
     """"A Printer to convert Python expressions to strings of JavaScript code
@@ -92,18 +110,6 @@ class JavascriptCodePrinter(CodePrinter):
                 'end': self._print(i.upper + 1)})
             close_lines.append("}")
         return open_lines, close_lines
-
-    def _print_Pow(self, expr):
-        PREC = precedence(expr)
-        if equal_valued(expr.exp, -1):
-            return '1/%s' % (self.parenthesize(expr.base, PREC))
-        elif equal_valued(expr.exp, 0.5):
-            return 'Math.sqrt(%s)' % self._print(expr.base)
-        elif expr.exp == S.One/3:
-            return 'Math.cbrt(%s)' % self._print(expr.base)
-        else:
-            return 'Math.pow(%s, %s)' % (self._print(expr.base),
-                                 self._print(expr.exp))
 
     def _print_Rational(self, expr):
         p, q = int(expr.p), int(expr.q)

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -59,9 +59,9 @@ class AbstractJavaFamilyPrinter(CodePrinter):
         else:
             return 'Math.pow(%s, %s)' % (self._print(expr.base),
                                  self._print(expr.exp))
-    
 
-class JavascriptCodePrinter(CodePrinter):
+
+class JavascriptCodePrinter(AbstractJavaFamilyPrinter):
     """"A Printer to convert Python expressions to strings of JavaScript code
     """
     printmethod = '_javascript'

--- a/sympy/printing/tests/test_java.py
+++ b/sympy/printing/tests/test_java.py
@@ -1,0 +1,5 @@
+from sympy.core import oo
+from sympy.printing.java import javacode
+
+def test_constants():
+    assert javacode(oo) == "Double.POSITIVE_INFINITY"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
JavaScript looks supported. But there is no printer for Java.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Code printer for Java
<!-- END RELEASE NOTES -->
