### PR TITLE
Fix digamma integral

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1418,6 +1418,7 @@ Robin Richard <raisin@ecomail.fr> robinechuca <61911191+robinechuca@users.norepl
 Robin Richard <raisin@ecomail.fr> robinechuca <raisin@ecomail.fr>
 Rodrigo Luger <rodluger@gmail.com>
 Roelof Rietbroek <r.rietbroek@utwente.nl> Roelof Rietbroek <strawpants@users.noreply.github.com>
+Roger Balsach <rogerbalsach2@gmail.com> Roger Balsach <rogerbalsach2@gmail.com>
 Rohit Jain <rohitjain3241@gmail.com>
 Rohit Rango <rohit.rango@gmail.com>
 Rohit Sharma <31184621+rohitx007@users.noreply.github.com>

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -232,7 +232,46 @@ def test_lerchphi_expansion():
 
 
 def test_lerchphi_finite():
+    assert lerchphi(0, -1, -1).is_finite is True
+    assert lerchphi(0, -1, 0).is_finite is True
+    assert lerchphi(0, 0, 0).is_finite is True
+    assert lerchphi(0, -1, a).is_finite is True
+    assert lerchphi(0, 1, -1).is_finite is True
+    assert lerchphi(0, 2, -1).is_finite is True
+    assert lerchphi(0, 1, 0).is_finite is False
+    assert lerchphi(0, 1, a).is_finite is None
+    assert lerchphi(0, s, -1).is_finite is True
+    assert lerchphi(0, s, 0).is_finite is None
+    assert lerchphi(0, s, a).is_finite is None
+
     assert lerchphi(1, 1, a).is_finite is False
+    assert lerchphi(1, 0, a).is_finite is True
+    assert lerchphi(1, s, 0).is_finite is None
+    assert lerchphi(1, 1, -1).is_finite is False
+    assert lerchphi(1, 2, -1).is_finite is True
+    assert lerchphi(z, 0, a).is_finite is True
+
+    assert lerchphi(z, 2, -1).is_finite is None
+    assert lerchphi(z, 1, -1).is_finite is None
+    assert lerchphi(z, -1, -1).is_finite is True
+    assert lerchphi(z, -3, 0).is_finite is True
+    assert lerchphi(-1, 1, -1).is_finite is False
+    assert lerchphi(2, 1, 0).is_finite is False
+    assert lerchphi(-1, 2, -1).is_finite is False
+    assert lerchphi(2, -1, 0).is_finite is True
+    assert lerchphi(0.5, -1, 0).is_finite is True
+    assert lerchphi(0.5+0.5j, 0, 0).is_finite is True
+    assert lerchphi(2, s, 0).is_finite is None
+    assert lerchphi(2, 1j, 0).is_finite is True
+    assert lerchphi(2, 1+1j, 0).is_finite is False
+
+    # The following tests return None for lack of proper implementation:
+    assert lerchphi(oo, 2, 2).is_finite is None
+    assert lerchphi(2, oo, 2).is_finite is None
+    assert lerchphi(2, 2, oo).is_finite is None
+    assert lerchphi(2, 2, 2).is_finite is None
+
+    assert lerchphi(a, s, z).is_finite is None
 
 
 def test_lerchphi_leadterm():

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -231,6 +231,16 @@ def test_lerchphi_expansion():
     assert myexpand(lerchphi(exp(I*pi*Rational(2, 5)), s, a), None)
 
 
+def test_lerchphi_finite():
+    assert lerchphi(1, 1, a).is_finite is False
+
+
+def test_lerchphi_leadterm():
+    from sympy.functions.special.gamma_functions import digamma
+    assert (lerchphi(1-x, 1, a)._eval_as_leading_term(x, logx=None, cdir=0)
+            == -log(x) - S.EulerGamma - digamma(a))
+
+
 def test_stieltjes():
     assert isinstance(stieltjes(x), stieltjes)
     assert isinstance(stieltjes(x, a), stieltjes)

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -85,6 +85,12 @@ def test_zeta_series():
         zeta(x, z) - x*(a-z)*zeta(x+1, z) + O((a-z)**2, (a, z))
 
 
+def test_zeta_leadterm():
+    assert zeta(2+x, 2-x).as_leading_term(x) == zeta(2, 2)
+    assert zeta(1+x, 4).as_leading_term(x) == 1 / x
+    assert zeta(1-I*x**3, 4).as_leading_term(x) == I / x**3
+
+
 def test_dirichlet_eta_eval():
     assert dirichlet_eta(0) == S.Half
     assert dirichlet_eta(-1) == Rational(1, 4)
