### PR TITLE
[GSoC]Adding series methods for gamma and incomplete gamma functions and expint

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1434,24 +1434,41 @@ class expint(Function):
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
+    def _eval_rewrite_as_tractable(self, nu, z, limitvar=None, **kwargs):
+        return exp(-z)*_expint(nu, z)
+
     def _eval_as_leading_term(self, x, logx, cdir):
-        nu, z = self.args
-        if nu == S.One:
-            return (-log(z) - EulerGamma).as_leading_term(x, logx=logx)
-        if nu.is_real and (nu > 1) is S.true:
-            arg = 1/(nu - 1)
-            return arg.as_leading_term(x, logx=logx)
+        if not self.args[0].has(x):
+            try:
+                _, ex = self.args[1].leadterm(x)
+            except (ValueError, NotImplementedError):
+                return self
+
+            if ex.is_positive:
+                nu = self.args[0]
+                if nu == S.One:
+                    f = self._eval_rewrite_as_Si(*self.args)
+                    return f._eval_as_leading_term(x, logx, cdir)
+                elif nu.is_Integer and (nu > 1) is S.true:
+                    f = self._eval_rewrite_as_Ei(*self.args)
+                    return f._eval_as_leading_term(x, logx, cdir)
         return super()._eval_as_leading_term(x, logx, cdir)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         if not self.args[0].has(x):
-            nu = self.args[0]
-            if nu == 1:
-                f = self._eval_rewrite_as_Si(*self.args)
-                return f._eval_nseries(x, n, logx)
-            elif nu.is_Integer and nu > 1:
-                f = self._eval_rewrite_as_Ei(*self.args)
-                return f._eval_nseries(x, n, logx)
+            try:
+                _, ex = self.args[1].leadterm(x)
+            except (ValueError, NotImplementedError):
+                return self
+
+            if ex.is_positive:
+                nu = self.args[0]
+                if nu == S.One:
+                    f = self._eval_rewrite_as_Si(*self.args)
+                    return f._eval_nseries(x, n, logx)
+                elif nu.is_Integer and nu > 1:
+                    f = self._eval_rewrite_as_Ei(*self.args)
+                    return f._eval_nseries(x, n, logx)
         return super()._eval_nseries(x, n, logx)
 
     def _eval_aseries(self, n, args0, x, logx):
@@ -1461,8 +1478,8 @@ class expint(Function):
 
         if point is S.Infinity:
             z = self.args[1]
-            s = [S.NegativeOne**k * RisingFactorial(nu, k) / z**k for k in range(n)] + [Order(1/z**n, x)]
-            return (exp(-z)/z) * Add(*s)
+            s = [S.NegativeOne**k * RisingFactorial(nu, k) / z**(k+1) for k in range(n)] + [Order(1/z**n, x)]
+            return exp(-z) * Add(*s)
 
         return super(expint, self)._eval_aseries(n, args0, x, logx)
 
@@ -2801,6 +2818,36 @@ class _eis(Function):
             f = self._eval_rewrite_as_intractable(*self.args)
             return f._eval_as_leading_term(x, logx=logx, cdir=cdir)
         return super()._eval_as_leading_term(x, logx=logx, cdir=cdir)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_intractable(*self.args)
+            return f._eval_nseries(x, n, logx)
+        return super()._eval_nseries(x, n, logx)
+
+
+class _expint(Function):
+    """
+    Helper function to make the $\\mathrm{expint}(nu, z)$
+    function tractable for the Gruntz algorithm.
+
+    """
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[1]
+        nu = self.args[0]
+
+        if point is S.Infinity:
+            z = self.args[1]
+            s = [S.NegativeOne**k * RisingFactorial(nu, k) / z**(k+1) for k in range(n)] + [Order(1/z**n, x)]
+            return Add(*s)
+
+        return super(expint, self)._eval_aseries(n, args0, x, logx)
+
+    def _eval_rewrite_as_intractable(self, nu, z, **kwargs):
+        return exp(z)*expint(nu, z)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         x0 = self.args[0].limit(x, 0)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1476,7 +1476,7 @@ class expint(Function):
         point = args0[1]
         nu = self.args[0]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             z = self.args[1]
             s = [S.NegativeOne**k * RisingFactorial(nu, k) / z**(k+1) for k in range(n)] + [Order(1/z**n, x)]
             return exp(-z) * Add(*s)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1434,11 +1434,11 @@ class expint(Function):
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
-    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+    def _eval_as_leading_term(self, x, logx, cdir):
         nu, z = self.args
