### PR TITLE
refactor(polys): Use mpmath mpf for RR and CC

### DIFF
--- a/doc/src/modules/polys/domainsintro.rst
+++ b/doc/src/modules/polys/domainsintro.rst
@@ -604,16 +604,16 @@ fields but this is not yet available in SymPy (contributions welcome!).
 Real and complex fields
 =======================
 
-The fields :ref:`RR` and :ref:`CC` are intended mathematically to correspond
-to the `reals`_ and the `complex numbers`_, `\mathbb{R}` and `\mathbb{C}`
+The fields :ref:`RR` and :ref:`CC` are intended mathematically to correspond to
+the `reals`_ and the `complex numbers`_, `\mathbb{R}` and `\mathbb{C}`
 respectively. The implementation of these uses floating point arithmetic. In
 practice this means that these are the domains that are used to represent
 expressions containing floats. Elements of :ref:`RR` are instances of the
-class :py:class:`~.RealElement` and have an ``mpf`` tuple which is used to
-represent a float in ``mpmath``. Elements of :ref:`CC` are instances of
-:py:class:`~.ComplexElement` and have an ``mpc`` tuple which is a pair of
-``mpf`` tuples representing the real and imaginary parts. See the
-`mpmath docs`_ for more about how floating point numbers are represented::
+``mpmath`` class ``mpf`` and have an ``_mpf_`` tuple which is how arbitrary
+floating point real numbers are represented in ``mpmath``. Elements of
+:ref:`CC` are instances of ``mpc`` and have an ``_mpc_`` tuple which is a pair
+of ``_mpf_`` tuples representing the real and imaginary parts. See the `mpmath
+docs`_ for more about how floating point numbers are represented::
 
   >>> from sympy import RR, CC
   >>> xr = RR(3)
@@ -641,7 +641,7 @@ The default domains :ref:`RR` and :ref:`CC` use 53 binary digits of precision
 much like standard `double precision`_ floating point which corresponds to
 approximately 15 decimal digits::
 
-  >>> from sympy.polys.domains.realfield import RealField
+  >>> from sympy import RealField
   >>> RR.precision
   53
   >>> RR.dps
@@ -649,25 +649,12 @@ approximately 15 decimal digits::
   >>> RR(1) / RR(3)
   0.333333333333333
   >>> RR100 = RealField(100)
-  >>> RR100.precision
+  >>> RR100.precision   # precision in binary bits
   100
-  >>> RR100.dps
+  >>> RR100.dps         # precision in decimal places
   29
   >>> RR100(1) / RR100(3)
   0.33333333333333333333333333333
-
-There is however a bug in the implementation of this so that actually a global
-precision setting is used by all :py:class:`~.RealElement`. This means that
-just creating ``RR100`` above has altered the global precision and we will
-need to restore it in the doctest here::
-
-  >>> RR(1) / RR(3)  # wrong result!
-  0.33333333333333333333333333333
-  >>> dummy = RealField(53)  # hack to restore precision
-  >>> RR(1) / RR(3)  # restored
-  0.333333333333333
-
-(Obviously that should be fixed!)
 
 .. _reals: https://en.wikipedia.org/wiki/Real_number
 .. _complex numbers: https://en.wikipedia.org/wiki/Complex_number

--- a/doc/src/modules/polys/domainsref.rst
+++ b/doc/src/modules/polys/domainsref.rst
@@ -255,9 +255,6 @@ RR
 .. autoclass:: RealField
    :members:
 
-.. autoclass:: sympy.polys.domains.mpelements.RealElement
-   :members:
-
 .. _CC:
 
 
@@ -265,9 +262,6 @@ CC
 ==
 
 .. autoclass:: ComplexField
-   :members:
-
-.. autoclass:: sympy.polys.domains.mpelements.ComplexElement
    :members:
 
 .. _K[x]:

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -6,10 +6,12 @@ from sympy.core.numbers import Float, I
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.gaussiandomains import QQ_I
-from sympy.polys.domains.mpelements import MPContext
 from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.polyerrors import DomainError, CoercionFailed
 from sympy.utilities import public
+
+from mpmath import MPContext
+
 
 @public
 class ComplexField(Field, CharacteristicZero, SimpleDomain):
@@ -41,16 +43,32 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
 
     @property
     def tolerance(self):
-        return self._context.tolerance
+        return self._tolerance
 
