### PR TITLE
polarify meijerg z param prior to hyperexpand

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -577,8 +577,10 @@ def test_cosine_transform():
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S.Half, 0), ()), (
         (S.Half, 0, 0), (S.Half,)), a**2*w**2/4)/(2*pi), w, t) == 1/(a + t)
 
-    assert cosine_transform(1/sqrt(a**2 + t**2), t, w) == sqrt(2)*meijerg(
-        ((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi))
+    res = cosine_transform(1/sqrt(a**2 + t**2), t, w)
+    assert res == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2*exp_polar(0)/4)/(2*sqrt(pi))
+    assert res.replace(exp_polar, exp) == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi))
+
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi)), w, t) == 1/(t*sqrt(a**2/t**2 + 1))
 
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2487,8 +2487,17 @@ def hyperexpand(f, allow_hyper=False, rewrite='default', place=None):
             return r
 
     def do_meijer(ap, bq, z):
-        r = _meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), z,
-                   allow_hyper, rewrite=rewrite, place=place)
+        c = 1
+        if z.extract_multiplicatively(-I):
+            c *= -1
+        zp = 1
+        for zf in z.as_ordered_factors():
+            if zf.is_number:
+                zp *= polarify(zf, lift=True)
+            else:
+                zp *= zf
+        r = c*_meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), zp,
+                             allow_hyper, rewrite=rewrite, place=place)
         if not r.has(nan, zoo, oo, -oo):
             return r
     return f.replace(hyper, do_replace).replace(meijerg, do_meijer)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

partially addresses #26525 (but not the first formula mentioned in the issue title)

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* simplify
    * polarify meijerg z param prior to hyperexpand to fix some flipped signs / incorrect results from hyperexpand for particular z

<!-- END RELEASE NOTES -->
