### PR TITLE
fix(printer) Add isnan and isinf support for tensorflow printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1675,3 +1675,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Zexuan Zhou <zzx498636727@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1675,4 +1675,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Zexuan Zhou <zzx498636727@gmail.com>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1675,3 +1675,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -1,3 +1,5 @@
+import sympy.codegen
+import sympy.codegen.cfunctions
 from sympy.external.importtools import version_tuple
 from collections.abc import Iterable
 
@@ -202,6 +204,12 @@ class TensorflowPrinter(ArrayPrinter, AbstractPythonCodePrinter):
         for subexpr in expr.args:
             ret.append(self._print(subexpr))
         return "\n".join(ret)
+
+    def _print_isnan(self, exp):
+        return f'tensorflow.math.is_nan({self._print(*exp.args)})'
+
+    def _print_isinf(self, exp):
+        return f'tensorflow.math.is_inf({self._print(*exp.args)})'
 
     _module = "tensorflow"
     _einsum = "linalg.einsum"

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -1,6 +1,7 @@
 import random
 from sympy.core.function import Derivative
 from sympy.core.symbol import symbols
+from sympy import Piecewise
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, \
     PermuteDims, ArrayDiagonal
 from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
@@ -9,6 +10,7 @@ from sympy.functions import \
     Abs, ceiling, exp, floor, sign, sin, asin, sqrt, cos, \
     acos, tan, atan, atan2, cosh, acosh, sinh, asinh, tanh, atanh, \
     re, im, arg, erf, loggamma, log
+from sympy.codegen.cfunctions import isnan, isinf
 from sympy.matrices import Matrix, MatrixBase, eye, randMatrix
 from sympy.matrices.expressions import \
     Determinant, HadamardProduct, Inverse, MatrixSymbol, Trace
@@ -463,3 +465,27 @@ def test_tensorflow_Derivative():
     expr = Derivative(sin(x), x)
     assert tensorflow_code(expr) == \
         "tensorflow.gradients(tensorflow.math.sin(x), x)[0]"
+
+def test_tensorflow_isnan_isinf():
+
+    # Test for isnan
+    x = symbols("x")
+    # Return 0 if x is of nan value, and 1 otherwise
+    expression = Piecewise((0.0, isnan(x)), (1.0, True))
+    printed_code = tensorflow_code(expression)
+    expected_printed_code = "tensorflow.where(tensorflow.math.is_nan(x), 0.0, 1.0)"
+    assert tensorflow_code(expression) == expected_printed_code, f"Incorrect printed result {printed_code}, expected {expected_printed_code}"
+    for _input, _expected in [(float('nan'), 0.0), (float('inf'), 1.0), (float('-inf'), 1.0), (1.0, 1.0)]:
+        _output = lambdify((x), expression, modules="tensorflow")(x=tf.constant([_input]))
+        assert (_output == _expected).numpy().all()
+
+    # Test for isinf
+    x = symbols("x")
+    # Return 0 if x is of nan value, and 1 otherwise
+    expression = Piecewise((0.0, isinf(x)), (1.0, True))
+    printed_code = tensorflow_code(expression)
+    expected_printed_code = "tensorflow.where(tensorflow.math.is_inf(x), 0.0, 1.0)"
+    assert tensorflow_code(expression) == expected_printed_code, f"Incorrect printed result {printed_code}, expected {expected_printed_code}"
+    for _input, _expected in [(float('inf'), 0.0), (float('-inf'), 0.0), (float('nan'), 1.0), (1.0, 1.0)]:
+        _output = lambdify((x), expression, modules="tensorflow")(x=tf.constant([_input]))
+        assert (_output == _expected).numpy().all()

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -467,6 +467,8 @@ def test_tensorflow_Derivative():
         "tensorflow.gradients(tensorflow.math.sin(x), x)[0]"
 
 def test_tensorflow_isnan_isinf():
+    if not tf:
+        skip("TensorFlow not installed")
 
     # Test for isnan
     x = symbols("x")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
A further improvement for the fix #26784. Specifically to address this [comment](https://github.com/sympy/sympy/issues/26784#issuecomment-2237483117)


#### Brief description of what is fixed or changed
Add isnan and isinf support for tensorflow printer


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- printing
  - Add `_print_isnan` and `_print_isinf` in TensorflowPrinter.

<!-- END RELEASE NOTES -->
