### PR TITLE
[GSoC] [WIP] Added nyquist plot to control plots.

### DIFF
--- a/sympy/physics/control/__init__.py
+++ b/sympy/physics/control/__init__.py
@@ -4,7 +4,7 @@ from .lti import (TransferFunction, Series, MIMOSeries, Parallel, MIMOParallel,
 from .control_plots import (pole_zero_numerical_data, pole_zero_plot, step_response_numerical_data,
     step_response_plot, impulse_response_numerical_data, impulse_response_plot, ramp_response_numerical_data,
     ramp_response_plot, bode_magnitude_numerical_data, bode_phase_numerical_data, bode_magnitude_plot,
-    bode_phase_plot, bode_plot)
+    bode_phase_plot, bode_plot, nyquist_plot)
 
 __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
     'MIMOParallel', 'Feedback', 'MIMOFeedback', 'TransferFunctionMatrix', 'StateSpace',
@@ -13,4 +13,5 @@ __all__ = ['TransferFunction', 'Series', 'MIMOSeries', 'Parallel',
     'step_response_plot', 'impulse_response_numerical_data', 'impulse_response_plot',
     'ramp_response_numerical_data', 'ramp_response_plot',
     'bode_magnitude_numerical_data', 'bode_phase_numerical_data',
-    'bode_magnitude_plot', 'bode_phase_plot', 'bode_plot']
+    'bode_magnitude_plot', 'bode_phase_plot', 'bode_plot',
+    'nyquist_plot']


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This release introduces the `nyquist_plot` function to the control module, providing users with the ability to generate Nyquist plots for Single-Input Single-Output (SISO) Linear Time-Invariant (LTI) systems. It plots the complex values of a system's frequency response as a function of frequency, showing how the output of the system changes in magnitude and phase as the frequency varies.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added Nyquist plot to control.
<!-- END RELEASE NOTES -->
