### PR TITLE
Implemented Influence Line Diagram Calculations for Beams with Hinges

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -136,7 +136,7 @@ class Beam:
     (-5*L**2*q1 + 7*L**2*q2 - 8*L*P1 + 4*L*P2 + 32*M1 - 32*M2)/(32*L)
     """
 
-    def __init__(self, length, elastic_modulus, second_moment, area=Symbol('A'), variable=Symbol('x'),  base_char='C', ild_variable=Symbol('a')):
+    def __init__(self, length, elastic_modulus, second_moment, area=Symbol('A'), variable=Symbol('x'), base_char='C', ild_variable=Symbol('a')):
         """Initializes the class.
 
         Parameters
@@ -170,15 +170,15 @@ class Beam:
             while representing the load, shear, moment, slope and deflection
             curve. By default, it is set to ``Symbol('x')``.
 
-        ild_variable : Symbol, optional
-            A Symbol object that will be used as the variable specifying the
-            location of the moving load in ILD calculations. By default, it
-            is set to ``Symbol('a')``.
-
         base_char : String, optional
             A String that will be used as base character to generate sequential
             symbols for integration constants in cases where boundary conditions
             are not sufficient to solve them.
+
+        ild_variable : Symbol, optional
+            A Symbol object that will be used as the variable specifying the
+            location of the moving load in ILD calculations. By default, it
+            is set to ``Symbol('a')``.
         """
         self.length = length
         self.elastic_modulus = elastic_modulus

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2023,7 +2023,7 @@ class Beam:
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_shear(4, 1, R_0, R_8)
             >>> b.ild_shear
-            Piecewise((a/8, a < 4), (a/8 - 1, a > 4))
+            a/8 - SingularityFunction(a, 4, 0)
 
         """
 
@@ -2040,7 +2040,7 @@ class Beam:
             shear_curve1 = shear_curve1.subs(reaction,self._ild_reactions[reaction])
             shear_curve2 = shear_curve2.subs(reaction,self._ild_reactions[reaction])
 
-        shear_eq = Piecewise((shear_curve1, a < distance), (shear_curve2, a > distance))
+        shear_eq = shear_curve1 - (shear_curve1 - shear_curve2) * SingularityFunction(a, distance, 0)
 
         self._ild_shear = shear_eq
 
@@ -2083,10 +2083,10 @@ class Beam:
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_shear(4, 1, R_0, R_8)
             >>> b.ild_shear
-            Piecewise((a/8, a < 4), (a/8 - 1, a > 4))
+            a/8 - SingularityFunction(a, 4, 0)
             >>> b.plot_ild_shear()
             Plot object containing:
-            [0]: cartesian line: Piecewise((a/8, a < 4), (a/8 - 1, a > 4)) for a over (0.0, 12.0)
+            [0]: cartesian line: a/8 - SingularityFunction(a, 4, 0) for a over (0.0, 12.0)
 
         """
 
@@ -2151,7 +2151,7 @@ class Beam:
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_moment(4, 1, R_0, R_8)
             >>> b.ild_moment
-            Piecewise((-a/2, a < 4), (a/2 - 4, a > 4))
+            -a/2 - (4 - a)*SingularityFunction(a, 4, 0)
 
         """
 
@@ -2168,7 +2168,8 @@ class Beam:
             moment_curve1 = moment_curve1.subs(reaction, self._ild_reactions[reaction])
             moment_curve2 = moment_curve2.subs(reaction, self._ild_reactions[reaction])
 
-        moment_eq = Piecewise((moment_curve1, a < distance), (moment_curve2, a > distance))
+        moment_eq = moment_curve1 - (moment_curve1 - moment_curve2) * SingularityFunction(a, distance, 0)
+
         self._ild_moment = moment_eq
 
     def plot_ild_moment(self,subs=None):
@@ -2210,10 +2211,10 @@ class Beam:
             >>> b.solve_for_ild_reactions(1, R_0, R_8)
             >>> b.solve_for_ild_moment(4, 1, R_0, R_8)
             >>> b.ild_moment
-            Piecewise((-a/2, a < 4), (a/2 - 4, a > 4))
+            -a/2 - (4 - a)*SingularityFunction(a, 4, 0)
             >>> b.plot_ild_moment()
             Plot object containing:
-            [0]: cartesian line: Piecewise((-a/2, a < 4), (a/2 - 4, a > 4)) for a over (0.0, 12.0)
+            [0]: cartesian line: -a/2 - (4 - a)*SingularityFunction(a, 4, 0) for a over (0.0, 12.0)
 
         """
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2233,7 +2233,7 @@ class Beam:
 
         Warning
         =======
-        The values for a = 0 and a = l, with l the lenght of the beam, in
+        The values for a = 0 and a = l, with l the length of the beam, in
         the plot can be incorrect.
 
         Examples

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1931,7 +1931,7 @@ class Beam:
 
         Warning
         =======
-        The values for a = 0 and a = l, with l the lenght of the beam, in
+        The values for a = 0 and a = l, with l the length of the beam, in
         the plot can be incorrect.
 
         Examples

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -136,7 +136,7 @@ class Beam:
     (-5*L**2*q1 + 7*L**2*q2 - 8*L*P1 + 4*L*P2 + 32*M1 - 32*M2)/(32*L)
     """
 
