### PR TITLE
Remove unnecessary `enumerate`

### DIFF
--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -687,7 +687,7 @@ def _pgroup_calcs():
                         range(len(ordered_faces))))
         flat_faces = flatten(ordered_faces)
         new_pgroup = []
-        for i, p in enumerate(pgroup):
+        for p in pgroup:
             h = polyh.copy()
             h.rotate(p)
             c = h.corners

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -588,7 +588,7 @@ def canonical_free(base, gens, g, num_free):
         if x not in base:
             base.append(x)
     h = g
-    for i, transv in enumerate(transversals):
+    for transv in transversals:
         h_i = [size]*num_free
         # find the element s in transversals[i] such that
         # _af_rmul(h, s) has its free elements with the lowest position in h

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1602,7 +1602,7 @@ def eval_sum_residue(f, i_a_b):
 
 def _eval_matrix_sum(expression):
     f = expression.function
-    for n, limit in enumerate(expression.limits):
+    for limit in expression.limits:
         i, a, b = limit
         dif = b - a
         if dif.is_Integer:

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -2626,9 +2626,9 @@ def _extend_y0(Holonomic, n):
     R = annihilator.parent.base
     K = R.get_field()
 
-    for i, j in enumerate(annihilator.listofpoly):
-            if isinstance(j, annihilator.parent.base.dtype):
-                listofpoly.append(K.new(j.to_list()))
+    for j in annihilator.listofpoly:
+        if isinstance(j, annihilator.parent.base.dtype):
+            listofpoly.append(K.new(j.to_list()))
 
     if len(y0) < a or n <= len(y0):
         return y0

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -146,7 +146,7 @@ def _initialize_first_polynomial(N, M, factor_base, idx_1000, idx_5000, seed=Non
     q = best_q
 
     B = []
-    for idx, val in enumerate(q):
+    for val in q:
         q_l = factor_base[val].prime
         gamma = factor_base[val].tmem_p * invert(a // q_l, q_l) % q_l
         if gamma > q_l / 2:

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -3256,9 +3256,9 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 `arg` param in TransferFunctionMatrix should
                 strictly be a nested list containing TransferFunction
                 objects."""))
-        for row_index, row in enumerate(arg):
+        for row in arg:
             temp = []
-            for col_index, element in enumerate(row):
+            for element in row:
                 if not isinstance(element, SISOLinearTimeInvariant):
                     raise TypeError(filldedent("""
                         Each element is expected to be of

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -127,13 +127,13 @@ class Dyadic(Printable, EvalfMixin):
         if isinstance(other, Dyadic):
             other = _check_dyadic(other)
             ol = Dyadic(0)
-            for i, v in enumerate(self.args):
-                for i2, v2 in enumerate(other.args):
+            for v in self.args:
+                for v2 in other.args:
                     ol += v[0] * v2[0] * (v[2].dot(v2[1])) * (v[1].outer(v2[2]))
         else:
             other = _check_vector(other)
             ol = Vector(0)
-            for i, v in enumerate(self.args):
+            for v in self.args:
                 ol += v[0] * v[1] * (v[2].dot(other))
         return ol
 
@@ -320,7 +320,7 @@ class Dyadic(Printable, EvalfMixin):
         from sympy.physics.vector.vector import _check_vector
         other = _check_vector(other)
         ol = Dyadic(0)
-        for i, v in enumerate(self.args):
+        for v in self.args:
             ol += v[0] * (v[1].outer((v[2].cross(other))))
         return ol
 

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -102,7 +102,7 @@ def express(expr, frame, frame2=None, variables=False):
             expr = expr.subs(subs_dict)
         # Re-express in this frame
         outvec = Vector([])
-        for i, v in enumerate(expr.args):
+        for v in expr.args:
             if v[1] != frame:
                 temp = frame.dcm(v[1]) * v[0]
                 if Vector.simp:
@@ -118,7 +118,7 @@ def express(expr, frame, frame2=None, variables=False):
             frame2 = frame
         _check_frame(frame2)
         ol = Dyadic(0)
-        for i, v in enumerate(expr.args):
+        for v in expr.args:
             ol += express(v[0], frame, variables=variables) * \
                   (express(v[1], frame, variables=variables) |
                    express(v[2], frame2, variables=variables))
@@ -198,7 +198,7 @@ def time_derivative(expr, frame, order=1):
 
     if isinstance(expr, Vector):
         outlist = []
-        for i, v in enumerate(expr.args):
+        for v in expr.args:
             if v[1] == frame:
                 outlist += [(express(v[0], frame, variables=True).diff(t),
                              frame)]
@@ -210,7 +210,7 @@ def time_derivative(expr, frame, order=1):
 
     if isinstance(expr, Dyadic):
         ol = Dyadic(0)
-        for i, v in enumerate(expr.args):
+        for v in expr.args:
             ol += (v[0].diff(t) * (v[1] | v[2]))
             ol += (v[0] * (time_derivative(v[1], frame) | v[2]))
             ol += (v[0] * (v[1] | time_derivative(v[2], frame)))

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -100,14 +100,14 @@ class Point:
         oldlist = [[]]
         while outlist != oldlist:
             oldlist = outlist[:]
-            for i, v in enumerate(outlist):
+            for v in outlist:
                 templist = v[-1]._pdlist[num].keys()
-                for i2, v2 in enumerate(templist):
+                for v2 in templist:
                     if not v.__contains__(v2):
                         littletemplist = v + [v2]
                         if not outlist.__contains__(littletemplist):
                             outlist.append(littletemplist)
-        for i, v in enumerate(oldlist):
+        for v in oldlist:
             if v[-1] != other:
                 outlist.remove(v)
         outlist.sort(key=len)

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -104,13 +104,13 @@ class Vector(Printable, EvalfMixin):
         if isinstance(other, Dyadic):
             other = _check_dyadic(other)
             ol = Vector(0)
-            for i, v in enumerate(other.args):
+            for v in other.args:
                 ol += v[0] * v[2] * (v[1].dot(self))
             return ol
         other = _check_vector(other)
         out = S.Zero
-        for i, v1 in enumerate(self.args):
-            for j, v2 in enumerate(other.args):
+        for v1 in self.args:
+            for v2 in other.args:
                 out += ((v2[0].T) * (v2[1].dcm(v1[1])) * (v1[0]))[0]
         if Vector.simp:
             return trigsimp(out, recursive=True)
@@ -205,8 +205,8 @@ class Vector(Printable, EvalfMixin):
         from sympy.physics.vector.dyadic import Dyadic
         other = _check_vector(other)
         ol = Dyadic(0)
-        for i, v in enumerate(self.args):
-            for i2, v2 in enumerate(other.args):
+        for v in self.args:
+            for v2 in other.args:
                 # it looks this way because if we are in the same frame and
                 # use the enumerate function on the same frame in a nested
                 # fashion, then bad things happen

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -152,7 +152,7 @@ def _linear_eq_to_dict(eqs, syms):
     coeffs = []
     ind = []
     symset = set(syms)
-    for i, e in enumerate(eqs):
+    for e in eqs:
         if e.is_Equality:
             coeff, terms = _lin_eq2dict(e.lhs, symset)
             cR, tR = _lin_eq2dict(e.rhs, symset)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1003,7 +1003,7 @@ class PrettyPrinter(Printer):
         from sympy.physics.control.lti import MIMOParallel
         args = list(expr.args)
         pretty_args = []
-        for i, a in enumerate(reversed(args)):
+        for a in reversed(args):
             if (isinstance(a, MIMOParallel) and len(expr.args) > 1):
                 expression = self._print(a)
                 expression.baseline = expression.height()//2
@@ -1257,7 +1257,7 @@ class PrettyPrinter(Printer):
         last_valence = None
         prev_map = None
 
-        for i, index in enumerate(indices):
+        for index in indices:
             indpic = self._print(index.args[0])
             if ((index in index_map) or prev_map) and last_valence == index.is_up:
                 if index.is_up:

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -417,7 +417,7 @@ class Linear(DiophantineEquationType):
         for Ai, Bi in zip(A, B):
             tot_x, tot_y = [], []
 
-            for j, arg in enumerate(Add.make_args(c)):
+            for arg in Add.make_args(c):
                 if arg.is_Integer:
                     # example: 5 -> k = 5
                     k, p = arg, S.One

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1746,7 +1746,7 @@ def _weak_component_solver(wcc, t):
 
     sol = []
 
-    for j, scc in enumerate(wcc):
+    for scc in wcc:
         eqs = scc
         funcs = _get_funcs_from_canon(eqs)
 

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -806,7 +806,7 @@ def _simplify_variable_coeff(sol, syms, func, funcarg):
         final = sol.subs(sym, func(funcarg))
 
     else:
-        for key, sym in enumerate(syms):
+        for sym in syms:
             final = sol.subs(sym, func(funcarg))
 
     return simplify(final.subs(eta, funcarg))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -97,7 +97,7 @@ def recast_to_symbols(eqs, symbols):
     symbols = list(ordered(symbols))
     swap_sym = {}
     i = 0
-    for j, s in enumerate(symbols):
+    for s in symbols:
         if not isinstance(s, Symbol) and s not in swap_sym:
             swap_sym[s] = Dummy('X%d' % i)
             i += 1
@@ -1418,7 +1418,7 @@ def _solve(f, *symbols, **flags):
             f = f.simplify()  # failure imminent w/o help
 
         cond = neg = True
-        for i, (expr, cnd) in enumerate(f.args):
+        for expr, cnd in f.args:
             # the explicit condition for this expr is the current cond
             # and none of the previous conditions
             cond = And(neg, cnd)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1079,7 +1079,7 @@ class ArrayContraction(_CodegenArrayAbstract):
         contraction_indices_remaining = []
         contraction_indices_args = [[] for i in expr.args]
         backshift = set()
-        for i, contraction_group in enumerate(contraction_indices):
+        for contraction_group in contraction_indices:
             for j in range(len(expr.args)):
                 if not isinstance(expr.args[j], ArrayAdd):
                     continue
@@ -1795,7 +1795,7 @@ class _EditArrayContraction:
     def get_contraction_indices(self) -> List[List[int]]:
         contraction_indices: List[List[int]] = [[] for i in range(self.number_of_contraction_indices)]
         current_position: int = 0
-        for i, arg_with_ind in enumerate(self.args_with_ind):
+        for arg_with_ind in self.args_with_ind:
             for j in arg_with_ind.indices:
                 if j is not None:
                     contraction_indices[j].append(current_position)

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -171,7 +171,7 @@ def _find_trivial_kronecker_products_broadcast(expr: ArrayTensorProduct):
     newargs: List[Basic] = []
     removed = []
     count_dims = 0
-    for i, arg in enumerate(expr.args):
+    for arg in expr.args:
         count_dims += get_rank(arg)
         shape = get_shape(arg)
         current_range = [count_dims-i for i in range(len(shape), 0, -1)]
@@ -443,7 +443,7 @@ def _(expr: PermuteDims):
     pinv = _af_invert(expr.permutation.array_form)
     shift = list(accumulate([1 if i in subremoved else 0 for i in range(len(p))]))
     premoved = [pinv[i] for i in subremoved]
-    p2 = [e - shift[e] for i, e in enumerate(p) if e not in subremoved]
+    p2 = [e - shift[e] for e in p if e not in subremoved]
     # TODO: check if subremoved should be permuted as well...
     newexpr = _permute_dims(subexpr, p2)
     premoved = sorted(premoved)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -171,7 +171,7 @@ class NDimArray(Printable):
 
     def _get_tuple_index(self, integer_index):
         index = []
-        for i, sh in enumerate(reversed(self.shape)):
+        for sh in reversed(self.shape):
             index.append(integer_index % sh)
             integer_index //= sh
         index.reverse()

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3323,7 +3323,7 @@ class TensMul(TensExpr, AssocOp):
 
         for pos1, arg_indices in enumerate(args_indices):
 
-            for index_pos, index in enumerate(arg_indices):
+            for index in arg_indices:
                 if not isinstance(index, TensorIndex):
                     raise TypeError("expected TensorIndex")
                 if -index in free2pos1:
@@ -3498,7 +3498,7 @@ class TensMul(TensExpr, AssocOp):
     def _get_position_offset_for_indices(self):
         arg_offset = [None for i in range(self.ext_rank)]
         counter = 0
-        for i, arg in enumerate(self.args):
+        for arg in self.args:
             if not isinstance(arg, TensExpr):
                 continue
             for j in range(arg.ext_rank):
@@ -3927,7 +3927,7 @@ class TensMul(TensExpr, AssocOp):
                 continue
             shifts[i] = shift
         free = [(ind, p - shifts[pos_map[p]]) for (ind, p) in free if pos_map[p] not in elim]
-        dum = [(p0 - shifts[pos_map[p0]], p1 - shifts[pos_map[p1]]) for i, (p0, p1) in enumerate(dum) if pos_map[p0] not in elim and pos_map[p1] not in elim]
+        dum = [(p0 - shifts[pos_map[p0]], p1 - shifts[pos_map[p1]]) for p0, p1 in dum if pos_map[p0] not in elim and pos_map[p1] not in elim]
 
         res = sign*TensMul(*args).doit()
         if not isinstance(res, TensExpr):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1428,7 +1428,7 @@ class JuliaCodeGen(CodeGen):
 
         # Inputs
         args = []
-        for i, arg in enumerate(routine.arguments):
+        for arg in routine.arguments:
             if isinstance(arg, OutputArgument):
                 raise CodeGenError("Julia: invalid argument of type %s" %
                                    str(type(arg)))
@@ -1463,7 +1463,7 @@ class JuliaCodeGen(CodeGen):
     def _call_printer(self, routine):
         declarations = []
         code_lines = []
-        for i, result in enumerate(routine.results):
+        for result in routine.results:
             if isinstance(result, Result):
                 assign_to = result.result_var
             else:
@@ -1636,7 +1636,7 @@ class OctaveCodeGen(CodeGen):
 
         # Outputs
         outs = []
-        for i, result in enumerate(routine.results):
+        for result in routine.results:
             if isinstance(result, Result):
                 # Note: name not result_var; want `y` not `y(i)` for Indexed
                 s = self._get_symbol(result.name)
@@ -1651,7 +1651,7 @@ class OctaveCodeGen(CodeGen):
 
         # Inputs
         args = []
-        for i, arg in enumerate(routine.arguments):
+        for arg in routine.arguments:
             if isinstance(arg, (OutputArgument, InOutArgument)):
                 raise CodeGenError("Octave: invalid argument of type %s" %
                                    str(type(arg)))
@@ -1681,7 +1681,7 @@ class OctaveCodeGen(CodeGen):
     def _call_printer(self, routine):
         declarations = []
         code_lines = []
-        for i, result in enumerate(routine.results):
+        for result in routine.results:
             if isinstance(result, Result):
                 assign_to = result.result_var
             else:
@@ -1920,7 +1920,7 @@ class RustCodeGen(CodeGen):
             if isinstance(arg, ResultBase) and not arg.dimensions:
                 dereference.append(arg.name)
 
-        for i, result in enumerate(routine.results):
+        for result in routine.results:
             if isinstance(result, Result):
                 assign_to = result.result_var
                 returns.append(str(result.result_var))

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -191,7 +191,7 @@ class BasisDependentAdd(BasisDependent, Add):
         components = {}
 
         # Check each arg and simultaneously learn the components
-        for i, arg in enumerate(args):
+        for arg in args:
             if not isinstance(arg, cls._expr_type):
                 if isinstance(arg, Mul):
                     arg = cls._mul_func(*(arg.args))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
