### PR TITLE
Modified `LambertW.eval` to not use `match`(1.13 branch)

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1162,24 +1162,12 @@ class LambertW(Function):
                 return S.Zero
             if x is S.Exp1:
                 return S.One
-            w = Wild('w')
-            # W(x*log(x)) = log(x) for x >= 1/e
-            # e.g., W(-1/e) = -1, W(2*log(2)) = log(2)
-            result = x.match(w*log(w))
-            if result is not None and Ge(result[w]*S.Exp1, S.One) is S.true:
-                return log(result[w])
+            if x == -1/S.Exp1:
+                return S.NegativeOne
             if x == -log(2)/2:
                 return -log(2)
-            # W(x**(x+1)*log(x)) = x*log(x) for x > 0
-            # e.g., W(81*log(3)) = 3*log(3)
-            result = x.match(w**(w+1)*log(w))
-            if result is not None and result[w].is_positive is True:
-                return result[w]*log(result[w])
-            # W(e**(1/n)/n) = 1/n
-            # e.g., W(sqrt(e)/2) = 1/2
-            result = x.match(S.Exp1**(1/w)/w)
-            if result is not None:
-                return 1 / result[w]
+            if x == 2*log(2):
+                return log(2)
             if x == -pi/2:
                 return I*pi/2
             if x == exp(1 + S.Exp1):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -11,7 +11,6 @@ from sympy.core.mul import Mul
 from sympy.core.numbers import Integer, Rational, pi, I
 from sympy.core.parameters import global_parameters
 from sympy.core.power import Pow
-from sympy.core.relational import Ge
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.core.sympify import sympify

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -605,10 +605,7 @@ def test_lambertw():
     assert LambertW(0) == 0
     assert LambertW(E) == 1
     assert LambertW(-1/E) == -1
-    assert LambertW(100*log(100)) == log(100)
     assert LambertW(-log(2)/2) == -log(2)
-    assert LambertW(81*log(3)) == 3*log(3)
-    assert LambertW(sqrt(E)/2) == S.Half
     assert LambertW(oo) is oo
     assert LambertW(0, 1) is -oo
     assert LambertW(0, 42) is -oo
@@ -630,7 +627,6 @@ def test_lambertw():
     assert LambertW(2, evaluate=False).is_real
     p = Symbol('p', positive=True)
     assert LambertW(p, evaluate=False).is_real
-    assert LambertW(p**(p+1)*log(p)) == p*log(p)
     assert LambertW(p - 1, evaluate=False).is_real is None
     assert LambertW(-p - 2/S.Exp1, evaluate=False).is_real is False
     assert LambertW(S.Half, -1, evaluate=False).is_real is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Backport of #26840 for 1.13 branch

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug that caused `LambertW` to hang on specific inputs.
<!-- END RELEASE NOTES -->
