### PR TITLE
TensMul: prevent dummy index conflicts when calling subs

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4286,6 +4286,21 @@ class TensMul(TensExpr, AssocOp):
                 exclude.update(get_indices(new_renamed))
         return newrule
 
+    def _eval_subs(self, old, new):
+        """
+        If new is an index which is already present in self as a dummy, the dummies in self should be renamed.
+        """
+
+        if not isinstance(new, TensorIndex):
+            return None
+
+        exclude = {new}
+        self_renamed = self._dedupe_indices(self, exclude)
+        if self_renamed is None:
+            return None
+        else:
+            return self_renamed._subs(old, new).doit(deep=False)
+
     def _eval_rewrite_as_Indexed(self, *args, **kwargs):
         from sympy.concrete.summations import Sum
         index_symbols = [i.args[0] for i in self.get_indices()]

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2097,11 +2097,13 @@ def test_TensMul_subs():
     V = TensorHead("V", [R3])
     A = TensorHead("A", [R3, R3])
     C0 = TensorIndex(R3.dummy_name + "_0", R3, True)
+    a = WildTensorIndex("a", R3, ignore_updown=True)
 
     assert ( K(p)*V(r)*K(-p) ).subs({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
     assert ( K(p)*V(r)*K(-p) ).xreplace({V(r): K(q)*K(-q)}) == K(p)*K(q)*K(-q)*K(-p)
     assert ( K(p)*V(r) ).xreplace({p: C0, V(r): K(q)*K(-q)}) == K(C0)*K(q)*K(-q)
     assert ( K(p)*A(q,-q)*K(-p) ).doit() == K(p)*A(q,-q)*K(-p)
+    assert ( K(p)*V(-p) ).replace( K(a), V(a)*V(q)*V(-q) ) == V(p)*V(q)*V(-q)*V(-p)
 
 
 def test_tensorsymmetry():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs -->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

In some cases, calling `subs` on `TensMul` would result in a dummy index conflict.
E.g. (on current master)
```
from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorHead, WildTensorIndex
R3 = TensorIndexType('R3', dim=3)
p, q, r = tensor_indices("p q r", R3)
K = TensorHead("K", [R3])
V = TensorHead("V", [R3])
a = WildTensorIndex("a", R3, ignore_updown=True)

expr = ( K(p)*V(-p) ).replace( K(a), V(a)*V(q)*V(-q) ) #ValueError: Repeated index: R_0
```

This is now fixed by defining a `_eval_subs` method for `TensMul`.

#### Other comments
Suggested reviewers: @Upabjojr 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* tensor
  * Calling `subs` on `TensMul` no longer leads to index conflicts in some cases
<!-- END RELEASE NOTES -->
