### PR TITLE
fix(core): don't sympify elements of GF(p)

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,6 +8,9 @@ import mpmath.libmp as mlib
 
 from inspect import getmro
 import string
+
+from sympy.external.gmpy import SYMPY_INTS_MOD
+
 from sympy.core.random import choice
 
 from .parameters import global_parameters
@@ -108,6 +111,9 @@ def _convert_numpy_types(a, **sympify_args):
             p, q = a.as_integer_ratio()
             a = mlib.from_rational(p, q, prec)
             return Float(a, precision=prec)
+
+
+DONT_SYMPIFY_TYPES = (CantSympify,) + SYMPY_INTS_MOD
 
 
 @overload
@@ -406,7 +412,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         else:
             raise SympifyError(a)
 
-    if isinstance(a, CantSympify):
+    if isinstance(a, DONT_SYMPIFY_TYPES):
         raise SympifyError(a)
 
     cls = getattr(a, "__class__", None)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -31,6 +31,9 @@ from sympy.external.gmpy import gmpy as _gmpy, flint as _flint
 from sympy.sets import FiniteSet, EmptySet
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 
+from sympy import ZZ, QQ, GF, RR, CC, RealField, ComplexField
+
+
 import mpmath
 from collections import defaultdict, OrderedDict
 
@@ -119,6 +122,82 @@ def test_sympify_flint():
 
         value = sympify(flint.fmpq(101, 127))
         assert value == Rational(101, 127) and type(value) is Rational
+
+        # Don't sympify elements of positive characteristic rings
+        val_nmod = flint.nmod(2, 7)
+        val_fmpz_mod = flint.fmpz_mod_ctx(7)(2)
+        raises(SympifyError, lambda: sympify(val_nmod))
+        raises(SympifyError, lambda: sympify(val_fmpz_mod))
+
+
+def test_sympify_numeric_tower_domains():
+    # Generally it is a mistake to mix domain elements with sympy expressions.
+    # It would be better if an error was raised whenever this happens. Those
+    # domains that resemble basic Python numeric types should be sympifiable
+    # because they fit in to Python's numeric tower though.
+    value = sympify(ZZ(2))
+    assert value == Integer(2) and type(value) is Integer
+
+    value = sympify(QQ(1, 3))
+    assert value == Rational(1, 3) and type(value) is Rational
+
+    # XXX: Reset global precision. The fact that this is needed is because of
+    # a bug in RR and CC where creating a new instance with different
+    # precision changes the precision globally for all instances. Some other
+    # tests create instances of RR and CC with different precision, so this
+    # is needed if those tests are run before this one.
+    #
+    #  >>> CC.dtype(1).context.prec
+    #  53
+    #  >>> ComplexField(100)
+    #  CC
+    #  >>> CC.dtype(1).context.prec
+    #  100
+    RealField(53)
+    ComplexField(53)
+
+    value = sympify(RR(1.0))
+    assert value == Float(1.0) and type(value) is Float
+
+    value = sympify(CC(1.0 + 2.0j))
+    assert value == Float(1.0) + Float(2.0)*I and type(value) is Add
+
+
+def test_cant_sympify_domain_elements():
+    # Don't sympify most domain elements. Explicit conversions should be used
+    # instead. Mixing domain elements with sympy expressions usually indicates
+    # a bug somewhere (e.g. a missing conversion). These domain elements should
+    # instead be converted with R.to_sympy(obj) or similar methods.
+    x = Symbol('x')
+
+    no_sympify = [
+        GF(7)(3),
+        QQ.algebraic_field(sqrt(2)).from_sympy(sqrt(2)),
+        QQ[x].from_sympy(x),
+        QQ.frac_field(x)(1/x),
+    ]
+
+    for obj in no_sympify:
+        raises(SympifyError, lambda: sympify(obj))
+
+    # https://github.com/sympy/sympy/issues/26791
+    #
+    # These previously gave inconsistent values due to Integer sympifying the
+    # domain elements but not understanding the significance of the nonzero
+    # characteristic.
+    #
+    # For now these give False if the ground types are flint and True
+    # otherwise. Either the flint types would need to be changed to recognise
+    # Integer (using __index__) or ModularInteger would need to be changed to
+    # reject Integer.
+    if _flint is None:
+        assert (GF(11)(3) == Integer(-8)) is True
+        assert (Integer(-8) == GF(11)(3)) is True
+    #else:
+    #    This is commented out because a future version of Flint might change
+    #    the behaviour of the flint types.
+    #    assert (GF(11)(3) == Integer(-8)) is False
+    #    assert (Integer(-8) == GF(11)(3)) is False
 
 
 @conserve_mpmath_dps

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -202,6 +202,7 @@ if _SYMPY_GROUND_TYPES == 'gmpy':
     HAS_GMPY = 2
     GROUND_TYPES = 'gmpy'
     SYMPY_INTS = (int, type(gmpy.mpz(0)))
