### PR TITLE
Fix min/max using `default_sort_key`

### DIFF
--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -193,7 +193,7 @@ class KroneckerDelta(Function):
         # to make KroneckerDelta canonical
         # following lines will check if inputs are in order
         # if not, will return KroneckerDelta with correct order
-        if i != min(i, j, key=default_sort_key):
+        if default_sort_key(j) < default_sort_key(i):
             if delta_range:
                 return cls(j, i, delta_range)
             else:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -12,7 +12,7 @@ def is_sqrt(expr):
     return expr.is_Pow and expr.exp.is_Rational and abs(expr.exp) is S.Half
 
 
-def sqrt_depth(p):
+def sqrt_depth(p) -> int:
     """Return the maximum depth of any square root argument of p.
 
     >>> from sympy.functions.elementary.miscellaneous import sqrt
@@ -34,12 +34,11 @@ def sqrt_depth(p):
         return 1
     if p.is_Atom:
         return 0
-    elif p.is_Add or p.is_Mul:
-        return max([sqrt_depth(x) for x in p.args], key=default_sort_key)
-    elif is_sqrt(p):
+    if p.is_Add or p.is_Mul:
+        return max(sqrt_depth(x) for x in p.args)
+    if is_sqrt(p):
         return sqrt_depth(p.base) + 1
-    else:
-        return 0
+    return 0
 
 
 def is_algebraic(p):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
