### PR TITLE
fix(polys): Add RootOf.is_algebraic

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -298,6 +298,7 @@ class ComplexRootOf(RootOf):
     is_complex = True
     is_number = True
     is_finite = True
+    is_algebraic = True
 
     def __new__(cls, f, x, index=None, radicals=False, expand=True):
         """ Construct an indexed complex root of a polynomial.

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -1,5 +1,7 @@
 """Tests for tools for constructing domains for expressions. """
 
+from sympy.testing.pytest import tooslow, XFAIL
+
 from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, RR, CC, EX
 from sympy.polys.domains.realfield import RealField
@@ -11,6 +13,8 @@ from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin
+from sympy import rootof
+
 from sympy.abc import x, y
 
 
@@ -166,6 +170,30 @@ def test_complex_exponential():
          alg.convert(w),
          alg.convert(1)]
     )
+
+
+def test_rootof():
+    r1 = rootof(x**3 + x + 1, 0)
+    r2 = rootof(x**3 + x + 1, 1)
+    K1 = QQ.algebraic_field(r1)
+    K2 = QQ.algebraic_field(r2)
+    assert construct_domain([r1]) == (EX, [EX(r1)])
+    assert construct_domain([r2]) == (EX, [EX(r2)])
+    assert construct_domain([r1, r2]) == (EX, [EX(r1), EX(r2)])
+
+    assert construct_domain([r1], extension=True) == (
+            K1, [K1.from_sympy(r1)])
+    assert construct_domain([r2], extension=True) == (
+            K2, [K2.from_sympy(r2)])
+
+
+@tooslow
+def test_rootof_primitive_element():
+    r1 = rootof(x**3 + x + 1, 0)
+    r2 = rootof(x**3 + x + 1, 1)
+    K12 = QQ.algebraic_field(r1 + r2)
+    assert construct_domain([r1, r2], extension=True) == (
+            K12, [K12.from_sympy(r1), K12.from_sympy(r2)])
 
 
 def test_composite_option():

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -1,6 +1,6 @@
 """Tests for tools for constructing domains for expressions. """
 
-from sympy.testing.pytest import tooslow, XFAIL
+from sympy.testing.pytest import tooslow
 
 from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, RR, CC, EX

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -79,7 +79,9 @@ from sympy.simplify.simplify import signsimp
 from sympy.utilities.iterables import iterable
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-from sympy.testing.pytest import raises, warns_deprecated_sympy, warns, tooslow
+from sympy.testing.pytest import (
+    raises, warns_deprecated_sympy, warns, tooslow, XFAIL
+)
 
 from sympy.abc import a, b, c, d, p, q, t, w, x, y, z
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -322,7 +322,7 @@ def test_Poly_rootof_extension_primitive_element():
 
 
 @XFAIL
-def test_Poly_rootof_same_symbol():
+def test_Poly_rootof_same_symbol_issue_26808():
     # XXX: This fails because r1 contains x.
     r1 = rootof(x**3 + x + 3, 0)
     K1 = QQ.algebraic_field(r1)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -175,6 +175,12 @@ def test_CRootOf_is_complex():
     assert rootof(x**3 + x + 3, 0).is_complex is True
 
 
+def test_CRootOf_is_algebraic():
+    assert rootof(x**3 + x + 3, 0).is_algebraic is True
+    assert rootof(x**3 + x + 3, 1).is_algebraic is True
+    assert rootof(x**3 + x + 3, 2).is_algebraic is True
+
+
 def test_CRootOf_subs():
     assert rootof(x**3 + x + 1, 0).subs(x, y) == rootof(y**3 + y + 1, 0)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/pull/26785#issuecomment-2223936260


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * `RootOf.is_algebraic` now returns True. This means that `Poly(..., extension=True)` can correctly construct extension fields when `RootOf` are in the coefficients.
<!-- END RELEASE NOTES -->
