### PR TITLE
TensMul: add matches method

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4380,6 +4380,20 @@ class TensMul(TensExpr, AssocOp):
 
         return repl_dict
 
+    def matches(self, expr, repl_dict=None, old=False):
+        expr = sympify(expr)
+
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
+
+        commute = all(arg.component.comm == 0 for arg in expr.args if isinstance(arg, Tensor))
+        if commute:
+            return self._matches_commutative(expr, repl_dict, old)
+        else:
+            raise NotImplementedError("Tensor matching not implemented for non-commuting tensors")
+
 class TensorElement(TensExpr):
     """
     Tensor with evaluated components.

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -38,6 +38,7 @@ from abc import abstractmethod, ABC
 from collections import defaultdict
 import operator
 import itertools
+
 from sympy.core.numbers import (Integer, Rational)
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
@@ -45,8 +46,9 @@ from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
 from sympy.core.cache import clear_cache
 from sympy.core.containers import Tuple, Dict
+from sympy.core.function import WildFunction
 from sympy.core.sorting import default_sort_key
-from sympy.core.symbol import Symbol, symbols
+from sympy.core.symbol import Symbol, symbols, Wild
 from sympy.core.sympify import CantSympify, _sympify
 from sympy.core.operations import AssocOp
 from sympy.external.gmpy import SYMPY_INTS
@@ -4991,6 +4993,10 @@ def _expand(expr, **kwargs):
         return expr._expand(**kwargs)
     else:
         return expr.expand(**kwargs)
+
+
+def _get_wilds(expr):
+    return list(expr.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead))
 
 
 def get_postprocessor(cls):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4226,6 +4226,160 @@ class TensMul(TensExpr, AssocOp):
         return TensAdd.fromiter(terms)
 
 
+    def _matches_commutative(self, expr, repl_dict=None, old=False):
+        """
+        Match assuming all tensors commute. But note that we are not assuming anything about their symmetry under index permutations.
+        """
+        #Take care of the various possible types for expr.
+        if not isinstance(expr, TensMul):
+            if isinstance(expr, (TensExpr, Expr)):
+                expr = TensMul(expr)
+            else:
+                return None
+
+        #The code that follows assumes expr is a TensMul
+
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
+
+            #Make sure that none of the dummy indices in self, expr conflict with the values already present in repl_dict. This may happen due to automatic index relabelling when rem_query and rem_expr are formed later on in this function (it calls itself recursively).
+            indices = [k for k in repl_dict.values() if isinstance(k ,TensorIndex)]
+
+            def dedupe(expr):
+                renamed = TensMul._dedupe_indices(expr, indices)
+                if renamed is not None:
+                    return renamed
+                else:
+                    return expr
+
+            self = dedupe(self)
+            expr = dedupe(expr)
+
+        #Find the non-tensor part of expr. This need not be the same as expr.coeff when expr.doit() has not been called.
+        expr_coeff = reduce(lambda a, b: a*b, [arg for arg in expr.args if not isinstance(arg, TensExpr)], S.One)
+
+        # handle simple patterns
+        if self == expr:
+            return repl_dict
+
+        if len(_get_wilds(self)) == 0:
+            return self._matches_simple(expr, repl_dict, old)
+
+        def siftkey(arg):
+            if isinstance(arg, WildTensor):
+                return "WildTensor"
+            elif isinstance(arg, (Tensor, TensExpr)):
+                return "Tensor"
+            else:
+                return "coeff"
+
+        query_sifted = sift(self.args, siftkey)
+        expr_sifted = sift(expr.args, siftkey)
+
+        #Sanity checks
+        if "coeff" in query_sifted.keys():
+            if TensMul(*query_sifted["coeff"]).doit(deep=False) != self.coeff:
+                raise NotImplementedError(f"Found something that we do not know to handle: {query_sifted['coeff']}")
+        if "coeff" in expr_sifted.keys():
+            if TensMul(*expr_sifted["coeff"]).doit(deep=False) != expr_coeff:
+                raise NotImplementedError(f"Found something that we do not know to handle: {expr_sifted['coeff']}")
+
+        query_tens_heads = {tuple(getattr(x, "components", [])) for x in query_sifted["Tensor"]} #We use getattr because, e.g. TensAdd does not have the 'components' attribute.
+        expr_tens_heads = {tuple(getattr(x, "components", [])) for x in expr_sifted["Tensor"]}
+        if not query_tens_heads.issubset(expr_tens_heads):
+            #Some tensorheads in self are not present in the expr
+            return None
+
+        #Try to match all non-wild tensors of self with tensors that compose expr
+        if len(query_sifted["Tensor"]) > 0:
+            q_tensor = query_sifted["Tensor"][0]
+            """
+            We need to iterate over all possible symmetrized forms of q_tensor since the matches given by some of them may map dummy indices to free indices; the information about which indices are dummy/free will only be available later, when we are doing rem_q.matches(rem_e)
+            """
+            for q_tens in q_tensor._get_symmetrized_forms():
+                for e in expr_sifted["Tensor"]:
+                    if isinstance(q_tens, TensMul):
+                        #q_tensor got a minus sign due to this permutation.
+                        sign = -1
+                    else:
+                        sign = 1
+
+                    """
+                    _matches is used here since we are already iterating over index permutations of q_tensor. Also note that the sign is removed from q_tensor, and will later be put into rem_q.
+                    """
+                    m = (sign*q_tens)._matches(e)
+                    if m is None:
+                        continue
+
+                    rem_query = self.func(sign, *[a for a in self.args if a != q_tensor]).doit(deep=False)
+                    rem_expr = expr.func(*[a for a in expr.args if a != e]).doit(deep=False)
+                    tmp_repl = {}
+                    tmp_repl.update(repl_dict)
+                    tmp_repl.update(m)
+                    rem_m = rem_query.matches(rem_expr, repl_dict=tmp_repl)
+                    if rem_m is not None:
+                        #Check that contracted indices are not mapped to different indices.
+                        internally_consistent = True
+                        for k in rem_m.keys():
+                            if isinstance(k,TensorIndex):
+                                if -k in rem_m.keys() and rem_m[-k] != -rem_m[k]:
+                                    internally_consistent = False
+                                    break
+                        if internally_consistent:
+                            repl_dict.update(rem_m)
+                            return repl_dict
+
+            return None
+
+        #Try to match WildTensor instances which have indices
+        matched_e_tensors = []
+        remaining_e_tensors = expr_sifted["Tensor"]
+        indexless_wilds, wilds = sift(query_sifted["WildTensor"], lambda x: len(x.get_free_indices()) == 0, binary=True)
+
+        for w in wilds:
+            free_this_wild = set(w.get_free_indices())
+            tensors_to_try = []
+            for t in remaining_e_tensors:
+                free = t.get_free_indices()
+                shares_indices_with_wild = True
+                for i in free:
+                    if all(j.matches(i) is None for j in free_this_wild):
+                        #The index i matches none of the indices in free_this_wild
+                        shares_indices_with_wild = False
+                if shares_indices_with_wild:
+                    tensors_to_try.append(t)
+
+            m = w.matches(TensMul(*tensors_to_try).doit(deep=False) )
+            if m is None:
+                return None
+            else:
+                for tens in tensors_to_try:
+                    matched_e_tensors.append(tens)
+                repl_dict.update(m)
+
+        #Try to match indexless WildTensor instances
+        remaining_e_tensors = [t for t in expr_sifted["Tensor"] if t not in matched_e_tensors]
+        if len(indexless_wilds) > 0:
+            #If there are any remaining tensors, match them with the indexless WildTensor
+            m =  indexless_wilds[0].matches( TensMul(1,*remaining_e_tensors).doit(deep=False) )
+            if m is None:
+                return None
+            else:
+                repl_dict.update(m)
+        elif len(remaining_e_tensors) > 0:
+            return None
+
+        #Try to match the non-tensorial coefficient
+        m = self.coeff.matches(expr_coeff, old=old)
+        if m is None:
+            return None
+        else:
+            repl_dict.update(m)
+
+        return repl_dict
+
 class TensorElement(TensExpr):
     """
     Tensor with evaluated components.

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3491,6 +3491,13 @@ class TensMul(TensExpr, AssocOp):
                 arg._replace_indices(repl) if isinstance(arg, TensExpr) else arg
                 for arg, repl in zip(args, replacements)]
 