-    def __init__(self, length, elastic_modulus, second_moment, area=Symbol('A'), variable=Symbol('x'), base_char='C'):
+    def __init__(self, length, elastic_modulus, second_moment, area=Symbol('A'), variable=Symbol('x'), ild_variable=Symbol('a'), base_char='C'):
         """Initializes the class.
 
         Parameters
@@ -170,6 +170,11 @@ class Beam:
             while representing the load, shear, moment, slope and deflection
             curve. By default, it is set to ``Symbol('x')``.
 
+        ild_variable : Symbol, optional
+            A Symbol object that will be used as the variable specifying the
+            location of the moving load in ILD calculations. By default, it
+            is set to ``Symbol('a')``.
+
         base_char : String, optional
             A String that will be used as base character to generate sequential
             symbols for integration constants in cases where boundary conditions
@@ -183,6 +188,7 @@ class Beam:
             self.cross_section = None
             self.second_moment = second_moment
         self.variable = variable
+        self.ild_variable = ild_variable
         self._base_char = base_char
         self._boundary_conditions = {'deflection': [], 'slope': [], 'bending_moment': [], 'shear_force': []}
         self._load = 0
@@ -1803,7 +1809,7 @@ class Beam:
         moment equations.
         """
         x = self.variable
-        a = Symbol('a')
+        a = self.ild_variable
         load = self._load + value * SingularityFunction(x, a, -1)
         shear_force = -integrate(load, x)
         bending_moment = integrate(shear_force, x)
@@ -1859,7 +1865,7 @@ class Beam:
         shear_force, bending_moment = self._solve_for_ild_equations(value)
         x = self.variable
         l = self.length
-        a = Symbol('a')
+        a = self.ild_variable
 
         rotation_jumps = tuple(self._rotation_hinge_symbols)
         deflection_jumps = tuple(self._sliding_hinge_symbols)
@@ -1978,7 +1984,7 @@ class Beam:
         if not self._ild_reactions:
             raise ValueError("I.L.D. reaction equations not found. Please use solve_for_ild_reactions() to generate the I.L.D. reaction equations.")
 
-        a = Symbol('a')
+        a = self.ild_variable
         ildplots = []
 
         if subs is None:
@@ -2054,7 +2060,7 @@ class Beam:
 
         x = self.variable
         l = self.length
-        a = Symbol('a')
+        a = self.ild_variable
 
         shear_force, _ = self._solve_for_ild_equations(value)
 
@@ -2129,7 +2135,7 @@ class Beam:
             raise ValueError("I.L.D. shear equation not found. Please use solve_for_ild_shear() to generate the I.L.D. shear equations.")
 
         l = self._length
-        a = Symbol('a')
+        a = self.ild_variable
 
         if subs is None:
             subs = {}
@@ -2199,7 +2205,7 @@ class Beam:
 
         x = self.variable
         l = self.length
-        a = Symbol('a')
+        a = self.ild_variable
 
         _, moment = self._solve_for_ild_equations(value)
 
@@ -2275,7 +2281,7 @@ class Beam:
         if not self._ild_moment:
             raise ValueError("I.L.D. moment equation not found. Please use solve_for_ild_moment() to generate the I.L.D. moment equations.")
 
-        a = Symbol('a')
+        a = self.ild_variable
 
         if subs is None:
             subs = {}

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -136,7 +136,7 @@ class Beam:
     (-5*L**2*q1 + 7*L**2*q2 - 8*L*P1 + 4*L*P2 + 32*M1 - 32*M2)/(32*L)
     """
 
-    def __init__(self, length, elastic_modulus, second_moment, area=Symbol('A'), variable=Symbol('x'), ild_variable=Symbol('a'), base_char='C'):
+    def __init__(self, length, elastic_modulus, second_moment, area=Symbol('A'), variable=Symbol('x'),  base_char='C', ild_variable=Symbol('a')):
         """Initializes the class.
 
         Parameters

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1823,6 +1823,11 @@ class Beam:
         reactions :
             The reaction forces applied on the beam.
 
+        Warning
+        =======
+        This method creates equations that can give incorrect results when
+        substituting a = 0 or a = l, with l the lenght of the beam.
+
         Examples
         ========
 
@@ -1924,6 +1929,11 @@ class Beam:
                Python dictionary containing Symbols as key and their
                corresponding values.
 
+        Warning
+        =======
+        The values for a = 0 and a = l, with l the lenght of the beam, in
+        the plot can be incorrect.
+
         Examples
         ========
 
@@ -1959,10 +1969,10 @@ class Beam:
             PlotGrid object containing:
             Plot[0]:Plot object containing:
             [0]: cartesian line: -SingularityFunction(a, 0, 0) + SingularityFunction(a, 0, 1)/7
-            - 3*SingularityFunction(a, 10, 0)/7 - SingularityFunction(a, 10, 1)/7 - 15/7 for a over (-0.0001, 10.0)
+            - 3*SingularityFunction(a, 10, 0)/7 - SingularityFunction(a, 10, 1)/7 - 15/7 for a over (0.0, 10.0)
             Plot[1]:Plot object containing:
             [0]: cartesian line: -SingularityFunction(a, 0, 1)/7 + 10*SingularityFunction(a, 10, 0)/7
