### PR TITLE
fix(printer) Add isnan and isinf support for tensorflow printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1555,6 +1555,7 @@ Zamrath Nizam <zamiguy_ni@yahoo.com> <zamiguy.ni@gmail.com>
 Zaz Brown <zazbrown@zazbrown.com>
 Zedmat <104870914+harshkasat@users.noreply.github.com>
 Zeel Shah <kshah215@gmail.com>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>
 Zhenxu Zhu <xzdlj@outlook.com> xzdlj <xzdlj@outlook.com>
 Zhi-Qiang Zhou <zzq_890709@hotmail.com> zhouzq-thu <zzq_890709@hotmail.com>
 Zhongshi <zj495@nyu.edu>
@@ -1675,4 +1676,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Zexuan Zhou (Bruce) <zzx498636727@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1675,3 +1675,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -1,3 +1,5 @@
+import sympy.codegen
+import sympy.codegen.cfunctions
 from sympy.external.importtools import version_tuple
 from collections.abc import Iterable
 
@@ -202,6 +204,12 @@ class TensorflowPrinter(ArrayPrinter, AbstractPythonCodePrinter):
         for subexpr in expr.args:
             ret.append(self._print(subexpr))
         return "\n".join(ret)
+
+    def _print_isnan(self, exp):
+        return f'tensorflow.math.is_nan({self._print(*exp.args)})'
+
+    def _print_isinf(self, exp):
+        return f'tensorflow.math.is_inf({self._print(*exp.args)})'
 
     _module = "tensorflow"
     _einsum = "linalg.einsum"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
A further improvement for the fix #26784. Specifically to address this [comment](https://github.com/sympy/sympy/issues/26784#issuecomment-2237483117)


#### Brief description of what is fixed or changed
Add isnan and isinf support for tensorflow printer


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- printing
  - Add `_print_isnan` and `_print_isinf` in TensorflowPrinter.

<!-- END RELEASE NOTES -->
