### PR TITLE
(2nd) Revert gh-26385 (maintain ordering in heurisch mapping)

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from collections import defaultdict
-from functools import reduce
 from itertools import permutations
+from functools import reduce
 
 from sympy.core.add import Add
 from sympy.core.basic import Basic
@@ -504,16 +503,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         # optimizing the number of permutations of mapping              #
         assert mapping[-1][0] == x # if not, find it and correct this comment
         unnecessary_permutations = [mapping.pop(-1)]
-        # only permute types of objects and let the ordering
-        # of types take care of the order of replacement
-        types = defaultdict(list)
-        for i in mapping:
-            types[type(i)].append(i)
-        mapping = [types[i] for i in types]
-        def _iter_mappings():
-            for i in permutations(mapping):
-                yield [j for i in i for j in i]
-        mappings = _iter_mappings()
+        mappings = permutations(mapping)
     else:
         unnecessary_permutations = unnecessary_permutations or []
 

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -2,7 +2,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.add import Add
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.numbers import (I, Rational, pi)
-from sympy.core.relational import Eq, Ne
+from sympy.core.relational import Ne
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (asinh, cosh, sinh, tanh)
@@ -12,8 +12,6 @@ from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sin
 from sympy.functions.special.bessel import (besselj, besselk, bessely, jn)
 from sympy.functions.special.error_functions import erf
 from sympy.integrals.integrals import Integral
-from sympy.logic.boolalg import And
-from sympy.matrices import Matrix
 from sympy.simplify.ratsimp import ratsimp
 from sympy.simplify.simplify import simplify
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
@@ -370,20 +368,3 @@ def test_heurisch_complex_erf_issue_26338():
     assert heurisch(a, x, hints=[]) is None  # None, not a wrong soln
     a = sqrt(pi)*erf((1 + I)/2)/2
     assert integrate(exp(-I*x**2/2), (x, 0, 1)) == a - I*a
-
-
-def test_issue_15498():
-    Z0 = Function('Z0')
-    k01, k10, t, s= symbols('k01 k10 t s', real=True, positive=True)
-    m = Matrix([[exp(-k10*t)]])
-    _83 = Rational(83, 100)  # 0.83 works, too
-    [a, b, c, d, e, f, g] = [100, 0.5, _83, 50, 0.6, 2, 120]
-    AIF_btf = a*(d*e*(1 - exp(-(t - b)/e)) + f*g*(1 - exp(-(t - b)/g)))
-    AIF_atf = a*(d*e*exp(-(t - b)/e)*(exp((c - b)/e) - 1
-        ) + f*g*exp(-(t - b)/g)*(exp((c - b)/g) - 1))
-    AIF_sym = Piecewise((0, t < b), (AIF_btf, And(b <= t, t < c)), (AIF_atf, c <= t))
-    aif_eq = Eq(Z0(t), AIF_sym)
-    f_vec = Matrix([[k01*Z0(t)]])
-    integrand = m*m.subs(t, s)**-1*f_vec.subs(aif_eq.lhs, aif_eq.rhs).subs(t, s)
-    solution = integrate(integrand[0], (s, 0, t))
-    assert solution is not None  # does not hang and takes less than 10 s

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1147,7 +1147,7 @@ def test_issue_3940():
     assert integrate(exp(-x**2 + I*c*x), x) == \
         -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
     assert integrate(exp(a*x**2 + b*x + c), x) == \
-        sqrt(pi)*exp(c - b**2/(4*a))*erfi((2*a*x + b)/(2*sqrt(a)))/(2*sqrt(a))
+        sqrt(pi)*exp(c)*exp(-b**2/(4*a))*erfi(sqrt(a)*x + b/(2*sqrt(a)))/(2*sqrt(a))
 
     from sympy.core.function import expand_mul
     from sympy.abc import k


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Replaces gh-26931

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
