### PR TITLE
Flint dense multivariate polynomials

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1730,7 +1730,7 @@ class DMP_Python(DMP):
 
 
 class DUP_Flint(DMP):
-    """Dense Multivariate Polynomials over `K`. """
+    """Dense Univariate Polynomials over `K`. """
 
     lev = 0
 
@@ -2378,6 +2378,11 @@ class DUP_Flint(DMP):
             return bool(f._rep.is_cyclotomic())
         else:
             return f.to_DMP_Python().is_cyclotomic
+
+
+class DMP_Flint(DMP):
+    """Dense Multivariate Polynomials over `K`. """
+    pass
 
 
 def init_normal_DMF(num, den, lev, dom):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
With https://github.com/flintlib/python-flint/pull/132 merged, `python-flint` now supports the `fmpz_mpoly` and `fmpq_mpoly` objects for multivariate polynomials. I believe SymPy could benefit from making use of these objects.

These changes will be in a similar style to, and build upon @oscarbenjamin's work in https://github.com/sympy/sympy/pull/25722.

Relevant mailing list discussion: https://groups.google.com/g/sympy/c/c9k696D1MT4/m/X0YXxwAMFwAJ

#### Brief description of what is fixed or changed
I aim to add a wrapper class around the `python-flint` objects to provide faster multivariate polynomial operations when `python-flint` is installed.

#### Other comments
The current question is whether these changes should be a part of DMP or PolyElement, from my persective I think it is most natural that these changes go as part of the DMP family, with it's own subclass, similar to `DUP_Flint`. However I'm open to ideas and discussion.

I plan to start this work sometime in the coming week.

This work is part of my BCompSci honours at the University of Queensland.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->