### PR TITLE
feat(polys): Add Poly.real_imag, RootOf.as_real_imag

### DIFF
--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -12,6 +12,7 @@ from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify
 from sympy.core.traversal import preorder_traversal
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.complexes import re, im
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.trigonometric import cos, sin, tan
 from sympy.ntheory.factor_ import divisors
@@ -56,7 +57,7 @@ def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
         # with `subs` argument but we only need a ballpark evaluation
         fe = [f.as_expr().xreplace({x:v}) for f in factors]
         if v.is_number:
-            fe = [f.n(prec) for f in fe]
+            fe = [f.n(prec1) for f in fe]
 
         # assign integers [0, n) to symbols (if any)
         for n in subsets(range(bound), k=len(symbols), repetition=True):
@@ -530,6 +531,42 @@ def _minpoly_rootof(ex, x):
     return result
 
 
+def _minpoly_re(ex, x):
+    """
+    Returns the minimal polynomial of the real part of an algebraic element
+    """
+    arg = ex.args[0]
+    if arg.is_real:
+        return _minpoly_compose(arg, x, QQ)
+    elif arg.is_real is False:
+        y = Dummy('y')
+        mp = _minpoly_compose(ex.args[0], x, QQ).as_poly(x)
+        p_re, p_imag = mp.real_imag(x, y)
+        p_re_x = resultant(p_re, p_imag, y).as_poly(x)
+        _, factors = factor_list(p_re_x.as_expr(), x)
+        result = _choose_factor(factors, x, ex)
+        return result
+
+
+def _minpoly_im(ex, y):
+    """
+    Returns the minimal polynomial of the imaginary part of an algebraic element
+    """
+    arg = ex.args[0]
+    if arg.is_real:
+        return y
+    elif arg.is_imaginary:
+        return _minpoly_compose(arg, y, QQ)
+    elif arg.is_imaginary is False:
+        x = Dummy('x')
+        mp = _minpoly_compose(ex.args[0], y, QQ).as_poly(y)
+        p_re, p_imag = mp.real_imag(x, y)
+        p_imag_y = resultant(p_re, p_imag, x).as_poly(y)
+        _, factors = factor_list(p_imag_y.as_expr(), y)
+        result = _choose_factor(factors, y, ex)
+        return result
+
+
 def _minpoly_compose(ex, x, dom):
     """
     Computes the minimal polynomial of an algebraic element
@@ -617,6 +654,10 @@ def _minpoly_compose(ex, x, dom):
         res = _minpoly_exp(ex, x)
     elif ex.__class__ is CRootOf:
         res = _minpoly_rootof(ex, x)
+    elif ex.__class__ is re:
+        res = _minpoly_re(ex, x)
+    elif ex.__class__ is im:
+        res = _minpoly_im(ex, x)
     else:
         raise NotAlgebraic("%s does not seem to be an algebraic element" % ex)
     return res

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -80,6 +80,7 @@ from sympy.polys.densetools import (
     dmp_ground_monic,
     dmp_compose,
     dup_decompose,
+    dup_real_imag,
     dup_shift,
     dmp_shift,
     dup_transform,
@@ -891,6 +892,13 @@ class DMP(CantSympify):
     def _decompose(f):
         raise NotImplementedError
 
+    def real_imag(f):
+        """Find f1 and f2 such that ``f(x+i*y) = f1(x,y) + i*f2(x,y)``. """
+        if f.lev:
+            raise ValueError('univariate polynomial expected')
+
+        return f._real_imag()
+
     def shift(f, a):
         """Efficiently compute Taylor shift ``f(x + a)``. """
         if f.lev:
@@ -1576,6 +1584,11 @@ class DMP_Python(DMP):
         """Computes functional decomposition of ``f``. """
         return list(map(f.per, dup_decompose(f._rep, f.dom)))
 
+    def _real_imag(f):
+        """Find f1 and f2 such that ``f(x+i*y) = f1(x,y) + i*f2(x,y)``. """
+        p_real, p_imag = dup_real_imag(f._rep, f.dom)
+        return f.new(p_real, f.dom, 1), f.new(p_imag, f.dom, 1)
+
     def _shift(f, a):
         """Efficiently compute Taylor shift ``f(x + a)``. """
         return f.per(dup_shift(f._rep, a, f.dom))
@@ -2198,6 +2211,11 @@ class DUP_Flint(DMP):
     def _decompose(f):
         """Computes functional decomposition of ``f``. """
         return [ g.to_DUP_Flint() for g in f.to_DMP_Python()._decompose() ]
+
+    def _real_imag(f):
+        """Find f1 and f2 such that ``f(x+i*y) = f1(x,y) + i*f2(x,y)``. """
+        p_real, p_imag = f.to_DMP_Python()._real_imag()
+        return p_real.to_best(), p_imag.to_best()
 
     def _shift(f, a):
         """Efficiently compute Taylor shift ``f(x + a)``. """

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3089,6 +3089,37 @@ class Poly(Basic):
 
         return list(map(f.per, result))
 
+    def real_imag(f, *gens):
+        """
+        Find ``p1``, ``p2`` such that ``f(x+I*y) = p1(x,y) + I*p2(x,y)``.
+
+        Examples
+        ========
+
+        >>> from sympy import Poly, I
+        >>> from sympy.abc import x, y, z
+
+        >>> f = Poly(z**2 + z + 1, z)
+        >>> p1, p2 = f.real_imag(x, y)
+
+        >>> p1
+        Poly(x**2 - y**2 + x + 1, x, y, domain='ZZ')
+        >>> p2
+        Poly(2*x*y + y, x, y, domain='ZZ')
+        >>> f(x + I*y).expand() == p1(x, y) + I*p2(x, y)
+        True
+
+        """
+        if not f.is_univariate:
+            raise MultivariatePolynomialError("only univariate polynomials are allowed")
+        dom = f.domain
+        if not (dom.is_ZZ or dom.is_QQ):
+            raise DomainError("only rational and integer domains are allowed")
+
+        p1, p2 = f.rep.real_imag()
+
+        return f.per(p1, gens), f.per(p2, gens)
+
     def shift(f, a):
         """
         Efficiently compute Taylor shift ``f(x + a)``.

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -17,7 +17,7 @@ from sympy.polys.polyfuncs import symmetrize, viete
 from sympy.polys.polyroots import (
     roots_linear, roots_quadratic, roots_binomial,
     preprocess_roots, roots)
