### PR TITLE
make all_close more robust

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4359,7 +4359,7 @@ def all_close(expr1, expr2, rtol=1e-5, atol=1e-8):
         if len(cd1) != len(cd2):
             return False
         for k in list(cd1):
-            if k in list(cd2):
+            if k in cd2:
                 if not _close_num(cd1.pop(k), cd2.pop(k)):
                     return False
             # k (or a close version in cd2) might have
@@ -4383,8 +4383,6 @@ def all_close(expr1, expr2, rtol=1e-5, atol=1e-8):
                 # no key matched
                 return False
         return True
-
-        assert None  # should never get here
 
     return _all_close(expr1, expr2)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4350,33 +4350,36 @@ def all_close(expr1, expr2, rtol=1e-5, atol=1e-8):
                 else:
                     return False
             return not(unmatched)
-        # expr1 is Add or function
-        cd1 = expr1.as_coefficients_dict()
-        cd2 = expr2.as_coefficients_dict()
-        for k in list(cd1):
-            if k in list(cd2):
-                if not _close_num(cd1.pop(k), cd2.pop(k)):
-                    return False
-            # k (or a close version in cd2) might have
-            # Floats in a factor of the term which will
-            # be handled below
-        if not cd1:
-            return True
-        for k1 in cd1:
-            for k2 in cd2:
-                if _all_close_ac(k1, k2):
-                    # found a matching key
-                    # XXX there could be a corner case where
-                    # more than 1 might match and the numbers are
-                    # such that one is better than the other
-                    # that is not being considered here
-                    if not _close_num(cd1[k1], cd2[k2]):
+        if expr1.is_Add:
+            cd1 = expr1.as_coefficients_dict()
+            cd2 = expr2.as_coefficients_dict()
+            for k in list(cd1):
+                if k in list(cd2):
+                    if not _close_num(cd1.pop(k), cd2.pop(k)):
                         return False
-                    break
-            else:
-                # no key matched
-                return False
-        return True
+                # k (or a close version in cd2) might have
+                # Floats in a factor of the term which will
+                # be handled below
+            if not cd1:
+                return True
+            for k1 in cd1:
+                for k2 in cd2:
+                    if _all_close_ac(k1, k2):
+                        # found a matching key
+                        # XXX there could be a corner case where
+                        # more than 1 might match and the numbers are
+                        # such that one is better than the other
+                        # that is not being considered here
+                        if not _close_num(cd1[k1], cd2[k2]):
+                            return False
+                        break
+                else:
+                    # no key matched
+                    return False
+            return True
+
+        # Pow or other object: handle arg-wise
+        return _all_close_expr(expr1, expr2)
 
     return _all_close(expr1, expr2)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2294,10 +2294,10 @@ def test_all_close():
     assert all_close(1/3, 1/3.0001, 1e-3, 1e-3) is True
     assert all_close(1/3, Rational(1, 3)) is True
     assert all_close(0.1*exp(0.2*x), exp(x/5)/10) is True
-    # The expressions should be structurally the same:
+    # The expressions should be structurally the same modulo identity:
     assert all_close(1.4142135623730951, sqrt(2)) is False
     assert all_close(1.4142135623730951, sqrt(2).evalf()) is True
-    assert all_close(x + 1e-20, x) is False
+    assert all_close(x + 1e-20, x) is True
     # We should be able to match terms of an Add/Mul in any order
     assert all_close(Add(1, 2, evaluate=False), Add(2, 1, evaluate=False))
     # coverage

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2285,6 +2285,8 @@ def test_equal_valued():
 
 def test_all_close():
     x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
     assert all_close(2, 2) is True
     assert all_close(2, 2.0000) is True
     assert all_close(2, 2.0001) is False
@@ -2298,3 +2300,16 @@ def test_all_close():
     assert all_close(x + 1e-20, x) is False
     # We should be able to match terms of an Add/Mul in any order
     assert all_close(Add(1, 2, evaluate=False), Add(2, 1, evaluate=False))
+    # coverage
+    assert not all_close(2*x, 3*x)
+    assert all_close(2*x, 3*x, 1)
+    assert not all_close(2*x, 3*x, 0, 0.5)
+    assert all_close(2*x, 3*x, 0, 1)
+    assert not all_close(y*x, z*x)
+    assert all_close(2*x*exp(1.0*x), 2.0*x*exp(x))
+    assert not all_close(2*x*exp(1.0*x), 2.0*x*exp(2.*x))
+    assert all_close(x + 2.*y, 1.*x + 2*y)
+    assert all_close(x + exp(2.*x)*y, 1.*x + exp(2*x)*y)
+    assert not all_close(x + exp(2.*x)*y, 1.*x + 2*exp(2*x)*y)
+    assert not all_close(x + exp(2.*x)*y, 1.*x + exp(3*x)*y)
+    assert not all_close(x + 2.*y, 1.*x + 3*y)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

`all_close` is more efficient in testing whether two expressions differ trivially in terms of literal numbers (not symbolic values).

#### Other comments

`all_close` is not a publically imported routine, but it is not underscore-named in `numbers`. It attempts to free the user from tedious analysis of two expressions to see if they are the same when, in fact, they might only differ trivially in numerical values used. It is currently only used in tests.

One thing that would make it fail in master is the inability to recognize that `x` and `1.0*x` are trivially the same since they do not have the expected identical structure; one is a Symbol and the other a Mul.

It is also recognized in master that searching for matching terms between two Add is very inefficient since a search for a given term is made factor by factor:
```python
args2 = list(expr2.args)
for arg1 in expr1.args:
    for i, arg2 in enumerate(args2):
        if _all_close(arg1, arg2, rtol, atol):
            args2.pop(i)
```

Here are a few simple tests:
```python
from random import shuffle
from sympy.core.numbers import *
from time import time
args = [Mul(*[Dummy() for i in range(10)]) for i in range(50)]
a=Add(*args)
shuffle(args)
b=Add(*args,evaluate=False)
>>> a==b
False
>>> t=time();all_close(a,b);time()-t
0.078  # 0.03 in this PR

args = [Mul(*[Dummy() for i in range(10)]) for i in range(500)]
a=Add(*args)
shuffle(args)
b=Add(*args,evaluate=False)
>>> a==b
False
>>> t=time();all_close(a,b);time()-t
6.78  # 0.73 in this PR
```

It might make more sense to have this somewhere other than in the `core.numbers` since it really has more to do with testing (and testing expressions) than it does with testing numbers.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
