### PR TITLE
[DOC] [PDF] Use normal size for DejaVu Sans Mono in code-blocks

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -385,6 +385,7 @@ latex_elements = {
 ''',
     'sphinxsetup': 'verbatimforcewraps',
     'printindex': r'\def\twocolumn[#1]{#1}\raggedright\printindex',
+    'fvset': r'\fvset{fontsize=auto}',
 }
 
 # SymPy logo on title page


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/26868

#### Brief description of what is fixed or changed

As a side-effect of merged https://github.com/sympy/sympy/pull/26868, [Sphinx 'fvset'](https://www.sphinx-doc.org/en/master/latex.html#the-latex-elements-configuration-setting) uses its default `fontsize=\small`, because Sphinx now knows the build will use `xelatex`.  This choice is appropriate for the default Sphinx font choices.


With the DejaVu family used by Sympy, and after testing I find that using the former `fontsize=auto` (which means to inherit ambient fontsize; code-blocks may appear in footnotes although I don't know if there is a single instance in SymPy) is better.

It is certainly better from an accessibility point of view.

So the aim of this PR is to re-enact the normal fontsize in code-blocks as used prior to merge of https://github.com/sympy/sympy/pull/26868.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
