### PR TITLE
maint(ci): run docs preview only if CI passes

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,9 +1,12 @@
 name: Docs Preview
-on: [status]
-
+on:
+  workflow_run:
+    # test is the name given for the workflow in runtests.yml
+    workflows: ["test"]
+    types: [completed]
 jobs:
   circleci_artifacts_redirector_job:
-    if: "${{ github.event.context == 'ci/circleci: Build Docs Preview' }}"
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
@@ -16,8 +19,7 @@ jobs:
           circleci-jobs: Build Docs Preview
           job-title: Click here to see a preview of the documentation.
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-      # This keeps failing even though the step above suceeds:
-      #- name: Check the URL
-      #  if: github.event.status != 'pending'
-      #  run: |
-      #    curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA
+      - name: Check the URL
+        if: github.event.status != 'pending'
+        run: |
+          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows gh-26646

#### Brief description of what is fixed or changed

Try to run the docs-preview workflow only after CI checks pass on a pull request instead of any time a status of a commit changes.

#### Other comments

This will not take effect until merged to master.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
