### PR TITLE
Computing roots of polynomials with real algebraic coefficients

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1680,3 +1680,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Muhammad Maaz <mmaaz6004@gmail.com?

--- a/.mailmap
+++ b/.mailmap
@@ -1027,7 +1027,7 @@ Mohit Shah <mohitshah3111999@gmail.com>
 Morten Olsen Lysgaard <morten@lysgaard.no>
 Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 Mridul Seth <seth.mridul@gmail.com>
-Muhammad Maaz <mmaaz6004@gmail.com>
+Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
 Nabanita Dash <dashnabanita@gmail.com> Naba7 <dashnabanita@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1027,6 +1027,7 @@ Mohit Shah <mohitshah3111999@gmail.com>
 Morten Olsen Lysgaard <morten@lysgaard.no>
 Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 Mridul Seth <seth.mridul@gmail.com>
+Muhammad Maaz <mmaaz6004@gmail.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
 Nabanita Dash <dashnabanita@gmail.com> Naba7 <dashnabanita@gmail.com>
@@ -1680,4 +1681,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Muhammad Maaz <mmaaz6004@gmail.com?

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6744,7 +6744,7 @@ def all_roots(f, multiple=True, radicals=True):
     >>> [r.evalf(3) for r in all_roots(p)]
     [1.17, -0.765 - 0.352*I, -0.765 + 0.352*I, 0.181 - 1.08*I, 0.181 + 1.08*I]
 
-    Irrational algebraic or transcendental coefficients cannot currently be
+    Irrational algebraic or transcendental coefficients can now be
     handled by :func:`all_roots` (or :func:`~.rootof` more generally):
 
     >>> from sympy import sqrt, expand
@@ -6752,9 +6752,7 @@ def all_roots(f, multiple=True, radicals=True):
     >>> print(p)
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
     >>> all_roots(p)
-    Traceback (most recent call last):
-    ...
-    NotImplementedError: sorted roots not supported over EX
+    [sqrt(2), sqrt(2), sqrt(3), sqrt(3)]
 
     In the case of algebraic or transcendental coefficients
     :func:`~.ground_roots` might be able to find some roots by factorisation:
@@ -6920,7 +6918,7 @@ def real_roots(f, multiple=True, radicals=True):
     polynomials of high degree which typically have many more complex roots
     than real roots.
 
-    Irrational algebraic or transcendental coefficients cannot be handled by
+    Irrational algebraic or transcendental coefficients can now be handled by
     :func:`real_roots` (or :func:`~.rootof` more generally):
 
     >>> from sympy import sqrt, expand
@@ -6928,9 +6926,7 @@ def real_roots(f, multiple=True, radicals=True):
     >>> print(p)
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
     >>> real_roots(p)
-    Traceback (most recent call last):
-    ...
-    NotImplementedError: sorted roots not supported over EX
+    [sqrt(2), sqrt(2), sqrt(3), sqrt(3)]
 
     In the case of algebraic or transcendental coefficients
     :func:`~.ground_roots` might be able to find some roots by factorisation:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6828,7 +6828,7 @@ def all_roots(f, multiple=True, radicals=True):
     .. [1] https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem
     """
     try:
-        F = Poly(f, greedy=False)
+        F = Poly(f, extension=True)
         if not isinstance(f, Poly) and not F.gen.is_Symbol:
             # root of sin(x) + 1 is -1 but when someone
             # passes an Expr instead of Poly they may not expect
@@ -6999,7 +6999,7 @@ def real_roots(f, multiple=True, radicals=True):
     .. [1] https://en.wikipedia.org/wiki/Casus_irreducibilis
     """
     try:
-        F = Poly(f, greedy=False)
+        F = Poly(f, extension=True)
         if not isinstance(f, Poly) and not F.gen.is_Symbol:
             # root of sin(x) + 1 is -1 but when someone
             # passes an Expr instead of Poly they may not expect

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3845,6 +3845,12 @@ class Poly(Basic):
         2
         >>> f.root_multiplicity(2)
         1