-            + SingularityFunction(a, 10, 1)/7 - 20/7 for a over (-0.0001, 10.0)
+            + SingularityFunction(a, 10, 1)/7 - 20/7 for a over (0.0, 10.0)
 
         """
         if not self._ild_reactions:
@@ -1985,7 +1995,7 @@ class Beam:
 
         for reaction in self._ild_reactions:
             ildplots.append(plot(self._ild_reactions[reaction].subs(subs),
-            (a, -0.0001, self._length.subs(subs)), title='I.L.D. for Reactions',
+            (a, 0, self._length.subs(subs)), title='I.L.D. for Reactions',
             xlabel=a, ylabel=reaction, line_color='blue', show=False))
 
         return PlotGrid(len(ildplots), 1, *ildplots)
@@ -2005,6 +2015,11 @@ class Beam:
             Magnitude of moving load
         reactions :
             The reaction forces applied on the beam.
+
+        Warning
+        =======
+        This method creates equations that can give incorrect results when
+        substituting a = 0 or a = l, with l the lenght of the beam.
 
         Examples
         ========
@@ -2069,6 +2084,11 @@ class Beam:
                Python dictionary containing Symbols as key and their
                corresponding values.
 
+        Warning
+        =======
+        The values for a = 0 and a = l, with l the lenght of the beam, in
+        the plot can be incorrect.
+
         Examples
         ========
 
@@ -2101,7 +2121,7 @@ class Beam:
             Plot object containing:
             [0]: cartesian line: -(-SingularityFunction(a, 0, 0) + SingularityFunction(a, 12, 0) + 2)*SingularityFunction(a, 4, 0)
             - SingularityFunction(-a, 0, 0) - SingularityFunction(a, 0, 0) + SingularityFunction(a, 0, 1)/8
-            + SingularityFunction(a, 12, 0)/2 - SingularityFunction(a, 12, 1)/8 + 1 for a over (-0.0001, 12.0)
+            + SingularityFunction(a, 12, 0)/2 - SingularityFunction(a, 12, 1)/8 + 1 for a over (0.0, 12.0)
 
         """
 
@@ -2122,7 +2142,7 @@ class Beam:
             if sym != a and sym not in subs:
                 raise ValueError('Value of %s was not passed.' %sym)
 
