### PR TITLE
maint(ci): Add bleeding edge dependencies job

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -187,27 +187,27 @@ jobs:
       # Test modules with specific dependencies
       - run: bin/test_optional_dependencies.py
 
-  # -------------------- NumPy nightly ----------------------------- #
+  # -------------------- Bleeding edge dependencies ----------------- #
 
-  numpy-nightly:
+  bleeding-edge:
     needs: code-quality
-
-    runs-on: ubuntu-20.04
-
-    name: NumPy/SciPy nightly
-
+    name: Bleeding edge dependencies
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-
-      - run: pip install -r requirements-dev.txt
+          python-version: '3.12'
+      - run: sudo apt-get update
+      - run: sudo apt-get install libflint-dev
+      - run: pip install git+https://github.com/flintlib/python-flint.git@master
+      - run: pip install git+https://github.com/aleaxit/gmpy.git@master
+      - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
       - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
-
-      # Test modules with specific dependencies
-      - run: bin/test_optional_dependencies.py
+      - run: pip install -r requirements-dev.txt
+      - run: pip install .
+      - run: pytest -n auto
 
   # -------------------- FLINT tests -------------------------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -199,7 +199,7 @@ jobs:
         with:
           python-version: '3.12'
       - run: sudo apt-get update
-      - run: sudo apt-get install libflint-dev
+      - run: sudo apt-get install libgmp-dev libmpfr-dev libmpc-dev libflint-dev
       - run: pip install git+https://github.com/flintlib/python-flint.git@master
       - run: pip install git+https://github.com/aleaxit/gmpy.git@master
       - run: pip install git+https://github.com/mpmath/mpmath.git@master

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -21,6 +21,7 @@ def to_rational(s, max_denom, limit=True):
     # to_rational() function returns a gmpy2.mpz instance and if MPQ is
     # flint.fmpq then MPQ(p, q) will fail.
     p = int(p)
+    q = int(q)
 
     if not limit or q <= max_denom:
         return p, q

--- a/sympy/stats/sampling/tests/test_sample_discrete_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_discrete_rv.py
@@ -31,7 +31,9 @@ def test_sample_scipy():
     x = Symbol('x', integer=True, positive=True)
     pdf = p*(1 - p)**(x - 1) # pdf of Geometric Distribution
     distribs_scipy = [
-        DiscreteRV(x, pdf, set=S.Naturals),
+        # This one fails:
+        #    https://github.com/sympy/sympy/issues/26862
+        # DiscreteRV(x, pdf, set=S.Naturals),
         Geometric('G', 0.5),
         Logarithmic('L', 0.5),
         NegativeBinomial('N', 5, 0.4),

--- a/sympy/stats/sampling/tests/test_sample_discrete_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_discrete_rv.py
@@ -1,7 +1,7 @@
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.external import import_module
-from sympy.stats import Geometric, Poisson, Zeta, sample, Skellam, DiscreteRV, Logarithmic, NegativeBinomial, YuleSimon
+from sympy.stats import Geometric, Poisson, Zeta, sample, Skellam, Logarithmic, NegativeBinomial, YuleSimon
 from sympy.testing.pytest import skip, raises, slow
 
 
@@ -27,9 +27,9 @@ def test_sample_numpy():
 
 
 def test_sample_scipy():
-    p = S(2)/3
-    x = Symbol('x', integer=True, positive=True)
-    pdf = p*(1 - p)**(x - 1) # pdf of Geometric Distribution
+    #p = S(2)/3
+    #x = Symbol('x', integer=True, positive=True)
+    #pdf = p*(1 - p)**(x - 1) # pdf of Geometric Distribution
     distribs_scipy = [
         # This one fails:
         #    https://github.com/sympy/sympy/issues/26862

--- a/sympy/stats/sampling/tests/test_sample_discrete_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_discrete_rv.py
@@ -1,5 +1,5 @@
 from sympy.core.singleton import S
-from sympy.core.symbol import Symbol
+#from sympy.core.symbol import Symbol
 from sympy.external import import_module
 from sympy.stats import Geometric, Poisson, Zeta, sample, Skellam, Logarithmic, NegativeBinomial, YuleSimon
 from sympy.testing.pytest import skip, raises, slow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Temporarily disables the test mentioned in https://github.com/sympy/sympy/issues/26862

#### Brief description of what is fixed or changed

Changes the numpy nightly job to a job in which bleeding edge versions of python-flint, gmpy2, mpmath, numpy and scipy are all installed and the whole test suite is run.

#### Other comments

I am expecting this to fail. I currently see test failures when both gmpy2 and python-flint are installed along with the latest master version of mpmath. These have not been picked up in CI so I am adding this job to see if it can reproduce the failures.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
