### PR TITLE
Extra \cdot in LaTeX output for Mul between a numeric power and a polynomial with numeric coefficient since SymPy 1.10

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -558,7 +558,14 @@ class LatexPrinter(Printer):
 
                 _tex += term_tex
                 last_term_tex = term_tex
-            return _tex
+
+            # Debug output before modification
+            # print("Original LaTeX:", _tex)
+            pattern = r'(\^\{[\d]+?\})\s*\\cdot\s*(\\left\(.+?\\right\))'
+            modified_latex = re.sub(pattern, r'\1 \2', _tex)
+            # print("Modified LaTeX:", modified_latex)
+            return modified_latex
+
 
         # Check for unevaluated Mul. In this case we need to make sure the
         # identities are visible, multiple Rational factors are not combined


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fix #26430 

#### Brief description of what is fixed or changed
fixed cdot issue by adding regex to take out the unnecessary cdots 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed cdot issue by adding regex to take out the unnecessary cdots 

* functions
  * Fixed this bug by modifying the _print_Mul function 
<!-- END RELEASE NOTES -->