-        return plot(self._ild_shear.subs(subs), (a, -0.0001, l),  title='I.L.D. for Shear',
+        return plot(self._ild_shear.subs(subs), (a, 0, l),  title='I.L.D. for Shear',
                xlabel=r'$\mathrm{a}$', ylabel=r'$\mathrm{V}$', line_color='blue',show=True)
 
     def solve_for_ild_moment(self, distance, value, *reactions):
@@ -2140,6 +2160,11 @@ class Beam:
             Magnitude of moving load
         reactions :
             The reaction forces applied on the beam.
+
+        Warning
+        =======
+        This method creates equations that can give incorrect results when
+        substituting a = 0 or a = l, with l the lenght of the beam.
 
         Examples
         ========
@@ -2206,6 +2231,11 @@ class Beam:
                Python dictionary containing Symbols as key and their
                corresponding values.
 
+        Warning
+        =======
+        The values for a = 0 and a = l, with l the lenght of the beam, in
+        the plot can be incorrect.
+
         Examples
         ========
 
@@ -2238,7 +2268,7 @@ class Beam:
             Plot object containing:
             [0]: cartesian line: -(4*SingularityFunction(a, 0, 0) - SingularityFunction(a, 0, 1)
             + SingularityFunction(a, 4, 1))*SingularityFunction(a, 4, 0) - SingularityFunction(a, 0, 1)/2
-            + SingularityFunction(a, 4, 1) - 2*SingularityFunction(a, 12, 0) - SingularityFunction(a, 12, 1)/2 for a over (-0.0001, 12.0)
+            + SingularityFunction(a, 4, 1) - 2*SingularityFunction(a, 12, 0) - SingularityFunction(a, 12, 1)/2 for a over (0.0, 12.0)
 
         """
 
@@ -2257,7 +2287,7 @@ class Beam:
         for sym in self._length.atoms(Symbol):
             if sym != a and sym not in subs:
                 raise ValueError('Value of %s was not passed.' %sym)
-        return plot(self._ild_moment.subs(subs), (a, -0.0001, self._length), title='I.L.D. for Moment',
+        return plot(self._ild_moment.subs(subs), (a, 0, self._length), title='I.L.D. for Moment',
                xlabel=r'$\mathrm{a}$', ylabel=r'$\mathrm{M}$', line_color='blue', show=True)
 
     @doctest_depends_on(modules=('numpy',))

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1826,7 +1826,7 @@ class Beam:
         Warning
         =======
         This method creates equations that can give incorrect results when
-        substituting a = 0 or a = l, with l the lenght of the beam.
+        substituting a = 0 or a = l, with l the length of the beam.
 
         Examples
         ========

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1872,14 +1872,14 @@ class Beam:
         for position, val in self._boundary_conditions['shear_force']:
             eqs = self.shear_force().subs(x, position) - val
             eqs_without_inf = sum(arg for arg in eqs.args if not any(num.is_infinite for num in arg.args))
-            shear_sinc = value - value * SingularityFunction(a, position, 0)
+            shear_sinc = value * SingularityFunction(- a, - position, 0)
             eqs_with_shear_sinc = eqs_without_inf - shear_sinc
             shear_force_eqs.append(eqs_with_shear_sinc)
 
         for position, val in self._boundary_conditions['bending_moment']:
             eqs = self.bending_moment().subs(x, position) - val
             eqs_without_inf = sum(arg for arg in eqs.args if not any(num.is_infinite for num in arg.args))
-            moment_sinc = value * (position - a) - value * (position - a) * SingularityFunction(a, position, 0)
+            moment_sinc = value * SingularityFunction(- a, - position, 1)
             eqs_with_moment_sinc = eqs_without_inf - moment_sinc
             bending_moment_eqs.append(eqs_with_moment_sinc)
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1959,10 +1959,10 @@ class Beam:
             PlotGrid object containing:
             Plot[0]:Plot object containing:
             [0]: cartesian line: -SingularityFunction(a, 0, 0) + SingularityFunction(a, 0, 1)/7
-            - 3*SingularityFunction(a, 10, 0)/7 - SingularityFunction(a, 10, 1)/7 - 15/7 for a over (0.0, 10.0)
+            - 3*SingularityFunction(a, 10, 0)/7 - SingularityFunction(a, 10, 1)/7 - 15/7 for a over (-0.0001, 10.0)
             Plot[1]:Plot object containing:
             [0]: cartesian line: -SingularityFunction(a, 0, 1)/7 + 10*SingularityFunction(a, 10, 0)/7
-            + SingularityFunction(a, 10, 1)/7 - 20/7 for a over (0.0, 10.0)
+            + SingularityFunction(a, 10, 1)/7 - 20/7 for a over (-0.0001, 10.0)
 
         """
         if not self._ild_reactions:
@@ -1985,7 +1985,7 @@ class Beam:
 
         for reaction in self._ild_reactions:
             ildplots.append(plot(self._ild_reactions[reaction].subs(subs),
-            (a, 0, self._length.subs(subs)), title='I.L.D. for Reactions',
+            (a, -0.0001, self._length.subs(subs)), title='I.L.D. for Reactions',
             xlabel=a, ylabel=reaction, line_color='blue', show=False))
 
         return PlotGrid(len(ildplots), 1, *ildplots)
@@ -2101,7 +2101,7 @@ class Beam:
             Plot object containing:
             [0]: cartesian line: -(-SingularityFunction(a, 0, 0) + SingularityFunction(a, 12, 0) + 2)*SingularityFunction(a, 4, 0)
             - SingularityFunction(-a, 0, 0) - SingularityFunction(a, 0, 0) + SingularityFunction(a, 0, 1)/8
-            + SingularityFunction(a, 12, 0)/2 - SingularityFunction(a, 12, 1)/8 + 1 for a over (0.0, 12.0)
+            + SingularityFunction(a, 12, 0)/2 - SingularityFunction(a, 12, 1)/8 + 1 for a over (-0.0001, 12.0)
 
         """
 
@@ -2122,7 +2122,7 @@ class Beam:
             if sym != a and sym not in subs:
                 raise ValueError('Value of %s was not passed.' %sym)
 
-        return plot(self._ild_shear.subs(subs), (a, 0, l),  title='I.L.D. for Shear',
+        return plot(self._ild_shear.subs(subs), (a, -0.0001, l),  title='I.L.D. for Shear',
                xlabel=r'$\mathrm{a}$', ylabel=r'$\mathrm{V}$', line_color='blue',show=True)
 
     def solve_for_ild_moment(self, distance, value, *reactions):
@@ -2238,7 +2238,7 @@ class Beam:
             Plot object containing:
             [0]: cartesian line: -(4*SingularityFunction(a, 0, 0) - SingularityFunction(a, 0, 1)
             + SingularityFunction(a, 4, 1))*SingularityFunction(a, 4, 0) - SingularityFunction(a, 0, 1)/2
-            + SingularityFunction(a, 4, 1) - 2*SingularityFunction(a, 12, 0) - SingularityFunction(a, 12, 1)/2 for a over (0.0, 12.0)
+            + SingularityFunction(a, 4, 1) - 2*SingularityFunction(a, 12, 0) - SingularityFunction(a, 12, 1)/2 for a over (-0.0001, 12.0)
 
         """
 
@@ -2257,7 +2257,7 @@ class Beam:
         for sym in self._length.atoms(Symbol):
             if sym != a and sym not in subs:
                 raise ValueError('Value of %s was not passed.' %sym)
-        return plot(self._ild_moment.subs(subs), (a, 0, self._length), title='I.L.D. for Moment',
+        return plot(self._ild_moment.subs(subs), (a, -0.0001, self._length), title='I.L.D. for Moment',
                xlabel=r'$\mathrm{a}$', ylabel=r'$\mathrm{M}$', line_color='blue', show=True)
 
     @doctest_depends_on(modules=('numpy',))

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2019,7 +2019,7 @@ class Beam:
         Warning
         =======
         This method creates equations that can give incorrect results when
-        substituting a = 0 or a = l, with l the lenght of the beam.
+        substituting a = 0 or a = l, with l the length of the beam.
 
         Examples
         ========

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -744,12 +744,12 @@ def test_max_deflection():
 def test_solve_for_ild_reactions():
     E = Symbol('E')
     I = Symbol('I')
-    a = Symbol('a')
     b = Beam(10, E, I)
     b.apply_support(0, type="pin")
     b.apply_support(10, type="pin")
     R_0, R_10 = symbols('R_0, R_10')
     b.solve_for_ild_reactions(1, R_0, R_10)
+    a = b.ild_variable
     assert b.ild_reactions == {R_0: -SingularityFunction(a, 0, 0) + SingularityFunction(a, 0, 1)/10
                                     - SingularityFunction(a, 10, 1)/10,
                                R_10: -SingularityFunction(a, 0, 1)/10 + SingularityFunction(a, 10, 0)
@@ -757,7 +757,6 @@ def test_solve_for_ild_reactions():
 
     E = Symbol('E')
     I = Symbol('I')
-    a = Symbol('a')
     F = Symbol('F')
     L = Symbol('L', positive=True)
     b = Beam(L, E, I)
@@ -765,6 +764,7 @@ def test_solve_for_ild_reactions():
     b.apply_load(F, 0, -1)
     R_L, M_L = symbols('R_L, M_L')
     b.solve_for_ild_reactions(F, R_L, M_L)
+    a = b.ild_variable
     assert b.ild_reactions == {R_L: -F*SingularityFunction(a, 0, 0) + F*SingularityFunction(a, L, 0) - F,
                                M_L: -F*L*SingularityFunction(a, 0, 0) - F*L + F*SingularityFunction(a, 0, 1)
                                     - F*SingularityFunction(a, L, 1)}
@@ -777,6 +777,7 @@ def test_solve_for_ild_reactions():
     r10 = b.apply_support(10, type="pin")
     r20, m20 = b.apply_support(20, type="fixed")
     b.solve_for_ild_reactions(1, r0, r5, r10, r20, m20)
+    a = b.ild_variable
     assert b.ild_reactions[r0].subs(a, 4) == -Rational(59, 475)
     assert b.ild_reactions[r5].subs(a, 4) == -Rational(2296, 2375)
     assert b.ild_reactions[r10].subs(a, 4) == Rational(243, 2375)
@@ -786,7 +787,6 @@ def test_solve_for_ild_reactions():
 def test_solve_for_ild_shear():
     E = Symbol('E')
     I = Symbol('I')
-    a = Symbol('a')
     F = Symbol('F')
     L1 = Symbol('L1', positive=True)
     L2 = Symbol('L2', positive=True)
@@ -795,6 +795,7 @@ def test_solve_for_ild_shear():
     rL = b.apply_support(L1 + L2, type="pin")
     b.solve_for_ild_reactions(F, r0, rL)
     b.solve_for_ild_shear(L1, F, r0, rL)
+    a = b.ild_variable
     expected_shear = (-F*L1*SingularityFunction(a, 0, 0)/(L1 + L2) - F*L2*SingularityFunction(a, 0, 0)/(L1 + L2)
                       - F*SingularityFunction(-a, 0, 0) + F*SingularityFunction(a, L1 + L2, 0) + F
                       + F*SingularityFunction(a, 0, 1)/(L1 + L2) - F*SingularityFunction(a, L1 + L2, 1)/(L1 + L2)
@@ -812,19 +813,20 @@ def test_solve_for_ild_shear():
     r20, m20 = b.apply_support(20, type="fixed")
     b.solve_for_ild_reactions(1, r0, r5, r10, r20, m20)
     b.solve_for_ild_shear(6, 1, r0, r5, r10, r20, m20)
+    a = b.ild_variable
     assert b.ild_shear.subs(a, 12) == Rational(96, 475)
     assert b.ild_shear.subs(a, 4) == -Rational(216, 2375)
 
 def test_solve_for_ild_moment():
     E = Symbol('E')
     I = Symbol('I')
-    a = Symbol('a')
     F = Symbol('F')
     L1 = Symbol('L1', positive=True)
     L2 = Symbol('L2', positive=True)
     b = Beam(L1 + L2, E, I)
     r0 = b.apply_support(0, type="pin")
     rL = b.apply_support(L1 + L2, type="pin")
+    a = b.ild_variable
     b.solve_for_ild_reactions(F, r0, rL)
     b.solve_for_ild_moment(L1, F, r0, rL)
     assert b.ild_moment.subs(a, 3).subs(L1, 5).subs(L2, 5) == -3*F/2
@@ -848,13 +850,13 @@ def test_ild_with_rotation_hinge():
     L1 = Symbol('L1', positive=True)
     L2 = Symbol('L2', positive=True)
     L3 = Symbol('L3', positive=True)
-    a = Symbol('a')
     b = Beam(L1 + L2 + L3, E, I)
     r0 = b.apply_support(0, type="pin")
     r1 = b.apply_support(L1 + L2, type="pin")
     r2 = b.apply_support(L1 + L2 + L3, type="pin")
     b.apply_rotation_hinge(L1 + L2)
     b.solve_for_ild_reactions(F, r0, r1, r2)
+    a = b.ild_variable
     assert b.ild_reactions[r0].subs(a, 4).subs(L1, 5).subs(L2, 5).subs(L3, 10) == -3*F/5
     assert b.ild_reactions[r0].subs(a, -10).subs(L1, 5).subs(L2, 5).subs(L3, 10) == 0
     assert b.ild_reactions[r0].subs(a, 25).subs(L1, 5).subs(L2, 5).subs(L3, 10) == 0
@@ -868,13 +870,13 @@ def test_ild_with_rotation_hinge():
     assert b.ild_moment.subs(a, 8).subs(L1, 5).subs(L2, 5).subs(L3, 10) == -F
 
 def test_ild_with_sliding_hinge():
-    a = Symbol('a')
     b = Beam(13, 200, 200)
     r0 = b.apply_support(0, type="pin")
     r6 = b.apply_support(6, type="pin")
     r13, m13 = b.apply_support(13, type="fixed")
     w3 = b.apply_sliding_hinge(3)
     b.solve_for_ild_reactions(1, r0, r6, r13, m13)
+    a = b.ild_variable
     assert b.ild_reactions[r0].subs(a, 3) == -1
     assert b.ild_reactions[r6].subs(a, 3) == Rational(9, 14)
     assert b.ild_reactions[r13].subs(a, 9) == -Rational(207, 343)

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -868,43 +868,32 @@ def test_ild_with_rotation_hinge():
     r2 = b.apply_support(L1 + L2 + L3, type="pin")
     b.apply_rotation_hinge(L1 + L2)
     b.solve_for_ild_reactions(F, r0, r1, r2)
+    assert b.ild_reactions[r0] == -F*SingularityFunction(-a, -L1 - L2, 1)/(L1 + L2)
+    assert (b.ild_reactions[r1] == -F*L1**2/(L1*L3 + L2*L3) - 2*F*L1*L2/(L1*L3 + L2*L3) - F*L1*L3/(L1*L3 + L2*L3)
+            + F*L1*a/(L1*L3 + L2*L3) + F*L1*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+            - F*L2**2/(L1*L3 + L2*L3) - F*L2*L3/(L1*L3 + L2*L3) + F*L2*a/(L1*L3 + L2*L3)
+            + F*L2*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+            + F*L3*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3))
+    assert b.ild_reactions[r2] == F*L1/L3 + F*L2/L3 - F*a/L3 - F*SingularityFunction(-a, -L1 - L2, 1)/L3
     b.solve_for_ild_shear(L1, F, r0, r1, r2)
-    assert b.ild_shear == Piecewise((F * L1 * SingularityFunction(a, L1 + L2, 0) / (L1 + L2)
-                                     - F * L1 / (L1 + L2) + F * L2 * SingularityFunction(a, L1 + L2, 0) / (L1 + L2)
-                                     - F * L2 / (L1 + L2) - F * a * SingularityFunction(a, L1 + L2, 0) / (L1 + L2)
-                                     + F * a / (L1 + L2) + F, L1 > a),
-                                    (F * L1 ** 2 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     + 2 * F * L1 * L2 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     + F * L1 * L3 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     - F * L1 * a * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     - F * L1 * SingularityFunction(a, L1 + L2, 0) / L3
-                                     + F * L2 ** 2 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     + F * L2 * L3 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     - F * L2 * a * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     - F * L2 * SingularityFunction(a, L1 + L2, 0) / L3
-                                     - F * L3 * a * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
-                                     + F * L3 * a / (L1 * L3 + L2 * L3) - F
-                                     + F * a * SingularityFunction(a, L1 + L2, 0) / L3, L1 < a))
+    assert b.ild_shear == Piecewise((F - F*SingularityFunction(-a, -L1 - L2, 1)/(L1 + L2), L1 > a),
+                                    (F*L1**2/(L1*L3 + L2*L3) + 2*F*L1*L2/(L1*L3 + L2*L3) + F*L1*L3/(L1*L3 + L2*L3)
+                                     - F*L1*a/(L1*L3 + L2*L3)
+                                     - F*L1*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+                                     - F*L1/L3 + F*L2**2/(L1*L3 + L2*L3) + F*L2*L3/(L1*L3 + L2*L3) - F*L2*a/(L1*L3 + L2*L3)
+                                     - F*L2*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+                                     - F*L2/L3 - F*L3*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+                                     - F + F*a/L3 + F*SingularityFunction(-a, -L1 - L2, 1)/L3, L1 < a))
     b.solve_for_ild_moment(L1, F, r0, r1, r2)
-    assert b.ild_moment == Piecewise((F*(L1 - a) + L1*(F*L1*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            - F*L1/(L1 + L2) + F*L2*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            - F*L2/(L1 + L2) - F*a*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            + F*a/(L1 + L2)), L1 > a),
-                                     (-F*(L1 + L2 + L3 - a) - L2*(F*L1*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            - F*L1/(L1 + L2) + F*L2*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            - F*L2/(L1 + L2) - F*a*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            + F*a/(L1 + L2)) - L3*(F*L1*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            - F*L1/(L1 + L2) + F*L2*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            - F*L2/(L1 + L2) - F*a*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
-                                            + F*a/(L1 + L2)) - L3*(-F*L1**2*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            - 2*F*L1*L2*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            - F*L1*L3*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            + F*L1*a*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            - F*L2**2*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            - F*L2*L3*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            + F*L2*a*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            + F*L3*a*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
-                                            - F*L3*a/(L1*L3 + L2*L3)), L1 < a))
+    assert b.ild_moment == Piecewise((-F*L1*SingularityFunction(-a, -L1 - L2, 1)/(L1 + L2) + F*(L1 - a), L1 > a),
+                                     (F*L2*SingularityFunction(-a, -L1 - L2, 1)/(L1 + L2)
+                                      + F*L3*SingularityFunction(-a, -L1 - L2, 1)/(L1 + L2)
+                                      - F*(L1 + L2 + L3 - a)
+                                      - L3*(-F*L1**2/(L1*L3 + L2*L3) - 2*F*L1*L2/(L1*L3 + L2*L3) - F*L1*L3/(L1*L3 + L2*L3)
+                                            + F*L1*a/(L1*L3 + L2*L3) + F*L1*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+                                            - F*L2**2/(L1*L3 + L2*L3) - F*L2*L3/(L1*L3 + L2*L3) + F*L2*a/(L1*L3 + L2*L3)
+                                            + F*L2*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)
+                                            + F*L3*SingularityFunction(-a, -L1 - L2, 1)/(L1*L3 + L2*L3)), L1 < a))
 
 def test_ild_with_sliding_hinge():
     a = Symbol('a', positive=True)
@@ -914,35 +903,31 @@ def test_ild_with_sliding_hinge():
     r13, m13 = b.apply_support(13, type="fixed")
     w3 = b.apply_sliding_hinge(3)
     b.solve_for_ild_reactions(1, r0, r6, r13, m13)
-    assert b.ild_reactions[r0] == SingularityFunction(a, 3, 0) - 1
+    assert b.ild_reactions[r0] == -SingularityFunction(-a, -3, 0)
     expected_r6 = (-SingularityFunction(6, a, 3)/686 - 3*SingularityFunction(13, a, 2)/98
-            + SingularityFunction(13, a, 3)/686 - 16*SingularityFunction(a, 3, 0)/7 + Rational(16, 7))
+                   + SingularityFunction(13, a, 3)/686 + 16*SingularityFunction(-a, -3, 0)/7)
     assert b.ild_reactions[r6].expand() == expected_r6.expand()
     expected_r13 = (SingularityFunction(6, a, 3)/686 + 3*SingularityFunction(13, a, 2)/98
-            - SingularityFunction(13, a, 3)/686 + 9*SingularityFunction(a, 3, 0)/7 - Rational(16, 7))
+                    - SingularityFunction(13, a, 3)/686 - 9*SingularityFunction(-a, -3, 0)/7 - 1)
     assert b.ild_reactions[r13].expand() == expected_r13.expand()
     expected_m13 = (a + SingularityFunction(6, a, 3)/98 + 3*SingularityFunction(13, a, 2)/14
-            - SingularityFunction(13, a, 3)/98 + 3*SingularityFunction(a, 3, 0) - 16)
+                    - SingularityFunction(13, a, 3)/98 - 3*SingularityFunction(-a, -3, 0) - 13)
     assert b.ild_reactions[m13] == expected_m13.expand()
     assert (b.ild_deflection_jumps[w3] == -SingularityFunction(6, a, 3)/105000
             - 3*SingularityFunction(13, a, 2)/80000 + 3*SingularityFunction(13, a, 3)/560000
-            + 27*SingularityFunction(a, 3, 0)/8000 - Rational(27,8000))
+            - 27*SingularityFunction(-a, -3, 0)/8000)
     b.solve_for_ild_shear(7, 1, r0, r6, r13, m13)
