### PR TITLE
fixing bug in simplify_logic

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1007,6 +1007,7 @@ Mihir Wadwekar <m.mihirw@gmail.com>
 Mike Boyle <boyle@astro.cornell.edu>
 Mikel Rouco <mikel.mrm@gmail.com>
 Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.noreply.github.com>
+Mikoláš Janota <mikolas.janota@gmail.com>
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #26847

#### Brief description of what is fixed or changed

The original code assumes that is underscore zero is either true or false but it can be none come up which results in incorrect simplifications. For example `print(Eq(f(1), x * f(0)).simplify(rational=True, doit=False))` sets `f(1)` to `0`.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
     * Corrected a semantical error in the expression simplification.
<!-- END RELEASE NOTES -->
