### PR TITLE
improve assumptions of roots of non-real expression

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -881,6 +881,7 @@ Liwei Cai <cai.lw123@gmail.com>
 Ljubiša Moćić <3rdslasher@gmail.com>
 Lokesh Sharma <lokeshhsharma@gmail.com> <your_email@youremail.com>
 Longqi Wang <iqgnol@gmail.com>
+Lorenz Winkler <lorenz.winkler@tuwien.ac.at>
 Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.noreply.github.com>
 Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -513,6 +513,11 @@ class Pow(Expr):
                 return self.exp.is_imaginary
             return
         real_e = self.exp.is_extended_real
+        if real_b == False and real_e:
+            if self.exp == S.Half:
+                return False
+            if type(self.exp) == Rational and self.exp.nominator == 1:
+                return False
         if real_e is None:
             return
         if real_b and real_e:
@@ -1837,6 +1842,6 @@ power = Dispatcher('power')
 power.add((object, object), Pow)
 
 from .add import Add
-from .numbers import Integer
+from .numbers import Integer, Rational
 from .mul import Mul, _keep_coeff
 from .symbol import Symbol, Dummy, symbols

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -516,7 +516,7 @@ class Pow(Expr):
         if real_b == False and real_e:
             if self.exp == S.Half:
                 return False
-            if type(self.exp) == Rational and self.exp.nominator == 1:
+            if type(self.exp) == Rational and self.exp.numerator == 1:
                 return False
         if real_e is None:
             return

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -513,11 +513,6 @@ class Pow(Expr):
                 return self.exp.is_imaginary
             return
         real_e = self.exp.is_extended_real
-        if real_b == False and real_e:
-            if self.exp == S.Half:
-                return False
-            if type(self.exp) == Rational and self.exp.numerator == 1:
-                return False
         if real_e is None:
             return
         if real_b and real_e:
@@ -565,6 +560,8 @@ class Pow(Expr):
                     return ok
 
         if real_b is False and real_e: # we already know it's not imag
+            if isinstance(self.exp, Rational) and self.exp.p == 1:
+                return False
             from sympy.functions.elementary.complexes import arg
             i = arg(self.base)*self.exp/S.Pi
             if i.is_complex: # finite

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -555,7 +555,7 @@ def test_issue_14815():
     assert sqrt(x).is_extended_negative is False
     x = Symbol('x', extended_real=True)
     assert sqrt(x).is_extended_negative is False
-    assert sqrt(zoo, evaluate=False).is_extended_negative is None
+    assert sqrt(zoo, evaluate=False).is_extended_negative is False
     assert sqrt(nan, evaluate=False).is_extended_negative is None
 
 
@@ -651,3 +651,13 @@ def test_powers_of_I():
 def test_issue_23918():
     b = S(2)/3
     assert (b**x).as_base_exp() == (1/b, -x)
+
+
+def test_issue_26546():
+    x = Symbol('x', real=True)
+    assert x.is_extended_real is True
+    assert sqrt(x+I).is_extended_real is False
+    assert Pow(x+I, S.Half).is_extended_real is False
+    assert Pow(x+I, Rational(1,2)).is_extended_real is False
+    assert Pow(x+I, Rational(1,13)).is_extended_real is False
+    assert Pow(x+I, Rational(2,3)).is_extended_real is None


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #26545 


#### Brief description of what is fixed or changed
Add a simple check in `_eval_is_extended_real` of the `Pow` class, to return `False`, when the n-th root of a non-real expression is taken, i.e. when the base is not real and the exponent is a rational number with a nominator of `1`.

#### Other comments
The explicit checking, wheather the exponent is `Half` using `if self.exp == S.Half:` seems not optimal. Did i forget other fixed fractions, or is there a better way to check this?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Improve the assumptions system by assuming roots of non-real expressions to be non-real themselves
<!-- END RELEASE NOTES -->