-    def __init__(self, prec=_default_precision, dps=None, tol=None):
-        context = MPContext(prec, dps, tol, False)
-        context._parent = self
+    def __init__(self, prec=None, dps=None, tolerance=None):
+        # XXX: The tolerance parameter is ignored but is kept for backward
+        # compatibility for now.
+
+        context = MPContext()
+
+        if prec is None and dps is None:
+            context.prec = self._default_precision
+        elif dps is None:
+            context.prec = prec
+        elif prec is None:
+            context.dps = dps
+        else:
+            raise TypeError("Cannot set both prec and dps")
+
         self._context = context
 
         self._dtype = context.mpc
         self.zero = self.dtype(0)
         self.one = self.dtype(1)
+
+        # XXX: Neither of these is actually used anywhere.
+        self._max_denom = max(2**context.prec // 200, 99)
+        self._tolerance = self.one / self._max_denom
 
     @property
     def tp(self):
@@ -71,12 +89,10 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         return self._dtype(x, y)
 
     def __eq__(self, other):
-        return (isinstance(other, ComplexField)
-           and self.precision == other.precision
-           and self.tolerance == other.tolerance)
+        return isinstance(other, ComplexField) and self.precision == other.precision
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self._dtype, self.precision, self.tolerance))
+        return hash((self.__class__.__name__, self._dtype, self.precision))
 
     def to_sympy(self, element):
         """Convert ``element`` to SymPy number. """

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -433,7 +433,15 @@ class Domain:
             return self.convert_from(parent(element), parent)
 
         if isinstance(element, complex):
-            parent = ComplexField(tol=False)
+            parent = ComplexField()
+            return self.convert_from(parent(element), parent)
+
+        if type(element).__name__ == 'mpf':
+            parent = RealField()
+            return self.convert_from(parent(element), parent)
+
+        if type(element).__name__ == 'mpc':
+            parent = ComplexField()
             return self.convert_from(parent(element), parent)
 
         if isinstance(element, DomainElement):

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -429,7 +429,7 @@ class Domain:
                 return self.convert_from(element, QQ)
 
         if isinstance(element, float):
-            parent = RealField(tol=False)
+            parent = RealField()
             return self.convert_from(parent(element), parent)
 
         if isinstance(element, complex):
@@ -772,14 +772,17 @@ class Domain:
 
         def mkinexact(cls, K0, K1):
             prec = max(K0.precision, K1.precision)
-            tol = max(K0.tolerance, K1.tolerance)
-            return cls(prec=prec, tol=tol)
+            return cls(prec=prec)
 
         if K1.is_ComplexField:
             K0, K1 = K1, K0
         if K0.is_ComplexField:
             if K1.is_ComplexField or K1.is_RealField:
-                return mkinexact(K0.__class__, K0, K1)
+                if K0.precision >= K1.precision:
+                    return K0
+                else:
+                    from sympy.polys.domains.complexfield import ComplexField
+                    return ComplexField(prec=K1.precision)
             else:
                 return K0
 
@@ -787,10 +790,13 @@ class Domain:
             K0, K1 = K1, K0
         if K0.is_RealField:
             if K1.is_RealField:
-                return mkinexact(K0.__class__, K0, K1)
+                if K0.precision >= K1.precision:
+                    return K0
+                else:
+                    return K1
             elif K1.is_GaussianRing or K1.is_GaussianField:
                 from sympy.polys.domains.complexfield import ComplexField
-                return ComplexField(prec=K0.precision, tol=K0.tolerance)
+                return ComplexField(prec=K0.precision)
             else:
                 return K0
 

--- a/sympy/polys/domains/mpelements.py
+++ b/sympy/polys/domains/mpelements.py
@@ -1,3 +1,7 @@
+#
+# This module is deprecated and should not be used any more. The actual
+# implementation of RR and CC now uses mpmath's mpf and mpc types directly.
+#
 """Real and complex elements. """
 
 

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -1,14 +1,54 @@
 """Implementation of :class:`RealField` class. """
 
 
