### PR TITLE
fix(core): don't flip rationals in as_base_exp

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -820,10 +820,9 @@ class Pow(Expr):
         (1/2, 2)
 
         """
-
         b, e = self.args
-        if b.is_Rational and b.p < b.q and b.p > 0:
-            return 1/b, -e
+        if b.is_Rational and b.p == 1 and b.q != 1:
+            return Integer(b.q), -e
         return b, e
 
     def _eval_adjoint(self):

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -282,7 +282,7 @@ def test_pow_as_base_exp():
     p = (S(3)/2)**x
     assert p.base, p.exp == p.as_base_exp() == (3*S.Half, x)
     p = (S(2)/3)**x
-    assert p.as_base_exp() == (S(3)/2, -x)
+    assert p.as_base_exp() == (S(2)/3, x)
     assert p.base, p.exp == (S(2)/3, x)
     # issue 8344:
     assert Pow(1, 2, evaluate=False).as_base_exp() == (S.One, S(2))
@@ -650,7 +650,7 @@ def test_powers_of_I():
 
 def test_issue_23918():
     b = S(2)/3
-    assert (b**x).as_base_exp() == (1/b, -x)
+    assert (b**x).as_base_exp() == (b, x)
 
 
 def test_issue_26546():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -259,9 +259,15 @@ def test_latex_basic():
     assert latex(Pow(Rational(1, 3), -2, evaluate=False)) == r"\frac{1}{(\frac{1}{3})^{2}}"
     assert latex(Pow(Integer(1)/100, -1, evaluate=False)) == r"\frac{1}{\frac{1}{100}}"
 
-
     p = Symbol('p', positive=True)
     assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left(p \right)}"
+
+    assert latex(Pow(Rational(2, 3), -1, evaluate=False)) == r'\frac{1}{\frac{2}{3}}'
+    assert latex(Pow(Rational(4, 3), -1, evaluate=False)) == r'\frac{1}{\frac{4}{3}}'
+    assert latex(Pow(Rational(-3, 4), -1, evaluate=False)) == r'\frac{1}{- \frac{3}{4}}'
+    assert latex(Pow(Rational(-4, 4), -1, evaluate=False)) == r'\frac{1}{-1}'
+    assert latex(Pow(Rational(1, 3), -1, evaluate=False)) == r'\frac{1}{\frac{1}{3}}'
+    assert latex(Pow(Rational(-1, 3), -1, evaluate=False)) == r'\frac{1}{- \frac{1}{3}}'
 
 
 def test_latex_builtins():

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -179,7 +179,7 @@ def FlorySchulz(name, a):
     >>> X = FlorySchulz("x", a)
 
     >>> density(X)(z)
-    (5/4)**(1 - z)*z/25
+    (4/5)**(z - 1)*z/25
 
     >>> E(X)
     9
@@ -252,7 +252,7 @@ def Geometric(name, p):
     >>> X = Geometric("x", p)
 
     >>> density(X)(z)
-    (5/4)**(1 - z)/5
+    (4/5)**(z - 1)/5
 
     >>> E(X)
     5

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -292,6 +292,6 @@ def test_product_spaces():
     assert str(P(X1 + X2 < 3).rewrite(Sum)) == (
         "Sum(Piecewise((1/(4*2**n), n >= -1), (0, True)), (n, -oo, -1))/3")
     assert str(P(X1 + X2 > 3).rewrite(Sum)) == (
-        'Sum(Piecewise((2**(X2 - n - 2)*(3/2)**(1 - X2)/6, '
+        'Sum(Piecewise((2**(X2 - n - 2)*(2/3)**(X2 - 1)/6, '
         'X2 - n <= 2), (0, True)), (X2, 1, oo), (n, 1, oo))')
     assert P(Eq(X1 + X2, 3)) == Rational(1, 12)


### PR DESCRIPTION
Reverts gh-23921 (e76564ad53a297079b0c567c607e1e57a9e75de6).

The long-standing behaviour has been that a power of a rational number with numerator one is treated as a negative power by `as_base_exp` e.g.:
```
 >>> ((S(1)/2)**x).as_base_exp()
 (2, -x)
```
The PR gh-23291 extended this to cover rationals with positive numerator where the numerator is less than the denominator:
```
 >>> ((S(3)/5)**y).as_base_exp()
 (5/3, -y)
```
This commit reverts that change to restore the previous behaviour.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Reverts gh-23921
Fixes gh-26880

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Pow.as_base_exp for positive Rationals: (2/3)**x->(3/2,-x) is not done ant more. This reverts a change in SymPy 1.12 to restore SymPy 1.11 behaviour.
* printing
    *  A bug in the LaTeX printer causing an infinite recursion for some inputs was fixed.
<!-- END RELEASE NOTES -->
