### PR TITLE
Added tests using symbolic matrices in StateSpace.

### DIFF
--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1838,6 +1838,8 @@ def test_StateSpace_symbolics():
                                        [a12*c1 + a22*c2]])]
     assert qc == Matrix([[0, 1], [1, -5]])
     assert qo == Matrix([[0, 1], [1, -5]])
+    assert ss.rewrite(TransferFunction) == [[TransferFunction(-c1*(a12*b2 - a22*b1 + b1*s) - c2*(-a11*b2 + a21*b1 + b2*s), 
+                                                              -a11*a22 + a11*s + a12*a21 + a22*s - s**2, s)]]
 
 
 def test_StateSpace_series():

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1811,6 +1811,35 @@ def test_StateSpace_functions():
     assert ss3.feedforward_matrix == Matrix([[0, 0], [0, 1]])
 
 
+def test_StateSpace_symbolics():
+    # Test for using StateSpace with symbolic matrices.
+    a11, a12, a21, a22, b1, b2, c1, c2 = symbols('a_11 a_12 a_21 a_22 b_1 b_2 c_1 c_2')
+    A = Matrix([[a11, a12], [a21, a22]])
+    B = Matrix([[b1], [b2]])
+    C = Matrix([[c1, c2]])
+    ss = StateSpace(A, B, C)
+    assert ss.state_matrix == A
+    assert ss.input_matrix == B
+    assert ss.output_matrix == C
+    assert ss.feedforward_matrix == Matrix([[0]])
+    assert ss.shape == (1, 1)
+    assert ss.num_states == 2
+    qc = ss.controllability_matrix().subs([(a11, 0), (a12, 1), (a21, -6), (a22, -5), (b1, 0), (b2, 1)])
+    qo = ss.observability_matrix().subs([(a11, 0), (a12, -6), (a21, 1), (a22, -5), (c1, 0), (c2, 1)])
+    assert ss.controllable_subspace() == [Matrix([
+                                         [b1],
+                                         [b2]]), Matrix([
+                                         [a11*b1 + a12*b2],
+                                         [a21*b1 + a22*b2]])]
+    assert ss.observable_subspace() == [Matrix([
+                                       [             c1],
+                                       [a11*c1 + a21*c2]]), Matrix([
+                                       [             c2],
+                                       [a12*c1 + a22*c2]])]
+    assert qc == Matrix([[0, 1], [1, -5]])
+    assert qo == Matrix([[0, 1], [1, -5]])
+
+
 def test_StateSpace_series():
     # For SISO Systems
     a1 = Matrix([[0, 1], [1, 0]])

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1669,6 +1669,7 @@ def test_conversion():
     C1 = Matrix([[1, 2]])
     D1 = Matrix([0])
     H1 = StateSpace(A1, B1, C1, D1)
+    H3 = StateSpace(Matrix([[a0, a1], [a2, a3]]), B = Matrix([[b1], [b2]]), C = Matrix([[c1, c2]]))
     tm1 = H1.rewrite(TransferFunction)
     tm2 = (-H1).rewrite(TransferFunction)
 
@@ -1691,7 +1692,8 @@ def test_conversion():
     assert tm3[0][0] == TransferFunction(2.0*s**3 + 1.0*s**2 - 10.5*s + 4.5, 1.0*s**3 + 0.5*s**2 - 6.5*s - 2.5, s)
     assert tm3[0][1] == TransferFunction(2.0*s**3 + 2.0*s**2 - 10.5*s - 3.5, 1.0*s**3 + 0.5*s**2 - 6.5*s - 2.5, s)
     assert tm3[0][2] == TransferFunction(2.0*s**2 + 5.0*s - 0.5, 1.0*s**3 + 0.5*s**2 - 6.5*s - 2.5, s)
-
+    assert H3.rewrite(TransferFunction) == [[TransferFunction(-c1*(a1*b2 - a3*b1 + b1*s) - c2*(-a0*b2 + a2*b1 + b2*s),
+                                                              -a0*a3 + a0*s + a1*a2 + a3*s - s**2, s)]]
     # TransferFunction to StateSpace
     SS = TF1.rewrite(StateSpace)
     assert SS == \
@@ -1717,6 +1719,7 @@ def test_StateSpace_dsolve():
     I1 = Matrix([[1], [2]])
     t = symbols('t')
     ss1 = StateSpace(A1, B1, C1, D1)
+
     # Zero input and Zero initial conditions
     assert ss1.dsolve() == Matrix([[0]])
     assert ss1.dsolve(initial_conditions=I1) == Matrix([[8*exp(-t) - 9*exp(-2*t)]])
