### PR TITLE
[DOC] [PDF] Fix the way PDF build is set to use xelatex

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -757,6 +757,7 @@ Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
+Jean-François B <2589111+jfbu@users.noreply.github.com>
 Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>
 Jeffrey Ryan <jeffaryan7@gmail.com>
 Jennifer White <jcrw122@googlemail.com>

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -102,7 +102,7 @@ htmlhelp:
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
 latex: logo
-	mkdir -p $(BUILDDIR)/latex $(BUILDDIR)/doctrees
+	mkdir -p $(BUILDDIR)/latex $(BUILDDIR)/doctrees-latex
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTSlatex) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,8 @@ RST2HTML     = rst2html
 SPHINXOPTS   =
 SPHINXVER    = 0.5
 SPHINXBUILD  = sphinx-build
-PAPER        =
+# This one can also be set in the environment
+PAPER        ?= letter
 BUILDDIR     = _build
 SOURCEDIR    = src
 LIVEHOST     = localhost
@@ -24,7 +25,7 @@ ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees $(SPHINXOPTS)
 WARNINGSFILE = $(BUILDDIR)/.sphinx-warnings
 SPHINXSAVEWARNINGS = -w $(WARNINGSFILE)
 ALLSPHINXOPTSapi = -d $(BUILDDIR)/doctrees-api $(SPHINXOPTS) api
