### PR TITLE
Defined Singularity Functions for Exponents -3 and -4.

### DIFF
--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -103,7 +103,7 @@ class SingularityFunction(Function):
 
         if argindex == 1:
             x, a, n = self.args
-            if n in (S.Zero, S.NegativeOne):
+            if n in (S.Zero, S.NegativeOne, S(-2), S(-3)):
                 return self.func(x, a, n-1)
             elif n.is_positive:
                 return n*self.func(x, a, n-1)
@@ -164,8 +164,8 @@ class SingularityFunction(Function):
             raise ValueError("Singularity Functions are not defined for imaginary exponents.")
         if shift is S.NaN or n is S.NaN:
             return S.NaN
-        if (n + 2).is_negative:
-            raise ValueError("Singularity Functions are not defined for exponents less than -2.")
+        if (n + 4).is_negative:
+            raise ValueError("Singularity Functions are not defined for exponents less than -4.")
         if shift.is_extended_negative:
             return S.Zero
         if n.is_nonnegative:
@@ -173,7 +173,7 @@ class SingularityFunction(Function):
                 return S.Zero**n
             if shift.is_extended_nonnegative:
                 return shift**n
-        if n in (S.NegativeOne, -2):
+        if n in (S.NegativeOne, -2, -3, -4):
             if shift.is_negative or shift.is_extended_positive:
                 return S.Zero
             if shift.is_zero:
@@ -186,7 +186,7 @@ class SingularityFunction(Function):
         '''
         x, a, n = self.args
 
-        if n in (S.NegativeOne, S(-2)):
+        if n in (S.NegativeOne, S(-2), S(-3), S(-4)):
             return Piecewise((oo, Eq(x - a, 0)), (0, True))
         elif n.is_nonnegative:
             return Piecewise(((x - a)**n, x - a >= 0), (0, True))
@@ -198,6 +198,10 @@ class SingularityFunction(Function):
         '''
         x, a, n = self.args
 
+        if n == -4:
+            return diff(Heaviside(x - a), x.free_symbols.pop(), 4)
+        if n == -3:
+            return diff(Heaviside(x - a), x.free_symbols.pop(), 3)
         if n == -2:
             return diff(Heaviside(x - a), x.free_symbols.pop(), 2)
         if n == -1:

--- a/sympy/functions/special/tests/test_singularity_functions.py
+++ b/sympy/functions/special/tests/test_singularity_functions.py
@@ -18,6 +18,8 @@ x, y, a, n = symbols('x y a n')
 def test_fdiff():
     assert SingularityFunction(x, 4, 5).fdiff() == 5*SingularityFunction(x, 4, 4)
     assert SingularityFunction(x, 4, -1).fdiff() == SingularityFunction(x, 4, -2)
+    assert SingularityFunction(x, 4, -2).fdiff() == SingularityFunction(x, 4, -3)
+    assert SingularityFunction(x, 4, -3).fdiff() == SingularityFunction(x, 4, -4)
     assert SingularityFunction(x, 4, 0).fdiff() == SingularityFunction(x, 4, -1)
 
     assert SingularityFunction(y, 6, 2).diff(y) == 2*SingularityFunction(y, 6, 1)
@@ -53,6 +55,10 @@ def test_eval():
     assert SingularityFunction(5, 6, -2) == 0
     assert SingularityFunction(4, 2, -2) == 0
     assert SingularityFunction(4, 4, -2) is oo
+    assert SingularityFunction(4, 2, -3) == 0
+    assert SingularityFunction(8, 8, -3) is oo
+    assert SingularityFunction(4, 2, -4) == 0
+    assert SingularityFunction(8, 8, -4) is oo
     assert (SingularityFunction(6.1, 4, 5)).evalf(5) == Float('40.841', '5')
     assert SingularityFunction(6.1, pi, 2) == (-pi + 6.1)**2
     assert SingularityFunction(x, a, nan) is nan
@@ -61,7 +67,7 @@ def test_eval():
 
     raises(ValueError, lambda: SingularityFunction(x, a, I))
     raises(ValueError, lambda: SingularityFunction(2*I, I, n))
-    raises(ValueError, lambda: SingularityFunction(x, a, -3))
+    raises(ValueError, lambda: SingularityFunction(x, a, -5))
 
 
 def test_leading_term():
@@ -72,6 +78,8 @@ def test_leading_term():
     assert SingularityFunction(x, 0, 0).as_leading_term(x, cdir=-1) == 0
     assert SingularityFunction(x, 0, -1).as_leading_term(x) == 0
     assert SingularityFunction(x, 0, -2).as_leading_term(x) == 0
+    assert SingularityFunction(x, 0, -3).as_leading_term(x) == 0
+    assert SingularityFunction(x, 0, -4).as_leading_term(x) == 0
     assert (SingularityFunction(x + l, 0, 1)/2\
         - SingularityFunction(x + l, l/2, 1)\
         + SingularityFunction(x + l, l, 1)/2).as_leading_term(x) == -x/2
@@ -85,6 +93,8 @@ def test_series():
     assert SingularityFunction(x, 0, 0).series(x, dir='-') == 0
     assert SingularityFunction(x, 0, -1).series(x) == 0
     assert SingularityFunction(x, 0, -2).series(x) == 0
+    assert SingularityFunction(x, 0, -3).series(x) == 0
+    assert SingularityFunction(x, 0, -4).series(x) == 0
     assert (SingularityFunction(x + l, 0, 1)/2\
         - SingularityFunction(x + l, l/2, 1)\
         + SingularityFunction(x + l, l, 1)/2).nseries(x) == -x/2 + O(x**6)

--- a/sympy/integrals/singularityfunctions.py
+++ b/sympy/integrals/singularityfunctions.py
@@ -52,7 +52,7 @@ def singularityintegrate(f, x):
         x, a, n = f.args
         if n.is_positive or n.is_zero:
             return SingularityFunction(x, a, n + 1)/(n + 1)
-        elif n in (-1, -2):
+        elif n in (-1, -2, -3, -4):
             return SingularityFunction(x, a, n + 1)
 
     if f.is_Mul or f.is_Pow:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
These functions are necessary to implement the mechanics described in this issue #26570.

#### Brief description of what is fixed or changed
Defined Singularity Functions for exponents -3 and -4 and their (anti)derivative. 

#### Other comments
It is now possible to use Singularity Functions with exponents -3 and -4. Untill now the lowest possible exponent was -2. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Defined singularity functions for exponents -3 and -4. 
<!-- END RELEASE NOTES -->
