### PR TITLE
test(stats): reenable disabled test

### DIFF
--- a/sympy/stats/sampling/tests/test_sample_discrete_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_discrete_rv.py
@@ -1,7 +1,17 @@
 from sympy.core.singleton import S
-#from sympy.core.symbol import Symbol
+from sympy.core.symbol import Symbol
 from sympy.external import import_module
-from sympy.stats import Geometric, Poisson, Zeta, sample, Skellam, Logarithmic, NegativeBinomial, YuleSimon
+from sympy.stats import (
+    Geometric,
+    Poisson,
+    Zeta,
+    sample,
+    Skellam,
+    Logarithmic,
+    NegativeBinomial,
+    YuleSimon,
+    DiscreteRV,
+)
 from sympy.testing.pytest import skip, raises, slow
 
 
@@ -27,13 +37,11 @@ def test_sample_numpy():
 
 
 def test_sample_scipy():
-    #p = S(2)/3
-    #x = Symbol('x', integer=True, positive=True)
-    #pdf = p*(1 - p)**(x - 1) # pdf of Geometric Distribution
+    p = S(2)/3
+    x = Symbol('x', integer=True, positive=True)
+    pdf = p*(1 - p)**(x - 1) # pdf of Geometric Distribution
     distribs_scipy = [
-        # This one fails:
-        #    https://github.com/sympy/sympy/issues/26862
-        # DiscreteRV(x, pdf, set=S.Naturals),
+        DiscreteRV(x, pdf, set=S.Naturals),
         Geometric('G', 0.5),
         Logarithmic('L', 0.5),
         NegativeBinomial('N', 5, 0.4),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-26862

The issue was fixed upstream in https://github.com/scipy/scipy/pull/21283#issuecomment-2282318632. This commit just enables the test again. It should pass once the SciPy nightly wheels are updated.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
