### PR TITLE
Enable PLR1736 useless enumerate check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ lint.select = [
     "LOG",
     "PIE810",
     "PLE",
+    "PLR1736",
     "SIM101",
     "TRY002",
 ]

--- a/sympy/physics/vector/fieldfunctions.py
+++ b/sympy/physics/vector/fieldfunctions.py
@@ -131,7 +131,7 @@ def gradient(scalar, frame):
     outvec = Vector(0)
     scalar = express(scalar, frame, variables=True)
     for i, x in enumerate(frame):
-        outvec += diff(scalar, frame[i]) * x
+        outvec += diff(scalar, frame[i]) * x  # noqa: PLR1736
     return outvec
 
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -389,8 +389,8 @@ class Vector(Printable, EvalfMixin):
             tempz = v[1].z
             tempm = ([[tempx, tempy, tempz],
                       [self.dot(tempx), self.dot(tempy), self.dot(tempz)],
-                      [Vector([ar[i]]).dot(tempx), Vector([ar[i]]).dot(tempy),
-                       Vector([ar[i]]).dot(tempz)]])
+                      [Vector([v]).dot(tempx), Vector([v]).dot(tempy),
+                       Vector([v]).dot(tempz)]])
             outlist += _det(tempm).args
         return Vector(outlist)
 

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -1186,7 +1186,7 @@ class SubModulePolyRing(SubModule):
         for j, f in enumerate(self.gens):
             m = [0]*(r + k)
             for i, v in enumerate(f):
-                m[i] = f[i]
+                m[i] = v
             for i in range(k):
                 m[r + i] = one if j == i else zero
             m = FreeModuleElement(Rkr, tuple(m))

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -53,7 +53,7 @@ def test_FourierSeries():
 
     def _check_iter(f, i):
         for ind, t in enumerate(f):
-            assert t == f[ind]
+            assert t == f[ind]  # noqa: PLR1736
             if ind == i:
                 break
 

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -657,11 +657,11 @@ class PermuteDims(_CodegenArrayAbstract):
             for j in range(len(cumulative_subranks) - 1):
                 if cyclic_min[i] >= cumulative_subranks[j] and cyclic_max[i] < cumulative_subranks[j+1]:
                     # Found a sinkable cycle.
-                    args[j] = _permute_dims(args[j], Permutation([[k - cumulative_subranks[j] for k in cyclic_form[i]]]))
+                    args[j] = _permute_dims(args[j], Permutation([[k - cumulative_subranks[j] for k in cycle]]))
                     flag = False
                     break
             if flag:
-                cyclic_keep.append(cyclic_form[i])
+                cyclic_keep.append(cycle)
         return _array_tensor_product(*args), Permutation(cyclic_keep, size=permutation.size)
 
     def nest_permutation(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Adds a new ruff lint that checks for useless index accesses 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
