### PR TITLE
fix(polys): Fix count_roots for real algebraic fields

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -325,6 +325,21 @@ def log_to_atan(f, g):
         return A + log_to_atan(s, t)
 
 
+def _get_real_roots(f, x):
+    """get real roots of f if possible"""
+    rs = roots(f, filter='R')
+
+    try:
+        num_roots = f.count_roots()
+    except DomainError:
+        return rs
+    else:
+        if len(rs) == num_roots:
+            return rs
+        else:
+            return None
+
+
 def log_to_real(h, q, x, t):
     r"""
     Convert complex logarithms to real functions.
@@ -372,15 +387,10 @@ def log_to_real(h, q, x, t):
 
     R = Poly(resultant(c, d, v), u)
 
-    R_u = roots(R, filter='R')
+    R_u = _get_real_roots(R, u)
 
-    try:
-        num_roots_R = R.count_roots()
-    except DomainError:
-        pass
-    else:
-        if len(R_u) != num_roots_R:
-            return None
+    if R_u is None:
+        return None
 
     result = S.Zero
 
@@ -397,15 +407,10 @@ def log_to_real(h, q, x, t):
             # nothing to check
             d = S.Zero
 
-        R_v = roots(C, filter='R')
+        R_v = _get_real_roots(C, v)
 
-        try:
-            num_roots_C = C.count_roots()
-        except DomainError:
-            pass
-        else:
-            if len(R_v) != num_roots_C:
-                return None
+        if R_v is None:
+            return None
 
         R_v_paired = [] # take one from each pair of conjugate roots
         for r_v in R_v:
@@ -429,15 +434,10 @@ def log_to_real(h, q, x, t):
 
             result += r_u*log(AB) + r_v*log_to_atan(A, B)
 
-    R_q = roots(q, filter='R')
+    R_q = _get_real_roots(q, t)
 
-    try:
-        num_roots_q = q.count_roots()
-    except DomainError:
-        pass
-    else:
-        if len(R_q) != num_roots_q:
-            return None
+    if R_q is None:
+        return None
 
     for r in R_q.keys():
         result += r*log(h.as_expr().subs(t, r))

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -6,6 +6,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.trigonometric import atan
+from sympy.polys.polyerrors import DomainError
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import cancel
 from sympy.polys.rootoftools import RootSum
@@ -373,8 +374,13 @@ def log_to_real(h, q, x, t):
 
     R_u = roots(R, filter='R')
 
-    if len(R_u) != R.count_roots():
-        return None
+    try:
+        num_roots_R = R.count_roots()
+    except DomainError:
+        pass
+    else:
+        if len(R_u) != num_roots_R:
+            return None
 
     result = S.Zero
 
@@ -393,8 +399,13 @@ def log_to_real(h, q, x, t):
 
         R_v = roots(C, filter='R')
 
-        if len(R_v) != C.count_roots():
-            return None
+        try:
+            num_roots_C = C.count_roots()
+        except DomainError:
+            pass
+        else:
+            if len(R_v) != num_roots_C:
+                return None
 
         R_v_paired = [] # take one from each pair of conjugate roots
         for r_v in R_v:
@@ -420,8 +431,13 @@ def log_to_real(h, q, x, t):
 
     R_q = roots(q, filter='R')
 
-    if len(R_q) != q.count_roots():
-        return None
+    try:
+        num_roots_q = q.count_roots()
+    except DomainError:
+        pass
+    else:
+        if len(R_q) != num_roots_q:
+            return None
 
     for r in R_q.keys():
         result += r*log(h.as_expr().subs(t, r))

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2999,6 +2999,25 @@ def test_count_roots():
     raises(PolynomialError, lambda: count_roots(1))
 
 
+def test_count_roots_extension():
+
+    p1 = Poly(sqrt(2)*x**2 - 2, x, extension=True)
+    assert p1.count_roots() == 2
+    assert p1.count_roots(inf=0) == 1
+    assert p1.count_roots(sup=0) == 1
+
+    p2 = Poly(x**2 + sqrt(2), x, extension=True)
+    assert p2.count_roots() == 0
+
+    p3 = Poly(x**2 + 2*sqrt(2)*x + 1, x, extension=True)
+    assert p3.count_roots() == 2
+    assert p3.count_roots(inf=-10, sup=10) == 2
+    assert p3.count_roots(inf=-10, sup=0) == 2
+    assert p3.count_roots(inf=-10, sup=-3) == 0
+    assert p3.count_roots(inf=-3, sup=-2) == 1
+    assert p3.count_roots(inf=-1, sup=0) == 1
+
+
 def test_Poly_root():
     f = Poly(2*x**3 - 7*x**2 + 4*x + 4)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for gh-26787. This makes `count_roots` correct but still `Domain.is_negative` should be changed as well.

#### Brief description of what is fixed or changed


#### Other comments

The fix here makes the `Poly.count_roots` method work for real algebraic fields. There is however no way to construct a polynomial over such a domain when using the top-level `count_roots` function. That function uses `greedy=False` which is incompatible with `extension=True`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * A bug in `count_roots` for polynomials over real algebraic extension fields was fixed. Previously incorrect results were returned when counting roots over a domain like `QQ.algebraic_field(sqrt(2))`.
<!-- END RELEASE NOTES -->
