### PR TITLE
Simplified a check in `_getitem_RepMatrix`

### DIFF
--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -957,8 +957,7 @@ def _getitem_RepMatrix(self, key):
             return self._rep.getitem_sympy(index_(i), index_(j))
         except (TypeError, IndexError):
             if (isinstance(i, Expr) and not i.is_number) or (isinstance(j, Expr) and not j.is_number):
-                if ((j < 0) is True) or ((j >= self.shape[1]) is True) or\
-                   ((i < 0) is True) or ((i >= self.shape[0]) is True):
+                if (j < 0) or (j >= self.shape[1]) or (i < 0) or (i >= self.shape[0]):
                     raise ValueError("index out of boundary")
                 from sympy.matrices.expressions.matexpr import MatrixElement
                 return MatrixElement(self, i, j)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

While investigating #26588, I noticed that there was a check that was awkwardly written. I simplified the check to make it easier to read and understand.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