-from sympy.polys.polytools import Poly, PurePoly, factor
+from sympy.polys.polytools import Poly, PurePoly, factor, resultant
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import (
     dup_isolate_complex_roots_sqf,
@@ -1003,6 +1003,25 @@ class ComplexRootOf(RootOf):
         # less) don't have much work to do to recompute the root
         self._set_interval(interval)
         return real + I*imag
+
+    def as_real_imag(self, deep=True, **hints):
+        """Return the real and imaginary part of the root."""
+        if self.is_real:
+            return self, S.Zero
+        if self.is_imaginary:
+            return S.Zero, self
+        x = Dummy('x')
+        y = Dummy('y')
+        p = self.poly.as_poly()
+        p_re, p_im = p.real_imag(x, y)
+        p_x = resultant(p_re, p_im, y).as_poly(x)
+        p_y = resultant(p_re, p_im, x).as_poly(y)
+        for rx in p_x.real_roots():
+            for ry in p_y.real_roots():
+                if p.same_root(self, rx + I*ry):
+                    return rx, ry
+        else:
+            assert False
 
 
 CRootOf = ComplexRootOf


### PR DESCRIPTION
Also add minpoly for re and im.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

```python
In [1]: r = RootOf(x**5 - x + 1, 1)

In [2]: minpoly(re(r), x)
Out[2]:
      10        6        5       2
1024⋅x   + 192⋅x  - 352⋅x  - 16⋅x  - 8⋅x - 1

In [3]: minpoly(im(r), x)
Out[3]:
         20           16           12           10          8           6         4          2
1048576⋅x   - 655360⋅x   - 389120⋅x   - 640000⋅x   - 10240⋅x  - 240000⋅x  + 6400⋅x  - 20000⋅x  + 2869

In [4]: r.as_real_imag()
Out[4]:
⎛       ⎛      10        6        5       2             ⎞         ⎛         20           16           12           10          8           6         4          2          ⎞⎞
⎝CRootOf⎝1024⋅x   + 192⋅x  - 352⋅x  - 16⋅x  - 8⋅x - 1, 0⎠, CRootOf⎝1048576⋅x   - 655360⋅x   - 389120⋅x   - 640000⋅x   - 10240⋅x  - 240000⋅x  + 6400⋅x  - 20000⋅x  + 2869, 0⎠⎠

In [5]: p = Poly(z**2 + z + 1)

In [6]: p.real_imag(x, y)
Out[6]: (Poly(x**2 + x - y**2 + 1, x, y, domain='ZZ'), Poly(2*x*y + y, x, y, domain='ZZ'))

In [7]: p(x + I*y).expand().collect(I)
Out[7]:
 2        2
x  + x - y  + ⅈ⋅(2⋅x⋅y + y) + 1
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * A `Poly.real_imag()` method was added to split a univariate polynomial function of a complex variable into real and imaginary polynomial functions of real variables.
   * `minpoly` can now compute the minimal polynomial of the real or imaginary part of an algebraic expression.
   * `RootOf` now has an `as_real_imag` method that can find the real and imaginary parts of a RootOf in terms of RootOf. 
<!-- END RELEASE NOTES -->
