### PR TITLE
Add _print_Idx to CodePrinter

### DIFF
--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -331,9 +331,6 @@ class C89CodePrinter(CodePrinter):
         return "%s[%s]" % (self._print(expr.base.label),
                            self._print(flat_index))
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
     @_as_macro_if_defined
     def _print_NumberSymbol(self, expr):
         return super()._print_NumberSymbol(expr)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -351,6 +351,9 @@ class CodePrinter(StrPrinter):
         else:
             return '%s_%d' % (expr.name, expr.dummy_index)
 
+    def _print_Idx(self, expr):
+        return self._print(expr.label)
+
     def _print_CodeBlock(self, expr):
         return '\n'.join([self._print(i) for i in expr.args])
 

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -376,9 +376,6 @@ class FCodePrinter(CodePrinter):
         inds = [ self._print(i) for i in expr.indices ]
         return "%s(%s)" % (self._print(expr.base.label), ", ".join(inds))
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
     def _print_AugmentedAssignment(self, expr):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -258,9 +258,6 @@ class GLSLPrinter(CodePrinter):
             last_line = ": (\n%s\n)" % self._print(expr.args[-1].expr)
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
     def _print_Indexed(self, expr):
         # calculate index for 1d array
         dims = expr.shape

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -137,9 +137,6 @@ class JavascriptCodePrinter(CodePrinter):
             offset *= dims[i]
         return "%s[%s]" % (self._print(expr.base.label), self._print(elem))
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
     def _print_Exp1(self, expr):
         return "Math.E"
 

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -384,11 +384,6 @@ class JuliaCodePrinter(CodePrinter):
         inds = [ self._print(i) for i in expr.indices ]
         return "%s[%s]" % (self._print(expr.base.label), ",".join(inds))
 
-
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
-
     def _print_Identity(self, expr):
         return "eye(%s)" % self._print(expr.shape[0])
 

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -183,9 +183,6 @@ class MapleCodePrinter(CodePrinter):
     def _print_Infinity(self, expr):
         return 'infinity'
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
     def _print_BooleanTrue(self, expr):
         return "true"
 

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -379,10 +379,6 @@ class OctaveCodePrinter(CodePrinter):
         return "%s(%s)" % (self._print(expr.base.label), ", ".join(inds))
 
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
-
     def _print_KroneckerDelta(self, expr):
         prec = PRECEDENCE["Pow"]
         return "double(%s == %s)" % tuple(self.parenthesize(x, prec)

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -157,9 +157,6 @@ class RCodePrinter(CodePrinter):
         inds = [ self._print(i) for i in expr.indices ]
         return "%s[%s]" % (self._print(expr.base.label), ", ".join(inds))
 
-    def _print_Idx(self, expr):
-        return self._print(expr.label)
-
     def _print_Exp1(self, expr):
         return "exp(1)"
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -33,7 +33,7 @@ from sympy.matrices.expressions.dotproduct import DotProduct
 from sympy.simplify.cse_main import cse
 from sympy.tensor.array import derive_by_array, Array
 from sympy.tensor.array.expressions import ArraySymbol
-from sympy.tensor.indexed import IndexedBase
+from sympy.tensor.indexed import IndexedBase, Idx
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.iterables import numbered_symbols
 from sympy.vector import CoordSys3D
@@ -1066,6 +1066,13 @@ def test_Indexed():
     i, j = symbols('i j')
     b = numpy.array([[1, 2], [3, 4]])
     assert lambdify(a, Sum(a[x, y], (x, 0, 1), (y, 0, 1)))(b) == 10
+
+def test_Idx():
+    # Issue 26888
+    a = IndexedBase('a')
+    i = Idx('i')
+    b = [1,2,3]
+    assert lambdify([a, i], a[i])(b, 2) == 3
 
 
 def test_issue_12173():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #26888


#### Brief description of what is fixed or changed
_print_Idx was missing in the Python code ptiner.

#### Other comments
Deduplicated some code in the child classes of CodePrinter by moving the implementation into the base class. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
