### PR TITLE
[GSoC]Added support for aseries and tractable classes for gruntz in airyai and airybi

### DIFF
--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -625,6 +625,14 @@ def test_airyai():
         -sqrt(3)*(-1 + (z**5)**Rational(1, 3)/z**Rational(5, 3))*airybi(2*3**Rational(1, 3)*z**Rational(5, 3))/6 +
          (1 + (z**5)**Rational(1, 3)/z**Rational(5, 3))*airyai(2*3**Rational(1, 3)*z**Rational(5, 3))/2)
 
+    assert airyai(x).series(x, oo) == sqrt(pi)*(-9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) - 3*gamma(S(7)/6)*\
+            gamma(S(11)/6)/(8*pi**2*x**2) + sqrt(1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + 9*(1/x)**(S(7)/2)*\
+            gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, oo)))*exp(-2/(3*(1/x)**(S(3)/2)))/(2*(1/x)**(S(1)/4))
+    assert airyai(x).series(x, -oo) == (-1)**(S(1)/4)*sqrt(pi)*(-9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) - \
+            3*gamma(S(7)/6)*gamma(S(11)/6)/(8*pi**2*x**2) - I*sqrt(-1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + \
+            9*I*(-1/x)**(S(7)/2)*gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, -oo)))*exp(2*I/(3*(-1/x)**\
+            (S(3)/2)))/(2*(-1/x)**(S(1)/4))
+
 
 def test_airybi():
     z = Symbol('z', real=False)
@@ -660,6 +668,13 @@ def test_airybi():
     assert expand_func(airybi(2*(3*z**5)**Rational(1, 3))) == (
         sqrt(3)*(1 - (z**5)**Rational(1, 3)/z**Rational(5, 3))*airyai(2*3**Rational(1, 3)*z**Rational(5, 3))/2 +
         (1 + (z**5)**Rational(1, 3)/z**Rational(5, 3))*airybi(2*3**Rational(1, 3)*z**Rational(5, 3))/2)
+
+    assert airybi(x).series(x, oo) == sqrt(pi)*(9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) + 3*gamma(S(7)/6)*\
+            gamma(S(11)/6)/(8*pi**2*x**2) + sqrt(1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + 9*(1/x)**(S(7)/2)*\
+            gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, oo)))*exp(2/(3*(1/x)**(S(3)/2)))/(1/x)**(S(1)/4)
+    assert airybi(x).series(x, -oo) == sqrt(I)*sqrt(pi)*(9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) + \
+            3*gamma(S(7)/6)*gamma(S(11)/6)/(8*pi**2*x**2) - I*sqrt(-1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + \
+            9*I*(-1/x)**(S(7)/2)*gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, -oo)))*exp(-2*I/(3*(-1/x)**(S(3)/2)))/(-1/x)**(S(1)/4)
 
 
 def test_airyaiprime():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -625,13 +625,13 @@ def test_airyai():
         -sqrt(3)*(-1 + (z**5)**Rational(1, 3)/z**Rational(5, 3))*airybi(2*3**Rational(1, 3)*z**Rational(5, 3))/6 +
          (1 + (z**5)**Rational(1, 3)/z**Rational(5, 3))*airyai(2*3**Rational(1, 3)*z**Rational(5, 3))/2)
 
-    assert airyai(x).series(x, oo) == sqrt(pi)*(-9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) - 3*gamma(S(7)/6)*\
-            gamma(S(11)/6)/(8*pi**2*x**2) + sqrt(1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + 9*(1/x)**(S(7)/2)*\
-            gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, oo)))*exp(-2/(3*(1/x)**(S(3)/2)))/(2*(1/x)**(S(1)/4))
-    assert airyai(x).series(x, -oo) == (-1)**(S(1)/4)*sqrt(pi)*(-9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) - \
-            3*gamma(S(7)/6)*gamma(S(11)/6)/(8*pi**2*x**2) - I*sqrt(-1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + \
-            9*I*(-1/x)**(S(7)/2)*gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, -oo)))*exp(2*I/(3*(-1/x)**\
-            (S(3)/2)))/(2*(-1/x)**(S(1)/4))
+    assert airyai(x).series(x, oo) == (385/(4608*x**3) + 1 - 5*(1/x)**(S(3)/2)/48 - 85085*(1/x)**(S(9)/2)/663552 + \
+            O(x**(-6), (x, oo)))*(1/x)**(S(1)/4)*exp(-2/(3*(1/x)**(S(3)/2)))/(2*sqrt(pi))
+    assert airyai(x).series(x, -oo, n=4) == (-1/x)**(S(1)/4)*((1 + 385/(4608*x**3) + 37182145/(127401984*x**6) + \
+            5849680962125/(1761205026816*x**9))*sin(pi/4 + 2/(3*(-1/x)**(S(3)/2))) + (-1267709431363375*(-1/x)**\
+            (S(21)/2)/84537841287168 + 5391411025*(-1/x)**(S(15)/2)/6115295232 - 85085*(-1/x)**(S(9)/2)/663552 + \
+            5*(-1/x)**(S(3)/2)/48)*cos(pi/4 + 2/(3*(-1/x)**(S(3)/2))))/sqrt(pi) + O(x**(-4), (x, -oo))
+
 
 
 def test_airybi():
