### PR TITLE
fix(polys): fix poly(expr) with mixed rational integer coefficients

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -7674,7 +7674,7 @@ def poly(expr, *gens, **args):
                     factor = Mul(*factors)
 
                     if factor.is_Number:
-                        product = product.mul(factor)
+                        product *= factor
                     else:
                         product = product.mul(Poly._from_expr(factor, opt))
 
@@ -7692,7 +7692,7 @@ def poly(expr, *gens, **args):
                 term = Add(*terms)
 
                 if term.is_Number:
-                    result = result.add(term)
+                    result += term
                 else:
                     result = result.add(Poly._from_expr(term, opt))
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3586,6 +3586,12 @@ def test_poly():
     assert poly(x + y, x, y) == Poly(x + y, x, y)
     assert poly(x + y, y, x) == Poly(x + y, y, x)
 
+    # https://github.com/sympy/sympy/issues/19755
+    expr1 = x + (2*x + 3)**2/5 + S(6)/5
+    assert poly(expr1).as_expr() == expr1.expand()
+    expr2 = y*(y+1) + S(1)/3
+    assert poly(expr2).as_expr() == expr2.expand()
+
 
 def test_keep_coeff():
     u = Mul(2, x + 1, evaluate=False)


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes gh-19755
fixes gh-26665
closes gh-20730

#### Brief description of what is fixed or changed

Allow unification of the ground domain in `poly(expr)` so that the domain can convert from e.g. ZZ to QQ as needed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * A bug in `poly(expr)` involving mixed integer and rational coefficients was fixed. This indirectly fixes some other things like `solve` for some inputs where previously an exception was raised.
<!-- END RELEASE NOTES -->
