### PR TITLE
perf(matrices): make values etc faster for sparse matrices (1.13)

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1529,7 +1529,6 @@ class MatrixProperties(MatrixRequired):
         simplification the matrix does not appear anti-symmetric:
 
         >>> m.is_anti_symmetric(simplify=False)
-        False
 
         But if the matrix were already expanded, then it would appear
         anti-symmetric and simplification in the is_anti_symmetric routine

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1528,7 +1528,8 @@ class MatrixProperties(MatrixRequired):
         simplified, this will speed things up. Here, we see that without
         simplification the matrix does not appear anti-symmetric:
 
-        >>> m.is_anti_symmetric(simplify=False)
+        >>> print(m.is_anti_symmetric(simplify=False))
+        None
 
         But if the matrix were already expanded, then it would appear
         anti-symmetric and simplification in the is_anti_symmetric routine

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -686,7 +686,7 @@ class MatrixBase(Printable):
 
         >>> from sympy import Matrix
         >>> d = {(0, 0): 1, (1, 2): 3, (2, 1): 4}
-        >>> Matrix.from_dok(d)
+        >>> Matrix.from_dok(3, 3, d)
         Matrix([
         [1, 0, 0],
         [0, 0, 3],
@@ -1489,8 +1489,8 @@ class MatrixBase(Printable):
         simplified, this will speed things up. Here, we see that without
         simplification the matrix does not appear anti-symmetric:
 
-        >>> m.is_anti_symmetric(simplify=False)
-        False
+        >>> print(m.is_anti_symmetric(simplify=False))
+        None
 
         But if the matrix were already expanded, then it would appear
         anti-symmetric and simplification in the is_anti_symmetric routine

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3656,6 +3656,23 @@ class MatrixBase(Printable):
         return MatrixKind(elemkind)
 
     def flat(self):
+        """
+        Returns a flat list of all elements in the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> m = Matrix([[0, 2], [3, 4]])
+        >>> m.flat()
+        [0, 2, 3, 4]
+
+        See Also
+        ========
+
+        tolist
+        values
+        """
         return [self[i, j] for i in range(self.rows) for j in range(self.cols)]
 
     def __array__(self, dtype=object, copy=None):

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -245,6 +245,13 @@ class MatrixBase(Printable):
                     dok[i, j] = val
         return dok
 
+    @classmethod
+    def _eval_from_dok(cls, rows, cols, dok):
+        out_flat = [cls.zero] * (rows * cols)
+        for (i, j), val in dok.items():
+            out_flat[i * cols + j] = val
+        return cls._new(rows, cols, out_flat)
+
     def _eval_vec(self):
         rows = self.rows
 
@@ -669,6 +676,24 @@ class MatrixBase(Printable):
         {(0, 0): 1, (1, 1): 1, (2, 2): 1}
         """
         return self._eval_todok()
+
+    @classmethod
+    def from_dok(cls, rows, cols, dok):
+        """Create a matrix from a dictionary of keys.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> d = {(0, 0): 1, (1, 2): 3, (2, 1): 4}
+        >>> Matrix.from_dok(d)
+        Matrix([
+        [1, 0, 0],
+        [0, 0, 3],
+        [0, 4, 0]])
+        """
+        dok = {ij: cls._sympify(val) for ij, val in dok.items()}
+        return cls._eval_from_dok(rows, cols, dok)
 
     def tolist(self):
         """Return the Matrix as a nested Python list.
@@ -1270,6 +1295,21 @@ class MatrixBase(Printable):
         n = as_int(n)
         return klass._eval_wilkinson(n)
 
+    # The RepMatrix subclass uses more efficient sparse implementations of
+    # _eval_iter_values and other things.
+
+    def _eval_iter_values(self):
+        return (i for i in self if i is not S.Zero)
+
+    def _eval_values(self):
+        return list(self.iter_values())
+
+    def _eval_iter_items(self):
+        for i in range(self.rows):
+            for j in range(self.cols):
+                if self[i, j]:
+                    yield (i, j), self[i, j]
+
     def _eval_atoms(self, *types):
         values = self.values()
         if len(values) < self.rows * self.cols and isinstance(S.Zero, types):
@@ -1279,71 +1319,52 @@ class MatrixBase(Printable):
         return s.union(*[v.atoms(*types) for v in values])
 
     def _eval_free_symbols(self):
-        return set().union(*(i.free_symbols for i in self if i))
+        return set().union(*(i.free_symbols for i in set(self.values())))
 
     def _eval_has(self, *patterns):
-        return any(a.has(*patterns) for a in self)
+        return any(a.has(*patterns) for a in self.iter_values())
 
-    def _eval_is_anti_symmetric(self, simpfunc):
-        if not all(simpfunc(self[i, j] + self[j, i]).is_zero for i in range(self.rows) for j in range(self.cols)):
-            return False
-        return True
-
-    def _eval_is_diagonal(self):
-        for i in range(self.rows):
-            for j in range(self.cols):
-                if i != j and self[i, j]:
-                    return False
-        return True
+    def _eval_is_symbolic(self):
+        return self.has(Symbol)
 
     # _eval_is_hermitian is called by some general SymPy
     # routines and has a different *args signature.  Make
     # sure the names don't clash by adding `_matrix_` in name.
     def _eval_is_matrix_hermitian(self, simpfunc):
-        mat = self._new(self.rows, self.cols, lambda i, j: simpfunc(self[i, j] - self[j, i].conjugate()))
-        return mat.is_zero_matrix
-
-    def _eval_is_Identity(self) -> FuzzyBool:
-        def dirac(i, j):
-            if i == j:
-                return 1
-            return 0
-
-        return all(self[i, j] == dirac(i, j)
-                for i in range(self.rows)
-                for j in range(self.cols))
-
-    def _eval_is_lower_hessenberg(self):
-        return all(self[i, j].is_zero
-                   for i in range(self.rows)
-                   for j in range(i + 2, self.cols))
-
-    def _eval_is_lower(self):
-        return all(self[i, j].is_zero
-                   for i in range(self.rows)
-                   for j in range(i + 1, self.cols))
-
-    def _eval_is_symbolic(self):
-        return self.has(Symbol)
-
-    def _eval_is_symmetric(self, simpfunc):
-        mat = self._new(self.rows, self.cols, lambda i, j: simpfunc(self[i, j] - self[j, i]))
-        return mat.is_zero_matrix
+        herm = lambda i, j: simpfunc(self[i, j] - self[j, i].conjugate()).is_zero
+        return fuzzy_and(herm(i, j) for (i, j), v in self.iter_items())
 
     def _eval_is_zero_matrix(self):
-        if any(i.is_zero == False for i in self):
-            return False
-        if any(i.is_zero is None for i in self):
-            return None
-        return True
+        return fuzzy_and(v.is_zero for v in self.iter_values())
+
+    def _eval_is_Identity(self) -> FuzzyBool:
+        one = self.one
+        zero = self.zero
+        ident = lambda i, j, v: v is one if i == j else v is zero
+        return all(ident(i, j, v) for (i, j), v in self.iter_items())
+
+    def _eval_is_diagonal(self):
+        return fuzzy_and(v.is_zero for (i, j), v in self.iter_items() if i != j)
+
+    def _eval_is_lower(self):
+        return all(v.is_zero for (i, j), v in self.iter_items() if i < j)
+
+    def _eval_is_upper(self):
+        return all(v.is_zero for (i, j), v in self.iter_items() if i > j)
+
+    def _eval_is_lower_hessenberg(self):
+        return all(v.is_zero for (i, j), v in self.iter_items() if i + 1 < j)
 
     def _eval_is_upper_hessenberg(self):
-        return all(self[i, j].is_zero
-                   for i in range(2, self.rows)
-                   for j in range(min(self.cols, (i - 1))))
+        return all(v.is_zero for (i, j), v in self.iter_items() if i > j + 1)
 
-    def _eval_values(self):
-        return [i for i in self if not i.is_zero]
+    def _eval_is_symmetric(self, simpfunc):
+        sym = lambda i, j: simpfunc(self[i, j] - self[j, i]).is_zero
+        return fuzzy_and(sym(i, j) for (i, j), v in self.iter_items())
+
+    def _eval_is_anti_symmetric(self, simpfunc):
+        anti = lambda i, j: simpfunc(self[i, j] + self[j, i]).is_zero
+        return fuzzy_and(anti(i, j) for (i, j), v in self.iter_items())
 
     def _has_positive_diagonals(self):
         diagonal_entries = (self[i, i] for i in range(self.rows))
@@ -1919,9 +1940,7 @@ class MatrixBase(Printable):
         is_diagonal
         is_upper_hessenberg
         """
-        return all(self[i, j].is_zero
-                   for i in range(1, self.rows)
-                   for j in range(min(i, self.cols)))
+        return self._eval_is_upper()
 
     @property
     def is_zero_matrix(self):
@@ -1955,14 +1974,82 @@ class MatrixBase(Printable):
         return self._eval_is_zero_matrix()
 
     def values(self):
-        """Return non-zero values of self."""
+        """Return non-zero values of self.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> m = Matrix([[0, 1], [2, 3]])
+        >>> m.values()
+        [1, 2, 3]
+
+        See Also
+        ========
+
+        iter_values
+        tolist
+        flat
+        """
         return self._eval_values()
+
+    def iter_values(self):
+        """
+        Iterate over non-zero values of self.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> m = Matrix([[0, 1], [2, 3]])
+        >>> list(m.iter_values())
+        [1, 2, 3]
+
+        See Also
+        ========
+
+        values
+        """
+        return self._eval_iter_values()
+
+    def iter_items(self):
+        """Iterate over indices and values of nonzero items.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> m = Matrix([[0, 1], [2, 3]])
+        >>> list(m.iter_items())
+        [((0, 1), 1), ((1, 0), 2), ((1, 1), 3)]
+
+        See Also
+        ========
+
+        iter_values
+        todok
+        """
+        return self._eval_iter_items()
 
     def _eval_adjoint(self):
         return self.transpose().conjugate()
 
     def _eval_applyfunc(self, f):
-        out = self._new(self.rows, self.cols, [f(x) for x in self])
+        cols = self.cols
+        size = self.rows*self.cols
+
+        dok = self.todok()
+        valmap = {v: f(v) for v in dok.values()}
+
+        if len(dok) < size and ((fzero := f(S.Zero)) is not S.Zero):
+            out_flat = [fzero]*size
+            for (i, j), v in dok.items():
+                out_flat[i*cols + j] = valmap[v]
+            out = self._new(self.rows, self.cols, out_flat)
+        else:
+            fdok = {ij: valmap[v] for ij, v in dok.items()}
+            out = self.from_dok(self.rows, self.cols, fdok)
+
         return out
 
     def _eval_as_real_imag(self):  # type: ignore

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -242,8 +242,29 @@ class RepMatrix(MatrixBase):
     def _eval_todok(self):
         return self._rep.to_sympy().to_dok()
 
+    @classmethod
+    def _eval_from_dok(cls, rows, cols, dok):
+        return cls._fromrep(cls._smat_to_DomainMatrix(rows, cols, dok))
+
     def _eval_values(self):
-        return list(self.todok().values())
+        return list(self._eval_iter_values())
+
+    def _eval_iter_values(self):
+        rep = self._rep
+        K = rep.domain
+        values = rep.iter_values()
+        if not K.is_EXRAW:
+            values = map(K.to_sympy, values)
+        return values
+
+    def _eval_iter_items(self):
+        rep = self._rep
+        K = rep.domain
+        to_sympy = K.to_sympy
+        items = rep.iter_items()
+        if not K.is_EXRAW:
+            items = ((i, to_sympy(v)) for i, v in items)
+        return items
 
     def copy(self):
         return self._fromrep(self._rep.copy())

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2509,12 +2509,12 @@ def test_anti_symmetric():
     assert Matrix([1, 2]).is_anti_symmetric() is False
     m = Matrix(3, 3, [0, x**2 + 2*x + 1, y, -(x + 1)**2, 0, x*y, -y, -x*y, 0])
     assert m.is_anti_symmetric() is True
-    assert m.is_anti_symmetric(simplify=False) is False
-    assert m.is_anti_symmetric(simplify=lambda x: x) is False
+    assert m.is_anti_symmetric(simplify=False) is None
+    assert m.is_anti_symmetric(simplify=lambda x: x) is None
 
     # tweak to fail
     m[2, 1] = -m[2, 1]
-    assert m.is_anti_symmetric() is False
+    assert m.is_anti_symmetric() is None
     # untweak
     m[2, 1] = -m[2, 1]
 

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -234,8 +234,8 @@ def test_is_anti_symmetric():
     assert Matrix(2, 1, [1, 2]).is_anti_symmetric() is False
     m = Matrix(3, 3, [0, x**2 + 2*x + 1, y, -(x + 1)**2, 0, x*y, -y, -x*y, 0])
     assert m.is_anti_symmetric() is True
-    assert m.is_anti_symmetric(simplify=False) is False
-    assert m.is_anti_symmetric(simplify=lambda x: x) is False
+    assert m.is_anti_symmetric(simplify=False) is None
+    assert m.is_anti_symmetric(simplify=lambda x: x) is None
 
     m = Matrix(3, 3, [x.expand() for x in m])
     assert m.is_anti_symmetric(simplify=False) is True
@@ -3200,12 +3200,12 @@ def test_anti_symmetric():
     assert Matrix([1, 2]).is_anti_symmetric() is False
     m = Matrix(3, 3, [0, x**2 + 2*x + 1, y, -(x + 1)**2, 0, x*y, -y, -x*y, 0])
     assert m.is_anti_symmetric() is True
-    assert m.is_anti_symmetric(simplify=False) is False
-    assert m.is_anti_symmetric(simplify=lambda x: x) is False
+    assert m.is_anti_symmetric(simplify=False) is None
+    assert m.is_anti_symmetric(simplify=lambda x: x) is None
 
     # tweak to fail
     m[2, 1] = -m[2, 1]
-    assert m.is_anti_symmetric() is False
+    assert m.is_anti_symmetric() is None
     # untweak
     m[2, 1] = -m[2, 1]
 

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -267,6 +267,31 @@ class DFM:
         """Convert to a DOK."""
         return self.to_ddm().to_dok()
 
+    @classmethod
+    def from_dok(cls, dok, shape, domain):
+        """Inverse of :math:`to_dod`."""
+        return DDM.from_dok(dok, shape, domain).to_dfm()
+
+    def iter_values(self):
+        """Iterater over the non-zero values of the matrix."""
+        m, n = self.shape
+        rep = self.rep
+        for i in range(m):
+            for j in range(n):
+                repij = rep[i, j]
+                if repij:
+                    yield rep[i, j]
+
+    def iter_items(self):
+        """Iterate over indices and values of nonzero elements of the matrix."""
+        m, n = self.shape
+        rep = self.rep
+        for i in range(m):
+            for j in range(n):
+                repij = rep[i, j]
+                if repij:
+                    yield ((i, j), repij)
+
     def convert_to(self, domain):
         """Convert to a new domain."""
         if domain == self.domain:

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -186,6 +186,7 @@ class DDM(list):
         ========
 
         to_list_flat
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_list
         """
         return list(self)
 
@@ -207,7 +208,7 @@ class DDM(list):
         See Also
         ========
 
-        from_list_flat
+        sympy.polys.matrices.domainmatrix.DomainMatrix.to_list_flat
         """
         flat = []
         for row in self:
@@ -234,6 +235,7 @@ class DDM(list):
         ========
 
         to_list_flat
+        sympy.polys.matrices.domainmatrix.DomainMatrix.from_list_flat
         """
         assert type(flat) is list
         rows, cols = shape
@@ -419,6 +421,54 @@ class DDM(list):
         for (i, j), element in dok.items():
             lol[i][j] = element
         return DDM(lol, shape, domain)
+
+    def iter_values(self):
+        """
+        Iterater over the non-zero values of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[QQ(1), QQ(0)], [QQ(3), QQ(4)]], (2, 2), QQ)
+        >>> list(A.iter_values())
+        [1, 3, 4]
+
+        See Also
+        ========
+
+        iter_items
+        to_list_flat
+        sympy.polys.matrices.domainmatrix.DomainMatrix.iter_values
+        """
+        for row in self:
+            yield from filter(None, row)
+
+    def iter_items(self):
+        """
+        Iterate over indices and values of nonzero elements of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> from sympy import QQ
+        >>> A = DDM([[QQ(1), QQ(0)], [QQ(3), QQ(4)]], (2, 2), QQ)
+        >>> list(A.iter_items())
+        [((0, 0), 1), ((1, 0), 3), ((1, 1), 4)]
+
+        See Also
+        ========
+
+        iter_values
+        to_dok
+        sympy.polys.matrices.domainmatrix.DomainMatrix.iter_items
+        """
+        for i, row in enumerate(self):
+            for j, element in enumerate(row):
+                if element:
+                    yield (i, j), element
 
     def to_ddm(self):
         """

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1111,7 +1111,7 @@ class DomainMatrix:
         >>> from sympy import ZZ
         >>> from sympy.polys.matrices import DomainMatrix
         >>> A = DomainMatrix([[ZZ(1), ZZ(0)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-        >>> list(A.values())
+        >>> list(A.iter_values())
         [1, 3, 4]
 
         See Also
@@ -1133,7 +1133,7 @@ class DomainMatrix:
         >>> from sympy import ZZ
         >>> from sympy.polys.matrices import DomainMatrix
         >>> A = DomainMatrix([[ZZ(1), ZZ(0)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
-        >>> list(A.items())
+        >>> list(A.iter_items())
         [((0, 0), 1), ((1, 0), 3), ((1, 1), 4)]
 
         See Also

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1101,6 +1101,50 @@ class DomainMatrix:
         """
         return cls.from_rep(SDM.from_dok(dok, shape, domain))
 
+    def iter_values(self):
+        """
+        Iterate over nonzero elements of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> A = DomainMatrix([[ZZ(1), ZZ(0)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> list(A.values())
+        [1, 3, 4]
+
+        See Also
+        ========
+
+        iter_items
+        to_list_flat
+        sympy.matrices.matrixbase.MatrixBase.iter_values
+        """
+        return self.rep.iter_values()
+
+    def iter_items(self):
+        """
+        Iterate over indices and values of nonzero elements of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> A = DomainMatrix([[ZZ(1), ZZ(0)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+        >>> list(A.items())
+        [((0, 0), 1), ((1, 0), 3), ((1, 1), 4)]
+
+        See Also
+        ========
+
+        iter_values
+        to_dok
+        sympy.matrices.matrixbase.MatrixBase.iter_items
+        """
+        return self.rep.iter_items()
+
     def nnz(self):
         """
         Number of nonzero elements in the matrix.

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -556,6 +556,45 @@ class SDM(dict):
                 sdm[i][j] = e
         return cls(sdm, shape, domain)
 
+    def iter_values(M):
+        """
+        Iterate over the nonzero values of a :py:class:`~.SDM` matrix.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0: {1: QQ(2)}, 1: {0: QQ(3)}}, (2, 2), QQ)
+        >>> list(A.iter_values())
+        [2, 3]
+
+        """
+        for row in M.values():
+            yield from row.values()
+
+    def iter_items(M):
+        """
+        Iterate over indices and values of the nonzero elements.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ
+        >>> A = SDM({0: {1: QQ(2)}, 1: {0: QQ(3)}}, (2, 2), QQ)
+        >>> list(A.iter_items())
+        [((0, 1), 2), ((1, 0), 3)]
+
+        See Also
+        ========
+
+        sympy.polys.matrices.domainmatrix.DomainMatrix.iter_items
+        """
+        for i, row in M.items():
+            for j, e in row.items():
+                yield (i, j), e
+
     def to_ddm(M):
         """
         Convert a :py:class:`~.SDM` object to a :py:class:`~.DDM` object

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -613,7 +613,6 @@ def test_XXM_iter_values(DM):
 
 @pytest.mark.parametrize('DM', DMZ_all)
 def test_XXM_iter_items(DM):
