### PR TITLE
Modify the behavior of physics.wigner.wigner_3j to make it more intuitive

### DIFF
--- a/sympy/physics/quantum/tests/test_cg.py
+++ b/sympy/physics/quantum/tests/test_cg.py
@@ -178,3 +178,6 @@ def test_doit():
     assert Wigner9j(
         2, 1, 1, Rational(3, 2), S.Half, 1, S.Half, S.Half, 0).doit() == sqrt(2)/12
     assert CG(S.Half, S.Half, S.Half, Rational(-1, 2), 1, 0).doit() == sqrt(2)/2
+    # J minus M is not integer
+    assert Wigner3j(1, -1, S.Half, S.Half, 1, S.Half).doit() == 0
+    assert CG(4, -1, S.Half, S.Half, 4, Rational(-1, 2)).doit() == 0

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -232,9 +232,9 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
         return S.Zero
     if (abs(m_1) > j_1) or (abs(m_2) > j_2) or (abs(m_3) > j_3):
         return S.Zero
-    if int(j_1 - m_1) != (j_1 - m_1) or \
-            int(j_2 - m_2) != (j_2 - m_2) or \
-            int(j_3 - m_3) != (j_3 - m_3):
+    if not (int_valued(j_1 - m_1) and \
+            int_valued(j_2 - m_2) and \
+            int_valued(j_3 - m_3)):
         return S.Zero
 
     maxfact = max(j_1 + j_2 + j_3 + 1, j_1 + abs(m_1), j_2 + abs(m_2),

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -230,6 +230,10 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
         return S.Zero
     if (abs(m_1) > j_1) or (abs(m_2) > j_2) or (abs(m_3) > j_3):
         return S.Zero
+    if int(j_1 - m_1) != (j_1 - m_1) or \
+            int(j_2 - m_2) != (j_2 - m_2) or \
+            int(j_3 - m_3) != (j_3 - m_3):
+        return S.Zero
 
     maxfact = max(j_1 + j_2 + j_3 + 1, j_1 + abs(m_1), j_2 + abs(m_2),
                   j_3 + abs(m_3))

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -197,7 +197,9 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     - zero for `m_1 + m_2 + m_3 \neq 0`
 
     - zero for violating any one of the conditions
-      `j_1 \ge |m_1|`,  `j_2 \ge |m_2|`,  `j_3 \ge |m_3|`
+         `m_1  \in \{-|j_1|, \ldots, |j_1|\}`,
+         `m_2  \in \{-|j_2|, \ldots, |j_2|\}`,
+         `m_3  \in \{-|j_3|, \ldots, |j_3|\}`
 
     Algorithm
     =========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26166 

#### Brief description of what is fixed or changed
The wigner_3j return 0 when j minus m is not a integer.

Before
```
Wigner3j(1, -1, S.half, S.half, 1, S.half).doit() == 0 # j3 - m3 == 1/2
>>False
```

Now
```
Wigner3j(1, -1, S.half, S.half, 1, S.half).doit() == 0 # j3 - m3 == 1/2
>>True
```

#### Refrence
[Wigner3j-wolfram](https://mathworld.wolfram.com/Wigner3j-Symbol.html)


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
  * Modify the behavior of  `physics.wigner.wigner_3j`

<!-- END RELEASE NOTES -->