@@ -276,8 +282,25 @@ def test_lerchphi_finite():
 
 def test_lerchphi_leadterm():
     from sympy.functions.special.gamma_functions import digamma
-    assert (lerchphi(1-x, 1, a)._eval_as_leading_term(x, logx=None, cdir=0)
+    h = S.Half
+    assert (lerchphi(1-x, 1, a).as_leading_term(x)
             == -log(x) - S.EulerGamma - digamma(a))
+    assert lerchphi(1+x, 3, 4).as_leading_term(x) == zeta(3, 4)
+    assert lerchphi(1, 1+x, 3).as_leading_term(x) == 1 / x
+    assert lerchphi(1, 1+x**2, 3).as_leading_term(x) == 1 / x**2
+    assert lerchphi(S.One/10, h, x).as_leading_term(x) == 1 / sqrt(x)
+    assert (lerchphi(S.One/10, h, x-2).as_leading_term(x)
+            == 1 / (100*sqrt(x)))
+    assert lerchphi(z+x, h/2, x-1).as_leading_term(x) == z / x**(h/2)
+    assert lerchphi(1-x, 2+x**2, a).as_leading_term(x) == zeta(2, a)
+    # Missing implementation
+    assert lerchphi(2 + x, 0, 1).as_leading_term(x) == lerchphi(2 + x, 0, 1)
+
+
+def test_lerchphi_nseries():
+    from sympy.core.function import PoleError
+    raises(PoleError,
+           lambda: lerchphi(1-x, 1, z)._eval_nseries(x, n=1, logx=None))
 
 
 def test_stieltjes():

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.function import ArgumentIndexError, expand_mul, DefinedFunction
-from sympy.core.logic import fuzzy_not
+from sympy.core.logic import fuzzy_not, fuzzy_or
 from sympy.core.numbers import pi, I, Integer
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -215,6 +215,37 @@ class lerchphi(DefinedFunction):
 
     def _eval_rewrite_as_polylog(self, z, s, a, **kwargs):
         return self._eval_rewrite_helper(polylog)
+
+    def _eval_is_finite(self):
+        z, s, a = self.args
+        if z.is_infinite or s.is_infinite or a.is_infinite:
+            # TODO: Write a valid implementation for infinite numbers.
+            return None
+        if z.is_zero:
+            # a^(-s)
+            # I follow the sympy convention of 0^0 = 1
+            return fuzzy_or([re(s).is_nonpositive, a.is_nonzero])
+        # The following parts assume analytic continuation
+        z_is_one = (z-1).is_zero
+        if z_is_one:
+            # zeta(s, a)
+            return (s-1).is_nonzero
+        if s.is_zero:
+            # 1/(1-z)
+            # One could be tempted to exclude z=1,
+            # but lerchphi(1,0,a)=zeta(0,a) is finite.
+            return True
+        if a.is_integer and a.is_nonpositive:
+            # The sum contains 0^(-s)
+            if re(s).is_positive:
+                # These are would be divergent results, but the actual result
+                # depends on z
+                if z_is_one is None and (s-1).is_zero is not True:
+                    return None
+                if z.is_zero is None and a.is_zero is not True:
+                    return None
+            return re(s).is_nonpositive
+        return None
 
 ###############################################################################
 ###################### POLYLOGARITHM ##########################################

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -247,6 +247,41 @@ class lerchphi(DefinedFunction):
             return re(s).is_nonpositive
         return None
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        '''
+        Use the relation lerchphi(1, s, a) = zeta(s, a) for z = 1 and the
+        expansions given in [1]
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Lerch_zeta_function#Series_representations
+
+        '''
+        from sympy.functions.special.gamma_functions import digamma, gamma
+        z, s, a = self.args
+        z0, s0, a0 = (arg.subs(x, 0).cancel() for arg in self.args)
+        lt = S.Zero
+        if (z - 1).is_zero:
+            # Let zeta function handle this case
+            lt = zeta(s, a)
+        elif (z0 - 1).is_zero:
+            if (s - 1).is_zero:
+                if not a.has(x):
+                    # This could be generalised for arbitrary a if we check
+                    # that this term doesn't vanish.
+                    lt = -log(-log(z)) - S.EulerGamma - digamma(a)
+            elif s.is_integer and s.is_positive or re(s0 - 1).is_positive:
+                return zeta(s0, a0)
+            elif re(s0 - 1).is_negative:
+                lt = gamma(1-s)*(-log(z))**(s-1)
+        elif a0.is_integer and a0.is_nonpositive:
+            if s.is_real and s.is_positive:
+                lt = z**(-a0)/(a-a0)**s
+        if lt.is_zero:
+            return super()._eval_as_leading_term(x, logx=logx, cdir=cdir)
+        return lt._eval_as_leading_term(x, logx=logx, cdir=cdir)
+
 ###############################################################################
 ###################### POLYLOGARITHM ##########################################
 ###############################################################################
@@ -609,6 +644,13 @@ class zeta(DefinedFunction):
 
         if e.is_negative and not s.is_positive:
             raise NotImplementedError
+
+        s0, a0 = (arg.subs(x, 0).cancel() for arg in self.args)
+        if (s0 - 1).is_nonzero:
+            if (lt := zeta(s0, a0)).is_nonzero:
+                return lt
+        elif s.has(x) and (s0 - 1).is_zero:
+            return (1 / (s - 1))._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
         return super(zeta, self)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2262,3 +2262,8 @@ def test_issue_29909():
 
     assert integrate(f, x) == F
     assert F.diff(x).equals(f)
+
+
+def test_issue_26523():
+    Int = Integral((1 - t**z) / (1 - t), (t, 0, 1))
+    assert Int.doit() == polygamma(0, z + 1) + EulerGamma

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -96,6 +96,9 @@ def heuristics(e, z, z0, dir):
                         return heuristics(m, z, z0, dir)
                     return
                 return
+            elif (not (l.has(S.Infinity) or l.has(S.NegativeInfinity))
+                  and l.is_finite is False):
+                r.append(S.ComplexInfinity)
             if isinstance(l, Limit) or l is S.NaN:
                 return
             r.append(l)
@@ -353,6 +356,8 @@ class Limit(Expr):
                 return coeff
             if coeff.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity, S.NaN):
                 return self
