### PR TITLE
Replace all assertions in the code in backend.py with real exceptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1025,6 +1025,7 @@ Nichita Utiu <nikita.utiu+github@gmail.com> <nichitautiu@nichitautiu-desktop.(no
 Nicholas Bollweg <nick.bollweg@gmail.com> <nbollweg@continuum.io>
 Nicholas J.S. Kinar <n.kinar@usask.ca>
 Nick Curtis <nicholas.curtis@uconn.edu> <arghdos@gmail.com>
+Nick Harder <nharder@umich.edu>
 Nicko van Someren <nicko@nicko.org>
 Nico Schlömer <nico.schloemer@gmail.com>
 Nicolas Pourcelot <nicolas.pourcelot@gmail.com>

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -100,7 +100,8 @@ else:
 
 def _simplify_matrix(M):
     """Return a simplified copy of the matrix M"""
-    assert isinstance(M, (Matrix, ImmutableMatrix))
+    if not isinstance(M, (Matrix, ImmutableMatrix)):
+        raise TypeError("The matrix M must be an instance of Matrix or ImmutableMatrix")
     Mnew = M.as_mutable() # makes a copy if mutable
     Mnew.simplify()
     if isinstance(M, ImmutableMatrix):


### PR DESCRIPTION
Replaced assertion with raising a TypeError in core/backend.py when matrix M
is not an instance of Matrix or Immutable Matrix. Does not create accompanying
core/tests/test_backend.py.

(Partially) Fixes #5090 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
