### PR TITLE
Add support for Typst printing

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4087,6 +4087,9 @@ class ImaginaryUnit(AtomicExpr, metaclass=Singleton):
     def _latex(self, printer):
         return printer._settings['imaginary_unit_latex']
 
+    def _typst(self, printer):
+        return printer._settings['imaginary_unit_typst']
+
     @staticmethod
     def __abs__():
         return S.One

--- a/sympy/printing/tests/test_typst.py
+++ b/sympy/printing/tests/test_typst.py
@@ -1,0 +1,44 @@
+from sympy.core.mul import Mul
+from sympy.core.numbers import (I, Rational)
+from sympy.core.power import Pow
+from sympy.core.singleton import S
+from sympy.core.symbol import symbols
+from sympy.functions.elementary.complexes import Abs
+from sympy.printing.typst import typst
+
+x, y = symbols('x, y')
+
+def test_printmethod():
+    class R(Abs):
+        def _typst(self, printer):
+            return "foo(%s)" % printer._print(self.args[0])
+    assert typst(R(x)) == r"foo(x)"
+
+    class R(Abs):
+        def _typst(self, printer):
+            return "foo"
+    assert typst(R(x)) == r"foo"
+
+
+def test_typst_basic():
+    assert typst(1 + x) == r"x + 1"
+    assert typst(x**2) == r"x^(2)"
+    assert typst(x**(1 + x)) == r"x^(x + 1)"
+    assert typst(x**3 + x + 1 + x**2) == r"x^(3) + x^(2) + x + 1"
+
+    assert typst(2*x*y) == r"2 x y"
+    assert typst(2*x*y, mul_symbol='dot') == r"2 dot x dot y"
+    assert typst(3*x**2*y, mul_symbol='#h(1cm)') == r"3#h(1cm)x^(2)#h(1cm)y"
+    assert typst(1.5*3**x, mul_symbol='#h(1cm)') == r"1.5#h(1cm)3^(x)"
+
+    assert typst(x**S.Half**5) == r"root(32, x)"
+    assert typst(Mul(S.Half, x**2, -5, evaluate=False)) == r"1/2 x^(2) (-5)"
+    assert typst(Mul(S.Half, x**2, 5, evaluate=False)) == r"1/2 x^(2) 5"
+    assert typst(Mul(-5, -5, evaluate=False)) == r"(-5) (-5)"
+    assert typst(Mul(5, -5, evaluate=False)) == r"5 (-5)"
+    assert typst(Mul(S.Half, -5, S.Half, evaluate=False)) == r"1/2 (-5) 1/2"
+    assert typst(Mul(5, I, 5, evaluate=False)) == r"5 i 5"
+    assert typst(Mul(5, I, -5, evaluate=False)) == r"5 i (-5)"
+    assert typst(Mul(Pow(x, 2), S.Half*x + 1)) == r"x^(2) (x/2 + 1)"
+    assert typst(Mul(Pow(x, 3), Rational(2, 3)*x + 1)) == r"x^(3) ((2 x)/3 + 1)"
+    assert typst(Mul(Pow(x, 11), 2*x + 1)) == r"x^(11) (2 x + 1)"

--- a/sympy/printing/tests/test_typst.py
+++ b/sympy/printing/tests/test_typst.py
@@ -1,3 +1,4 @@
+from sympy.concrete.summations import Sum
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Rational)
 from sympy.core.power import Pow
@@ -42,3 +43,13 @@ def test_typst_basic():
     assert typst(Mul(Pow(x, 2), S.Half*x + 1)) == r"x^(2) (x/2 + 1)"
     assert typst(Mul(Pow(x, 3), Rational(2, 3)*x + 1)) == r"x^(3) ((2 x)/3 + 1)"
     assert typst(Mul(Pow(x, 11), 2*x + 1)) == r"x^(11) (2 x + 1)"
