### PR TITLE
Minor Change to Lambdify Mapping Dictionary for Spherical Bessel Functions.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -507,6 +507,7 @@ David Roberts <dvdr18@gmail.com> David Roberts (dvdr18 [at] gmail [dot] com) <de
 David T <derDavidT@users.noreply.github.com>
 Davide Sandonà <sandona.davide@gmail.com>
 Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
+Dean Price <dean1357price1357@gmail.com>
 Demian Wassermann <demian@bwh.harvard.edu>
 Denis Ivanenko <ivanenko@ucu.edu.ua> Jack <ivanenko@ucu.edu.ua>
 Denis Ivanenko <ivanenko@ucu.edu.ua> LilJohny <ivanenko@ucu.edu.ua>

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -94,7 +94,10 @@ MPMATH_TRANSLATIONS = {
 NUMPY_TRANSLATIONS: dict[str, str] = {
     "Heaviside": "heaviside",
 }
-SCIPY_TRANSLATIONS: dict[str, str] = {}
+SCIPY_TRANSLATIONS: dict[str, str] = {
+    "jn" : "spherical_jn",
+    "yn" : "spherical_yn"
+}
 CUPY_TRANSLATIONS: dict[str, str] = {}
 JAX_TRANSLATIONS: dict[str, str] = {}
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -381,10 +381,10 @@ def test_spherical_bessel():
         skip("scipy not installed.")
     test_point = 4.2 #randomly selected
     x = symbols("x")
-    jtest = jn(test_point, x)
+    jtest = jn(2, x)
     assert abs(lambdify(x,jtest)(test_point) -
             jtest.subs(x,test_point).evalf()) < 1e-8
-    ytest = yn(test_point, x)
+    ytest = yn(2, x)
     assert abs(lambdify(x,ytest)(test_point) -
             ytest.subs(x,test_point).evalf()) < 1e-8
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1157,7 +1157,7 @@ def test_scipy_fns():
             if sympy_fn in (RisingFactorial, polygamma):
                 tv2 = numpy.real(tv2)
             if sympy_fn == polygamma:
-                tv1 = abs(int(tv1))  # first argument to polygamma must be a non-negative integral.
+                tv1 = abs(int(tv1))  # first argument to polygamma must be a non-negative integer.
             sympy_result = sympy_fn(tv1, tv2).evalf()
             assert abs(f(tv1, tv2) - sympy_result) < 1e-13*(1 + abs(sympy_result))
             assert abs(f(tv1, tv2) - scipy_fn(tv1, tv2)) < 1e-13*(1 + abs(sympy_result))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -22,7 +22,7 @@ from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, cos, cot, sin,
                                                       sinc, tan)
-from sympy.functions.special.bessel import (besseli, besselj, besselk, bessely)
+from sympy.functions.special.bessel import (besseli, besselj, besselk, bessely, jn, yn)
 from sympy.functions.special.beta_functions import (beta, betainc, betainc_regularized)
 from sympy.functions.special.delta_functions import (Heaviside)
 from sympy.functions.special.error_functions import (Ei, erf, erfc, fresnelc, fresnels, Si, Ci)
@@ -375,6 +375,18 @@ def test_double_integral():
     l = lambdify([z], i)
     d = l(1)
     assert 1.23370055 < d < 1.233700551
+
+def test_spherical_bessel():
+    if numpy and not scipy:
+        skip("scipy not installed.")
+    test_point = 4.2 #randomly selected
+    x = symbols("x")
+    jtest = jn(1, x)
+    assert abs(lambdify(x,jtest)(test_point) -
+            jtest.subs(x,test_point).evalf()) < 1e-8
+    ytest = yn(1, x)
+    assert abs(lambdify(x,ytest)(test_point) -
+            ytest.subs(x,test_point).evalf()) < 1e-8
 
 
 #================== Test vectors ===================================

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -381,10 +381,10 @@ def test_spherical_bessel():
         skip("scipy not installed.")
     test_point = 4.2 #randomly selected
     x = symbols("x")
-    jtest = jn(1, x)
+    jtest = jn(test_point, x)
     assert abs(lambdify(x,jtest)(test_point) -
             jtest.subs(x,test_point).evalf()) < 1e-8
-    ytest = yn(1, x)
+    ytest = yn(test_point, x)
     assert abs(lambdify(x,ytest)(test_point) -
             ytest.subs(x,test_point).evalf()) < 1e-8
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Originally, when using  `lambdify` on the spherical bessel functions `jn` and `yn` these would automatically map to the **normal** Bessel functions in scipy.  This can cause major bugs which are difficult to detect for most users.

I have added the correct mapping to the `SCIPY_TRANSLATIONS` variable in the `utilities/lambdify.py` file. I have also included a regression test which assures these functions are treated correctly.


#### Other comments
I did not expand the `test_scipy_fns` in `utilities/tests/test_lambdify.py` because it seemed generally incompatible. Although I did try to make it work with minor changes, I ultimately wrote a separate test called `test_spherical_bessel`. I also fixed a minor typo in a comment in `test_scipy_fns`.


<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fixed previously incorrect mapping of sympy spherical bessel function to normal scipy bessel function
<!-- END RELEASE NOTES -->
