### PR TITLE
[GSoC]Added support for piecewise for limit calculations

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -240,23 +240,6 @@ class Piecewise(Function):
             if S.Zero in bound[1] and not S.Zero in bound[1].boundary:
                 return bound[0].as_leading_term(x)
 
-    def _at_infinity(self, x):
-        at_infinity = []
-
-        for i, pair in enumerate(self.as_expr_set_pairs()):
-            if pair[1].inf == S.NegativeInfinity:
-                at_infinity.append((self.args[i][0].subs(x, 1/x), 1/x < 0))
-                break
-        for i, pair in enumerate(self.as_expr_set_pairs()):
-            if pair[1].sup == S.Infinity:
-                at_infinity.append((self.args[i][0].subs(x, 1/x), 1/x > 0))
-                break
-
-        if at_infinity[0][0] == at_infinity[1][0]:
-            at_infinity = [(at_infinity[0][0], True)]
-
-        return Piecewise(*tuple(at_infinity))
-
     def _eval_adjoint(self):
         return self.func(*[(e.adjoint(), c) for e, c in self.args])
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -222,9 +222,40 @@ class Piecewise(Function):
         return piecewise_simplify(self, **kwargs)
 
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
-        for e, c in self.args:
-            if c == True or c.subs(x, 0) == True:
-                return e.as_leading_term(x)
+        if cdir == S.Zero:
+            l = self._eval_as_leading_term(x, logx=None, cdir=-1)
+            r = self._eval_as_leading_term(x, logx=None, cdir=1)
+            if l != r:
+                raise ValueError("Two sided limit of %s around 0 does not exist" % self)
+            return r
+
+        expr_pairs = self.as_expr_set_pairs()
+
+        for pair in expr_pairs:
+            point = pair[1].sup if cdir == -1 else pair[1].inf
+            if point is S.Zero:
+                return pair[0].as_leading_term(x)
+
+        for bound in expr_pairs:
+            if S.Zero in bound[1] and not S.Zero in bound[1].boundary:
+                return bound[0].as_leading_term(x)
+
+    def _at_infinity(self, x):
+        at_infinity = []
+
+        for i, pair in enumerate(self.as_expr_set_pairs()):
+            if pair[1].inf == S.NegativeInfinity:
+                at_infinity.append((self.args[i][0].subs(x, 1/x), 1/x < 0))
+                break
+        for i, pair in enumerate(self.as_expr_set_pairs()):
+            if pair[1].sup == S.Infinity:
+                at_infinity.append((self.args[i][0].subs(x, 1/x), 1/x > 0))
+                break
+
+        if at_infinity[0][0] == at_infinity[1][0]:
+            at_infinity = [(at_infinity[0][0], True)]
+
+        return Piecewise(*tuple(at_infinity))
 
     def _eval_adjoint(self):
         return self.func(*[(e.adjoint(), c) for e, c in self.args])

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -16,7 +16,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import (Piecewise,
     piecewise_fold, piecewise_exclusive, Undefined, ExprCondPair)
-from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.functions.elementary.trigonometric import (cos, sin, csc)
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.integrals.integrals import (Integral, integrate)
@@ -443,6 +443,12 @@ def test_piecewise_integrate5_independent_conditions():
     p = Piecewise((0, Eq(y, 0)), (x*y, True))
     assert integrate(p, (x, 1, 3)) == Piecewise((0, Eq(y, 0)), (4*y, True))
 
