### PR TITLE
polys: allow python-flint 0.6-0.9 for ground types.

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -92,13 +92,13 @@ __all__ = [
 # Tested python-flint version. Future versions might work but we will only use
 # them if explicitly requested by SYMPY_GROUND_TYPES=flint.
 #
-_PYTHON_FLINT_VERSION_NEEDED = "0.6.*"
+_PYTHON_FLINT_VERSION_NEEDED = ["0.6", "0.7", "0.8", "0.9"]
 
 
 def _flint_version_okay(flint_version):
-    flint_ver = flint_version.split('.')[:2]
-    needed_ver = _PYTHON_FLINT_VERSION_NEEDED.split('.')[:2]
-    return flint_ver == needed_ver
+    major, minor = flint_version.split('.')[:2]
+    flint_ver = f'{major}.{minor}'
+    return flint_ver in _PYTHON_FLINT_VERSION_NEEDED
 
 #
 # We will only use gmpy2 >= 2.0.0
@@ -123,15 +123,11 @@ def _get_flint(sympy_ground_types):
     if _flint_version_okay(_flint_version):
         return flint
     elif sympy_ground_types == 'auto':
-        warn(f"python-flint {_flint_version} is installed but only version "
-             f"{_PYTHON_FLINT_VERSION_NEEDED} will be used by default. "
-             f"Falling back to other ground types. Use "
-             f"SYMPY_GROUND_TYPES=flint to force the use of python-flint.")
         return None
     else:
         warn(f"Using python-flint {_flint_version} because SYMPY_GROUND_TYPES "
-             f"is set to flint but this version of SymPy has only been tested "
-             f"with python-flint {_PYTHON_FLINT_VERSION_NEEDED}.")
+             f"is set to flint but this version of SymPy is only tested "
+             f"with python-flint versions {_PYTHON_FLINT_VERSION_NEEDED}.")
         return flint
 
 


### PR DESCRIPTION
This is to allow future releases of python-flint to be compatible with sympy 1.13 but not leave that completely open-ended.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * python-flint versions 0.6.0-0.9.0 will be used automatically for the ground types. It is still possible to force the use of other versions of python-flint by setting `SYMPY_GROUND_TYPES=flint`.
<!-- END RELEASE NOTES -->
