### PR TITLE
Enable ruff rule RUF015

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ lint.select = [
     "LOG",
     "PIE810",
     "PLE",
+    "RUF015",
     "SIM101",
     "TRY002",
 ]

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -483,7 +483,7 @@ class DiagramGrid:
         # This gets the set of objects of the triangle and then
         # subtracts the set of objects employed in ``edge`` to get the
         # vertex opposite to ``edge``.
-        return list(DiagramGrid._triangle_objects(triangle) - set(edge))[0]
+        return next(iter(DiagramGrid._triangle_objects(triangle) - set(edge)))
 
     @staticmethod
     def _empty_point(pt, grid):
@@ -763,7 +763,7 @@ class DiagramGrid:
 
                 # Get the object at the other end of the edge.
                 edge = edges[0]
-                other_obj = tuple(edge - frozenset([obj]))[0]
+                other_obj = next(iter(edge - frozenset([obj])))
 
                 # Now check for free directions.  When checking for
                 # free directions, prefer the horizontal and vertical
@@ -934,7 +934,7 @@ class DiagramGrid:
             # There only one object in the diagram, just put in on 1x1
             # grid.
             grid = _GrowableGrid(1, 1)
-            grid[0, 0] = tuple(all_objects)[0]
+            grid[0, 0] = next(iter(all_objects))
             return grid
 
         skeleton = DiagramGrid._build_skeleton(merged_morphisms)

--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -254,7 +254,7 @@ def groups_count(n):
         raise ValueError("n must be a positive integer, not %i" % n)
     factors = factorint(n)
     if len(factors) == 1:
-        (p, e) = list(factors.items())[0]
+        (p, e) = next(iter(factors.items()))
         if p == 2:
             A000679 = [1, 1, 2, 5, 14, 51, 267, 2328, 56092, 10494213, 49487367289]
             if e < len(A000679):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4539,7 +4539,7 @@ class PermutationGroup(Basic):
             nu = block_homomorphism(self, blocks[1])
             return _sylow_reduce(mu, nu)
         elif len(blocks) == 1:
-            block = list(blocks)[0]
+            block = next(iter(blocks))
             if any(e != 0 for e in block):
                 # self is imprimitive
                 mu = block_homomorphism(self, block)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1618,7 +1618,7 @@ class Derivative(Expr):
         """
         if len(self.free_symbols) != 1 or len(self.variables) != 1:
             raise NotImplementedError('partials and higher order derivatives')
-        z = list(self.free_symbols)[0]
+        z = next(iter(self.free_symbols))
 
         def eval(x):
             f0 = self.expr.subs(z, Expr._from_mpmath(x, prec=mpmath.mp.prec))
@@ -2034,8 +2034,8 @@ class Lambda(Expr):
                    'argument%(plural)s (%(given)s given)')
             raise BadArgumentsError(temp % {
                 'name': self,
-                'args': list(self.nargs)[0],
-                'plural': 's'*(list(self.nargs)[0] != 1),
+                'args': next(iter(self.nargs)),
+                'plural': 's'*(next(iter(self.nargs)) != 1),
                 'given': n})
 
         d = self._match_signature(self.signature, args)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -41,7 +41,7 @@ def test_lattice_print():
 def test_lattice_make_args():
     assert join.make_args(join(2, 3, 4)) == {S(2), S(3), S(4)}
     assert join.make_args(0) == {0}
-    assert list(join.make_args(0))[0] is S.Zero
+    assert next(iter(join.make_args(0))) is S.Zero
     assert Add.make_args(0)[0] is S.Zero
 
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -87,7 +87,7 @@ class TrigonometricFunction(Function):
     def _period(self, general_period, symbol=None):
         f = expand_mul(self.args[0])
         if symbol is None:
-            symbol = next(iter(f.free_symbols))
+            symbol = next(iter(f.free_symbols), None)
 
         if not f.has(symbol):
             return S.Zero

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -87,7 +87,7 @@ class TrigonometricFunction(Function):
     def _period(self, general_period, symbol=None):
         f = expand_mul(self.args[0])
         if symbol is None:
-            symbol = tuple(f.free_symbols)[0]
+            symbol = next(iter(f.free_symbols))
 
         if not f.has(symbol):
             return S.Zero

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -330,8 +330,7 @@ def interpolating_spline(d, x, X, Y):
 
     A = [[b.subs(x, v) for b in basis] for v in X]
 
-    coeff = linsolve((Matrix(A), Matrix(Y)), symbols("c0:{}".format(len(X)), cls=Dummy))
-    coeff = next(iter(coeff))
+    (coeff,) = linsolve((Matrix(A), Matrix(Y)), symbols("c0:{}".format(len(X)), cls=Dummy))
     intervals = {c for b in basis for (e, c) in b.args if c != True}
 
     # Sorting the intervals

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -331,7 +331,7 @@ def interpolating_spline(d, x, X, Y):
     A = [[b.subs(x, v) for b in basis] for v in X]
 
     coeff = linsolve((Matrix(A), Matrix(Y)), symbols("c0:{}".format(len(X)), cls=Dummy))
-    coeff = list(coeff)[0]
+    coeff = next(iter(coeff))
     intervals = {c for b in basis for (e, c) in b.args if c != True}
 
     # Sorting the intervals

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -434,7 +434,7 @@ class Plane(GeometryEntity):
                 c = list(a.cross(b))
                 d = self.equation(x, y, z)
                 e = o.equation(x, y, z)
-                result = list(linsolve([d, e], x, y, z))[0]
+                result = next(iter(linsolve([d, e], x, y, z)))
                 for i in (x, y, z): result = result.subs(i, 0)
                 return [Line3D(Point3D(result), direction_ratio=c)]
 

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -125,7 +125,7 @@ def test_farthest_points_closest_points():
 
         for points in (p1, p2, p3, p4, p5, dup, s):
             d = how(i.distance(j) for i, j in subsets(set(points), 2))
-            ans = a, b = list(func(*points))[0]
+            ans = a, b = next(iter(func(*points)))
             assert a.distance(b) == d
             assert ans == _ordered_points(ans)
 
@@ -136,7 +136,7 @@ def test_farthest_points_closest_points():
             points.add(Point2D(randint(1, 100), randint(1, 100)))
         points = list(points)
         d = how(i.distance(j) for i, j in subsets(points, 2))
-        ans = a, b = list(func(*points))[0]
+        ans = a, b = next(iter(func(*points)))
         assert a.distance(b) == d
         assert ans == _ordered_points(ans)
 

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -535,7 +535,7 @@ class HolonomicFunction:
         """
         Converts a singular initial condition to ordinary if possible.
         """
-        a = list(self.y0)[0]
+        a = next(iter(self.y0))
         b = self.y0[a]
 
         if len(self.y0) == 1 and a == int(a) and a > 0:
@@ -1084,7 +1084,7 @@ class HolonomicFunction:
             if self.y0 is None:
                 y0 = None
             else:
-                y0 = [list(self.y0)[0] ** n]
+                y0 = [next(iter(self.y0)) ** n]
 
             p0 = ann.listofpoly[0]
             p1 = ann.listofpoly[1]
@@ -1171,7 +1171,7 @@ class HolonomicFunction:
             if sol.is_zero_matrix is not True:
                 break
 
-        tau = list(taus)[0]
+        tau = next(iter(taus))
         sol = sol.subs(tau, 1)
         sol = _normalize(sol[0:], R, negative=False)
 
@@ -2716,7 +2716,7 @@ def _convert_meijerint(func, x, initcond=True, domain=QQ):
             z = z.subs(exp_polar, exp)
 
         d = z.collect(x, evaluate=False)
-        b = list(d)[0]
+        b = next(iter(d))
         a = d[b]
 
         t = b.as_base_exp()

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -2118,7 +2118,7 @@ def _inverse_laplace_rational(fn, s, t, plane, *, simplify):
                 if b.is_negative:
                     b = -b
                     hyp = True
-                b2 = list(roots(x_**2-b, x_).keys())[0]
+                b2 = next(iter(roots(x_**2-b, x_).keys()))
                 bs = sqrt(b).simplify()
                 if hyp:
                     r = (

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -21,7 +21,7 @@ for about, category in t.items():
         doc += 'Elementary functions:\n\n'
     else:
         doc += 'Functions involving ' + ', '.join('`%s`' % latex(
-            list(category[0][0].atoms(func))[0]) for func in about) + ':\n\n'
+            next(iter(category[0][0].atoms(func)))) for func in about) + ':\n\n'
     for formula, gs, cond, hint in category:
         if not isinstance(gs, list):
             g = Symbol('\\text{generated}')

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -554,7 +554,7 @@ def test_linsolve_underdetermined_AND_gauss_jordan_solve():
     [0,  0, 0,  0, 1,  1, 1,  1,  f]
     ])
 
-    sol_1=Matrix(list(linsolve(A))[0])
+    sol_1=Matrix(next(iter(linsolve(A))))
 
     tau0, tau1, tau2, tau3, tau4 = symbols('tau:5')
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -705,7 +705,7 @@ class TransferFunction(SISOLinearTimeInvariant):
             _free_symbols = expr.free_symbols
             _len_free_symbols = len(_free_symbols)
             if _len_free_symbols == 1:
-                var = list(_free_symbols)[0]
+                var = next(iter(_free_symbols))
             elif _len_free_symbols == 0:
                 raise ValueError(filldedent("""
                     Positional argument `var` not found in the

--- a/sympy/physics/mechanics/tests/test_system_class.py
+++ b/sympy/physics/mechanics/tests/test_system_class.py
@@ -703,8 +703,8 @@ class TestSystemExamples:
             (-g * mp * sin(qp) + k * qp / l + l * mc * sin(2 * qp) * up ** 2 / 2
              - l * mp * sin(2 * qp) * up ** 2 / 2 - F * cos(qp)) /
             (l * (mc * cos(qp) ** 2 + mp * sin(qp) ** 2)))
-        upd_sol = tuple(solve(system.form_eoms().xreplace(subs),
-                              up.diff(t)).values())[0]
+        upd_sol = next(iter(solve(system.form_eoms().xreplace(subs),
+                              up.diff(t)).values()))
         assert simplify(upd_sol - upd_expected) == 0
         assert isinstance(system.eom_method, KanesMethod)
 

--- a/sympy/physics/vector/fieldfunctions.py
+++ b/sympy/physics/vector/fieldfunctions.py
@@ -162,7 +162,7 @@ def is_conservative(field):
     # Take the first frame in the result of the separate method of Vector
     if field == Vector(0):
         return True
-    frame = list(field.separate())[0]
+    frame = next(iter(field.separate()))
     return curl(field, frame).simplify() == Vector(0)
 
 
@@ -193,7 +193,7 @@ def is_solenoidal(field):
     # Take the first frame in the result of the separate method in Vector
     if field == Vector(0):
         return True
-    frame = list(field.separate())[0]
+    frame = next(iter(field.separate()))
     return divergence(field, frame).simplify() is S.Zero
 
 

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -757,5 +757,5 @@ def test_pickle_frame():
     A.orient_axis(N, N.x, 1)
     A_C_N = A.dcm(N)
     N1 = pickle.loads(pickle.dumps(N))