+
+def test_typst_sum():
+    assert typst(Sum(x*y**2, (x, -2, 2), (y, -5, 5))) == \
+        r"sum_(-2 <= x <= 2 \ -5 <= y <= 5) x y^(2)"
+    assert typst(Sum(x**2, (x, -2, 2))) == \
+        r"sum_(x=-2)^(2) x^(2)"
+    assert typst(Sum(x**2 + y, (x, -2, 2))) == \
+        r"sum_(x=-2)^(2) (x^(2) + y)"
+    assert typst(Sum(x**2 + y, (x, -2, 2))**2) == \
+        r"(sum_(x=-2)^(2) (x^(2) + y))^(2)"

--- a/sympy/printing/typst.py
+++ b/sympy/printing/typst.py
@@ -1,0 +1,402 @@
+"""
+A Printer which converts an expression into its Typst equivalent.
+"""
+from __future__ import annotations
+from typing import Any
+
+from sympy.core import Mod, Mul, Number, S, Expr
+from sympy.core.power import Pow
+
+from sympy.printing.precedence import precedence_traditional
+from sympy.printing.printer import Printer, print_function
+from sympy.printing.precedence import PRECEDENCE
+
+from mpmath.libmp.libmpf import prec_to_dps, to_str as mlib_to_str
+
+from sympy.utilities.iterables import sift
+
+import re
+
+_between_two_numbers_p = (
+    re.compile(r'[0-9]$'),  # search
+    re.compile(r'(\d|\d+/\d+)'),  # match
+)
+
+class TypstPrinter(Printer):
+    printmethod = "_typst"
+
+    _default_settings: dict[str, Any] = {
+        "full_prec": False,
+        "fold_frac_powers": False,
+        "fold_func_brackets": False,
+        "fold_short_frac": None,
+        "inv_trig_style": "abbreviated",
+        "itex": False,
+        "ln_notation": False,
+        "long_frac_ratio": None,
+        "mat_delim": "[",
+        "mat_str": None,
+        "mode": "plain",
+        "mul_symbol": None,
+        "order": None,
+        "symbol_names": {},
+        "root_notation": True,
+        "mat_symbol_style": "plain",
+        "imaginary_unit": "i",
+        "gothic_re_im": False,
+        "decimal_separator": "period",
+        "perm_cyclic": True,
+        "parenthesize_super": True,
+        "min": None,
+        "max": None,
+        "diff_operator": "d",
+        "adjoint_style": "dagger",
+    }
+
+    def __init__(self, settings=None):
+        Printer.__init__(self, settings)
+
+        mul_symbol_table = {
+            None: r" ",
+            "dot": r" dot ",
+            "times": r" times "
+        }
+        try:
+            self._settings['mul_symbol_typst'] = \
+                mul_symbol_table[self._settings['mul_symbol']]
+        except KeyError:
+            self._settings['mul_symbol_typst'] = \
+                self._settings['mul_symbol']
+        try:
+            self._settings['mul_symbol_typst_numbers'] = \
+                mul_symbol_table[self._settings['mul_symbol'] or 'dot']
+        except KeyError:
+            if (self._settings['mul_symbol'].strip() in
+                    ['', ' ']):
+                self._settings['mul_symbol_typst_numbers'] = \
+                    mul_symbol_table['dot']
+            else:
+                self._settings['mul_symbol_typst_numbers'] = \
+                    self._settings['mul_symbol']
+
+        # TODO need to be checked
+        imaginary_unit_table = {
+            None: r"i",
+            "i": r"i",
+            "ri": r"\mathrm(i)",
+            "ti": r"text(i)",
+            "j": r"j",
+            "rj": r"bold(j)",
+            "tj": r"text(j)",
+        }
+        imag_unit = self._settings['imaginary_unit']
+        self._settings['imaginary_unit_typst'] = imaginary_unit_table.get(imag_unit, imag_unit)
+
+
+    def _add_parens(self, s) -> str:
+        return r"({})".format(s)
+
+    def parenthesize(self, item, level, is_neg=False, strict=False) -> str:
+        prec_val = precedence_traditional(item)
+        if is_neg and strict:
+            return self._add_parens(self._print(item))
+
+        if (prec_val < level) or ((not strict) and prec_val <= level):
+            return self._add_parens(self._print(item))
+        else:
+            return self._print(item)
+
+    def parenthesize_super(self, s):
+        """
+        Protect superscripts in s
+
+        If the parenthesize_super option is set, protect with parentheses, else
+        wrap in braces.
+        """
+        if "^" in s and self._settings['parenthesize_super']:
+            return self._add_parens(s)
+        return s
+
+    def doprint(self, expr) -> str:
+        typ = Printer.doprint(self, expr)
+
+        return typ
+
+    def _needs_add_brackets(self, expr) -> bool:
+        """
+        Returns True if the expression needs to be wrapped in brackets when
+        printed as part of an Add, False otherwise.  This is False for most
+        things.
+        """
+        if expr.is_Relational:
+            return True
+        if any(expr.has(x) for x in (Mod,)):
+            return True
+        if expr.is_Add:
+            return True
+        return False
+
+    def _needs_mul_brackets(self, expr, first=False, last=False) -> bool:
+        """
+        Returns True if the expression needs to be wrapped in brackets when
+        printed as part of a Mul, False otherwise. This is True for Add,
+        but also for some container objects that would not need brackets
+        when appearing last in a Mul, e.g. an Integral. ``last=True``
+        specifies that this expr is the last to appear in a Mul.
+        ``first=True`` specifies that this expr is the first to appear in
+        a Mul.
+        """
+        from sympy.concrete.products import Product
+        from sympy.concrete.summations import Sum
+        from sympy.integrals.integrals import Integral
+
+        if expr.is_Mul:
+            if not first and expr.could_extract_minus_sign():
+                return True
+        elif precedence_traditional(expr) < PRECEDENCE["Mul"]:
+            return True
+        elif expr.is_Relational:
+            return True
+        if expr.is_Piecewise:
+            return True
+        if any(expr.has(x) for x in (Mod,)):
+            return True
+        if (not last and
+                any(expr.has(x) for x in (Integral, Product, Sum))):
+            return True
+
+        return False
+
+    def _print_Add(self, expr, order=None):
+        terms = self._as_ordered_terms(expr, order=order)
+
+        typ = ""
+        for i, term in enumerate(terms):
+            if i == 0:
+                pass
+            elif term.could_extract_minus_sign():
+                typ += " - "
+                term = -term
+            else:
+                typ += " + "
+            term_typ = self._print(term)
+            if self._needs_add_brackets(term):
+                term_typ = r"(%s)" % term_typ
+            typ += term_typ
+
+        return typ
+
+    def _print_Float(self, expr):
+        # Based off of that in StrPrinter
+        dps = prec_to_dps(expr._prec)
+        strip = False if self._settings['full_prec'] else True
+        low = self._settings["min"] if "min" in self._settings else None
+        high = self._settings["max"] if "max" in self._settings else None
+        str_real = mlib_to_str(expr._mpf_, dps, strip_zeros=strip, min_fixed=low, max_fixed=high)
+
+        # Must always have a mul symbol (as 2.5 10^{20} just looks odd)
+        # thus we use the number separator
+        separator = self._settings['mul_symbol_typst_numbers']
+
+        if 'e' in str_real:
+            (mant, exp) = str_real.split('e')
+
+            if exp[0] == '+':
+                exp = exp[1:]
+            if self._settings['decimal_separator'] == 'comma':
+                mant = mant.replace('.','{,}')
+
+            return r"%s%s10^(%s)" % (mant, separator, exp)
+        elif str_real == "+inf":
+            return r"infinity"
+        elif str_real == "-inf":
+            return r"- infinity"
+        else:
+            if self._settings['decimal_separator'] == 'comma':
+                str_real = str_real.replace('.',',')
+            return str_real
+
+    def _print_Mul(self, expr: Expr):
+        from sympy.simplify import fraction
+        separator: str = self._settings['mul_symbol_typst']
+        numbersep: str = self._settings['mul_symbol_typst_numbers']
+
+        def convert(expr) -> str:
+            if not expr.is_Mul:
+                return str(self._print(expr))
+            else:
+                if self.order not in ('old', 'none'):
+                    args = expr.as_ordered_factors()
+                else:
+                    args = list(expr.args)
+
+                # If there are quantities or prefixes, append them at the back.
+                units, nonunits = sift(args, lambda x: (hasattr(x, "_scale_factor") or hasattr(x, "is_physical_constant")) or
+                              (isinstance(x, Pow) and
+                               hasattr(x.base, "is_physical_constant")), binary=True)
+                prefixes, units = sift(units, lambda x: hasattr(x, "_scale_factor"), binary=True)
+                return convert_args(nonunits + prefixes + units)
+
+        def convert_args(args) -> str:
+            _typ = last_term_typ = ""
+
+            for i, term in enumerate(args):
+                term_typ = self._print(term)
+                if not (hasattr(term, "_scale_factor") or hasattr(term, "is_physical_constant")):
+                    if self._needs_mul_brackets(term, first=(i == 0),
+                                                last=(i == len(args) - 1)):
+                        term_typ = r"(%s)" % term_typ
+
+                    if  _between_two_numbers_p[0].search(last_term_typ) and \
+                        _between_two_numbers_p[1].match(term_typ):
+                        # between two numbers
+                        _typ += numbersep
+                    elif _typ:
+                        _typ += separator
+                elif _typ:
+                    _typ += separator
+
+                _typ += term_typ
+                last_term_typ = term_typ
+            return _typ
+
+        # Check for unevaluated Mul. In this case we need to make sure the
+        # identities are visible, multiple Rational factors are not combined
+        # etc so we display in a straight-forward form that fully preserves all
+        # args and their order.
+        # XXX: _print_Pow calls this routine with instances of Pow...
+        if isinstance(expr, Mul):
+            args = expr.args
+            if args[0] is S.One or any(isinstance(arg, Number) for arg in args[1:]):
+                return convert_args(args)
+
+        include_parens = False
+        if expr.could_extract_minus_sign():
+            expr = -expr
+            typ = "- "
+            if expr.is_Add:
+                typ += "("
+                include_parens = True
+        else:
+            typ = ""
+
+        numer, denom = fraction(expr, exact=True)
+
+        if denom is S.One and Pow(1, -1, evaluate=False) not in expr.args:
+            # use the original expression here, since fraction() may have
+            # altered it when producing numer and denom
+            typ += convert(expr)
+
+        else:
+            snumer = convert(numer)
+            sdenom = convert(denom)
+            ldenom = len(sdenom.split())
+            ratio = self._settings['long_frac_ratio']
+            if self._settings['fold_short_frac'] and ldenom <= 2 and \
+                    "^" not in sdenom:
+                # handle short fractions
+                if self._needs_mul_brackets(numer, last=False):
+                    typ += r"(%s)/%s" % (snumer, sdenom)
+                else:
+                    typ += r"%s/%s" % (snumer, sdenom)
+            elif ratio is not None and \
+                    len(snumer.split()) > ratio*ldenom:
+                # handle long fractions
+                if self._needs_mul_brackets(numer, last=True):
+                    typ += r"1/%s %s(%s)" \
+                        % (sdenom, separator, snumer)
+                elif numer.is_Mul:
+                    # split a long numerator
+                    a = S.One
+                    b = S.One
+                    for x in numer.args:
+                        if self._needs_mul_brackets(x, last=False) or \
+                                len(convert(a*x).split()) > ratio*ldenom or \
+                                (b.is_commutative is x.is_commutative is False):
+                            b *= x
+                        else:
+                            a *= x
+                    if self._needs_mul_brackets(b, last=True):
+                        typ += r"%s/%s %s(%s)" \
+                            % (convert(a), sdenom, separator, convert(b))
+                    else:
+                        typ += r"%s/%s %s%s" \
+                            % (convert(a), sdenom, separator, convert(b))
+                else:
+                    typ += r"1/%s %s%s" % (sdenom, separator, snumer)
+            else:
+                if numer.is_number or numer.is_symbol:
+                    typ += r"%s/%s" % (snumer, sdenom)
+                else:
+                    typ += r"(%s)/%s" % (snumer, sdenom)
+
+        if include_parens:
+            typ += ")"
+        return typ
+
+    def _print_Pow(self, expr: Pow):
+        # Treat x**Rational(1,n) as special case
+        if expr.exp.is_Rational:
+            p: int = expr.exp.p
+            q: int = expr.exp.q
+            if abs(p) == 1 and q != 1 and self._settings['root_notation']:
+                base = self._print(expr.base)
+                if q == 2:
+                    typ = r"sqrt(%s)" % base
+                else:
+                    typ = r"root(%d, %s)" % (q, base)
+                if expr.exp.is_negative:
+                    return r"1/%s" % typ
+                else:
+                    return typ
+            elif self._settings['fold_frac_powers'] and q != 1:
+                base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+                # issue #12886: add parentheses for superscripts raised to powers
+                if expr.base.is_Symbol:
+                    base = self.parenthesize_super(base)
+                if expr.base.is_Function:
+                    return self._print(expr.base, exp="%s/%s" % (p, q))
+                return r"%s^(%s/%s)" % (base, p, q)
+            elif expr.exp.is_negative and expr.base.is_commutative:
+                # special case for 1^(-x), issue 9216
+                if expr.base == 1:
+                    return r"%s^(%s)" % (expr.base, expr.exp)
+                # special case for (1/x)^(-y) and (-1/-x)^(-y), issue 20252
+                if expr.base.is_Rational:
+                    base_p: int = expr.base.p  # type: ignore
+                    base_q: int = expr.base.q  # type: ignore
+                    if base_p * base_q == abs(base_q):
+                        if expr.exp == -1:
+                            return r"1/(%s/%s)" % (base_p, base_q)
+                        else:
+                            return r"1/(%s/%s)^(%s)" % (base_p, base_q, abs(expr.exp))
+                # things like 1/x
+                return self._print_Mul(expr)
+        if expr.base.is_Function:
+            return self._print(expr.base, exp=self._print(expr.exp))
+        typ = r"%s^(%s)"
+        return self._helper_print_standard_power(expr, typ)
+
+    def _helper_print_standard_power(self, expr, template: str) -> str:
+        exp = self._print(expr.exp)
+        # issue #12886: add parentheses around superscripts raised
+        # to powers
+        base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+        if expr.base.is_Symbol:
+            base = self.parenthesize_super(base)
+        elif expr.base.is_Float:
+            base = r"(%s)" % base
+        # elif (isinstance(expr.base, Derivative)
+        #     and base.startswith(r'(')
+        #     and re.match(r'(\d?d?dot', base)
+        #     and base.endswith(r'\right)')):
+        #     # don't use parentheses around dotted derivative
+        #     base = base[6: -7]  # remove outermost added parens
+        return template % (base, exp)
+
+
+@print_function(TypstPrinter)
+def typst(expr, **settings):
+    r"""Convert the given expression to Typst string representation.
+    """
+    return TypstPrinter(settings).doprint(expr)

--- a/sympy/printing/typst.py
+++ b/sympy/printing/typst.py
@@ -337,8 +337,8 @@ class TypstPrinter(Printer):
     def _print_Pow(self, expr: Pow):
         # Treat x**Rational(1,n) as special case
         if expr.exp.is_Rational:
-            p: int = expr.exp.p
-            q: int = expr.exp.q
+            p: int = expr.exp.p  # type: ignore
+            q: int = expr.exp.q  # type: ignore
             if abs(p) == 1 and q != 1 and self._settings['root_notation']:
                 base = self._print(expr.base)
                 if q == 2:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
As discussed in #24959 , a new printer(TypstPrinter) was implemented, which should mostly reuse the code of the LatexPrinter for convenience. 


#### TODO

- [x] Add
- [x] Mul
- [x] Pow
- [ ] Log
- [ ] Derivative
- [ ] Permutation
- [ ] Cross, Curl, Divergence
- [x] Sum
- [ ] Limit
- [ ] Function

- [ ] Greek letters
- [ ] Printing settings 

#### Brief description of what is fixed or changed
The TypstPrinter is mostly consistent with the LatexPrinter and tries to reuse its code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added TypstPrinter 

<!-- END RELEASE NOTES -->
