### PR TITLE
[GSoC]Fixed bugs in limits and gruntz for erroneous results

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -414,7 +414,7 @@ def sign(e, x):
             return 1
         if e.exp.is_Integer:
             return s**e.exp
-    elif isinstance(e, log):
+    elif isinstance(e, log) and e.args[0].is_positive:
         return sign(e.args[0] - 1, x)
 
     # if all else fails, do it the hard way

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -273,16 +273,19 @@ class Limit(Expr):
             arg_flag = isinstance(expr, arg)
             sign_flag = isinstance(expr, sign)
             if abs_flag or sign_flag or arg_flag:
-                sig = limit(expr.args[0], z, z0, dir)
-                if sig.is_zero:
-                    sig = limit(1/expr.args[0], z, z0, dir)
-                if sig.is_extended_real:
-                    if (sig < 0) == True:
-                        return (-expr.args[0] if abs_flag else
-                                S.NegativeOne if sign_flag else S.Pi)
-                    elif (sig > 0) == True:
-                        return (expr.args[0] if abs_flag else
-                                S.One if sign_flag else S.Zero)
+                try:
+                    sig = limit(expr.args[0], z, z0, dir)
+                    if sig.is_zero:
+                        sig = limit(1/expr.args[0], z, z0, dir)
+                    if sig.is_extended_real:
+                        if (sig < 0) == True:
+                            return (-expr.args[0] if abs_flag else
+                                    S.NegativeOne if sign_flag else S.Pi)
+                        elif (sig > 0) == True:
+                            return (expr.args[0] if abs_flag else
+                                    S.One if sign_flag else S.Zero)
+                except NotImplementedError:
+                    pass
             return expr
 
         if e.has(Float):
@@ -365,8 +368,8 @@ class Limit(Expr):
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
         # factorial is defined to be zero for negative inputs (which
-        # differs from gamma) so only rewrite for positive z0.
-        if z0.is_extended_positive:
+        # differs from gamma) so only rewrite for non-negative z0.
+        if z0.is_extended_nonnegative:
             e = e.rewrite(factorial, gamma)
 
         l = None

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -116,7 +116,10 @@ def dominant(expr, n):
 
 def _limit_inf(expr, n):
     try:
-        return Limit(expr, n, S.Infinity).doit(deep=False)
+        l = Limit(expr, n, S.Infinity).doit(deep=False)
+        if isinstance(l, Limit):
+            return None
+        return l
     except (NotImplementedError, PoleError):
         return None
 
@@ -127,23 +130,20 @@ def _limit_seq(expr, n, trials):
     for i in range(trials):
         if not expr.has(Sum):
             result = _limit_inf(expr, n)
-            if result is not None:
-                return result
+            return result
 
         num, den = expr.as_numer_denom()
         if not den.has(n) or not num.has(n):
             result = _limit_inf(expr.doit(), n)
-            if result is not None:
-                return result
-            return None
+            return result
+
 
         num, den = (difference_delta(t.expand(), n) for t in [num, den])
         expr = (num / den).gammasimp()
 
         if not expr.has(Sum):
             result = _limit_inf(expr, n)
-            if result is not None:
-                return result
+            return result
 
         num, den = expr.as_numer_denom()
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1412,3 +1412,12 @@ def test_issue_26250():
     e1 = ((1-3*x**2)*e**2/2 - (x**2-2*x+1)*e*k/2)
     e2 = pi**2*(x**8 - 2*x**7 - x**6 + 4*x**5 - x**4 - 2*x**3 + x**2)
     assert limit(e1/e2, x, 0) == -S(1)/8
+
+
+def test_issue_26513():
+    assert limit(abs((-n/(n+1))**n), n ,oo) == exp(-1)
+    raises (NotImplementedError, lambda: limit((-n/(n+1))**n, n, oo))
+
+
+def test_issue_22836_limit():
+    assert limit(2**(1/x)/factorial(1/(x)), x, 0) == S.Zero

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -544,8 +544,8 @@ def test_order_oo():
 
 
 def test_issue_5436():
