### PR TITLE
[GSoC] Changed the output_vector to dsolve and added support of symbolic matrices.

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -3850,11 +3850,11 @@ class StateSpace(LinearTimeInvariant):
         ============
 
         initial_conditions : Matrix
-            The initial conditions of `x` state vector.
+            The initial conditions of `x` state vector. If not provided, it defaults to a zero vector.
         input_vector : Matrix
-            The input vector for state space.
+            The input vector for state space. If not provided, it defaults to a zero vector.
         var : Symbol
-            The symbol representing time.
+            The symbol representing time. If not provided, it defaults to `t`.
 
         Examples
         ==========
@@ -3869,6 +3869,11 @@ class StateSpace(LinearTimeInvariant):
         >>> ss = StateSpace(A, B, C)
         >>> ss.dsolve(input_vector=ip, initial_conditions=i).simplify()
         Matrix([[15/2 - 5*exp(-t) - 5*exp(-2*t)/2]])
+
+        If no input is provided it defaults to solving the system with zero initial conditions and zero input.
+
+        >>> ss.dsolve()
+        Matrix([[0]])
 
         References
         ==========

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -3840,7 +3840,7 @@ class StateSpace(LinearTimeInvariant):
         """
         return self._D.rows
 
-    def state_vector(self, initial_conditions=None, input_vector=None, var=None):
+    def state_vector(self, initial_conditions=None, input_vector=None, var=Symbol('t')):
         r"""
         Returns the State vector `x` given by the solution of the state equation
             x'(t) = A * x(t) + B * u(t)
@@ -3875,9 +3875,7 @@ class StateSpace(LinearTimeInvariant):
         .. [2] https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.systems.linodesolve
         """
 
-        if not var:
-            var = Symbol('t')
-        elif not isinstance(var, Symbol):
+        if not isinstance(var, Symbol):
             raise ValueError("Variable for representing time must be a Symbol.")
         if not initial_conditions:
             initial_conditions = zeros(self._A.shape[0], 1)
@@ -3889,11 +3887,17 @@ class StateSpace(LinearTimeInvariant):
         elif input_vector.shape != (self._B.shape[1], 1):
             raise ShapeError("Input vector should have the same number of "
                              "columns as the input matrix.")
-        sol = linodesolve(self._A, var, self._B*input_vector, type='type2', doit=True)
+        sol = linodesolve(A=self._A, t=var, b=self._B*input_vector, type='type2', doit=True)
         mat1 = Matrix(sol)
         mat2 = mat1.replace(var, 0)
+        free1 = self._A.free_symbols | self._B.free_symbols | input_vector.free_symbols
+        print("Free 1 are : ")
+        print(free1)
+        free2 = mat2.free_symbols
+        print("Free 2 are : ")
+        print(free2)
         # Get all the free symbols form the matrix
-        dummy_symbols = list(mat2.free_symbols)
+        dummy_symbols = list(free2-free1)
         # Convert the matrix to a Coefficient matrix
         r1, r2 = linear_eq_to_matrix(mat2, dummy_symbols)
         s = linsolve((r1, initial_conditions+r2))
@@ -3902,7 +3906,7 @@ class StateSpace(LinearTimeInvariant):
             mat1 = mat1.replace(dummy_symbols[ind], v)
         return mat1
 
-    def output_vector(self, initial_conditions=None, input_vector=None, var=None):
+    def output_vector(self, initial_conditions=None, input_vector=None, var=Symbol('t')):
         r"""
         Returns the Output vector `x` given by the solution of the output equation
             y(t) = C * x(t) + D * u(t)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1755,6 +1755,15 @@ def test_StateSpace_dsolve():
     ss5 = StateSpace(A5, B5, C5)
     op5 = ss5.dsolve(initial_conditions=I5, input_vector=U5, var=t).simplify()
     assert op5[0].args[0][0] == x0 + t/(a*m) - 1/(a**2*m) + exp(-a*t)/(a**2*m)
+    a11, a12, a21, a22, b1, b2, c1, c2, i1, i2 = symbols('a_11 a_12 a_21 a_22 b_1 b_2 c_1 c_2 i_1 i_2')
+    A6 = Matrix([[a11, a12], [a21, a22]])
+    B6 = Matrix([b1, b2])
+    C6 = Matrix([[c1, c2]])
+    I6 = Matrix([i1, i2])
+    ss6 = StateSpace(A6, B6, C6)
+    expr6 = ss6.dsolve(initial_conditions=I6)[0]
+    expr6 = expr6.subs([(a11, 0), (a12, 1), (a21, -2), (a22, -3), (b1, 0), (b2, 1), (c1, 1), (c2, -1), (i1, 1), (i2, 2)])
+    assert expr6 == 8*exp(-t) - 9*exp(-2*t)
 
 
 def test_StateSpace_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
`dsolve()` in StateSpace is added to find the solution of the equations : 

$$
\begin{align}
y &= C \cdot x + D \cdot u \tag{1} \\
\dot{x} &= A \cdot x + B \cdot u \tag{2}
\end{align}
$$

by solving ODE.
#### References to other Issues or PRs
#26685
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added method to solve `StateSpace` equations using `dsolve()`.
<!-- END RELEASE NOTES -->