+
+        See Also
+        =======
+
+        same_root
+        which_roots
         """
         p = f
         multiplicity = 0
@@ -3891,6 +3897,12 @@ class Poly(Basic):
         [sqrt(2)/2]
         >>> f.real_roots() # note this is already done internally
         [sqrt(2)/2]
+
+        See Also
+        =======
+
+        same_root
+        root_multiplicity
         """
         if f.is_multivariate:
             raise MultivariatePolynomialError(
@@ -3954,6 +3966,11 @@ class Poly(Basic):
         PolynomialError
             If the polynomial is of degree < 2.
 
+        See Also
+        =======
+
+        which_root
+        root_multiplicity
         """
         if f.is_multivariate:
             raise MultivariatePolynomialError(

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6767,7 +6767,7 @@ def count_roots(f, inf=None, sup=None):
 
 
 @public
-def all_roots(f, multiple=True, radicals=True):
+def all_roots(f, multiple=True, radicals=True, extension=False):
     """
     Returns the real and complex roots of ``f`` with multiplicities.
 
@@ -6810,14 +6810,14 @@ def all_roots(f, multiple=True, radicals=True):
     >>> [r.evalf(3) for r in all_roots(p)]
     [1.17, -0.765 - 0.352*I, -0.765 + 0.352*I, 0.181 - 1.08*I, 0.181 + 1.08*I]
 
-    Irrational algebraic or transcendental coefficients are
-    handled by :func:`all_roots` (or :func:`~.rootof` more generally):
+    Irrational algebraic coefficients are handled by :func:`all_roots`
+    if `extension=True` is set.
 
     >>> from sympy import sqrt, expand
     >>> p = expand((x - sqrt(2))*(x - sqrt(3)))
     >>> print(p)
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
-    >>> all_roots(p)
+    >>> all_roots(p, extension=True)
     [sqrt(2), sqrt(2), sqrt(3), sqrt(3)]
 
     In the case of algebraic or transcendental coefficients
@@ -6855,6 +6855,10 @@ def all_roots(f, multiple=True, radicals=True):
     radicals : ``bool`` (default ``True``)
         Use simple radical formulae rather than :py:class:`~.ComplexRootOf` for
         some irrational roots.
+    extension: ``bool`` (default ``False``)
+        Whether to construct an algebraic extension domain before computing
+        the roots. Setting to ``True`` is necessary for finding roots of a
+        polynomial with (irrational) algebraic coefficients but can be slow.
 
     Returns
     =======
@@ -6894,7 +6898,10 @@ def all_roots(f, multiple=True, radicals=True):
     .. [1] https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem
     """
     try:
-        F = Poly(f, extension=True)
+        F = Poly(f, greedy=False)
+        if extension and not F.domain.is_AlgebraicField:
+            F = Poly(F.expr, extension=True)
+
         if not isinstance(f, Poly) and not F.gen.is_Symbol:
             # root of sin(x) + 1 is -1 but when someone
             # passes an Expr instead of Poly they may not expect
@@ -6908,7 +6915,7 @@ def all_roots(f, multiple=True, radicals=True):
 
 
 @public
-def real_roots(f, multiple=True, radicals=True):
+def real_roots(f, multiple=True, radicals=True, extension=False):
     """
     Returns the real roots of ``f`` with multiplicities.
 
@@ -6984,14 +6991,14 @@ def real_roots(f, multiple=True, radicals=True):
     polynomials of high degree which typically have many more complex roots
     than real roots.
 
-    Irrational algebraic or transcendental coefficients are handled by
-    :func:`real_roots` (or :func:`~.rootof` more generally):
+    Irrational algebraic coefficients are handled by :func:`all_roots`
+    if `extension=True` is set.
 
     >>> from sympy import sqrt, expand
     >>> p = expand((x - sqrt(2))*(x - sqrt(3)))
     >>> print(p)
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
-    >>> real_roots(p)
+    >>> all_roots(p, extension=True)
     [sqrt(2), sqrt(2), sqrt(3), sqrt(3)]
 
     In the case of algebraic or transcendental coefficients
@@ -7029,6 +7036,10 @@ def real_roots(f, multiple=True, radicals=True):
     radicals : ``bool`` (default ``True``)
         Use simple radical formulae rather than :py:class:`~.ComplexRootOf` for
         some irrational roots.
+    extension: ``bool`` (default ``False``)
+        Whether to construct an algebraic extension domain before computing
+        the roots. Setting to ``True`` is necessary for finding roots of a
+        polynomial with (irrational) algebraic coefficients but can be slow.
 
     Returns
     =======
@@ -7065,7 +7076,10 @@ def real_roots(f, multiple=True, radicals=True):
     .. [1] https://en.wikipedia.org/wiki/Casus_irreducibilis
     """
     try:
-        F = Poly(f, extension=True)
+        F = Poly(f, greedy=False)
+        if extension and not F.domain.is_AlgebraicField:
+            F = Poly(F.expr, extension=True)
+
         if not isinstance(f, Poly) and not F.gen.is_Symbol:
             # root of sin(x) + 1 is -1 but when someone
             # passes an Expr instead of Poly they may not expect

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3969,7 +3969,7 @@ class Poly(Basic):
         See Also
         ========
 
-        which_root
+        which_roots
         root_multiplicity
         """
         if f.is_multivariate:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3847,7 +3847,7 @@ class Poly(Basic):
         1
 
         See Also
-        =======
+        ========
 
         same_root
         which_roots
@@ -3899,7 +3899,7 @@ class Poly(Basic):
         [sqrt(2)/2]
 
         See Also
-        =======
+        ========
 
         same_root
         root_multiplicity
@@ -3967,7 +3967,7 @@ class Poly(Basic):
             If the polynomial is of degree < 2.
 
         See Also
-        =======
+        ========
 
         which_root
         root_multiplicity

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3918,7 +3918,7 @@ class Poly(Basic):
         Examples
         ========
 
-        >>> from sympy import Poly, I, sqrt
+        >>> from sympy import Poly, I
         >>> from sympy.abc import x
 
         >>> f = Poly(x**4 - 1)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3866,15 +3866,15 @@ class Poly(Basic):
             raise MultivariatePolynomialError(
                 "Must be a univariate polynomial")
 
-        # must be QQ, ZZ, or Alg for proper counting
         dom = f.get_domain()
-        if not (dom.is_ZZ or dom.is_QQ or dom.is_AlgebraicField):
-            raise NotImplementedError(
-                "root counting not supported over %s" % dom)
 
         # note real count counts uniques
         # but complex count counts with multiplicity
         if real:
+            # must be QQ, ZZ, or Alg for proper counting
+            if not (dom.is_ZZ or dom.is_QQ or dom.is_AlgebraicField):
+                raise NotImplementedError(
+                    "root counting not supported over %s" % dom)
             num_roots = f.count_roots()
         else:
             num_roots = f.degree()
@@ -6836,6 +6836,13 @@ def all_roots(f, multiple=True, radicals=True, extension=False):
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
     >>> all_roots(p, extension=True)
     [sqrt(2), sqrt(3)]
+
+    Algebraic coefficients can be complex as well.
+
+    >>> all_roots(x**2 - I, extension=True)
+    [-sqrt(2)/2 - sqrt(2)*I/2, sqrt(2)/2 + sqrt(2)*I/2]
+    >>> all_roots(x**2 - sqrt(2)*I, extension=True)
+    [-2**(3/4)/2 - 2**(3/4)*I/2, 2**(3/4)/2 + 2**(3/4)*I/2]
 
     In the case of algebraic or transcendental coefficients
     :func:`~.ground_roots` might be able to find some roots by factorisation:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3825,7 +3825,7 @@ class Poly(Basic):
         ===========
 
         If ``f`` is a square-free polynomial and ``candidates`` is a superset
-        of the roots of ``f``, then ``f.which_roots(candidates)`` returns a
+        of the roots of ``f``, then ``f.which_real_roots(candidates)`` returns a
         list containing exactly the set of roots of ``f``. The domain must be
         :ref:`ZZ`, :ref:`QQ`, or :ref:`QQ(a)` and``f`` must be univariate and
         square-free.
@@ -3880,23 +3880,7 @@ class Poly(Basic):
             raise NotImplementedError(
                 "root counting not supported over %s" % dom)
 
-        num_roots = f.count_roots()
-
-        prec = 10
-        # using Counter bc its like an ordered set
-        root_counts = Counter(candidates)
-
-        while len(root_counts) > num_roots:
-            for r in list(root_counts.keys()):
-                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
-                f_r = f(r).evalf(prec, maxn=2*prec)
-                if abs(f_r)._prec >= 2:
-                    root_counts.pop(r)
-
-            prec *= 2
-
-        roots = list(root_counts.keys())
-        return roots
+        return f._which_roots(candidates, f.count_roots())
 
     def which_all_roots(f, candidates):
         """
@@ -3959,8 +3943,9 @@ class Poly(Basic):
             raise MultivariatePolynomialError(
                 "Must be a univariate polynomial")
 
-        num_roots = f.degree()
+        return f._which_roots(candidates, f.degree())
 
+    def _which_roots(f, candidates, num_roots):
         prec = 10
         # using Counter bc its like an ordered set
         root_counts = Counter(candidates)
@@ -3974,8 +3959,7 @@ class Poly(Basic):
 
             prec *= 2
 
-        roots = list(root_counts.keys())
-        return roots
+        return list(root_counts.keys())
 
     def same_root(f, a, b):
         """

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6839,6 +6839,7 @@ def all_roots(f, multiple=True, radicals=True, extension=False):
 
     Algebraic coefficients can be complex as well.
 
+    >>> from sympy import I
     >>> all_roots(x**2 - I, extension=True)
     [-sqrt(2)/2 - sqrt(2)*I/2, sqrt(2)/2 + sqrt(2)*I/2]
     >>> all_roots(x**2 - sqrt(2)*I, extension=True)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6962,9 +6962,16 @@ def all_roots(f, multiple=True, radicals=True, extension=False):
     .. [1] https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem
     """
     try:
-        F = Poly(f, greedy=False)
-        if extension and not F.domain.is_AlgebraicField:
-            F = Poly(F.expr, extension=True)
+        if isinstance(f, Poly):
+            if extension and not f.domain.is_AlgebraicField:
+                F = Poly(f.expr, extension=True)
+            else:
+                F = f
+        else:
+            if extension:
+                F = Poly(f, extension=True)
+            else:
+                F = Poly(f, greedy=False)
 
         if not isinstance(f, Poly) and not F.gen.is_Symbol:
             # root of sin(x) + 1 is -1 but when someone
@@ -7140,9 +7147,16 @@ def real_roots(f, multiple=True, radicals=True, extension=False):
     .. [1] https://en.wikipedia.org/wiki/Casus_irreducibilis
     """
     try:
-        F = Poly(f, greedy=False)
-        if extension and not F.domain.is_AlgebraicField:
-            F = Poly(F.expr, extension=True)
+        if isinstance(f, Poly):
+            if extension and not f.domain.is_AlgebraicField:
+                F = Poly(f.expr, extension=True)
+            else:
+                F = f
+        else:
+            if extension:
+                F = Poly(f, extension=True)
+            else:
+                F = Poly(f, greedy=False)
 
         if not isinstance(f, Poly) and not F.gen.is_Symbol:
             # root of sin(x) + 1 is -1 but when someone

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3824,7 +3824,10 @@ class Poly(Basic):
         not a superset of the roots of f. The list returned has
         unique elements, is at most the length of the number of
         unique roots of f, and preserves the order of the original
-        list of candidates.
+        list of candidates. The `real` argument only controls
+        the root counting: if `real=True`, the `.count_roots()` method
+        is used (only supported over ZZ, QQ, or AlgebraicField); if
+        `real=False`, the degree is used.
 
         Examples
         ========
@@ -3839,6 +3842,8 @@ class Poly(Basic):
         >>> f.which_roots([-1, 1, -I, I, 0], real=False)
         [-1, 1, -I, I]
         >>> f.which_roots([-1, 1, 1, 1, 1], real=True)
+        [-1, 1]
+        >>> f.which_roots([-1, -1, 1, 1], real=False)
         [-1, 1]
 
         # expected behaviour if not a superset of roots

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3816,11 +3816,28 @@ class Poly(Basic):
 
         return r.replace(t, x)
 
-    def _numerically_filter_roots(f, candidates, real):
+    def which_roots(f, candidates, real=True):
         """
-        Given a superset of roots of f, finds which ones are roots of f.
-        Note this won't work properly if candidates is not a superset of roots!
-        This is not a public function, and is used internally for root-finding.
+        Given a superset of roots of f, finds which ones are
+        roots of f. Note this won't work properly if candidates is
+        not a superset of the roots of f. The list returned is the
+        same length as the number of roots of f, counted with
+        multiplicity, and preserves the order of the original candidates list.
+
+        Examples
+        ========
+
+        >>> from sympy import Poly, I
+        >>> from sympy.abc import x
+
+        >>> f = Poly(x**4 - 1)
+
+        >>> f.which_roots([-1, 1, 0, -2, 2], real=True)
+        [-1, 1]
+        >>> f.which_roots([-1, 1, -I, I, 0], real=False)
+        [-1, 1, -I, I]
+        >>> f.which_roots([2, 5], real=True) # expectedly wrong
+        [2, 5]
         """
         if f.is_multivariate:
             raise MultivariatePolynomialError(
@@ -3857,7 +3874,12 @@ class Poly(Basic):
             prec *= 2
             candidates = candidates_filtered
 
-        assert len(set(candidates)) == num_roots
+        if len(set(candidates)) != num_roots:
+            raise PolynomialError(
+                """
+                Number of roots found does not match expected root count.
+                """)
+
         return candidates
 
     def same_root(f, a, b):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3827,7 +3827,7 @@ class Poly(Basic):
         Examples
         ========
 
-        >>> from sympy import Poly, sqrt
+        >>> from sympy import Poly
         >>> from sympy.abc import x
 
         >>> f = Poly(x**2 - 1)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6744,7 +6744,7 @@ def all_roots(f, multiple=True, radicals=True):
     >>> [r.evalf(3) for r in all_roots(p)]
     [1.17, -0.765 - 0.352*I, -0.765 + 0.352*I, 0.181 - 1.08*I, 0.181 + 1.08*I]
 
-    Irrational algebraic or transcendental coefficients can now be
+    Irrational algebraic or transcendental coefficients are
     handled by :func:`all_roots` (or :func:`~.rootof` more generally):
 
     >>> from sympy import sqrt, expand

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6834,6 +6834,10 @@ def all_roots(f, multiple=True, radicals=True, extension=False):
     >>> p = expand((x - sqrt(2))*(x - sqrt(3)))
     >>> print(p)
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
+    >>> all_roots(p)
+    Traceback (most recent call last):
+    ...
+    NotImplementedError: sorted roots not supported over EX
     >>> all_roots(p, extension=True)
     [sqrt(2), sqrt(3)]
 
@@ -6845,7 +6849,8 @@ def all_roots(f, multiple=True, radicals=True, extension=False):
     >>> all_roots(x**2 - sqrt(2)*I, extension=True)
     [-2**(3/4)/2 - 2**(3/4)*I/2, 2**(3/4)/2 + 2**(3/4)*I/2]
 
-    In the case of algebraic or transcendental coefficients
+    Transcendental coefficients cannot currently be handled by
+    :func:`all_roots`. In the case of algebraic or transcendental coefficients
     :func:`~.ground_roots` might be able to find some roots by factorisation:
 
     >>> from sympy import ground_roots
@@ -7023,17 +7028,22 @@ def real_roots(f, multiple=True, radicals=True, extension=False):
     polynomials of high degree which typically have many more complex roots
     than real roots.
 
-    Irrational algebraic coefficients are handled by :func:`all_roots`
+    Irrational algebraic coefficients are handled by :func:`real_roots`
     if `extension=True` is set.
 
     >>> from sympy import sqrt, expand
     >>> p = expand((x - sqrt(2))*(x - sqrt(3)))
     >>> print(p)
     x**2 - sqrt(3)*x - sqrt(2)*x + sqrt(6)
-    >>> all_roots(p, extension=True)
+    >>> real_roots(p)
+    Traceback (most recent call last):
+    ...
+    NotImplementedError: sorted roots not supported over EX
+    >>> real_roots(p, extension=True)
     [sqrt(2), sqrt(3)]
 
-    In the case of algebraic or transcendental coefficients
+    Transcendental coefficients cannot currently be handled by
+    :func:`real_roots`. In the case of algebraic or transcendental coefficients
     :func:`~.ground_roots` might be able to find some roots by factorisation:
 
     >>> from sympy import ground_roots

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4005,7 +4005,8 @@ class Poly(Basic):
         See Also
         ========
 
-        which_roots
+        which_real_roots
+        which_all_roots
         """
         if f.is_multivariate:
             raise MultivariatePolynomialError(

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3817,59 +3817,14 @@ class Poly(Basic):
 
         return r.replace(t, x)
 
-    def root_multiplicity(f, root, prec=10):
-        """
-        Computes the multiplicity of a root for f, at a given
-        numerical precision. Works by evaluating derivatives of
-        f at the given root. If it is not a root of f (up to
-        numerical precision), returns zero.
-
-        Examples
-        ========
-
-        >>> from sympy import Poly
-        >>> from sympy.abc import x
-
-        >>> f = Poly(x**2 - 1)
-        >>> f.root_multiplicity(1)
-        1
-        >>> f.root_multiplicity(-1)
-        1
-        >>> f.root_multiplicity(2)
-        0
-
-        >>> f = Poly((x-1)**2 * (x-2))
-        >>> f
-        Poly(x**3 - 4*x**2 + 5*x - 2, x, domain='ZZ')
-        >>> f.root_multiplicity(1)
-        2
-        >>> f.root_multiplicity(2)
-        1
-
-        See Also
-        ========
-
-        same_root
-        which_roots
-        """
-        p = f
-        multiplicity = 0
-        while p != 0:
-            p_r = p(root).evalf(prec, maxn=2*prec)
-            if abs(p_r)._prec >= 2:
-                break
-            multiplicity += 1
-            p = p.diff()
-
-        return multiplicity
-
     def which_roots(f, candidates, real=True):
         """
         Given a superset of roots of f, finds which ones are
         roots of f. Note this won't work properly if candidates is
-        not a superset of the roots of f. The list returned is the
-        same length as the number of roots of f, counted with
-        multiplicity, and preserves the order of the original candidates list.
+        not a superset of the roots of f. The list returned has
+        unique elements, is at most the length of the number of
+        unique roots of f, and preserves the order of the original
+        list of candidates.
 
         Examples
         ========
@@ -3885,6 +3840,10 @@ class Poly(Basic):
         [-1, 1, -I, I]
         >>> f.which_roots([-1, 1, 1, 1, 1], real=True)
         [-1, 1]
+
+        # expected behaviour if not a superset of roots
+        >>> f.which_roots([2, 5], real=True)
+        [2, 5]
 
         # lifting to rational coeffs produces extraneous roots
         # which we can filter out with this method
@@ -3902,7 +3861,6 @@ class Poly(Basic):
         ========
 
         same_root
-        root_multiplicity
         """
         if f.is_multivariate:
             raise MultivariatePolynomialError(
@@ -3922,7 +3880,7 @@ class Poly(Basic):
             num_roots = f.degree()
 
         prec = 10
-
+        # using Counter bc its like an ordered set
         root_counts = Counter(candidates)
 
         while len(root_counts) > num_roots:
@@ -3934,11 +3892,7 @@ class Poly(Basic):
 
             prec *= 2
 
-        # handle multiplicity here
-        for r in list(root_counts.keys()):
-            root_counts[r] = f.root_multiplicity(r, prec)
-
-        roots = sum([[r]*c for r, c in root_counts.items()], [])
+        roots = list(root_counts.keys())
         return roots
 
     def same_root(f, a, b):
@@ -3970,7 +3924,6 @@ class Poly(Basic):
         ========
 
         which_roots
-        root_multiplicity
         """
         if f.is_multivariate:
             raise MultivariatePolynomialError(

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6918,7 +6918,7 @@ def real_roots(f, multiple=True, radicals=True):
     polynomials of high degree which typically have many more complex roots
     than real roots.
 
-    Irrational algebraic or transcendental coefficients can now be handled by
+    Irrational algebraic or transcendental coefficients are handled by
     :func:`real_roots` (or :func:`~.rootof` more generally):
 
     >>> from sympy import sqrt, expand

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -775,7 +775,7 @@ class ComplexRootOf(RootOf):
         free_names = {str(i) for i in poly.free_symbols}
         for x in chain((symbols('x'),), numbered_symbols('x')):
             if x.name not in free_names:
-                poly = poly.replace({d: x})
+                poly = poly.replace(d, x)
                 break
 
         if dom.is_QQ or dom.is_ZZ:

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -776,18 +776,20 @@ class ComplexRootOf(RootOf):
         for x in chain((symbols('x'),), numbered_symbols('x')):
             if x.name not in free_names:
                 # xreplace makes alg field domain back into EX
-                # so make sure it stays same
-                poly = Poly(poly.xreplace({d: x}), domain=dom)
+                # XXX: so make sure it stays same?
+                poly = poly.xreplace({d: x})
+                if dom.is_AlgebraicField:
+                    poly = Poly(poly, domain=dom)
                 break
 
         if dom.is_QQ or dom.is_ZZ:
             return cls._get_roots_qq(method, poly, radicals)
-            # any better way to check if real?
+            # XXX: any better way to check if real?
             # without this check, some doctests fail (with complex terms)
         if dom.is_AlgebraicField and all(c.is_real for c in poly.coeffs()):
             return cls._get_roots_alg(method, poly, radicals)
         else:
-            # not sure how to handle ZZ[x] which appears in some tests?
+            # XXX: not sure how to handle ZZ[x] which appears in some tests?
             # this makes the tests pass alright but has to be a better way?
             return cls._get_roots_qq(method, poly, radicals)
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -815,9 +815,9 @@ class ComplexRootOf(RootOf):
             roots.append(coeff*cls._postprocess_root(root, radicals))
 
         if method == "_real_roots":
-            roots = poly._numerically_filter_roots(roots, real=True)
+            roots = poly.which_roots(roots, real=True)
         elif method == "_all_roots":
-            roots = poly._numerically_filter_roots(roots, real=False)
+            roots = poly.which_roots(roots, real=False)
 
         return roots
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -822,11 +822,13 @@ class ComplexRootOf(RootOf):
             for r in roots_filt:
                 subroots[r] = m
 
-        # loop over unique roots, keep ones in subroots, and store multiplicity
-        roots_filtered_mult = [(r, subroots[r]) for r in list(dict.fromkeys(roots)) if r in subroots]
-
-        # flatten the roots list according to multiplicity
-        roots_flat = sum(([r] * m for r, m in roots_filtered_mult), [])
+        roots_seen = set()
+        roots_flat = []
+        for r in roots:
+            if r in subroots and r not in roots_seen:
+                m = subroots[r]
+                roots_flat.extend([r] * m)
+                roots_seen.add(r)
 
         return roots_flat
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -816,9 +816,9 @@ class ComplexRootOf(RootOf):
         subroots = {}
         for f, m in poly.sqf_list()[1]:
             if method == "_real_roots":
-                roots_filt = f.which_roots(roots, real=True)
+                roots_filt = f.which_real_roots(roots)
             elif method == "_all_roots":
-                roots_filt = f.which_roots(roots, real=False)
+                roots_filt = f.which_all_roots(roots)
             for r in roots_filt:
                 subroots[r] = m
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -813,7 +813,6 @@ class ComplexRootOf(RootOf):
         else:
             # XXX: not sure how to handle ZZ[x] which appears in some tests?
             # this makes the tests pass alright but has to be a better way?
-            print('hey')
             return cls._get_roots_qq(method, poly, radicals)
 
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -415,20 +415,25 @@ class ComplexRootOf(RootOf):
         _real_sorted() and _complexes_sorted() use isolating
         intervals, and these are typically used in the root
         finding methods in this class. This method is used
-        internally if that data is not available.
+        internally if that data is not available. It falls
+        back on numerical evaluation if necessary.
         """
-        real_roots = [r for r in roots if r.is_real]
-        complex_roots = [r for r in roots if not r.is_real and im(r) < 0]
+        real_roots = sorted(r for r in roots if r.is_real)
 
-        real_roots.sort()
-        complex_roots.sort(key=lambda r: (re(r), -im(r)))
+        try:
+            complex_roots = sorted((r for r in roots if not r.is_real),
+                                key=lambda root: (re(root), im(root)))
+            """
+            Example error
+            TypeError: cannot determine truth value of Relational:
+            re(CRootOf(x**6 - 2*x**4 - 2*x**3 + 1, 3)) <
+                re(CRootOf(x**6 - 2*x**4 - 2*x**3 + 1, 2))
+            """
+        except TypeError:
+            complex_roots = sorted((r for r in roots if not r.is_real),
+                                key=lambda root: (re(root.evalf()), im(root.evalf())))
 
-        all_roots = real_roots
-        for cr in complex_roots:
-            all_roots.append(cr)
-            all_roots.append(cr.conjugate())
-
-        return all_roots
+        return real_roots + complex_roots
 
     @classmethod
     def real_roots(cls, poly, radicals=True):

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -775,11 +775,7 @@ class ComplexRootOf(RootOf):
         free_names = {str(i) for i in poly.free_symbols}
         for x in chain((symbols('x'),), numbered_symbols('x')):
             if x.name not in free_names:
-                # xreplace makes alg field domain back into EX
-                # XXX: so make sure it stays same?
-                poly = poly.xreplace({d: x})
-                if dom.is_AlgebraicField:
-                    poly = Poly(poly, domain=dom)
+                poly = poly.replace({d: x})
                 break
 
         if dom.is_QQ or dom.is_ZZ:

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -820,10 +820,7 @@ class ComplexRootOf(RootOf):
             elif method == "_all_roots":
                 roots_filt = f.which_roots(roots, real=False)
             for r in roots_filt:
-                if r in subroots:
-                    subroots[r] += m
-                else:
-                    subroots[r] = m
+                subroots[r] = m
 
         # loop over unique roots, keep ones in subroots, and store multiplicity
         roots_filtered_mult = [(r, subroots[r]) for r in list(dict.fromkeys(roots)) if r in subroots]

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -760,7 +760,6 @@ class ComplexRootOf(RootOf):
 
     @classmethod
     def _get_roots(cls, method, poly, radicals):
-        print(poly)
         """Return postprocessed roots of specified kind. """
         if not poly.is_univariate:
             raise PolynomialError("only univariate polynomials are allowed")

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -784,9 +784,7 @@ class ComplexRootOf(RootOf):
 
         if dom.is_QQ or dom.is_ZZ:
             return cls._get_roots_qq(method, poly, radicals)
-            # XXX: any better way to check if real?
-            # without this check, some doctests fail (with complex terms)
-        if dom.is_AlgebraicField and all(c.is_real for c in poly.coeffs()):
+        if dom.is_AlgebraicField:
             return cls._get_roots_alg(method, poly, radicals)
         else:
             # XXX: not sure how to handle ZZ[x] which appears in some tests?

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -775,9 +775,12 @@ class ComplexRootOf(RootOf):
                 poly = poly.xreplace({d: x})
                 break
 
-        # compute rational lift if algebraic
+        # compute rational lift if real algebraic
         has_alg_coeff = any(c.is_algebraic and not c.is_rational
                             for c in poly.all_coeffs())
+        has_alg_coeff = has_alg_coeff and all(c.is_real
+                            for c in poly.all_coeffs())
+
         if has_alg_coeff:
             poly_original = poly
             poly = Poly(poly.expr, poly.gen, extension=True)

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -819,47 +819,11 @@ class ComplexRootOf(RootOf):
             roots.append(coeff*cls._postprocess_root(root, radicals))
 
         if method == "_real_roots":
-            roots = cls._numerically_filter_roots(poly, roots, real=True)
+            roots = poly._numerically_filter_roots(roots, real=True)
         elif method == "_all_roots":
-            roots = cls._numerically_filter_roots(poly, roots, real=False)
+            roots = poly._numerically_filter_roots(roots, real=False)
 
         return roots
-
-    @classmethod
-    def _numerically_filter_roots(cls, poly, candidates, real):
-        # must be QQ, ZZ, or Alg for proper counting
-        dom = poly.get_domain()
-        if not (dom.is_ZZ or dom.is_QQ or dom.is_AlgebraicField):
-            raise NotImplementedError(
-                "root counting not supported over %s" % dom)
-
-        if real:
-            num_roots = poly.count_roots()
-        else:
-            num_roots = poly.degree()
-
-        prec = 10
-        # compare len(set()) bc expected behavior is for multiple roots
-        while len(set(candidates)) > num_roots:
-            candidates_filtered = []
-            processed = set() # track already seen
-
-            for c in candidates:
-                if c not in processed:
-                    r_f = poly(c).evalf(prec, maxn=2*prec)
-                    processed.add(c)
-                    if abs(r_f)._prec < 2: candidates_filtered.append(c)
-                else:
-                    if c in candidates_filtered:
-                        # already approved this candidate
-                        candidates_filtered.append(c)
-
-            prec *= 2
-            candidates = candidates_filtered
-
-        assert len(set(candidates)) == num_roots
-
-        return candidates
 
     @classmethod
     def clear_cache(cls):

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -808,11 +808,12 @@ class ComplexRootOf(RootOf):
 
         if dom.is_QQ or dom.is_ZZ:
             return cls._get_roots_qq(method, poly, radicals)
-        if dom.is_AlgebraicField:
+        elif dom.is_AlgebraicField or dom.is_ZZ_I or dom.is_QQ_I:
             return cls._get_roots_alg(method, poly, radicals)
         else:
             # XXX: not sure how to handle ZZ[x] which appears in some tests?
             # this makes the tests pass alright but has to be a better way?
+            print('hey')
             return cls._get_roots_qq(method, poly, radicals)
 
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3221,18 +3221,43 @@ def test_nth_power_roots_poly():
     raises(MultivariatePolynomialError, lambda: nth_power_roots_poly(
         x + y, 2, x, y))
 
-def test_which_roots():
+def test_which_real_roots():
     f = Poly(x**4 - 1)
 
-    assert f.which_roots([1, -1], real=True) == [1, -1]
-    assert f.which_roots([1, -1, I, -I], real=False) == [1, -1, I, -I]
+    assert f.which_real_roots([1, -1]) == [1, -1]
+    assert f.which_real_roots([1, -1, 2, 4]) == [1, -1]
+    assert f.which_real_roots([1, -1, -1, 1, 2, 5]) == [1, -1]
+    assert f.which_real_roots([10, 8, 7, -1, 1]) == [-1, 1]
+
+    # no real roots
+    # (technically its still a superset)
+    f = Poly(x**2 + 1)
+    assert f.which_real_roots([5, 10]) == []
+
+    # not square free
+    f = Poly((x-1)**2)
+    assert f.which_real_roots([1, 1, -1, 2]) == [1]
+
+    # candidates not superset
+    f = Poly(x**2 - 1)
+    assert f.which_real_roots([0, 2]) == [0, 2]
+
+def test_which_all_roots():
+    f = Poly(x**4 - 1)
+
+    assert f.which_all_roots([1, -1, I, -I]) == [1, -1, I, -I]
+    assert f.which_all_roots([I, I, -I, 1, -1]) == [I, -I, 1, -1]
 
     f = Poly(x**2 + 1)
+    assert f.which_all_roots([I, -I, I/2]) == [I, -I]
 
-    assert f.which_roots([5, 10], real=True) == []
-    assert f.which_roots([I, -I], real=False) == [I, -I]
+    # not square free
+    f = Poly((x-I)**2)
+    assert f.which_all_roots([I, I, 1, -1, 0]) == [I]
 
-    assert f.which_roots([1, 1, -1, -1], real=False) == [1, -1]
+    # candidates not superset
+    f = Poly(x**2 + 1)
+    assert f.which_all_roots([I/2, -I/2]) == [I/2, -I/2]
 
 def test_same_root():
     f = Poly(x**4 + x**3 + x**2 + x + 1)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3221,17 +3221,6 @@ def test_nth_power_roots_poly():
     raises(MultivariatePolynomialError, lambda: nth_power_roots_poly(
         x + y, 2, x, y))
 
-def test_root_multiplicity():
-    f = Poly(x**4 - 1)
-
-    assert f.root_multiplicity(1) == 1
-    assert f.root_multiplicity(-1) == 1
-    assert f.root_multiplicity(2) == 0
-
-    f = Poly((x-1)**3 * (x-2))
-    assert f.root_multiplicity(1) == 3
-    assert f.root_multiplicity(2) == 1
-
 def test_which_roots():
     f = Poly(x**4 - 1)
 
@@ -3243,7 +3232,7 @@ def test_which_roots():
     assert f.which_roots([5, 10], real=True) == []
     assert f.which_roots([I, -I], real=False) == [I, -I]
 
-    assert f.which_roots([1, -1], real=False) == []
+    assert f.which_roots([1, -1], real=False) == [1, -1]
 
 def test_same_root():
     f = Poly(x**4 + x**3 + x**2 + x + 1)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3203,6 +3203,19 @@ def test_nth_power_roots_poly():
     raises(MultivariatePolynomialError, lambda: nth_power_roots_poly(
         x + y, 2, x, y))
 
+def test_which_roots():
+    f = Poly(x**4 - 1)
+
+    assert f.which_roots([1, -1], real=True) == [1, -1]
+    assert f.which_roots([1, -1, I, -I], real=False) == [1, -1, I, -I]
+
+    f = Poly(x**2 + 1)
+
+    assert f.which_roots([5, 10], real=True) == []
+    assert f.which_roots([I, -I], real=False) == [I, -I]
+
+    # expectedly wrong, maybe change in future
+    assert f.which_roots([1, -1], real=False) == [1, -1]
 
 def test_same_root():
     f = Poly(x**4 + x**3 + x**2 + x + 1)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3232,7 +3232,7 @@ def test_which_roots():
     assert f.which_roots([5, 10], real=True) == []
     assert f.which_roots([I, -I], real=False) == [I, -I]
 
-    assert f.which_roots([1, -1], real=False) == [1, -1]
+    assert f.which_roots([1, 1, -1, -1], real=False) == [1, -1]
 
 def test_same_root():
     f = Poly(x**4 + x**3 + x**2 + x + 1)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3232,8 +3232,7 @@ def test_which_roots():
     assert f.which_roots([5, 10], real=True) == []
     assert f.which_roots([I, -I], real=False) == [I, -I]
 
-    # expectedly wrong, maybe change in future
-    assert f.which_roots([1, -1], real=False) == [1, -1]
+    assert f.which_roots([1, -1], real=False) == []
 
 def test_same_root():
     f = Poly(x**4 + x**3 + x**2 + x + 1)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3221,6 +3221,17 @@ def test_nth_power_roots_poly():
     raises(MultivariatePolynomialError, lambda: nth_power_roots_poly(
         x + y, 2, x, y))
 
+def test_root_multiplicity():
+    f = Poly(x**4 - 1)
+
+    assert f.root_multiplicity(1) == 1
+    assert f.root_multiplicity(-1) == 1
+    assert f.root_multiplicity(2) == 0
+
+    f = Poly((x-1)**3 * (x-2))
+    assert f.root_multiplicity(1) == 3
+    assert f.root_multiplicity(2) == 1
+
 def test_which_roots():
     f = Poly(x**4 - 1)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3073,6 +3073,15 @@ def test_real_roots():
     assert Poly(f).real_roots() == [Rational(-1, 2), 2, 2]
     assert Poly(g).real_roots() == [rootof(g, 0)]
 
+    # testing extension
+    f = x**2 - sqrt(2)
+    roots = [-2**(S(1)/4), 2**(S(1)/4)]
+    raises(NotImplementedError, lambda: real_roots(f))
+    raises(NotImplementedError, lambda: real_roots(Poly(f, x)))
+    assert real_roots(f, extension=True) == roots
+    assert real_roots(Poly(f, extension=True)) == roots
+    assert real_roots(Poly(f), extension=True) == roots
+
 
 def test_all_roots():
 
@@ -3095,6 +3104,15 @@ def test_all_roots():
     assert all_roots(p) == [
         rootof(p, 0), rootof(p, 1), rootof(p, 2), rootof(p, 3), rootof(p, 4)
     ]
+
+    # testing extension
+    f = x**2 + sqrt(2)
+    roots = [-2**(S(1)/4)*I, 2**(S(1)/4)*I]
+    raises(NotImplementedError, lambda: all_roots(f))
+    raises(NotImplementedError, lambda : all_roots(Poly(f, x)))
+    assert all_roots(f, extension=True) == roots
+    assert all_roots(Poly(f, extension=True)) == roots
+    assert all_roots(Poly(f), extension=True) == roots
 
 
 def test_nroots():

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -326,6 +326,12 @@ def test_CRootOf_real_roots():
         rootof(x**25 - 5*x**20 + x**17 + 10*x**15 - 3*x**12 -
                10*x**10 + 3*x**7 + 6*x**5 - x**2 - 1, 0)
     ]
+    # roots with multiplicity
+    assert Poly((x-1) * (x-sqrt(2))**2, x, extension=True).real_roots() ==\
+    [
+        S(1), sqrt(2), sqrt(2)
+    ]
+
 
 
 def test_CRootOf_all_roots():
@@ -351,6 +357,11 @@ def test_CRootOf_all_roots():
         rootof(x**6 - 2*x**4 - 2*x**3 + 1, 0),
         rootof(x**6 - 2*x**4 - 2*x**3 + 1, 2),
         rootof(x**6 - 2*x**4 - 2*x**3 + 1, 3)
+    ]
+    # roots with multiplicity
+    assert Poly((x-1) * (x-sqrt(2))**2 * (x-I) * (x+I), x, extension=True).all_roots() ==\
+    [
+        S(1), sqrt(2), sqrt(2), -I, I
     ]
 
 def test_CRootOf_eval_rational():

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -313,6 +313,20 @@ def test_CRootOf_real_roots():
     p = Poly(-3*x**4 - 10*x**3 - 12*x**2 - 6*x - 1, x, domain='ZZ')
     assert CRootOf.real_roots(p) == [S(-1), S(-1), S(-1), S(-1)/3]
 
+    # with real algebraic coefficients
+    assert Poly(x**3 + sqrt(2)*x**2 - 1, x).real_roots() == [
+        rootof(x**6 - 2*x**4 - 2*x**3 + 1, 0)
+    ]
+    assert Poly(x**5 + sqrt(2) * x**3 - 1, x).real_roots() == [
+        rootof(x**10 - 2*x**6 - 2*x**5 + 1, 0)
+    ]
+    r = rootof(y**5 + y**3 - 1, 0)
+    assert Poly(x**5 + r*x - 1, x).real_roots() ==\
+    [
+        rootof(x**25 - 5*x**20 + x**17 + 10*x**15 - 3*x**12 -
+               10*x**10 + 3*x**7 + 6*x**5 - x**2 - 1, 0)
+    ]
+
 
 def test_CRootOf_all_roots():
     assert Poly(x**5 + x + 1).all_roots() == [
@@ -331,6 +345,13 @@ def test_CRootOf_all_roots():
         rootof(x**3 - x**2 + 1, 2),
     ]
 
+    # with real algebraic coefficients
+    assert Poly(x**3 + sqrt(2)*x**2 - 1, x).all_roots() ==\
+    [
+        rootof(x**6 - 2*x**4 - 2*x**3 + 1, 0),
+        rootof(x**6 - 2*x**4 - 2*x**3 + 1, 2),
+        rootof(x**6 - 2*x**4 - 2*x**3 + 1, 3)
+    ]
 
 def test_CRootOf_eval_rational():
     p = legendre_poly(4, x, polys=True)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -314,14 +314,14 @@ def test_CRootOf_real_roots():
     assert CRootOf.real_roots(p) == [S(-1), S(-1), S(-1), S(-1)/3]
 
     # with real algebraic coefficients
-    assert Poly(x**3 + sqrt(2)*x**2 - 1, x).real_roots() == [
+    assert Poly(x**3 + sqrt(2)*x**2 - 1, x, extension=True).real_roots() == [
         rootof(x**6 - 2*x**4 - 2*x**3 + 1, 0)
     ]
-    assert Poly(x**5 + sqrt(2) * x**3 - 1, x).real_roots() == [
+    assert Poly(x**5 + sqrt(2) * x**3 - 1, x, extension=True).real_roots() == [
         rootof(x**10 - 2*x**6 - 2*x**5 + 1, 0)
     ]
     r = rootof(y**5 + y**3 - 1, 0)
-    assert Poly(x**5 + r*x - 1, x).real_roots() ==\
+    assert Poly(x**5 + r*x - 1, x, extension=True).real_roots() ==\
     [
         rootof(x**25 - 5*x**20 + x**17 + 10*x**15 - 3*x**12 -
                10*x**10 + 3*x**7 + 6*x**5 - x**2 - 1, 0)
@@ -346,7 +346,7 @@ def test_CRootOf_all_roots():
     ]
 
     # with real algebraic coefficients
-    assert Poly(x**3 + sqrt(2)*x**2 - 1, x).all_roots() ==\
+    assert Poly(x**3 + sqrt(2)*x**2 - 1, x, extension=True).all_roots() ==\
     [
         rootof(x**6 - 2*x**4 - 2*x**3 + 1, 0),
         rootof(x**6 - 2*x**4 - 2*x**3 + 1, 2),

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -190,6 +190,12 @@ def test_CRootOf_diff():
     assert rootof(x**3 + x + 1, 0).diff(y) == 0
 
 
+def test_CRootOf__sort_roots():
+    assert CRootOf._sort_roots([S(1), -S(1), S(0)]) == [-S(1), S(0), S(1)]
+    assert CRootOf._sort_roots([S(1), sqrt(2), I]) == [S(1), sqrt(2), I]
+    assert CRootOf._sort_roots([S(1), I, I/2, -I]) == [S(1), -I, I/2, I]
+
+
 @slow
 def test_CRootOf_evalf():
     real = rootof(x**3 + x + 3, 0).evalf(n=20)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -189,13 +189,6 @@ def test_CRootOf_diff():
     assert rootof(x**3 + x + 1, 0).diff(x) == 0
     assert rootof(x**3 + x + 1, 0).diff(y) == 0
 
-
-def test_CRootOf__sort_roots():
-    assert CRootOf._sort_roots([S(1), -S(1), S(0)]) == [-S(1), S(0), S(1)]
-    assert CRootOf._sort_roots([S(1), sqrt(2), I]) == [S(1), sqrt(2), I]
-    assert CRootOf._sort_roots([S(1), I, I/2, -I]) == [S(1), -I, I/2, I]
-
-
 @slow
 def test_CRootOf_evalf():
     real = rootof(x**3 + x + 3, 0).evalf(n=20)
@@ -372,8 +365,8 @@ def test_CRootOf_all_roots():
     # imaginary algebraic coeffs (gaussian domain)
     assert Poly(x**2 - I/2, x, extension=True).all_roots() ==\
     [
-        -S(1)/2 - I/2,
-        S(1)/2 + I/2
+        S(1)/2 + I/2,
+        -S(1)/2 - I/2
     ]
 
 

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -370,6 +370,13 @@ def test_CRootOf_all_roots():
         S(1), sqrt(2), sqrt(2), -I, I
     ]
 
+    # imaginary algebraic coeffs (gaussian domain)
+    assert Poly(x**2 - I/2, x, extension=True).all_roots() ==\
+    [
+        -1/2 - I/2,
+        1/2 + I/2
+    ]
+
 def test_CRootOf_eval_rational():
     p = legendre_poly(4, x, polys=True)
     roots = [r.eval_rational(n=18) for r in p.real_roots()]

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -339,7 +339,6 @@ def test_CRootOf_real_roots():
     ]
 
 
-
 def test_CRootOf_all_roots():
     assert Poly(x**5 + x + 1).all_roots() == [
         rootof(x**3 - x**2 + 1, 0),
@@ -373,9 +372,10 @@ def test_CRootOf_all_roots():
     # imaginary algebraic coeffs (gaussian domain)
     assert Poly(x**2 - I/2, x, extension=True).all_roots() ==\
     [
-        -1/2 - I/2,
-        1/2 + I/2
+        -S(1)/2 - I/2,
+        S(1)/2 + I/2
     ]
+
 
 def test_CRootOf_eval_rational():
     p = legendre_poly(4, x, polys=True)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -329,10 +329,9 @@ def test_quintics_2():
         CRootOf(x**5 - 6*x**3 - 6*x**2 + x - 6, 3),
         CRootOf(x**5 - 6*x**3 - 6*x**2 + x - 6, 4)]
 
-@slow
 def test_quintics_3():
     y = x**5 + x**3 - 2**Rational(1, 3)
-    assert solve(y) == solve(-y)
+    assert solve(y) == solve(-y) == []
 
 
 def test_highorder_poly():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -329,10 +329,10 @@ def test_quintics_2():
         CRootOf(x**5 - 6*x**3 - 6*x**2 + x - 6, 3),
         CRootOf(x**5 - 6*x**3 - 6*x**2 + x - 6, 4)]
 
-
+@slow
 def test_quintics_3():
     y = x**5 + x**3 - 2**Rational(1, 3)
-    assert solve(y) == solve(-y) == []
+    assert solve(y) == solve(-y)
 
 
 def test_highorder_poly():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Addresses a challenge brought up in the discussion in #26785. #23077 was also previously opened to do the same thing but was not merged. This was initially brought up in #22943 I believe.

#### Brief description of what is fixed or changed

We can now compute roots of polynomials with algebraic coefficients. This would previously fail. It computes the "rational lift" of the polynomial, i.e., a polynomial with rational coefficients whose roots are a superset of the original polynomial's, and then uses numerical comparison to find which roots are also roots of the original polynomial. This leverages the recent fixes in #26813 and #26816. The numerical comparison code is taken nearly verbatim from https://github.com/sympy/sympy/issues/22943#issuecomment-2220562152.

Examples:
```
>>> from sympy import *
>>> from sympy.abc import x,y,z
>>> Poly(x**3 + sqrt(2)*x**2 - 1, x).real_roots()
[CRootOf(x**6 - 2*x**4 - 2*x**3 + 1, 0)]
>>> Poly(x**3 + sqrt(2)*x**2 - 1, x).all_roots()
[CRootOf(x**6 - 2*x**4 - 2*x**3 + 1, 0), CRootOf(x**6 - 2*x**4 - 2*x**3 + 1, 2), CRootOf(x**6 - 2*x**4 - 2*x**3 + 1, 3)]
>>> Poly(x**3 + CRootOf(y**5+y**3-1,0)*x**2 - 1, x).real_roots()
[CRootOf(x**15 + x**13 - 5*x**12 - 2*x**10 + 10*x**9 + 3*x**7 - 10*x**6 - x**4 + 5*x**3 - 1, 0)]
```

The fix is in ComplexRootOf._get_roots(), which is ultimately what Poly.real_roots() or Poly.all_roots() call (and hence ultimately what functions like solve() call I think). I think this makes logical sense in terms of integrating well into how the root functions already work. But, happy to hear feedback on this.

#### Other comments

This change breaks a test in `test_quintics_3()` in solvers/tests/test_solvers.py. The test asserted:

```
y = x**5 + x**3 - 2**Rational(1, 3)
assert solve(y) == solve(-y) == []
```

But now that this polynomial can be solved the roots should not be an empty list, but `solve(y) == solve(-y)` should still be correct. I changed the test accordingly. As well, the computation for complex roots can be somewhat slow, eg this test takes 210 seconds on my computer, hence I added a slow decorator.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* polys
  * It is now possible to compute the roots of polynomials with algebraic coefficients as RootOf using `real_roots(p, extension=True)` or `all_roots(p, extension=True)`.

<!-- END RELEASE NOTES -->
