### PR TITLE
Add missing type(...) in _trigsimp_inverse

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -229,6 +229,7 @@ Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141
 Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>
+Adrian Kriegel <adrian.kriegel@tu-ilmenau.de>
 Advait Pote <apote2050@gmail.com> <advaitpote@192.168.1.4>
 Advait Pote <apote2050@gmail.com> Advait <apote2050@gmail.com>
 Advait Pote <apote2050@gmail.com> Advait Pote <92469698+AdvaitPote@users.noreply.github.com>

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -518,3 +518,11 @@ def test_trigsimp_inverse():
             assert angle_inverted != angle  # assures simplification happened
             assert sin(angle_inverted) == trigsimp(sin(angle))
             assert cos(angle_inverted) == trigsimp(cos(angle))
+
+def test_trigsimp_inverse_26541():
+    '''
+    Some expressions would raise a TypeError due to a missing type(...).
+    See: https://github.com/sympy/sympy/pull/26541
+    '''
+    # this would throw before
+    trigsimp(cos('x')**2, inverse=True)

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -526,3 +526,4 @@ def test_trigsimp_inverse_26541():
     '''
     # this would throw before
     trigsimp(cos('x')**2, inverse=True)
+    

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -526,4 +526,3 @@ def test_trigsimp_inverse_26541():
     '''
     # this would throw before
     trigsimp(cos('x')**2, inverse=True)
-    

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -438,7 +438,7 @@ def _trigsimp_inverse(rv):
     def f(rv):
         # for simple functions
         g = getattr(rv, 'inverse', None)
-        if (g is not None and isinstance(rv.args[0], g()) and
+        if (g is not None and isinstance(rv.args[0], type(g())) and
                 isinstance(g()(1), TrigonometricFunction)):
             return rv.args[0].args[0]
 

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -438,9 +438,11 @@ def _trigsimp_inverse(rv):
     def f(rv):
         # for simple functions
         g = getattr(rv, 'inverse', None)
-        if (g is not None and isinstance(rv.args[0], type(g())) and
-                isinstance(g()(1), TrigonometricFunction)):
-            return rv.args[0].args[0]
+
+        if g is not None: 
+            g_type = g()
+            if g_type is not None and isinstance(rv.args[0], g_type) and isinstance(g_type(1), TrigonometricFunction):
+                return rv.args[0].args[0]
 
         # for atan2 simplifications, harder because atan2 has 2 args
         if isinstance(rv, atan2):

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -439,7 +439,7 @@ def _trigsimp_inverse(rv):
         # for simple functions
         g = getattr(rv, 'inverse', None)
 
-        if g is not None: 
+        if g is not None:
             g_type = g()
             if g_type is not None and isinstance(rv.args[0], g_type) and isinstance(g_type(1), TrigonometricFunction):
                 return rv.args[0].args[0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Brief description of what is fixed or changed
Changed `isinstance(rv.args[0], g())` to `isinstance(rv.args[0], type(g()))` 
as `g()` does not return a type and this line would therefore raise a TypeError.
>> TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
