### PR TITLE
fix type casting of number literals in rust code printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -632,6 +632,7 @@ Gautam Menghani <gum3ng@protonmail.com> gum3ng <gum3ng@protonmail.com>
 Geetika Vadali <geetika.vadali4@gmail.com> Geetika V <geetika047btcsai21@igdtuw.ac.in>
 Geetika Vadali <geetika.vadali4@gmail.com> Geetika Vadali <123307246+geetHonve@users.noreply.github.com>
 Geoffry Song <goffrie@gmail.com>
+George Frolov <gosha@fro.lv>
 George Korepanov <gkorepanov.gk@gmail.com>
 George Pittock <gpittock4@gmail.com>
 George Waksman <waksman@gwax.com>

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -392,7 +392,7 @@ Rust code printing
 
    .. autoattribute:: RustCodePrinter.printmethod
 
-.. autofunction:: sympy.printing.rust.rust_code
+.. autofunction:: sympy.printing.codeprinter.rust_code
 
 Aesara Code printing
 --------------------

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -5219,6 +5219,22 @@ def test_sympy__codegen__matrix_nodes__MatrixSolve():
     assert _test_args(MatrixSolve(A, v))
 
 
+def test_sympy__printing__rust__TypeCast():
+    from sympy.printing.rust import TypeCast
+    from sympy.codegen.ast import real
+    assert _test_args(TypeCast(x, real))
+
+
+def test_sympy__printing__rust__float_floor():
+    from sympy.printing.rust import float_floor
+    assert _test_args(float_floor(x))
+
+
+def test_sympy__printing__rust__float_ceiling():
+    from sympy.printing.rust import float_ceiling
+    assert _test_args(float_ceiling(x))
+
+
 def test_sympy__vector__coordsysrect__CoordSys3D():
     from sympy.vector.coordsysrect import CoordSys3D
     assert _test_args(CoordSys3D('C'))

--- a/sympy/printing/__init__.py
+++ b/sympy/printing/__init__.py
@@ -12,7 +12,7 @@ from .pycode import pycode
 
 from .codeprinter import print_ccode, print_fcode
 
-from .codeprinter import ccode, fcode, cxxcode # noqa:F811
+from .codeprinter import ccode, fcode, cxxcode, rust_code # noqa:F811
 
 from .smtlib import smtlib_code
 
@@ -27,8 +27,6 @@ from .julia import julia_code
 from .mathematica import mathematica_code
 
 from .octave import octave_code
-
-from .rust import rust_code
 
 from .gtk import print_gtk
 
