### PR TITLE
[GSoC] Refactored the `Series` and `MIMOSeries` to support `StateSpace` connection.

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1398,12 +1398,12 @@ class Series(SISOLinearTimeInvariant):
     You can also connect StateSpace which results in SISO
 
     >>> A1 = Matrix([[-1]])
-    >>> A2 = Matrix([[0]])
     >>> B1 = Matrix([[1]])
-    >>> B2 = Matrix([[1]])
     >>> C1 = Matrix([[-1]])
-    >>> C2 = Matrix([[1]])
     >>> D1 = Matrix([1])
+    >>> A2 = Matrix([[0]])
+    >>> B2 = Matrix([[1]])
+    >>> C2 = Matrix([[1]])
     >>> D2 = Matrix([[0]])
     >>> ss1 = StateSpace(A1, B1, C1, D1)
     >>> ss2 = StateSpace(A2, B2, C2, D2)
@@ -1412,10 +1412,10 @@ class Series(SISOLinearTimeInvariant):
     Series(StateSpace(Matrix([[-1]]), Matrix([[1]]), Matrix([[-1]]), Matrix([[1]])), StateSpace(Matrix([[0]]), Matrix([[1]]), Matrix([[1]]), Matrix([[0]])))
     >>> S5.doit()
     StateSpace(Matrix([
-    [0,  0],
-    [1, -1]]), Matrix([
+    [-1,  0],
+    [-1, 0]]), Matrix([
     [1],
-    [0]]), Matrix([[1, -1]]), Matrix([[0]]))
+    [1]]), Matrix([[0, 1]]), Matrix([[0]]))
 
     Notes
     =====
@@ -1511,7 +1511,7 @@ class Series(SISOLinearTimeInvariant):
                 else:
                     arg = arg.doit()
                 arg = arg.doit()
-                res *= arg
+                res = arg * res
                 return res
 
         _num_arg = (arg.doit().num for arg in self.args)
@@ -1766,20 +1766,20 @@ class MIMOSeries(MIMOLinearTimeInvariant):
             [ 0, 1]])))
     >>> S1.doit()
     StateSpace(Matrix([
-    [ -3,   4,  2, 0,  0],
-    [ -1,  -3,  0, 0,  0],
-    [  2,   5,  3, 0,  0],
-    [ 22,  18, -9, 4,  1],
-    [-15, -18,  0, 2, -3]]), Matrix([
-    [  1,   4],
-    [ -3,  -3],
-    [ -2,   1],
-    [-10,  22],
-    [  6, -15]]), Matrix([
-    [14, 14, -3, 2, -4],
-    [ 3, -2, -6, 0,  1]]), Matrix([
-    [-6, 14],
-    [-2,  3]]))
+    [ 4,  1,  0,  0, 0],
+    [ 2, -3,  0,  0, 0],
+    [ 2,  0, -3,  4, 2],
+    [-6,  9, -1, -3, 0],
+    [-4,  9,  2,  5, 3]]), Matrix([
+    [  5,  2],
+    [ -3, -3],
+    [  7, -2],
+    [-12, -3],
+    [ -5, -5]]), Matrix([
+    [-4, 12, 4, 2, -3],
+    [ 0,  1, 1, 4,  3]]), Matrix([
+    [-2, -8],
+    [ 1, -1]]))
 
     Notes
     =====
@@ -1801,8 +1801,8 @@ class MIMOSeries(MIMOLinearTimeInvariant):
             # Check compatibility
             for i in range(1, len(args)):
                 if args[i].num_inputs != args[i - 1].num_outputs:
-                    raise ValueError(filldedent("""Systems with incompatible inputs and outputs "
-                        cannot be connected in MIMOSeries"""))
+                    raise ValueError(filldedent("""Systems with incompatible inputs and outputs
+                        cannot be connected in MIMOSeries."""))
             obj = super().__new__(cls, *args)
             cls._is_series_StateSpace = True
         else:
@@ -1888,7 +1888,7 @@ class MIMOSeries(MIMOLinearTimeInvariant):
                     arg = arg.doit().rewrite(StateSpace)
                 else:
                     arg = arg.doit()
-                res *= arg
+                res = arg * res
             return res
 
         _arg = (arg.doit()._expr_mat for arg in reversed(self.args))

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1505,10 +1505,13 @@ class Series(SISOLinearTimeInvariant):
             res = self.args[0]
             if not isinstance(res, StateSpace):
                 res = res.doit().rewrite(StateSpace)