-        if nu == 1:
-            arg = -log(z) - EulerGamma
-        if nu.is_real and nu > 1:
+        if nu == S.One:
+            return (-log(z) - EulerGamma).as_leading_term(x, logx=logx)
+        if nu.is_real and (nu > 1) is S.true:
             arg = 1/(nu - 1)
             return arg.as_leading_term(x, logx=logx)
         return super()._eval_as_leading_term(x, logx, cdir)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1434,6 +1434,15 @@ class expint(Function):
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        nu, z = self.args
+        if nu == 1:
+            arg = -log(z) - EulerGamma
+        if nu.is_real and nu > 1:
+            arg = 1/(nu - 1)
+            return arg.as_leading_term(x, logx=logx)
+        return super()._eval_as_leading_term(x, logx, cdir)
+
     def _eval_nseries(self, x, n, logx, cdir=0):
         if not self.args[0].has(x):
             nu = self.args[0]

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2839,7 +2839,7 @@ class _expint(Function):
         point = args0[1]
         nu = self.args[0]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             z = self.args[1]
             s = [S.NegativeOne**k * RisingFactorial(nu, k) / z**(k+1) for k in range(n)] + [Order(1/z**n, x)]
             return Add(*s)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -214,6 +214,15 @@ class gamma(Function):
             return self.func(x0)
         raise PoleError()
 
+    def _eval_aseries(self, n, args0, x, logx):
+        point = args0[0]
+        if point is S.Infinity:
+            z = self.args[0]
+            r = exp((log(z)*(z - S.Half) - z + log(2*pi)/2).expand())
+            l = [bernoulli(2*k) / (2*k*(2*k - 1)*z**(2*k - 1)) for k in range(1, n)]
+            return (exp(Add(*l))._eval_nseries(x, n, logx))*r
+        return super()._eval_aseries(n, args0, x, logx)
+
 
 ###############################################################################
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################
@@ -380,14 +389,29 @@ class lowergamma(Function):
             return coeff*sum_expr + o
         return super()._eval_aseries(n, args0, x, logx)
 
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.series.order import O
+        s, z = self.args
+        if z.has(x):
+            coeff = z**s*exp(-z)*gamma(s)
+            sum_expr = sum(z**k/gamma(s + k + 1) for k in range(n - 1))
+            o = O(z**s*s**(-n))
+            return coeff*sum_expr + o
+        return super()._eval_nseries(x, n, logx)
+
     def _eval_rewrite_as_uppergamma(self, s, x, **kwargs):
         return gamma(s) - uppergamma(s, x)
+
+    _eval_rewrite_as_tractable = _eval_rewrite_as_uppergamma
 
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy.functions.special.error_functions import expint
         if s.is_integer and s.is_nonpositive:
             return self
         return self.rewrite(uppergamma).rewrite(expint)
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        return self.rewrite(uppergamma)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_is_zero(self):
         x = self.args[1]
@@ -555,6 +579,10 @@ class uppergamma(Function):
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy.functions.special.error_functions import expint
         return expint(1 - s, x)*x**s
+
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        from sympy.functions.special.error_functions import expint
+        return self.rewrite(expint)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
 
 ###############################################################################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -392,8 +392,6 @@ class lowergamma(Function):
     def _eval_rewrite_as_uppergamma(self, s, x, **kwargs):
         return gamma(s) - uppergamma(s, x)
 
-    _eval_rewrite_as_tractable = _eval_rewrite_as_uppergamma
-
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy.functions.special.error_functions import expint
         if s.is_integer and s.is_nonpositive:
@@ -563,12 +561,12 @@ class uppergamma(Function):
     def _eval_rewrite_as_lowergamma(self, s, x, **kwargs):
         return gamma(s) - lowergamma(s, x)
 
-    def _eval_rewrite_as_tractable(self, s, x, **kwargs):
-        return exp(loggamma(s)) - lowergamma(s, x)
-
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy.functions.special.error_functions import expint
         return expint(1 - s, x)*x**s