+            """
+            The order of indices might've changed due to the replacements (e.g. if one of the args is a TensAdd, replacing an index can change the sort order of the terms, thus changing the order of indices returned by its get_indices() method).
+            To stay on the safe side, we calculate these quantities again.
+            """
+            args_indices = [get_indices(arg) for arg in args]
+            indices, free, free_names, dummy_data = TensMul._indices_to_free_dum(args_indices)
+
         dum = TensMul._dummy_data_to_dum(dummy_data)
         return args, indices, free, dum
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2395,6 +2395,28 @@ class TensExpr(Expr, ABC):
                     if isinstance(a, TensExpr) else a
                     for a in self.args])
 
+    def _matches_simple(self, expr, repl_dict=None, old=False):
+        """
+        Matches assuming there are no wild objects in self.
+        """
+        if repl_dict is None:
+            repl_dict = {}
+        else:
+            repl_dict = repl_dict.copy()
+
+        if not isinstance(expr, TensExpr):
+            if len(self.get_free_indices()) > 0:
+                #self has indices, but expr does not.
+                return None
+        elif set(self.get_free_indices()) != set(expr.get_free_indices()):
+                #If there are no wilds and the free indices are not the same, they cannot match.
+                return None
+
+        if canon_bp(self - expr) == S.Zero:
+            return repl_dict
+        else:
+            return None
+
 
 class TensAdd(TensExpr, AssocOp):
     """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3482,7 +3482,7 @@ class TensMul(TensExpr, AssocOp):
                     dummy_name = dummy_name_gen(index_type)
                     if dummy_name not in free_names:
                         break
-                dummy = TensorIndex(dummy_name, index_type, True)
+                dummy = old_index.func(dummy_name, index_type, *old_index.args[2:])
                 replacements[pos1cov][old_index] = dummy
                 replacements[pos1contra][-old_index] = -dummy
                 indices[pos2cov] = dummy

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.core.numbers import Integer
 from sympy.matrices.dense import (Matrix, eye)
 from sympy.tensor.indexed import Indexed
 from sympy.combinatorics import Permutation
-from sympy.core import S, Rational, Symbol, Basic, Add
+from sympy.core import S, Rational, Symbol, Basic, Add, Wild
 from sympy.core.containers import Tuple
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -2010,6 +2010,65 @@ def test_tensor_matching():
     assert delta(p,q).matches(delta(q,p)) == {}
     assert eps(p,q,r).matches(eps(q,p,r)) is None
     assert eps(p,q,r).matches(eps(q,r,p)) == {}
+
+def test_TensMul_matching():
+    """
+    Test match and replace with the pattern being a TensMul
+    """
+    R3 = TensorIndexType('R3', dim=3)
+    p, q, r, s, t = tensor_indices("p q r s t", R3)
+    wi = Wild("wi")
+    a,b,c,d,e,f = symbols("a b c d e f", cls = WildTensorIndex, tensor_index_type=R3, ignore_updown=True)
+    delta = R3.delta
+    eps = R3.epsilon
+    K = TensorHead("K", [R3])
+    V = TensorHead("V", [R3])
+    W = WildTensorHead('W', unordered_indices=True)
+    U = WildTensorHead('U')
+    k = Symbol("K")
+
+    assert ( wi*K(p) ).matches( K(p) ) == {wi: 1}
+    assert ( wi * eps(p,q,r) ).matches(eps(p,r,q)) == {wi:-1}
+    assert ( K(p)*V(-p) ).replace( W(a)*V(-a), 1) == 1
+    assert ( K(q)*K(p)*V(-p) ).replace( W(q,a)*V(-a), 1) == 1
+    assert ( K(p)*V(-p) ).replace( K(-a)*V(a), 1 ) == 1
+    assert ( K(q)*K(p)*V(-p) ).replace( W(q)*U(p)*V(-p), 1) == 1
+    assert (
+        (K(p)*V(q)).replace(W()*K(p)*V(q), W()*V(p)*V(q)).doit()
+        == V(p)*V(q)
+        )
+    assert (
+        ( eps(r,p,q)*eps(-r,-s,-t) ).replace(
+            eps(e,a,b)*eps(-e,c,d),
+            delta(a,c)*delta(b,d) - delta(a,d)*delta(b,c),
+            ).doit().canon_bp()
+        == delta(p,-s)*delta(q,-t) - delta(p,-t)*delta(q,-s)
+        )
+    assert (
+        ( eps(r,p,q)*eps(-r,-p,-q) ).replace(
+            eps(c,a,b)*eps(-c,d,f),
+            delta(a,d)*delta(b,f) - delta(a,f)*delta(b,d),
+            ).contract_delta(delta).doit()
+        == 6
+        )
+    assert ( V(-p)*V(q)*V(-q) ).replace( wi*W()*V(a)*V(-a), wi*W() ).doit() == V(-p)
+    assert ( k**4*K(r)*K(-r) ).replace( wi*W()*K(a)*K(-a), wi*W()*k**2 ).doit() == k**6
+
+    #Multiple occurrence of WildTensor in value
+    assert (
+        ( K(p)*V(q) ).replace(W(q)*K(p), W(p)*W(q))
+        == V(p)*V(q)
+        )
+    assert (
+        ( K(p)*V(q)*V(r) ).replace(W(q,r)*K(p), W(p,r)*W(q,s)*V(-s) )
+        == V(p)*V(r)*V(q)*V(s)*V(-s)
+        )
+
+    #Edge case involving automatic index relabelling
+    D0, D1, D2, D3 = tensor_indices("R_0 R_1 R_2 R_3", R3)
+    expr = delta(-D0, -D1)*K(D2)*K(D3)*K(-D3)
+    m = ( W()*K(a)*K(-a) ).matches(expr)
+    assert D2 not in m.values()
 
 def test_TensMul_subs():
     """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
<!-- 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This PR implements matching for TensMul which contain only commuting tensors (a `NotImplementedError` is raised when non-commuting tensors are present).

#### Other comments

This should help fix the non-working replacements pointed out by https://github.com/sympy/sympy/issues/18435#issuecomment-586121651 .

There is one issue to be discussed: should `( K(p)*K(-p)*K(r)*K(-r) ).replace( wi*W()*K(a)*K(-a), wi*W()*k**2 ).doit()` (where `wi`, `W`, and `a` are various types of wild objects) return `k**2*K(R0)*K(-R0)` or `k**4`? Many users would expect the latter, but in this PR it returns the former (due to the way `match` is implemented in Sympy, I could not figure out a simple way to get the latter result). The workaround I use in my own code is to define a wrapper `replace_repeat` that calls `replace` in a loop till the expression stops changing.

Suggested reviewers: @Upabjojr 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* tensor
  * Matching now works for TensMul whose arguments all commute.
 
<!-- END RELEASE NOTES -->