-            for model in self.args[1:]:
-                if not isinstance(model, StateSpace):
-                    model = model.doit()
-                res *= model
+            for arg in self.args[1:]:
+                if not isinstance(arg, StateSpace):
+                    arg = arg.doit().rewrite(StateSpace)
+                else:
+                    arg = arg.doit()
+                arg = arg.doit()
+                res *= arg
                 return res
 
         _num_arg = (arg.doit().num for arg in self.args)
@@ -1880,10 +1883,12 @@ class MIMOSeries(MIMOLinearTimeInvariant):
             res = self.args[0]
             if not isinstance(res, StateSpace):
                 res = res.doit().rewrite(StateSpace)
-            for model in self.args[1:]:
-                if not isinstance(model, StateSpace):
-                    model = model.doit()
-                res *= model
+            for arg in self.args[1:]:
+                if not isinstance(arg, StateSpace):
+                    arg = arg.doit().rewrite(StateSpace)
+                else:
+                    arg = arg.doit()
+                res *= arg
             return res
 
         _arg = (arg.doit()._expr_mat for arg in reversed(self.args))

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -392,6 +392,17 @@ class LinearTimeInvariant(Basic, EvalfMixin):
 class SISOLinearTimeInvariant(LinearTimeInvariant):
     """A common class for all the SISO Linear Time-Invariant Dynamical Systems."""
     # Users should not directly interact with this class.
+
+    @property
+    def num_inputs(self):
+        """Return the number of inputs for SISOLinearTimeInvariant."""
+        return 1
+
+    @property
+    def num_outputs(self):
+        """Return the number of outputs for a SISOLinearTimeInvariant."""
+        return 1
+
     _is_SISO = True
 
 
