### PR TITLE
Prevent RecursionError in nc_simplify for floating point coefficients

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1654,3 +1654,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+rrodenbusch <rrodenbusch@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1616,6 +1616,7 @@ richierichrawr <richierichrawr@users.noreply.github.com>
 rimibis <33387803+rimibis@users.noreply.github.com>
 risubaba <risubhjain1010@gmail.com>
 ritikBhandari <ritikbhandari68@gmail.com>
+rrodenbusch <rrodenbusch@gmail.com>
 rushyam <rushyamsonu@gmail.com>
 sachinSingh16-09 <sachinishu02@gmail.com>
 samithkavishke <55777141+samithkavishke@users.noreply.github.com>
@@ -1654,4 +1655,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-rrodenbusch <rrodenbusch@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1188,6 +1188,7 @@ Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
 Rich LaSota <rjlasota@gmail.com>
 Richard Otis <richard.otis@outlook.com> <ovolve@users.noreply.github.com>
 Richard Otis <richard.otis@outlook.com> <richard.otis@jpl.nasa.gov>
+Richard Rodenbusch <rrodenbusch@gmail.com> rrodenbusch <rrodenbusch@gmail.com>
 Richard Samuel <98638849+samuelard7@users.noreply.github.com>
 Richard Samuel <samuelrichard214@gmail.com>
 Rick Muller <rpmuller@gmail.com>
@@ -1616,7 +1617,6 @@ richierichrawr <richierichrawr@users.noreply.github.com>
 rimibis <33387803+rimibis@users.noreply.github.com>
 risubaba <risubhjain1010@gmail.com>
 ritikBhandari <ritikbhandari68@gmail.com>
-rrodenbusch <rrodenbusch@gmail.com>
 rushyam <rushyamsonu@gmail.com>
 sachinSingh16-09 <sachinishu02@gmail.com>
 samithkavishke <55777141+samithkavishke@users.noreply.github.com>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -9,7 +9,7 @@ from sympy.core.exprtools import factor_nc
 from sympy.core.parameters import global_parameters
 from sympy.core.function import (expand_log, count_ops, _mexpand,
     nfloat, expand_mul, expand)
-from sympy.core.numbers import Float, I, pi, Rational
+from sympy.core.numbers import Float, I, pi, Rational, equal_valued
 from sympy.core.relational import Relational
 from sympy.core.rules import Transform
 from sympy.core.sorting import ordered
@@ -1758,7 +1758,7 @@ def nc_simplify(expr, deep=True):
         # get the non-commutative part
         c_args, args = expr.args_cnc()
         com_coeff = Mul(*c_args)
-        if com_coeff != 1 and com_coeff != 1.0:
+        if not equal_valued(com_coeff, 1):
             return com_coeff*nc_simplify(expr/com_coeff, deep=deep)
 
     inv_tot, args = _reduce_inverses(args)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1758,7 +1758,7 @@ def nc_simplify(expr, deep=True):
         # get the non-commutative part
         c_args, args = expr.args_cnc()
         com_coeff = Mul(*c_args)
-        if com_coeff != 1:
+        if com_coeff != 1 and com_coeff != 1.0:
             return com_coeff*nc_simplify(expr/com_coeff, deep=deep)
 
     inv_tot, args = _reduce_inverses(args)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1080,3 +1080,8 @@ def test_reduce_inverses_nc_pow():
     x, y = symbols("x y", positive=True)
     assert expand((x*y)**Z) == x**Z * y**Z
     assert simplify(x**Z * y**Z) == expand((x*y)**Z)
+
+def test_nc_recursion_coeff():
+    X = symbols("X", commutative = False)
+    assert (2 * cos(pi/3) * X).simplify() == X
+    assert (2.0 * cos(pi/3) * X).simplify() == X


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26556

#### Brief description of what is fixed or changed
Allow simplification of expressions with floating point coefficients for non-commutative symbols 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
   * Prevent RecursionError when simplifying expressions with floating-point coefficients on a non-commutative symbol
<!-- END RELEASE NOTES -->