@@ -64,7 +62,7 @@ __all__ = [
     'pycode',
 
     # sympy.printing.codeprinter
-    'ccode', 'print_ccode', 'cxxcode', 'fcode', 'print_fcode',
+    'ccode', 'print_ccode', 'cxxcode', 'fcode', 'print_fcode', 'rust_code',
 
     # sympy.printing.smtlib
     'smtlib_code',
@@ -86,9 +84,6 @@ __all__ = [
 
     # sympy.printing.octave
     'octave_code',
-
-    # sympy.printing.rust
-    'rust_code',
 
     # sympy.printing.gtk
     'print_gtk',

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -5,7 +5,7 @@ from functools import wraps
 
 from sympy.core import Add, Mul, Pow, S, sympify, Float
 from sympy.core.basic import Basic
-from sympy.core.expr import UnevaluatedExpr
+from sympy.core.expr import Expr, UnevaluatedExpr
 from sympy.core.function import Lambda
 from sympy.core.mul import _keep_coeff
 from sympy.core.sorting import default_sort_key
@@ -892,3 +892,125 @@ def cxxcode(expr, assign_to=None, standard='c++11', **settings):
     """ C++ equivalent of :func:`~.ccode`. """
     from sympy.printing.cxx import cxx_code_printers
     return cxx_code_printers[standard.lower()](settings).doprint(expr, assign_to)
+
+
+def rust_code(expr, assign_to=None, **settings):
+    """Converts an expr to a string of Rust code
+
+    Parameters
+    ==========
+
+    expr : Expr
+        A SymPy expression to be converted.
+    assign_to : optional
+        When given, the argument is used as the name of the variable to which
+        the expression is assigned. Can be a string, ``Symbol``,
+        ``MatrixSymbol``, or ``Indexed`` type. This is helpful in case of
+        line-wrapping, or for expressions that generate multi-line statements.
+    precision : integer, optional
+        The precision for numbers such as pi [default=15].
+    user_functions : dict, optional
+        A dictionary where the keys are string representations of either
+        ``FunctionClass`` or ``UndefinedFunction`` instances and the values
+        are their desired C string representations. Alternatively, the
+        dictionary value can be a list of tuples i.e. [(argument_test,
+        cfunction_string)].  See below for examples.
+    dereference : iterable, optional
+        An iterable of symbols that should be dereferenced in the printed code
+        expression. These would be values passed by address to the function.
+        For example, if ``dereference=[a]``, the resulting code would print
+        ``(*a)`` instead of ``a``.
+    human : bool, optional
+        If True, the result is a single string that may contain some constant
+        declarations for the number symbols. If False, the same information is
+        returned in a tuple of (symbols_to_declare, not_supported_functions,
+        code_text). [default=True].
+    contract: bool, optional
+        If True, ``Indexed`` instances are assumed to obey tensor contraction
+        rules and the corresponding nested loops over indices are generated.
+        Setting contract=False will not generate loops, instead the user is
+        responsible to provide values for the indices in the code.
+        [default=True].
+
+    Examples
+    ========
+
+    >>> from sympy import rust_code, symbols, Rational, sin, ceiling, Abs, Function
+    >>> x, tau = symbols("x, tau")
+    >>> rust_code((2*tau)**Rational(7, 2))
+    '8.0*1.4142135623731*tau.powf(7_f64/2.0)'
+    >>> rust_code(sin(x), assign_to="s")
+    's = x.sin();'
+
+    Simple custom printing can be defined for certain types by passing a
+    dictionary of {"type" : "function"} to the ``user_functions`` kwarg.
+    Alternatively, the dictionary value can be a list of tuples i.e.
+    [(argument_test, cfunction_string)].
+
+    >>> custom_functions = {
+    ...   "ceiling": "CEIL",
+    ...   "Abs": [(lambda x: not x.is_integer, "fabs", 4),
+    ...           (lambda x: x.is_integer, "ABS", 4)],
+    ...   "func": "f"
+    ... }
+    >>> func = Function('func')
+    >>> rust_code(func(Abs(x) + ceiling(x)), user_functions=custom_functions)
+    '(fabs(x) + x.ceil()).f()'
+
+    ``Piecewise`` expressions are converted into conditionals. If an
+    ``assign_to`` variable is provided an if statement is created, otherwise
+    the ternary operator is used. Note that if the ``Piecewise`` lacks a
+    default term, represented by ``(expr, True)`` then an error will be thrown.
+    This is to prevent generating an expression that may not evaluate to
+    anything.
+
+    >>> from sympy import Piecewise
+    >>> expr = Piecewise((x + 1, x > 0), (x, True))
+    >>> print(rust_code(expr, tau))
+    tau = if (x > 0.0) {
+        x + 1
+    } else {
+        x
+    };
+
+    Support for loops is provided through ``Indexed`` types. With
+    ``contract=True`` these expressions will be turned into loops, whereas
+    ``contract=False`` will just print the assignment expression that should be
+    looped over:
+
+    >>> from sympy import Eq, IndexedBase, Idx
+    >>> len_y = 5
+    >>> y = IndexedBase('y', shape=(len_y,))
+    >>> t = IndexedBase('t', shape=(len_y,))
+    >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
+    >>> i = Idx('i', len_y-1)
+    >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
+    >>> rust_code(e.rhs, assign_to=e.lhs, contract=False)
+    'Dy[i] = (y[i + 1] - y[i])/(t[i + 1] - t[i]);'
+
+    Matrices are also supported, but a ``MatrixSymbol`` of the same dimensions
+    must be provided to ``assign_to``. Note that any expression that can be
+    generated normally can also exist inside a Matrix:
+
+    >>> from sympy import Matrix, MatrixSymbol
+    >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
+    >>> A = MatrixSymbol('A', 3, 1)
+    >>> print(rust_code(mat, A))
+    A = [x.powi(2), if (x > 0.0) {
+        x + 1
+    } else {
+        x
+    }, x.sin()];
+    """
+    from sympy.printing.rust import RustCodePrinter
+    printer = RustCodePrinter(settings)
+    expr = printer._rewrite_known_functions(expr)
+    if isinstance(expr, Expr):
+        for src_func, dst_func in printer.function_overrides.values():
+            expr = expr.replace(src_func, dst_func)
+    return printer.doprint(expr, assign_to)
+
+
+def print_rust_code(expr, **settings):
+    """Prints Rust representation of the given expression."""
+    print(rust_code(expr, **settings))

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -9,9 +9,10 @@ from sympy.utilities.lambdify import implemented_function
 from sympy.tensor import IndexedBase, Idx
 from sympy.matrices import MatrixSymbol, SparseMatrix, Matrix
 
-from sympy.printing.rust import rust_code
+from sympy.printing.codeprinter import rust_code
 
-x, y, z = symbols('x,y,z')
+x, y, z = symbols('x,y,z', integer=False, real=True)
+k, m, n = symbols('k,m,n', integer=True)
 
 
 def test_Integer():
@@ -41,9 +42,11 @@ def test_basic_ops():
     assert rust_code(x + y) == "x + y"
     assert rust_code(x - y) == "x - y"
     assert rust_code(x * y) == "x*y"
-    assert rust_code(x / y) == "x/y"
+    assert rust_code(x / y) == "x*y.recip()"
     assert rust_code(-x) == "-x"
-
+    assert rust_code(2 * x) == "2.0*x"
+    assert rust_code(y + 2) == "y + 2.0"
+    assert rust_code(x + n) == "n as f64 + x"
 
 def test_printmethod():
     class fabs(Abs):
@@ -61,7 +64,7 @@ def test_Functions():
     assert rust_code(floor(x)) == "x.floor()"
 
     # Automatic rewrite
-    assert rust_code(Mod(x, 3)) == 'x - 3*((1_f64/3.0)*x).floor()'
+    assert rust_code(Mod(x, 3)) == 'x - 3.0*((1_f64/3.0)*x).floor()'
 
 
 def test_Pow():
@@ -86,7 +89,7 @@ def test_Pow():
 
     g = implemented_function('g', Lambda(x, 2*x))
     assert rust_code(1/(g(x)*3.5)**(x - y**x)/(x**2 + y)) == \
-        "(3.5*2*x).powf(-x + y.powf(x))/(x.powi(2) + y)"
+        "(3.5*2.0*x).powf(-x + y.powf(x))/(x.powi(2) + y)"
     _cond_cfunc = [(lambda base, exp: exp.is_integer, "dpowi", 1),
                    (lambda base, exp: not exp.is_integer, "pow", 1)]
     assert rust_code(x**3, user_functions={'Pow': _cond_cfunc}) == 'x.dpowi(3)'
@@ -105,10 +108,10 @@ def test_constants():
 
 
 def test_constants_other():
-    assert rust_code(2*GoldenRatio) == "const GoldenRatio: f64 = %s;\n2*GoldenRatio" % GoldenRatio.evalf(17)
+    assert rust_code(2*GoldenRatio) == "const GoldenRatio: f64 = %s;\n2.0*GoldenRatio" % GoldenRatio.evalf(17)
     assert rust_code(
-            2*Catalan) == "const Catalan: f64 = %s;\n2*Catalan" % Catalan.evalf(17)
-    assert rust_code(2*EulerGamma) == "const EulerGamma: f64 = %s;\n2*EulerGamma" % EulerGamma.evalf(17)
+            2*Catalan) == "const Catalan: f64 = %s;\n2.0*Catalan" % Catalan.evalf(17)
+    assert rust_code(2*EulerGamma) == "const EulerGamma: f64 = %s;\n2.0*EulerGamma" % EulerGamma.evalf(17)
 
 
 def test_boolean():
@@ -116,50 +119,50 @@ def test_boolean():
     assert rust_code(S.true) == "true"
     assert rust_code(False) == "false"
     assert rust_code(S.false) == "false"
-    assert rust_code(x & y) == "x && y"
-    assert rust_code(x | y) == "x || y"
-    assert rust_code(~x) == "!x"
-    assert rust_code(x & y & z) == "x && y && z"
-    assert rust_code(x | y | z) == "x || y || z"
-    assert rust_code((x & y) | z) == "z || x && y"
-    assert rust_code((x | y) & z) == "z && (x || y)"
+    assert rust_code(k & m) == "k && m"
+    assert rust_code(k | m) == "k || m"
+    assert rust_code(~k) == "!k"
+    assert rust_code(k & m & n) == "k && m && n"
+    assert rust_code(k | m | n) == "k || m || n"
+    assert rust_code((k & m) | n) == "n || k && m"
+    assert rust_code((k | m) & n) == "n && (k || m)"
 
 
 def test_Piecewise():
     expr = Piecewise((x, x < 1), (x + 2, True))
     assert rust_code(expr) == (
-            "if (x < 1) {\n"
+            "if (x < 1.0) {\n"
             "    x\n"
             "} else {\n"
-            "    x + 2\n"
+            "    x + 2.0\n"
             "}")
     assert rust_code(expr, assign_to="r") == (
-        "r = if (x < 1) {\n"
+        "r = if (x < 1.0) {\n"
         "    x\n"
         "} else {\n"
-        "    x + 2\n"
+        "    x + 2.0\n"
         "};")
     assert rust_code(expr, assign_to="r", inline=True) == (
-        "r = if (x < 1) { x } else { x + 2 };")
+        "r = if (x < 1.0) { x } else { x + 2.0 };")
     expr = Piecewise((x, x < 1), (x + 1, x < 5), (x + 2, True))
     assert rust_code(expr, inline=True) == (
-        "if (x < 1) { x } else if (x < 5) { x + 1 } else { x + 2 }")
+        "if (x < 1.0) { x } else if (x < 5.0) { x + 1.0 } else { x + 2.0 }")
     assert rust_code(expr, assign_to="r", inline=True) == (
-        "r = if (x < 1) { x } else if (x < 5) { x + 1 } else { x + 2 };")
+        "r = if (x < 1.0) { x } else if (x < 5.0) { x + 1.0 } else { x + 2.0 };")
     assert rust_code(expr, assign_to="r") == (
-        "r = if (x < 1) {\n"
+        "r = if (x < 1.0) {\n"
         "    x\n"
-        "} else if (x < 5) {\n"
-        "    x + 1\n"
+        "} else if (x < 5.0) {\n"
+        "    x + 1.0\n"
         "} else {\n"
-        "    x + 2\n"
+        "    x + 2.0\n"
         "};")
     expr = 2*Piecewise((x, x < 1), (x + 1, x < 5), (x + 2, True))
     assert rust_code(expr, inline=True) == (
-        "2*if (x < 1) { x } else if (x < 5) { x + 1 } else { x + 2 }")
+        "2.0*if (x < 1.0) { x } else if (x < 5.0) { x + 1.0 } else { x + 2.0 }")
     expr = 2*Piecewise((x, x < 1), (x + 1, x < 5), (x + 2, True)) - 42
     assert rust_code(expr, inline=True) == (
-        "2*if (x < 1) { x } else if (x < 5) { x + 1 } else { x + 2 } - 42")
+        "2.0*if (x < 1.0) { x } else if (x < 5.0) { x + 1.0 } else { x + 2.0 } - 42.0")
     # Check that Piecewise without a True (default) condition error
     expr = Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))
     raises(ValueError, lambda: rust_code(expr))