@@ -869,13 +880,6 @@ class TransferFunction(SISOLinearTimeInvariant):
 
         """
         return self.args[2]
-
-    @property
-    def num_inputs(self):
-        """Return the number of inputs of a given TransferFunction."""
-        return 1
-
-    num_outputs = num_inputs
 
     def _eval_subs(self, old, new):
         arg_num = self.num.subs(old, new)
@@ -1653,12 +1657,6 @@ class Series(SISOLinearTimeInvariant):
     @property
     def is_StateSpace_object(self):
         return self._is_series_StateSpace
-
-    @property
-    def num_inputs(self):
-        return 1
-
-    num_outputs = num_inputs
 
 def _mat_mul_compatible(*args):
     """To check whether shapes are compatible for matrix mul."""

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -400,7 +400,7 @@ class SISOLinearTimeInvariant(LinearTimeInvariant):
 
     @property
     def num_outputs(self):
-        """Return the number of outputs for a SISOLinearTimeInvariant."""
+        """Return the number of outputs for SISOLinearTimeInvariant."""
         return 1
 
     _is_SISO = True

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1752,12 +1752,17 @@ def test_StateSpace_functions():
 
 def test_StateSpace_series():
     # For SISO Systems
-    A1 = Matrix([[0, 1], [1, 0]])
-    B1 = Matrix([[0], [1]])
-    C1 = Matrix([[0, 1]])
-    D1 = Matrix([[0]])
-    ss1 = StateSpace(A1, B1, C1, D1)
-    ss2 = StateSpace(Matrix([[1, 0], [0, 1]]), Matrix([[1], [0]]), Matrix([[1, 0]]), Matrix([[1]]))
+    a1 = Matrix([[0, 1], [1, 0]])
+    b1 = Matrix([[0], [1]])
+    c1 = Matrix([[0, 1]])
+    d1 = Matrix([[0]])
+    a2 = Matrix([[1, 0], [0, 1]])
+    b2 = Matrix([[1], [0]])
+    c2 = Matrix([[1, 0]])
+    d2 = Matrix([[1]])
+
+    ss1 = StateSpace(a1, b1, c1, d1)
+    ss2 = StateSpace(a2, b2, c2, d2)
     tf1 = TransferFunction(s, s+1, s)
     ser1 = Series(ss1, ss2)
     assert ser1 == Series(StateSpace(Matrix([
@@ -1771,16 +1776,16 @@ def test_StateSpace_series():
                             [0]]), Matrix([[1, 0]]), Matrix([[1]])))
     assert ser1.doit() == StateSpace(
                             Matrix([
-                            [1, 0, 0, 0],
                             [0, 1, 0, 0],
-                            [0, 0, 0, 1],
-                            [1, 0, 1, 0]]),
+                            [1, 0, 0, 0],
+                            [0, 1, 1, 0],
+                            [0, 0, 0, 1]]),
                             Matrix([
+                            [0],
                             [1],
                             [0],
-                            [0],
-                            [1]]),
-                            Matrix([[0, 0, 0, 1]]),
+                            [0]]),
+                            Matrix([[0, 1, 1, 0]]),
                             Matrix([[0]]))
 
     assert ser1.num_inputs == 1
@@ -1798,27 +1803,27 @@ def test_StateSpace_series():
                             [1]]), Matrix([[0, 1]]), Matrix([[0]])))
     assert ser_tf.doit() == StateSpace(
                             Matrix([
-                            [0, 1,  0],
-                            [1, 0,  0],
-                            [0, 1, -1]]),
+                            [-1, 0,  0],
+                            [0, 0,  1],
+                            [-1, 1, 0]]),
                             Matrix([
-                            [0],
                             [1],
-                            [0]]),
-                            Matrix([[0, 1, -1]]),
+                            [0],
+                            [1]]),
+                            Matrix([[0, 0, 1]]),
                             Matrix([[0]]))
     assert ser_tf.rewrite(TransferFunction) == TransferFunction(s**2, s**3 + s**2 - s - 1, s)
     # For MIMO Systems
-    A2 = Matrix([[4, 1], [2, -3]])
-    B2 = Matrix([[5, 2], [-3, -3]])
-    C2 = Matrix([[2, -4], [0, 1]])
-    D2 = Matrix([[3, 2], [1, -1]])
-    ss3 = StateSpace(A2, B2, C2, D2)
-    A3 = Matrix([[-3, 4, 2], [-1, -3, 0], [2, 5, 3]])
-    B3 = Matrix([[1, 4], [-3, -3], [-2, 1]])
-    C3 = Matrix([[4, 2, -3], [1, 4, 3]])
-    D3 = Matrix([[-2, 4], [0, 1]])
-    ss4 = StateSpace(A3, B3, C3, D3)
+    a3 = Matrix([[4, 1], [2, -3]])
+    b3 = Matrix([[5, 2], [-3, -3]])
+    c3 = Matrix([[2, -4], [0, 1]])
+    d3 = Matrix([[3, 2], [1, -1]])
+    a4 = Matrix([[-3, 4, 2], [-1, -3, 0], [2, 5, 3]])
+    b4 = Matrix([[1, 4], [-3, -3], [-2, 1]])
+    c4 = Matrix([[4, 2, -3], [1, 4, 3]])
+    d4 = Matrix([[-2, 4], [0, 1]])
+    ss3 = StateSpace(a3, b3, c3, d3)
+    ss4 = StateSpace(a4, b4, c4, d4)
     ser4 = MIMOSeries(ss3, ss4)
     assert ser4 == MIMOSeries(StateSpace(Matrix([
                     [4,  1],
@@ -1841,23 +1846,23 @@ def test_StateSpace_series():
                     [ 0, 1]])))
     assert ser4.doit() == StateSpace(
                         Matrix([
-                        [-3,   4,  2, 0,  0],
-                        [-1,  -3,  0, 0,  0],
-                        [2,   5,  3, 0,  0],
-                        [22,  18, -9, 4,  1],
-                        [-15, -18,  0, 2, -3]]),
+                        [4,   1,  0, 0,  0],
+                        [2,  -3,  0, 0,  0],
+                        [2,   0,  -3, 4,  2],
+                        [-6,  9, -1, -3,  0],
+                        [-4, 9,  2, 5, 3]]),
                         Matrix([
-                        [1,   4],
+                        [5,   2],
                         [-3,  -3],
-                        [-2,   1],
-                        [-10,  22],
-                        [6, -15]]),
+                        [7,   -2],
+                        [-12,  -3],
+                        [-5, -5]]),
                         Matrix([
-                        [14, 14, -3, 2, -4],
-                        [3, -2, -6, 0,  1]]),
+                        [-4, 12, 4, 2, -3],
+                        [0, 1, 1, 4, 3]]),
                         Matrix([
-                        [-6, 14],
-                        [-2,  3]]))
+                        [-2, -8],
+                        [1, -1]]))
     assert ser4.num_inputs == ss3.num_inputs
     assert ser4.num_outputs == ss4.num_outputs
     ser5 = MIMOSeries(ss3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added support for `StateSpace` in `Series` and `MIMOSeries` connection.
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed
 - `TransferFunction` & `TransferFunctionMatrix` can be used in series with `StateSpace`.
 -  For the connection having `StateSpace` in it, `.doit()` will return the equivalent `StateSpace` object.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added support to use `StateSpace` with `Series` and `MIMOSeries`.
<!-- END RELEASE NOTES -->
