### PR TITLE
Print relational when cannot determine truth value

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -541,6 +541,7 @@ Dustin Gadal <Dustin.Gadal@gmail.com> <dustin.gadal@gmail.com>
 Dzhelil Rufat <drufat@caltech.edu>
 Ebrahim Byagowi <ebrahim@gnu.org>
 Edward Schembor <eschemb1@jhu.edu>
+Edward Z. Yang <ezyang@mit.edu> Edward Z. Yang <ezyang@meta.com>
 Eh Tan <tan2tan2@gmail.com>
 Ehren Metcalfe <ehren.m@gmail.com>
 Ekansh Purohit <purohit.e15@gmail.com>

--- a/sympy/core/coreerrors.py
+++ b/sympy/core/coreerrors.py
@@ -16,7 +16,7 @@ class LazyExceptionMessage:
     error message that is only evaluated if the error is rendered."""
     callback: Callable[[], str]
 
-    def __init__(self, callback: Callable[[], str]): 
+    def __init__(self, callback: Callable[[], str]):
         self.callback = callback
 
     def __str__(self):

--- a/sympy/core/coreerrors.py
+++ b/sympy/core/coreerrors.py
@@ -1,5 +1,7 @@
 """Definitions of common exceptions for :mod:`sympy.core` module. """
 
+from typing import Callable
+
 
 class BaseCoreError(Exception):
     """Base class for core related exceptions. """
@@ -7,3 +9,15 @@ class BaseCoreError(Exception):
 
 class NonCommutativeExpression(BaseCoreError):
     """Raised when expression didn't have commutative property. """
+
+
+class LazyExceptionMessage:
+    """Wrapper class that lets you specify an expensive to compute
+    error message that is only evaluated if the error is rendered."""
+    callback: Callable[[], str]
+
+    def __init__(self, callback: Callable[[], str]): 
+        self.callback = callback
+
+    def __str__(self):
+        return self.callback()

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -513,7 +513,7 @@ class Relational(Boolean, EvalfMixin):
         return self.func(*args)
 
     def __bool__(self):
-        raise TypeError("cannot determine truth value of Relational")
+        raise TypeError(f"cannot determine truth value of Relational {self}")
 
     def _eval_as_set(self):
         # self is univariate and periodicity(self, x) in (0, None)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .basic import Atom, Basic
+from .coreerrors import LazyExceptionMessage
 from .sorting import ordered
 from .evalf import EvalfMixin
 from .function import AppliedUndef
@@ -513,7 +514,11 @@ class Relational(Boolean, EvalfMixin):
         return self.func(*args)
 
     def __bool__(self):
-        raise TypeError(f"cannot determine truth value of Relational {self}")
+        raise TypeError(
+            LazyExceptionMessage(
+                lambda: f"cannot determine truth value of Relational: {self}"
+            )
+        )
 
     def _eval_as_set(self):
         # self is univariate and periodicity(self, x) in (0, None)


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I just kept getting annoyed by "cannot determine truth value" without telling me what the expression is. So print it out.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Print the expression when you cannot determine truth value of relational

<!-- END RELEASE NOTES -->
