### PR TITLE
ArraySymbol: Fixes recursion error with lambdify

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1671,3 +1671,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Andrew Mosson <amosson@yahoo.com>

--- a/.mailmap
+++ b/.mailmap
@@ -308,6 +308,7 @@ Andre de Fortier Smit <freevryheid@gmail.com>
 Andreas Klöckner <inform@tiker.net> Andreas Kloeckner <inform@tiker.net>
 Andrej Tokarčík <androsis@gmail.com>
 Andrew Docherty <andrewd@maths.usyd.edu.au>
+Andrew Mosson <amosson@yahoo.com>
 Andrew Straw <strawman@astraw.com>
 Andrew Taber <andrew.e.taber@gmail.com>
 Andrey Grozin <A.G.Grozin@inp.nsk.su>
@@ -1671,4 +1672,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Andrew Mosson <amosson@yahoo.com>

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -54,6 +54,8 @@ class ArraySymbol(_ArrayExpr):
     Symbol representing an array expression
     """
 
+    _iterable = False
+
     def __new__(cls, symbol, shape: typing.Iterable) -> "ArraySymbol":
         if isinstance(symbol, str):
             symbol = Symbol(symbol)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -32,6 +32,7 @@ from sympy.logic.boolalg import (And, false, ITE, Not, Or, true)
 from sympy.matrices.expressions.dotproduct import DotProduct
 from sympy.simplify.cse_main import cse
 from sympy.tensor.array import derive_by_array, Array
+from sympy.tensor.array.expressions import ArraySymbol
 from sympy.tensor.indexed import IndexedBase
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.iterables import numbered_symbols
@@ -1915,3 +1916,9 @@ def test_assoc_legendre_numerical_evaluation():
 
     assert all_close(sympy_result_integer, mpmath_result_integer, tol)
     assert all_close(sympy_result_complex, mpmath_result_complex, tol)
+
+
+def test_array_symbol():
+    a = ArraySymbol('a', (3,))
+    f = lambdify((a), a)
+    assert numpy.all(f(numpy.array([1,2,3])) == numpy.array([1,2,3]))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -529,7 +529,7 @@ def test_numpy_old_matrix():
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
     f = lambdify((x, y, z), A, [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy'])
     with ignore_warnings(PendingDeprecationWarning):
-        numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
+        umpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
         assert isinstance(f(1, 2, 3), numpy.matrix)
 
 
@@ -1919,6 +1919,8 @@ def test_assoc_legendre_numerical_evaluation():
 
 
 def test_array_symbol():
+    if not numpy:
+        skip("numpy not installed.")
     a = ArraySymbol('a', (3,))
     f = lambdify((a), a)
     assert numpy.all(f(numpy.array([1,2,3])) == numpy.array([1,2,3]))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -529,7 +529,7 @@ def test_numpy_old_matrix():
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
     f = lambdify((x, y, z), A, [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy'])
     with ignore_warnings(PendingDeprecationWarning):
-        umpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
+        numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
         assert isinstance(f(1, 2, 3), numpy.matrix)
 
 


### PR DESCRIPTION
Marks ArraySymbol as not iterable as it doesn't
support iteration.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26807

#### Brief description of what is fixed or changed
Adds _iterable = False to ArraySymbol

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* tensor
  * Marks ArraySymbol as not iterable to allow lambdify to work with ArraySymbols

<!-- END RELEASE NOTES -->