+
+    def _eval_rewrite_as_tractable(self, s, x, **kwargs):
+        return exp(loggamma(s)) - lowergamma(s, x)
 
     def _eval_as_leading_term(self, x, logx, cdir):
         from sympy.functions.special.error_functions import expint

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -215,8 +215,9 @@ class gamma(Function):
         raise PoleError()
 
     def _eval_aseries(self, n, args0, x, logx):
+        # Refer: https://functions.wolfram.com/GammaBetaErf/Gamma/06/02/0003/
         point = args0[0]
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             z = self.args[0]
             r = exp((log(z)*(z - S.Half) - z + log(2*pi)/2).expand())
             l = [bernoulli(2*k) / (2*k*(2*k - 1)*z**(2*k - 1)) for k in range(1, n)]
@@ -1037,8 +1038,9 @@ class loggamma(Function):
         return super()._eval_nseries(x, n, logx)
 
     def _eval_aseries(self, n, args0, x, logx):
+        # Refer: https://functions.wolfram.com/GammaBetaErf/LogGamma/06/03/0001/
         from sympy.series.order import Order
-        if args0[0] != oo:
+        if args0[0] not in [S.Infinity, S.NegativeInfinity]:
             return super()._eval_aseries(n, args0, x, logx)
         z = self.args[0]
         r = log(z)*(z - S.Half) - z + log(2*pi)/2

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -389,16 +389,6 @@ class lowergamma(Function):
             return coeff*sum_expr + o
         return super()._eval_aseries(n, args0, x, logx)
 
-    def _eval_nseries(self, x, n, logx, cdir=0):
-        from sympy.series.order import O
-        s, z = self.args
-        if z.has(x):
-            coeff = z**s*exp(-z)*gamma(s)
-            sum_expr = sum(z**k/gamma(s + k + 1) for k in range(n - 1))
-            o = O(z**s*s**(-n))
-            return coeff*sum_expr + o
-        return super()._eval_nseries(x, n, logx)
-
     def _eval_rewrite_as_uppergamma(self, s, x, **kwargs):
         return gamma(s) - uppergamma(s, x)
 
@@ -410,7 +400,7 @@ class lowergamma(Function):
             return self
         return self.rewrite(uppergamma).rewrite(expint)
 
-    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+    def _eval_as_leading_term(self, x, logx, cdir):
         return self.rewrite(uppergamma)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_is_zero(self):
@@ -580,7 +570,7 @@ class uppergamma(Function):
         from sympy.functions.special.error_functions import expint
         return expint(1 - s, x)*x**s
 
-    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+    def _eval_as_leading_term(self, x, logx, cdir):
         from sympy.functions.special.error_functions import expint
         return self.rewrite(expint)._eval_as_leading_term(x, logx=logx, cdir=cdir)
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -499,6 +499,7 @@ def test_expint():
     assert expint(n, x).series(x, oo, n=3) == (1/x - n/x**2 + O(x**(-3), (x, oo)))*exp(-x)
     assert expint(4, x).series(x, oo, n=4) == (20/x**3 - 4/x**2 + 1/x + O(x**(-4), (x, oo)))*exp(-x)
     assert expint(1, x).series(x, oo, n=4) == (2/x**3 - 1/x**2 + 1/x + O(x**(-4), (x, oo)))*exp(-x)
+    assert expint(4, x).series(x, -oo, n=4) == (20/x**3 - 4/x**2 + 1/x + O(x**(-4), (x, -oo)))*exp(-x)
 
     assert expint(z, y).series(z, 0, 2) == exp(-y)/y - z*meijerg(((), (1, 1)),
                                   ((0, 0, 1), ()), y)/y + O(z**2)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -511,10 +511,16 @@ def test_expint():
     # test leading term
     assert expint(1, x).as_leading_term(x) == -log(x) - EulerGamma
     assert expint(3, x).as_leading_term(x) == S.Half
+    assert expint(1, 1/x).as_leading_term(x, logx=None, cdir=1) ==  expint(1, 1/x)
+    assert expint(1, 1/x).as_leading_term(x, logx=None, cdir=-1) ==  expint(1, 1/x)
 
     # test limits
     assert limit(expint(3, x), x, oo) == S.Zero
     assert limit(expint(1, x), x, oo) == S.Zero