-    assert b.ild_shear == Piecewise((-SingularityFunction(6, a, 3)/686
-                                     - 3*SingularityFunction(13, a, 2)/98
+    assert b.ild_shear == Piecewise((-SingularityFunction(6, a, 3)/686 - 3*SingularityFunction(13, a, 2)/98
                                      + SingularityFunction(13, a, 3)/686
-                                     - 9*SingularityFunction(a, 3, 0)/7 + Rational(16, 7), a < 7),
+                                     + 9*SingularityFunction(-a, -3, 0)/7 + 1, a < 7),
                                     (-SingularityFunction(6, a, 3)/686 - 3*SingularityFunction(13, a, 2)/98
-                                     + SingularityFunction(13, a, 3)/686
-                                     - 9*SingularityFunction(a, 3, 0)/7 + Rational(9, 7), a > 7))
+                                     + SingularityFunction(13, a, 3)/686 + 9*SingularityFunction(-a, -3, 0)/7, a > 7))
     b.solve_for_ild_moment(8, 1, r0, r6, r13, m13)
-    assert b.ild_moment == Piecewise((-a - SingularityFunction(6, a, 3)/343
-                                      - 3*SingularityFunction(13, a, 2)/49
+    assert b.ild_moment == Piecewise((-a - SingularityFunction(6, a, 3)/343 - 3*SingularityFunction(13, a, 2)/49
                                       + SingularityFunction(13, a, 3)/343
-                                      + 24*SingularityFunction(a, 3, 0)/7 + Rational(32, 7), a < 8),
+                                      - 24*SingularityFunction(-a, -3, 0)/7 + 8, a < 8),
                                      (-SingularityFunction(6, a, 3)/343 - 3*SingularityFunction(13, a, 2)/49
-                                      + SingularityFunction(13, a, 3)/343 + 24*SingularityFunction(a, 3, 0)/7
-                                      - Rational(24, 7), a > 8))
+                                      + SingularityFunction(13, a, 3)/343 - 24*SingularityFunction(-a, -3, 0)/7, a > 8))
 
 def test_Beam3D():
     l, E, G, I, A = symbols('l, E, G, I, A')

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -854,6 +854,96 @@ def test_solve_for_ild_moment():
                                       - 3*SingularityFunction(20, a, 2)/190
                                       + 3*SingularityFunction(20, a, 3)/1900, a > 5))
 