+    SYMPY_INTS_MOD = ()
     MPZ = gmpy.mpz
     MPQ = gmpy.mpq
 
@@ -248,6 +249,7 @@ elif _SYMPY_GROUND_TYPES == 'flint':
     HAS_GMPY = 0
     GROUND_TYPES = 'flint'
     SYMPY_INTS = (int, flint.fmpz) # type: ignore
+    SYMPY_INTS_MOD = (flint.nmod, flint.fmpz_mod) # type: ignore
     MPZ = flint.fmpz # type: ignore
     MPQ = flint.fmpq # type: ignore
 
@@ -309,6 +311,7 @@ elif _SYMPY_GROUND_TYPES == 'python':
     HAS_GMPY = 0
     GROUND_TYPES = 'python'
     SYMPY_INTS = (int,)
+    SYMPY_INTS_MOD = ()
     MPZ = int
     MPQ = PythonMPQ
 

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -2,6 +2,7 @@ from sympy.core.numbers import oo
 from sympy.core.symbol import symbols
 from sympy.polys.domains import FiniteField, QQ, RationalField, FF
 from sympy.polys.polytools import Poly
+from sympy.polys.rings import ring
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.misc import as_int
@@ -52,9 +53,13 @@ class EllipticCurve:
         self._a3 = a3
         self._a4 = a4
         self._a6 = a6
-        x, y, z = symbols('x y z')
-        self.x, self.y, self.z = x, y, z
-        self._poly = Poly(y**2*z + a1*x*y*z + a3*y*z**2 - x**3 - a2*x**2*z - a4*x*z**2 - a6*z**3, domain=domain)
+
+        self.x, self.y, self.z = xe, ye, ze = symbols('x y z')
+
+        R, x, y, z = ring([xe,ye,ze], domain)
+        poly = y**2*z + a1*x*y*z + a3*y*z**2 - x**3 - a2*x**2*z - a4*x*z**2 - a6*z**3
+        self._poly = Poly.from_dict(poly, [xe,ye,ze], domain=domain)
+
         if isinstance(self._domain, FiniteField):
             self._rank = 0
         elif isinstance(self._domain, RationalField):

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import operator
 
+from sympy.core.sympify import CantSympify
+
 from sympy.polys.polyutils import PicklableWithSlots
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.domains.domainelement import DomainElement
@@ -13,7 +15,7 @@ from sympy.utilities import public
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 @public
-class ModularInteger(PicklableWithSlots, DomainElement):
+class ModularInteger(CantSympify, PicklableWithSlots, DomainElement):
     """A class representing a modular integer. """
 
     mod, dom, sym, _parent = None, None, None, None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for gh-26791

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * BREAKING CHANGE: `sympify` now rejects elements of `GF(p)` domains e.g. `sympify(GF(3)(2))` will raise `SympifyError`. Previously this was allowed unintentionally because `sympify` assumes that any type with an `__int__` method can be coerced to `Integer`. This is typically erroneous though because SymPy expressions are always assumed to be in characteristic zero. Now e.g. `expr + GF(7)(1)` for a SymPy expression will raise an error instead of converting the domain element to `1`.
<!-- END RELEASE NOTES -->
