### PR TITLE
Revised conditions for `erf.is_real`

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -6,7 +6,7 @@ from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.function import Function, ArgumentIndexError, expand_mul
 from sympy.core.logic import fuzzy_or
-from sympy.core.numbers import I, pi, Rational
+from sympy.core.numbers import I, pi, Rational, Integer
 from sympy.core.relational import is_eq
 from sympy.core.power import Pow
 from sympy.core.singleton import S
@@ -983,7 +983,7 @@ class erfcinv (Function):
 
     def _eval_is_infinite(self):
         z = self.args[0]
-        return fuzzy_or([z.is_zero, (z - 2).is_zero])
+        return fuzzy_or([z.is_zero, is_eq(z, Integer(2))])
 
 
 class erf2inv(Function):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -196,8 +196,7 @@ class erf(Function):
         # even if z is a complex number
 
     def _eval_is_imaginary(self):
-        t = self.args[0].extract_multiplicatively(I)
-        if t is not None and t.is_real is True and t.is_zero is False:
+        if self.args[0].is_imaginary is True:
             return True
 
     def _eval_is_finite(self):
@@ -427,11 +426,8 @@ class erfc(Function):
     def _eval_is_real(self):
         if self.args[0].is_extended_real is True:
             return True
-
-    def _eval_is_imaginary(self):
-        t = self.args[0].extract_multiplicatively(I)
-        if t is not None and t.is_real is True and t.is_zero is False:
-            return True
+        if self.args[0].is_imaginary is True:
+            return False
 
     def _eval_rewrite_as_tractable(self, z, limitvar=None, **kwargs):
         return self.rewrite(erf).rewrite("tractable", deep=True, limitvar=limitvar)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -195,6 +195,11 @@ class erf(Function):
         # There are cases where erf(z) becomes a real number
         # even if z is a complex number
 
+    def _eval_is_imaginary(self):
+        t = self.args[0].extract_multiplicatively(I)
+        if t is not None and t.is_real is True and t.is_zero is False:
+            return True
+
     def _eval_is_finite(self):
         z = self.args[0]
         return fuzzy_or([z.is_finite, z.is_extended_real])
@@ -421,6 +426,11 @@ class erfc(Function):
 
     def _eval_is_real(self):
         if self.args[0].is_extended_real is True:
+            return True
+
+    def _eval_is_imaginary(self):
+        t = self.args[0].extract_multiplicatively(I)
+        if t is not None and t.is_real is True and t.is_zero is False:
             return True
 
     def _eval_rewrite_as_tractable(self, z, limitvar=None, **kwargs):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -190,20 +190,26 @@ class erf(Function):
         return self.func(self.args[0].conjugate())
 
     def _eval_is_real(self):
-        return self.args[0].is_extended_real
+        if self.args[0].is_extended_real is True:
+            return True
+        # There are cases where erf(z) becomes a real number
+        # even if z is a complex number
 
     def _eval_is_finite(self):
         z = self.args[0]
         return fuzzy_or([z.is_finite, z.is_extended_real])
 
     def _eval_is_zero(self):
-        return self.args[0].is_zero
+        if self.args[0].is_extended_real is True:
+            return self.args[0].is_zero
 
     def _eval_is_positive(self):
-        return self.args[0].is_extended_positive
+        if self.args[0].is_extended_real is True:
+            return self.args[0].is_extended_positive
 
     def _eval_is_negative(self):
-        return self.args[0].is_extended_negative
+        if self.args[0].is_extended_real is True:
+            return self.args[0].is_extended_negative
 
     def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy.functions.special.gamma_functions import uppergamma
@@ -414,7 +420,8 @@ class erfc(Function):
         return self.func(self.args[0].conjugate())
 
     def _eval_is_real(self):
-        return self.args[0].is_extended_real
+        if self.args[0].is_extended_real is True:
+            return True
 
     def _eval_rewrite_as_tractable(self, z, limitvar=None, **kwargs):
         return self.rewrite(erf).rewrite("tractable", deep=True, limitvar=limitvar)
@@ -975,7 +982,8 @@ class erfcinv (Function):
         return (self.args[0] - 1).is_zero
 
     def _eval_is_infinite(self):
