### PR TITLE
TESTING: Set Float(0).is_zero to None

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -758,8 +758,8 @@ class Float(Number):
     is_irrational = None
     is_number = True
 
-    is_real = True
-    is_extended_real = True
+    # is_real = True
+    # is_extended_real = True
 
     is_Float = True
 
@@ -974,8 +974,8 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        if self._mpf_ == fzero:
-            return True
+        # if self._mpf_ == fzero:
+        #     return True
         if not int_valued(self):
             return False
 
@@ -1003,8 +1003,8 @@ class Float(Number):
             return False
         return self.num > 0
 
-    def _eval_is_zero(self):
-        return self._mpf_ == fzero
+    # def _eval_is_zero(self):
+    #     return self._mpf_ == fzero
 
     def __bool__(self):
         return self._mpf_ != fzero


### PR DESCRIPTION
This also sets Float.is_real and Float.is_extended_real to None, and by implication sets Float(0).is_integer and Float(0).is_rational to None.

This is a test to see what tests fail.

See #26620.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
