### PR TITLE
[DOC] Use Sphinx 7.1 maximum_signature_line_length

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -190,6 +190,8 @@ pygments_dark_style = 'styles.NativeHighContrastStyle'
 # Don't show the source code hyperlinks when using matplotlib plot directive.
 plot_html_show_source_link = False
 
+maximum_signature_line_length = 50
+
 # Options for HTML output
 # -----------------------
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

PR #26867 discussed the overflows in PDF margins (see below screenshots).  This PR solves that problem.

#### Brief description of what is fixed or changed

Signatures which would be wider than a certain set line length (here tentatively set at 50 characters) will display each parameter on its own line.  This solves a problem for PDF version of the documentation.  But it applies to both HTML and PDF outputs.

This requires Sphinx 7.1 added configuration [maximum_signature_line_length](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-maximum_signature_line_length).  It has domain specific variants.  But it applies to both HTML and PDF.

(with Sphinx<7.1 the `conf.py` setting is silently ignored)

#### Other comments

Here is current HTML output: (as seen on my small laptop screen)

![Capture d’écran 2024-08-03 à 12 03 42](https://github.com/user-attachments/assets/e2c50c24-86c2-4d50-94e6-bbd6c65b1746)

and how it will render with this commit 

![Capture d’écran 2024-08-03 à 12 25 19](https://github.com/user-attachments/assets/74b98011-25b7-462a-8604-deec4e88e271)



Regarding LaTeX PDF:


![Capture d’écran 2024-08-03 à 12 39 06](https://github.com/user-attachments/assets/5c8cebac-891f-4cf7-b5da-d4c2afe8173d)

versus

![Capture d’écran 2024-08-03 à 12 37 17](https://github.com/user-attachments/assets/cca7e8c8-72e1-46d4-844a-5e830f213ab4)

Two last PDF examples to illustrate that threshold is set at 50.  

![Capture d’écran 2024-08-03 à 12 35 28](https://github.com/user-attachments/assets/c6c10514-111f-4460-941a-df924e0e10d0)

![Capture d’écran 2024-08-03 à 12 34 25](https://github.com/user-attachments/assets/7f05444e-aeab-4a52-ad4d-3b25d60f6114)

An option would be to set the configuration value at `1`.

Building docs takes long time on my old hardware so I can't really test comprehensively.

EDIT: regarding  `sympy.sets.fancysets.ComplexRegion(sets, polar=False)` which occupies 53 characters, I think `class` is not considered part of signature and I am not sure why it did not trigger the one-param-per-line, perhaps the default `False` was ignored, but this is surpriseing, I would have to check Sphinx source code more closely.

EDIT2: I am not sure either why ``LUsolve(rhs, iszerofunc=<function _iszero>)`` is considered exceeding the 50 characters setting.  I would need to know better `autodoc` internals... alas I never get time to learn these things as LaTeX aspects swallow all my spare time...

As I indicated above an option would be to set value to 1 so that output behaves uniformly.  That may not be so important because perhaps it is only important to be uniform per page in HTML output, and for PDF, even though it is a single document you can't be bothered on page 500 that somethinh will be a bit different on page 3400.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
