### PR TITLE
Enable Calculation of Reaction Forces with Specified Supports

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -837,6 +837,12 @@ class Beam:
         """
         Solves for the reaction forces.
 
+        Parameters
+        ==========
+        *reactions : Symbol, optional
+            Symbols representing the reaction forces. If not provided, the method
+            will attempt to use the reaction forces from the beam's supports.
+
         Examples
         ========
         There is a beam of length 30 meters. A moment of magnitude 120 Nm is
@@ -868,7 +874,29 @@ class Beam:
         >>> b.load
         -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1)
             + 120*SingularityFunction(x, 30, -2) + 2*SingularityFunction(x, 30, -1)
+
+        This same example can be solved by applying the supports on the beam.
+        >>> from sympy.physics.continuum_mechanics.beam import Beam
+        >>> from sympy import symbols
+        >>> E, I = symbols('E, I')
+        >>> b = Beam(30, E, I)
+        >>> b.apply_load(-8, 0, -1)
+        >>> b.apply_load(120, 30, -2)
+        >>> b.apply_support(10, type="pin")
+        >>> b.apply_support(30, type="roller")
+        >>> b.load
+        R_10*SingularityFunction(x, 10, -1) + R_30*SingularityFunction(x, 30, -1)
+            - 8*SingularityFunction(x, 0, -1) + 120*SingularityFunction(x, 30, -2)
+        >>> b.solve_for_reaction_loads()
+        >>> b.reaction_loads
+        {R_10: 6, R_30: 2}
+        >>> b.load
+        -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1)
+            + 120*SingularityFunction(x, 30, -2) + 2*SingularityFunction(x, 30, -1)
         """
+        if not reactions:
+            reactions = tuple(support[0] for support in self._support_as_loads)
+
         if self._composite_type == "hinge":
             return self._solve_hinge_beams(*reactions)
 

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -491,6 +491,12 @@ def test_apply_support():
     b.solve_for_reaction_loads(R_0, R_L, M_0, M_L)
     assert b.reaction_loads == {R_0: P/2, R_L: P/2, M_0: -L*P/8, M_L: L*P/8}
 
+    b = Beam(10, E, I)
+    b.apply_support(0, type='fixed')
+    b.apply_load(-P, 10, -1)
+    b.solve_for_reaction_loads()
+    assert b.reaction_loads == {R_0: P, M_0: -10*P}
+
 
 def test_max_shear_force():
     E = Symbol('E')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Small change to the ``.solve_for_reaction_loads()`` method in the Beam class for it to be able to solve for reaction forces using specified supports. This prevents users from having to specify reaction symbols and applying reaction loads. 

#### Other comments
This change doesn't affect the original functionality of the ``.solve_for_reaction_loads()`` method. It adds the option for users to calculate reaction forces based on specified supports. This can be an easier and more intuitive way to find reaction forces. If the symbol of the reaction force is necessary in later calculations for the user the original way of solving for reaction forces should be used. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Added possibility to calculate reaction forces in beams using specified supports. 
<!-- END RELEASE NOTES -->
