### PR TITLE
maint(release): bump version to 1.14.dev on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,18 @@ name: release
 on:
   push:
     branches:
-      - '1.12'
+      - '1.13'
     tags:
-      - 'sympy-1.12.*'
+      - 'sympy-1.13.*'
   pull_request:
     branches:
-      - '1.12'
+      - '1.13'
 env:
-  release_branch: '1.12'
-  release_version: '1.12.1'
-  final_release_version: '1.12.1'
-  previous_version: '1.12'
-  dev_version: '1.13-dev'
+  release_branch: '1.13'
+  release_version: '1.13.1'
+  final_release_version: '1.13.1'
+  previous_version: '1.13'
+  dev_version: '1.14-dev'
 
 jobs:
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -74,6 +74,10 @@ will need to either add a `warnings` filter as above or use pytest to filter
 SymPy deprecation warnings.
 ```
 
+## Version 1.14
+
+There are no deprecations yet for SymPy 1.14.
+
 ## Version 1.13
 
 (deprecated-mechanics-body-class)=

--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "1.13.dev"
+__version__ = "1.14.dev"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

1.13 release issue: gh-26169

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