+            from sympy.simplify.gammasimp import gammasimp
+            coeff = gammasimp(coeff)
             if not coeff.has(newz):
                 if ex.is_positive:
                     return S.Zero

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -319,7 +319,7 @@ def test_heuristic():
     assert heuristics(sin(1/x) + atan(x), x, 0, '+') == AccumBounds(-1, 1)
     assert limit(log(2 + sqrt(atan(x))*sqrt(sin(1/x))), x, 0) == log(2)
     # https://github.com/sympy/sympy/issues/26523
-    assert heuristics(lerchphi(x, 1, a), x, 1, '-') != lerchphi(1, 1, a)
+    assert heuristics(lerchphi(x, 1, a) + log(x-1), x, 1, '-') is None
 
 
 def test_issue_3871():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -20,7 +20,8 @@ from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, as
                                                       atan, cos, cot, csc, sec, sin, tan)
 from sympy.functions.special.bessel import (besseli, bessely, besselj, besselk)
 from sympy.functions.special.error_functions import (Ei, erf, erfc, erfi, fresnelc, fresnels)
-from sympy.functions.special.gamma_functions import (digamma, gamma, uppergamma)
+from sympy.functions.special.gamma_functions import (digamma, gamma, polygamma, uppergamma)
+from sympy.functions.special.zeta_functions import lerchphi
 from sympy.functions.special.hyper import meijerg
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.series.limits import (Limit, limit)
@@ -314,8 +315,11 @@ def test_set_signs():
 
 def test_heuristic():
     x = Symbol("x", real=True)
+    a = Symbol("a")
     assert heuristics(sin(1/x) + atan(x), x, 0, '+') == AccumBounds(-1, 1)
     assert limit(log(2 + sqrt(atan(x))*sqrt(sin(1/x))), x, 0) == log(2)
+    # https://github.com/sympy/sympy/issues/26523
+    assert heuristics(lerchphi(x, 1, a), x, 1, '-') != lerchphi(1, 1, a)
 
 
 def test_issue_3871():
@@ -1487,3 +1491,14 @@ def test_issue_28975():
     assert limit(3**(1/(x-1)), x, 1, dir='+') == oo
     assert limit(3**(tan(x)), x, pi/2, dir='-') == oo
     assert limit(3**(tan(x)), x, pi/2, dir='+') == 0
+
+
+def test_issue_26523():
+    expr = -x**(z + 1)*lerchphi(x, 1, z + 1) - log(x - 1)
+    L = Limit(expr, x, 1, '-')
+    assert L.doit() == polygamma(0, z + 1) + EulerGamma - I*pi
+    expr = (-x*x**z*z*lerchphi(x, 1, z + 1)*gamma(z + 1)/gamma(z + 2)
+            - x*x**z*lerchphi(x, 1, z + 1)*gamma(z + 1)/gamma(z + 2)
+            - log(x - 1))
+    L = Limit(expr, x, 1, '-')
+    assert L.doit() == polygamma(0, z + 1) + EulerGamma - I*pi


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26523
Fixes #26707


