### PR TITLE
fixes permutation of types in heurisch

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -508,7 +508,8 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         # of types take care of the order of replacement
         types = defaultdict(list)
         for i in mapping:
-            types[type(i)].append(i)
+            e, _ = i
+            types[type(e)].append(i)
         mapping = [types[i] for i in types]
         def _iter_mappings():
             for i in permutations(mapping):

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -504,8 +504,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         # optimizing the number of permutations of mapping              #
         assert mapping[-1][0] == x # if not, find it and correct this comment
         unnecessary_permutations = [mapping.pop(-1)]
-        # only permute types of objects and let the ordering
-        # of types take care of the order of replacement
+        # permute types of objects
         types = defaultdict(list)
         for i in mapping:
             e, _ = i
@@ -513,7 +512,8 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         mapping = [types[i] for i in types]
         def _iter_mappings():
             for i in permutations(mapping):
-                yield [j for i in i for j in i]
+                # make the expression of a given type be ordered
+                yield [j for i in i for j in ordered(i)]
         mappings = _iter_mappings()
     else:
         unnecessary_permutations = unnecessary_permutations or []

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -19,7 +19,7 @@ from sympy.simplify.simplify import simplify
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.testing.pytest import XFAIL, slow
 from sympy.integrals.integrals import integrate
-from sympy import S, Matrix, And, Eq
+from sympy import S
 
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
@@ -404,8 +404,9 @@ def test_heurisch_issue_26922():
 
     a, b, x = symbols("a, b, x", real=True, positive=True)
     C = symbols("C", real=True)
-    i = Integral(-C*x*exp(-a*x**2 - sqrt(b)*x), x) + Integral(C*x*exp(-a*x**2 + sqrt(b)*x), x)
-
+    i1 = -C*x*exp(-a*x**2 - sqrt(b)*x)
+    i2 = C*x*exp(-a*x**2 + sqrt(b)*x)
+    i = Integral(i1, x) + Integral(i2, x)
     res = (
         -C*exp(-a*x**2)*exp(sqrt(b)*x)/(2*a)
         + C*exp(-a*x**2)*exp(-sqrt(b)*x)/(2*a)
@@ -413,4 +414,4 @@ def test_heurisch_issue_26922():
         + sqrt(pi)*C*sqrt(b)*exp(b/(4*a))*erf(sqrt(a)*x + sqrt(b)/(2*sqrt(a)))/(4*a**(S(3)/2))
     )
 
-    assert i.doit().expand() == res
+    assert i.doit(heurisch=False).expand() == res

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -19,6 +19,8 @@ from sympy.simplify.simplify import simplify
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.testing.pytest import XFAIL, slow
 from sympy.integrals.integrals import integrate
+from sympy import S
+
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
 
@@ -359,10 +361,22 @@ def test_issue_22527():
     assert Ut == Uz.subs(z, t)
 
 
-def test_heurisch_complex_erf_issue_26338():
+def test_heurisch_complex_erf_issue_26338_broken():
     r = symbols('r', real=True)
     a = exp(-r**2/(2*(2 - I)**2))
-    assert heurisch(a, r, hints=[]) is None  # None, not a wrong soln
+    wrong_result = (
+        -4*I*r*exp(-3*r**2/50)*exp(-2*I*r**2/25)/3
+        + 5*sqrt(2)*sqrt(pi)*erf(sqrt(2)*r/5 + sqrt(2)*I*r/10)/3
+        + 5*sqrt(2)*I*sqrt(pi)*erf(sqrt(2)*r/5 + sqrt(2)*I*r/10)/6
+    )
+    # This result is wrong. If this test fails then hopefully that means that
+    # the bug is fixed. Please update the test with the new result after
+    # checking if it is actually correct.
+    assert heurisch(a, r, hints=[]) == wrong_result
+
+
+def test_heurisch_complex_erf_issue_26338():
+    r = symbols('r', real=True)
     a = sqrt(pi)*erf((1 + I)/2)/2
     assert integrate(exp(-I*r**2/2), (r, 0, 1)) == a - I*a
 
@@ -387,3 +401,23 @@ def test_issue_15498():
     integrand = m*m.subs(t, s)**-1*f_vec.subs(aif_eq.lhs, aif_eq.rhs).subs(t, s)
     solution = integrate(integrand[0], (s, 0, t))
     assert solution is not None  # does not hang and takes less than 10 s
+
+
+def test_heurisch_issue_26930():
+    assert integrate(x**Rational(4, 3)*log(x), (x, 0, 1)) == -S(9)/49
+
+
+def test_heurisch_issue_26922():
+
+    a, b, x = symbols("a, b, x", real=True, positive=True)
+    C = symbols("C", real=True)
+    i = Integral(-C*x*exp(-a*x**2 - sqrt(b)*x), x) + Integral(C*x*exp(-a*x**2 + sqrt(b)*x), x)
+
+    res = (
+        -C*exp(-a*x**2)*exp(sqrt(b)*x)/(2*a)
+        + C*exp(-a*x**2)*exp(-sqrt(b)*x)/(2*a)
+        + sqrt(pi)*C*sqrt(b)*exp(b/(4*a))*erf(sqrt(a)*x - sqrt(b)/(2*sqrt(a)))/(4*a**(S(3)/2))
+        + sqrt(pi)*C*sqrt(b)*exp(b/(4*a))*erf(sqrt(a)*x + sqrt(b)/(2*sqrt(a)))/(4*a**(S(3)/2))
+    )
+
+    assert i.doit().expand() == res

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1146,8 +1146,8 @@ def test_issue_3940():
     a, b, c, d = symbols('a:d', positive=True)
     assert integrate(exp(-x**2 + I*c*x), x) == \
         -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
-    assert integrate(exp(a*x**2 + b*x + c), x) == \
-        sqrt(pi)*exp(c - b**2/(4*a))*erfi((2*a*x + b)/(2*sqrt(a)))/(2*sqrt(a))
+    assert integrate(exp(a*x**2 + b*x + c), x).equals(
+        sqrt(pi)*exp(c - b**2/(4*a))*erfi((2*a*x + b)/(2*sqrt(a)))/(2*sqrt(a)))
 
     from sympy.core.function import expand_mul
     from sympy.abc import k


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
closes #26922 
closes #26930 
closes #26934 as alternative to reversion

cf #26358
#### Brief description of what is fixed or changed

Type of *expressions* (not the tuple containing the expression and replacement) are now permuted.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