@@ -172,8 +175,8 @@ def test_dereference_printing():
 
 def test_sign():
     expr = sign(x) * y
-    assert rust_code(expr) == "y*x.signum()"
-    assert rust_code(expr, assign_to='r') == "r = y*x.signum();"
+    assert rust_code(expr) == "y*x.signum() as f64"
+    assert rust_code(expr, assign_to='r') == "r = y*x.signum() as f64;"
 
     expr = sign(x + y) + 42
     assert rust_code(expr) == "(x + y).signum() + 42"
@@ -197,12 +200,12 @@ def test_reserved_words():
 
 
 def test_ITE():
-    expr = ITE(x < 1, y, z)
-    assert rust_code(expr) == (
-            "if (x < 1) {\n"
-            "    y\n"
+    ekpr = ITE(k < 1, m, n)
+    assert rust_code(ekpr) == (
+            "if (k < 1) {\n"
+            "    m\n"
             "} else {\n"
-            "    z\n"
+            "    n\n"
             "}")
 
 
@@ -325,7 +328,7 @@ def test_inline_function():
 
     g = implemented_function('g', Lambda(x, 2*x/Catalan))
     assert rust_code(g(x)) == (
-        "const Catalan: f64 = %s;\n2*x/Catalan" % Catalan.evalf(17))
+        "const Catalan: f64 = %s;\n2.0*x/Catalan" % Catalan.evalf(17))
 
     A = IndexedBase('A')
     i = Idx('i', symbols('n', integer=True))

