### PR TITLE
fix(polys): cleanup after gh-26861

### DIFF
--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -45,7 +45,7 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
     def tolerance(self):
         return self._tolerance
 
-    def __init__(self, prec=None, dps=None, tolerance=None):
+    def __init__(self, prec=None, dps=None, tol=None):
         # XXX: The tolerance parameter is ignored but is kept for backward
         # compatibility for now.
 
@@ -72,10 +72,10 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
 
     @property
     def tp(self):
-        # XXX: Domain treats tp as an alis of dtype. Here we need to two
-        # separate things: dtype is a callable to make/convert instances.
-        # We use tp with isinstance to check if an object is an instance
-        # of the domain already.
+        # XXX: Domain treats tp as an alias of dtype. Here we need two separate
+        # things: dtype is a callable to make/convert instances. We use tp with
+        # isinstance to check if an object is an instance of the domain
+        # already.
         return self._dtype
 
     def dtype(self, x, y=0):

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -778,10 +778,6 @@ class Domain:
         if K0.is_Composite or K1.is_Composite:
             return K0.unify_composite(K1)
 
-        def mkinexact(cls, K0, K1):
-            prec = max(K0.precision, K1.precision)
-            return cls(prec=prec)
-
         if K1.is_ComplexField:
             K0, K1 = K1, K0
         if K0.is_ComplexField:

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -83,9 +83,9 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
     def tolerance(self):
         return self._tolerance
 
-    def __init__(self, prec=None, dps=None, tolerance=None):
-        # XXX: The tolerance parameter is ignored but is kept for now for
-        # backwards compatibility.
+    def __init__(self, prec=None, dps=None, tol=None):
+        # XXX: The tol parameter is ignored but is kept for now for backwards
+        # compatibility.
 
         context = MPContext()
 


### PR DESCRIPTION
The tol parameter of RealField and ComplexField was accidentally renamed in gh-26861. This commit restores the names of the parameters and removes the no longer needed mkinexact function.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
