### PR TITLE
fix(polys): fix DMP.cancel for GF(p) with Flint

### DIFF
--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -151,7 +151,7 @@ class DFM:
     @classmethod
     def _supports_domain(cls, domain):
         """Return True if the given domain is supported by DFM."""
-        return domain in (ZZ, QQ) or domain.is_FF
+        return domain in (ZZ, QQ) or domain.is_FF and domain._is_flint
 
     @classmethod
     def _get_flint_func(cls, domain):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2138,19 +2138,28 @@ class DUP_Flint(DMP):
 
     def _cancel(f, g):
         """Cancel common factors in a rational function ``f/g``. """
+        assert f.dom == g.dom
+        R = f.dom
+
         # Think carefully about how to handle denominators and coefficient
         # canonicalisation if more domains are permitted...
-        assert f.dom == g.dom in (ZZ, QQ)
+        assert R.is_ZZ or R.is_QQ or R.is_FiniteField
 
-        if f.dom.is_QQ:
+        if R.is_FiniteField:
+            h = f._gcd(g)
+            F, G = f.exquo(h), g.exquo(h)
+            return R.one, R.one, F, G
+
+        if R.is_QQ:
             cG, F = f.clear_denoms()
             cF, G = g.clear_denoms()
         else:
-            cG, F = f.dom.one, f
-            cF, G = g.dom.one, g
+            cG, F = R.one, f
+            cF, G = R.one, g
 
