### PR TITLE
Revert "maint(ci): run docs preview only if CI passes"

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,12 +1,9 @@
 name: Docs Preview
-on:
-  workflow_run:
-    # test is the name given for the workflow in runtests.yml
-    workflows: ["test"]
-    types: [completed]
+on: [status]
+
 jobs:
   circleci_artifacts_redirector_job:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: "${{ github.event.context == 'ci/circleci: Build Docs Preview' }}"
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
@@ -19,7 +16,8 @@ jobs:
           circleci-jobs: Build Docs Preview
           job-title: Click here to see a preview of the documentation.
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-      - name: Check the URL
-        if: github.event.status != 'pending'
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA
+      # This keeps failing even though the step above suceeds:
+      #- name: Check the URL
+      #  if: github.event.status != 'pending'
+      #  run: |
+      #    curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
This reverts commit e26dba4728568495e093294c70256632c3811ed7.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Reverts gh-26657 because it didn't work.


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