@@ -1736,6 +1739,7 @@ def test_StateSpace_dsolve():
     op = ss3.dsolve(input_vector=U3, var=t)
     assert str(op.simplify().expand().evalf()[0]) == str(5.0 + 20.7880460155075*exp(-5*t/2)*sin(sqrt(7)*t/2)
                                             - 5.0*exp(-5*t/2)*cos(sqrt(7)*t/2))
+
     # Test with Heaviside as input
     A4 = Matrix([[-1, 1], [-4, -4]])
     B4 = Matrix([[0], [4]])
@@ -1745,6 +1749,7 @@ def test_StateSpace_dsolve():
     op4 = str(ss4.dsolve(var=t, input_vector=U4)[0].simplify().expand().evalf())
     assert op4 == str(5.0*Heaviside(t) + 20.7880460155075*exp(-5*t/2)*sin(sqrt(7)*t/2)*Heaviside(t)
                                             - 5.0*exp(-5*t/2)*cos(sqrt(7)*t/2)*Heaviside(t))
+
     # Test with Symbolic Matrices
     m, a, x0 = symbols('m a x_0')
     A5 = Matrix([[0, 1], [0, 0]])
@@ -1776,6 +1781,7 @@ def test_StateSpace_functions():
     SS1 = StateSpace(A_mat, B_mat, C_mat, D_mat)
     SS2 = StateSpace(Matrix([[1, 1], [4, -2]]),Matrix([[0, 1], [0, 2]]),Matrix([[-1, 1], [1, -1]]))
     SS3 = StateSpace(Matrix([[1, 1], [4, -2]]),Matrix([[1, -1], [1, -1]]))
+    SS4 = StateSpace(Matrix([[a0, a1], [a2, a3]]), Matrix([[b1], [b2]]), Matrix([[c1, c2]]))
 
     # Observability
     assert SS1.is_observable() == True
@@ -1784,6 +1790,8 @@ def test_StateSpace_functions():
     assert SS2.observability_matrix() == Matrix([[-1,  1], [ 1, -1], [ 3, -3], [-3,  3]])
     assert SS1.observable_subspace() == [Matrix([[0], [1]]), Matrix([[1], [0]])]
     assert SS2.observable_subspace() == [Matrix([[-1], [ 1], [ 3], [-3]])]
+    Qo = SS4.observability_matrix().subs([(a0, 0), (a1, -6), (a2, 1), (a3, -5), (c1, 0), (c2, 1)])
+    assert Qo == Matrix([[0, 1], [1, -5]])
 
     # Controllability
     assert SS1.is_controllable() == True
@@ -1792,6 +1800,13 @@ def test_StateSpace_functions():
     assert SS3.controllability_matrix() == Matrix([[1, -1, 2, -2], [1, -1, 2, -2]])
     assert SS1.controllable_subspace() == [Matrix([[0.5], [  0]]), Matrix([[-0.75], [  0.5]])]
     assert SS3.controllable_subspace() == [Matrix([[1], [1]])]
+    assert SS4.controllable_subspace() == [Matrix([
+                                          [b1],
+                                          [b2]]), Matrix([
+                                          [a0*b1 + a1*b2],
+                                          [a2*b1 + a3*b2]])]
+    Qc = SS4.controllability_matrix().subs([(a0, 0), (a1, 1), (a2, -6), (a3, -5), (b1, 0), (b2, 1)])
+    assert Qc == Matrix([[0, 1], [1, -5]])
 
     # Append
     A1 = Matrix([[0, 1], [1, 0]])
@@ -1801,6 +1816,7 @@ def test_StateSpace_functions():
     ss1 = StateSpace(A1, B1, C1, D1)
     ss2 = StateSpace(Matrix([[1, 0], [0, 1]]), Matrix([[1], [0]]), Matrix([[1, 0]]), Matrix([[1]]))
     ss3 = ss1.append(ss2)
+    ss4 = SS4.append(ss1)
 
     assert ss3.num_states == ss1.num_states + ss2.num_states
     assert ss3.num_inputs == ss1.num_inputs + ss2.num_inputs
@@ -1810,36 +1826,14 @@ def test_StateSpace_functions():
     assert ss3.output_matrix == Matrix([[0, 1, 0, 0], [0, 0, 1, 0]])
     assert ss3.feedforward_matrix == Matrix([[0, 0], [0, 1]])
 
