### PR TITLE
Continue: Obtaining reaction loads from apply_support

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -926,6 +926,7 @@ Mark Dewing <markdewing@gmail.com>
 Mark Dickinson <dickinsm@gmail.com>
 Mark Jeromin <mark.jeromin@sysfrog.net>
 Mark Shoulson <mark@kli.org>
+Mark van Gelder <m.j.vangelder@student.tudelft.nl>
 Markus Mohrhard <markus.mohrhard@googlemail.com>
 Markus Müller <markus.mueller.1.g@googlemail.com>
 Martha Giannoudovardi <maapxa@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1267,4 +1267,3 @@ Han Wei Ang <ang.h.w@u.nus.edu>
 Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Congxu Yang <u7189828@anu.edu.au>
 Saicharan <62512681+saicharan2804@users.noreply.github.com>
-Mark van Gelder <m.j.vangelder@student.tudelft.nl>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1267,3 +1267,4 @@ Han Wei Ang <ang.h.w@u.nus.edu>
 Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Congxu Yang <u7189828@anu.edu.au>
 Saicharan <62512681+saicharan2804@users.noreply.github.com>
+Mark van Gelder <m.j.vangelder@student.tudelft.nl>

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -434,6 +434,12 @@ class Beam:
             - one degree of freedom, type = "pin"
             - two degrees of freedom, type = "roller"
 
+        Returns
+        =======
+        The unknown reaction load as a symbol.
+            - Symbol(reaction_force) if type = "pin" or "roller"
+            - Symbol(reaction_force), Symbol(reaction_moment) if type = "fixed"
+
         Examples
         ========
         There is a beam of length 20 meters. A moment of magnitude 100 Nm is
@@ -454,7 +460,7 @@ class Beam:
         >>> b.apply_load(100, 20, -2)
         >>> b.solve_for_reaction_loads(p0, m0, p1)
         >>> b.reaction_loads
-        {R_0: -2, M_0: 20, R_20: 10}
+        {M_0: 20, R_0: -2, R_20: 10}
         >>> b.reaction_loads[p0]
         -2
         >>> b.load

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -436,7 +436,8 @@ class Beam:
 
         Returns
         =======
-        The unknown reaction load as a symbol.
+        Symbol or tuple of Symbol
+            The unknown reaction load as a symbol.
             - Symbol(reaction_force) if type = "pin" or "roller"
             - Symbol(reaction_force), Symbol(reaction_moment) if type = "fixed"
 
@@ -2192,14 +2193,14 @@ class Beam:
             >>> p0, m0 = b.apply_support(0, "fixed")
             >>> p20 = b.apply_support(20, "roller")
             >>> p = b.draw()  # doctest: +SKIP
-            >>> p  # doctest: +SKIP
+            >>> p  # doctest: +ELLIPSIS
             Plot object containing:
             [0]: cartesian line: 25*SingularityFunction(x, 5, 0) - 25*SingularityFunction(x, 23, 0)
             + SingularityFunction(x, 30, 1) - 20*SingularityFunction(x, 50, 0)
             - SingularityFunction(x, 50, 1) + 5 for x over (0.0, 50.0)
             [1]: cartesian line: 5 for x over (0.0, 50.0)
             ...