-    A1 = tuple(N1._dcm_dict.keys())[0]
+    A1 = next(iter(N1._dcm_dict.keys()))
     assert A1.dcm(N1) == A_C_N

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -1212,7 +1212,7 @@ class SubModulePolyRing(SubModule):
             order="ilex", TOP=False)  # We want decreasing order!
         G = S._groebner_vec()
         # This list cannot not be empty since e is an element
-        e = [x for x in G if self.ring.is_unit(x[0])][0]
+        e = next(x for x in G if self.ring.is_unit(x[0]))
         return [-x/e[0] for x in e[1:]]
 
     def reduce_element(self, x, NF=None):

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -512,8 +512,8 @@ class Monomial(PicklableWithSlots):
     def __init__(self, monom, gens=None):
         if not iterable(monom):
             rep, gens = dict_from_expr(sympify(monom), gens=gens)
-            if len(rep) == 1 and list(rep.values())[0] == 1:
-                monom = list(rep.keys())[0]
+            if len(rep) == 1 and next(iter(rep.values())) == 1:
+                monom = next(iter(rep.keys()))
             else:
                 raise ValueError("Expected a monomial got {}".format(monom))
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1189,7 +1189,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             else:
                 raise ValueError("0**0")
         elif len(self) == 1:
-            monom, coeff = list(self.items())[0]
+            monom, coeff = next(iter(self.items()))
             p = ring.zero
             if coeff == ring.domain.one:
                 p[ring.monomial_pow(monom, n)] = coeff
@@ -2172,7 +2172,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ground_quo = ring.domain.quo
         monomial_gcd = ring.monomial_gcd
         monomial_ldiv = ring.monomial_ldiv
-        mf, cf = list(f.iterterms())[0]
+        mf, cf = next(iter(f.iterterms()))
         _mgcd, _cgcd = mf, cf
         for mg, cg in g.iterterms():
             _mgcd = monomial_gcd(_mgcd, mg)

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -551,7 +551,7 @@ def test_roots0():
     }
 
     r = roots(x**3 + 40*x + 64)
-    real_root = [rx for rx in r if rx.is_real][0]
+    real_root = next(rx for rx in r if rx.is_real)
     cr = 108 + 6*sqrt(1074)
     assert real_root == -2*root(cr, 3)/3 + 20/root(cr, 3)
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -336,7 +336,7 @@ def mrv_max3(f, expsf, g, expsg, union, expsboth, x):
     elif f.meets(g):
         return union, expsboth
 
-    c = compare(list(f.keys())[0], list(g.keys())[0], x)
+    c = compare(next(iter(f.keys())), next(iter(g.keys())), x)
     if c == ">":
         return f, expsf
     elif c == "<":

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -449,7 +449,7 @@ def _(a, b):
                     #this is to ensure that if Eq(a.start, b.start) but
                     #type(a.start) != type(b.start) the order of a and b
                     #does not matter for the result
-                    start = list(ordered([a,b]))[0].start
+                    start = next(iter(ordered([a,b]))).start
             left_open = a.left_open or b.left_open
 
         if a.end < b.end:
@@ -467,7 +467,7 @@ def _(a, b):
                 elif a.end.has(Float) and not b.end.has(Float):
                     end = a.end
                 else:
-                    end = list(ordered([a,b]))[0].end
+                    end = next(iter(ordered([a,b]))).end
             right_open = a.right_open or b.right_open
 
         if end - start == 0 and (left_open or right_open):

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -830,7 +830,7 @@ class HomogeneousTernaryQuadratic(DiophantineEquationType):
 
         def unpack_sol(sol):
             if len(sol) > 0:
-                return list(sol)[0]
+                return next(iter(sol))
             return None, None, None
 
         if not any(coeff[i**2] for i in var):
@@ -1753,7 +1753,7 @@ def diop_linear(eq, param=symbols("t", integer=True)):
             result = result(*[0]*len(result.parameters))
 
         if len(result) > 0:
-            return list(result)[0]
+            return next(iter(result))
         else:
             return tuple([None]*len(result.parameters))
 
@@ -2678,7 +2678,7 @@ def diop_ternary_quadratic(eq, parameterize=False):
             HomogeneousTernaryQuadraticNormal.name):
         sol = _diop_ternary_quadratic(var, coeff)
         if len(sol) > 0:
-            x_0, y_0, z_0 = list(sol)[0]
+            x_0, y_0, z_0 = next(iter(sol))
         else:
             x_0, y_0, z_0 = None, None, None
 
@@ -2852,7 +2852,7 @@ def parametrize_ternary_quadratic(eq):
     if diop_type in (
             "homogeneous_ternary_quadratic",
             "homogeneous_ternary_quadratic_normal"):
-        x_0, y_0, z_0 = list(_diop_ternary_quadratic(var, coeff))[0]
+        x_0, y_0, z_0 = next(iter(_diop_ternary_quadratic(var, coeff)))
         return _parametrize_ternary_quadratic(
             (x_0, y_0, z_0), var, coeff)
 
@@ -2932,7 +2932,7 @@ def diop_ternary_quadratic_normal(eq, parameterize=False):
     if diop_type == HomogeneousTernaryQuadraticNormal.name:
         sol = _diop_ternary_quadratic_normal(var, coeff)
         if len(sol) > 0:
-            x_0, y_0, z_0 = list(sol)[0]
+            x_0, y_0, z_0 = next(iter(sol))
         else:
             x_0, y_0, z_0 = None, None, None
         if parameterize:
@@ -3351,7 +3351,7 @@ def diop_general_pythagorean(eq, param=symbols("m", integer=True)):
             params = None
         else:
             params = symbols('%s1:%i' % (param, len(var)), integer=True)