-    raises(NotImplementedError, lambda: limit(exp(x*y), x, oo))
-    raises(NotImplementedError, lambda: limit(exp(-x*y), x, oo))
+    assert limit(exp(x*y), x, oo) == Limit(exp(x*y), x, oo, dir='-')
+    assert limit(exp(-x*y), x, oo) == Limit(exp(-x*y), x, oo, dir='-')
 
 
 def test_Limit_dir():
@@ -745,7 +745,7 @@ def test_issue_9252():
     c = Symbol('c', positive=True)
     assert limit((log(n))**(n/log(n)) / (1 + c)**n, n, oo) == 0
     # limit should depend on the value of c
-    raises(NotImplementedError, lambda: limit((log(n))**(n/log(n)) / c**n, n, oo))
+    assert limit((log(n))**(n/log(n)) / c**n, n, oo) == Limit(log(n)**(n/log(n))/c**n, n, oo, dir='-')
 
 
 def test_issue_9558():
@@ -913,7 +913,7 @@ def test_issue_10102():
 
 
 def test_issue_14377():
-    raises(NotImplementedError, lambda: limit(exp(I*x)*sin(pi*x), x, oo))
+    assert limit(exp(I*x)*sin(pi*x), x, oo) == Limit(exp(I*x)*sin(pi*x), x, oo, dir='-')
 
 
 def test_issue_15146():
@@ -1078,7 +1078,7 @@ def test_issue_18508():
 
 
 def test_issue_18521():
-    raises(NotImplementedError, lambda: limit(exp((2 - n) * x), x, oo))
+    assert limit(exp((2 - n) * x), x, oo) == Limit(exp(x*(2 - n)), x, oo, dir='-')
 
 
 def test_issue_18969():
@@ -1323,7 +1323,7 @@ def test_issue_25230():
     b = Symbol('b', positive = True)
     c = Symbol('c', negative = True)
     n = Symbol('n', integer = True)
-    raises(NotImplementedError, lambda: limit(Mod(x, a), x, a))
+    assert limit(Mod(x, a), x, a) == 0
     assert limit(Mod(x, b), x, n*b, '+') == 0
     assert limit(Mod(x, b), x, n*b, '-') == b
     assert limit(Mod(x, c), x, n*c, '+') == c
@@ -1416,7 +1416,7 @@ def test_issue_26250():
 
 def test_issue_26513():
     assert limit(abs((-n/(n+1))**n), n ,oo) == exp(-1)
-    raises (NotImplementedError, lambda: limit((-n/(n+1))**n, n, oo))
+    assert limit((-n/(n+1))**n, n, oo) == Limit((-n/(n + 1))**n, n, oo, dir='-')
 
 
 def test_issue_22836_limit():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -3,6 +3,7 @@ from sympy.core.function import (Function, expand)
 from sympy.core.numbers import (I, Rational, nan, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
+from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (conjugate, transpose)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -475,3 +476,9 @@ def test_issue_23231():
 
 def test_issue_9917():
     assert O(x*sin(x) + 1, (x, oo)) == O(x, (x, oo))
+
+
+def test_issue_22836():
+    assert O(2**x + factorial(x), (x, oo)) == O(factorial(x), (x, oo))
+    assert O(2**x + factorial(x) + x**x, (x, oo)) == O(exp(x*log(x)), (x, oo))
+    assert O(x + factorial(x), (x, oo)) == O(factorial(x), (x, oo))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #26513 
Fixes #22836
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->



#### Brief description of what is fixed or changed
`sign` function in gruntz gave erroneous results for negative logarithmic arguments, and fixed code handling factorials in `limits.py` to rewrite factorials to gamma for non-negative arguments to allow expected results in order computations.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Better handling of terms having negative bases in power expressions with symbolic exponents.
  * Better Order computations to handle simplification of complex expressions. 
  * Limits will now return self as the results instead of `NotImplementedError` for unevaluated limits.
 <!-- END RELEASE NOTES -->
