### PR TITLE
[GSoC] Added methods to StateSpace class to calculate state and output vectors.

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -22,6 +22,8 @@ from sympy.polys.polyroots import roots
 from sympy.polys.polytools import (cancel, degree)
 from sympy.series import limit
 from sympy.utilities.misc import filldedent
+from sympy.solvers.ode.systems import linodesolve
+from sympy.solvers.solveset import linsolve, linear_eq_to_matrix
 
 from mpmath.libmp.libmpf import prec_to_dps
 
@@ -3837,6 +3839,108 @@ class StateSpace(LinearTimeInvariant):
 
         """
         return self._D.rows
+
+    def state_vector(self, initial_conditions=None, input_vector=None, var=None):
+        r"""
+        Returns the State vector `x` given by the solution of the state equation
+            x'(t) = A * x(t) + B * u(t)
+
+        Parameters
+        ============
+
+        initial_conditions : Matrix
+            The initial conditions of `x` state vector.
+        input_vector : Matrix
+            The input vector for state space.
+        var : Symbol
+            The symbol representing time.
+
+        Examples
+        ==========
+
+        >>> from sympy import Matrix, Symbol
+        >>> from sympy.physics.control import StateSpace
+        >>> A = Matrix([[-2, 0], [1, -1]])
+        >>> i = Matrix([2, 3])
+        >>> t = Symbol('t')
+        >>> ss = StateSpace(A)
+        >>> ss.state_vector(initial_conditions=i, var=t)
+        Matrix([
+        [            2*exp(-2*t)],
+        [5*exp(-t) - 2*exp(-2*t)]])
+
+        References
+        ==========
+        .. [1] https://web.mit.edu/2.14/www/Handouts/StateSpaceResponse.pdf
+        .. [2] https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.systems.linodesolve
+        """
+
+        if not var:
+            var = Symbol('t')
+        elif not isinstance(var, Symbol):
+            raise ValueError("Variable for representing time must be a Symbol.")
+        if not initial_conditions:
+            initial_conditions = zeros(self._A.shape[0], 1)
+        elif initial_conditions.shape != (self._A.shape[0], 1):
+            raise ShapeError("Initial condition vector should have the same number of "
+                             "rows as the state matrix.")
+        if not input_vector:
+            input_vector = zeros(self._B.shape[1], 1)
+        elif input_vector.shape != (self._B.shape[1], 1):
+            raise ShapeError("Input vector should have the same number of "
+                             "columns as the input matrix.")
+        sol = linodesolve(self._A, var, self._B*input_vector, type='type2', doit=True)
+        mat1 = Matrix(sol)
+        mat2 = mat1.replace(var, 0)
+        # Get all the free symbols form the matrix
+        dummy_symbols = list(mat2.free_symbols)
+        # Convert the matrix to a Coefficient matrix
+        r1, r2 = linear_eq_to_matrix(mat2, dummy_symbols)
+        s = linsolve((r1, initial_conditions+r2))
+        res_tuple = next(iter(s))
+        for ind, v in enumerate(res_tuple):
+            mat1 = mat1.replace(dummy_symbols[ind], v)
+        return mat1
+
+    def output_vector(self, initial_conditions=None, input_vector=None, var=None):
+        r"""
+        Returns the Output vector `x` given by the solution of the output equation
+            y(t) = C * x(t) + D * u(t)
+
+        Parameters
+        ============
+
+        initial_conditions : Matrix
+            The initial conditions of `x` state vector.
+        input_vector : Matrix
+            The input vector for state space.
+        var : Symbol
+            The symbol representing time.
+
+        Examples
+        ==========
+
+        >>> from sympy import Matrix
+        >>> from sympy.physics.control import StateSpace
+        >>> A = Matrix([[-2, 0], [1, -1]])
+        >>> B = Matrix([[1], [0]])
+        >>> C = Matrix([[2, 1]])
+        >>> ip = Matrix([5])
+        >>> i = Matrix([0, 0])
+        >>> ss = StateSpace(A, B, C)
+        >>> ss.output_vector(input_vector=ip, initial_conditions=i)
+        Matrix([[15/2 - 5*exp(-t) - 5*exp(-2*t)/2]])
+
+        References
+        ==========
+        .. [1] https://web.mit.edu/2.14/www/Handouts/StateSpaceResponse.pdf
+        .. [2] https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.systems.linodesolve
+        """
+        if not input_vector:
+            input_vector = zeros(self._B.shape[1], 1)
+        sv = self.state_vector(initial_conditions, input_vector, var)
+        res = self._C*sv + self._D*input_vector
+        return res.simplify()
 
     def _eval_evalf(self, prec):
         """

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -14,6 +14,7 @@ from sympy.polys.rootoftools import CRootOf
 from sympy.simplify.simplify import simplify
 from sympy.core.containers import Tuple
 from sympy.matrices import ImmutableMatrix, Matrix, ShapeError
+from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.physics.control import (TransferFunction, Series, Parallel,
     Feedback, TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback,
     StateSpace, gbt, bilinear, forward_diff, backward_diff, phase_margin, gain_margin)
@@ -1703,6 +1704,30 @@ def test_conversion():
 
     # Transfer function has to be proper
     raises(ValueError, lambda: TransferFunction(b*s**2 + p**2 - a*p + s, b - p**2, s).rewrite(StateSpace))
+
+
+def test_StateSpace_state_output_vector():
+    # https://web.mit.edu/2.14/www/Handouts/StateSpaceResponse.pdf
+    # https://lpsa.swarthmore.edu/Transient/TransMethSS.html
+    A1 = Matrix([[0, 1], [-2, -3]])
+    B1 = Matrix([[0], [1]])
+    C1 = Matrix([[1, -1]])
+    D1 = Matrix([0])
+    i1 = Matrix([[1], [2]])
+    t = symbols('t')
+    ss1 = StateSpace(A1, B1, C1, D1)
+    assert ss1.state_vector(initial_conditions=i1, var=t) == Matrix([[ 4*exp(-t) - 3*exp(-2*t)],
+                                                              [-4*exp(-t) + 6*exp(-2*t)]])
+    assert ss1.output_vector(initial_conditions=i1) == Matrix([[(8*exp(t) - 9)*exp(-2*t)]])
+    A2 = Matrix([[-1, 1], [-4, -4]])
+    B2 = Matrix([[0], [4]])
+    C2 = Matrix([[0, 1]])
+    D2 = Matrix([0])
+    u = Matrix([10])
+    ss2 = StateSpace(A2, B2, C2, D2)
+    op = ss2.output_vector(input_vector=u, var=t)
+    assert str(op.expand().evalf()[0]) == str(5.0 + 20.7880460155075*exp(-5*t/2)*sin(sqrt(7)*t/2)
+                                            - 5.0*exp(-5*t/2)*cos(sqrt(7)*t/2))
 
 
 def test_StateSpace_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added methods to `StateSpace` class to calculate state and output vectors by using the ODE module.
1. State vector can be found by solving the equation $\dot x= Ax + Bu$ by using the ODE module. `linodesolve()` function `type2` has been used to find the solution.
2. Output vector is calculated by using the `state_vector` function and by using the equation $y = Cx + Du$.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added methods to find state and output vectors for StateSpace.
<!-- END RELEASE NOTES -->
