### PR TITLE
Handling negative arguments for inverse trigonometric functions

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1001,10 +1001,13 @@ def test_acos():
     assert acos(-sqrt(2)/2) == pi*Rational(3, 4)
 
     # check round-trip for exact values:
-    for d in [5, 6, 8, 10, 12]:
+    for d in range(5, 13):
         for num in range(d):
             if gcd(num, d) == 1:
                 assert acos(cos(num*pi/d)) == num*pi/d
+                assert acos(-cos(num*pi/d)) == pi - num*pi/d
+                assert acos(sin(num*pi/d)) == pi/2 - asin(sin(num*pi/d))
+                assert acos(-sin(num*pi/d)) == pi/2 - asin(-sin(num*pi/d))
 
     assert acos(2*I) == pi/2 - asin(2*I)
 
@@ -1824,6 +1827,14 @@ def test_asec():
     assert asec(sqrt(2 + 2*sqrt(5)/5)) == pi*Rational(3, 10)
     assert asec(-sqrt(2 + 2*sqrt(5)/5)) == pi*Rational(7, 10)
     assert asec(sqrt(2) - sqrt(6)) == pi*Rational(11, 12)
+
+    for d in [3, 4, 6]:
+        for num in range(d):
+            if gcd(num, d) == 1:
+                assert asec(sec(num*pi/d)) == num*pi/d
+                assert asec(-sec(num*pi/d)) == pi - num*pi/d
+                assert asec(csc(num*pi/d)) == pi/2 - acsc(csc(num*pi/d))
+                assert asec(-csc(num*pi/d)) == pi/2 - acsc(-csc(num*pi/d))
 
     assert asec(x).diff(x) == 1/(x**2*sqrt(1 - 1/x**2))
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2428,19 +2428,30 @@ class acos(InverseTrigonometricFunction):
         if i_coeff is not None:
             return pi/2 - asin(arg)
 
-        if isinstance(arg, cos):
-            ang = arg.args[0]
+        if arg.is_Mul and len(arg.args) == 2 and arg.args[0] == -1:
+            narg = arg.args[1]
+            minus = True
+        else:
+            narg = arg
+            minus = False
+
+        if isinstance(narg, cos):
+            # acos(cos(x)) = x or acos(-cos(x)) = pi - x
+            ang = narg.args[0]
             if ang.is_comparable:
+                if minus:
+                    ang = pi - ang
                 ang %= 2*pi # restrict to [0,2*pi)
                 if ang > pi: # restrict to [0,pi]
                     ang = 2*pi - ang
-
                 return ang
 
-        if isinstance(arg, sin): # acos(x) + asin(x) = pi/2
-            ang = arg.args[0]
+        if isinstance(narg, sin): # acos(x) + asin(x) = pi/2
+            ang = narg.args[0]
             if ang.is_comparable:
-                return pi/2 - asin(arg)
+                if minus:
+                    return pi/2 + asin(narg)
+                return pi/2 - asin(narg)
 
     @staticmethod
     @cacheit
@@ -3085,19 +3096,30 @@ class asec(InverseTrigonometricFunction):
         if arg.is_infinite:
             return pi/2
 
-        if isinstance(arg, sec):
-            ang = arg.args[0]
+        if arg.is_Mul and len(arg.args) == 2 and arg.args[0] == -1:
+            narg = arg.args[1]
+            minus = True
+        else:
+            narg = arg
+            minus = False
+
+        if isinstance(narg, sec):
+            # asec(sec(x)) = x or asec(-sec(x)) = pi - x
+            ang = narg.args[0]
             if ang.is_comparable:
+                if minus:
+                    ang = pi - ang
                 ang %= 2*pi # restrict to [0,2*pi)
                 if ang > pi: # restrict to [0,pi]
                     ang = 2*pi - ang
-
                 return ang
 
-        if isinstance(arg, csc): # asec(x) + acsc(x) = pi/2
-            ang = arg.args[0]
+        if isinstance(narg, csc): # asec(x) + acsc(x) = pi/2
+            ang = narg.args[0]
             if ang.is_comparable:
-                return pi/2 - acsc(arg)
+                if minus:
+                    pi/2 + acsc(narg)
+                return pi/2 - acsc(narg)
 
     def fdiff(self, argindex=1):
         if argindex == 1:


### PR DESCRIPTION
`acos` and `asec` have the following properties:

$$
\begin{align*}
\arccos (-x) &= \pi - \arccos (x) \\
arcsec (-x) &= \pi - arcsec (x)
\end{align*}
$$

Since `acos` and `asec` do not have the functionality to rewrite these expressions, `acos(-cos(x))` cannot be evaluated as `pi-x`. However, unconditionally performing this rewrite might just increase the number of terms. Therefore, I have implemented the rewrite to be performed only for specific functions.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
