### PR TITLE
Rewriting to `min` and `max` functions

### DIFF
--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1058,16 +1058,7 @@ class DiagramGrid:
         # graph of ``merged_morphisms``.
         adjlists = DiagramGrid._get_undirected_graph(objects, merged_morphisms)
 
-        # Find an object with the minimal degree.  This is going to be
-        # the root.
-        root = sorted_objects[0]
-        mindegree = len(adjlists[root])
-        for obj in sorted_objects:
-            current_degree = len(adjlists[obj])
-            if current_degree < mindegree:
-                root = obj
-                mindegree = current_degree
-
+        root = min(sorted_objects, key=lambda x: len(adjlists[x]))
         grid = _GrowableGrid(1, 1)
         grid[0, 0] = root
 

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -2127,7 +2127,7 @@ class Permutation(Atom):
         pos = [i for i in range(len(a) - 1) if a[i] > a[i + 1]]
         return pos
 
-    def max(self):
+    def max(self) -> int:
         """
         The maximum element moved by the permutation.
 
@@ -2144,14 +2144,12 @@ class Permutation(Atom):
 
         min, descents, ascents, inversions
         """
-        max = 0
         a = self.array_form
-        for i in range(len(a)):
-            if a[i] != i and a[i] > max:
-                max = a[i]
-        return max
+        if not a:
+            return 0
+        return max(_a for i, _a in enumerate(a) if _a != i)
 
-    def min(self):
+    def min(self) -> int:
         """
         The minimum element moved by the permutation.
 
@@ -2169,11 +2167,9 @@ class Permutation(Atom):
         max, descents, ascents, inversions
         """
         a = self.array_form
-        min = len(a)
-        for i in range(len(a)):
-            if a[i] != i and a[i] < min:
-                min = a[i]
-        return min
+        if not a:
+            return len(a)
+        return min(_a for i, _a in enumerate(a) if _a != i)
 
     def inversions(self):
         """

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -2168,7 +2168,7 @@ class Permutation(Atom):
         """
         a = self.array_form
         if not a:
-            return len(a)
+            return 0
         return min(_a for i, _a in enumerate(a) if _a != i)
 
     def inversions(self):

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1177,8 +1177,7 @@ class HolonomicFunction:
         """
         Returns the highest power of `x` in the annihilator.
         """
-        sol = [i.degree() for i in self.annihilator.listofpoly]
-        return max(sol)
+        return max(i.degree() for i in self.annihilator.listofpoly)
 
     def composition(self, expr, *args, **kwargs):
         """
@@ -1764,15 +1763,11 @@ class HolonomicFunction:
             else:
                 return 0
 
-        degree = [j.degree() for j in list_coeff]
-        degree = max(degree)
+        degree = max(j.degree() for j in list_coeff)
         inf = 10 * (max(1, degree) + max(1, self.annihilator.order))
 
         deg = lambda q: inf if q.is_zero else _pole_degree(q)
-        b = deg(list_coeff[0])
-
-        for j in range(1, len(list_coeff)):
-            b = min(b, deg(list_coeff[j]) - j)
+        b = min(deg(q) - j for j, q in enumerate(list_coeff))
 
         for i, j in enumerate(list_coeff):
             listofdmp = j.all_coeffs()

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -836,15 +836,7 @@ class HomogeneousTernaryQuadratic(DiophantineEquationType):
         if not any(coeff[i**2] for i in var):
             if coeff[x*z]:
                 sols = diophantine(coeff[x*y]*x + coeff[y*z]*z - x*z)
-                s = sols.pop()
-                min_sum = abs(s[0]) + abs(s[1])
-
-                for r in sols:
-                    m = abs(r[0]) + abs(r[1])
-                    if m < min_sum:
-                        s = r
-                        min_sum = m
-
+                s = min(sols, key=lambda r: abs(r[0]) + abs(r[1]))
                 result.add(_remove_gcd(s[0], -coeff[x*z], s[1]))
                 return result
 

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -149,20 +149,8 @@ def _pivot(M, i, j):
 
 def _choose_pivot_row(A, B, candidate_rows, pivot_col, Y):
     # Choose row with smallest ratio
-    first_row = candidate_rows[0]
-    min_ratio = B[first_row] / A[first_row, pivot_col]
-    min_rows = [first_row]
-    for i in candidate_rows[1:]:
-        ratio = B[i] / A[i, pivot_col]
-        if ratio < min_ratio:
-            min_ratio = ratio
-            min_rows = [i]
-        elif ratio == min_ratio:
-            min_rows.append(i)
-
     # If there are ties, pick using Bland's rule
-    _, row = min((Y[i], i) for i in min_rows)
-    return row
+    return min(candidate_rows, key=lambda i: (B[i] / A[i, pivot_col], Y[i]))
 
 
 def _simplex(A, B, C, D=None, dual=False):


### PR DESCRIPTION
Rewrote the part of the loop to find the minimum and maximum values to `min` and `max` functions. This improves readability.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
