### PR TITLE
23918: `as_base_exp` restored

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -821,8 +821,8 @@ class Pow(Expr):
 
         """
         b, e = self.args
-        if b.is_Rational and b.p == 1 and b.q != 1:
-            return Integer(b.q), -e
+        if b.is_Rational and b.p < b.q and b.p > 0:
+            return 1/b, -e
         return b, e
 
     def _eval_adjoint(self):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -803,7 +803,7 @@ class Pow(Expr):
         Explanation
         ===========
 
-        If base a Rational less than 1, then return 1/Rational, -exp.
+        If base is a Rational less than 1, then return 1/Rational, -exp.
         If this extra processing is not needed, the base and exp
         properties will give the raw arguments.
 

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -274,15 +274,17 @@ def test_zero():
     assert power(0, -oo) is zoo
     assert Float(0)**-oo is zoo
 
+
 def test_pow_as_base_exp():
     assert (S.Infinity**(2 - x)).as_base_exp() == (S.Infinity, 2 - x)
     assert (S.Infinity**(x - 2)).as_base_exp() == (S.Infinity, x - 2)
+    # issue 23918
     p = S.Half**x
     assert p.base, p.exp == p.as_base_exp() == (S(2), -x)
     p = (S(3)/2)**x
     assert p.base, p.exp == p.as_base_exp() == (3*S.Half, x)
     p = (S(2)/3)**x
-    assert p.as_base_exp() == (S(2)/3, x)
+    assert p.as_base_exp() == (S(3)/2, -x)
     assert p.base, p.exp == (S(2)/3, x)
     # issue 8344:
     assert Pow(1, 2, evaluate=False).as_base_exp() == (S.One, S(2))
@@ -646,11 +648,6 @@ def test_powers_of_I():
         1, sqrt(I), I, sqrt(I)**3, -1, -sqrt(I), -I, -sqrt(I)**3,
         1, sqrt(I), I, sqrt(I)**3, -1]
     assert sqrt(I)**(S(9)/2) == -I**(S(1)/4)
-
-
-def test_issue_23918():
-    b = S(2)/3
-    assert (b**x).as_base_exp() == (b, x)
 
 
 def test_issue_26546():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -263,6 +263,7 @@ def test_latex_basic():
     assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left(p \right)}"
 
     assert latex(Pow(Rational(2, 3), -1, evaluate=False)) == r'\frac{1}{\frac{2}{3}}'
+    assert latex(Pow(Rational(2, 3), -2, evaluate=False)) == r'\frac{1}{\left(\frac{2}{3}\right)^{2}}'
     assert latex(Pow(Rational(4, 3), -1, evaluate=False)) == r'\frac{1}{\frac{4}{3}}'
     assert latex(Pow(Rational(-3, 4), -1, evaluate=False)) == r'\frac{1}{- \frac{3}{4}}'
     assert latex(Pow(Rational(-4, 4), -1, evaluate=False)) == r'\frac{1}{-1}'

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -364,3 +364,10 @@ def test_issue_22546():
     ans = ref.subs(i, e)
     assert ans.is_Pow
     assert powsimp(x**e/y**e) == ans
+
+
+def test_issue_23918():
+    # the change happens in as_base_exp but
+    # shows up in powsimp
+    b = S(2)/3
+    assert powsimp(b**x) == (1/b)**-x

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -179,7 +179,7 @@ def FlorySchulz(name, a):
     >>> X = FlorySchulz("x", a)
 
     >>> density(X)(z)
-    (4/5)**(z - 1)*z/25
+    (5/4)**(1 - z)*z/25
 
     >>> E(X)
     9
@@ -252,7 +252,7 @@ def Geometric(name, p):
     >>> X = Geometric("x", p)
 
     >>> density(X)(z)
-    (4/5)**(z - 1)/5
+    (5/4)**(1 - z)/5
 
     >>> E(X)
     5

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -292,6 +292,6 @@ def test_product_spaces():
     assert str(P(X1 + X2 < 3).rewrite(Sum)) == (
         "Sum(Piecewise((1/(4*2**n), n >= -1), (0, True)), (n, -oo, -1))/3")
     assert str(P(X1 + X2 > 3).rewrite(Sum)) == (
-        'Sum(Piecewise((2**(X2 - n - 2)*(2/3)**(X2 - 1)/6, '
+        'Sum(Piecewise((2**(X2 - n - 2)*(3/2)**(1 - X2)/6, '
         'X2 - n <= 2), (0, True)), (X2, 1, oo), (n, 1, oo))')
     assert P(Eq(X1 + X2, 3)) == Rational(1, 12)


### PR DESCRIPTION
* the behavior of `as_base_exp` again matches the docstring desciption.
* the recursion error encountered when using unevaluated Pow with latex has been fixed
* the unevaluated Pow is no longer evaluated, e.g. `Pow(2/S(3), -2, evaluate=False)` no longer prints as `Pow(4/9,-1,evaluate=0)`

cf #23921 which made the original change for issue #23918

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * fixed recursion error when printing `latex` form of unevaluated power of a Rational
  * unevaluated power of Rational now remains unevaluated
<!-- END RELEASE NOTES -->