-        cH = cF.gcd(cG)
-        cF, cG = cF // cH, cG // cH
+        if R.is_ZZ or R.is_QQ:
+            cH = cF.gcd(cG)
+            cF, cG = cF // cH, cG // cH
 
         H = F._gcd(G)
         F, G = F.exquo(H), G.exquo(H)

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -128,7 +128,7 @@ from sympy.polys.polyerrors import (
 if GROUND_TYPES == 'flint':
     import flint
     def _supported_flint_domain(D):
-        return D.is_ZZ or D.is_QQ or D.is_FF
+        return D.is_ZZ or D.is_QQ or D.is_FF and D._is_flint
 else:
     flint = None
     def _supported_flint_domain(D):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1762,10 +1762,7 @@ class DUP_Flint(DMP):
         elif dom.is_QQ:
             return flint.fmpq_poly
         elif dom.is_FF:
-            if type(dom.one) is flint.nmod:
-                return lambda rep: flint.nmod_poly(rep, dom.characteristic())
-            else:
-                return lambda rep: flint.fmpz_mod_poly(rep, dom.characteristic())
+            return dom._poly_ctx
         else:
             raise RuntimeError("Domain %s is not supported with flint" % dom)
 
@@ -1913,7 +1910,7 @@ class DUP_Flint(DMP):
         return f.from_rep(f._rep // c, f.dom)
 
     def _exquo_ground(f, c):
-        """Exact quotient of ``f`` by a an element of the ground domain. """
+        """Exact quotient of ``f`` by an element of the ground domain. """
         q, r = divmod(f._rep, c)
         if r:
             raise ExactQuotientFailed(f, c)
@@ -2040,14 +2037,20 @@ class DUP_Flint(DMP):
 
     def clear_denoms(f):
         """Clear denominators, but keep the ground domain. """
-        denom = f._rep.denom()
-        numer = f.from_rep(f._cls(f._rep.numer()), f.dom)
-        return denom, numer
+        R = f.dom
+        if R.is_QQ:
+            denom = f._rep.denom()
+            numer = f.from_rep(f._cls(f._rep.numer()), f.dom)
+            return denom, numer
+        elif R.is_ZZ or R.is_FiniteField:
+            return R.one, f
+        else:
+            raise NotImplementedError
 
     def _integrate(f, m=1, j=0):
         """Computes the ``m``-th order indefinite integral of ``f`` in ``x_j``. """
         assert j == 0
-        if f.dom.is_QQ:
+        if f.dom.is_Field:
             rep = f._rep
             for i in range(m):
                 rep = rep.integral()
@@ -2064,6 +2067,10 @@ class DUP_Flint(DMP):
         return f.from_rep(rep, f.dom)
 
     def _eval(f, a):
+        # XXX: This method is called with many different input types. Ideally
+        # we could use e.g. fmpz_poly.__call__ here but more thought needs to
+        # go into which types this is supposed to be called with and what types
+        # it should return.
         return f.to_DMP_Python()._eval(a)
 
     def _eval_lev(f, a, j):
@@ -2082,34 +2089,45 @@ class DUP_Flint(DMP):
 
     def _invert(f, g):
         """Invert ``f`` modulo ``g``, if possible. """
-        if f.dom.is_QQ:
+        R = f.dom
+        if R.is_Field:
             gcd, F_inv, _ = f._rep.xgcd(g._rep)
-            if gcd != 1:
+            # XXX: Should be gcd != 1 but nmod_poly does not compare equal to
+            # other types.
+            if gcd != 0*gcd + 1:
                 raise NotInvertible("zero divisor")
-            return f.from_rep(F_inv, f.dom)
+            return f.from_rep(F_inv, R)
         else:
+            # fmpz_poly does not have xgcd or invert and this is not well
+            # defined in general.
             return f.to_DMP_Python()._invert(g.to_DMP_Python()).to_DUP_Flint()
 
     def _revert(f, n):
         """Compute ``f**(-1)`` mod ``x**n``. """
+        # XXX: Use fmpz_series etc for reversion?
+        # Maybe python-flint should provide revert for fmpz_poly...
         return f.to_DMP_Python()._revert(n).to_DUP_Flint()
 
     def _subresultants(f, g):
         """Computes subresultant PRS sequence of ``f`` and ``g``. """
+        # XXX: Maybe _fmpz_poly_pseudo_rem_cohen could be used...
         R = f.to_DMP_Python()._subresultants(g.to_DMP_Python())
         return [ g.to_DUP_Flint() for g in R ]
 
     def _resultant_includePRS(f, g):
         """Computes resultant of ``f`` and ``g`` via PRS. """
+        # XXX: Maybe _fmpz_poly_pseudo_rem_cohen could be used...
         res, R = f.to_DMP_Python()._resultant_includePRS(g.to_DMP_Python())
         return res, [ g.to_DUP_Flint() for g in R ]
 
     def _resultant(f, g):
         """Computes resultant of ``f`` and ``g``. """
+        # XXX: Use fmpz_mpoly etc when possible...
         return f.to_DMP_Python()._resultant(g.to_DMP_Python())
 
     def discriminant(f):
         """Computes discriminant of ``f``. """
+        # XXX: Use fmpz_mpoly etc when possible...
         return f.to_DMP_Python().discriminant()
 
     def _cofactors(f, g):
@@ -2186,6 +2204,7 @@ class DUP_Flint(DMP):
 
     def monic(f):
         """Divides all coefficients by ``LC(f)``. """
+        # XXX: python-flint should add monic
         return f._exquo_ground(f.LC())
 
     def content(f):
@@ -2254,6 +2273,7 @@ class DUP_Flint(DMP):
 
     def sqf_list(f, all=False):
         """Returns a list of square-free factors of ``f``. """
+        # XXX: python-flint should provide square free factorisation.
         coeff, factors = f.to_DMP_Python().sqf_list(all=all)
         return coeff, [ (g.to_DUP_Flint(), k) for g, k in factors ]
 
@@ -2318,6 +2338,9 @@ class DUP_Flint(DMP):
         return f.to_DMP_Python()._isolate_real_roots_sqf(eps, inf, sup, fast)
 
     def _isolate_all_roots(f, eps, inf, sup, fast):
+        # fmpz_poly and fmpq_poly have a complex_roots method that could be
+        # used here. It probably makes more sense to add analogous methods in
+        # python-flint though.
         return f.to_DMP_Python()._isolate_all_roots(eps, inf, sup, fast)
 
     def _isolate_all_roots_sqf(f, eps, inf, sup, fast):
@@ -2362,7 +2385,8 @@ class DUP_Flint(DMP):
     @property
     def is_monomial(f):
         """Returns ``True`` if ``f`` is zero or has only one term. """
-        return f.to_DMP_Python().is_monomial
+        fr = f._rep
+        return fr.degree() < 0 or not any(fr[n] for n in range(fr.degree()))
 
     @property
     def is_monic(f):
@@ -2382,20 +2406,33 @@ class DUP_Flint(DMP):
     @property
     def is_sqf(f):
         """Returns ``True`` if ``f`` is a square-free polynomial. """
-        return f.to_DMP_Python().is_sqf
+        g = f._rep.gcd(f._rep.derivative())
+        return g.degree() <= 0
 
     @property
     def is_irreducible(f):
         """Returns ``True`` if ``f`` has no factors over its domain. """
-        return f.to_DMP_Python().is_irreducible
+        _, factors = f._rep.factor()
+        if len(factors) == 0:
+            return True
+        elif len(factors) == 1:
+            return factors[0][1] == 1
+        else:
+            return False
 
     @property
     def is_cyclotomic(f):
         """Returns ``True`` if ``f`` is a cyclotomic polynomial. """
+        if f.dom.is_QQ:
+            try:
+                f = f.convert(ZZ)
+            except CoercionFailed:
+                return False
         if f.dom.is_ZZ:
             return bool(f._rep.is_cyclotomic())
         else:
-            return f.to_DMP_Python().is_cyclotomic
+            # This is what dup_cyclotomic_p does...
+            return False
 
 
 def init_normal_DMF(num, den, lev, dom):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2157,9 +2157,8 @@ class DUP_Flint(DMP):
             cG, F = R.one, f
             cF, G = R.one, g
 
-        if R.is_ZZ or R.is_QQ:
-            cH = cF.gcd(cG)
-            cF, cG = cF // cH, cG // cH
+        cH = cF.gcd(cG)
+        cF, cG = cF // cH, cG // cH
 
         H = F._gcd(G)
         F, G = F.exquo(H), G.exquo(H)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3405,6 +3405,12 @@ def test_cancel():
     assert cancel((x**2 + 1)/(x - I)) == x + I
 
 
+def test_cancel_modulus():
+    assert cancel((x**2 - 1)/(x + 1), modulus=2) == x + 1
+    assert Poly(x**2 - 1, modulus=2).cancel(Poly(x + 1, modulus=2)) ==\
+            (1, Poly(x + 1, modulus=2), Poly(1, x, modulus=2))
+
+
 def test_make_monic_over_integers_by_scaling_roots():
     f = Poly(x**2 + 3*x + 4, x, domain='ZZ')
     g, c = f.make_monic_over_integers_by_scaling_roots()

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -445,6 +445,9 @@ def test_Poly__new__():
         Poly(3*x**5 + 65536*x**4 + x**3 + 65536*x** 2 + 1, x,
              modulus=65537, symmetric=False)
 
+    N = 10**100
+    assert Poly(-1, x, modulus=N, symmetric=False).as_expr() == N - 1
+
     assert isinstance(Poly(x**2 + x + 1.0).get_domain(), RealField)
     assert isinstance(Poly(x**2 + x + I + 1.0).get_domain(), ComplexField)
 
@@ -1540,6 +1543,10 @@ def test_Poly_clear_denoms():
     coeff, poly = Poly(x/2 + 1, x).clear_denoms()
     assert coeff == 2 and poly == Poly(
         x + 2, x, domain='QQ') and poly.get_domain() == QQ
+
+    coeff, poly = Poly(2*x**2 + 3, modulus=5).clear_denoms()
+    assert coeff == 1 and poly == Poly(
+        2*x**2 + 3, x, modulus=5) and poly.get_domain() == FF(5)
 
     coeff, poly = Poly(x/2 + 1, x).clear_denoms(convert=True)
     assert coeff == 2 and poly == Poly(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-26804

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
