### PR TITLE
select minpoly from factors

### DIFF
--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -3,7 +3,7 @@
 from functools import reduce
 
 from sympy.core.add import Add
-from sympy.core.exprtools import Factors, factor_terms
+from sympy.core.exprtools import Factors
 from sympy.core.function import expand_mul, expand_multinomial, _mexpand
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Rational, pi, _illegal)
@@ -571,18 +571,13 @@ def _minpoly_compose(ex, x, dom):
         return x - ex
 
     if dom.is_QQ and _is_sum_surds(ex):
-        # extract gcd's from all radicals to confirm
-        # non-zero value
-        ex = _mexpand(factor_terms(ex, radical=True))
-        if not ex:
-            return x
         # eliminate the square roots
+        v = ex
         ex -= x
         while 1:
             ex1 = _separate_sq(ex)
             if ex1 is ex:
-                assert ex.is_Add, 'unexpected return value'
-                return ex
+                return _choose_factor(_factor_list(ex)[1], x, v)
             else:
                 ex = ex1
 

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -577,7 +577,7 @@ def _minpoly_compose(ex, x, dom):
         while 1:
             ex1 = _separate_sq(ex)
             if ex1 is ex:
-                return _choose_factor(_factor_list(ex)[1], x, v)
+                return _choose_factor(factor_list(ex)[1], x, v)
             else:
                 ex = ex1
 

--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -3,7 +3,7 @@
 from functools import reduce
 
 from sympy.core.add import Add
-from sympy.core.exprtools import Factors
+from sympy.core.exprtools import Factors, factor_terms
 from sympy.core.function import expand_mul, expand_multinomial, _mexpand
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Rational, pi, _illegal)
@@ -571,11 +571,17 @@ def _minpoly_compose(ex, x, dom):
         return x - ex
 
     if dom.is_QQ and _is_sum_surds(ex):
+        # extract gcd's from all radicals to confirm
+        # non-zero value
+        ex = _mexpand(factor_terms(ex, radical=True))
+        if not ex:
+            return x
         # eliminate the square roots
         ex -= x
         while 1:
             ex1 = _separate_sq(ex)
             if ex1 is ex:
+                assert ex.is_Add, 'unexpected return value'
                 return ex
             else:
                 ex = ex1

--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -181,7 +181,9 @@ def test_issue_26903():
     p1 = nextprime(10**16)  # greater than 10**15
     p2 = nextprime(p1)
     assert sqrt(p1**2*p2).is_Pow  # square not extracted
-    assert minimal_polynomial(sqrt(p1**2*p2) - p1*sqrt(p2)).is_Symbol
+    zero = sqrt(p1**2*p2) - p1*sqrt(p2)
+    assert minimal_polynomial(z, x) == x
+    assert minimal_polynomial(sqrt(2) - zero, x) == x**2 - 2
 
 
 def test_minimal_polynomial_issue_19732():

--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -8,6 +8,7 @@ from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import (cbrt, sqrt)
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
+from sympy.ntheory.generate import nextprime
 from sympy.polys.polytools import Poly
 from sympy.polys.rootoftools import CRootOf
 from sympy.solvers.solveset import nonlinsolve
@@ -174,6 +175,13 @@ def test_minimal_polynomial():
     # Wester H24
     phi = AlgebraicNumber(S.GoldenRatio.expand(func=True), alias='phi')
     assert minimal_polynomial(phi, x) == x**2 - x - 1
+
+
+def test_issue_26903():
+    p1 = nextprime(10**16)  # greater than 10**15
+    p2 = nextprime(p1)
+    assert sqrt(p1**2*p2).is_Pow  # square not extracted
+    assert minimal_polynomial(sqrt(p1**2*p2) - p1*sqrt(p2)).is_Symbol
 
 
 def test_minimal_polynomial_issue_19732():

--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -182,7 +182,7 @@ def test_issue_26903():
     p2 = nextprime(p1)
     assert sqrt(p1**2*p2).is_Pow  # square not extracted
     zero = sqrt(p1**2*p2) - p1*sqrt(p2)
-    assert minimal_polynomial(z, x) == x
+    assert minimal_polynomial(zero, x) == x
     assert minimal_polynomial(sqrt(2) - zero, x) == x**2 - 2
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
closes #26903

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

A check that the number is not trivially 0 before starting removal of square roots is now done. If it is not done, then `-x**2` can be returned from the `_separate_sq` helper (which is only called from `_minpoly_compose`).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * fixed minpoly to not return `-x**2` instead of `x` for an unsimplified value of 0 comprised of a difference of square roots
<!-- END RELEASE NOTES -->
