### PR TITLE
fix(polys): reduce powers in AlgebraicField.to_sympy

### DIFF
--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -330,6 +330,15 @@ def test_Poly_rootof_same_symbol_issue_26808():
     assert Poly(r1, x, extension=True) == Poly(r1, x, domain=K1)
 
 
+def test_Poly_rootof_extension_to_sympy():
+    # Verify that when primitive elements and RootOf are used, the expression
+    # is not exploded on the way back to sympy.
+    r1 = rootof(y**3 + y**2 - 1, 0)
+    r2 = rootof(z**5 + z**2 - 1, 0)
+    p = -x**5 + x**2 + x*r1 - r2 + 3*r1**2
+    assert p.as_poly(x, extension=True).as_expr() == p
+
+
 def test_poly_from_domain_element():
     dom = ZZ[x]
     assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See gh-26785

#### Brief description of what is fixed or changed

Reduce expressions generated in AlgebraicField.to_sympy using the minimal polynomial of the generators in the case of a field generated by a primitive element.

When there are multiple generators of an algebraic field like `QQ.algebraic_field(sqrt(2), sqrt(3))` a primitive element is chosen as a linear combination of the generators e.g. `ext=sqrt(2)+sqrt(3)`. Then elements of the algebraic field are represented as polynomial functions of `ext`. When converting back to `Expr` there are lots of terms like `(sqrt(2) + sqrt(3))**3`. The current code for handling this expands those expressions which automatically simplifies things like `sqrt(2)**2 -> 2` or `sqrt(2)*sqrt(3) -> sqrt(6)`. This was optimised in gh-20274 to cache the result of the expansion so that repeated calls to `K.to_sympy` can be more efficient.

The current approach works well for algebraic generators that automatically simplify in the Expr representation but for example powers of RootOf do not simplify as Expr and it is more efficient to simplify them in the domain representation before converting them back. The change here makes it so that all powers of the generator like `(r1 + r2)**n` are computed, expanded and reduced modulo the minimal polynomials for `r1` and `r2`. Then finally the result is converted to Expr and expanded for the last automatic simplifications that gives.

