### PR TITLE
fix(core): fix pickling of undefined functions

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -927,7 +927,7 @@ class UndefinedFunction(FunctionClass):
         return False
 
 
-# Using copyreg is the only way to make a dyanmically generated instance of a
+# Using copyreg is the only way to make a dynamically generated instance of a
 # metaclass picklable without using a custom pickler. It is not possible to
 # define e.g. __reduce__ on the metaclass because obj.__reduce__ will retrieve
 # the __reduce__ method for reducing instances of the type rather than for the

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -33,6 +33,7 @@ There are three types of functions implemented in SymPy:
 from __future__ import annotations
 from typing import Any
 from collections.abc import Iterable
+import copyreg
 
 from .add import Add
 from .basic import Basic, _atomic
@@ -924,6 +925,20 @@ class UndefinedFunction(FunctionClass):
     @property
     def _diff_wrt(self):
         return False
+
+
+# Using copyreg is the only way to make a dyanmically generated instance of a
+# metaclass picklable without using a custom pickler. It is not possible to
+# define e.g. __reduce__ on the metaclass because obj.__reduce__ will retrieve
+# the __reduce__ method for reducing instances of the type rather than for the
+# type itself.
+def _reduce_undef(f):
+    return (_rebuild_undef, (f.name, f._kwargs))
+
+def _rebuild_undef(name, kwargs):
+    return Function(name, **kwargs)
+
+copyreg.pickle(UndefinedFunction, _reduce_undef)
 
 
 # XXX: The type: ignore on WildFunction is because mypy complains:

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -42,6 +42,10 @@ deprecated_attrs = {
     'expr_free_symbols',  # Deprecated from SymPy 1.9. This can be removed when exr_free_symbols is removed.
 }
 
+dont_check_attrs = {
+    '_sage_',  # Fails because Sage is not installed
+}
+
 
 def check(a, exclude=[], check_attr=True, deprecated=()):
     """ Check that pickling and copying round-trips.
@@ -78,7 +82,9 @@ def check(a, exclude=[], check_attr=True, deprecated=()):
 
         def c(a, b, d):
             for i in d:
-                if i in not_equal_attrs:
+                if i in dont_check_attrs:
+                    continue
+                elif i in not_equal_attrs:
                     if hasattr(a, i):
                         assert hasattr(b, i), i
                 elif i in deprecated_attrs or i in deprecated:
@@ -166,18 +172,13 @@ def test_core_function():
 
 def test_core_undefinedfunctions():
     f = Function("f")
-    # Full XFAILed test below
-    exclude = list(range(5))
-    # https://github.com/cloudpipe/cloudpickle/issues/65
-    # https://github.com/cloudpipe/cloudpickle/issues/190
-    exclude.append(cloudpickle)
-    check(f, exclude=exclude)
-
-@XFAIL
-def test_core_undefinedfunctions_fail():
-    # This fails because f is assumed to be a class at sympy.basic.function.f
-    f = Function("f")
     check(f)
+
+
+def test_core_appliedundef():
+    x = Symbol("_long_unique_name_1")
+    f = Function("_long_unique_name_2")
+    check(f(x))
 
 
 def test_core_interval():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes gh-26873

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * It is now possible to pickle expressions containing undefined functions (like `Function('f')`). Previously trying to pickle such expressions would fail with an exception.
<!-- END RELEASE NOTES -->