-            >>> p.show() # doctest: +SKIP
+            >>> p.show()
 
         """
         if not numpy:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1765,8 +1765,8 @@ class Beam:
             >>> E, I = symbols('E, I')
             >>> R_0, R_10 = symbols('R_0, R_10')
             >>> b = Beam(10, E, I)
-            >>> b.apply_support(0, 'roller')
-            >>> b.apply_support(10, 'roller')
+            >>> p0 = b.apply_support(0, 'roller')
+            >>> p10 = b.apply_support(10, 'roller')
             >>> b.solve_for_ild_reactions(1,R_0,R_10)
             >>> b.ild_reactions
             {R_0: x/10 - 1, R_10: -x/10}
@@ -1838,8 +1838,8 @@ class Beam:
             >>> E, I = symbols('E, I')
             >>> R_0, R_7 = symbols('R_0, R_7')
             >>> b = Beam(10, E, I)
-            >>> b.apply_support(0, 'roller')
-            >>> b.apply_support(7, 'roller')
+            >>> p0 = b.apply_support(0, 'roller')
+            >>> p7 = b.apply_support(7, 'roller')
             >>> b.apply_load(5,4,-1)
             >>> b.solve_for_ild_reactions(1,R_0,R_7)
             >>> b.ild_reactions
@@ -1913,8 +1913,8 @@ class Beam:
             >>> E, I = symbols('E, I')
             >>> R_0, R_8 = symbols('R_0, R_8')
             >>> b = Beam(12, E, I)
-            >>> b.apply_support(0, 'roller')
-            >>> b.apply_support(8, 'roller')
+            >>> p0 = b.apply_support(0, 'roller')
+            >>> p8 = b.apply_support(8, 'roller')
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_shear(4, 1, R_0, R_8)
             >>> b.ild_shear
@@ -1972,8 +1972,8 @@ class Beam:
             >>> E, I = symbols('E, I')
             >>> R_0, R_8 = symbols('R_0, R_8')
             >>> b = Beam(12, E, I)
-            >>> b.apply_support(0, 'roller')
-            >>> b.apply_support(8, 'roller')
+            >>> p0 = b.apply_support(0, 'roller')
+            >>> p8 = b.apply_support(8, 'roller')
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_shear(4, 1, R_0, R_8)
             >>> b.ild_shear
@@ -2040,8 +2040,8 @@ class Beam:
             >>> E, I = symbols('E, I')
             >>> R_0, R_8 = symbols('R_0, R_8')
             >>> b = Beam(12, E, I)
-            >>> b.apply_support(0, 'roller')
-            >>> b.apply_support(8, 'roller')
+            >>> p0 = b.apply_support(0, 'roller')
+            >>> p8 = b.apply_support(8, 'roller')
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_moment(4, 1, R_0, R_8)
             >>> b.ild_moment
@@ -2098,8 +2098,8 @@ class Beam:
             >>> E, I = symbols('E, I')
             >>> R_0, R_8 = symbols('R_0, R_8')
             >>> b = Beam(12, E, I)
-            >>> b.apply_support(0, 'roller')
-            >>> b.apply_support(8, 'roller')
+            >>> p0 = b.apply_support(0, 'roller')
+            >>> p8 = b.apply_support(8, 'roller')
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_moment(4, 1, R_0, R_8)
             >>> b.ild_moment
@@ -2188,18 +2188,18 @@ class Beam:
             >>> b.apply_load(10, 30, 1, 50)
             >>> b.apply_load(M, 15, -2)
             >>> b.apply_load(-M, 30, -2)
-            >>> b.apply_support(50, "pin")
-            >>> b.apply_support(0, "fixed")
-            >>> b.apply_support(20, "roller")
+            >>> p50 = b.apply_support(50, "pin")
+            >>> p0, m0 = b.apply_support(0, "fixed")
+            >>> p20 = b.apply_support(20, "roller")
             >>> p = b.draw()  # doctest: +SKIP
-            >>> p  # doctest: +ELLIPSIS
+            >>> p  # doctest: +SKIP
             Plot object containing:
             [0]: cartesian line: 25*SingularityFunction(x, 5, 0) - 25*SingularityFunction(x, 23, 0)
             + SingularityFunction(x, 30, 1) - 20*SingularityFunction(x, 50, 0)
             - SingularityFunction(x, 50, 1) + 5 for x over (0.0, 50.0)
             [1]: cartesian line: 5 for x over (0.0, 50.0)
             ...
-            >>> p.show()
+            >>> p.show() # doctest: +SKIP
 
         """
         if not numpy:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -420,7 +420,8 @@ class Beam:
 
     def apply_support(self, loc, type="fixed"):
         """
-        This method applies support to a particular beam object.
+        This method applies support to a particular beam object and returns
+        the symbol of the unknown reaction load(s).
 
         Parameters
         ==========
@@ -435,12 +436,10 @@ class Beam:
 
         Examples
         ========
-        There is a beam of length 30 meters. A moment of magnitude 120 Nm is
+        There is a beam of length 20 meters. A moment of magnitude 100 Nm is
         applied in the clockwise direction at the end of the beam. A pointload
-        of magnitude 8 N is applied from the top of the beam at the starting
-        point. There are two simple supports below the beam. One at the end
-        and another one at a distance of 10 meters from the start. The
-        deflection is restricted at both the supports.
+        of magnitude 8 N is applied from the top of the beam at a distance of 10 meters.
+        There is one fixed support at the start of the beam and a roller at the end.
 
         Using the sign convention of upward forces and clockwise moment
         being positive.
@@ -448,19 +447,20 @@ class Beam:
         >>> from sympy.physics.continuum_mechanics.beam import Beam
         >>> from sympy import symbols
         >>> E, I = symbols('E, I')
-        >>> b = Beam(30, E, I)
-        >>> b.apply_support(10, 'roller')
-        >>> b.apply_support(30, 'roller')
-        >>> b.apply_load(-8, 0, -1)
-        >>> b.apply_load(120, 30, -2)
-        >>> R_10, R_30 = symbols('R_10, R_30')
-        >>> b.solve_for_reaction_loads(R_10, R_30)
+        >>> b = Beam(20, E, I)
+        >>> p0, m0 = b.apply_support(0, 'fixed')
+        >>> p1 = b.apply_support(20, 'roller')
+        >>> b.apply_load(-8, 10, -1)
+        >>> b.apply_load(100, 20, -2)
+        >>> b.solve_for_reaction_loads(p0, m0, p1)
+        >>> b.reaction_loads
+        {R_0: -2, M_0: 20, R_20: 10}
+        >>> b.reaction_loads[p0]
+        -2
         >>> b.load
-        -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1)
-        + 120*SingularityFunction(x, 30, -2) + 2*SingularityFunction(x, 30, -1)
-        >>> b.slope()
-        (-4*SingularityFunction(x, 0, 2) + 3*SingularityFunction(x, 10, 2)
-            + 120*SingularityFunction(x, 30, 1) + SingularityFunction(x, 30, 2) + 4000/3)/(E*I)
+        20*SingularityFunction(x, 0, -2) - 2*SingularityFunction(x, 0, -1)
+        - 8*SingularityFunction(x, 10, -1) + 100*SingularityFunction(x, 20, -2)
+        + 10*SingularityFunction(x, 20, -1)
         """
         loc = sympify(loc)
         self._applied_supports.append((loc, type))