+    assert limit(expint(3, x), x, -oo) == S.NegativeInfinity
+    assert limit(expint(1, x), x, -oo) == S.NegativeInfinity
+    assert limit(expint(1, 1/x), x, 0, dir='+') == S.Zero
+    assert limit(expint(1, 1/x), x, 0, dir='-') == S.NegativeInfinity
 
 def test__eis():
     assert _eis(z).diff(z) == -_eis(z) + 1/z

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -496,8 +496,9 @@ def test_expint():
         z**3*(log(z)/6 - Rational(11, 36) + EulerGamma/6 - I*pi/6) - z**4/24 + \
         z**5/240 + O(z**6)
 
-    assert expint(n, x).series(x, oo, n=3) == \
-        (n*(n + 1)/x**2 - n/x + 1 + O(x**(-3), (x, oo)))*exp(-x)/x
+    assert expint(n, x).series(x, oo, n=3) == (1/x - n/x**2 + O(x**(-3), (x, oo)))*exp(-x)
+    assert expint(4, x).series(x, oo, n=4) == (20/x**3 - 4/x**2 + 1/x + O(x**(-4), (x, oo)))*exp(-x)
+    assert expint(1, x).series(x, oo, n=4) == (2/x**3 - 1/x**2 + 1/x + O(x**(-4), (x, oo)))*exp(-x)
 
     assert expint(z, y).series(z, 0, 2) == exp(-y)/y - z*meijerg(((), (1, 1)),
                                   ((0, 0, 1), ()), y)/y + O(z**2)
@@ -506,6 +507,13 @@ def test_expint():
     neg = Symbol('neg', negative=True)
     assert Ei(neg).rewrite(Si) == Shi(neg) + Chi(neg) - I*pi
 
+    # test leading term
+    assert expint(1, x).as_leading_term(x) == -log(x) - EulerGamma
+    assert expint(3, x).as_leading_term(x) == S.Half
+
+    # test limits
+    assert limit(expint(3, x), x, oo) == S.Zero
+    assert limit(expint(1, x), x, oo) == S.Zero
 
 def test__eis():
     assert _eis(z).diff(z) == -_eis(z) + 1/z

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -106,6 +106,10 @@ def test_gamma_series():
         -1/(x + 1) + EulerGamma - 1 + (x + 1)*(-1 - pi**2/12 - EulerGamma**2/2 + \
        EulerGamma) + (x + 1)**2*(-1 - pi**2/12 - EulerGamma**2/2 + EulerGamma**3/6 - \
        polygamma(2, 1)/6 + EulerGamma*pi**2/12 + EulerGamma) + O((x + 1)**3, (x, -1))
+    assert gamma(x + 1).series(x, oo, 3) == sqrt(2)*sqrt(pi)*sqrt(x + 1)*(-23/(288*x**2) + \
+            1/(12*x) + 1 + O(x**(-3), (x, oo)))*exp(x*log(x + 1) - x - 1)
+    assert gamma(x).series(x, oo, 3) == sqrt(2)*sqrt(pi)*(1/(288*x**2) + 1/(12*x) + 1 + \
+            O(x**(-3), (x, oo)))*sqrt(1/x)*exp(-x*log(1/x) - x)
 
 
 def tn_branch(s, func):

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -10,6 +10,7 @@ from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import tanh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin, atan)
+from sympy.series.limits import limit
 from sympy.functions.special.error_functions import (Ei, erf, erfc)
 from sympy.functions.special.gamma_functions import (digamma, gamma, loggamma, lowergamma, multigamma, polygamma, trigamma, uppergamma)
 from sympy.functions.special.zeta_functions import zeta
@@ -110,6 +111,17 @@ def test_gamma_series():
             1/(12*x) + 1 + O(x**(-3), (x, oo)))*exp(x*log(x + 1) - x - 1)
     assert gamma(x).series(x, oo, 3) == sqrt(2)*sqrt(pi)*(1/(288*x**2) + 1/(12*x) + 1 + \
             O(x**(-3), (x, oo)))*sqrt(1/x)*exp(-x*log(1/x) - x)
