### PR TITLE
Removing unnecessary codeblock for handling symbolic exponents in gruntz

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -275,9 +275,6 @@ def mrv(e, x):
         if b1 == 1:
             return SubsSet(), b1
         if e1.has(x):
-            if limitinf(b1, x) is S.One:
-                if limitinf(e1, x).is_infinite is False:
-                    return mrv(exp(e1*(b1 - 1)), x)
             return mrv(exp(e1*log(b1)), x)
         else:
             s, expr = mrv(b1, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25931
#### Brief description of what is fixed or changed
As pointed out in #25931, the removed conditional has no mention in algorithm and all operations are taken care of in the following conditional(when base is E).

#### Other comments
see #25931 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* series
  * removal of unnecesary conditional in mrv term calculation in gruntz.
<!-- END RELEASE NOTES -->
