### PR TITLE
Delegate analytic_func to mutable matrix in ImmutableMatrix

### DIFF
--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -74,7 +74,9 @@ class ImmutableRepMatrix(RepMatrix, MatrixExpr): # type: ignore
 
     is_diagonalizable.__doc__ = SparseRepMatrix.is_diagonalizable.__doc__
     is_diagonalizable = cacheit(is_diagonalizable)
-
+    
+    def analytic_func(self, f, x):
+        return self.as_mutable().analytic_func(f, x).as_immutable()
 
 
 class ImmutableDenseMatrix(DenseMatrix, ImmutableRepMatrix):  # type: ignore

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -74,7 +74,7 @@ class ImmutableRepMatrix(RepMatrix, MatrixExpr): # type: ignore
 
     is_diagonalizable.__doc__ = SparseRepMatrix.is_diagonalizable.__doc__
     is_diagonalizable = cacheit(is_diagonalizable)
-    
+
     def analytic_func(self, f, x):
         return self.as_mutable().analytic_func(f, x).as_immutable()
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #26553
analytic_func() method to delegate the call to the mutable version of the matrix temporarily, allowing the method to operate correctly while preserving immutability.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Delegate analytic_func to mutable matrix in ImmutableMatrix
<!-- END RELEASE NOTES -->
