### PR TITLE
Fix reference

### DIFF
--- a/doc/src/guides/solving/solve-diophantine-equation.md
+++ b/doc/src/guides/solving/solve-diophantine-equation.md
@@ -1,4 +1,5 @@
-(solving-guide-diophantine)=
+<!-- (solving-guide-diophantine)= -->
+.. _solving-guide-diophantine:
 # Solve a Diophantine Equation Algebraically
 
 Use SymPy to solve a [Diophantine

--- a/doc/src/guides/solving/solve-diophantine-equation.md
+++ b/doc/src/guides/solving/solve-diophantine-equation.md
@@ -1,6 +1,10 @@
 <!-- (solving-guide-diophantine)= -->
-.. _solving-guide-diophantine:
-# Solve a Diophantine Equation Algebraically
+# [solving-guide-diophantine](https://github.com/sympy/sympy/blob/master/doc/src/guides/solving/solve-diophantine-equation.md)
+
+## Solve a Diophantine Equation Algebraically
+
+Use SymPy to solve a Diophantine equation (find integer solutions to a polynomial equation) :ref:`solving-guide-diophantine`.
+
 
 Use SymPy to solve a [Diophantine
 equation](https://en.wikipedia.org/wiki/Diophantine_equation) (find integer


### PR DESCRIPTION
Fix broken link to Diophantine solver guide

Updated the link in doc/src/modules/solvers/diophantine to point to the correct guide at https://github.com/sympy/sympy/blob/master/doc/src/guides/solving/solve-diophantine-equation.md.