+def test_ild_with_rotation_hinge():
+    E = Symbol('E')
+    I = Symbol('I')
+    F = Symbol('F')
+    L1 = Symbol('L1', positive=True)
+    L2 = Symbol('L2', positive=True)
+    L3 = Symbol('L3', positive=True)
+    a = Symbol('a', positive=True)
+    b = Beam(L1 + L2 + L3, E, I)
+    r0 = b.apply_support(0, type="pin")
+    r1 = b.apply_support(L1 + L2, type="pin")
+    r2 = b.apply_support(L1 + L2 + L3, type="pin")
+    b.apply_rotation_hinge(L1 + L2)
+    b.solve_for_ild_reactions(F, r0, r1, r2)
+    b.solve_for_ild_shear(L1, F, r0, r1, r2)
+    assert b.ild_shear == Piecewise((F * L1 * SingularityFunction(a, L1 + L2, 0) / (L1 + L2)
+                                     - F * L1 / (L1 + L2) + F * L2 * SingularityFunction(a, L1 + L2, 0) / (L1 + L2)
+                                     - F * L2 / (L1 + L2) - F * a * SingularityFunction(a, L1 + L2, 0) / (L1 + L2)
+                                     + F * a / (L1 + L2) + F, L1 > a),
+                                    (F * L1 ** 2 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     + 2 * F * L1 * L2 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     + F * L1 * L3 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     - F * L1 * a * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     - F * L1 * SingularityFunction(a, L1 + L2, 0) / L3
+                                     + F * L2 ** 2 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     + F * L2 * L3 * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     - F * L2 * a * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     - F * L2 * SingularityFunction(a, L1 + L2, 0) / L3
+                                     - F * L3 * a * SingularityFunction(a, L1 + L2, 0) / (L1 * L3 + L2 * L3)
+                                     + F * L3 * a / (L1 * L3 + L2 * L3) - F
+                                     + F * a * SingularityFunction(a, L1 + L2, 0) / L3, L1 < a))
+    b.solve_for_ild_moment(L1, F, r0, r1, r2)
+    assert b.ild_moment == Piecewise((F*(L1 - a) + L1*(F*L1*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            - F*L1/(L1 + L2) + F*L2*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            - F*L2/(L1 + L2) - F*a*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            + F*a/(L1 + L2)), L1 > a),
+                                     (-F*(L1 + L2 + L3 - a) - L2*(F*L1*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            - F*L1/(L1 + L2) + F*L2*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            - F*L2/(L1 + L2) - F*a*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            + F*a/(L1 + L2)) - L3*(F*L1*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            - F*L1/(L1 + L2) + F*L2*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            - F*L2/(L1 + L2) - F*a*SingularityFunction(a, L1 + L2, 0)/(L1 + L2)
+                                            + F*a/(L1 + L2)) - L3*(-F*L1**2*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            - 2*F*L1*L2*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            - F*L1*L3*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            + F*L1*a*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            - F*L2**2*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            - F*L2*L3*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            + F*L2*a*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            + F*L3*a*SingularityFunction(a, L1 + L2, 0)/(L1*L3 + L2*L3)
+                                            - F*L3*a/(L1*L3 + L2*L3)), L1 < a))
+
+def test_ild_with_sliding_hinge():
+    a = Symbol('a', positive=True)
+    b = Beam(13, 200, 200)
+    r0 = b.apply_support(0, type="pin")
+    r6 = b.apply_support(6, type="pin")
+    r13, m13 = b.apply_support(13, type="fixed")
+    w3 = b.apply_sliding_hinge(3)
+    b.solve_for_ild_reactions(1, r0, r6, r13, m13)
+    assert b.ild_reactions[r0] == SingularityFunction(a, 3, 0) - 1
+    expected_r6 = (-SingularityFunction(6, a, 3)/686 - 3*SingularityFunction(13, a, 2)/98
+            + SingularityFunction(13, a, 3)/686 - 16*SingularityFunction(a, 3, 0)/7 + Rational(16, 7))
+    assert b.ild_reactions[r6].expand() == expected_r6.expand()
+    expected_r13 = (SingularityFunction(6, a, 3)/686 + 3*SingularityFunction(13, a, 2)/98
+            - SingularityFunction(13, a, 3)/686 + 9*SingularityFunction(a, 3, 0)/7 - Rational(16, 7))
+    assert b.ild_reactions[r13].expand() == expected_r13.expand()
+    expected_m13 = (a + SingularityFunction(6, a, 3)/98 + 3*SingularityFunction(13, a, 2)/14
+            - SingularityFunction(13, a, 3)/98 + 3*SingularityFunction(a, 3, 0) - 16)
+    assert b.ild_reactions[m13] == expected_m13.expand()
+    assert (b.ild_deflection_jumps[w3] == -SingularityFunction(6, a, 3)/105000
+            - 3*SingularityFunction(13, a, 2)/80000 + 3*SingularityFunction(13, a, 3)/560000
+            + 27*SingularityFunction(a, 3, 0)/8000 - Rational(27,8000))
+    b.solve_for_ild_shear(7, 1, r0, r6, r13, m13)
+    assert b.ild_shear == Piecewise((-SingularityFunction(6, a, 3)/686
+                                     - 3*SingularityFunction(13, a, 2)/98
+                                     + SingularityFunction(13, a, 3)/686
+                                     - 9*SingularityFunction(a, 3, 0)/7 + Rational(16, 7), a < 7),
+                                    (-SingularityFunction(6, a, 3)/686 - 3*SingularityFunction(13, a, 2)/98
+                                     + SingularityFunction(13, a, 3)/686
+                                     - 9*SingularityFunction(a, 3, 0)/7 + Rational(9, 7), a > 7))
+    b.solve_for_ild_moment(8, 1, r0, r6, r13, m13)
+    assert b.ild_moment == Piecewise((-a - SingularityFunction(6, a, 3)/343
+                                      - 3*SingularityFunction(13, a, 2)/49
+                                      + SingularityFunction(13, a, 3)/343
+                                      + 24*SingularityFunction(a, 3, 0)/7 + Rational(32, 7), a < 8),
+                                     (-SingularityFunction(6, a, 3)/343 - 3*SingularityFunction(13, a, 2)/49
+                                      + SingularityFunction(13, a, 3)/343 + 24*SingularityFunction(a, 3, 0)/7
+                                      - Rational(24, 7), a > 8))
+
 def test_Beam3D():
     l, E, G, I, A = symbols('l, E, G, I, A')
     R1, R2, R3, R4 = symbols('R1, R2, R3, R4')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #26601
Fixes #26602




#### Brief description of what is fixed or changed
Changed the methods for ILD calculations so that they are able to generate correct results for beams with hinges. Also added tests for ILD methods, these methods didn't have any tests.  

#### Other comments
This change fixes problems with the previous ILD calculation methods. They did generate incorrect results for statically indeterminate beams, they were not tested and they could not calculate beams with hinges. In this change these 3 problems are fixed. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Implemented ILD calculations for beams with hinges.
<!-- END RELEASE NOTES -->