+
+def test_piecewise_meromorphic():
+    p = Piecewise((csc(1/x), x < 1), (2*x**2 + 1, x < 5), (log(x), True))
+    assert p.is_meromorphic(x, 0) == False
+    assert p.is_meromorphic(x, 2) == True
+    assert p.is_meromorphic(x, 10) == True
 
 def test_issue_22917():
     p = (Piecewise((0, ITE((x - y > 1) | (2 * x - 2 * y > 1), False,

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -5,6 +5,7 @@ from sympy.core.numbers import Float, _illegal
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (Abs, sign, arg, re)
 from sympy.functions.elementary.exponential import (exp, log)
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys import PolynomialError, factor
 from sympy.series.order import Order
@@ -321,7 +322,10 @@ class Limit(Expr):
         if z0 is S.Infinity:
             if e.is_Mul:
                 e = factor_terms(e)
-            newe = e.subs(z, 1/z)
+            if isinstance(e, Piecewise):
+                newe = e._at_infinity(z)
+            else:
+                newe = e.subs(z, 1/z)
             # cdir changes sign as oo- should become 0+
             cdir = -cdir
         else:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -196,6 +196,23 @@ class Limit(Expr):
         if base_lim is S.NegativeInfinity and ex_lim is S.Infinity:
             return S.ComplexInfinity
 
+    def piecewise_sub(self, e):
+        _, z, _, _ = self.args
+        at_infinity = []
+
+        for i, pair in enumerate(e.as_expr_set_pairs()):
+            if pair[1].inf == S.NegativeInfinity:
+                at_infinity.append((e.args[i][0].subs(z, 1/z), 1/z < 0))
+                break
+        for i, pair in enumerate(e.as_expr_set_pairs()):
+            if pair[1].sup == S.Infinity:
+                at_infinity.append((e.args[i][0].subs(z, 1/z), 1/z > 0))
+                break
+
+        if at_infinity[0][0] == at_infinity[1][0]:
+            at_infinity = [(at_infinity[0][0], True)]
+
+        return Piecewise(*tuple(at_infinity))
 
     def doit(self, **hints):
         """Evaluates the limit.
@@ -323,7 +340,7 @@ class Limit(Expr):
             if e.is_Mul:
                 e = factor_terms(e)
             if isinstance(e, Piecewise):
-                newe = e._at_infinity(z)
+                newe = self.piecewise_sub(e)
             else:
                 newe = e.subs(z, 1/z)
             # cdir changes sign as oo- should become 0+

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -163,6 +163,70 @@ def test_piecewise2():
     assert limit(func3, x, -1) == 2
 
 
+def test_piecewise_basic():
+    expr1 = Piecewise((x, x < 0), (10, True))
+    expr2 = Piecewise((x - 3, x <= 0), ((x + 1)**2, x < 10), (5, True))
+    assert limit(expr1, x, 0, dir = '+') == 10
+    assert limit(expr1, x, 0, dir = '-') == 0
+    assert limit(expr1, x, oo) == 10
+    assert limit(expr1, x, -oo) == -oo
+    assert limit(expr2, x, 0, dir = '+') == 1
+    assert limit(expr2, x, 0, dir = '-') == -3
+    assert limit(expr2, x, 10, dir = '+') == 5
+    assert limit(expr2, x, 10, dir = '-') == 121
+    assert limit(expr2, x, oo) == 5
+    assert limit(expr2, x, -oo) == -oo
+    raises(ValueError, lambda: limit(expr1, x, 0, dir='+-'))
+    raises(ValueError, lambda: limit(expr2, x, 0, dir='+-'))
+    raises(ValueError, lambda: limit(expr2, x, 10, dir='+-'))
+
+
+def test_piecewise_basic2():
+    from sympy.logic.boolalg import (And, Or)
+    p0 = Piecewise((0, Or(x < -2, x > 2)), (1, True))
+    p1 = Piecewise((0, x < -2), (0, x > 2), (1, True))
+    p2 = Piecewise((0, x > 2), (0, x < -2), (1, True))
+    p3 = Piecewise((0, x < -2), (1, x < 2), (0, True))
+    p4 = Piecewise((0, x > 2), (1, x > -2), (0, True))
+    p5 = Piecewise((1, And(-2< x, x < 2)), (0, True))
+    Functions = [p0, p1, p2, p3, p4, p5]
+    for function in Functions:
+        assert limit(function, x, -oo) == 0
+        assert limit(function, x, -2, '-') == 0
+        assert limit(function, x, -2, '+') == 1
+        raises(ValueError, lambda: limit(function, x, -2, dir='+-'))
+        assert limit(function, x, 0, '+-') == 1
+        assert limit(function, x, 2, '-') == 1
+        assert limit(function, x, 2, '+') == 0
+        raises(ValueError, lambda: limit(function, x, 2, dir='+-'))
+        assert limit(function, x, oo) == 0
+
+
+def test_piecewise_basic3():
+    p0 = Piecewise((0, x < -2), (2, x > 2), (1, True))
+    p1 = Piecewise((2, x > 2), (0, x < -2), (1, True))
+    p2 = Piecewise((0, x < -2), (1, x < 2), (2, True))
+    p3 = Piecewise((2, x > 2), (1, x > -2), (0, True))
+    Functions = [p0, p1, p2, p3]
+    for function in Functions:
+        assert limit(function, x, -oo) == 0
+        assert limit(function, x, -2, '-') == 0
+        assert limit(function, x, -2, '+') == 1
+        raises(ValueError, lambda: limit(function, x, -2, dir='+-'))
+        assert limit(function, x, 0, '+-') == 1
+        assert limit(function, x, 2, '-') == 1
+        assert limit(function, x, 2, '+') == 2
+        raises(ValueError, lambda: limit(function, x, 2, dir='+-'))
+        assert limit(function, x, oo) == 2
+
+
+def test_piecewise_basic4():
+    f = Piecewise((asinh(x), x < 1), ( x + 5, x < 5), (log(x), True))
+    assert limit(f, x, 10, dir = '+-') == log(10)
+    raises(ValueError, lambda: limit(f, x, 5, dir = '+-'))
+    raises(ValueError, lambda: limit(f, x, 1, dir = '+-'))
+
+
 def test_basic5():
     class my(Function):
         @classmethod
@@ -1424,3 +1488,16 @@ def test_issue_22982_15323():
     assert limit((1 - 1/x)**x*(log(1 - 1/x) + 1/(x*(1 - 1/x))), x, 1, dir='+') == 1
     assert limit((log(E + 1/x) )**(1 - sqrt(E + 1/x)), x, oo) == 1
     assert limit((log(E + 1/x) - 1)**(- sqrt(E + 1/x)), x, oo) == oo
+
+
+def test_issue_26313():
+    p = Piecewise((x**2, x <= 2), (5*x - 7, x > 2))
+    assert limit(p, x, 2, '+') == 3
+    assert limit(p, x, 2, '-') == 4
+
+
+def test_issue_23836():
+    p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
+    assert limit(p, x, 3, '+') == -9
+    assert limit(p, x, 3, '-') == 27
+    raises(ValueError, lambda: limit(p, x, 3, dir='+-'))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26313 
Fixes #24127
Fixes #23836 
Closes #22555 

#### Brief description of what is fixed or changed

Added `_eval_as_leading-term` for piecewise functions and thereby enabling limit computation.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * `_eval_as_leading-term` method has been added for piecewise functions class.
<!-- END RELEASE NOTES -->