-        return list(GeneralPythagorean(eq).solve(parameters=params))[0]
+        return next(iter(GeneralPythagorean(eq).solve(parameters=params)))
 
 
 def diop_general_sum_of_squares(eq, limit=1):

--- a/sympy/solvers/ode/hypergeometric.py
+++ b/sympy/solvers/ode/hypergeometric.py
@@ -117,11 +117,11 @@ def equivalence_hypergeometric(A, B, func):
             if isinstance(arg, Pow):
                 # (x-a)**n
                 dem_pow.append(arg.as_base_exp()[1])
-                sing_point.append(list(roots(arg.as_base_exp()[0], x).keys())[0])
+                sing_point.append(next(iter(roots(arg.as_base_exp()[0], x).keys())))
             else:
                 # (x-a) type
                 dem_pow.append(arg.as_base_exp()[1])
-                sing_point.append(list(roots(arg, x).keys())[0])
+                sing_point.append(next(iter(roots(arg, x).keys())))
 
     dem_pow.sort()
     # checking if equivalence is exists or not.

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -566,7 +566,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
         eq = match['eq']
         order = match['order']
         func = match['func']
-        t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+        t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
 
         # keep highest order term coefficient positive
         for i in range(len(eq)):
@@ -579,7 +579,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
         match['eq'] = eq
         if len(set(order.values()))!=1:
             raise ValueError("It solves only those systems of equations whose orders are equal")
-        match['order'] = list(order.values())[0]
+        match['order'] = next(iter(order.values()))
         def recur_len(l):
             return sum(recur_len(item) if isinstance(item,list) else 1 for item in l)
         if recur_len(func) != len(eq):
@@ -762,7 +762,7 @@ def solve_ics(sols, funcs, constants, ics):
     for funcarg, value in ics.items():
         if isinstance(funcarg, AppliedUndef):
             x0 = funcarg.args[0]
-            matching_func = [f for f in funcs if f.func == funcarg.func][0]
+            matching_func = next(f for f in funcs if f.func == funcarg.func)
             S = sols
         elif isinstance(funcarg, (Subs, Derivative)):
             if isinstance(funcarg, Subs):
@@ -1224,7 +1224,7 @@ def classify_sysode(eq, funcs=None, **kwargs):
         if isinstance(fi, Equality):
             eq[i] = fi.lhs - fi.rhs
 
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     matching_hints = {"no_of_equation":i+1}
     matching_hints['eq'] = eq
     if i==0:
@@ -1319,7 +1319,7 @@ def classify_sysode(eq, funcs=None, **kwargs):
 
 
     if len(set(order.values())) == 1:
-        order_eq = list(matching_hints['order'].values())[0]
+        order_eq = next(iter(matching_hints['order'].values()))
         if matching_hints['is_linear'] == True:
             if matching_hints['no_of_equation'] == 2:
                 if order_eq == 1:
@@ -1358,7 +1358,7 @@ def check_linear_2eq_order1(eq, func, func_coef):
     x = func[0].func
     y = func[1].func
     fc = func_coef
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     r = {}
     # for equations Eq(a1*diff(x(t),t), b1*x(t) + c1*y(t) + d1)
     # and Eq(a2*diff(y(t),t), b2*x(t) + c2*y(t) + d2)
@@ -1410,7 +1410,7 @@ def check_linear_2eq_order1(eq, func, func_coef):
                 # Equations for type 7 are Eq(diff(x(t),t), f(t)*x(t) + g(t)*y(t)) and Eq(diff(y(t),t), h(t)*x(t) + p(t)*y(t))
                 return "type7"
 def check_nonlinear_2eq_order1(eq, func, func_coef):
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     f = Wild('f')
     g = Wild('g')
     u, v = symbols('u, v', cls=Dummy)
@@ -1489,7 +1489,7 @@ def check_nonlinear_3eq_order1(eq, func, func_coef):
     y = func[1].func
     z = func[2].func
     fc = func_coef
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     u, v, w = symbols('u, v, w', cls=Dummy)
     a = Wild('a', exclude=[x(t), y(t), z(t), t])
     b = Wild('b', exclude=[x(t), y(t), z(t), t])
@@ -2884,7 +2884,7 @@ def sysode_linear_2eq_order1(match_):
     fc = match_['func_coeff']
     eq = match_['eq']
     r = {}
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     for i in range(2):
         eq[i] = Add(*[terms/fc[i,func[i],1] for terms in Add.make_args(eq[i])])
 
@@ -3031,7 +3031,7 @@ def sysode_nonlinear_2eq_order1(match_):
     func = match_['func']
     eq = match_['eq']
     fc = match_['func_coeff']
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     if match_['type_of_equation'] == 'type5':
         sol = _nonlinear_2eq_order1_type5(func, t, eq)
         return sol
@@ -3282,7 +3282,7 @@ def sysode_nonlinear_3eq_order1(match_):
     y = match_['func'][1].func
     z = match_['func'][2].func
     eq = match_['eq']
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
+    t = next(iter(next(iter(eq[0].atoms(Derivative))).atoms(Symbol)))
     if match_['type_of_equation'] == 'type1':
         sol = _nonlinear_3eq_order1_type1(x, y, z, t, eq)
     if match_['type_of_equation'] == 'type2':

--- a/sympy/solvers/ode/riccati.py
+++ b/sympy/solvers/ode/riccati.py
@@ -271,7 +271,7 @@ def linsolve_dict(eq, syms):
     sol = linsolve(eq, syms)
     if not sol:
         return {}
-    return dict(zip(syms, list(sol)[0]))
+    return dict(zip(syms, next(iter(sol))))
 
 
 def match_riccati(eq, f, x):

