### PR TITLE
[GSoC]Fixed `_eval_subs` method for Orders

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -476,7 +476,12 @@ class Order(Expr):
                     # First, try to substitute self.point in the "new"
                     # expr to see if this is a fixed point.
                     # E.g.  O(y).subs(y, sin(x))
-                    point = new.subs(var, self.point[i])
+                    from sympy import limit
+                    if new.has(Order) and limit(new.getO().expr, var, new.getO().point[0]) == self.point[i]:
+                        point = new.getO().point[0]
+                        return Order(newexpr, *zip([var], [point]))
+                    else:
+                        point = new.subs(var, self.point[i])
                     if point != self.point[i]:
                         from sympy.solvers.solveset import solveset
                         d = Dummy()

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -437,7 +437,7 @@ def test_order_subs_limits():
 
 @XFAIL
 def test_order_failing_due_to_solveset():
-    assert O(x**3).subs(x, exp(-x**2)) == O(exp(-3*x**2), (x, oo))
+    assert O(x**3).subs(x, exp(-x**2)) == O(exp(-3*x**2), (x, -oo))
     raises(NotImplementedError, lambda: O(x).subs(x, O(1/x))) # mixing of order at different points
 
 

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -12,6 +12,7 @@ from sympy.series.order import O, Order
 from sympy.core.expr import unchanged
 from sympy.testing.pytest import raises
 from sympy.abc import w, x, y, z
+from sympy.testing.pytest import XFAIL
 
 
 def test_caching_bug():
@@ -420,6 +421,24 @@ def test_order_subs_limits():
 
     assert Order(x**2).subs(x, y - 1) == Order((y - 1)**2, (y, 1))
     assert Order(10*x**2, (x, 2)).subs(x, y - 1) == Order(1, (y, 3))
+
+    #issue 19120
+    assert O(x).subs(x, O(x)) == O(x)
+    assert O(x**2).subs(x, x + O(x)) == O(x**2)
+    assert O(x, (x, oo)).subs(x, O(x, (x, oo))) == O(x, (x, oo))
+    assert O(x**2, (x, oo)).subs(x, x + O(x, (x, oo))) == O(x**2, (x, oo))
+    assert (x + O(x**2)).subs(x, x + O(x**2)) == x + O(x**2)
+    assert (x**2 + O(x**2) + 1/x**2).subs(x, x + O(x**2)) == (x + O(x**2))**(-2) + O(x**2)
+    assert (x**2 + O(x**2) + 1).subs(x, x + O(x**2)) == 1 + O(x**2)
+    assert O(x, (x, oo)).subs(x, x + O(x**2, (x, oo))) == O(x**2, (x, oo))
+    assert sin(x).series(n=8).subs(x,sin(x).series(n=8)).expand() == x - x**3/3 + x**5/10 - 8*x**7/315 + O(x**8)
+    assert cos(x).series(n=8).subs(x,sin(x).series(n=8)).expand() == 1 - x**2/2 + 5*x**4/24 - 37*x**6/720 + O(x**8)
+    assert O(x).subs(x, O(1/x, (x, oo))) == O(1/x, (x, oo))
+
+@XFAIL
+def test_order_failing_due_to_solveset():
+    assert O(x**3).subs(x, exp(-x**2)) == O(exp(-3*x**2), (x, oo))
+    raises(NotImplementedError, lambda: O(x).subs(x, O(1/x))) # mixing of order at different points
 
 
 def test_issue_9351():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #19120
Closes #22339 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

For substitution of order terms or expression containing order terms onto an order term we should be checking the asymptotic nature of the new expression and if it goes to the same point as the old then we can allow such substitution.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Better handling of Substitution of expression containing order terms in order terms.
<!-- END RELEASE NOTES -->
