### PR TITLE
Replace asserts in parsing/mathematica.py with exceptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -556,6 +556,7 @@ Eric Nelson <eric.the.red.XLII@gmail.com>
 Eric Wieser <wieser.eric@gmail.com>
 Erik R. Gomez <gomez@kth.se> erik <gomez@kth.se>
 Erik Welch <erik.n.welch@gmail.com>
+Ethan DeGuire <ethandeguire@gmail.com>
 Ethan Ward <etkewa@gmail.com>
 Ethan Ward <etkewa@gmail.com> <ethanward@email.arizona.edu>
 Ethan Ward <etkewa@gmail.com> Ethan Ward <14932247+ethankward@users.noreply.github.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -738,7 +738,8 @@ class MathematicaParser:
             else:
                 stack[-1].append(token)
             pointer += 1
-        assert len(stack) == 1
+        if len(stack) != 1:
+            raise RuntimeError("Stack should have only one element")
         return self._parse_after_braces(stack[0])
 
     def _util_remove_newlines(self, lines: list, tokens: list, inside_enclosure: bool):
@@ -875,14 +876,16 @@ class MathematicaParser:
                         else:
                             node.append(arg2)
                     elif op_type == self.PREFIX:
-                        assert grouping_strat is None
+                        if grouping_strat is not None:
+                            raise TypeError("'Prefix' op_type should not have a grouping strat")
                         if pointer == size - 1 or self._is_op(tokens[pointer + 1]):
                             tokens[pointer] = self._missing_arguments_default[token]()
                         else:
                             node.append(tokens.pop(pointer+1))
                             size -= 1
                     elif op_type == self.POSTFIX:
-                        assert grouping_strat is None
+                        if grouping_strat is not None:
+                            raise TypeError("'Prefix' op_type should not have a grouping strat")
                         if pointer == 0 or self._is_op(tokens[pointer - 1]):
                             tokens[pointer] = self._missing_arguments_default[token]()
                         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #5090


#### Brief description of what is fixed or changed
Asserts in parsing/mathematica.py are replaced with conditional statements that throw relevant errors.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Replaced 3 assert statements with if statements that throw exceptions.
<!-- END RELEASE NOTES -->
