### PR TITLE
units: fixed convert_to() bug and added some tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -799,6 +799,7 @@ Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>
 José Senart <jose.senart@gmail.com>
+João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 João Moura <operte@gmail.com>
 Juan Barbosa <js.barbosa10@uniandes.edu.co>
 Juan Felipe Osorio <jfosorio@gmail.com>

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -76,7 +76,9 @@ def test_convert_to_quantities():
 
 
 def test_convert_to_tuples_of_quantities():
-    from sympy.abc import alpha, beta
+    from sympy.core.symbol import symbols
+
+    alpha, beta = symbols('alpha beta')
 
     assert convert_to(speed_of_light, [meter, second]) == 299792458 * meter / second
     assert convert_to(speed_of_light, (meter, second)) == 299792458 * meter / second

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -76,6 +76,8 @@ def test_convert_to_quantities():
 
 
 def test_convert_to_tuples_of_quantities():
+    from sympy.abc import alpha, beta
+
     assert convert_to(speed_of_light, [meter, second]) == 299792458 * meter / second
     assert convert_to(speed_of_light, (meter, second)) == 299792458 * meter / second
     assert convert_to(speed_of_light, Tuple(meter, second)) == 299792458 * meter / second
@@ -98,6 +100,9 @@ def test_convert_to_tuples_of_quantities():
     assert convert_to(sqrt(meter**2 + second**2.0), [meter, second]) == sqrt(meter**2 + second**2.0)
     assert convert_to((meter**2 + second**2.0)**2, [meter, second]) == (meter**2 + second**2.0)**2
 
+    # similar to https://github.com/sympy/sympy/issues/21463
+    assert convert_to(1/(beta*meter + meter), 1/meter) == 1/(beta*meter + meter)
+    assert convert_to(1/(beta*meter + alpha*meter), 1/kilometer) == (1/(kilometer*beta/1000 + alpha*kilometer/1000))
 
 def test_eval_simplify():
     from sympy.physics.units import cm, mm, km, m, K, kilo

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -12,6 +12,7 @@ from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
+from sympy.core.function import Function
 from sympy.matrices.exceptions import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension, DimensionSystem
 from sympy.physics.units.prefixes import Prefix
@@ -109,6 +110,9 @@ def convert_to(expr, target_units, unit_system="SI"):
 
     expr = sympify(expr)
     target_units = sympify(target_units)
+
+    if isinstance(expr, Function):
+        expr = expr.together()
 
     if not isinstance(expr, Quantity) and expr.has(Quantity):
         expr = expr.replace(lambda x: isinstance(x, Quantity),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #21463

#### Brief description of what is fixed or changed

Fixed a convert_to() function bug where the result for some inverse sums duplicated the expression units incorrectly.
I found that by using the together() function, these duplicates are prevented when the expression is a function.

Examples:

- Before

In [1]: convert_to(1/(beta*meter+meter), 1/meter)
Out [1]: 1/(meter*(meter*beta + meter))

- After

In [2]: convert_to(1/(beta*meter+meter), 1/meter) 
Out [2]: 1/(meter*beta + meter)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Fixed a bug with convert_to function.
<!-- END RELEASE NOTES -->
