### PR TITLE
Defined Singularity Functions for Negative Integer Exponents.

### DIFF
--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -103,7 +103,7 @@ class SingularityFunction(Function):
 
         if argindex == 1:
             x, a, n = self.args
-            if n in (S.Zero, S.NegativeOne):
+            if n.is_nonpositive:
                 return self.func(x, a, n-1)
             elif n.is_positive:
                 return n*self.func(x, a, n-1)
@@ -164,8 +164,8 @@ class SingularityFunction(Function):
             raise ValueError("Singularity Functions are not defined for imaginary exponents.")
         if shift is S.NaN or n is S.NaN:
             return S.NaN
-        if (n + 2).is_negative:
-            raise ValueError("Singularity Functions are not defined for exponents less than -2.")
+        if n.is_negative and not n.is_integer:
+            raise ValueError("Singularity Functions are not defined for negative non-integer exponents.")
         if shift.is_extended_negative:
             return S.Zero
         if n.is_nonnegative:
@@ -173,7 +173,7 @@ class SingularityFunction(Function):
                 return S.Zero**n
             if shift.is_extended_nonnegative:
                 return shift**n
-        if n in (S.NegativeOne, -2):
+        if n.is_negative:
             if shift.is_negative or shift.is_extended_positive:
                 return S.Zero
             if shift.is_zero:
@@ -186,7 +186,7 @@ class SingularityFunction(Function):
         '''
         x, a, n = self.args
 
-        if n in (S.NegativeOne, S(-2)):
+        if n.is_negative:
             return Piecewise((oo, Eq(x - a, 0)), (0, True))
         elif n.is_nonnegative:
             return Piecewise(((x - a)**n, x - a >= 0), (0, True))
@@ -198,10 +198,8 @@ class SingularityFunction(Function):
         '''
         x, a, n = self.args
 
-        if n == -2:
-            return diff(Heaviside(x - a), x.free_symbols.pop(), 2)
-        if n == -1:
-            return diff(Heaviside(x - a), x.free_symbols.pop(), 1)
+        if n.is_negative:
+            return diff(Heaviside(x - a), x.free_symbols.pop(), -n)
         if n.is_nonnegative:
             return (x - a)**n*Heaviside(x - a, 1)
 

--- a/sympy/functions/special/tests/test_singularity_functions.py
+++ b/sympy/functions/special/tests/test_singularity_functions.py
@@ -61,7 +61,7 @@ def test_eval():
 
     raises(ValueError, lambda: SingularityFunction(x, a, I))
     raises(ValueError, lambda: SingularityFunction(2*I, I, n))
-    raises(ValueError, lambda: SingularityFunction(x, a, -3))
+    raises(ValueError, lambda: SingularityFunction(x, a, -3.5))
 
 
 def test_leading_term():

--- a/sympy/integrals/singularityfunctions.py
+++ b/sympy/integrals/singularityfunctions.py
@@ -52,7 +52,7 @@ def singularityintegrate(f, x):
         x, a, n = f.args
         if n.is_positive or n.is_zero:
             return SingularityFunction(x, a, n + 1)/(n + 1)
-        elif n in (-1, -2):
+        elif n.is_negative:
             return SingularityFunction(x, a, n + 1)
 
     if f.is_Mul or f.is_Pow:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This PR follows from a conversation in this PR #26576
These functions are necessary to implement the mechanics described in this issue #26570 

#### Brief description of what is fixed or changed
Defined Singularity Functions for negative integer exponents.

#### Other comments
It is now possible to use Singularity Functions with any negative integer exponent. Untill now the lowest possible exponent was -2.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Defined singularity functions for all negative integer exponents. 
<!-- END RELEASE NOTES -->
