### PR TITLE
fix(polys): fix apart(full=True) with floats

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4290,9 +4290,25 @@ def all_close(expr1, expr2, rtol=1e-5, atol=1e-8):
             return expr1 == expr2
         elif expr1.func != expr2.func or len(expr1.args) != len(expr2.args):
             return False
+        elif expr1.is_Add or expr1.is_Mul:
+            return _all_close_ac(expr1, expr2, rtol, atol)
         else:
             args = zip(expr1.args, expr2.args)
             return all(_all_close(a1, a2, rtol, atol) for a1, a2 in args)
+
+    def _all_close_ac(expr1, expr2, rtol, atol):
+        # Compare expressions with associative commutative operators for
+        # approximate equality. This could be horribly inefficient for large
+        # expressions e.g. an Add with many terms.
+        args2 = list(expr2.args)
+        for arg1 in expr1.args:
+            for i, arg2 in enumerate(args2):
+                if _all_close(arg1, arg2, rtol, atol):
+                    args2.pop(i)
+                    break
+            else:
+                return False
+        return True
 
     return _all_close(_sympify(expr1), _sympify(expr2), rtol, atol)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -32,6 +32,7 @@ from sympy.polys.domains.groundtypes import PythonRational
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.iterables import permutations
 from sympy.testing.pytest import XFAIL, raises, _both_exp_pow
+from sympy import Add
 
 from mpmath import mpf
 import mpmath
@@ -2295,3 +2296,5 @@ def test_all_close():
     assert all_close(1.4142135623730951, sqrt(2)) is False
     assert all_close(1.4142135623730951, sqrt(2).evalf()) is True
     assert all_close(x + 1e-20, x) is False
+    # We should be able to match terms of an Add/Mul in any order
+    assert all_close(Add(1, 2, evaluate=False), Add(2, 1, evaluate=False))

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -368,7 +368,7 @@ def apart_list_full_decomposition(P, Q, dummygen):
     .. [1] [Bronstein93]_
 
     """
-    f, x, U = P/Q, P.gen, []
+    P_orig, Q_orig, x, U = P, Q, P.gen, []
 
     u = Function('u')(x)
     a = Dummy('a')
@@ -379,7 +379,7 @@ def apart_list_full_decomposition(P, Q, dummygen):
         b = d.as_expr()
         U += [ u.diff(x, n - 1) ]
 
-        h = cancel(f*b**n) / u**n
+        h = cancel(P_orig/Q_orig.quo(d**n)) / u**n
 
         H, subs = [h], []
 

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -19,7 +19,6 @@ from sympy.polys.polytools import (Poly, factor)
 from sympy.polys.rationaltools import together
 from sympy.polys.rootoftools import RootSum
 from sympy.testing.pytest import raises, XFAIL
-from sympy import numer
 from sympy.abc import x, y, a, b, c
 
 

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -9,7 +9,7 @@ from sympy.polys.partfrac import (
 
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
-from sympy.core.numbers import (E, I, Rational, pi)
+from sympy.core.numbers import (E, I, Rational, pi, all_close)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol)
@@ -19,6 +19,7 @@ from sympy.polys.polytools import (Poly, factor)
 from sympy.polys.rationaltools import together
 from sympy.polys.rootoftools import RootSum
 from sympy.testing.pytest import raises, XFAIL
+from sympy import numer
 from sympy.abc import x, y, a, b, c
 
 
@@ -146,6 +147,34 @@ def test_apart_full():
     assert apart(f, full=True).dummy_eq(
         -RootSum(x**4 - x**3 + x**2 - x + 1,
         Lambda(a, a/(x - a)), auto=False)/5 + (Rational(1, 5))/(x + 1))
+
+
+def test_apart_full_floats():
+    # https://github.com/sympy/sympy/issues/26648
+    f = (
+        6.43369157032015e-9*x**3 + 1.35203404799555e-5*x**2
+        + 0.00357538393743079*x + 0.085
+        )/(
+        4.74334912634438e-11*x**4 + 4.09576274286244e-6*x**3
+        + 0.00334241812250921*x**2 + 0.15406018058983*x + 1.0
+    )
+
+    expected = (
+        133.599202650992/(x + 85524.0054884464)
+        + 1.07757928431867/(x + 774.88576677949)
+        + 0.395006955518971/(x + 40.7977016133126)
+        + 0.564264854137341/(x + 7.79746609204661)
+    )
+
+    f_apart = apart(f, full=True).evalf()
+
+    expected_terms = sorted(expected.args, key=numer)
+    found_terms = sorted(f_apart.args, key=numer)
+
+    assert len(expected_terms) == len(found_terms)
+
+    for e, f in zip(expected_terms, found_terms):
+        assert all_close(e, f, rtol=1e-3, atol=1e-5)
 
 
 def test_apart_undetermined_coeffs():

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -168,13 +168,8 @@ def test_apart_full_floats():
 
     f_apart = apart(f, full=True).evalf()
 
-    expected_terms = sorted(expected.args, key=numer)
-    found_terms = sorted(f_apart.args, key=numer)
-
-    assert len(expected_terms) == len(found_terms)
-
-    for e, f in zip(expected_terms, found_terms):
-        assert all_close(e, f, rtol=1e-3, atol=1e-5)
+    # There is a significant floating point error in this operation.
+    assert all_close(f_apart, expected, rtol=1e-3, atol=1e-5)
 
 
 def test_apart_undetermined_coeffs():


### PR DESCRIPTION
Don't assume that the factors divide the original polynomial exactly because if the domain is inexact then they might not. Instead compute the quotient and discard the remainder.

Fixes gh-26648

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * A bug in `apart(full=True)` was fixed. Previously incorrect results might be returned if the expression contained floats.
<!-- END RELEASE NOTES -->
