### PR TITLE
Fixed custom _latex() printer in secondquant such that printer._print() is used

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -699,6 +699,7 @@ Hugo van Kemenade <hugovk@users.noreply.github.com> Hugo <hugovk@users.noreply.g
 Huijun Mai <m.maihuijun@gmail.com>
 Hwayeon Kang <hwayeonniii@gmail.com> <97640870+eh111eh@users.noreply.github.com>
 Hwayeon Kang <hwayeonniii@gmail.com> eh111eh <hwayeonniii@gmail.com>
+Håkon Kvernmoen <haakon.kvernmoen@gmail.com> hkve <haakon.kvernmoen@gmail.com>
 Ian Swire <oversizedpenguin@gmail.com>
 Idan Pazi <idan.kp@gmail.com>
 Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -232,8 +232,8 @@ class AntiSymmetricTensor(TensorSymbol):
     def _latex(self, printer):
         return "{%s^{%s}_{%s}}" % (
             self.symbol,
-            "".join([ i.name for i in self.args[1]]),
-            "".join([ i.name for i in self.args[2]])
+            "".join([ printer._print(i) for i in self.args[1]]),
+            "".join([ printer._print(i) for i in self.args[2]])
         )
 
     @property
@@ -432,7 +432,7 @@ class AnnihilateBoson(BosonicOperator, Annihilator):
         if self.state is S.Zero:
             return "b_{0}"
         else:
-            return "b_{%s}" % self.state.name
+            return "b_{%s}" % printer._print(self.state)
 
 class CreateBoson(BosonicOperator, Creator):
     """
@@ -473,7 +473,7 @@ class CreateBoson(BosonicOperator, Creator):
         if self.state is S.Zero:
             return "{b^\\dagger_{0}}"
         else:
-            return "{b^\\dagger_{%s}}" % self.state.name
+            return "{b^\\dagger_{%s}}" % printer._print(self.state)
 
 B = AnnihilateBoson
 Bd = CreateBoson
@@ -791,7 +791,7 @@ class AnnihilateFermion(FermionicOperator, Annihilator):
         if self.state is S.Zero:
             return "a_{0}"
         else:
-            return "a_{%s}" % self.state.name
+            return "a_{%s}" % printer._print(self.state)
 
 
 class CreateFermion(FermionicOperator, Creator):
@@ -940,7 +940,7 @@ class CreateFermion(FermionicOperator, Creator):
         if self.state is S.Zero:
             return "{a^\\dagger_{0}}"
         else:
-            return "{a^\\dagger_{%s}}" % self.state.name
+            return "{a^\\dagger_{%s}}" % printer._print(self.state)
 
 Fd = CreateFermion
 F = AnnihilateFermion
@@ -3018,7 +3018,7 @@ class PermutationOperator(Expr):
             return expr
 
     def _latex(self, printer):
-        return "P(%s%s)" % self.args
+        return "P(%s%s)" % tuple(printer._print(i) for i in self.args)
 
 
 def simplify_index_permutations(expr, permutation_operators):

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -39,6 +39,8 @@ def test_PermutationOperator():
         P(p, q)*P(r, s)*f(p)*g(q)*h(r)*i(s))
     assert latex(P(p, q)) == 'P(pq)'
 
+    p1, p2 = symbols('p1,p2')
+    assert latex(P(p1,p2) == 'P(p_{1}p_{2})')
 
 def test_index_permutations_with_dummies():
     a, b, c, d = symbols('a b c d')
@@ -98,9 +100,10 @@ def test_operator():
 
 
 def test_create():
-    i, j, n, m = symbols('i,j,n,m')
+    i, j, n, m, p1 = symbols('i,j,n,m,p1')
     o = Bd(i)
     assert latex(o) == "{b^\\dagger_{i}}"
+    assert latex(Bd(p1)) == "{b^\\dagger_{p_{1}}}"
     assert isinstance(o, CreateBoson)
     o = o.subs(i, j)
     assert o.atoms(Symbol) == {j}
@@ -111,9 +114,10 @@ def test_create():
 
 
 def test_annihilate():
-    i, j, n, m = symbols('i,j,n,m')
+    i, j, n, m, p1 = symbols('i,j,n,m,p1')
     o = B(i)
     assert latex(o) == "b_{i}"
+    assert latex(B(p1)) == "b_{p_{1}}"
     assert isinstance(o, AnnihilateBoson)
     o = o.subs(i, j)
     assert o.atoms(Symbol) == {j}
@@ -287,6 +291,7 @@ def test_create_f():
     i, j, k, l = symbols('i,j,k,l', below_fermi=True)
     a, b, c, d = symbols('a,b,c,d', above_fermi=True)
     p, q, r, s = symbols('p,q,r,s')
+    p1 = symbols("p1")
 
     assert Fd(i).apply_operator(FKet([i, j, k], 4)) == FKet([j, k], 4)
     assert Fd(a).apply_operator(FKet([i, b, k], 4)) == FKet([a, i, b, k], 4)
@@ -295,6 +300,7 @@ def test_create_f():
     assert repr(Fd(p)) == 'CreateFermion(p)'
     assert srepr(Fd(p)) == "CreateFermion(Symbol('p'))"
     assert latex(Fd(p)) == r'{a^\dagger_{p}}'
+    assert latex(Fd(p1)) == r'{a^\dagger_{p_{1}}}'
 
 
 def test_annihilate_f():
@@ -312,6 +318,8 @@ def test_annihilate_f():
     i, j, k, l = symbols('i,j,k,l', below_fermi=True)
     a, b, c, d = symbols('a,b,c,d', above_fermi=True)
     p, q, r, s = symbols('p,q,r,s')
+    p1 = symbols('p1')
+
     assert F(i).apply_operator(FKet([i, j, k], 4)) == 0
     assert F(a).apply_operator(FKet([i, b, k], 4)) == 0
     assert F(l).apply_operator(FKet([i, j, k], 3)) == 0
@@ -320,6 +328,7 @@ def test_annihilate_f():
     assert repr(F(p)) == 'AnnihilateFermion(p)'
     assert srepr(F(p)) == "AnnihilateFermion(Symbol('p'))"
     assert latex(F(p)) == 'a_{p}'
+    assert latex(F(p1)) == 'a_{p_{1}}'
 
 
 def test_create_b():
@@ -542,6 +551,12 @@ def test_Tensors():
 
     assert AT('t', (a, a), (i, j)).subs(a, b) == AT('t', (b, b), (i, j))
     assert AT('t', (a, i), (a, j)).subs(a, b) == AT('t', (b, i), (b, j))
+
+    a1, a2, a3, a4 = symbols('alpha1:5')
+    u_alpha1234 = AntiSymmetricTensor("u", (a1, a2), (a3, a4))
+
+    assert latex(u_alpha1234) == r'{u^{\alpha_{1}\alpha_{2}}_{\alpha_{3}\alpha_{4}}}'
+    assert str(u_alpha1234) == 'u((alpha1, alpha2),(alpha3, alpha4))'
 
 
 def test_fully_contracted():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed custom `_latex()` methods for different components of `physics.secondquant`. Now uses `printer._print()` following the printer class guidelines, which produces correct output for e.g. indices with subscripts. 

This concerns:
- `AntiSymmetricTensor`
- `AnnihilateBoson`
- `AnnihilateFermion`
- `CreateBoson`
- `CreateFermion`
- `PermutationOperator`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
