### PR TITLE
Prevent extra \cdot in latex output for unevaluated Mul 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1645,6 +1645,7 @@ vishal <vishal.panjwani15@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>
+xzdlj <xzdlj@outlook.com>
 ylemkimon <ylemkimon@naver.com> <mail@ylem.kim>
 znxftw <vishnu2101@gmail.com>
 zsc347 <zsc347@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -120,7 +120,7 @@ greek_letters_set = frozenset(greeks)
 
 _between_two_numbers_p = (
     re.compile(r'[0-9][} ]*$'),  # search
-    re.compile(r'[0-9]'),  # match
+    re.compile(r'(\d|\\frac{\d+}{\d+})'),  # match
 )
 
 
@@ -548,7 +548,7 @@ class LatexPrinter(Printer):
                         term_tex = r"\left(%s\right)" % term_tex
 
                     if  _between_two_numbers_p[0].search(last_term_tex) and \
-                        _between_two_numbers_p[1].match(str(term)):
+                        _between_two_numbers_p[1].match(term_tex):
                         # between two numbers
                         _tex += numbersep
                     elif _tex:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -133,6 +133,9 @@ def test_latex_basic():
     assert latex(Mul(S.Half, -5, S.Half, evaluate=False)) == r"\frac{1}{2} \left(-5\right) \frac{1}{2}"
     assert latex(Mul(5, I, 5, evaluate=False)) == r"5 i 5"
     assert latex(Mul(5, I, -5, evaluate=False)) == r"5 i \left(-5\right)"
+    assert latex(Mul(Pow(x, 2), S.Half*x + 1)) == r"x^{2} \left(\frac{x}{2} + 1\right)"
+    assert latex(Mul(Pow(x, 3), Rational(2, 3)*x + 1)) == r"x^{3} \left(\frac{2 x}{3} + 1\right)"
+    assert latex(Mul(Pow(x, 11), 2*x + 1)) == r"x^{11} \left(2 x + 1\right)"
 
     assert latex(Mul(0, 1, evaluate=False)) == r'0 \cdot 1'
     assert latex(Mul(1, 0, evaluate=False)) == r'1 \cdot 0'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix https://github.com/sympy/sympy/issues/26430
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Updated the regex which match to the latter argument in `Mul` to prevent extra `\dot` in latex output.

Now it looks like
```python
>>> latex(Mul(Pow(x, 2), 2*x + 1))
x^{2} \\left(2 x + 1\\right)
```

instead of
```python
>>> latex(Mul(Pow(x, 2), 2*x + 1))
x^{2} \\cdot \\left(2 x + 1\\right)
```


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Fixed issue with latex output for unevaluated Mul.
<!-- END RELEASE NOTES -->