### PR TITLE
maint(ci): test gmpy2 2.2.0rc1 prerelease in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -179,11 +179,12 @@ jobs:
                          'antlr4-python3-runtime==4.11.*'                 \
                          symengine                                        \
                          numba llvmlite pymc                              \
+                         'gmpy2>=2.2.0rc1'                                \
                          #
 
-      # Not available in CPython 3.12 (yet).
-      - if: ${{ ! contains(matrix.python-version, '3.12') }}
-        run: pip install gmpy2
+      ## Not available in CPython 3.13 (yet).
+      #- if: ${{ ! contains(matrix.python-version, '3.13') }}
+      #  run: pip install gmpy2
 
       # Test external imports
       - run: bin/test_external_imports.py
@@ -301,7 +302,7 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pip install python-flint==0.6 gmpy2
+      - run: pip install python-flint==0.6 'gmpy2>=2.2.0rc1'
       # Test the modules that most directly use python-flint
       - run: pytest sympy/polys sympy/ntheory sympy/matrices
         env:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/aleaxit/gmpy/issues/475#issuecomment-2165334720

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