#### Brief description of what is fixed or changed

Added regression tests
Implemented the functions _eval_is_finite and _eval_as_leading_term for the lerchphi class.
`lerchphi._eval_is_finite` has been implemented with finite complex numbers in mind. A possible extension to handle infinite arguments is left for the future.
The divergences considered are the following:
$$\Phi(0, s, a) = \frac{1}{a^s}$$
Which diverges when $a=0$ and $s \in \mathbb{R}^+$.
When $z \neq 0$, the function diverges when $a \in - \mathbb{N}$ and $s \in \mathbb{R}^+$.
$$\Phi(z, s, -k) = \sum\_{n=0}^\infty \frac{z^n}{(n-k)^s}$$
Finally, for $z=1$, the function has the same poles as the zeta function: $s = 1$.
No analytic continuation has been considered, except for $\Phi(1,s,a)=\zeta(s,a)$.
`lerchphi._eval_as_leading_term` has been implemented. It handles the following limits:
$$\lim\_{z \to 1} \Phi(z, 1, a_0) = -\log(\log(z)) - \gamma_E - \psi(a_0)$$
If $s \in \mathbb{N}^+$ or $\Re(s_0) > 1$:
$$\lim\_{(z, s, a) \to (1, s_0, a_0)} \Phi(z, s, a) = \zeta(s_0, a_0)$$
If $\Re(s_0) < 1$:
$$\lim\_{(z, s) \to (1, s_0)} \Phi(z, s, a) = \Gamma(1-s) (-\log(z))^{s-1}$$
If $a_0 \in -\mathbb{N}$ and $s \in \mathbb{R}^+$:
$$\lim\_{a \to a_0} \Phi(z, s, a) = \frac{z^{-a_0}}{(a-a_0)^s}$$

Added new functionality to the `zeta._eval_as_leading_term` method.
It adds the following cases:
$$\lim\_{(s,a) \to (s_0, a_0)} \zeta(s, a) = \zeta(s_0, a_0), \qquad \text{if} \qquad s_0 \neq 1$$
$$\lim\_{(s,a) \to (1, a_0)} \zeta(s, a) = \frac{1}{s-1}$$
Added tests for all the new changes.

#### Other comments

Road map:

Following the discussion at https://github.com/sympy/sympy/issues/26523, in order to solve the bug with the integral
$$\int\_0^1 \frac{1-t^z}{1-t} \mathrm{d}t = \psi(z+1) + \gamma_E$$
We need to correctly compute the following limit:
$$\lim\_{t \to 1^-} \left\[-t^{z+1}\Phi(t, 1, z+1) - \log(t - 1)\right\] = \psi(z+1) + \gamma_E - i \pi$$
Sympy currently gives the wrong result for this limit, which causes the bug. To avoid returning the wrong value, we need the following:
We first need sympy to identify that $\Phi(1, 1, z+1)$ is infinite to avoid simply substituting $t=1$. This requires the implementation of `lerchphi._eval_is_finite`.
This is enough to solve the bug in the `gruntz` algorithm. However, Sympy will also try to solve the limit using the `heuristics` algorithm, which also has this bug.
The `heuristics` algorithm seems to just do the substitution $t = 1$. So a check to make sure the result is finite is needed.
With these, the integral should no longer return the wrong result but rather either raise an error or return the unevaluated result.

In order to compute the correct limit, an implementation of `lerchphi._eval_as_leading_term` is needed, which should be able to correctly identify
$$\lim\_{\varepsilon \to 0^+} \Phi(1-\varepsilon, 1, z+1) = -\log(\varepsilon) - \gamma_E - \psi(z+1)$$
Finally, a simplification needs to be added somewhere to simplify
```python
(-t*t**z*z*lerchphi(t, 1, z + 1)*gamma(z + 1)/gamma(z + 2)
 - t*t**z*lerchphi(t, 1, z + 1)*gamma(z + 1)/gamma(z + 2)
 - log(t - 1))
```
to
```python
-t**(z + 1)*lerchphi(t, 1, z + 1) - log(t - 1)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* functions
  * Implemented `lerchphi._eval_is_finite`
  * Implemented `lerchphi._eval_as_leading_term`
  * Added functionality to `zeta._eval_as_leading_term`

* printing
  * Changed Mathematica translation of `lerchphi` to `HurwitzLerchPhi`

<!-- END RELEASE NOTES -->
