### PR TITLE
fix test on i686

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -647,6 +647,7 @@ Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
 GolimarOurHero <metalera94@hotmail.com>
+Gonzalo Tornaría <tornaria@cmat.edu.uy>
 Goutham Lakshminarayan <dl.goutham@gmail.com> Goutham <devnull@localhost>
 Govind Sahai <gsiitbhu@gmail.com>
 Grace Su <grace.duansu@gmail.com>

--- a/sympy/codegen/tests/test_fnodes.py
+++ b/sympy/codegen/tests/test_fnodes.py
@@ -44,7 +44,7 @@ def test_size_assumed_shape():
             'program myprog\n'
             'use mod_rms, only: rms\n'
             'real*8, dimension(4), parameter :: x = [4, 2, 2, 2]\n'
-            'print *, dsqrt(7d0) - rms(x)\n'
+            'print "(f7.5)", dsqrt(7d0) - rms(x)\n'
             'end program\n'
         ))
     ], clean=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

On i686 there's the following error in testing
```
    @may_xfail
    def test_size_assumed_shape():
        if not has_fortran():
            skip("No fortran compiler found.")
        a = Symbol('a', real=True)
        body = [Return((sum_(a**2)/size(a))**.5)]
        arr = array(a, dim=[':'], intent='in')
        fd = FunctionDefinition(real, 'rms', [arr], body)
        render_as_module([fd], 'mod_rms')
    
        (stdout, stderr), info = compile_run_strings([
            ('rms.f90', render_as_module([fd], 'mod_rms')),
            ('main.f90', (
                'program myprog\n'
                'use mod_rms, only: rms\n'
                'real*8, dimension(4), parameter :: x = [4, 2, 2, 2]\n'
                'print *, dsqrt(7d0) - rms(x)\n'
                'end program\n'
            ))
        ], clean=True)
>       assert '0.00000' in stdout
E       AssertionError: assert '0.00000' in '   1.2576745200831851E-016\n'

sympy/codegen/tests/test_fnodes.py:51: AssertionError
```

The result is clearly zero but not printed as '0.00000'.
This commit changes the output format so it will indeed print as '0.00000'

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->