### PR TITLE
Added negative support for acos, asin

### DIFF
--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -12,7 +12,7 @@ from sympy.core.sorting import _nodes
 from sympy.core.symbol import Dummy, symbols, Wild
 from sympy.external.gmpy import SYMPY_INTS
 from sympy.functions import sin, cos, exp, cosh, tanh, sinh, tan, cot, coth
-from sympy.functions import atan2
+from sympy.functions import atan2, asin, acos
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.polys import Poly, factor, cancel, parallel_poly_from_expr
@@ -438,6 +438,18 @@ def _trigsimp_inverse(rv):
     def f(rv):
         # for simple functions
         g = getattr(rv, 'inverse', None)
+        if isinstance(rv, asin):
+            x = rv.args[0]
+            if _coeff_isneg(x):
+                print(x.args)
+                return -f(x.args[1].args[0])
+        
+        if isinstance(rv, acos):
+            x = rv.args[0]
+            if _coeff_isneg(x):
+                print(x.args)
+                return S.Pi-f(x.args[1].args[0])
+        
         if (g is not None and isinstance(rv.args[0], g()) and
                 isinstance(g()(1), TrigonometricFunction)):
             return rv.args[0].args[0]


### PR DESCRIPTION
acos(-cos(x)) after simplify(..., inverse=True) fails to simplify to pi - x.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Corrected asin, acos not working in the case for negative numbers. Formerly, `acos(-cos(x))` does not simplify to `pi - x`, `asin(-sin(x))` does not simplify to -x. (This fix only applies to the inverse=True flag)
<!-- END RELEASE NOTES -->
