### PR TITLE
fix: treat floats like rationals in as_coeff_mul

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2163,7 +2163,11 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
     if coeff is S.One:
         return factors
     elif coeff.is_Float and equal_valued(coeff, S.One):
-        return Add(*[coeff*term for term in Add.make_args(factors)])
+        c, a = factors.as_coeff_add()
+        if c.is_Number and c:
+            return coeff*c + a
+        else:
+            return Add(*[coeff*term for term in Add.make_args(factors)])
     elif not sign and coeff is S.NegativeOne:
         return -factors
     elif not sign and coeff.is_Float and equal_valued(coeff, S.NegativeOne):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2156,8 +2156,12 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
         return coeff
     if coeff is S.One:
         return factors
-    elif coeff is S.NegativeOne and not sign:
+    elif coeff.is_Float and equal_valued(coeff, S.One):
+        return Add(*[coeff*term for term in Add.make_args(factors)])
+    elif not sign and coeff is S.NegativeOne:
         return -factors
+    elif not sign and coeff.is_Float and equal_valued(coeff, S.NegativeOne):
+        return Add(*[coeff*term for term in Add.make_args(factors)])
     elif factors.is_Add:
         if not clear and coeff.is_Rational and coeff.q != 1:
             args = [i.as_coeff_Mul() for i in factors.args]
@@ -2191,6 +2195,6 @@ def expand_2arg(e):
     return bottom_up(e, do)
 
 