-from sympy.external.gmpy import SYMPY_INTS
+from sympy.external.gmpy import SYMPY_INTS, MPQ
 from sympy.core.numbers import Float
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
-from sympy.polys.domains.mpelements import MPContext
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
+
+from mpmath import MPContext
+from mpmath.libmp import to_rational as _mpmath_to_rational
+
+
+def to_rational(s, max_denom, limit=True):
+
+    p, q = _mpmath_to_rational(s._mpf_)
+
+    # Needed for GROUND_TYPES=flint if gmpy2 is installed because mpmath's
+    # to_rational() function returns a gmpy2.mpz instance and if MPQ is
+    # flint.fmpq then MPQ(p, q) will fail.
+    p = int(p)
+
+    if not limit or q <= max_denom:
+        return p, q
+
+    p0, q0, p1, q1 = 0, 1, 1, 0
+    n, d = p, q
+
+    while True:
+        a = n//d
+        q2 = q0 + a*q1
+        if q2 > max_denom:
+            break
+        p0, q0, p1, q1 = p1, q1, p0 + a*p1, q2
+        n, d = d, n - a*d
+
+    k = (max_denom - q0)//q1
+
+    number = MPQ(p, q)
+    bound1 = MPQ(p0 + k*p1, q0 + k*q1)
+    bound2 = MPQ(p1, q1)
+
+    if not bound2 or not bound1:
+        return p, q
+    elif abs(bound2 - number) <= abs(bound1 - number):
+        return bound2.numerator, bound2.denominator
+    else:
+        return bound1.numerator, bound1.denominator
+
 
 @public
 class RealField(Field, CharacteristicZero, SimpleDomain):
@@ -41,16 +81,33 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
 
     @property
     def tolerance(self):
-        return self._context.tolerance
+        return self._tolerance
 
-    def __init__(self, prec=_default_precision, dps=None, tol=None):
-        context = MPContext(prec, dps, tol, True)
-        context._parent = self
+    def __init__(self, prec=None, dps=None, tolerance=None):
+        # XXX: The tolerance parameter is ignored but is kept for now for
+        # backwards compatibility.
+
+        context = MPContext()
+
+        if prec is None and dps is None:
+            context.prec = self._default_precision
+        elif dps is None:
+            context.prec = prec
+        elif prec is None:
+            context.dps = dps
+        else:
+            raise TypeError("Cannot set both prec and dps")
+
         self._context = context
 
         self._dtype = context.mpf
         self.zero = self.dtype(0)
         self.one = self.dtype(1)
+
+        # Only max_denom here is used for anything and is only used for
+        # to_rational.
+        self._max_denom = max(2**context.prec // 200, 99)
+        self._tolerance = self.one / self._max_denom
 
     @property
     def tp(self):
@@ -69,12 +126,10 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
         return self._dtype(arg)
 
     def __eq__(self, other):
-        return (isinstance(other, RealField)
-           and self.precision == other.precision
-           and self.tolerance == other.tolerance)
+        return isinstance(other, RealField) and self.precision == other.precision
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self._dtype, self.precision, self.tolerance))
+        return hash((self.__class__.__name__, self._dtype, self.precision))
 
     def to_sympy(self, element):
         """Convert ``element`` to SymPy number. """
@@ -126,7 +181,7 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
 
     def to_rational(self, element, limit=True):
         """Convert a real number to rational number. """
-        return self._context.to_rational(element, limit)
+        return to_rational(element, self._max_denom, limit=limit)
 
     def get_ring(self):
         """Returns a ring associated with ``self``. """

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1281,11 +1281,6 @@ def test_canonical_unit():
     assert (K.one + i)/(i - K.one) == -i
 
 
-def test_issue_18278():
-    assert str(RR(2).parent()) == 'RR'
-    assert str(CC(2).parent()) == 'CC'
-
-
 def test_Domain_is_negative():
     I = S.ImaginaryUnit
     a, b = [CC.convert(x) for x in (2 + I, 5)]


### PR DESCRIPTION
Remove the MPElement subclasses of mpmath's mpf and mpc and SymPy's custom MPContext subclass. This means that RR and CC only use mpmath's public interface.

This also fixes a bug where all RealField domains share a global precision.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The RR and CC domains now use mpmath's mpf and mpc types directly rather than making custom subclasses of mpf, mpc and PythonMPContext. This ensures that only mpmath's public interface is used. This also means that elements of RR and CC no longer have a `.parent` attribute (as is also the case for ZZ , QQ and GF(p)). A bug causing all RealField domains to share a global precision setting was also fixed. The tolerance parameter of RealField and ComplexField is also removed.
    * BREAKING CHANGE: The elements of RR and CC no longer have a `.parent()` method. This is because they are no plain mpmath `mpf` and `mpc` instances rather than subclasses.
<!-- END RELEASE NOTES -->
