### PR TITLE
Python's built-in rational in the documentation; integer division in Py 2; tuple behavior

### DIFF
--- a/doc/src/explanation/best-practices.md
+++ b/doc/src/explanation/best-practices.md
@@ -1312,7 +1312,7 @@ assumptions queries is bad for performance compared to querying the desired
 property more directly.
 
 This generally means using methods like {meth}`~.as_independent` or
-`{meth}`~.as_coeff_mul` and checking
+{meth}`~.as_coeff_mul` and checking
 the `args` of expressions directly (see the [custom functions
 guide](custom-functions-assumptions) for an example).
 

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -332,7 +332,7 @@ automatically, but there is one gotcha you should be aware of.  If you
 do ``<number>/<number>`` inside of a SymPy expression, Python will
 evaluate the two numbers before SymPy has a chance to get
 to them.  The solution is to :func:`~.sympify` one of the numbers, or use
-:obj:`~.Rational` (or alternatively Python's `Fraction
+:obj:`~.Rational` (or Python's `Fraction
 <https://docs.python.org/3/library/fractions.html>`_).
 
     >>> x**(1/2)  # evaluates to x**0 or x**0.5

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -378,7 +378,7 @@ you don't have to worry about this problem:
     >>> S("22/7")
     22/7
 
-Also, if you do not use :command:`isympy`, you could use ``from
+Also, if you use Python 2 and do not use :command:`isympy`, you could use ``from
 __future__ import division`` to prevent the ``/`` sign from performing
 `integer division <https://en.wikipedia.org/wiki/Integer_division>`_.
 

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -364,8 +364,8 @@ you don't have to worry about this problem:
     >>> x = Symbol('x')
     >>> print(solve(7*x -22, x))
     [22/7]
-    >>> 22/7  #copy and paste gives int 3 (in Python 2) or a float
-    3.142857142857143 (in Python 3)
+    >>> 22/7  #copy and paste gives int (in Python 2) or a float (in Python 3)
+    3.142857142857143
     >>> # One solution is to just assign the expression to a variable
     >>> # if we need to use it again.
     >>> a = solve(7*x - 22, x)[0]
@@ -722,7 +722,7 @@ square brackets.
     Parentheses are not needed for non-empty tuples; the commas are:
 
     >>> x,y
-    (x,y)
+    (x, y)
     >>> x,
     (x,)
 

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -332,11 +332,12 @@ automatically, but there is one gotcha you should be aware of.  If you
 do ``<number>/<number>`` inside of a SymPy expression, Python will
 evaluate the two numbers before SymPy has a chance to get
 to them.  The solution is to :func:`~.sympify` one of the numbers, or use
-:obj:`~.Rational`.
+:obj:`~.Rational` (or alternatively Python's `Fraction
+<https://docs.python.org/3/library/fractions.html>`_).
 
     >>> x**(1/2)  # evaluates to x**0 or x**0.5
     x**0.5
-    >>> x**(S(1)/2)  # sympyify one of the ints
+    >>> x**(S(1)/2)  # sympify one of the ints
     sqrt(x)
     >>> x**Rational(1, 2)  # use the Rational class
     sqrt(x)

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -719,7 +719,7 @@ square brackets.
     >>> (x)
     x
 
-    Actually parentheses are not needed for non-empty tuples; the commas are:
+    Parentheses are not needed for non-empty tuples; the commas are:
 
     >>> x,y
     (x,y)

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -365,7 +365,7 @@ you don't have to worry about this problem:
     >>> print(solve(7*x -22, x))
     [22/7]
     >>> 22/7  # If we just copy and paste we get int 3 or a float
-    3.142857142857143
+    3.142857142857143, depending on whether we use Python 2 or 3
     >>> # One solution is to just assign the expression to a variable
     >>> # if we need to use it again.
     >>> a = solve(7*x - 22, x)[0]
@@ -718,6 +718,18 @@ square brackets.
 
     >>> (x)
     x
+
+    Actually parentheses are not needed for non-empty tuples; the commas are:
+
+    >>> x,y
+    (x,y)
+    >>> x,
+    (x,)
+
+    An empty tuple can be created with bare parentheses:
+
+    >>> ()
+    ()
 
     integrate takes a sequence as the second argument if you want to integrate
     with limits (and a tuple or list will work):

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -364,8 +364,8 @@ you don't have to worry about this problem:
     >>> x = Symbol('x')
     >>> print(solve(7*x -22, x))
     [22/7]
-    >>> 22/7  #copy and paste gives int 3 (in Python 2) or a float (in Python 3)
-    3.142857142857143, depending on whether we use Python 2 or 3
+    >>> 22/7  #copy and paste gives int 3 (in Python 2) or a float
+    3.142857142857143 (in Python 3)
     >>> # One solution is to just assign the expression to a variable
     >>> # if we need to use it again.
     >>> a = solve(7*x - 22, x)[0]

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -364,7 +364,7 @@ you don't have to worry about this problem:
     >>> x = Symbol('x')
     >>> print(solve(7*x -22, x))
     [22/7]
-    >>> 22/7  # If we just copy and paste we get int 3 or a float
+    >>> 22/7  #copy and paste gives int 3 (in Python 2) or a float (in Python 3)
     3.142857142857143, depending on whether we use Python 2 or 3
     >>> # One solution is to just assign the expression to a variable
     >>> # if we need to use it again.

--- a/doc/src/tutorials/intro-tutorial/gotchas.rst
+++ b/doc/src/tutorials/intro-tutorial/gotchas.rst
@@ -248,8 +248,9 @@ object.
     <... 'int'>
 
 This is usually not a big deal. Python ints work much the same as SymPy
-Integers, but there is one important exception:  division.  In SymPy, the
-division of two Integers gives a Rational:
+Integers, but there is one important exception: division. In SymPy, the
+division of two Integers gives a Rational (which is similar to Python's `Fraction
+<https://docs.python.org/3/library/fractions.html>`_):
 
     >>> Integer(1)/Integer(3)
     1/3

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2177,9 +2177,9 @@ def test_known_facts_consistent():
 
 def test_Add_queries():
     assert ask(Q.prime(12345678901234567890 + (cos(1)**2 + sin(1)**2))) is True
-    assert ask(Q.even(Add(S(2), S(2), evaluate=0))) is True
-    assert ask(Q.prime(Add(S(2), S(2), evaluate=0))) is False
-    assert ask(Q.integer(Add(S(2), S(2), evaluate=0))) is True
+    assert ask(Q.even(Add(S(2), S(2), evaluate=False))) is True
+    assert ask(Q.prime(Add(S(2), S(2), evaluate=False))) is False
+    assert ask(Q.integer(Add(S(2), S(2), evaluate=False))) is True
 
 
 def test_positive_assuming():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2009,7 +2009,7 @@ def test_round():
 
     assert S.Zero.round() == 0
 
-    a = (Add(1, Float('1.' + '9'*27, ''), evaluate=0))
+    a = (Add(1, Float('1.' + '9'*27, ''), evaluate=False))
     assert a.round(10) == Float('3.000000000000000000000000000', '')
     assert a.round(25) == Float('3.000000000000000000000000000', '')
     assert a.round(26) == Float('3.000000000000000000000000000', '')

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -180,7 +180,7 @@ def test_sympify_bool():
     assert sympify(False) is false
 
 
-def test_sympyify_iterables():
+def test_sympify_iterables():
     ans = [Rational(3, 10), Rational(1, 5)]
     assert sympify(['.3', '.2'], rational=True) == ans
     assert sympify({"x": 0, "y": 1}) == {x: 0, y: 1}

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -968,7 +968,7 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
     This feature allows one to tell exactly how the expression was entered:
 
     >>> a = parse_expr('1 + x', evaluate=False)
-    >>> b = parse_expr('x + 1', evaluate=0)
+    >>> b = parse_expr('x + 1', evaluate=False)
     >>> a == b
     False
     >>> a.args

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -179,8 +179,8 @@ def test_issue_2515():
 def test_issue_7663():
     x = Symbol('x')
     e = '2*(x+1)'
-    assert parse_expr(e, evaluate=0) == parse_expr(e, evaluate=False)
-    assert parse_expr(e, evaluate=0).equals(2*(x+1))
+    assert parse_expr(e, evaluate=False) == parse_expr(e, evaluate=False)
+    assert parse_expr(e, evaluate=False).equals(2*(x+1))
 
 def test_recursive_evaluate_false_10560():
     inputs = {


### PR DESCRIPTION
Some rather minor documentation fixes and improvements.

#### References to other Issues or PRs
Recreated as https://github.com/sympy/sympy/pull/26815; please review the newer one.

#### Brief description of what is fixed or changed
Added a mention about `fractions.Fraction` in the tutorial.
Fixed typos in "sympify".
Added some details about tuples in Python.
Boolean params as `bool`s, not `int`s.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