-ALLSPHINXOPTSlatex = -d $(BUILDDIR)/doctrees-latex -D latex_element.papersize=$(PAPER)paper \
+ALLSPHINXOPTSlatex = -d $(BUILDDIR)/doctrees-latex -D latex_elements.papersize=$(PAPER)paper \
                 $(SPHINXOPTS) src
 
 .PHONY: changes cheatsheet clean help html _html htmlapi htmlhelp info latex \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,10 +17,6 @@ LIVEPORT     = 0
 SVGFILES = $(wildcard src/modules/physics/vector/*.svg) $(wildcard src/modules/physics/mechanics/examples/*.svg) $(wildcard src/modules/vector/*.svg)
 PDFFILES = $(SVGFILES:%.svg=%.pdf)
 
-# This must be set for the recursive make pdf build to work in make latexpdf
-export LATEXMKOPTS = -halt-on-error -xelatex
-
-
 ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees $(SPHINXOPTS)
 WARNINGSFILE = $(BUILDDIR)/.sphinx-warnings
 SPHINXSAVEWARNINGS = -w $(WARNINGSFILE)
@@ -110,11 +106,13 @@ latex: logo
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTSlatex) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
-	@echo "Set the environment variable LATEXMKOPTS='-xelatex -silent'"
-	@echo "And run \`make all' in that directory to run these through xelatex."
+	@echo "Run \`make all' in that directory to run these through xelatex."
 
 pdf pdflatex latexpdf: latex
-	$(MAKE) -C $(BUILDDIR)/latex
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf \
+	LATEXOPTS="-halt-on-error -interaction=batchmode" \
+	LATEXMKOPTS="-xelatex" \
+	|| echo "LaTeX error"'!'" Check .log in $(BUILDDIR)/latex for lineno in .tex file."
 
 changes:
 	mkdir -p $(BUILDDIR)/changes $(BUILDDIR)/doctrees

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -105,7 +105,7 @@ htmlhelp:
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-latex:
+latex: logo
 	mkdir -p $(BUILDDIR)/latex $(BUILDDIR)/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTSlatex) $(BUILDDIR)/latex
 	@echo

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -109,7 +109,7 @@ latex: logo
 	@echo "Run \`make all' in that directory to run these through xelatex."
 
 pdf pdflatex latexpdf: latex
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf \
+	@$(MAKE) -C $(BUILDDIR)/latex all-pdf \
 	LATEXOPTS="-halt-on-error -interaction=batchmode" \
 	LATEXMKOPTS="-xelatex" \
 	|| echo "LaTeX error"'!'" Check .log in $(BUILDDIR)/latex for lineno in .tex file."

--- a/doc/aptinstall.sh
+++ b/doc/aptinstall.sh
@@ -18,8 +18,6 @@ sudo apt-get install\
   texlive-fonts-recommended\
   texlive-fonts-extra\
   texlive-xetex\
-  xindy\
-  xindy-rules\
   latexmk\
   dvipng\
   librsvg2-bin\

--- a/doc/aptinstall.sh
+++ b/doc/aptinstall.sh
@@ -18,6 +18,8 @@ sudo apt-get install\
   texlive-fonts-recommended\
   texlive-fonts-extra\
   texlive-xetex\
+  xindy\
+  xindy-rules\
   latexmk\
   dvipng\
   librsvg2-bin\

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -375,7 +375,8 @@ latex_elements = {
 ''',
     'preamble':  r'''
 % Define version of \LaTeX that is usable in math mode
-\let\OldLaTeX\LaTeX
+\usepackage{letltxmacro}
+\LetLtxMacro\OldLaTeX\LaTeX
 \renewcommand{\LaTeX}{\text{\OldLaTeX}}
 '''
 }

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -364,6 +364,7 @@ latex_documents = [('index', 'sympy-%s.tex' % release, 'SymPy Documentation',
 # Additional stuff for the LaTeX preamble.
 # Tweaked to work with XeTeX.
 latex_engine = 'xelatex'
+latex_use_xindy = False
 latex_elements = {
     'babel': r'\usepackage[english]{babel}',
     'fontpkg': r'''

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -363,26 +363,20 @@ latex_documents = [('index', 'sympy-%s.tex' % release, 'SymPy Documentation',
 
 # Additional stuff for the LaTeX preamble.
 # Tweaked to work with XeTeX.
+latex_engine = 'xelatex'
 latex_elements = {
-    'babel':     '',
-    'fontenc': r'''
-% Define version of \LaTeX that is usable in math mode
-\let\OldLaTeX\LaTeX
-\renewcommand{\LaTeX}{\text{\OldLaTeX}}
-
+    'babel': r'\usepackage[english]{babel}',
+    'fontpkg': r'''
 \usepackage{bm}
-\usepackage{amssymb}
-\usepackage{fontspec}
-\usepackage[english]{babel}
 \defaultfontfeatures{Mapping=tex-text}
 \setmainfont{DejaVu Serif}
 \setsansfont{DejaVu Sans}
 \setmonofont{DejaVu Sans Mono}
 ''',
-    'fontpkg':   '',
-    'inputenc':  '',
-    'utf8extra': '',
     'preamble':  r'''
+% Define version of \LaTeX that is usable in math mode
+\let\OldLaTeX\LaTeX
+\renewcommand{\LaTeX}{\text{\OldLaTeX}}
 '''
 }
 

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -362,14 +362,10 @@ latex_documents = [('index', 'sympy-%s.tex' % release, 'SymPy Documentation',
                     'SymPy Development Team', 'manual', True)]
 
 # Additional stuff for the LaTeX preamble.
-# Tweaked to work with XeTeX.
 latex_engine = 'xelatex'
 latex_use_xindy = False
 latex_elements = {
-    'babel': r'\usepackage[english]{babel}',
     'fontpkg': r'''
-\usepackage{bm}
-\defaultfontfeatures{Mapping=tex-text}
 \setmainfont{DejaVu Serif}
 \setsansfont{DejaVu Sans}
 \setmonofont{DejaVu Sans Mono}

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -377,7 +377,7 @@ latex_elements = {
 % Define version of \LaTeX that is usable in math mode
 \usepackage{letltxmacro}
 \LetLtxMacro\OldLaTeX\LaTeX
-\renewcommand{\LaTeX}{\text{\OldLaTeX}}
+\AtBeginDocument{\DeclareRobustCommand{\LaTeX}{\text{\OldLaTeX}}}
 '''
 }
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The current way of using `xelatex` is wrong.  The `latex_engine` configuration value should be used. Else the Makefile put by Sphinx in builddir will be wrong and also the latexmkrc file setting for the Latexmk configuration.

The advice in doc/Makefile to use `LATEXMKOPTS='-xelatex -silent'` can be kept unchanged but is now only optional as the build will proceed with `xelatex` even without `-xelatex` (and anyhow it can not use anything else even prior to this PR). So the advice has value only about `-silent` now and one could (should?) redo the rules for `latexpdf` target to actually do the `make all-pdf` in builddir.

Setting `latex_engine` correctly avoids Sphinx putting in produced `.tex` file loading of packages such as `inputenc` which are irrelevant to `xelatex` and such extra packages may cause breakage in future depending on LaTeX installation, better to proceed only Sphinx docs instructions.


#### Other comments

The ``\defaultfontfeatures{Mapping=tex-text}`` line should probably be removed.  First it makes it incompatible to switching latex_engine to `'lualatex'`(syntax `Ligatures=TeX` should be used)) second the default Sphinx configuration has issued ``\defaultfontfeatures[\rmfamily,\sffamily,\ttfamily]{}`` for a reason, although perhaps here it is not important due to DejaVu font (untested).

For Sphinx related discussion see
[sphinx-doc/sphinx/pull/6888](https://github.com/sphinx-doc/sphinx/pull/6888)

The `latex_engine` configuration value was added at Sphinx Release 1.5 (released Dec 5, 2016).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