+    assert gamma(x + 1).series(x, -oo, 3) == sqrt(2)*sqrt(pi)*sqrt(x + 1)*(-23/(288*x**2) + \
+            1/(12*x) + 1 + O(-1/x**3, (x, -oo)))*exp(x*log(x + 1) - x - 1)
+    assert gamma(x).series(x, -oo, 3) ==  -sqrt(2)*I*sqrt(pi)*sqrt(-1/x)*(1/(288*x**2) + \
+            1/(12*x) + 1 + O(-1/x**3, (x, -oo)))*exp(-x*log(-1/x) - x + I*pi*x)
+
+
+def test_gamma_limit():
+    assert limit(gamma(x), x, oo) == S.Infinity
+    assert limit(gamma(x), x, -oo) == S.Zero
+    assert limit(gamma(1/x), x, 0, dir='+') == S.Infinity
+    assert limit(gamma(1/x), x, 0, dir='-') == S.Zero
 
 
 def tn_branch(s, func):
@@ -593,6 +605,16 @@ def test_loggamma():
     assert s1 == -log(x) - EulerGamma*x + pi**2*x**2/12 + x**3*polygamma(2, 1)/6 + \
         pi**4*x**4/360 + x**5*polygamma(4, 1)/120 + O(x**6)
     assert s1 == loggamma(x).rewrite('intractable').series(x).cancel()
+    assert loggamma(x).series(x, oo) == 1/(1260*x**5) - 1/(360*x**3) + 1/(12*x) + log(2*pi)/2 + \
+        log(1/x)/2 + x*(-log(1/x) - 1) + O(x**(-6), (x, oo))
+    assert loggamma(x).series(x, -oo) == 1/(1260*x**5) - 1/(360*x**3) + 1/(12*x) - I*pi/2 + log(2*pi)/2 + \
+        log(-1/x)/2 - x*(log(-1/x) + 1 - I*pi) + O(x**(-6), (x, -oo))
+
+    # test limits
+    assert limit(loggamma(x), x, oo) == S.Infinity
+    assert limit(loggamma(x), x, -oo) == S.NegativeInfinity
+    assert limit(loggamma(1/x), x, 0, dir='+') == S.Infinity
+    assert limit(loggamma(1/x), x, 0, dir='-') == S.NegativeInfinity
 
     assert conjugate(loggamma(x)) == loggamma(conjugate(x))
     assert conjugate(loggamma(0)) is oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -19,7 +19,7 @@ from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, as
                                                       atan, cos, cot, csc, sec, sin, tan)
 from sympy.functions.special.bessel import (besseli, bessely, besselj, besselk)
 from sympy.functions.special.error_functions import (Ei, erf, erfc, erfi, fresnelc, fresnels)
-from sympy.functions.special.gamma_functions import (digamma, gamma, uppergamma)
+from sympy.functions.special.gamma_functions import (digamma, gamma, lowergamma, uppergamma)
 from sympy.functions.special.hyper import meijerg
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.series.limits import (Limit, limit)
@@ -390,6 +390,16 @@ def test_bessel_functions_at_infinity():
 
     # test issue 14874
     assert limit(besselk(0, x), x, oo) == 0
+
+
+def test_lowergamma_at_origin():
+    a, x = symbols('a x')
+    assert limit(lowergamma(a, x), a, 0) == oo
+    assert limit(lowergamma(a, x), a, 0, '-') == -oo
+    assert limit(lowergamma(I*a, x), a, 0) == -oo*I
+    assert limit(lowergamma(I*a, x), a, 0, '-') == oo*I
+    assert limit(lowergamma(a, 1), a, 0) == oo
+    assert limit(x*lowergamma(x, 1)/gamma(x + 1), x, 0) == 1
 
 
 @XFAIL

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -590,7 +590,7 @@ def test_factorial():
     # see Stirling's approximation:
     # https://en.wikipedia.org/wiki/Stirling's_approximation
     assert limit(f/(sqrt(2*pi*x)*(x/E)**x), x, oo) == 1
-    assert limit(f, x, -oo) == gamma(-oo)
+    assert limit(f, x, -oo) == S.Zero
 
 
 def test_issue_6560():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #24027

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Implemented leading term methods for expint error funciton.
  * Implemented leading term methods for uppergamma and lowergamma fucntion.
  * Implemented aseries method for gamma function.
  * Added helper classes for expint for being tractable for gruntz.
  * Extends aseries expansion for loggamma in negative infinity and corresponding limits
<!-- END RELEASE NOTES -->
