### PR TITLE
Fix update-docs final version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,11 +173,22 @@ jobs:
 
   # -------------------- Update the docs repository ---------------- #
 
+  # Dummy job to determine whether the release is final
+  check-final:
+    name: Check whether the release is final
+    needs: [build, pypi-publish]
+    runs-on: ubuntu-latest
+    outputs:
+      # The env context is not available in jobs.<job id>.if so we set it here
+      is-final: ${{ env.release_version == env.final_release_version }}
+    steps:
+      - run: echo "null"
+
   update-docs:
     name: Update the docs repository
-    needs: [build, pypi-publish]
+    needs: [check-final]
     # Only run for a final release
-    if: ${{ github.env.release_version == github.env.final_release_version }}
+    if: ${{ needs.check-final.outputs.is-final == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.mailmap
+++ b/.mailmap
@@ -690,6 +690,7 @@ Hong Xu <hong@topbug.net>
 Hou-Rui <houruinus@gmail.com> Hou-Rui <13244639785@163.com>
 Huangduirong <huangduirong@huawei.com> Huangxiaodui <hdrong.42@163.com>
 Hubert Tsang <intsangity@gmail.com>
+Hugo Kerstens <hugo@kerstens.me> Hugo Kerstens <hugokk@hotmail.nl>
 Hugo van Kemenade <hugovk@users.noreply.github.com> Hugo <hugovk@users.noreply.github.com>
 Huijun Mai <m.maihuijun@gmail.com>
 Hwayeon Kang <hwayeonniii@gmail.com> <97640870+eh111eh@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1307 authors.
+There are a total of 1308 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1313,3 +1313,4 @@ Emile Fourcini <emile.fourcin1@gmail.com>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 Dean Price <dean1357price1357@gmail.com>
+Hugo Kerstens <hugo@kerstens.me>


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
In #26688 it was noted that the guard that should not push non-final version to the public docs was not working. This fixes that.

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The guard that prevents non-final versions to be pushed to the public docs is not working. This is due to accidentally using [`github.env.xxx`](https://docs.github.com/en/actions/learn-github-actions/contexts#:~:text=github.env) instead of `env.xxx`. This PR updates the guard.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
