### PR TITLE
fix(vector): fix printing of negative scalars

### DIFF
--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -84,6 +84,10 @@ b         a         b     \
     assert ascii_vpretty(o) == expected
     assert unicode_vpretty(o) == uexpected
 
+    # https://github.com/sympy/sympy/issues/26731
+    assert ascii_vpretty(-A.x) == '-a_x'
+    assert unicode_vpretty(-A.x) == '-a_x'
+
 
 def test_vector_latex():
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -275,7 +275,7 @@ class Vector(Printable, EvalfMixin):
                 elif M[i] == 1:
                     terms.append(prettyForm(N.pretty_vecs[i]))
                 elif M[i] == -1:
-                    terms.append(prettyForm.NEG + prettyForm(N.pretty_vecs[i]))
+                    terms.append(prettyForm("-1") * prettyForm(N.pretty_vecs[i]))
                 else:
                     terms.append(juxtapose(M[i], N.pretty_vecs[i]))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of gh-26733

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
