### PR TITLE
Fix GF __call__ with Integer argument (1.13 branch)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -733,6 +733,7 @@ James Harrop <ebc121@gmail.com>
 James Pearson <xiong.chiamiov@gmail.com>
 James Taylor <user234683@tutanota.com>
 James Whitehead <whiteheadj@gmail.com> jcwhitehead <whiteheadj@gmail.com>
+Jan Jancar <johny@neuromancer.sk> J08nY <johny@neuromancer.sk>
 Jan Kruse <janckruse@t-online.de>
 Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com> Jan-Philipp Hoffmann <90828785+jan-philipp-hoffmann@users.noreply.github.com>
 Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1308 authors.
+There are a total of 1309 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1314,3 +1314,4 @@ Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 Dean Price <dean1357price1357@gmail.com>
 Hugo Kerstens <hugo@kerstens.me>
+Jan Jancar <johny@neuromancer.sk>

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -35,21 +35,42 @@ def _modular_int_factory(mod, dom, symmetric, self):
 
     # Use flint if available
     if flint is not None:
+
+        nmod = flint.nmod
+        fmpz_mod_ctx = flint.fmpz_mod_ctx
+        index = operator.index
+
         try:
             mod = dom.convert(mod)
         except CoercionFailed:
             raise ValueError('modulus must be an integer, got %s' % mod)
 
+        # mod might be e.g. Integer
+        try:
+            fmpz_mod_ctx(mod)
+        except TypeError:
+            mod = index(mod)
+
         # flint's nmod is only for moduli up to 2^64-1 (on a 64-bit machine)
         try:
-            flint.nmod(0, mod)
+            nmod(0, mod)
         except OverflowError:
             # Use fmpz_mod
-            fctx = flint.fmpz_mod_ctx(mod)
-            ctx = lambda x: fctx(operator.index(x))
+            fctx = fmpz_mod_ctx(mod)
+
+            def ctx(x):
+                try:
+                    return fctx(x)
+                except TypeError:
+                    # x might be Integer
+                    return fctx(index(x))
         else:
             # Use nmod
-            ctx = lambda x: flint.nmod(operator.index(x), mod)
+            def ctx(x):
+                try:
+                    return nmod(x, mod)
+                except TypeError:
+                    return nmod(index(x), mod)
 
         return ctx
 

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -1,5 +1,7 @@
 """Implementation of :class:`FiniteField` class. """
 
+import operator
+
 from sympy.external.gmpy import GROUND_TYPES
 from sympy.utilities.decorator import doctest_depends_on
 
@@ -43,10 +45,11 @@ def _modular_int_factory(mod, dom, symmetric, self):
             flint.nmod(0, mod)
         except OverflowError:
             # Use fmpz_mod
-            ctx = flint.fmpz_mod_ctx(mod)
+            fctx = flint.fmpz_mod_ctx(mod)
+            ctx = lambda x: fctx(operator.index(x))
         else:
             # Use nmod
-            ctx = lambda x: flint.nmod(x, mod)
+            ctx = lambda x: flint.nmod(operator.index(x), mod)
 
         return ctx
 

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1047,9 +1047,15 @@ def test_ModularInteger():
                 raises(TypeError, lambda: F5(n1) > F5(n2))
                 raises(TypeError, lambda: F5(n1) >= F5(n2))
 
+    # https://github.com/sympy/sympy/issues/26789
+    assert GF(Integer(5)) == F5
+    assert F5(Integer(3)) == F5(3)
+
+
 def test_QQ_int():
     assert int(QQ(2**2000, 3**1250)) == 455431
     assert int(QQ(2**100, 3)) == 422550200076076467165567735125
+
 
 def test_RR_double():
     assert RR(3.14) > 1e-50
@@ -1058,6 +1064,7 @@ def test_RR_double():
     assert RR(1e-15) > 1e-50
     assert RR(1e-20) > 1e-50
     assert RR(1e-40) > 1e-50
+
 
 def test_RR_Float():
     f1 = Float("1.01")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of gh-26790 for 1.13 release branch.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * Fix GF with Integer argument. A regression in 1.13.0 meant that when the ground types are flint GF(3)(Integer(2)) would raise an exception.
<!-- END RELEASE NOTES -->