### PR TITLE
Tests for floor function precision errors 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1221,6 +1221,7 @@ Robin Richard <raisin@ecomail.fr> Nornort <francois.lalleve@laposte.net>
 Robin Richard <raisin@ecomail.fr> robinechuca <61911191+robinechuca@users.noreply.github.com>
 Robin Richard <raisin@ecomail.fr> robinechuca <raisin@ecomail.fr>
 Rodrigo Luger <rodluger@gmail.com>
+Rohan Agrawal <rohanagr@umich.edu>
 Rohit Jain <rohitjain3241@gmail.com>
 Rohit Rango <rohit.rango@gmail.com>
 Rohit Sharma <31184621+rohitx007@users.noreply.github.com>

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -732,3 +732,17 @@ def test_issue_20733():
     assert srepr(expr.evalf(2, subs={x: 1})) == "Float('4.0271e+2561', precision=10)"
     assert srepr(expr.evalf(10, subs={x: 1})) == "Float('4.02790050126e+2561', precision=37)"
     assert srepr(expr.evalf(53, subs={x: 1})) == "Float('4.0279005012722099453824067459760158730668154575647110393e+2561', precision=179)"
+
+
+def test_issue_26368():
+    assert floor(log(2**30-1,2)+1) == 30
+    assert floor(log(2**31-1,2)+1) == 31
+    assert floor(log(2**32-1,2)+1) == 32
+    assert floor(log(2**40-1,2)+1) == 40
+    assert floor(log(2**50-1,2)+1) == 50
+
+    assert 2**31 == 2**floor(log(2**31-1,2)+1)
+
+    assert (1 / floor(log(2**40-1,2)+1)) == 0.025
+    assert floor(1/2**40) == 0
+    assert floor (1/2**40) != (1/2**40)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Adds tests related to issue #26368

#### Brief description of what is fixed or changed
Adds tests for floor function to verify that large numbers do not result in precision errors


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
    * Adds tests to test_evalf.py for floor() function 

<!-- END RELEASE NOTES -->
