### PR TITLE
[PDF] Improve TOC and Index

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -389,7 +389,7 @@ latex_elements = {
 \renewcommand{\@tocrmarg}{3.5em}%  default is 2.55em
 \makeatother
 ''',
-    'printindex': r'\footnotesize\raggedright\printindex',
+    'printindex': r'\def\twocolumn[#1]{#1}\raggedright\printindex',
 }
 
 # SymPy logo on title page

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -383,7 +383,13 @@ latex_elements = {
     'inputenc':  '',
     'utf8extra': '',
     'preamble':  r'''
-'''
+% increase room on TOC page for page numbers going into the thousands
+\makeatletter
+\renewcommand{\@pnumwidth}{2.5em}% default is 1.55em
+\renewcommand{\@tocrmarg}{3.5em}%  default is 2.55em
+\makeatother
+''',
+    'printindex': r'\footnotesize\raggedright\printindex',
 }
 
 # SymPy logo on title page


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



#### Brief description of what is fixed or changed

Avoid page numbers like this in TOC from PDF:

![Capture d’écran 2024-07-27 à 13 27 13](https://github.com/user-attachments/assets/d7076609-8a2d-4fdf-8227-4b95b65d80c4)

or like this

![Capture d’écran 2024-07-27 à 13 27 21](https://github.com/user-attachments/assets/a061e291-968f-4d02-b91c-45670080687e)

and try to avoid (untested because I did not build the PDF docs locally; but we do use that for our (Sphinx) own docs) things like that in index:

![Capture d’écran 2024-07-27 à 13 29 33](https://github.com/user-attachments/assets/4e57f1cd-9967-4672-928e-7f9af055d8df)

Not sure the index will be free of all such glitches but it can only improve it.

Screenshots on 1.13.1 PDF docs as available today.

#### Other comments

None

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