For an example of why this is worthwhile see the test case:
```python
    r1 = rootof(y**3 + y**2 - 1, 0)
    r2 = rootof(z**5 + z**2 - 1, 0)
    p = -x**5 + x**2 + x*r1 - r2 + 3*r1**2
    assert p.as_poly(x, extension=True).as_expr() == p
```
With the PR that gives:
```python
In [2]: p.as_poly(x, extension=True).as_expr()
Out[2]:
                                                                                           2
   5    2            ⎛ 3    2       ⎞          ⎛ 5    2       ⎞            ⎛ 3    2       ⎞
- x  + x  + x⋅CRootOf⎝y  + y  - 1, 0⎠ - CRootOf⎝z  + z  - 1, 0⎠ + 3⋅CRootOf⎝y  + y  - 1, 0⎠
```
With master it is:
```python
In [2]: print(p.as_poly(x, extension=True).as_expr())
-x**5 + x**2 + x*(-1361821477626110*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 1361821477626110*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 - 304921810816396*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 - 609843621632792*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 680910738813055*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 - 609843621632792*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 142709969313743*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 - 142709969313743*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)/708821907687 - 680910738813055*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 500880027556280*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 125220006889070*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**4/708821907687 - 140211264653234*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 79921415602126*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**5/236273969229 - 125220006889070*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 - 142709969313743*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 79921415602126*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**4/236273969229 - 152460905408198*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 - 142709969313743*CRootOf(y**3 + y**2 - 1, 0)**3/2126465723061 - 26285303032660*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**5/78757989743 - 159842831204252*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 - 65713257581650*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**6/236273969229 - 152460905408198*CRootOf(y**3 + y**2 - 1, 0)**4/2126465723061 - 136182147762611*CRootOf(z**5 + z**2 - 1, 0)**5/2126465723061 - 159842831204252*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**3/708821907687 - 65713257581650*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**4/236273969229 - 70105632326617*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 - 70105632326617*CRootOf(y**3 + y**2 - 1, 0)**2/2126465723061 - 50088002755628*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 - 136182147762611*CRootOf(y**3 + y**2 - 1, 0)**5/2126465723061 - 37550432903800*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**7/236273969229 - 50088002755628*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)/708821907687 - 22834690172036*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**7/236273969229 - 37550432903800*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**3/236273969229 - 22834690172036*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**2/236273969229 - 22192406036605*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 22192406036605*CRootOf(y**3 + y**2 - 1, 0)/2126465723061 - 4693804112975*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**8/78757989743 - 4693804112975*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**2/78757989743 - 5708672543009*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**8/236273969229 - 25044001377814*CRootOf(z**5 + z**2 - 1, 0)**6/2126465723061 - 25044001377814*CRootOf(y**3 + y**2 - 1, 0)**6/2126465723061 - 5708672543009*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)/236273969229 - 358996135043/236273969229 - 9387608225950*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**9/708821907687 - 9387608225950*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)/708821907687 - 5708672543009*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 - 5708672543009*CRootOf(y**3 + y**2 - 1, 0)**9/2126465723061 - 938760822595*CRootOf(z**5 + z**2 - 1, 0)**10/708821907687 - 938760822595*CRootOf(y**3 + y**2 - 1, 0)**10/708821907687 + 559667376622*CRootOf(y**3 + y**2 - 1, 0)**14/2126465723061 + 559667376622*CRootOf(z**5 + z**2 - 1, 0)**14/2126465723061 + 2651238493942*CRootOf(y**3 + y**2 - 1, 0)**13/2126465723061 + 3035219759674*CRootOf(y**3 + y**2 - 1, 0)**11/2126465723061 + 7835343272708*CRootOf(y**3 + y**2 - 1, 0)**13*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 4867605853559*CRootOf(y**3 + y**2 - 1, 0)**12/2126465723061 + 2651238493942*CRootOf(z**5 + z**2 - 1, 0)**13/2126465723061 + 3035219759674*CRootOf(z**5 + z**2 - 1, 0)**11/2126465723061 + 7835343272708*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**13/2126465723061 + 4867605853559*CRootOf(z**5 + z**2 - 1, 0)**12/2126465723061 + 34466100421246*CRootOf(y**3 + y**2 - 1, 0)**12*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 50929731272602*CRootOf(y**3 + y**2 - 1, 0)**12*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 + 3891525098632*CRootOf(y**3 + y**2 - 1, 0)**8/708821907687 + 33387417356414*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 34466100421246*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**12/2126465723061 + 3891525098632*CRootOf(z**5 + z**2 - 1, 0)**8/708821907687 + 19470423414236*CRootOf(y**3 + y**2 - 1, 0)**11*CRootOf(z**5 + z**2 - 1, 0)/708821907687 + 50929731272602*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**12/2126465723061 + 33387417356414*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**10/2126465723061 + 19470423414236*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**11/708821907687 + 203718925090408*CRootOf(y**3 + y**2 - 1, 0)**11*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 36003892562578*CRootOf(y**3 + y**2 - 1, 0)**7/2126465723061 + 68932200842492*CRootOf(y**3 + y**2 - 1, 0)**11*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 36003892562578*CRootOf(z**5 + z**2 - 1, 0)**7/2126465723061 + 203718925090408*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**11/2126465723061 + 166937086782070*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 + 31132200789056*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)/708821907687 + 68932200842492*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**11/708821907687 + 107087328778298*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 166937086782070*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 560227043998622*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 + 31132200789056*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 560227043998622*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**10/2126465723061 + 107087328778298*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**10/708821907687 + 758254209267412*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 166937086782070*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**3/708821907687 + 1120454087997244*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**5/2126465723061 + 252027247938046*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 758254209267412*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**10/2126465723061 + 166937086782070*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**8/708821907687 + 108962702761696*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 1120454087997244*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 1070873287782980*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 560227043998622*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 108962702761696*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 252027247938046*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**6/2126465723061 + 560227043998622*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**8/708821907687 + 333874173564140*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**4/708821907687 + 640259478855568*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 1895635523168530*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 + 1070873287782980*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 333874173564140*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 217925405523392*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**3/708821907687 + 467423842989796*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 + 1895635523168530*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 467423842989796*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 217925405523392*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 + 267718321945745*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**4/236273969229 + 272406756904240*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**4/708821907687 + 252027247938046*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 379127104633706*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**5/236273969229 + 267718321945745*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**8/236273969229 + 252027247938046*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 + 379127104633706*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**8/236273969229 + 1516508418534824*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 428349315113192*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**5/236273969229 + 1516508418534824*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 428349315113192*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**7/236273969229 + 1260136239690230*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 1260136239690230*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 + 1499222602896172*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687) - 390444128602750*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 - 1443974587229900*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 1443974587229900*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 - 780888257205500*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 780888257205500*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 721987293614950*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 - 145500092913761*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 - 145500092913761*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)/708821907687 - 721987293614950*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 201721980732014*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 100041951455698*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**5/236273969229 - 100041951455698*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**4/236273969229 - 195222064301375*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 - 145500092913761*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 200083902911396*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 - 100860990366007*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 - 195222064301375*CRootOf(y**3 + y**2 - 1, 0)**4/2126465723061 - 145500092913761*CRootOf(y**3 + y**2 - 1, 0)**3/2126465723061 - 200083902911396*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**3/708821907687 - 100860990366007*CRootOf(y**3 + y**2 - 1, 0)**2/2126465723061 - 144397458722990*CRootOf(z**5 + z**2 - 1, 0)**5/2126465723061 - 21492377357332*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**5/78757989743 - 53730943393330*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**6/236273969229 - 53730943393330*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**4/236273969229 - 144397458722990*CRootOf(y**3 + y**2 - 1, 0)**5/2126465723061 - 28583414701628*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**7/236273969229 - 30703396224760*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**7/236273969229 - 28583414701628*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**2/236273969229 - 28688949064411*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 - 28688949064411*CRootOf(y**3 + y**2 - 1, 0)/2126465723061 - 30703396224760*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**3/236273969229 - 3837924528095*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**8/78757989743 - 46925331414920*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 - 7145853675407*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**8/236273969229 - 11731332853730*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**4/708821907687 - 11731332853730*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 - 3837924528095*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**2/78757989743 - 7145853675407*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)/236273969229 - 1275781728700/708821907687 - 4692533141492*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 - 4692533141492*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)/708821907687 - 7675849056190*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**9/708821907687 - 7675849056190*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)/708821907687 - 7145853675407*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 - 2346266570746*CRootOf(z**5 + z**2 - 1, 0)**6/2126465723061 - 7145853675407*CRootOf(y**3 + y**2 - 1, 0)**9/2126465723061 - 2346266570746*CRootOf(y**3 + y**2 - 1, 0)**6/2126465723061 - 767584905619*CRootOf(z**5 + z**2 - 1, 0)**10/708821907687 - 767584905619*CRootOf(y**3 + y**2 - 1, 0)**10/708821907687 + 443504286433*CRootOf(y**3 + y**2 - 1, 0)**14/2126465723061 + 443504286433*CRootOf(z**5 + z**2 - 1, 0)**14/2126465723061 + 2497320268660*CRootOf(y**3 + y**2 - 1, 0)**13/2126465723061 + 6209060010062*CRootOf(y**3 + y**2 - 1, 0)**13*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 2497320268660*CRootOf(z**5 + z**2 - 1, 0)**13/2126465723061 + 5424022868285*CRootOf(y**3 + y**2 - 1, 0)**12/2126465723061 + 4459106603278*CRootOf(y**3 + y**2 - 1, 0)**11/2126465723061 + 6209060010062*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**13/2126465723061 + 5424022868285*CRootOf(z**5 + z**2 - 1, 0)**12/2126465723061 + 4459106603278*CRootOf(z**5 + z**2 - 1, 0)**11/2126465723061 + 2534238423041*CRootOf(y**3 + y**2 - 1, 0)**8/708821907687 + 32465163492580*CRootOf(y**3 + y**2 - 1, 0)**12*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 40358890065403*CRootOf(y**3 + y**2 - 1, 0)**12*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 + 2534238423041*CRootOf(z**5 + z**2 - 1, 0)**8/708821907687 + 40358890065403*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**12/2126465723061 + 32465163492580*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**12/2126465723061 + 49050172636058*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 21696091473140*CRootOf(y**3 + y**2 - 1, 0)**11*CRootOf(z**5 + z**2 - 1, 0)/708821907687 + 161435560261612*CRootOf(y**3 + y**2 - 1, 0)**11*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 49050172636058*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**10/2126465723061 + 21696091473140*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**11/708821907687 + 39384827304364*CRootOf(y**3 + y**2 - 1, 0)**7/2126465723061 + 64930326985160*CRootOf(y**3 + y**2 - 1, 0)**11*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 161435560261612*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**11/2126465723061 + 20273907384328*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)/708821907687 + 39384827304364*CRootOf(z**5 + z**2 - 1, 0)**7/2126465723061 + 20273907384328*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 64930326985160*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**11/708821907687 + 443947790719433*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 + 245250863180290*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**2/2126465723061 + 119328503102270*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 443947790719433*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**10/2126465723061 + 245250863180290*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 714233596836760*CRootOf(y**3 + y**2 - 1, 0)**10*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 119328503102270*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**10/708821907687 + 887895581438866*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**5/2126465723061 + 70958675845148*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 887895581438866*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 70958675845148*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 714233596836760*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**10/2126465723061 + 443947790719433*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 245250863180290*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**3/708821907687 + 275693791130548*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)/2126465723061 + 443947790719433*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**8/708821907687 + 507368903679352*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 1193285031022700*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 141917351690296*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**3/708821907687 + 245250863180290*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**8/708821907687 + 275693791130548*CRootOf(y**3 + y**2 - 1, 0)*CRootOf(z**5 + z**2 - 1, 0)**6/2126465723061 + 1785583992091900*CRootOf(y**3 + y**2 - 1, 0)**9*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 + 141917351690296*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 + 177396689612870*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**4/708821907687 + 1193285031022700*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 1785583992091900*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**9/2126465723061 + 490501726360580*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**4/708821907687 + 490501726360580*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 357116798418380*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**5/236273969229 + 298321257755675*CRootOf(y**3 + y**2 - 1, 0)**8*CRootOf(z**5 + z**2 - 1, 0)**4/236273969229 + 686702416904812*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 + 275693791130548*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**2/708821907687 + 686702416904812*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 357116798418380*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**8/236273969229 + 298321257755675*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**8/236273969229 + 275693791130548*CRootOf(y**3 + y**2 - 1, 0)**2*CRootOf(z**5 + z**2 - 1, 0)**5/708821907687 + 1428467193673520*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687 + 1428467193673520*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**7/708821907687 + 477314012409080*CRootOf(y**3 + y**2 - 1, 0)**7*CRootOf(z**5 + z**2 - 1, 0)**5/236273969229 + 1378468955652740*CRootOf(y**3 + y**2 - 1, 0)**4*CRootOf(z**5 + z**2 - 1, 0)**3/2126465723061 + 477314012409080*CRootOf(y**3 + y**2 - 1, 0)**5*CRootOf(z**5 + z**2 - 1, 0)**7/236273969229 + 1378468955652740*CRootOf(y**3 + y**2 - 1, 0)**3*CRootOf(z**5 + z**2 - 1, 0)**4/2126465723061 + 1670599043431780*CRootOf(y**3 + y**2 - 1, 0)**6*CRootOf(z**5 + z**2 - 1, 0)**6/708821907687
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * Elements of algebraic numberfields are converted to simpler expressions in many cases when converted back to ordinary expressions. This can lead to big simplifications of expressions generated when using algebraic fields with multiple generators of types like RootOf that do not simplify automatically in the Expr representation.
<!-- END RELEASE NOTES -->
