### PR TITLE
maint(ci): only test numpy nightly wheels on 3.12

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -410,12 +410,7 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1, 2, 3, 4]
-
-    name: mpmath-master ${{ matrix.group }}/4 Tests
+    name: mpmath-master Tests
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -179,43 +179,13 @@ jobs:
                          'antlr4-python3-runtime==4.11.*'                 \
                          symengine                                        \
                          numba llvmlite pymc                              \
-                         'gmpy2>=2.2.0rc1'                                \
+                         gmpy2                                            \
                          #
-
-      ## Not available in CPython 3.13 (yet).
-      #- if: ${{ ! contains(matrix.python-version, '3.13') }}
-      #  run: pip install gmpy2
 
       # Test external imports
       - run: bin/test_external_imports.py
       - run: bin/test_submodule_imports.py
       - run: bin/test_executable.py
-
-      # Test modules with specific dependencies
-      - run: bin/test_optional_dependencies.py
-
-  # -------------------- NumPy 2.0 job ----------------------------- #
-
-  numpy-prerelease:
-    needs: code-quality
-
-    runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-
-    name: ${{ matrix.python-version }} NumPy Prerelease
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - run: pip install -r requirements-dev.txt
-      - run: pip install --pre numpy scipy
 
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py
@@ -227,18 +197,13 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-
-    name: ${{ matrix.python-version }} NumPy nightly
+    name: NumPy/SciPy nightly
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
 
       - run: pip install -r requirements-dev.txt
       - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