-    T = type(DM([[0]]))
     items = [((0, 0), ZZ(1)), ((0, 2), ZZ(4)),
              ((1, 0), ZZ(4)), ((1, 1), ZZ(5)), ((1, 2), ZZ(6))]
     assert sorted(DM([[1, 0, 4], [4, 5, 6]]).iter_items()) == items

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -591,6 +591,35 @@ def test_XXM_from_dod(DM):
 
 
 @pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_to_dok(DM):
+    dod = {(0, 0): ZZ(1), (0, 2): ZZ(4),
+           (1, 0): ZZ(4), (1, 1): ZZ(5), (1, 2): ZZ(6)}
+    assert DM([[1, 0, 4], [4, 5, 6]]).to_dok() == dod
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_from_dok(DM):
+    T = type(DM([[0]]))
+    dod = {(0, 0): ZZ(1), (0, 2): ZZ(4),
+           (1, 0): ZZ(4), (1, 1): ZZ(5), (1, 2): ZZ(6)}
+    assert T.from_dok(dod, (2, 3), ZZ) == DM([[1, 0, 4], [4, 5, 6]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_iter_values(DM):
+    values = [ZZ(1), ZZ(4), ZZ(4), ZZ(5), ZZ(6)]
+    assert sorted(DM([[1, 0, 4], [4, 5, 6]]).iter_values()) == values
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_iter_items(DM):
+    T = type(DM([[0]]))
+    items = [((0, 0), ZZ(1)), ((0, 2), ZZ(4)),
+             ((1, 0), ZZ(4)), ((1, 1), ZZ(5)), ((1, 2), ZZ(6))]
+    assert sorted(DM([[1, 0, 4], [4, 5, 6]]).iter_items()) == items
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
 def test_XXM_from_ddm(DM):
     T = type(DM([[0]]))
     ddm = DDM([[1, 2, 4], [4, 5, 6]], (2, 3), ZZ)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of gh-26058 to 1.13 release branch.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * Two new Matrix methods `iter_values` and `iter_items` are added for lazy iteration over the nonzero elements of a `Matrix`. A Matrix method `from_dok` is added for efficient direct construction of sparse matrices. Some basic matrix operations are made faster by using these methods.
<!-- END RELEASE NOTES -->