-from .numbers import Rational
+from .numbers import Rational, equal_valued
 from .power import Pow
 from .add import Add, _unevaluated_Add

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1738,9 +1738,15 @@ class Mul(Expr, AssocOp):
             but not vice versa, and 2/5 does not divide 1/3) then return
             the integer number of times it divides, else return 0.
             """
-            if not b.q % a.q or not a.q % b.q:
-                return int(a/b)
-            return 0
+            if a.is_Rational and b.is_Rational:
+                if not b.q % a.q or not a.q % b.q:
+                    return int(a/b)
+                else:
+                    return 0
+            elif a.is_Float and b.is_Float:
+                return ndiv(Rational(a), Rational(b))
+            else:
+                assert False
 
         # give Muls in the denominator a chance to be changed (see issue 5651)
         # rv will be the default return value

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2171,7 +2171,11 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
     elif not sign and coeff is S.NegativeOne:
         return -factors
     elif not sign and coeff.is_Float and equal_valued(coeff, S.NegativeOne):
-        return Add(*[coeff*term for term in Add.make_args(factors)])
+        c, a = factors.as_coeff_add()
+        if c.is_Number and c:
+            return coeff*c - a
+        else:
+            return Add(*[coeff*term for term in Add.make_args(factors)])
     elif factors.is_Add:
         if not clear and coeff.is_Rational and coeff.q != 1:
             args = [i.as_coeff_Mul() for i in factors.args]

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -537,7 +537,7 @@ class Number(AtomicExpr):
     def is_constant(self, *wrt, **flags):
         return True
 
-    def as_coeff_mul(self, *deps, rational=True, **kwargs):
+    def as_coeff_mul(self, *deps, rational=False, **kwargs):
         # a -> c*t
         if self.is_Rational or not rational:
             return self, ()

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1250,9 +1250,10 @@ def test_as_coeff_add():
 
 def test_as_coeff_mul():
     assert S(2).as_coeff_mul() == (2, ())
-    assert S(3.0).as_coeff_mul() == (1, (S(3.0),))
-    assert S(-3.0).as_coeff_mul() == (-1, (S(3.0),))
+    assert S(3.0).as_coeff_mul() == (S(3.0), ())
+    assert S(-3.0).as_coeff_mul() == (S(-3.0), ())
     assert S(-3.0).as_coeff_mul(rational=False) == (-S(3.0), ())
+    assert S(-3.0).as_coeff_mul(rational=True) == (-1, (S(3.0),))
     assert x.as_coeff_mul() == (1, (x,))
     assert (-x).as_coeff_mul() == (-1, (x,))
     assert (2*x).as_coeff_mul() == (2, (x,))

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -624,7 +624,7 @@ def test_to_expr():
     q = 1.4*a*x**2
     assert p == q
     p = (expr_to_holonomic(1.4*x)+expr_to_holonomic(a*x, x)).to_expr()
-    q = x*(a + 1.4)
+    q = x*(1.0*a + 1.4)
     assert p == q
     p = (expr_to_holonomic(1.4*x)+expr_to_holonomic(x)).to_expr()
     assert p == 2.4*x

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -20,6 +20,7 @@ from sympy.integrals.meijerint import (_rewrite_single, _rewrite1,
 from sympy.testing.pytest import slow
 from sympy.core.random import (verify_numerically,
         random_complex_number as randcplx)
+from sympy import nsimplify
 from sympy.abc import x, y, a, b, c, d, s, t, z
 
 
@@ -761,6 +762,14 @@ def test_pr_23583():
     # This result is wrong. Check whether new result is correct when this test fail.
     assert integrate(1/sqrt((x - I)**2-1), meijerg=True) == \
            Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+
+
+def test_meijerint_hyper_float():
+    # https://github.com/sympy/sympy/issues/26571
+    from sympy.integrals.meijerint import meijerint_indefinite
+    res = 0.125*x*gamma(S(1)/8)*hyper((0.5, S(1)/8), (S(9)/8,), x**8*exp_polar(I*pi))/gamma(S(9)/8)
+    assert meijerint_indefinite((x**8+1)**(-1/2), x) == res
+    assert meijerint_indefinite((x**8+1)**(-S(1)/2), x) == nsimplify(res)
 
 
 # 25786

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1663,7 +1663,7 @@ def _get_examples_ode_sol_nth_linear_undetermined_coefficients():
 def _get_examples_ode_sol_separable():
     # test_separable1-5 are from Ordinary Differential Equations, Tenenbaum and
     # Pollard, pg. 55
-    t,a = symbols('a,t')
+    a, t = symbols('a, t')
     m = 96
     g = 9.8
     k = .2
@@ -1813,7 +1813,7 @@ def _get_examples_ode_sol_separable():
     # https://github.com/sympy/sympy/issues/10379
     'separable_24': {
         'eq': f(t).diff(t)-(1-51.05*y*f(t)),
-        'sol': [Eq(f(t), (0.019588638589618023*exp(y*(C1 - 51.049999999999997*t)) + 0.019588638589618023)/y)],
+        'sol': [Eq(f(t), (1.0*exp(y*(C1 - 51.05*t)) + 0.019588638589618023)/y)],
         'func': f(t),
     },
 
@@ -1825,7 +1825,7 @@ def _get_examples_ode_sol_separable():
 
     'separable_26': {
         'eq': f1 - k * (v(t) ** 2) - m * Derivative(v(t)),
-        'sol': [Eq(v(t), -68.585712797928991/tanh(C1 - 0.14288690166235204*t))],
+        'sol': [Eq(v(t), (-1.0*exp(0.2857738033247041*C1 - 0.2857738033247041*t) - 1.0)/(0.014580296087995107*exp(0.2857738033247041*C1 - 0.2857738033247041*t) - 0.014580296087995107))],
         'func': v(t),
         'checkodesol_XFAIL': True,
     },

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -40,7 +40,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions.elementary.complexes import (im, re)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
-from sympy.functions.elementary.hyperbolic import (asinh, cosh, sinh, tanh)
+from sympy.functions.elementary.hyperbolic import (asinh, cosh, sinh)
 from sympy.functions.elementary.miscellaneous import (cbrt, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sec, sin, tan)
@@ -1825,7 +1825,10 @@ def _get_examples_ode_sol_separable():
 
     'separable_26': {
         'eq': f1 - k * (v(t) ** 2) - m * Derivative(v(t)),
-        'sol': [Eq(v(t), (-1.0*exp(0.2857738033247041*C1 - 0.2857738033247041*t) - 1.0)/(0.014580296087995107*exp(0.2857738033247041*C1 - 0.2857738033247041*t) - 0.014580296087995107))],
+        'sol': [Eq(v(t), (
+            -1.0*exp(0.2857738033247041*C1 - 0.2857738033247041*t) - 1.0)
+            /(0.014580296087995107*exp(0.2857738033247041*C1 - 0.2857738033247041*t)
+              - 0.014580296087995107))],
         'func': v(t),
         'checkodesol_XFAIL': True,
     },


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-26571

#### Brief description of what is fixed or changed

Treat floats like rationals in as_coeff_mul by default. This mirrors the behaviour of as_coeff_Mul.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * The `as_coeff_mul` method now treats floats like rationals by default. This fixes some integration bugs relating to integrals with floats.
<!-- END RELEASE NOTES -->