-        return self.args[0].is_zero
+        z = self.args[0]
+        return fuzzy_or([z.is_zero, (z - 2).is_zero])
 
 
 class erf2inv(Function):

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -47,13 +47,19 @@ def test_erf():
     assert erf(erf2inv(0, x, evaluate=False)) == x # To cover code in erf
     assert erf(erf2inv(0, erf(erfcinv(1 - erf(erfinv(x)))))) == x
 
+    alpha = symbols('alpha', extended_real=True)
+    assert erf(alpha).is_real is True
+    assert erf(alpha).is_finite is True
     alpha = symbols('alpha', extended_real=False)
+    assert erf(alpha).is_real is None
     assert erf(alpha).is_finite is None
+    assert erf(alpha).is_zero is None
+    assert erf(alpha).is_positive is None
+    assert erf(alpha).is_negative is None
     alpha = symbols('alpha', extended_positive=True)
     assert erf(alpha).is_positive is True
     alpha = symbols('alpha', extended_negative=True)
     assert erf(alpha).is_negative is True
-    assert erf(I).is_real is False
     assert erf(0, evaluate=False).is_real
     assert erf(0, evaluate=False).is_zero
 
@@ -143,7 +149,10 @@ def test_erfc():
     assert erfc(-x) == S(2) - erfc(x)
     assert erfc(erfcinv(x)) == x
 
-    assert erfc(I).is_real is False
+    alpha = symbols('alpha', extended_real=True)
+    assert erfc(alpha).is_real is True
+    alpha = symbols('alpha', extended_real=False)
+    assert erfc(alpha).is_real is None
     assert erfc(0, evaluate=False).is_real
     assert erfc(0, evaluate=False).is_zero is False
 
@@ -284,7 +293,6 @@ def test_erf2():
     assert erf2(x, y).rewrite('uppergamma') == erf(y).rewrite(uppergamma) - erf(x).rewrite(uppergamma)
     assert erf2(x, y).rewrite('expint') == erf(y).rewrite(expint)-erf(x).rewrite(expint)
 
-    assert erf2(I, 0).is_real is False
     assert erf2(0, 0, evaluate=False).is_real
     assert erf2(0, 0, evaluate=False).is_zero
     assert erf2(x, x, evaluate=False).is_zero
@@ -332,6 +340,8 @@ def test_erfinv_evalf():
 def test_erfcinv():
     assert erfcinv(1) is S.Zero
     assert erfcinv(0) is S.Infinity
+    assert erfcinv(0, evaluate=False).is_infinite is True
+    assert erfcinv(2, evaluate=False).is_infinite is True
     assert erfcinv(nan) is S.NaN
 
     assert erfcinv(x).diff() == -sqrt(pi)*exp(erfcinv(x)**2)/2

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -60,6 +60,7 @@ def test_erf():
     assert erf(alpha).is_positive is True
     alpha = symbols('alpha', extended_negative=True)
     assert erf(alpha).is_negative is True
+    assert erf(I).is_real is False
     assert erf(0, evaluate=False).is_real
     assert erf(0, evaluate=False).is_zero
 
@@ -153,6 +154,7 @@ def test_erfc():
     assert erfc(alpha).is_real is True
     alpha = symbols('alpha', extended_real=False)
     assert erfc(alpha).is_real is None
+    assert erfc(I).is_real is False
     assert erfc(0, evaluate=False).is_real
     assert erfc(0, evaluate=False).is_zero is False
 
@@ -293,6 +295,7 @@ def test_erf2():
     assert erf2(x, y).rewrite('uppergamma') == erf(y).rewrite(uppergamma) - erf(x).rewrite(uppergamma)
     assert erf2(x, y).rewrite('expint') == erf(y).rewrite(expint)-erf(x).rewrite(expint)
 
+    assert erf2(I, 0).is_real is False
     assert erf2(0, 0, evaluate=False).is_real
     assert erf2(0, 0, evaluate=False).is_zero
     assert erf2(x, x, evaluate=False).is_zero


### PR DESCRIPTION
We had not considered the possibility that `erf` and `erfc` could yield real numbers when given complex numbers as input. Therefore, conditions such as `is_real` and `is_extended_positive` now return True (or False) only when the arguments are extended real numbers. In this context, `erf(I)` is not a real number, but since it can no longer be determined here, it has been removed from the test cases.

Additionally, the conditions for `erfcinv.is_infinite` have also been revised.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#26831

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