@@ -669,12 +669,13 @@ def test_airybi():
         sqrt(3)*(1 - (z**5)**Rational(1, 3)/z**Rational(5, 3))*airyai(2*3**Rational(1, 3)*z**Rational(5, 3))/2 +
         (1 + (z**5)**Rational(1, 3)/z**Rational(5, 3))*airybi(2*3**Rational(1, 3)*z**Rational(5, 3))/2)
 
-    assert airybi(x).series(x, oo) == sqrt(pi)*(9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) + 3*gamma(S(7)/6)*\
-            gamma(S(11)/6)/(8*pi**2*x**2) + sqrt(1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + 9*(1/x)**(S(7)/2)*\
-            gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, oo)))*exp(2/(3*(1/x)**(S(3)/2)))/(1/x)**(S(1)/4)
-    assert airybi(x).series(x, -oo) == sqrt(I)*sqrt(pi)*(9*gamma(S(19)/6)*gamma(S(23)/6)/(256*pi**2*x**5) + \
-            3*gamma(S(7)/6)*gamma(S(11)/6)/(8*pi**2*x**2) - I*sqrt(-1/x)*gamma(S(1)/6)*gamma(S(5)/6)/(2*pi**2) + \
-            9*I*(-1/x)**(S(7)/2)*gamma(S(13)/6)*gamma(S(17)/6)/(64*pi**2) + O(x**(-6), (x, -oo)))*exp(-2*I/(3*(-1/x)**(S(3)/2)))/(-1/x)**(S(1)/4)
+    assert airybi(x).series(x, oo) == (385/(4608*x**3) + 1 + 5*(1/x)**(S(3)/2)/48 + 85085*(1/x)**(S(9)/2)/663552 + \
+            O(x**(-6), (x, oo)))*(1/x)**(S(1)/4)*exp(2/(3*(1/x)**(S(3)/2)))/sqrt(pi)
+    assert airybi(x).series(x, -oo, n=4) == (-1/x)**(S(1)/4)*((1 + 385/(4608*x**3) + 37182145/(127401984*x**6) + \
+            5849680962125/(1761205026816*x**9))*cos(pi/4 + 2/(3*(-1/x)**(S(3)/2))) + (-1267709431363375*(-1/x)**\
+            (S(21)/2)/84537841287168 + 5391411025*(-1/x)**(S(15)/2)/6115295232 - 85085*(-1/x)**(S(9)/2)/663552 + \
+            5*(-1/x)**(S(3)/2)/48)*sin(pi/4 + 2/(3*(-1/x)**(S(3)/2))))/sqrt(pi) + O(x**(-4), (x, -oo))
+
 
 
 def test_airyaiprime():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -809,8 +809,14 @@ def test_issue_10610():
 
 
 def test_issue_10804():
-    assert limit(airybi(x)*x**(S(1)/4)*exp(-2*x**Rational(3, 2)/3), x, oo)**2 == gamma(S(1)/6)**2*gamma(S(5)/6)**2/(4*pi**3)
-    assert limit(2*airyai(x)*x**(S(1)/4)*exp(2*x**Rational(3, 2)/3), x, oo)**2 == gamma(S(1)/6)**2*gamma(S(5)/6)**2/(4*pi**3)
+    assert limit(airybi(x)*x**(S(1)/4)*exp(-2*x**Rational(3, 2)/3), x, oo)**2 == 1/pi
+    assert limit(2*airyai(x)*x**(S(1)/4)*exp(2*x**Rational(3, 2)/3), x, oo)**2 == 1/pi
+    assert limit(airyai(x), x, oo) == S.Zero
+    assert limit(airyai(x), x, -oo) == S.Zero
+    assert limit(airybi(x), x, oo) ==  S.Infinity
+    assert limit(airybi(x), x, -oo) == S.Zero
+    assert limit(airyai(x), x, 0) == 3**(S(5)/6)*gamma(S(1)/3)/(6*pi)
+    assert limit(airybi(x), x, 0) == 3**(S(1)/3)*gamma(S(1)/3)/(2*pi)
 
 
 def test_issue_10868():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -17,7 +17,7 @@ from sympy.functions.elementary.miscellaneous import (cbrt, real_root, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin,
                                                       atan, cos, cot, csc, sec, sin, tan)
-from sympy.functions.special.bessel import (besseli, bessely, besselj, besselk)
+from sympy.functions.special.bessel import (besseli, bessely, besselj, besselk, airyai, airybi)
 from sympy.functions.special.error_functions import (Ei, erf, erfc, erfi, fresnelc, fresnels)
 from sympy.functions.special.gamma_functions import (digamma, gamma, uppergamma)
 from sympy.functions.special.hyper import meijerg
@@ -806,6 +806,11 @@ def test_limit_with_Float():
 
 def test_issue_10610():
     assert limit(3**x*3**(-x - 1)*(x + 1)**2/x**2, x, oo) == Rational(1, 3)
+
+
+def test_issue_10804():
+    assert limit(airybi(x)*x**(S(1)/4)*exp(-2*x**Rational(3, 2)/3), x, oo)**2 == gamma(S(1)/6)**2*gamma(S(5)/6)**2/(4*pi**3)
+    assert limit(2*airyai(x)*x**(S(1)/4)*exp(2*x**Rational(3, 2)/3), x, oo)**2 == gamma(S(1)/6)**2*gamma(S(5)/6)**2/(4*pi**3)
 
 
 def test_issue_10868():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #10804
Fixes #23563

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Added helper classes for airyai and airybi for being tractable for gruntz.
  * Added `_eval_aseries` methods for asymptotic expansion of airyai and airybi functions at infinity
<!-- END RELEASE NOTES -->