--- a/sympy/solvers/ode/subscheck.py
+++ b/sympy/solvers/ode/subscheck.py
@@ -363,7 +363,7 @@ def checksysodesol(eqs, sols, func=None):
         raise ValueError("number of solutions provided does not match the number of equations")
     dictsol = {}
     for sol in sols:
-        func = list(sol.atoms(AppliedUndef))[0]
+        func = next(iter(sol.atoms(AppliedUndef)))
         if sol.rhs == func:
             sol = sol.reversed
         solved = sol.lhs == func and not sol.rhs.has(func)
@@ -386,7 +386,7 @@ def checksysodesol(eqs, sols, func=None):
         else:
             eq = 0
         checkeq.append(eq)
-    if len(set(checkeq)) == 1 and list(set(checkeq))[0] == 0:
+    if len(set(checkeq)) == 1 and set(checkeq).pop() == 0:
         return (True, checkeq)
     else:
         return (False, checkeq)

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -331,7 +331,7 @@ def _first_order_type5_6_subs(A, t, b=None):
             A = factor_terms[1]
             if not is_homogeneous:
                 b = b / factor_terms[0]
-                b = b.subs(t, list(inverse)[0])
+                b = b.subs(t, next(iter(inverse)))
             type = "type{}".format(5 + (not is_homogeneous))
             match.update({'func_coeff': A, 'tau': F_t,
                           't_': t_, 'type_of_equation': type, 'rhs': b})
