### PR TITLE
Fix a bug with diophantine() when cornacchia() is not called properly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1550,6 +1550,7 @@ Zeel Shah <kshah215@gmail.com>
 Zhenxu Zhu <xzdlj@outlook.com> xzdlj <xzdlj@outlook.com>
 Zhi-Qiang Zhou <zzq_890709@hotmail.com> zhouzq-thu <zzq_890709@hotmail.com>
 Zhongshi <zj495@nyu.edu>
+Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <zy.li@stu.pku.edu.cn>
 Zlatan Vasović <zlatanvasovic@gmail.com>
 Zoufiné Lauer-Baré <raszoufine@gmail.com> Zoufiné Lauer-Baré <82505312+zolabar@users.noreply.github.com>
 Zoufiné Lauer-Baré <raszoufine@gmail.com> zolabar <raszoufine@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1550,6 +1550,7 @@ Zeel Shah <kshah215@gmail.com>
 Zhenxu Zhu <xzdlj@outlook.com> xzdlj <xzdlj@outlook.com>
 Zhi-Qiang Zhou <zzq_890709@hotmail.com> zhouzq-thu <zzq_890709@hotmail.com>
 Zhongshi <zj495@nyu.edu>
+Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <123136644+zylipku@users.noreply.github.com>
 Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <zy.li@stu.pku.edu.cn>
 Zlatan Vasović <zlatanvasovic@gmail.com>
 Zoufiné Lauer-Baré <raszoufine@gmail.com> Zoufiné Lauer-Baré <82505312+zolabar@users.noreply.github.com>

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2176,9 +2176,9 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
     sols = set()
 
     if a + b > m:
-        # a = 0 or b = 0 must hold if there is a solution
+        # xy = 0 must hold if there exists a solution
         if m % a == 0:
-            # b = 0
+            # y = 0
             s, _exact = iroot(m // a, 2)
             if _exact:
                 sols.add((int(s), int(0)))
@@ -2186,7 +2186,7 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
             # only keep one solution
                 return sols
         if m % b == 0:
-            # a = 0
+            # x = 0
             s, _exact = iroot(m // b, 2)
             if _exact:
                 sols.add((int(0), int(s)))

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2181,7 +2181,7 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
             # y = 0
             s, _exact = iroot(m // a, 2)
             if _exact:
-                sols.add((int(s), int(0)))
+                sols.add((int(s), 0))
             if a == b:
             # only keep one solution
                 return sols

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2177,7 +2177,7 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
 
     if a + b > m:
         # xy = 0 must hold if there exists a solution
-        if m % a == 0:
+        if a == 1:
             # y = 0
             s, _exact = iroot(m // a, 2)
             if _exact:

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2183,7 +2183,7 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
             if _exact:
                 sols.add((int(s), 0))
             if a == b:
-            # only keep one solution
+                # only keep one solution
                 return sols
         if m % b == 0:
             # x = 0

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2189,7 +2189,7 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
             # x = 0
             s, _exact = iroot(m // b, 2)
             if _exact:
-                sols.add((int(0), int(s)))
+                sols.add((0, int(s)))
         return sols
 
     # the original cornacchia

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -2174,6 +2174,25 @@ def cornacchia(a:int, b:int, m:int) -> set[tuple[int, int]]:
     """
     # Assume gcd(a, b) = gcd(a, m) = 1 and a, b > 0 but no error checking
     sols = set()
+
+    if a + b > m:
+        # a = 0 or b = 0 must hold if there is a solution
+        if m % a == 0:
+            # b = 0
+            s, _exact = iroot(m // a, 2)
+            if _exact:
+                sols.add((int(s), int(0)))
+            if a == b:
+            # only keep one solution
+                return sols
+        if m % b == 0:
+            # a = 0
+            s, _exact = iroot(m // b, 2)
+            if _exact:
+                sols.add((int(0), int(s)))
+        return sols
+
+    # the original cornacchia
     for t in sqrt_mod_iter(-b*invert(a, m), m):
         if t < m // 2:
             continue

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -1049,3 +1049,11 @@ def test_quadratic_parameter_passing():
     # test that parameters are passed all the way to the final solution
     assert solution == {(t, 11*t), (t, -22*t)}
     assert solution(0, 0) == {(0, 0)}
+
+def test_issue_18628():
+    eq1 = x**2 - 15*x + y**2 - 8*y
+    sol = diophantine(eq1)
+    assert sol == {(15, 0), (15, 8), (-1, 4), (0, 0), (0, 8), (16, 4)}
+    eq2 = 2*x**2 - 9*x + 4*y**2 - 8*y + 14
+    sol = diophantine(eq2)
+    assert sol == {(2, 1)}


### PR DESCRIPTION
Occasionally diophantine() and diop_quadratic() result in a DN form $X^2 - DY^2 = N$ which cannot be handled by the current cornacchia() properly. For example, previously the diophantine solver will miss some solutions:
```
>>> eq1 = x**2 - 15*x + y**2 - 8*y # also mentioned in #18628
>>> diophantine(eq1)
{(0, 0), (15, 0), (15, 8), (0, 8)}
>>> eq1.subs({x: 16, y: 4})
0
```
```
>>> eq2 = 2*x**2 - 9*x + 4*y**2 - 8*y + 14
>>> diophantine(eq2)
set()
>>> eq2.subs({x: 2, y: 1})
0
```
Both the two examples lead to a function call of cornacchia(1, X, 1) with X > 1, which incorrrectly turns out to have no solution by using cornacchia(). The solver can only be applied when $a+b\le m$. See reference from docs:
http://www.numbertheory.org/php/cornacchia.html 
An additional check has been added before the algorithm based on the fact that $ax^2 + by^2 = m$ admits a solution for $a + b > m$ only if $x = 0$ or $y = 0$. A test function including both the two examples has been appended as well.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18628 

#### Brief description of what is fixed or changed
An additional check has been added before the cornacchia algorithm body based on the fact that $ax^2 + by^2 = m$ admits a solution for $a + b > m$ only if $x = 0$ or $y = 0$.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fix a bug with cornacchia(). Formerly diophantine() and diop_quadratic() may miss some solutions for quadratic equations.
<!-- END RELEASE NOTES -->