@@ -478,6 +478,11 @@ class Beam:
             self._support_as_loads.append((reaction_moment, loc, -2, None))
 
         self._support_as_loads.append((reaction_load, loc, -1, None))
+
+        if type in ("pin", "roller"):
+            return reaction_load
+        else:
+            return reaction_load, reaction_moment
 
     def apply_load(self, value, start, order, end=None):
         """

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -470,16 +470,20 @@ def test_apply_support():
                 + 10*SingularityFunction(x, 4, 3)/3)/(E*I))
 
     b = Beam(30, E, I)
-    b.apply_support(10, "pin")
-    b.apply_support(30, "roller")
+    p0 = b.apply_support(10, "pin")
+    p1 = b.apply_support(30, "roller")
     b.apply_load(-8, 0, -1)
     b.apply_load(120, 30, -2)
-    R_10, R_30 = symbols('R_10, R_30')
-    b.solve_for_reaction_loads(R_10, R_30)
+    b.solve_for_reaction_loads(p0, p1)
     assert b.slope() == (-4*SingularityFunction(x, 0, 2) + 3*SingularityFunction(x, 10, 2)
             + 120*SingularityFunction(x, 30, 1) + SingularityFunction(x, 30, 2) + Rational(4000, 3))/(E*I)
     assert b.deflection() == (x*Rational(4000, 3) - 4*SingularityFunction(x, 0, 3)/3 + SingularityFunction(x, 10, 3)
             + 60*SingularityFunction(x, 30, 2) + SingularityFunction(x, 30, 3)/3 - 12000)/(E*I)
+    R_10 = Symbol('R_10')
+    R_30 = Symbol('R_30')
+    assert p0 == R_10
+    assert b.reaction_loads == {R_10: 6, R_30: 2}
+    assert b.reaction_loads[p0] == 6
 
     P = Symbol('P', positive=True)
     L = Symbol('L', positive=True)

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -485,6 +485,20 @@ def test_apply_support():
     assert b.reaction_loads == {R_10: 6, R_30: 2}
     assert b.reaction_loads[p0] == 6
 
+    b = Beam(8, E, I)
+    p0, m0 = b.apply_support(0, "fixed")
+    p1 = b.apply_support(8, "roller")
+    b.apply_load(-5, 0, 0, 8)
+    b.solve_for_reaction_loads(p0, m0, p1)
+    R_0 = Symbol('R_0')
+    M_0 = Symbol('M_0')
+    R_8 = Symbol('R_8')
+    assert p0 == R_0
+    assert m0 == M_0
+    assert p1 == R_8
+    assert b.reaction_loads == {R_0: 25, M_0: -40, R_8: 15}
+    assert b.reaction_loads[m0] == -40
+
     P = Symbol('P', positive=True)
     L = Symbol('L', positive=True)
     b = Beam(L, E, I)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. --> 
Uses the code proposed in PR #26296
Different solution for the same problem as PR #26567 


#### Brief description of what is fixed or changed
The ``apply_support()`` now returns reaction load symbols that can be used in ``solve_for_reaction_loads()``. This prevents users from having to create the symbols for unknown reactions. 

#### Other comments
This pull request uses the solution proposed in PR #26296 after this possible solution was pointed out to me in PR #26567. The documentation is updated and the test is modified. 

PR #26296 used the following code:
```
def apply_support(self, loc, type="fixed", return_ = False):

if not return_:
      return
if type in ("pin", "roller"):
      return reaction_load
else:
      return reaction_load, reaction_moment
```
This solution has the following code:
```
def apply_support(self, loc, type="fixed"):

if type in ("pin", "roller"):
     return reaction_load
else:
     return reaction_load, reaction_moment
```

The ` return_` parameter was left out in this proposed solution, because I didn't see the real added value.
I thought leaving it out would be better for clarity and simplisity of the code. As I'm quite new to SymPy I might have overlooked something and leaving it in would be better. Please let me know if this is the case (and also why for my own learning process). 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
   * Changed `apply_support()` to prevent having to create unknown reaction symbols. 
<!-- END RELEASE NOTES -->
