### PR TITLE
[GSoC] Added bandwidth method to TransferFunction class.

### DIFF
--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -351,6 +351,22 @@ def test_TransferFunction_functions():
     assert tf10.to_expr() == Mul(S(0), Pow(1, -1, evaluate=False), evaluate=False)
     assert tf11.to_expr() == Pow(1, -1, evaluate=False)
 
+    # Bandwidth of TransferFunction
+    tf12 = TransferFunction(2*(s+3), (s+6)*(s+1), s)
+    assert str(tf12.bandwidth()) == str(1.09195001097817)
+    tf13 = TransferFunction(1, s**2+s+1, s)
+    assert str(tf13.bandwidth()) == str(1.27201964951407)
+    tf14 = TransferFunction(s, s**2+s+1, s)
+    assert tf14.bandwidth() == oo
+    tf15 = TransferFunction(s+1, s**2+s+1, s)
+    assert str(tf15.bandwidth()) == str(1.81735402102397)
+    tf16 = TransferFunction(2*(s+3), (s+6)*(s+1), s)
+    assert str(tf16.bandwidth()) == str(1.09195001097817)
+    q, r1 = symbols('q r1', real=True, positive=True)
+    tf17 = TransferFunction(r1, s-q, s)
+    assert str(tf17.bandwidth()) == '1.0*q'
+
+
 def test_TransferFunction_addition_and_subtraction():
     tf1 = TransferFunction(s + 6, s - 5, s)
     tf2 = TransferFunction(s + 3, s + 1, s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added a method to calculate bandwidth of a TransferFunction.

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This method calculates the bandwidth of a given transfer function, which is useful for analyzing the frequency response of control systems.

#### Other comments

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added `bandwidth()` method to `TransferFunction` class.
<!-- END RELEASE NOTES -->