--- a/sympy/utilities/tests/test_codegen_rust.py
+++ b/sympy/utilities/tests/test_codegen_rust.py
@@ -228,11 +228,11 @@ def test_piecewise_():
     source = result[1]
     expected = (
         "fn pwtest(x: f64) -> f64 {\n"
-        "    let out1 = if (x < -1) {\n"
+        "    let out1 = if (x < -1.0) {\n"
         "        0\n"
-        "    } else if (x <= 1) {\n"
+        "    } else if (x <= 1.0) {\n"
         "        x.powi(2)\n"
-        "    } else if (x > 1) {\n"
+        "    } else if (x > 1.0) {\n"
         "        2 - x\n"
         "    } else {\n"
         "        1\n"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25173 as far as integer and floating point types are concerned.
The complex type remains broken: it is not native in rust and is typically handled with an external library such as [num-complex](https://crates.io/crates/num-complex)
Matrices, represented as arrays, seem to be fine, as long as the entries are int or float.


#### Brief description of what is fixed or changed

Added automatic type casting in the rust code printer. Integers are always cast to floats if it is detected that an Add, Mul, or Relational expression contains mixed types

The functions floor and ceiling need special treatment, because they return integers in sympy, but floats in rust. Added type-aware versions `float_floor` and `float_ceiling`, specific for rust codegen, that are substituted before printing.

In order for this substitution to work, the automatic rewrites needed to be decoupled from the `_print` method. Now all rewrites happen at once in `rust_code()` before the printing begins. This is a change in behavior: we rewrite the whole expression rather than individual function nodes. I have not stumbled upon any problems with it, but cannot vouch for all use cases.

UPD moved rust_code to from printing.rust to printing.codeprinter, otherwise it ends up polluting the sympy namespace because of new imports
#### Other comments

I'm completely new to the code base, so very open to any suggestions

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Rust codegen now automatically casts integers to floats in mixed expressions to prevent compilation errors
<!-- END RELEASE NOTES -->