-
-def test_StateSpace_symbolics():
-    # Test for using StateSpace with symbolic matrices.
-    a11, a12, a21, a22, b1, b2, c1, c2 = symbols('a_11 a_12 a_21 a_22 b_1 b_2 c_1 c_2')
-    A = Matrix([[a11, a12], [a21, a22]])
-    B = Matrix([[b1], [b2]])
-    C = Matrix([[c1, c2]])
-    ss = StateSpace(A, B, C)
-    assert ss.state_matrix == A
-    assert ss.input_matrix == B
-    assert ss.output_matrix == C
-    assert ss.feedforward_matrix == Matrix([[0]])
-    assert ss.shape == (1, 1)
-    assert ss.num_states == 2
-    qc = ss.controllability_matrix().subs([(a11, 0), (a12, 1), (a21, -6), (a22, -5), (b1, 0), (b2, 1)])
-    qo = ss.observability_matrix().subs([(a11, 0), (a12, -6), (a21, 1), (a22, -5), (c1, 0), (c2, 1)])
-    assert ss.controllable_subspace() == [Matrix([
-                                         [b1],
-                                         [b2]]), Matrix([
-                                         [a11*b1 + a12*b2],
-                                         [a21*b1 + a22*b2]])]
-    assert ss.observable_subspace() == [Matrix([
-                                       [             c1],
-                                       [a11*c1 + a21*c2]]), Matrix([
-                                       [             c2],
-                                       [a12*c1 + a22*c2]])]
-    assert qc == Matrix([[0, 1], [1, -5]])
-    assert qo == Matrix([[0, 1], [1, -5]])
-    assert ss.rewrite(TransferFunction) == [[TransferFunction(-c1*(a12*b2 - a22*b1 + b1*s) - c2*(-a11*b2 + a21*b1 + b2*s),
-                                                              -a11*a22 + a11*s + a12*a21 + a22*s - s**2, s)]]
+    # Using symbolic matrices
+    assert ss4.num_states == SS4.num_states + ss1.num_states
+    assert ss4.num_inputs == SS4.num_inputs + ss1.num_inputs
+    assert ss4.num_outputs == SS4.num_outputs + ss1.num_outputs
+    assert ss4.state_matrix == Matrix([[a0, a1, 0, 0], [a2, a3, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+    assert ss4.input_matrix == Matrix([[b1, 0], [b2, 0], [0, 0], [0, 1]])
+    assert ss4.output_matrix == Matrix([[c1, c2, 0, 0], [0, 0, 0, 1]])
+    assert ss4.feedforward_matrix == Matrix([[0, 0], [0, 0]])
 
 
 def test_StateSpace_series():
@@ -1886,6 +1880,7 @@ def test_StateSpace_series():
     ser2 = Series(ss1)
     ser3 = Series(ser2, ss2)
     assert ser3.doit() == ser1.doit()
+
     # TransferFunction interconnection with StateSpace
     ser_tf = Series(tf1, ss1)
     assert ser_tf == Series(TransferFunction(s, s + 1, s), StateSpace(Matrix([
@@ -1905,6 +1900,7 @@ def test_StateSpace_series():
                             Matrix([[0, 0, 1]]),
                             Matrix([[0]]))
     assert ser_tf.rewrite(TransferFunction) == TransferFunction(s**2, s**3 + s**2 - s - 1, s)
+
     # For MIMO Systems
     a3 = Matrix([[4, 1], [2, -3]])
     b3 = Matrix([[5, 2], [-3, -3]])
@@ -2007,6 +2003,7 @@ def test_StateSpace_parallel():
                         Matrix([[0, 1, 1, 0]]),
                         Matrix([[1]]))
     assert p1.rewrite(TransferFunction) == TransferFunction(s*(s + 2), s**2 - 1, s)
+
     # Connecting StateSpace with TransferFunction
     tf1 = TransferFunction(s, s+1, s)
     p2 = Parallel(ss1, tf1)
@@ -2077,6 +2074,7 @@ def test_StateSpace_parallel():
                         Matrix([
                         [1, 6],
                         [1, 0]]))
+
     # Using StateSpace with MIMOParallel.
     tf2 = TransferFunction(1, s, s)
     tf3 = TransferFunction(1, s + 1, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1838,7 +1838,7 @@ def test_StateSpace_symbolics():
                                        [a12*c1 + a22*c2]])]
     assert qc == Matrix([[0, 1], [1, -5]])
     assert qo == Matrix([[0, 1], [1, -5]])
-    assert ss.rewrite(TransferFunction) == [[TransferFunction(-c1*(a12*b2 - a22*b1 + b1*s) - c2*(-a11*b2 + a21*b1 + b2*s), 
+    assert ss.rewrite(TransferFunction) == [[TransferFunction(-c1*(a12*b2 - a22*b1 + b1*s) - c2*(-a11*b2 + a21*b1 + b2*s),
                                                               -a11*a22 + a11*s + a12*a21 + a22*s - s**2, s)]]
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added tests to test the use of symbolic matrices in `StateSpace` methods.
#### References to other Issues or PRs
This PR is related to comment : https://github.com/sympy/sympy/pull/26685#discussion_r1647034859
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
