### PR TITLE
vector: created VectorKind and Add with vectors now calls VectorAdd

### DIFF
--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -17,10 +17,13 @@ from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradie
 from sympy.vector.implicitregion import ImplicitRegion
 from sympy.vector.parametricregion import (ParametricRegion, parametric_region_list)
 from sympy.vector.integrals import (ParametricIntegral, vector_integrate)
+from sympy.vector.kind import VectorKind
 
 __all__ = [
     'Vector', 'VectorAdd', 'VectorMul', 'BaseVector', 'VectorZero', 'Cross',
     'Dot', 'cross', 'dot',
+
+    'VectorKind',
 
     'Dyadic', 'DyadicAdd', 'DyadicMul', 'BaseDyadic', 'DyadicZero',
 

--- a/sympy/vector/kind.py
+++ b/sympy/vector/kind.py
@@ -1,6 +1,6 @@
 #sympy.vector.kind
 
-from sympy.core.kind import Kind, _NumberKind
+from sympy.core.kind import Kind, _NumberKind, NumberKind
 from sympy.core.mul import Mul
 
 class VectorKind(Kind):
@@ -9,7 +9,11 @@ class VectorKind(Kind):
 
     Parameters
     ==========
-    No parameters.
+
+    element_kind : Kind
+        Kind of the element. Default is
+        :class:`sympy.core.kind.NumberKind`,
+        which means that the vector contains only numbers.
 
     Examples
     ========
@@ -43,15 +47,21 @@ class VectorKind(Kind):
     sympy.matrices.kind.MatrixKind
 
     """
-    def __new__(cls):
-        return super().__new__(cls)
+    def __new__(cls, element_kind=NumberKind):
+        obj = super().__new__(cls, element_kind)
+        obj.element_kind = element_kind
+        return obj
 
     def __repr__(self):
-        return "VectorKind"
+        return "VectorKind(%s)" % self.element_kind
 
 @Mul._kind_dispatcher.register(_NumberKind, VectorKind)
 def num_vec_mul(k1, k2):
     """
     The result of a multiplication between a number and a Vector should be of VectorKind.
+    The element kind is selected by recursive dispatching.
     """
-    return VectorKind()
+    if not isinstance(k2, VectorKind):
+        k1, k2 = k2, k1
+    elemk = Mul._kind_dispatcher(k1, k2.element_kind)
+    return VectorKind(elemk)

--- a/sympy/vector/kind.py
+++ b/sympy/vector/kind.py
@@ -1,6 +1,6 @@
 #sympy.vector.kind
 
-from sympy.core.kind import Kind, _NumberKind, NumberKind
+from sympy.core.kind import Kind, _NumberKind
 from sympy.core.mul import Mul
 
 class VectorKind(Kind):
@@ -33,16 +33,8 @@ class VectorKind(Kind):
     >>> Add(v1, v2).kind
     VectorKind
 
-    Subclasses of Vector also have the kind ``VectorKind``:
-
-    >>> Cross(v1, v2).doit().kind
-    VectorKind
-    >>> VectorAdd(v1, v2).kind
-    VectorKind
-    >>> VectorMul(2, v1).kind
-    VectorKind
-    >>> VectorZero().kind
-    VectorKind
+    Subclasses of Vector also have the kind ``VectorKind``, such as
+    Cross, VectorAdd, VectorMul or VectorZero.
 
     See Also
     ========

--- a/sympy/vector/kind.py
+++ b/sympy/vector/kind.py
@@ -1,0 +1,65 @@
+#sympy.vector.kind
+
+from sympy.core.kind import Kind, _NumberKind, NumberKind
+from sympy.core.mul import Mul
+
+class VectorKind(Kind):
+    """
+    Kind for all vector objects in SymPy.
+
+    Parameters
+    ==========
+    No parameters.
+
+    Examples
+    ========
+
+    Any instance of Vector class has kind ``VectorKind``:
+
+    >>> from sympy.vector.coordsysrect import CoordSys3D
+    >>> Sys = CoordSys3D('Sys')
+    >>> Sys.i.kind
+    VectorKind
+
+    Operations between instances of Vector keep also have the kind ``VectorKind``:
+
+    >>> from sympy.core.add import Add
+    >>> v1 = Sys.i * 2 + Sys.j * 3 + Sys.k * 4
+    >>> v2 = Sys.i * Sys.x + Sys.j * Sys.y + Sys.k * Sys.z
+    >>> v1.kind
+    VectorKind
+    >>> v2.kind
+    VectorKind
+    >>> Add(v1, v2).kind
+    VectorKind
+
+    Subclasses of Vector also have the kind ``VectorKind``:
+
+    >>> Cross(v1, v2).doit().kind
+    VectorKind
+    >>> VectorAdd(v1, v2).kind
+    VectorKind
+    >>> VectorMul(2, v1).kind
+    VectorKind
+    >>> VectorZero().kind
+    VectorKind
+
+    See Also
+    ========
+
+    sympy.core.kind.Kind
+    sympy.matrices.kind.MatrixKind
+
+    """
+    def __new__(cls):
+        return super().__new__(cls)
+
+    def __repr__(self):
+        return "VectorKind"
+
+@Mul._kind_dispatcher.register(_NumberKind, VectorKind)
+def num_vec_mul(k1, k2):
+    """
+    The result of a multiplication between a number and a Vector should be of VectorKind.
+    """
+    return VectorKind()

--- a/sympy/vector/kind.py
+++ b/sympy/vector/kind.py
@@ -23,7 +23,7 @@ class VectorKind(Kind):
     >>> from sympy.vector.coordsysrect import CoordSys3D
     >>> Sys = CoordSys3D('Sys')
     >>> Sys.i.kind
-    VectorKind
+    VectorKind(NumberKind)
 
     Operations between instances of Vector keep also have the kind ``VectorKind``:
 
@@ -31,11 +31,11 @@ class VectorKind(Kind):
     >>> v1 = Sys.i * 2 + Sys.j * 3 + Sys.k * 4
     >>> v2 = Sys.i * Sys.x + Sys.j * Sys.y + Sys.k * Sys.z
     >>> v1.kind
-    VectorKind
+    VectorKind(NumberKind)
     >>> v2.kind
-    VectorKind
+    VectorKind(NumberKind)
     >>> Add(v1, v2).kind
-    VectorKind
+    VectorKind(NumberKind)
 
     Subclasses of Vector also have the kind ``VectorKind``, such as
     Cross, VectorAdd, VectorMul or VectorZero.

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -2,6 +2,7 @@ from sympy.core import AtomicExpr, Symbol, S
 from sympy.core.sympify import _sympify
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.printing.precedence import PRECEDENCE
+from sympy.core.kind import NumberKind
 
 
 class BaseScalar(AtomicExpr):
@@ -11,6 +12,8 @@ class BaseScalar(AtomicExpr):
     Ideally, users should not instantiate this class.
 
     """
+
+    kind = NumberKind
 
     def __new__(cls, index, system, pretty_str=None, latex_str=None):
         from sympy.vector.coordsysrect import CoordSys3D

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -1,4 +1,4 @@
-from sympy.core import Rational, S
+from sympy.core import Rational, S, Add, Mul
 from sympy.simplify import simplify, trigsimp
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.numbers import pi
@@ -12,6 +12,8 @@ from sympy.vector.vector import Vector, BaseVector, VectorAdd, \
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.vector import Cross, Dot, cross
 from sympy.testing.pytest import raises
+from sympy.vector.kind import VectorKind
+from sympy.core.kind import NumberKind
 
 C = CoordSys3D('C')
 
@@ -50,6 +52,44 @@ def test_vector_sympy():
     v3 = 2*i + 4*j + i + 4*k + k
     assert v3 == v2
     assert v3.__hash__() == v2.__hash__()
+
+def test_kind():
+    assert C.i.kind is VectorKind()
+    assert C.j.kind is VectorKind()
+    assert C.k.kind is VectorKind()
+
+    assert Mul._kind_dispatcher(NumberKind, VectorKind()) is VectorKind()
+    assert Mul(2, C.i).kind is VectorKind()
+
+    v1 = C.x * i + C.z * C.z * j
+    v2 = C.x * i + C.y * j + C.z * k
+    assert v1.kind is VectorKind()
+    assert v2.kind is VectorKind()
+
+    assert (v1 + v2).kind is VectorKind()
+    assert Add(v1, v2).kind is VectorKind()
+    assert Cross(v1, v2).doit().kind is VectorKind()
+    assert VectorAdd(v1, v2).kind is VectorKind()
+    assert VectorMul(2, v1).kind is VectorKind()
+    assert VectorZero().kind is VectorKind()
+
+    assert v1.projection(v2).kind is VectorKind()
+    assert v2.projection(v1).kind is VectorKind()
+
+def test_vectoradd():
+    assert isinstance(Add(C.i, C.j), VectorAdd)
+    v1 = C.x * i + C.z * C.z * j
+    v2 = C.x * i + C.y * j + C.z * k
+    assert isinstance(Add(v1, v2), VectorAdd)
+
+    # https://github.com/sympy/sympy/issues/26121
+
+    E = Matrix([C.i, C.j, C.k]).T
+    a = Matrix([1, 2, 3])
+    av = E*a
+
+    assert av[0].kind == VectorKind()
+    assert isinstance(av[0], VectorAdd)
 
 
 def test_vector():

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -55,31 +55,31 @@ def test_vector_sympy():
 
 
 def test_kind():
-    assert C.i.kind is VectorKind()
-    assert C.j.kind is VectorKind()
-    assert C.k.kind is VectorKind()
+    assert C.i.kind is VectorKind(NumberKind)
+    assert C.j.kind is VectorKind(NumberKind)
+    assert C.k.kind is VectorKind(NumberKind)
 
     assert C.x.kind is NumberKind
     assert C.y.kind is NumberKind
     assert C.z.kind is NumberKind
 
-    assert Mul._kind_dispatcher(NumberKind, VectorKind()) is VectorKind()
-    assert Mul(2, C.i).kind is VectorKind()
+    assert Mul._kind_dispatcher(NumberKind, VectorKind(NumberKind)) is VectorKind(NumberKind)
+    assert Mul(2, C.i).kind is VectorKind(NumberKind)
 
     v1 = C.x * i + C.z * C.z * j
     v2 = C.x * i + C.y * j + C.z * k
-    assert v1.kind is VectorKind()
-    assert v2.kind is VectorKind()
+    assert v1.kind is VectorKind(NumberKind)
+    assert v2.kind is VectorKind(NumberKind)
 
-    assert (v1 + v2).kind is VectorKind()
-    assert Add(v1, v2).kind is VectorKind()
-    assert Cross(v1, v2).doit().kind is VectorKind()
-    assert VectorAdd(v1, v2).kind is VectorKind()
-    assert VectorMul(2, v1).kind is VectorKind()
-    assert VectorZero().kind is VectorKind()
+    assert (v1 + v2).kind is VectorKind(NumberKind)
+    assert Add(v1, v2).kind is VectorKind(NumberKind)
+    assert Cross(v1, v2).doit().kind is VectorKind(NumberKind)
+    assert VectorAdd(v1, v2).kind is VectorKind(NumberKind)
+    assert VectorMul(2, v1).kind is VectorKind(NumberKind)
+    assert VectorZero().kind is VectorKind(NumberKind)
 
-    assert v1.projection(v2).kind is VectorKind()
-    assert v2.projection(v1).kind is VectorKind()
+    assert v1.projection(v2).kind is VectorKind(NumberKind)
+    assert v2.projection(v1).kind is VectorKind(NumberKind)
 
 
 def test_vectoradd():

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -53,10 +53,15 @@ def test_vector_sympy():
     assert v3 == v2
     assert v3.__hash__() == v2.__hash__()
 
+
 def test_kind():
     assert C.i.kind is VectorKind()
     assert C.j.kind is VectorKind()
     assert C.k.kind is VectorKind()
+
+    assert C.x.kind is NumberKind
+    assert C.y.kind is NumberKind
+    assert C.z.kind is NumberKind
 
     assert Mul._kind_dispatcher(NumberKind, VectorKind()) is VectorKind()
     assert Mul(2, C.i).kind is VectorKind()
@@ -75,6 +80,7 @@ def test_kind():
 
     assert v1.projection(v2).kind is VectorKind()
     assert v2.projection(v1).kind is VectorKind()
+
 
 def test_vectoradd():
     assert isinstance(Add(C.i, C.j), VectorAdd)

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from itertools import product
 
-from sympy.core.add import Add
+from sympy.core import Add, Basic
 from sympy.core.assumptions import StdFactKB
 from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.power import Pow
@@ -349,6 +349,24 @@ class Vector(BasisDependent):
         else:
             raise TypeError("Invalid division involving a vector")
 
+# The following is adapted from the matrices.expressions.matexpr file
+
+def get_postprocessor(cls):
+    def _postprocessor(expr):
+        mat_class = {Add: VectorAdd}[cls]
+        vectors = []
+        for term in expr.args:
+            if isinstance(term, Vector):
+                vectors.append(term)
+
+        if mat_class == VectorAdd:
+            return VectorAdd(*vectors).doit(deep=False)
+    return _postprocessor
+
+
+Basic._constructor_postprocessor_mapping[Vector] = {
+    "Add": [get_postprocessor(Add)],
+}
 
 class BaseVector(Vector, AtomicExpr):
     """

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -354,7 +354,7 @@ def get_postprocessor(cls):
         vec_class = {Add: VectorAdd}[cls]
         vectors = []
         for term in expr.args:
-            if term.kind is VectorKind():
+            if isinstance(term.kind, VectorKind):
                 vectors.append(term)
 
         if vec_class == VectorAdd:

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -14,6 +14,7 @@ from sympy.vector.basisdependent import (BasisDependentZero,
     BasisDependent, BasisDependentMul, BasisDependentAdd)
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.dyadic import Dyadic, BaseDyadic, DyadicAdd
+from sympy.vector.kind import VectorKind
 
 
 class Vector(BasisDependent):
@@ -272,6 +273,10 @@ class Vector(BasisDependent):
             return (S.Zero, S.Zero, S.Zero)
         base_vec = next(iter(_get_coord_systems(self))).base_vectors()
         return tuple([self.dot(i) for i in base_vec])
+
+    @property
+    def kind(self) -> VectorKind:
+        return VectorKind()
 
     def __or__(self, other):
         return self.outer(other)

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -353,13 +353,13 @@ class Vector(BasisDependent):
 
 def get_postprocessor(cls):
     def _postprocessor(expr):
-        mat_class = {Add: VectorAdd}[cls]
+        vec_class = {Add: VectorAdd}[cls]
         vectors = []
         for term in expr.args:
-            if isinstance(term, Vector):
+            if term.kind is VectorKind():
                 vectors.append(term)
 
-        if mat_class == VectorAdd:
+        if vec_class == VectorAdd:
             return VectorAdd(*vectors).doit(deep=False)
     return _postprocessor
 

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -35,6 +35,8 @@ class Vector(BasisDependent):
     _base_func: type[Vector]
     zero: VectorZero
 
+    kind: VectorKind = VectorKind()
+
     @property
     def components(self):
         """
@@ -273,10 +275,6 @@ class Vector(BasisDependent):
             return (S.Zero, S.Zero, S.Zero)
         base_vec = next(iter(_get_coord_systems(self))).base_vectors()
         return tuple([self.dot(i) for i in base_vec])
-
-    @property
-    def kind(self) -> VectorKind:
-        return VectorKind()
 
     def __or__(self, other):
         return self.outer(other)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #26121

#### Brief description of what is fixed or changed

Created a VectorKind class, which is the kind for all vector objects in Sympy. The result of operations between vectors, such as Cross, also has VectorKind.
Added a postprocessor for Add with respect to Vector class to make sure that when calling Add with vectors as arguments the result is an instance of VectorAdd.
Added tests to verify all this.

Example:

In [1]: Sys = CoordSys3D('Sys')

In [2]: Sys.i.kind

Out [2]: VectorKind

In [3]: isinstance(Add(Sys.i, Sys.j), VectorAdd)

Out [3]: True

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* vector
  * Added VectorKind
  * Add with vectors now calls VectorAdd

<!-- END RELEASE NOTES -->