@@ -1895,7 +1895,7 @@ def _higher_order_to_first_order(eqs, sys_order, t, funcs=None, type="type0", **
 
             if isinstance(expr, Mul):
                 coeff = expr.args[0]
-                order = list(_get_coeffs_from_subs_expression(expr.args[1]).keys())[0]
+                order = next(iter(_get_coeffs_from_subs_expression(expr.args[1]).keys()))
                 return {order: coeff}
 
             if isinstance(expr, Add):
@@ -1906,7 +1906,7 @@ def _higher_order_to_first_order(eqs, sys_order, t, funcs=None, type="type0", **
                         coeffs.update(_get_coeffs_from_subs_expression(arg))
 
                     else:
-                        order = list(_get_coeffs_from_subs_expression(arg).keys())[0]
+                        order = next(iter(_get_coeffs_from_subs_expression(arg).keys()))
                         coeffs[order] = 1
 
                 return coeffs
@@ -2094,7 +2094,7 @@ def dsolve_system(eqs, funcs=None, t=None, ics=None, doit=False, simplify=True):
         '''))
 
     if t is None:
-        t = list(list(eqs[0].atoms(Derivative))[0].atoms(Symbol))[0]
+        t = next(iter(next(iter(eqs[0].atoms(Derivative))).atoms(Symbol)))
 
     sols = []
     canon_eqs = canonical_odes(eqs, funcs, t)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1586,7 +1586,7 @@ def _solve(f, *symbols, **flags):
                     # if no Functions left, we can proceed with usual solve
                     if not ftry.has(symbol):
                         cv_sols = _solve(ftry, t, **flags)
-                        cv_inv = list(ordered(_vsolve(t - f1, symbol, **flags)))[0]
+                        cv_inv = next(iter(ordered(_vsolve(t - f1, symbol, **flags))))
                         result = [{symbol: cv_inv.subs(sol)} for sol in cv_sols]
 
                 if result is False:
@@ -3525,7 +3525,7 @@ def unrad(eq, *syms, **flags):
                 x = b.free_symbols
             else:
                 x = syms
-            x = list(ordered(x))[0]
+            x = next(iter(ordered(x)))
             try:
                 inv = _vsolve(covsym**lcm - b, x, **uflags)
                 if not inv:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1221,7 +1221,7 @@ def solve_decomposition(f, symbol, domain):
 
             for iset in iter_iset:
                 new_solutions = solveset(Eq(iset.lamda.expr, g), symbol, domain)
-                dummy_var = tuple(iset.lamda.expr.free_symbols)[0]
+                dummy_var = next(iter(iset.lamda.expr.free_symbols))
                 (base_set,) = iset.base_sets
                 if isinstance(new_solutions, FiniteSet):
                     new_exprs = new_solutions
@@ -1649,7 +1649,7 @@ def _solve_modular(f, symbol, domain):
     """
     # extract modterm and g_y from f
     unsolved_result = ConditionSet(symbol, Eq(f, 0), domain)
-    modterm = list(f.atoms(Mod))[0]
+    modterm = next(iter(f.atoms(Mod)))
     rhs = -S.One*(f.subs(modterm, S.Zero))
     if f.as_coefficients_dict()[modterm].is_negative:
         # checks if coefficient of modterm is negative in main equation.

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1659,8 +1659,8 @@ def test_float_handling():
     assert test(nfloat(1 + 2*x), 1.0 + 2.0*x)
     for contain in [list, tuple, set]:
         ans = nfloat(contain([1 + 2*x]))
-        assert type(ans) is contain and test(list(ans)[0], 1.0 + 2.0*x)
-    k, v = list(nfloat({2*x: [1 + 2*x]}).items())[0]
+        assert type(ans) is contain and test(next(iter(ans)), 1.0 + 2.0*x)
+    k, v = next(iter(nfloat({2*x: [1 + 2*x]}).items()))
     assert test(k, 2*x) and test(v[0], 1.0 + 2.0*x)
     assert test(nfloat(cos(2*x)), cos(2.0*x))
     assert test(nfloat(3*x**2), 3.0*x**2)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -490,7 +490,7 @@ def test_return_root_of():
     # equation only to get CRootOf solutions which are then numerically
     # evaluated. So for eq = x**5 + 3*x + 7 do Poly(eq).nroots() rather
     # than [i.n() for i in solve(eq)] to get the numerical roots of eq.
-    assert nfloat(list(solveset_complex(x**5 + 3*x**3 + 7, x))[0],
+    assert nfloat(next(iter(solveset_complex(x**5 + 3*x**3 + 7, x))),
                   exponent=False) == CRootOf(x**5 + 3*x**3 + 7, 0).n()
 
     sol = list(solveset_complex(x**6 - 2*x + 2, x))
@@ -2549,7 +2549,7 @@ def test_issue_10214():
 
     ans = FiniteSet(-2**Rational(2, 3))
     assert solveset(x**(S(3)) + 4, x, S.Reals) == ans
-    assert (x**(S(3)) + 4).subs(x,list(ans)[0]) == 0 # substituting ans and verifying the result.
+    assert (x**(S(3)) + 4).subs(x,next(iter(ans))) == 0 # substituting ans and verifying the result.
     assert (x**(S(3)) + 4).subs(x,-(-2)**Rational(2, 3)) == 0
 
 

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -143,7 +143,7 @@ class ConditionalContinuousDomain(ContinuousDomain, ConditionalDomain):
     def set(self):
         if len(self.symbols) == 1:
             return (self.fulldomain.set & reduce_rational_inequalities_wrap(
-                self.condition, tuple(self.symbols)[0]))
+                self.condition, next(iter(self.symbols))))
         else:
             raise NotImplementedError(
                 "Set of Conditional Domain not Implemented")
@@ -401,7 +401,7 @@ class ContinuousPSpace(PSpace):
         # Univariate case can be handled by where
         try:
             domain = self.where(condition)
-            rv = [rv for rv in self.values if rv.symbol == domain.symbol][0]
+            rv = next(rv for rv in self.values if rv.symbol == domain.symbol)
             # Integrate out all other random variables
             pdf = self.compute_density(rv, **kwargs)
             # return S.Zero if `domain` is empty set
@@ -438,7 +438,7 @@ class ContinuousPSpace(PSpace):
         if not (len(rvs) == 1 and rvs.issubset(self.values)):
             raise NotImplementedError(
                 "Multiple continuous random variables not supported")
-        rv = tuple(rvs)[0]
+        rv = next(iter(rvs))
         interval = reduce_rational_inequalities_wrap(condition, rv)
         interval = interval.intersect(self.domain.set)
         return SingleContinuousDomain(rv.symbol, interval)

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -201,7 +201,7 @@ class ConditionalDiscreteDomain(DiscreteDomain, ConditionalDomain):
         if len(self.symbols) > 1:
             raise NotImplementedError(filldedent('''
                 Multivariate conditional domains are not yet implemented.'''))
-        rv = list(rv)[0]
+        rv = next(iter(rv))
         return reduce_rational_inequalities_wrap(self.condition,
             rv).intersect(self.fulldomain.set)
 
@@ -251,7 +251,7 @@ class DiscretePSpace(PSpace):
         return prob if not complement else S.One - prob
 
     def eval_prob(self, _domain):
-        sym = list(self.symbols)[0]
+        sym = next(iter(self.symbols))
         if isinstance(_domain, Range):
             n = symbols('n', integer=True)
             inf, sup, step = (r for r in _domain.args)

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -121,7 +121,7 @@ class SingleFiniteDomain(FiniteDomain):
         return (frozenset(((self.symbol, elem),)) for elem in self.set)
 
     def __contains__(self, other):
-        sym, val = tuple(other)[0]
+        sym, val = next(iter(other))
         return sym == self.symbol and val in self.set
 
 
@@ -251,9 +251,9 @@ class FinitePSpace(PSpace):
     def prob_of(self, elem):
         elem = sympify(elem)
         density = self._density
-        if isinstance(list(density.keys())[0], FiniteSet):
+        if isinstance(next(iter(density.keys())), FiniteSet):
             return density.get(elem, S.Zero)
-        return density.get(tuple(elem)[0][1], S.Zero)
+        return density.get(next(iter(elem))[1], S.Zero)
 
     def where(self, condition):
         assert all(r.symbol in self.symbols for r in random_symbols(condition))
@@ -309,7 +309,7 @@ class FinitePSpace(PSpace):
         expr = rv_subs(expr, rvs)
         probs = [self.prob_of(elem) for elem in self.domain]
         if isinstance(expr, (Logic, Relational)):
-            parse_domain = [tuple(elem)[0][1] for elem in self.domain]
+            parse_domain = [next(iter(elem))[1] for elem in self.domain]
             bools = [expr.xreplace(dict(elem)) for elem in self.domain]
         else:
             parse_domain = [expr.xreplace(dict(elem)) for elem in self.domain]
@@ -335,7 +335,7 @@ class FinitePSpace(PSpace):
             (not cond.free_symbols.issubset(self.domain.free_symbols)):
             rv = condition.lhs if isinstance(condition.rhs, Symbol) else condition.rhs
             return sum(Piecewise(
-                       (self.prob_of(elem), condition.subs(rv, list(elem)[0][1])),
+                       (self.prob_of(elem), condition.subs(rv, next(iter(elem))[1])),
                        (S.Zero, True)) for elem in self.domain)
         return sympify(sum(self.prob_of(elem) for elem in self.where(condition)))
 
@@ -421,7 +421,7 @@ class SingleFinitePSpace(SinglePSpace, FinitePSpace):
 
     def compute_density(self, expr):
         if self._is_symbolic:
-            rv = list(random_symbols(expr))[0]
+            rv = next(iter(random_symbols(expr)))
             k = Dummy('k', integer=True)
             cond = True if not isinstance(expr, (Relational, Logic)) \
                      else expr.subs(rv, k)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -121,7 +121,7 @@ class SingleDomain(RandomDomain):
     def __contains__(self, other):
         if len(other) != 1:
             return False
-        sym, val = tuple(other)[0]
+        sym, val = next(iter(other))
         return self.symbol == sym and val in self.set
 
 
@@ -639,7 +639,7 @@ def pspace(expr):
     if isinstance(expr, RandomSymbol) and expr.pspace is not None:
         return expr.pspace
     if expr.has(RandomMatrixSymbol):
-        rm = list(expr.atoms(RandomMatrixSymbol))[0]
+        rm = next(iter(expr.atoms(RandomMatrixSymbol)))
         return rm.pspace
 
     rvs = random_symbols(expr)
@@ -679,7 +679,7 @@ def rs_swap(a, b):
     """
     d = {}
     for rsa in a:
-        d[rsa] = [rsb for rsb in b if rsa.symbol == rsb.symbol][0]
+        d[rsa] = next(rsb for rsb in b if rsa.symbol == rsb.symbol)
     return d
 
 
@@ -731,7 +731,7 @@ def given(expr, condition=None, **kwargs):
     condsymbols = random_symbols(condition)
     if (isinstance(condition, Eq) and len(condsymbols) == 1 and
         not isinstance(pspace(expr).domain, ConditionalDomain)):
-        rv = tuple(condsymbols)[0]
+        rv = next(iter(condsymbols))
 
         results = solveset(condition, rv)
         if isinstance(results, Intersection) and S.Reals in results.args:

--- a/sympy/stats/sampling/tests/test_sample_continuous_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_continuous_rv.py
@@ -163,7 +163,7 @@ def test_sample_continuous():
     if not scipy:
         skip('Scipy is not installed. Abort tests')
     assert sample(Z) in Z.pspace.domain.set
-    sym, val = list(Z.pspace.sample().items())[0]
+    sym, val = next(iter(Z.pspace.sample().items()))
     assert sym == Z and val in Interval(0, oo)
 
     libraries = ['scipy', 'numpy', 'pymc']

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -644,7 +644,7 @@ class MarkovProcess(StochasticProcess):
                                     else (gc.lhs, gc.rhs)
                         gr = gp.args[0]
                         gset = Intersection(gr.as_set(), state_index)
-                        gstate = list(gset)[0]
+                        gstate = next(iter(gset))
                         prob[gset] = p
                     else:
                         _, gstate = (gc.lhs.key, gc.rhs) if isinstance(gc.lhs, RandomIndexedSymbol) \
@@ -662,11 +662,11 @@ class MarkovProcess(StochasticProcess):
             if prob:
                 gstates = Union(*prob.keys())
                 if len(gstates) == 1:
-                    gstate = list(gstates)[0]
-                    gprob = list(prob.values())[0]
+                    gstate = next(iter(gstates))
+                    gprob = next(iter(prob.values()))
                     prob[gstates] = gprob
                 elif len(gstates) == len(state_index) - 1:
-                    gstate = list(state_index - gstates)[0]
+                    gstate = next(iter(state_index - gstates))
                     gprob = S.One - sum(prob.values())
                     prob[state_index - gstates] = gprob
                 else:
@@ -691,7 +691,7 @@ class MarkovProcess(StochasticProcess):
             compute_later, state2cond, conds = [], {}, condition.args
             for expr in conds:
                 if isinstance(expr, Relational):
-                    ris = list(expr.atoms(RandomIndexedSymbol))[0]
+                    ris = next(iter(expr.atoms(RandomIndexedSymbol)))
                     if state2cond.get(ris, None) is None:
                         state2cond[ris] = S.true
                     state2cond[ris] &= expr
@@ -803,7 +803,7 @@ class MarkovProcess(StochasticProcess):
             # handle queries similar to E(f(X[i]), Eq(X[i-m], <some-state>))
             condition=self.replace_with_index(condition)
             state_index=self.replace_with_index(state_index)
-            rv = list(rvs)[0]
+            rv = next(iter(rvs))
             lhsg, rhsg = condition.lhs, condition.rhs
             if not isinstance(lhsg, RandomIndexedSymbol):
                 lhsg, rhsg = (rhsg, lhsg)
@@ -1256,7 +1256,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         b = zeros(n, 1)
         b[0, 0] = 1
 
-        soln = list(linsolve((a, b)))[0]
+        soln = next(iter(linsolve((a, b))))
         return ImmutableMatrix([soln])
 
     def fixed_row_vector(self):
@@ -1612,7 +1612,7 @@ class ContinuousMarkovChain(ContinuousTimeStochasticProcess, MarkovProcess):
         wm = Matrix([wi])
         eqs = (wm*gen_mat).tolist()[0]
         eqs.append(sum(wi) - 1)
-        soln = list(linsolve(eqs, wi))[0]
+        soln = next(iter(linsolve(eqs, wi)))
         return ImmutableMatrix([soln])
 
 

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -387,7 +387,7 @@ def _(expr: ArrayTensorProduct):
             else:
                 newargs.append(arg)
         elif 1 in arg.shape:
-            k = [i for i in arg.shape if i != 1][0]
+            k = next(i for i in arg.shape if i != 1)
             if pending is None:
                 pending = k
                 prev_i = i
@@ -489,8 +489,8 @@ def _remove_diagonalized_identity_matrices(expr: ArrayDiagonal):
         counter += len(arg_with_ind.indices)
         if isinstance(arg_with_ind.element, Identity):
             if None in arg_with_ind.indices and any(i is not None and (i < 0) == True for i in arg_with_ind.indices):
-                diag_ind = [j for j in arg_with_ind.indices if j is not None][0]
-                other = [j for j in mapping[diag_ind] if j != arg_with_ind][0]
+                diag_ind = next(j for j in arg_with_ind.indices if j is not None)
+                other = next(j for j in mapping[diag_ind] if j != arg_with_ind)
                 if not isinstance(other.element, MatrixExpr):
                     continue
                 if 1 not in other.element.shape:
@@ -819,7 +819,7 @@ def identify_removable_identity_matrices(expr):
                     # Free identity matrix, will be cleared by _remove_trivial_dims:
                     continue
                 elif None in arg_with_ind.indices:
-                    ind = [j for j in arg_with_ind.indices if j is not None][0]
+                    ind = next(j for j in arg_with_ind.indices if j is not None)
                     counted = editor.count_args_with_index(ind)
                     if counted == 1:
                         # Identity matrix contracted only on one index with itself,
@@ -883,7 +883,7 @@ def remove_identity_matrices(expr: ArrayContraction):
         if number_identity_matrices != len(args) - 1 or number_identity_matrices == 0:
             continue
         # Get the non-identity element:
-        non_identity = [i for i in args if not isinstance(i.element, Identity)][0]
+        non_identity = next(i for i in args if not isinstance(i.element, Identity))
         # Check that all identity matrices have at least one free index
         # (otherwise they would be contractions to some other elements)
         if any(None not in i.indices for i in identity_matrices):
@@ -979,7 +979,7 @@ def _array_contraction_to_diagonal_multiple_identity(expr: ArrayContraction):
             if None not in id1.indices:
                 flag = True
                 break
-            free_pos = list(range(*editor.get_absolute_free_range(id1)))[0]
+            free_pos = next(iter(range(*editor.get_absolute_free_range(id1))))
             editor._track_permutation[-1].append(free_pos) # type: ignore
             id1.element = None
             flag = False

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -89,7 +89,7 @@ class CompilerRunner:
                     self.compiler_name = v
                     break
             else:
-                self.compiler_vendor, self.compiler_name = list(self.compiler_dict.items())[0]
+                self.compiler_vendor, self.compiler_name = next(iter(self.compiler_dict.items()))
                 warnings.warn("failed to determine what kind of compiler %s is, assuming %s" %
                               (self.compiler_binary, self.compiler_name))
         else:

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -224,7 +224,7 @@ class BasisDependentAdd(BasisDependent, Add):
         assumptions = {'commutative': True}
         obj._assumptions = StdFactKB(assumptions)
         obj._components = components
-        obj._sys = (list(components.keys()))[0]._sys
+        obj._sys = next(iter(components.keys()))._sys
 
         return obj
 

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -105,7 +105,7 @@ class ImplicitRegion(Basic):
         equation = self.equation
 
         if len(self.variables) == 1:
-            return (list(solveset(equation, self.variables[0], domain=S.Reals))[0],)
+            return (next(iter(solveset(equation, self.variables[0], domain=S.Reals))),)
         elif len(self.variables) == 2:
 
             if self.degree == 2:
@@ -123,7 +123,7 @@ class ImplicitRegion(Basic):
             for x_reg in range(-10, 10):
                 for y_reg in range(-10, 10):
                     if not solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals).is_empty:
-                        return (x_reg, y_reg, list(solveset(equation.subs({x: x_reg, y: y_reg})))[0])
+                        return (x_reg, y_reg, next(iter(solveset(equation.subs({x: x_reg, y: y_reg})))))
 
         if len(self.singular_points()) != 0:
             return list[self.singular_points()][0]
@@ -395,7 +395,7 @@ class ImplicitRegion(Basic):
                 return (equation,)
             elif len(self.variables) == 2:
                 x, y = self.variables
-                y_par = list(solveset(equation, y))[0]
+                y_par = next(iter(solveset(equation, y)))
                 return x, y_par
             else:
                 raise NotImplementedError()
@@ -410,7 +410,7 @@ class ImplicitRegion(Basic):
                 point = reg_point
             else:
                 if len(self.singular_points()) != 0:
-                    point = list(self.singular_points())[0]
+                    point = next(iter(self.singular_points()))
                 else:
                     point = self.regular_point()
 

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -163,7 +163,7 @@ def curl(vect, doit=True):
                 args = vect.args
             return VectorAdd.fromiter(curl(i, doit=doit) for i in args)
         elif isinstance(vect, (Mul, VectorMul)):
-            vector = [i for i in vect.args if isinstance(i, (Vector, Cross, Gradient))][0]
+            vector = next(i for i in vect.args if isinstance(i, (Vector, Cross, Gradient)))
             scalar = Mul.fromiter(i for i in vect.args if not isinstance(i, (Vector, Cross, Gradient)))
             res = Cross(gradient(scalar), vector).doit() + scalar*curl(vector, doit=doit)
             if doit:
@@ -230,7 +230,7 @@ def divergence(vect, doit=True):
         if isinstance(vect, (Add, VectorAdd)):
             return Add.fromiter(divergence(i, doit=doit) for i in vect.args)
         elif isinstance(vect, (Mul, VectorMul)):
-            vector = [i for i in vect.args if isinstance(i, (Vector, Cross, Gradient))][0]
+            vector = next(i for i in vect.args if isinstance(i, (Vector, Cross, Gradient)))
             scalar = Mul.fromiter(i for i in vect.args if not isinstance(i, (Vector, Cross, Gradient)))
             res = Dot(vector, gradient(scalar)) + scalar*divergence(vector, doit=doit)
             if doit:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Enables ruff rule015 and which tries to avoid a temporary data struct just to access the first element of an iterable. Instead, it will try use the `next(iter(x))` idiom to access the element. Not only does the prevent the temporary list or tuple for taking up a massive amount of memory, it turns an `O(n)` operation into an `O(1)` one.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
