### PR TITLE
fix(matrices): handle multiplication of zero/inf in matmul

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -280,7 +280,9 @@ def test_multiplication_inf_zero():
     [                                      pi*b*x**4/8 + pi*a*x**4/8 + O(x**5),   O(x**6), pi*b**2*x**6/32 + pi*a*b*x**6/48 + pi*a**2*x**6/32 + O(x**7),                                           pi*b*x**6/12 + pi*a*x**6/12 + O(x**7)],
     [                                                               -pi*x**2/2,         0,                       -pi*b*x**4/16 - pi*a*x**4/16 + O(x**5),       -pi*x**4/4 - pi*b**2*x**6/64 - pi*a*b*x**6/96 - pi*a**2*x**6/64 + O(x**7)]])
 
-    assert A*B == C
+    C2 = Matrix(4, 4, lambda i, j: Add(*(A[i,k]*B[k,j] for k in range(4))))
+
+    assert A*B == C == C2
 
 
 def test_power():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -51,6 +51,8 @@ from sympy.tensor.array.array_derivatives import ArrayDerivative
 from sympy.matrices.expressions import MatPow
 from sympy.algebras import Quaternion
 
+from sympy import O
+
 from sympy.abc import a, b, c, d, x, y, z, t
 
 
@@ -251,11 +253,34 @@ def test_multiplication():
         assert c[1, 0] == 3*5
         assert c[1, 1] == 0
 
+
+def test_multiplication_inf_zero():
+
     M = Matrix([[oo, 0], [0, oo]])
     assert M ** 2 == M
 
     M = Matrix([[oo, oo], [0, 0]])
     assert M ** 2 == Matrix([[nan, nan], [nan, nan]])
+
+    A = Matrix([
+        [0, 0, 0, -S(1)/2],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [-S(1)/2, 0, 0, 0]])
+
+    B = Matrix([
+        [pi*x**2, 0, pi*b*x**4/8 + pi*a*x**4/8 + O(x**5), pi*x**4/2 + pi*b**2*x**6/32 + pi*a*b*x**6/48 + pi*a**2*x**6/32 + O(x**7)],
+        [0, pi*x**4/4, O(x**6), O(x**8)],
+        [pi*b*x**4/8 + pi*a*x**4/8 + O(x**5), O(x**6), pi*b**2*x**6/32 + pi*a*b*x**6/48 + pi*a**2*x**6/32 + O(x**7), pi*b*x**6/12 + pi*a*x**6/12 + O(x**7)],
+        [pi*x**4/2 + pi*b**2*x**6/32 + pi*a*b*x**6/48 + pi*a**2*x**6/32 + O(x**7), O(x**8), pi*b*x**6/12 + pi*a*x**6/12 + O(x**7), pi*x**6/3 + 3*pi*b**2*x**8/64 + pi*a*b*x**8/32 + 3*pi*a**2*x**8/64 + O(x**9)]])
+
+    C = Matrix([
+    [-pi*x**4/4 - pi*b**2*x**6/64 - pi*a*b*x**6/96 - pi*a**2*x**6/64 + O(x**7),   O(x**8),                       -pi*b*x**6/24 - pi*a*x**6/24 + O(x**7), -pi*x**6/6 - 3*pi*b**2*x**8/128 - pi*a*b*x**8/64 - 3*pi*a**2*x**8/128 + O(x**9)],
+    [                                                                        0, pi*x**4/4,                                                      O(x**6),                                                                         O(x**8)],
+    [                                      pi*b*x**4/8 + pi*a*x**4/8 + O(x**5),   O(x**6), pi*b**2*x**6/32 + pi*a*b*x**6/48 + pi*a**2*x**6/32 + O(x**7),                                           pi*b*x**6/12 + pi*a*x**6/12 + O(x**7)],
+    [                                                               -pi*x**2/2,         0,                       -pi*b*x**4/16 - pi*a*x**4/16 + O(x**5),       -pi*x**4/4 - pi*b**2*x**6/64 - pi*a*b*x**6/96 - pi*a**2*x**6/64 + O(x**7)]])
+
+    assert A*B == C
 
 
 def test_power():

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1547,11 +1547,13 @@ def sdm_matmul_exraw(A, B, K, m, o):
                         Cij = Ci.get(j, zero) + Aik * Bkj
                         if Cij != zero:
                             Ci[j] = Cij
-                        else:  # pragma: no cover
-                            # Not sure how we could get here but let's raise an
-                            # exception just in case.
-                            raise RuntimeError
-                        C[i] = Ci
+                            C[i] = Ci
+                        else:
+                            Ci.pop(j, None)
+                            if Ci:
+                                C[i] = Ci
+                            else:
+                                C.pop(i, None)
 
     return C
 


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/24947

Sparse matrix multiplication is complicated by the fact that some SymPy expressions do not satisfy basic rules like 0*expr == 0. Make sure to respect whatever strange behaviour such expressions have in matrix multiplication.

<!-- BEGIN RELEASE NOTES -->
* matrices
   * A bug (gh-24947) in matrix multiplcation with Order expressions was fixed. Previously `RuntimeError` was raised when multiplying matrices with certain expressions that do not behave as expected under multiplication by zero.
<!-- END RELEASE NOTES -->
