### PR TITLE
Fix radsimp for non-Expr arguments

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -895,7 +895,9 @@ def radsimp(expr, symbolic=True, max_terms=4):
         from sympy.core.expr import Expr
         from sympy.simplify.simplify import nsimplify
 
-        if (not isinstance(expr, Expr)) or expr.is_Atom:
+        if not isinstance(expr, Expr):
+            return expr.func(*[handle(a) for a in expr.args])
+        elif expr.is_Atom:
             return expr
 
         n, d = fraction(expr)

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -892,11 +892,15 @@ def radsimp(expr, symbolic=True, max_terms=4):
         # Handle first reduces to the case
         # expr = 1/d, where d is an add, or d is base**p/2.
         # We do this by recursively calling handle on each piece.
+        from sympy.core.expr import Expr
         from sympy.simplify.simplify import nsimplify
+
+        if (not isinstance(expr, Expr)) or expr.is_Atom:
+            return expr
 
         n, d = fraction(expr)
 
-        if expr.is_Atom or (d.is_Atom and n.is_Atom):
+        if d.is_Atom and n.is_Atom:
             return expr
         elif not n.is_Atom:
             n = n.func(*[handle(a) for a in n.args])

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -895,10 +895,10 @@ def radsimp(expr, symbolic=True, max_terms=4):
         # We do this by recursively calling handle on each piece.
         from sympy.simplify.simplify import nsimplify
 
-        if not isinstance(expr, Expr):
-            return expr.func(*[handle(a) for a in expr.args])
-        elif expr.is_Atom:
+        if expr.is_Atom:
             return expr
+        elif not isinstance(expr, Expr):
+            return expr.func(*[handle(a) for a in expr.args])
 
         n, d = fraction(expr)
 

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -841,6 +841,7 @@ def radsimp(expr, symbolic=True, max_terms=4):
     1/(a + b*sqrt(c))
 
     """
+    from sympy.core.expr import Expr
     from sympy.simplify.simplify import signsimp
 
     syms = symbols("a:d A:D")
@@ -892,7 +893,6 @@ def radsimp(expr, symbolic=True, max_terms=4):
         # Handle first reduces to the case
         # expr = 1/d, where d is an add, or d is base**p/2.
         # We do this by recursively calling handle on each piece.
-        from sympy.core.expr import Expr
         from sympy.simplify.simplify import nsimplify
 
         if not isinstance(expr, Expr):
@@ -998,6 +998,9 @@ def radsimp(expr, symbolic=True, max_terms=4):
         if not keep:
             return expr
         return _unevaluated_Mul(n, 1/d)
+
+    if not isinstance(expr, Expr):
+        return expr.func(*[radsimp(a, symbolic=symbolic, max_terms=max_terms) for a in expr.args])
 
     coeff, expr = expr.as_coeff_Add()
     expr = expr.normal()

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (root, sqrt)
 from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.integrals.integrals import Integral
 from sympy.polys.polytools import factor
 from sympy.series.order import O
 from sympy.simplify.radsimp import (collect, collect_const, fraction, radsimp, rcollect)
@@ -159,6 +160,9 @@ def test_radsimp():
     eq = sqrt(x)/y**2
     assert radsimp(eq) == eq
 
+    # skip non-Expr args
+    eq = Integral(x/(sqrt(2) - 1), (x, 0, 1))
+    assert radsimp(eq) == Integral((sqrt(2) + 1)*x , (x, 0, 1))
 
 def test_radsimp_issue_3214():
     c, p = symbols('c p', positive=True)

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -9,7 +9,6 @@ from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (root, sqrt)
 from sympy.functions.elementary.trigonometric import (cos, sin)
-from sympy.integrals.integrals import Integral
 from sympy.polys.polytools import factor
 from sympy.series.order import O
 from sympy.simplify.radsimp import (collect, collect_const, fraction, radsimp, rcollect)
@@ -161,8 +160,13 @@ def test_radsimp():
     assert radsimp(eq) == eq
 
     # handle non-Expr args
+    from sympy.integrals.integrals import Integral
     eq = Integral(x/(sqrt(2) - 1), (x, 0, 1/(sqrt(2) + 1)))
     assert radsimp(eq) == Integral((sqrt(2) + 1)*x , (x, 0, sqrt(2) - 1))
+
+    from sympy.sets import FiniteSet
+    eq = FiniteSet(x/(sqrt(2) - 1))
+    assert radsimp(eq) == FiniteSet((sqrt(2) + 1)*x)
 
 def test_radsimp_issue_3214():
     c, p = symbols('c p', positive=True)

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -160,9 +160,9 @@ def test_radsimp():
     eq = sqrt(x)/y**2
     assert radsimp(eq) == eq
 
-    # skip non-Expr args
-    eq = Integral(x/(sqrt(2) - 1), (x, 0, 1))
-    assert radsimp(eq) == Integral((sqrt(2) + 1)*x , (x, 0, 1))
+    # handle non-Expr args
+    eq = Integral(x/(sqrt(2) - 1), (x, 0, 1/(sqrt(2) + 1)))
+    assert radsimp(eq) == Integral((sqrt(2) + 1)*x , (x, 0, sqrt(2) - 1))
 
 def test_radsimp_issue_3214():
     c, p = symbols('c p', positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

None

#### Brief description of what is fixed or changed

`radsimp` would raise a deprecation warning when one of its arguments is a non-Expr object (e.g. a sympy tuple). This is because it tries to perform `fraction` on the non-Expr argument. Also, if calling `radsimp` on a non-Expr object, it would raise AttributeError: xxx object has no attribute 'as_coeff_Add'. This PR fixes `radsimp` to handle non-Expr objects correctly.
```py
radsimp(Integral(x/(sqrt(2) - 1), (x, 0, 1/(sqrt(2) + 1))))
radsimp(FiniteSet(x/(sqrt(2) - 1)))
```
 
 
#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Made `radsimp` handle non-Expr arguments.

<!-- END RELEASE NOTES -->
