### PR TITLE
[DOC] Remove obsolete config for non-existent sphinx.ext.pngmath

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -757,6 +757,7 @@ Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
+Jean-François B <2589111+jfbu@users.noreply.github.com>
 Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>
 Jeffrey Ryan <jeffaryan7@gmail.com>
 Jennifer White <jcrw122@googlemail.com>

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -107,9 +107,6 @@ html_baseurl = "https://docs.sympy.org/latest/"
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
-# Use this to use pngmath instead
-#extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.pngmath', ]
-
 # Enable warnings for all bad cross references. These are turned into errors
 # with the -W flag in the Makefile.
 nitpicky = True
@@ -401,14 +398,6 @@ latex_show_pagerefs = True
 latex_use_modindex = False
 
 default_role = 'math'
-pngmath_divpng_args = ['-gamma 1.5', '-D 110']
-# Note, this is ignored by the mathjax extension
-# Any \newcommand should be defined in the file
-pngmath_latex_preamble = '\\usepackage{amsmath}\n' \
-    '\\usepackage{bm}\n' \
-    '\\usepackage{amsfonts}\n' \
-    '\\usepackage{amssymb}\n' \
-    '\\setlength{\\parindent}{0pt}\n'
 
 texinfo_documents = [
     (master_doc, 'sympy', 'SymPy Documentation', 'SymPy Development Team',


### PR DESCRIPTION
Fix #26886

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
