### PR TITLE
Replace `sorted(x)[0]` calls with `min(x)`

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -66,7 +66,7 @@ class Optimization:
         self.priority=priority
 
     def cheapest(self, *args):
-        return sorted(args, key=self.cost_function)[0]
+        return min(args, key=self.cost_function)
 
 
 class ReplaceOptim(Optimization):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -874,7 +874,7 @@ class PermutationGroup(Basic):
         base = self.base
         base_ordering = _base_ordering(base, self.degree)
         def step(l, x):
-            gamma = sorted(orbits[l], key = lambda y: base_ordering[y^x])[0]
+            gamma = min(orbits[l], key = lambda y: base_ordering[y^x])
             i = [base[l]^h for h in h_transversals[l]].index(gamma)
             x = h_transversals[l][i]*x
             if l < len(orbits)-1:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -584,7 +584,7 @@ class LRASolver():
             if len(cand) == 0:
                 return True, {var: var.assign for var in self.all_var}
 
-            xi = sorted(cand, key=lambda v: v.col_idx)[0] # Bland's rule
+            xi = min(cand, key=lambda v: v.col_idx) # Bland's rule
             i = basic[xi]
 
             if xi.assign < xi.lower:
@@ -601,7 +601,7 @@ class LRASolver():
                     conflict.append(Boundary.from_lower(xi))
                     conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
                     return False, conflict
-                xj = sorted(cand, key=lambda v: str(v))[0]
+                xj = min(cand, key=str)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
 
             if xi.assign > xi.upper:
@@ -620,7 +620,7 @@ class LRASolver():
 
                     conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
                     return False, conflict
-                xj = sorted(cand, key=lambda v: v.col_idx)[0]
+                xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
 
     def _pivot_and_update(self, M, basic, nonbasic, xi, xj, v):

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1114,7 +1114,7 @@ def __trigsimp(expr, deep=False):
             raise TypeError
         fnew = factor(new)
         if fnew != new:
-            new = sorted([new, factor(new)], key=count_ops)[0]
+            new = min([new, factor(new)], key=count_ops)
         # if all exp that were introduced disappeared then accept it
         if not (new.atoms(exp) - e):
             expr = new


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Replaces `sorted(x)[0]` with `min`. Doing so is both reduces peak memory and reduces the complexity of the call from O(log(n)n) to O(n).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
