### PR TITLE
fix(core): disallow `(x**z*y**z) -> (x*y)**z` in as_base_exp

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -637,12 +637,6 @@ class Function(Application, Expr):
         return fuzzy_or(a.is_infinite if s is S.ComplexInfinity
                         else (a - s).is_zero for s in ss)
 
-    def as_base_exp(self):
-        """
-        Returns the method as the 2-tuple (base, exponent).
-        """
-        return self, S.One
-
     def _eval_aseries(self, n, args0, x, logx):
         """
         Compute an asymptotic expansion around args0, in terms of self.args.

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1245,7 +1245,7 @@ class Mul(Expr, AssocOp):
                 nc += 1
             if e1 is None:
                 e1 = e
-            elif e != e1 or nc > 1:
+            elif e != e1 or nc > 1 or not e.is_Integer:
                 return self, S.One
             bases.append(b)
         return self.func(*bases), e1

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1503,6 +1503,8 @@ def test_as_base_exp():
     assert (x*y*z).as_base_exp() == (x*y*z, S.One)
     assert (x + y + z).as_base_exp() == (x + y + z, S.One)
     assert ((x + y)**z).as_base_exp() == (x + y, z)
+    assert (x**2*y**2).as_base_exp() == (x*y, 2)
+    assert (x**z*y**z).as_base_exp() == (x**z*y**z, S.One)
 
 
 def test_issue_4963():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -568,8 +568,7 @@ def test_function__eval_nseries():
 
     # issue 6725:
     assert expint(Rational(3, 2), -x)._eval_nseries(x, 5, None) == \
-        2 - 2*sqrt(pi)*sqrt(-x) - 2*x + x**2 + x**3/3 + x**4/12 + 4*I*x**(S(3)/2)*sqrt(-x)/3 + \
-        2*I*x**(S(5)/2)*sqrt(-x)/5 + 2*I*x**(S(7)/2)*sqrt(-x)/21 + O(x**5)
+        2 - 2*x - x**2/3 - x**3/15 - x**4/84 - 2*I*sqrt(pi)*sqrt(x) + O(x**5)
     assert sin(sqrt(x))._eval_nseries(x, 3, None) == \
         sqrt(x) - x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + O(x**3)
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -783,12 +783,6 @@ class log(Function):
                         else:
                             return cls(modulus) + I * (pi - atan_table[t1])
 
-    def as_base_exp(self):
-        """
-        Returns this function in the form (base, exponent).
-        """
-        return self, S.One
-
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):  # of log(1+x)

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -107,12 +107,11 @@ def test_laplace_transform():
             (sqrt(pi)*sqrt(1/s)*exp(-2*sqrt(a)*sqrt(s)), 0, True))
     assert (LT(exp(-a/t)/(t*sqrt(t)), t, s) ==
             (sqrt(pi)*sqrt(1/a)*exp(-2*sqrt(a)*sqrt(s)), 0, True))
-    assert (
-        LT(exp(-2*sqrt(a*t)), t, s) ==
-        (1/s - sqrt(pi)*sqrt(a) * exp(a/s)*erfc(sqrt(a)*sqrt(1/s)) /
-         s**(S(3)/2), 0, True))
+    assert (LT(exp(-2*sqrt(a*t)), t, s) ==
+        (sqrt(a)*(-sqrt(pi)*erfc(sqrt(a)/sqrt(s))
+        + sqrt(s)*exp(-a/s)/sqrt(a))*exp(a/s)/s**(S(3)/2), 0, True))
     assert LT(exp(-2*sqrt(a*t))/sqrt(t), t, s) == (
-        exp(a/s)*erfc(sqrt(a) * sqrt(1/s))*(sqrt(pi)*sqrt(1/s)), 0, True)
+        (sqrt(pi)*exp(a/s)*erfc(sqrt(a)/sqrt(s))/sqrt(s), 0, True))
     assert (LT(t**4*exp(-2/t), t, s) ==
             (8*sqrt(2)*(1/s)**(S(5)/2)*besselk(5, 2*sqrt(2)*sqrt(s)),
              0, True))
@@ -142,24 +141,35 @@ def test_laplace_transform():
     assert (LT(sinh(2*sqrt(a*t)), t, s) ==
             (sqrt(pi)*sqrt(a)*exp(a/s)/s**(S(3)/2), 0, True))
     assert (LT(sqrt(t)*sinh(2*sqrt(a*t)), t, s, simplify=True) ==
-            ((-sqrt(a)*s**(S(5)/2) + sqrt(pi)*s**2*(2*a + s)*exp(a/s) *
-              erf(sqrt(a)*sqrt(1/s))/2)/s**(S(9)/2), 0, True))
+            ((sqrt(a)*sqrt(s) + sqrt(pi)*(2*a + s)*exp(a/s)*
+              erf(sqrt(a)/sqrt(s))/2)/s**(S(5)/2), 0, True))
     assert (LT(sinh(2*sqrt(a*t))/sqrt(t), t, s) ==
-            (sqrt(pi)*exp(a/s)*erf(sqrt(a)*sqrt(1/s))/sqrt(s), 0, True))
+            (sqrt(pi)*exp(a/s)*erf(sqrt(a)/sqrt(s))/sqrt(s), 0, True))
     assert (LT(sinh(sqrt(a*t))**2/sqrt(t), t, s) ==
-            (sqrt(pi)*(exp(a/s) - 1)/(2*sqrt(s)), 0, True))
+            (sqrt(pi)*(2*exp(a/s) - 2)/(4*sqrt(s)), 0, True))
     assert (LT(t**(S(3)/7)*cosh(a*t), t, s) ==
             (((a + s)**(-S(10)/7) + (-a+s)**(-S(10)/7))*gamma(S(10)/7)/2,
              a, True))
     assert (LT(cosh(2*sqrt(a*t)), t, s) ==
-            (sqrt(pi)*sqrt(a)*exp(a/s)*erf(sqrt(a)*sqrt(1/s))/s**(S(3)/2) +
-             1/s, 0, True))
+            (2*((sqrt(a)*(sqrt(pi)*(2 - erfc(sqrt(a)/sqrt(s)))
+            + sqrt(s)*exp(-a/s)/sqrt(a))/(4*s**(S(3)/2))
+            + sqrt(a)*(-sqrt(pi)*erfc(sqrt(a)/sqrt(s))
+            + sqrt(s)*exp(-a/s)/sqrt(a))/(4*s**(S(3)/2)))*exp(a/s)), 0, True))
     assert (LT(sqrt(t)*cosh(2*sqrt(a*t)), t, s) ==
-            (sqrt(pi)*(a + s/2)*exp(a/s)/s**(S(5)/2), 0, True))
+            ((((sqrt(pi)*(2 - erfc(sqrt(a)/sqrt(s)))
+            + sqrt(s)*exp(-a/s)/sqrt(a))*(2*a/s + 1)/2
+            - (-sqrt(pi)*erfc(sqrt(a)/sqrt(s))
+            + sqrt(s)*exp(-a/s)/sqrt(a))*(2*a/s + 1)/2)*exp(a/s)
+            - sqrt(pi))/(4*s**(S(3)/2)) + (((sqrt(pi)*(2 - erfc(sqrt(a)/sqrt(s)))
+            + sqrt(s)*exp(-a/s)/sqrt(a))*(2*a/s + 1)/2
+            - (-sqrt(pi)*erfc(sqrt(a)/sqrt(s))
+            + sqrt(s)*exp(-a/s)/sqrt(a))*(2*a/s + 1)/2)*exp(a/s)
+            + sqrt(pi))/(4*s**(S(3)/2)), 0, True))
     assert (LT(cosh(2*sqrt(a*t))/sqrt(t), t, s) ==
-            (sqrt(pi)*exp(a/s)/sqrt(s), 0, True))
+            (sqrt(pi)*(2*exp(a/s) - 2)/(4*sqrt(s))
+             + sqrt(pi)*(2*exp(a/s) + 2)/(4*sqrt(s)), 0, True))
     assert (LT(cosh(sqrt(a*t))**2/sqrt(t), t, s) ==
-            (sqrt(pi)*(exp(a/s) + 1)/(2*sqrt(s)), 0, True))
+            (sqrt(pi)*(2*exp(a/s) + 2)/(4*sqrt(s)), 0, True))
     assert LT(log(t), t, s, simplify=True) == (
         (-log(s) - EulerGamma)/s, 0, True)
     assert (LT(-log(t/a), t, s, simplify=True) ==
@@ -187,14 +197,14 @@ def test_laplace_transform():
             (a*atan(2*a/s) - s*log(4*a**2/s**2 + 1)/4, 0, True))
     assert (LT(sin(2*sqrt(a*t)), t, s) ==
             (sqrt(pi)*sqrt(a)*exp(-a/s)/s**(S(3)/2), 0, True))
-    assert LT(sin(2*sqrt(a*t))/t, t, s) == (pi*erf(sqrt(a)*sqrt(1/s)), 0, True)
+    assert LT(sin(2*sqrt(a*t))/t, t, s) == (pi*erf(sqrt(a)/sqrt(s)), 0, True)
     assert LT(cos(a*t), t, s) == (s/(a**2 + s**2), 0, True)
     assert (LT(cos(a*t)**2, t, s) ==
             ((2*a**2 + s**2)/(s*(4*a**2 + s**2)), 0, True))
     assert (LT(sqrt(t)*cos(2*sqrt(a*t)), t, s, simplify=True) ==
             (sqrt(pi)*(-a + s/2)*exp(-a/s)/s**(S(5)/2), 0, True))
     assert (LT(cos(2*sqrt(a*t))/sqrt(t), t, s) ==
-            (sqrt(pi)*sqrt(1/s)*exp(-a/s), 0, True))
+            (sqrt(pi)*exp(-a/s)/sqrt(s), 0, True))
     assert (LT(sin(a*t)*sin(b*t), t, s) ==
             (2*a*b*s/((s**2 + (a - b)**2)*(s**2 + (a + b)**2)), 0, True))
     assert (LT(cos(a*t)*sin(b*t), t, s) ==
@@ -214,16 +224,18 @@ def test_laplace_transform():
     assert L - (s*cos(3) - sin(3))/(s**2 + 1) == 0
     # Error functions (laplace7.pdf)
     assert LT(erf(a*t), t, s) == (exp(s**2/(4*a**2))*erfc(s/(2*a))/s, 0, True)
-    assert LT(erf(sqrt(a*t)), t, s) == (sqrt(a)/(s*sqrt(a + s)), 0, True)
+    assert LT(erf(sqrt(a*t)), t, s) == (1/(s*sqrt(1 + s/a)), 0, True)
     assert (LT(exp(a*t)*erf(sqrt(a*t)), t, s, simplify=True) ==
             (-sqrt(a)/(sqrt(s)*(a - s)), a, True))
     assert (LT(erf(sqrt(a/t)/2), t, s, simplify=True) ==
             (1/s - exp(-sqrt(a)*sqrt(s))/s, 0, True))
     assert (LT(erfc(sqrt(a*t)), t, s, simplify=True) ==
-            (-sqrt(a)/(s*sqrt(a + s)) + 1/s, -a, True))
+            (-sqrt(a)/(s*sqrt(a + s)) + 1/s, 0, True))
     assert (LT(exp(a*t)*erfc(sqrt(a*t)), t, s) ==
             (1/(sqrt(a)*sqrt(s) + s), 0, True))
-    assert LT(erfc(sqrt(a/t)/2), t, s) == (exp(-sqrt(a)*sqrt(s))/s, 0, True)
+    assert (LT(erfc(sqrt(a/t)/2), t, s) ==
+            (a*(-4*sqrt(pi)*sinh(sqrt(a)*sqrt(s))/(a*s)
+             + 4*sqrt(pi)*cosh(sqrt(a)*sqrt(s))/(a*s))/(4*sqrt(pi)), 0, True))
     # Bessel functions (laplace8.pdf)
     assert LT(besselj(0, a*t), t, s) == (1/sqrt(a**2 + s**2), 0, True)
     assert (LT(besselj(1, a*t), t, s, simplify=True) ==
@@ -272,7 +284,9 @@ def test_laplace_transform():
     assert (LT(exp(-a*t)*f(t), t, s) ==
             (LaplaceTransform(f(t), t, a + s), -oo, True))
     assert (LT(exp(-a*t)*erfc(sqrt(b/t)/2), t, s) ==
-            (exp(-sqrt(b)*sqrt(a + s))/(a + s), -a, True))
+            (b*(-4*sqrt(pi)*sinh(sqrt(b)*sqrt(a + s))/(b*(a + s))
+            + 4*sqrt(pi)*cosh(sqrt(b)*sqrt(a + s))/(b*(a + s)))/(4*sqrt(pi)),
+            -a, True))
     assert (LT(sinh(a*t)*f(t), t, s) ==
             (LaplaceTransform(f(t), t, -a + s)/2 -
              LaplaceTransform(f(t), t, a + s)/2, -oo, True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Without assumptions on x, y and z it does not hold that `(x**z)*(y**z)`
is equal to `(x*y)**z` so as_base_exp should not return `(x*y, z)`.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * `Mul.as_base_exp` no longer allows `(x**z*y**z) -> (x*y)**z` unless `z` is an integer. Previously this could lead to incorrect results if the bases are not positive and the exponent is not an integer.
<!-- END RELEASE NOTES -->
