### PR TITLE
Add return type annotation in `_load_pre_generated_assumption_rules` function.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1649,3 +1649,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+HeeJae Chang <hechang@microsoft.com>

--- a/.mailmap
+++ b/.mailmap
@@ -675,6 +675,7 @@ Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
 Haruki Moriguchi <harukimoriguchi@gmail.com>
+HeeJae Chang <hechang@microsoft.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
 Henrik Johansson <henjo2006@gmail.com>
 Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
@@ -1649,4 +1650,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-HeeJae Chang <hechang@microsoft.com>

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -217,7 +217,7 @@ from .sympify import sympify
 from sympy.core.random import _assumptions_shuffle as shuffle
 from sympy.core.assumptions_generated import generated_assumptions as _assumptions
 
-def _load_pre_generated_assumption_rules():
+def _load_pre_generated_assumption_rules() -> FactRules:
     """ Load the assumption rules from pre-generated data
 
     To update the pre-generated data, see :method::`_generate_assumption_rules`


### PR DESCRIPTION
According to a performance log of `pyright` (https://github.com/microsoft/pyright/pull/7729), `inferring` the return type of the method is very expensive. Explicitly adding a return type annotation completely removes this cost.

The root cause is how `full_implications` is constructed (https://github.com/sympy/sympy/blob/master/sympy/core/assumptions_generated.py#L40), but there seems to be no easy way to skip the cost. Therefore, the type is annotated in `_load_pre_generated_assumption_rules` instead. This seems to be the only place where `full_implications` is used (indirectly).

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
