### PR TITLE
[GSoC] Added StateSpace and PIDController documentation to SymPy.

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -30,7 +30,7 @@ jobs:
         run: bin/test quality
 
       - name: Run Ruff on the sympy package
-        run: ruff check .
+        run: ruff check sympy
 
       - name: Run flake8 on the sympy package
         run: flake8 sympy

--- a/doc/src/modules/physics/control/control.rst
+++ b/doc/src/modules/physics/control/control.rst
@@ -14,13 +14,13 @@ with ``TransferFunctionMatrix`` as the base class for representing one. ``MIMOSe
 ``MIMOParallel``  and ``MIMOFeedback`` are MIMO equivalent of ``Series``, ``Parallel``
 and ``Feedback`` classes.
 
-Alongside ``TransferFunction`` representations, the ``StateSpace`` class can be used to model
-state-space systems. These representations are more general and can handle both
-continuous-time and discrete-time systems. The ``StateSpace`` class supports various
-methods for analyzing and manipulating systems, such as controllability, observability,
-and transformations between state-space and transfer function representations. MIMO
-state-space systems are also supported, making this module versatile for dealing with
-a wide range of control system problems.
+Alongside ``TransferFunction`` representations, the ``StateSpace`` class can be used
+to model state-space systems. These representations are more general and can handle
+both continuous-time and discrete-time systems. The ``StateSpace`` class supports
+various methods for analyzing and manipulating systems, such as controllability,
+observability, and transformations between state-space and transfer function
+representations. MIMO state-space systems are also supported, making this module
+versatile for dealing with a wide range of control system problems.
 
 The advantage of this symbolic Control system package is that the solutions obtained
 from it are highly accurate and do not rely on numerical methods to approximate the

--- a/doc/src/modules/physics/control/control.rst
+++ b/doc/src/modules/physics/control/control.rst
@@ -14,6 +14,14 @@ with ``TransferFunctionMatrix`` as the base class for representing one. ``MIMOSe
 ``MIMOParallel``  and ``MIMOFeedback`` are MIMO equivalent of ``Series``, ``Parallel``
 and ``Feedback`` classes.
 
+Alongside ``TransferFunction`` representations, the ``StateSpace`` class can be used to model
+state-space systems. These representations are more general and can handle both
+continuous-time and discrete-time systems. The ``StateSpace`` class supports various
+methods for analyzing and manipulating systems, such as controllability, observability,
+and transformations between state-space and transfer function representations. MIMO
+state-space systems are also supported, making this module versatile for dealing with
+a wide range of control system problems.
+
 The advantage of this symbolic Control system package is that the solutions obtained
 from it are highly accurate and do not rely on numerical methods to approximate the
 solutions. Symbolic solutions obtained are also in a compact form that can be used for

--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -19,6 +19,9 @@ lti
 .. autoclass:: Feedback
    :members:
 
+.. autoclass:: PIDController
+   :members:
+
 .. autoclass:: TransferFunctionMatrix
    :members:
 
@@ -29,6 +32,9 @@ lti
    :members:
 
 .. autoclass:: MIMOFeedback
+   :members:
+
+.. autoclass:: StateSpace
    :members:
 
 .. autofunction:: gbt

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2967,6 +2967,11 @@ class Expr(Basic, EvalfMixin):
         if len(dir) != 1 or dir not in '+-':
             raise ValueError("Dir must be '+' or '-'")
 
+        if n is not None:
+            n = int(n)
+            if n < 0:
+                raise ValueError("Number of terms should be nonnegative")
+
         x0 = sympify(x0)
         cdir = sympify(cdir)
         from sympy.functions.elementary.complexes import im, sign

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3241,7 +3241,8 @@ class Expr(Basic, EvalfMixin):
             logw = log(1/res)
 
         s = func.series(k, 0, n)
-
+        from sympy.core.function import expand_mul
+        s = expand_mul(s)
         # Hierarchical series
         if hir:
             return s.subs(k, exp(logw))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -637,12 +637,6 @@ class Function(Application, Expr):
         return fuzzy_or(a.is_infinite if s is S.ComplexInfinity
                         else (a - s).is_zero for s in ss)
 
-    def as_base_exp(self):
-        """
-        Returns the method as the 2-tuple (base, exponent).
-        """
-        return self, S.One
-
     def _eval_aseries(self, n, args0, x, logx):
         """
         Compute an asymptotic expansion around args0, in terms of self.args.

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1245,7 +1245,7 @@ class Mul(Expr, AssocOp):
                 nc += 1
             if e1 is None:
                 e1 = e
-            elif e != e1 or nc > 1:
+            elif e != e1 or nc > 1 or not e.is_Integer:
                 return self, S.One
             bases.append(b)
         return self.func(*bases), e1

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1503,6 +1503,8 @@ def test_as_base_exp():
     assert (x*y*z).as_base_exp() == (x*y*z, S.One)
     assert (x + y + z).as_base_exp() == (x + y + z, S.One)
     assert ((x + y)**z).as_base_exp() == (x + y, z)
+    assert (x**2*y**2).as_base_exp() == (x*y, 2)
+    assert (x**z*y**z).as_base_exp() == (x**z*y**z, S.One)
 
 
 def test_issue_4963():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -568,8 +568,7 @@ def test_function__eval_nseries():
 
     # issue 6725:
     assert expint(Rational(3, 2), -x)._eval_nseries(x, 5, None) == \
-        2 - 2*sqrt(pi)*sqrt(-x) - 2*x + x**2 + x**3/3 + x**4/12 + 4*I*x**(S(3)/2)*sqrt(-x)/3 + \
-        2*I*x**(S(5)/2)*sqrt(-x)/5 + 2*I*x**(S(7)/2)*sqrt(-x)/21 + O(x**5)
+        2 - 2*x - x**2/3 - x**3/15 - x**4/84 - 2*I*sqrt(pi)*sqrt(x) + O(x**5)
     assert sin(sqrt(x))._eval_nseries(x, 3, None) == \
         sqrt(x) - x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + O(x**3)
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -797,6 +797,27 @@ class arg(Function):
         x, y = self.args[0].as_real_imag()
         return atan2(y, x)
 
+    def _eval_as_leading_term(self, x, logx=None, cdir=0):
+        arg0 = self.args[0]
+        t = Dummy('t', positive=True)
+        z = arg0.subs(x, cdir*t)
+        z = z.as_leading_term(t, cdir=cdir)
+        if z.has(t):
+            return self.func(cdir)
+        return self.func(z)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        from sympy.series.order import Order
+        if n <= 0:
+            return Order(1)
+        arg0 = self.args[0]
+        t = Dummy('t', positive=True)
+        z = arg0.subs(x, cdir*t)
+        z = z.as_leading_term(t, cdir=cdir)
+        if z.has(t):
+            return self.func(cdir)
+        return self.func(z)
+
 
 class conjugate(Function):
     """

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -783,12 +783,6 @@ class log(Function):
                         else:
                             return cls(modulus) + I * (pi - atan_table[t1])
 
-    def as_base_exp(self):
-        """
-        Returns this function in the form (base, exponent).
-        """
-        return self, S.One
-
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):  # of log(1+x)

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,5 +1,5 @@
 from sympy.core.expr import Expr
-from sympy.core.function import (Derivative, Function, Lambda, expand)
+from sympy.core.function import (Derivative, Function, Lambda, expand, PoleError)
 from sympy.core.numbers import (E, I, Rational, comp, nan, oo, pi, zoo)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -675,16 +675,12 @@ def test_arg_rewrite():
 def test_arg_leading_term_and_series():
     x = Symbol('x')
     assert arg(x).as_leading_term(x, cdir = 1) == 0
-    assert arg(x).as_leading_term(x, cdir = 1) == 0
-    assert arg(x + I).as_leading_term(x, cdir = 1) == pi/2
-    assert arg(x + I).as_leading_term(x, cdir = -1) == pi/2
-    assert arg(2*x).as_leading_term(x, cdir = I) == pi/2
-    assert arg(2*x).as_leading_term(x, cdir = -I) == -pi/2
+    assert arg(x).as_leading_term(x, cdir = -1) == pi
+    raises(PoleError, lambda: arg(x + I).as_leading_term(x, cdir = 1))
+    raises(PoleError, lambda: arg(2*x).as_leading_term(x, cdir = I))
 
-    assert arg(x + I).series(x, 0) == pi/2
-    assert arg(x + I).series(x, 1) == pi/4
-    assert arg(x + I).series(x, -1) == 3*pi/4
-    assert arg(x).nseries(x, 0, 0) == Order(1)
+    assert arg(x).nseries(x) == 0
+    assert arg(x).nseries(x, n=0) == Order(1)
 
 
 def test_adjoint():

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -20,6 +20,7 @@ from sympy.matrices import SparseMatrix
 from sympy.sets.sets import Interval
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
+from sympy.series.order import Order
 from sympy.testing.pytest import XFAIL, raises, _both_exp_pow
 
 
@@ -669,6 +670,21 @@ def test_arg_rewrite():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)
     assert arg(x + I*y).rewrite(atan2) == atan2(y, x)
+
+
+def test_arg_leading_term_and_series():
+    x = Symbol('x')
+    assert arg(x).as_leading_term(x, cdir = 1) == 0
+    assert arg(x).as_leading_term(x, cdir = 1) == 0
+    assert arg(x + I).as_leading_term(x, cdir = 1) == pi/2
+    assert arg(x + I).as_leading_term(x, cdir = -1) == pi/2
+    assert arg(2*x).as_leading_term(x, cdir = I) == pi/2
+    assert arg(2*x).as_leading_term(x, cdir = -I) == -pi/2
+
+    assert arg(x + I).series(x, 0) == pi/2
+    assert arg(x + I).series(x, 1) == pi/4
+    assert arg(x + I).series(x, -1) == 3*pi/4
+    assert arg(x).nseries(x, 0, 0) == Order(1)
 
 
 def test_adjoint():

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -595,10 +595,10 @@ class besseli(BesselBase):
         from sympy.series.order import Order
         point = args0[1]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
             s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(Rational(2*nu + 1, 2), k))/\
-                 ((2)**(k)*z**(Rational(2*k+1, 2))*factorial(k)) for k in range(n)] + [Order(1/z**(Rational(2*n+1, 2)), x)]
+            ((2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] + [Order(1/z**(Rational(2*n + 1, 2)), x)]
             return exp(z)/sqrt(2*pi) * (Add(*s))
 
         return super()._eval_aseries(n, args0, x, logx)
@@ -764,10 +764,10 @@ class besselk(BesselBase):
         from sympy.series.order import Order
         point = args0[1]
 
-        if point is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
-            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
-                Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] +[Order(1/z**(Rational(2*n + 1, 2)), x)]
+            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(Rational(2*nu + 1, 2), k))/\
+            ((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] +[Order(1/z**(Rational(2*n + 1, 2)), x)]
             return (exp(-z)*sqrt(pi/2))*Add(*s)
 
         return super()._eval_aseries(n, args0, x, logx)
@@ -2132,8 +2132,9 @@ class _besseli(Function):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
+        point = args0[1]
 
-        if args0[1] == S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
             l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
                     Rational(2*nu + 1, 2), k))/((2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]
@@ -2162,8 +2163,9 @@ class _besselk(Function):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
+        point = args0[1]
 
-        if args0[1] is S.Infinity:
+        if point in [S.Infinity, S.NegativeInfinity]:
             nu, z = self.args
             l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
                     Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -586,6 +586,19 @@ class besseli(BesselBase):
 
         return super(besseli, self)._eval_nseries(x, n, logx, cdir)
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+        nu, z = self.args
+        point = args0[1]
+
+        if point is S.Infinity:
+            s = [(RisingFactorial(S.Half-nu,k)*RisingFactorial(
+                S.Half+nu,k))/((2)**(k)*z**((2*k+1)/2)*factorial(k)) for k in range(n)] + [Order(1/z**((2*n+1)/2), x)]
+            return (exp(z)/sqrt((2*pi))) * Add(*s)
+
+        return super()._eval_aseries(n, args0, x, logx)
+
 
 class besselk(BesselBase):
     r"""
@@ -737,6 +750,19 @@ class besselk(BesselBase):
             return a + Add(*b) + Add(*c) # Order term comes from a
 
         return super(besselk, self)._eval_nseries(x, n, logx, cdir)
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+        nu, z = self.args
+        point = args0[1]
+
+        if point is S.Infinity:
+            s = [((RisingFactorial(S.Half - nu, k)*RisingFactorial(
+                S.Half + nu, k))/((-2)**(k)*z**((2*k+1)/2)*factorial(k))) for k in range(n)] +[Order(1/z**((2*n+1)/2), x)]
+            return ((exp(-z)*sqrt(pi/(2))) * Add(*s))
+
+        return super()._eval_aseries(n, args0, x, logx)
 
 
 class hankel1(BesselBase):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -518,6 +518,10 @@ class besseli(BesselBase):
         if nu != nnu:
             return besseli(nnu, z)
 
+    def _eval_rewrite_as_tractable(self, nu, z, limitvar=None, **kwargs):
+        if z.is_extended_real:
+            return exp(z)*_besseli(nu, z)
+
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         return exp(-I*pi*nu/2)*besselj(nu, polar_lift(I)*z)
 
@@ -589,13 +593,13 @@ class besseli(BesselBase):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
-        nu, z = self.args
         point = args0[1]
 
         if point is S.Infinity:
-            s = [(RisingFactorial(S.Half-nu,k)*RisingFactorial(
-                S.Half+nu,k))/((2)**(k)*z**((2*k+1)/2)*factorial(k)) for k in range(n)] + [Order(1/z**((2*n+1)/2), x)]
-            return (exp(z)/sqrt((2*pi))) * Add(*s)
+            nu, z = self.args
+            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(Rational(2*nu + 1, 2), k))/\
+                 ((2)**(k)*z**(Rational(2*k+1, 2))*factorial(k)) for k in range(n)] + [Order(1/z**(Rational(2*n+1, 2)), x)]
+            return exp(z)/sqrt(2*pi) * (Add(*s))
 
         return super()._eval_aseries(n, args0, x, logx)
 
@@ -681,6 +685,10 @@ class besselk(BesselBase):
         if nu.is_integer and z.is_positive:
             return True
 
+    def _eval_rewrite_as_tractable(self, nu, z, limitvar=None, **kwargs):
+        if z.is_extended_real:
+            return exp(-z)*_besselk(nu, z)
+
     def _eval_as_leading_term(self, x, logx=None, cdir=0):
         nu, z = self.args
         try:
@@ -754,13 +762,13 @@ class besselk(BesselBase):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.functions.combinatorial.factorials import RisingFactorial
         from sympy.series.order import Order
-        nu, z = self.args
         point = args0[1]
 
         if point is S.Infinity:
-            s = [((RisingFactorial(S.Half - nu, k)*RisingFactorial(
-                S.Half + nu, k))/((-2)**(k)*z**((2*k+1)/2)*factorial(k))) for k in range(n)] +[Order(1/z**((2*n+1)/2), x)]
-            return ((exp(-z)*sqrt(pi/(2))) * Add(*s))
+            nu, z = self.args
+            s = [(RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
+                Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k)) for k in range(n)] +[Order(1/z**(Rational(2*n + 1, 2)), x)]
+            return (exp(-z)*sqrt(pi/2))*Add(*s)
 
         return super()._eval_aseries(n, args0, x, logx)
 
@@ -2113,3 +2121,62 @@ class marcumq(Function):
     def _eval_is_zero(self):
         if all(arg.is_zero for arg in self.args):
             return True
+
+class _besseli(Function):
+    """
+    Helper function to make the $\\mathrm{besseli}(nu, z)$
+    function tractable for the Gruntz algorithm.
+
+    """
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+
+        if args0[1] == S.Infinity:
+            nu, z = self.args
+            l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
+                    Rational(2*nu + 1, 2), k))/((2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]
+            return sqrt(pi/(2))*(Add(*l)) + Order(1/z**(Rational(2*n + 1, 2)), x)
+
+        return super()._eval_aseries(n, args0, x, logx)
+
+    def _eval_rewrite_as_intractable(self, nu, z, **kwargs):
+        return exp(-z)*besseli(nu, z)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_intractable(*self.args)
+            return f._eval_nseries(x, n, logx)
+        return super()._eval_nseries(x, n, logx)
+
+
+class _besselk(Function):
+    """
+    Helper function to make the $\\mathrm{besselk}(nu, z)$
+    function tractable for the Gruntz algorithm.
+
+    """
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.functions.combinatorial.factorials import RisingFactorial
+        from sympy.series.order import Order
+
+        if args0[1] is S.Infinity:
+            nu, z = self.args
+            l = [((RisingFactorial(Rational(2*nu - 1, 2), k)*RisingFactorial(
+                    Rational(2*nu + 1, 2), k))/((-2)**(k)*z**(Rational(2*k + 1, 2))*factorial(k))) for k in range(n)]
+            return sqrt(pi/(2))*(Add(*l)) + Order(1/z**(Rational(2*n + 1, 2)), x)
+
+        return super()._eval_aseries(n, args0, x, logx)
+
+    def _eval_rewrite_as_intractable(self,nu, z, **kwargs):
+        return exp(z)*besselk(nu, z)
+
+    def _eval_nseries(self, x, n, logx, cdir=0):
+        x0 = self.args[0].limit(x, 0)
+        if x0.is_zero:
+            f = self._eval_rewrite_as_intractable(*self.args)
+            return f._eval_nseries(x, n, logx)
+        return super()._eval_nseries(x, n, logx)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1263,7 +1263,7 @@ class Ei(Function):
         from sympy.series.order import Order
         point = args0[0]
 
-        if point is S.Infinity:
+        if point in (S.Infinity, S.NegativeInfinity):
             z = self.args[0]
             s = [factorial(k) / (z)**k for k in range(n)] + \
                     [Order(1/z**n, x)]
@@ -2766,8 +2766,8 @@ class _eis(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy.series.order import Order
-        if args0[0] != S.Infinity:
-            return super(_erfs, self)._eval_aseries(n, args0, x, logx)
+        if args0[0] not in (S.Infinity, S.NegativeInfinity):
+            return super()._eval_aseries(n, args0, x, logx)
 
         z = self.args[0]
         l = [factorial(k) * (1/z)**(k + 1) for k in range(n)]

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -145,6 +145,8 @@ def test_besseli_series():
     #test for aseries
     assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(sqrt(1/x) - (1/x)**(S(3)/2)/8 - \
         3*(1/x)**(S(5)/2)/128 - 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(x)/(2*sqrt(pi))
+    assert besseli(0,x).series(x,-oo, n=4) == sqrt(2)*(sqrt(-1/x) - (-1/x)**(S(3)/2)/8 - 3*(-1/x)**(S(5)/2)/128 - \
+        15*(-1/x)**(S(7)/2)/1024 + O((-1/x)**(S(9)/2), (x, -oo)))*exp(-x)/(2*sqrt(pi))
 
 
 def test_besselk_series():
@@ -174,6 +176,9 @@ def test_besselk_series():
     #test for aseries
     assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(sqrt(1/x) + (1/x)**(S(3)/2)/8 - \
             3*(1/x)**(S(5)/2)/128 + 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(-x)/2
+    assert besselk(0,x).series(x, -oo, n=4) == sqrt(2)*sqrt(pi)*(-I*sqrt(-1/x) + I*(-1/x)**(S(3)/2)/8 + \
+            3*I*(-1/x)**(S(5)/2)/128 + 15*I*(-1/x)**(S(7)/2)/1024 + O((-1/x)**(S(9)/2), (x, -oo)))*exp(-x)/2
+
 
 
 def test_diff():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -142,6 +142,10 @@ def test_besseli_series():
         x**(S(7)/2)/144 + x**(S(9)/2)/2880 + x**(S(11)/2)/86400 + O(x**6)
     assert besseli(-2, sin(x)).series(x, n=4) == besseli(2, sin(x)).series(x, n=4)
 
+    #test for aseries
+    assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(75*(1/x)**3.5/1024 + 9*(1/x)**2.5/128 + \
+    (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(x)/(2*sqrt(pi))
+
 
 def test_besselk_series():
     const = log(2) - S.EulerGamma - log(x)
@@ -166,6 +170,10 @@ def test_besselk_series():
         sqrt(x)*(log(x)/2 - S(1)/2 + S.EulerGamma) + x**(S(3)/2)*(log(x)/4 - S(5)/8 + \
         S.EulerGamma/2) + x**(S(5)/2)*(log(x)/24 - S(5)/36 + S.EulerGamma/12) + O(x**3*log(x))
     assert besselk(-2, sin(x)).series(x, n=4) == besselk(2, sin(x)).series(x, n=4)
+
+    #test for aseries
+    assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(-75*(1/x)**3.5/1024 + \
+    9*(1/x)**2.5/128 - (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(-x)/2
 
 
 def test_diff():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -143,8 +143,8 @@ def test_besseli_series():
     assert besseli(-2, sin(x)).series(x, n=4) == besseli(2, sin(x)).series(x, n=4)
 
     #test for aseries
-    assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(75*(1/x)**3.5/1024 + 9*(1/x)**2.5/128 + \
-    (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(x)/(2*sqrt(pi))
+    assert besseli(0,x).series(x, oo, n=4) == sqrt(2)*(sqrt(1/x) - (1/x)**(S(3)/2)/8 - \
+        3*(1/x)**(S(5)/2)/128 - 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(x)/(2*sqrt(pi))
 
 
 def test_besselk_series():
@@ -172,8 +172,8 @@ def test_besselk_series():
     assert besselk(-2, sin(x)).series(x, n=4) == besselk(2, sin(x)).series(x, n=4)
 
     #test for aseries
-    assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(-75*(1/x)**3.5/1024 + \
-    9*(1/x)**2.5/128 - (1/x)**1.5/8 + (1/x)**0.5 + O((1/x)**4.5, (x, oo)))*exp(-x)/2
+    assert besselk(0,x).series(x, oo, n=4) == sqrt(2)*sqrt(pi)*(sqrt(1/x) + (1/x)**(S(3)/2)/8 - \
+            3*(1/x)**(S(5)/2)/128 + 15*(1/x)**(S(7)/2)/1024 + O((1/x)**(S(9)/2), (x, oo)))*exp(-x)/2
 
 
 def test_diff():

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -437,6 +437,11 @@ def test_ei():
     assert Ei(x).series(x, 1, 3) == Ei(1) + E*(x - 1) + O((x - 1)**3, (x, 1))
     assert Ei(x).series(x, oo) == \
         (120/x**5 + 24/x**4 + 6/x**3 + 2/x**2 + 1/x + 1 + O(x**(-6), (x, oo)))*exp(x)/x
+    assert Ei(x).series(x, -oo) == \
+        (120/x**5 + 24/x**4 + 6/x**3 + 2/x**2 + 1/x + 1 + O(x**(-6), (x, -oo)))*exp(x)/x
+    assert Ei(-x).series(x, oo).expand() == \
+        120*exp(-x)/x**6 - 24*exp(-x)/x**5 + 6*exp(-x)/x**4 - 2*exp(-x)/x**3 + \
+        exp(-x)/x**2 - exp(-x)/x + O(exp(-x)/x**7, (x, oo))
 
     assert str(Ei(cos(2)).evalf(n=10)) == '-0.6760647401'
     raises(ArgumentIndexError, lambda: Ei(x).fdiff(2))

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -439,9 +439,8 @@ def test_ei():
         (120/x**5 + 24/x**4 + 6/x**3 + 2/x**2 + 1/x + 1 + O(x**(-6), (x, oo)))*exp(x)/x
     assert Ei(x).series(x, -oo) == \
         (120/x**5 + 24/x**4 + 6/x**3 + 2/x**2 + 1/x + 1 + O(x**(-6), (x, -oo)))*exp(x)/x
-    assert Ei(-x).series(x, oo).expand() == \
-        120*exp(-x)/x**6 - 24*exp(-x)/x**5 + 6*exp(-x)/x**4 - 2*exp(-x)/x**3 + \
-        exp(-x)/x**2 - exp(-x)/x + O(exp(-x)/x**7, (x, oo))
+    assert Ei(-x).series(x, oo) == \
+        -((-120/x**5 + 24/x**4 - 6/x**3 + 2/x**2 - 1/x + 1 + O(x**(-6), (x, oo)))*exp(-x)/x)
 
     assert str(Ei(cos(2)).evalf(n=10)) == '-0.6760647401'
     raises(ArgumentIndexError, lambda: Ei(x).fdiff(2))

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -398,11 +398,13 @@ def _laplace_build_rules():
          re(a) > 0, S.Zero, dco),  # 4.5.28
         (t**n*exp(-a/t), 2*(a/s)**((n+1)/2)*besselk(n+1, 2*sqrt(a*s)),
          re(a) > 0, S.Zero, dco),  # 4.5.29
-        (exp(-2*sqrt(a*t)),
-         s**(-1)-sqrt(pi*a)*s**(-S(3)/2)*exp(a/s) * erfc(sqrt(a/s)),
-         Abs(arg(a)) < pi, S.Zero, dco),  # 4.5.31
-        (exp(-2*sqrt(a*t))/sqrt(t), (pi/s)**(S(1)/2)*exp(a/s)*erfc(sqrt(a/s)),
-         Abs(arg(a)) < pi, S.Zero, dco),  # 4.5.33
+        # TODO: rules with sqrt(a*t) and sqrt(a/t) have stopped working after
+        #       changes to as_base_exp
+        # (exp(-2*sqrt(a*t)),
+        #  s**(-1)-sqrt(pi*a)*s**(-S(3)/2)*exp(a/s) * erfc(sqrt(a/s)),
+        #  Abs(arg(a)) < pi, S.Zero, dco),  # 4.5.31
+        # (exp(-2*sqrt(a*t))/sqrt(t), (pi/s)**(S(1)/2)*exp(a/s)*erfc(sqrt(a/s)),
+        #  Abs(arg(a)) < pi, S.Zero, dco),  # 4.5.33
         (exp(-a*exp(-t)), a**(-s)*lowergamma(s, a),
          S.true, S.Zero, dco),  # 4.5.36
         (exp(-a*exp(t)), a**s*uppergamma(-s, a),
@@ -430,18 +432,18 @@ def _laplace_build_rules():
         (sin(omega*t)**2/t**2,
          omega*atan(2*omega/s)-s*log(1+4*omega**2/s**2)/4,
          S.true, 2*Abs(im(omega)), dco),  # 4.7.20
-        (sin(2*sqrt(a*t)), sqrt(pi*a)/s/sqrt(s)*exp(-a/s),
-         S.true, S.Zero, dco),  # 4.7.32
-        (sin(2*sqrt(a*t))/t, pi*erf(sqrt(a/s)),
-         S.true, S.Zero, dco),  # 4.7.34
+        # (sin(2*sqrt(a*t)), sqrt(pi*a)/s/sqrt(s)*exp(-a/s),
+        #  S.true, S.Zero, dco),  # 4.7.32
+        # (sin(2*sqrt(a*t))/t, pi*erf(sqrt(a/s)),
+        #  S.true, S.Zero, dco),  # 4.7.34
         (cos(omega*t), s/(s**2+omega**2),
          S.true, Abs(im(omega)), dco),  # 4.7.43
         (cos(omega*t)**2, (s**2+2*omega**2)/(s**2+4*omega**2)/s,
          S.true, 2*Abs(im(omega)), dco),  # 4.7.45
-        (sqrt(t)*cos(2*sqrt(a*t)), sqrt(pi)/2*s**(-S(5)/2)*(s-2*a)*exp(-a/s),
-         S.true, S.Zero, dco),  # 4.7.66
-        (cos(2*sqrt(a*t))/sqrt(t), sqrt(pi/s)*exp(-a/s),
-         S.true, S.Zero, dco),  # 4.7.67
+        # (sqrt(t)*cos(2*sqrt(a*t)), sqrt(pi)/2*s**(-S(5)/2)*(s-2*a)*exp(-a/s),
+        #  S.true, S.Zero, dco),  # 4.7.66
+        # (cos(2*sqrt(a*t))/sqrt(t), sqrt(pi/s)*exp(-a/s),
+        #  S.true, S.Zero, dco),  # 4.7.67
         (sin(a*t)*sin(b*t), 2*a*b*s/(s**2+(a+b)**2)/(s**2+(a-b)**2),
          S.true, Abs(im(a))+Abs(im(b)), dco),  # 4.7.78
         (cos(a*t)*sin(b*t), b*(s**2-a**2+b**2)/(s**2+(a+b)**2)/(s**2+(a-b)**2),
@@ -462,40 +464,41 @@ def _laplace_build_rules():
          n > -2, Abs(a), dco),  # 4.9.18
         (t**n*cosh(a*t), gamma(n+1)/2*((s-a)**(-n-1)+(s+a)**(-n-1)),
          n > -1, Abs(a), dco),  # 4.9.19
-        (sinh(2*sqrt(a*t)), sqrt(pi*a)/s/sqrt(s)*exp(a/s),
-         S.true, S.Zero, dco),  # 4.9.34
-        (cosh(2*sqrt(a*t)), 1/s+sqrt(pi*a)/s/sqrt(s)*exp(a/s)*erf(sqrt(a/s)),
-         S.true, S.Zero, dco),  # 4.9.35
-        (
-            sqrt(t)*sinh(2*sqrt(a*t)),
-            pi**(S(1)/2)*s**(-S(5)/2)*(s/2+a) *
-            exp(a/s)*erf(sqrt(a/s))-a**(S(1)/2)*s**(-2),
-            S.true, S.Zero, dco),  # 4.9.36
-        (sqrt(t)*cosh(2*sqrt(a*t)), pi**(S(1)/2)*s**(-S(5)/2)*(s/2+a)*exp(a/s),
-         S.true, S.Zero, dco),  # 4.9.37
-        (sinh(2*sqrt(a*t))/sqrt(t),
-         pi**(S(1)/2)*s**(-S(1)/2)*exp(a/s) * erf(sqrt(a/s)),
-            S.true, S.Zero, dco),  # 4.9.38
-        (cosh(2*sqrt(a*t))/sqrt(t), pi**(S(1)/2)*s**(-S(1)/2)*exp(a/s),
-         S.true, S.Zero, dco),  # 4.9.39
-        (sinh(sqrt(a*t))**2/sqrt(t), pi**(S(1)/2)/2*s**(-S(1)/2)*(exp(a/s)-1),
-         S.true, S.Zero, dco),  # 4.9.40
-        (cosh(sqrt(a*t))**2/sqrt(t), pi**(S(1)/2)/2*s**(-S(1)/2)*(exp(a/s)+1),
-         S.true, S.Zero, dco),  # 4.9.41
+        # TODO
+        # (sinh(2*sqrt(a*t)), sqrt(pi*a)/s/sqrt(s)*exp(a/s),
+        #  S.true, S.Zero, dco),  # 4.9.34
+        # (cosh(2*sqrt(a*t)), 1/s+sqrt(pi*a)/s/sqrt(s)*exp(a/s)*erf(sqrt(a/s)),
+        #  S.true, S.Zero, dco),  # 4.9.35
+        # (
+        #     sqrt(t)*sinh(2*sqrt(a*t)),
+        #     pi**(S(1)/2)*s**(-S(5)/2)*(s/2+a) *
+        #     exp(a/s)*erf(sqrt(a/s))-a**(S(1)/2)*s**(-2),
+        #     S.true, S.Zero, dco),  # 4.9.36
+        # (sqrt(t)*cosh(2*sqrt(a*t)), pi**(S(1)/2)*s**(-S(5)/2)*(s/2+a)*exp(a/s),
+        #   S.true, S.Zero, dco),  # 4.9.37
+        # (sinh(2*sqrt(a*t))/sqrt(t),
+        #  pi**(S(1)/2)*s**(-S(1)/2)*exp(a/s) * erf(sqrt(a/s)),
+        #     S.true, S.Zero, dco),  # 4.9.38
+        # (cosh(2*sqrt(a*t))/sqrt(t), pi**(S(1)/2)*s**(-S(1)/2)*exp(a/s),
+        #  S.true, S.Zero, dco),  # 4.9.39
+        # (sinh(sqrt(a*t))**2/sqrt(t), pi**(S(1)/2)/2*s**(-S(1)/2)*(exp(a/s)-1),
+        #  S.true, S.Zero, dco),  # 4.9.40
+        # (cosh(sqrt(a*t))**2/sqrt(t), pi**(S(1)/2)/2*s**(-S(1)/2)*(exp(a/s)+1),
+        #  S.true, S.Zero, dco),  # 4.9.41
         (erf(a*t), exp(s**2/(2*a)**2)*erfc(s/(2*a))/s,
          4*Abs(arg(a)) < pi, S.Zero, dco),  # 4.12.2
-        (erf(sqrt(a*t)), sqrt(a)/sqrt(s+a)/s,
-         S.true, Max(S.Zero, -re(a)), dco),  # 4.12.4
-        (exp(a*t)*erf(sqrt(a*t)), sqrt(a)/sqrt(s)/(s-a),
-         S.true, Max(S.Zero, re(a)), dco),  # 4.12.5
-        (erf(sqrt(a/t)/2), (1-exp(-sqrt(a*s)))/s,
-         re(a) > 0, S.Zero, dco),  # 4.12.6
-        (erfc(sqrt(a*t)), (sqrt(s+a)-sqrt(a))/sqrt(s+a)/s,
-         S.true, -re(a), dco),  # 4.12.9
-        (exp(a*t)*erfc(sqrt(a*t)), 1/(s+sqrt(a*s)),
-         S.true, S.Zero, dco),  # 4.12.10
-        (erfc(sqrt(a/t)/2), exp(-sqrt(a*s))/s,
-         re(a) > 0, S.Zero, dco),  # 4.2.11
+        # (erf(sqrt(a*t)), sqrt(a)/sqrt(s+a)/s,
+        #  S.true, Max(S.Zero, -re(a)), dco),  # 4.12.4
+        # (exp(a*t)*erf(sqrt(a*t)), sqrt(a)/sqrt(s)/(s-a),
+        #  S.true, Max(S.Zero, re(a)), dco),  # 4.12.5
+        # (erf(sqrt(a/t)/2), (1-exp(-sqrt(a*s)))/s,
+        #  re(a) > 0, S.Zero, dco),  # 4.12.6
+        # (erfc(sqrt(a*t)), (sqrt(s+a)-sqrt(a))/sqrt(s+a)/s,
+        #  S.true, -re(a), dco),  # 4.12.9
+        # (exp(a*t)*erfc(sqrt(a*t)), 1/(s+sqrt(a*s)),
+        #  S.true, S.Zero, dco),  # 4.12.10
+        # (erfc(sqrt(a/t)/2), exp(-sqrt(a*s))/s,
+        #  re(a) > 0, S.Zero, dco),  # 4.2.11
         (besselj(n, a*t), a**n/(sqrt(s**2+a**2)*(s+sqrt(s**2+a**2))**n),
          re(n) > -1, Abs(im(a)), dco),  # 4.14.1
         (t**b*besselj(n, a*t),
@@ -504,10 +507,10 @@ def _laplace_build_rules():
         (t**b*besselj(n, a*t),
          2**(n+1)/sqrt(pi)*gamma(n+S(3)/2)*a**n*s*(s**2+a**2)**(-n-S(3)/2),
          And(re(n) > -1, Eq(b, n+1)), Abs(im(a)), dco),  # 4.14.8
-        (besselj(0, 2*sqrt(a*t)), exp(-a/s)/s,
-         S.true, S.Zero, dco),  # 4.14.25
-        (t**(b)*besselj(n, 2*sqrt(a*t)), a**(n/2)*s**(-n-1)*exp(-a/s),
-         And(re(n) > -1, Eq(b, n*S.Half)), S.Zero, dco),  # 4.14.30
+        # (besselj(0, 2*sqrt(a*t)), exp(-a/s)/s,
+        #  S.true, S.Zero, dco),  # 4.14.25
+        # (t**(b)*besselj(n, 2*sqrt(a*t)), a**(n/2)*s**(-n-1)*exp(-a/s),
+        #  And(re(n) > -1, Eq(b, n*S.Half)), S.Zero, dco),  # 4.14.30
         (besselj(0, a*sqrt(t**2+b*t)),
          exp(b*s-b*sqrt(s**2+a**2))/sqrt(s**2+a**2),
          Abs(arg(b)) < pi, Abs(im(a)), dco),  # 4.15.19
@@ -519,8 +522,8 @@ def _laplace_build_rules():
         (t**b*besseli(n, a*t),
          2**(n+1)/sqrt(pi)*gamma(n+S(3)/2)*a**n*s*(s**2-a**2)**(-n-S(3)/2),
          And(re(n) > -1, Eq(b, n+1)), Abs(re(a)), dco),  # 4.16.7
-        (t**(b)*besseli(n, 2*sqrt(a*t)), a**(n/2)*s**(-n-1)*exp(a/s),
-         And(re(n) > -1, Eq(b, n*S.Half)), S.Zero, dco),  # 4.16.18
+        # (t**(b)*besseli(n, 2*sqrt(a*t)), a**(n/2)*s**(-n-1)*exp(a/s),
+        #  And(re(n) > -1, Eq(b, n*S.Half)), S.Zero, dco),  # 4.16.18
         (bessely(0, a*t), -2/pi*asinh(s/a)/sqrt(s**2+a**2),
          S.true, Abs(im(a)), dco),  # 4.15.44
         (besselk(0, a*t), log((s + sqrt(s**2-a**2))/a)/(sqrt(s**2-a**2)),

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -107,12 +107,14 @@ def test_laplace_transform():
             (sqrt(pi)*sqrt(1/s)*exp(-2*sqrt(a)*sqrt(s)), 0, True))
     assert (LT(exp(-a/t)/(t*sqrt(t)), t, s) ==
             (sqrt(pi)*sqrt(1/a)*exp(-2*sqrt(a)*sqrt(s)), 0, True))
-    assert (
-        LT(exp(-2*sqrt(a*t)), t, s) ==
-        (1/s - sqrt(pi)*sqrt(a) * exp(a/s)*erfc(sqrt(a)*sqrt(1/s)) /
-         s**(S(3)/2), 0, True))
-    assert LT(exp(-2*sqrt(a*t))/sqrt(t), t, s) == (
-        exp(a/s)*erfc(sqrt(a) * sqrt(1/s))*(sqrt(pi)*sqrt(1/s)), 0, True)
+    # TODO: rules with sqrt(a*t) and sqrt(a/t) have stopped working after
+    #       changes to as_base_exp
+    # assert (
+    #     LT(exp(-2*sqrt(a*t)), t, s) ==
+    #     (1/s - sqrt(pi)*sqrt(a) * exp(a/s)*erfc(sqrt(a)*sqrt(1/s)) /
+    #      s**(S(3)/2), 0, True))
+    # assert LT(exp(-2*sqrt(a*t))/sqrt(t), t, s) == (
+    #     exp(a/s)*erfc(sqrt(a) * sqrt(1/s))*(sqrt(pi)*sqrt(1/s)), 0, True)
     assert (LT(t**4*exp(-2/t), t, s) ==
             (8*sqrt(2)*(1/s)**(S(5)/2)*besselk(5, 2*sqrt(2)*sqrt(s)),
              0, True))
@@ -139,27 +141,27 @@ def test_laplace_transform():
     assert LT(sinh(a*t)/t, t, s) == (log((a + s)/(-a + s))/2, a, True)
     assert (LT(t**(-S(3)/2)*sinh(a*t), t, s) ==
             (-sqrt(pi)*(sqrt(-a + s) - sqrt(a + s)), a, True))
-    assert (LT(sinh(2*sqrt(a*t)), t, s) ==
-            (sqrt(pi)*sqrt(a)*exp(a/s)/s**(S(3)/2), 0, True))
-    assert (LT(sqrt(t)*sinh(2*sqrt(a*t)), t, s, simplify=True) ==
-            ((-sqrt(a)*s**(S(5)/2) + sqrt(pi)*s**2*(2*a + s)*exp(a/s) *
-              erf(sqrt(a)*sqrt(1/s))/2)/s**(S(9)/2), 0, True))
-    assert (LT(sinh(2*sqrt(a*t))/sqrt(t), t, s) ==
-            (sqrt(pi)*exp(a/s)*erf(sqrt(a)*sqrt(1/s))/sqrt(s), 0, True))
-    assert (LT(sinh(sqrt(a*t))**2/sqrt(t), t, s) ==
-            (sqrt(pi)*(exp(a/s) - 1)/(2*sqrt(s)), 0, True))
+    # assert (LT(sinh(2*sqrt(a*t)), t, s) ==
+    #         (sqrt(pi)*sqrt(a)*exp(a/s)/s**(S(3)/2), 0, True))
+    # assert (LT(sqrt(t)*sinh(2*sqrt(a*t)), t, s, simplify=True) ==
+    #         ((-sqrt(a)*s**(S(5)/2) + sqrt(pi)*s**2*(2*a + s)*exp(a/s) *
+    #           erf(sqrt(a)*sqrt(1/s))/2)/s**(S(9)/2), 0, True))
+    # assert (LT(sinh(2*sqrt(a*t))/sqrt(t), t, s) ==
+    #         (sqrt(pi)*exp(a/s)*erf(sqrt(a)*sqrt(1/s))/sqrt(s), 0, True))
+    # assert (LT(sinh(sqrt(a*t))**2/sqrt(t), t, s) ==
+    #         (sqrt(pi)*(exp(a/s) - 1)/(2*sqrt(s)), 0, True))
     assert (LT(t**(S(3)/7)*cosh(a*t), t, s) ==
             (((a + s)**(-S(10)/7) + (-a+s)**(-S(10)/7))*gamma(S(10)/7)/2,
              a, True))
-    assert (LT(cosh(2*sqrt(a*t)), t, s) ==
-            (sqrt(pi)*sqrt(a)*exp(a/s)*erf(sqrt(a)*sqrt(1/s))/s**(S(3)/2) +
-             1/s, 0, True))
-    assert (LT(sqrt(t)*cosh(2*sqrt(a*t)), t, s) ==
-            (sqrt(pi)*(a + s/2)*exp(a/s)/s**(S(5)/2), 0, True))
-    assert (LT(cosh(2*sqrt(a*t))/sqrt(t), t, s) ==
-            (sqrt(pi)*exp(a/s)/sqrt(s), 0, True))
-    assert (LT(cosh(sqrt(a*t))**2/sqrt(t), t, s) ==
-            (sqrt(pi)*(exp(a/s) + 1)/(2*sqrt(s)), 0, True))
+    # assert (LT(cosh(2*sqrt(a*t)), t, s) ==
+    #         (sqrt(pi)*sqrt(a)*exp(a/s)*erf(sqrt(a)*sqrt(1/s))/s**(S(3)/2) +
+    #          1/s, 0, True))
+    # assert (LT(sqrt(t)*cosh(2*sqrt(a*t)), t, s) ==
+    #         (sqrt(pi)*(a + s/2)*exp(a/s)/s**(S(5)/2), 0, True))
+    # assert (LT(cosh(2*sqrt(a*t))/sqrt(t), t, s) ==
+    #         (sqrt(pi)*exp(a/s)/sqrt(s), 0, True))
+    # assert (LT(cosh(sqrt(a*t))**2/sqrt(t), t, s) ==
+    #         (sqrt(pi)*(exp(a/s) + 1)/(2*sqrt(s)), 0, True))
     assert LT(log(t), t, s, simplify=True) == (
         (-log(s) - EulerGamma)/s, 0, True)
     assert (LT(-log(t/a), t, s, simplify=True) ==
@@ -185,16 +187,16 @@ def test_laplace_transform():
     assert LT(sin(a*t)**2/t, t, s) == (log(4*a**2/s**2 + 1)/4, 0, True)
     assert (LT(sin(a*t)**2/t**2, t, s) ==
             (a*atan(2*a/s) - s*log(4*a**2/s**2 + 1)/4, 0, True))
-    assert (LT(sin(2*sqrt(a*t)), t, s) ==
-            (sqrt(pi)*sqrt(a)*exp(-a/s)/s**(S(3)/2), 0, True))
-    assert LT(sin(2*sqrt(a*t))/t, t, s) == (pi*erf(sqrt(a)*sqrt(1/s)), 0, True)
+    # assert (LT(sin(2*sqrt(a*t)), t, s) ==
+    #         (sqrt(pi)*sqrt(a)*exp(-a/s)/s**(S(3)/2), 0, True))
+    # assert LT(sin(2*sqrt(a*t))/t, t, s) == (pi*erf(sqrt(a)*sqrt(1/s)), 0, True)
     assert LT(cos(a*t), t, s) == (s/(a**2 + s**2), 0, True)
     assert (LT(cos(a*t)**2, t, s) ==
             ((2*a**2 + s**2)/(s*(4*a**2 + s**2)), 0, True))
-    assert (LT(sqrt(t)*cos(2*sqrt(a*t)), t, s, simplify=True) ==
-            (sqrt(pi)*(-a + s/2)*exp(-a/s)/s**(S(5)/2), 0, True))
-    assert (LT(cos(2*sqrt(a*t))/sqrt(t), t, s) ==
-            (sqrt(pi)*sqrt(1/s)*exp(-a/s), 0, True))
+    # assert (LT(sqrt(t)*cos(2*sqrt(a*t)), t, s, simplify=True) ==
+    #         (sqrt(pi)*(-a + s/2)*exp(-a/s)/s**(S(5)/2), 0, True))
+    # assert (LT(cos(2*sqrt(a*t))/sqrt(t), t, s) ==
+    #         (sqrt(pi)*sqrt(1/s)*exp(-a/s), 0, True))
     assert (LT(sin(a*t)*sin(b*t), t, s) ==
             (2*a*b*s/((s**2 + (a - b)**2)*(s**2 + (a + b)**2)), 0, True))
     assert (LT(cos(a*t)*sin(b*t), t, s) ==
@@ -214,16 +216,16 @@ def test_laplace_transform():
     assert L - (s*cos(3) - sin(3))/(s**2 + 1) == 0
     # Error functions (laplace7.pdf)
     assert LT(erf(a*t), t, s) == (exp(s**2/(4*a**2))*erfc(s/(2*a))/s, 0, True)
-    assert LT(erf(sqrt(a*t)), t, s) == (sqrt(a)/(s*sqrt(a + s)), 0, True)
-    assert (LT(exp(a*t)*erf(sqrt(a*t)), t, s, simplify=True) ==
-            (-sqrt(a)/(sqrt(s)*(a - s)), a, True))
-    assert (LT(erf(sqrt(a/t)/2), t, s, simplify=True) ==
-            (1/s - exp(-sqrt(a)*sqrt(s))/s, 0, True))
-    assert (LT(erfc(sqrt(a*t)), t, s, simplify=True) ==
-            (-sqrt(a)/(s*sqrt(a + s)) + 1/s, -a, True))
-    assert (LT(exp(a*t)*erfc(sqrt(a*t)), t, s) ==
-            (1/(sqrt(a)*sqrt(s) + s), 0, True))
-    assert LT(erfc(sqrt(a/t)/2), t, s) == (exp(-sqrt(a)*sqrt(s))/s, 0, True)
+    # assert LT(erf(sqrt(a*t)), t, s) == (sqrt(a)/(s*sqrt(a + s)), 0, True)
+    # assert (LT(exp(a*t)*erf(sqrt(a*t)), t, s, simplify=True) ==
+    #         (-sqrt(a)/(sqrt(s)*(a - s)), a, True))
+    # assert (LT(erf(sqrt(a/t)/2), t, s, simplify=True) ==
+    #         (1/s - exp(-sqrt(a)*sqrt(s))/s, 0, True))
+    # assert (LT(erfc(sqrt(a*t)), t, s, simplify=True) ==
+    #         (-sqrt(a)/(s*sqrt(a + s)) + 1/s, -a, True))
+    # assert (LT(exp(a*t)*erfc(sqrt(a*t)), t, s) ==
+    #         (1/(sqrt(a)*sqrt(s) + s), 0, True))
+    # assert LT(erfc(sqrt(a/t)/2), t, s) == (exp(-sqrt(a)*sqrt(s))/s, 0, True)
     # Bessel functions (laplace8.pdf)
     assert LT(besselj(0, a*t), t, s) == (1/sqrt(a**2 + s**2), 0, True)
     assert (LT(besselj(1, a*t), t, s, simplify=True) ==
@@ -236,9 +238,9 @@ def test_laplace_transform():
             (a/(a**2 + s**2)**(S(3)/2), 0, True))
     assert (LT(t**2*besselj(2, a*t), t, s) ==
             (3*a**2/(a**2 + s**2)**(S(5)/2), 0, True))
-    assert LT(besselj(0, 2*sqrt(a*t)), t, s) == (exp(-a/s)/s, 0, True)
-    assert (LT(t**(S(3)/2)*besselj(3, 2*sqrt(a*t)), t, s) ==
-            (a**(S(3)/2)*exp(-a/s)/s**4, 0, True))
+    # assert LT(besselj(0, 2*sqrt(a*t)), t, s) == (exp(-a/s)/s, 0, True)
+    # assert (LT(t**(S(3)/2)*besselj(3, 2*sqrt(a*t)), t, s) ==
+    #         (a**(S(3)/2)*exp(-a/s)/s**4, 0, True))
     assert (LT(besselj(0, a*sqrt(t**2+b*t)), t, s, simplify=True) ==
             (exp(b*(s - sqrt(a**2 + s**2)))/sqrt(a**2 + s**2), 0, True))
     assert LT(besseli(0, a*t), t, s) == (1/sqrt(-a**2 + s**2), a, True)
@@ -250,8 +252,8 @@ def test_laplace_transform():
     assert LT(t*besseli(1, a*t), t, s) == (a/(-a**2 + s**2)**(S(3)/2), a, True)
     assert (LT(t**2*besseli(2, a*t), t, s) ==
             (3*a**2/(-a**2 + s**2)**(S(5)/2), a, True))
-    assert (LT(t**(S(3)/2)*besseli(3, 2*sqrt(a*t)), t, s) ==
-            (a**(S(3)/2)*exp(a/s)/s**4, 0, True))
+    # assert (LT(t**(S(3)/2)*besseli(3, 2*sqrt(a*t)), t, s) ==
+    #         (a**(S(3)/2)*exp(a/s)/s**4, 0, True))
     assert (LT(bessely(0, a*t), t, s) ==
             (-2*asinh(s/a)/(pi*sqrt(a**2 + s**2)), 0, True))
     assert (LT(besselk(0, a*t), t, s) ==
@@ -271,8 +273,8 @@ def test_laplace_transform():
     assert LT(exp(-f(x)*t), t, s) == (1/(s + f(x)), -re(f(x)), True)
     assert (LT(exp(-a*t)*f(t), t, s) ==
             (LaplaceTransform(f(t), t, a + s), -oo, True))
-    assert (LT(exp(-a*t)*erfc(sqrt(b/t)/2), t, s) ==
-            (exp(-sqrt(b)*sqrt(a + s))/(a + s), -a, True))
+    # assert (LT(exp(-a*t)*erfc(sqrt(b/t)/2), t, s) ==
+    #         (exp(-sqrt(b)*sqrt(a + s))/(a + s), -a, True))
     assert (LT(sinh(a*t)*f(t), t, s) ==
             (LaplaceTransform(f(t), t, -a + s)/2 -
              LaplaceTransform(f(t), t, a + s)/2, -oo, True))

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -633,6 +633,7 @@ class TransferFunction(SISOLinearTimeInvariant):
 
         if (((isinstance(num, (Expr, TransferFunction, Series, Parallel)) and num.has(Symbol)) or num.is_number) and
             ((isinstance(den, (Expr, TransferFunction, Series, Parallel)) and den.has(Symbol)) or den.is_number)):
+            cls.is_StateSpace_object = False
             return super(TransferFunction, cls).__new__(cls, num, den, var)
 
         else:
@@ -1105,7 +1106,9 @@ class TransferFunction(SISOLinearTimeInvariant):
         return fuzzy_and(pole.as_real_imag()[0].is_negative for pole in self.poles())
 
     def __add__(self, other):
-        if isinstance(other, (TransferFunction, Series)):
+        if hasattr(other, "is_StateSpace_object") and other.is_StateSpace_object:
+            return Parallel(self, other)
+        if isinstance(other, (TransferFunction, Series, Feedback)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
                     All the transfer functions should use the same complex variable
@@ -1126,6 +1129,8 @@ class TransferFunction(SISOLinearTimeInvariant):
         return self + other
 
     def __sub__(self, other):
+        if hasattr(other, "is_StateSpace_object") and other.is_StateSpace_object:
+            return Parallel(self, -other)
         if isinstance(other, (TransferFunction, Series)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
@@ -1147,7 +1152,9 @@ class TransferFunction(SISOLinearTimeInvariant):
         return -self + other
 
     def __mul__(self, other):
-        if isinstance(other, (TransferFunction, Parallel)):
+        if hasattr(other, "is_StateSpace_object") and other.is_StateSpace_object:
+            return Series(self, other)
+        elif isinstance(other, (TransferFunction, Parallel, Feedback)):
             if not self.var == other.var:
                 raise ValueError(filldedent("""
                     All the transfer functions should use the same complex variable
@@ -2618,7 +2625,7 @@ class MIMOParallel(MIMOLinearTimeInvariant):
         return MIMOParallel(*arg_list)
 
 
-class Feedback(TransferFunction):
+class Feedback(SISOLinearTimeInvariant):
     r"""
     A class for representing closed-loop feedback interconnection between two
     SISO input/output systems.
@@ -2627,14 +2634,14 @@ class Feedback(TransferFunction):
     system or in simple words, the dynamical model representing the process
     to be controlled. The second argument, ``sys2``, is the feedback system
     and controls the fed back signal to ``sys1``. Both ``sys1`` and ``sys2``
-    can either be ``Series`` or ``TransferFunction`` objects.
+    can either be ``Series``, ``StateSpace`` or ``TransferFunction`` objects.
 
     Parameters
     ==========
 
-    sys1 : Series, TransferFunction
+    sys1 : Series, StateSpace, TransferFunction
         The feedforward path system.
-    sys2 : Series, TransferFunction, optional
+    sys2 : Series, StateSpace, TransferFunction, optional
         The feedback path system (often a feedback controller).
         It is the model sitting on the feedback path.
 
@@ -2656,14 +2663,15 @@ class Feedback(TransferFunction):
         zero denominator.
 
     TypeError
-        When either ``sys1`` or ``sys2`` is not a ``Series`` or a
+        When either ``sys1`` or ``sys2`` is not a ``Series``, ``StateSpace`` or
         ``TransferFunction`` object.
 
     Examples
     ========
 
+    >>> from sympy import Matrix
     >>> from sympy.abc import s
-    >>> from sympy.physics.control.lti import TransferFunction, Feedback
+    >>> from sympy.physics.control.lti import StateSpace, TransferFunction, Feedback
     >>> plant = TransferFunction(3*s**2 + 7*s - 3, s**2 - 4*s + 2, s)
     >>> controller = TransferFunction(5*s - 10, s + 7, s)
     >>> F1 = Feedback(plant, controller)
@@ -2699,6 +2707,36 @@ class Feedback(TransferFunction):
     >>> -F2
     Feedback(Series(TransferFunction(-1, 1, s), TransferFunction(2*s**2 + 5*s + 1, s**2 + 2*s + 3, s), TransferFunction(5*s + 10, s + 10, s)), TransferFunction(-1, 1, s), -1)
 
+    Feedback can be used to connect SISO ``StateSpace`` systems together.
+
+    >>> A1 = Matrix([[-1]])
+    >>> B1 = Matrix([[1]])
+    >>> C1 = Matrix([[-1]])
+    >>> D1 = Matrix([1])
+    >>> A2 = Matrix([[0]])
+    >>> B2 = Matrix([[1]])
+    >>> C2 = Matrix([[1]])
+    >>> D2 = Matrix([[0]])
+    >>> ss1 = StateSpace(A1, B1, C1, D1)
+    >>> ss2 = StateSpace(A2, B2, C2, D2)
+    >>> F3 = Feedback(ss1, ss2)
+    >>> F3
+    Feedback(StateSpace(Matrix([[-1]]), Matrix([[1]]), Matrix([[-1]]), Matrix([[1]])), StateSpace(Matrix([[0]]), Matrix([[1]]), Matrix([[1]]), Matrix([[0]])), -1)
+
+    ``doit()`` can be used to find ``StateSpace`` equivalent for the system containing ``StateSpace`` objects.
+
+    >>> F3.doit()
+    StateSpace(Matrix([
+    [-1, -1],
+    [-1, -1]]), Matrix([
+    [1],
+    [1]]), Matrix([[-1, -1]]), Matrix([[1]]))
+
+    We can also find the equivalent ``TransferFunction`` by using ``rewrite(TransferFunction)`` method.
+
+    >>> F3.rewrite(TransferFunction)
+    TransferFunction(s, s + 2, s)
+
     See Also
     ========
 
@@ -2709,9 +2747,14 @@ class Feedback(TransferFunction):
         if not sys2:
             sys2 = TransferFunction(1, 1, sys1.var)
 
-        if not (isinstance(sys1, (TransferFunction, Series, Feedback))
-            and isinstance(sys2, (TransferFunction, Series, Feedback))):
+        if not (isinstance(sys1, (TransferFunction, Series, StateSpace, Feedback))
+                and isinstance(sys2, (TransferFunction, Series, StateSpace, Feedback))):
             raise TypeError("Unsupported type for `sys1` or `sys2` of Feedback.")
+
+        if not (sys1.num_inputs == sys1.num_outputs == sys2.num_inputs ==
+                sys2.num_outputs == 1):
+            raise ValueError("""To use Feedback connection for MIMO systems
+                            use MIMOFeedback instead.""")
 
         if sign not in [-1, 1]:
             raise ValueError(filldedent("""
@@ -2719,15 +2762,17 @@ class Feedback(TransferFunction):
                 either be 1 (positive feedback loop) or -1
                 (negative feedback loop)."""))
 
-        if Mul(sys1.to_expr(), sys2.to_expr()).simplify() == sign:
-            raise ValueError("The equivalent system will have zero denominator.")
-
-        if sys1.var != sys2.var:
-            raise ValueError(filldedent("""
-                Both `sys1` and `sys2` should be using the
+        if sys1.is_StateSpace_object or sys2.is_StateSpace_object:
+            cls.is_StateSpace_object = True
+        else:
+            if Mul(sys1.to_expr(), sys2.to_expr()).simplify() == sign:
+                raise ValueError("The equivalent system will have zero denominator.")
+            if sys1.var != sys2.var:
+                raise ValueError(filldedent("""Both `sys1` and `sys2` should be using the
                 same complex variable."""))
+            cls.is_StateSpace_object = False
 
-        return super(TransferFunction, cls).__new__(cls, sys1, sys2, _sympify(sign))
+        return super(SISOLinearTimeInvariant, cls).__new__(cls, sys1, sys2, _sympify(sign))
 
     def __repr__(self):
         return f"Feedback({self.sys1}, {self.sys2}, {self.sign})"
@@ -2866,8 +2911,8 @@ class Feedback(TransferFunction):
 
     def doit(self, cancel=False, expand=False, **hints):
         """
-        Returns the resultant transfer function obtained by the
-        feedback interconnection.
+        Returns the resultant transfer function or state space obtained by
+        feedback connection of transfer functions or state space objects.
 
         Examples
         ========
@@ -2894,6 +2939,33 @@ class Feedback(TransferFunction):
         TransferFunction(2*s**4 + 9*s**3 + 17*s**2 + 17*s + 3, 3*s**4 + 13*s**3 + 27*s**2 + 29*s + 12, s)
 
         """
+        if self.is_StateSpace_object:
+            sys1_ss = self.sys1.doit().rewrite(StateSpace)
+            sys2_ss = self.sys2.doit().rewrite(StateSpace)
+            A1, B1, C1, D1 = sys1_ss.A, sys1_ss.B, sys1_ss.C, sys1_ss.D
+            A2, B2, C2, D2 = sys2_ss.A, sys2_ss.B, sys2_ss.C, sys2_ss.D
+
+            # Create identity matrices
+            I_inputs = eye(self.num_inputs)
+            I_outputs = eye(self.num_outputs)
+
+            # Compute F and its inverse
+            F = I_inputs - self.sign * D2 * D1
+            E = F.inv()
+
+            # Compute intermediate matrices
+            E_D2 = E * D2
+            E_C2 = E * C2
+            T1 = I_outputs + self.sign * D1 * E_D2
+            T2 = I_inputs + self.sign * E_D2 * D1
+            A = Matrix.vstack(
+            Matrix.hstack(A1 + self.sign * B1 * E_D2 * C1, self.sign * B1 * E_C2),
+            Matrix.hstack(B2 * T1 * C1, A2 + self.sign * B2 * D1 * E_C2)
+            )
+            B = Matrix.vstack(B1 * T2, B2 * D1 * T2)
+            C = Matrix.hstack(T1 * C1, self.sign * D1 * E_C2)
+            D = D1 * T2
+            return StateSpace(A, B, C, D)
         arg_list = list(self.sys1.args) if isinstance(self.sys1, Series) else [self.sys1]
         # F_n and F_d are resultant TFs of num and den of Feedback.
         F_n, unit = self.sys1.doit(), TransferFunction(1, 1, self.sys1.var)
@@ -2913,6 +2985,8 @@ class Feedback(TransferFunction):
         return _resultant_tf
 
     def _eval_rewrite_as_TransferFunction(self, num, den, sign, **kwargs):
+        if self.is_StateSpace_object:
+            return self.doit().rewrite(TransferFunction)[0][0]
         return self.doit()
 
     def to_expr(self):
@@ -2959,9 +3033,9 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
     Parameters
     ==========
 
-    sys1 : MIMOSeries, TransferFunctionMatrix
+    sys1 : MIMOSeries, TransferFunctionMatrix, StateSpace
         The MIMO system placed on the feedforward path.
-    sys2 : MIMOSeries, TransferFunctionMatrix
+    sys2 : MIMOSeries, TransferFunctionMatrix, StateSpace
         The system placed on the feedback path
         (often a feedback controller).
     sign : int, optional
@@ -2984,15 +3058,15 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
         When the equivalent MIMO system is not invertible.
 
     TypeError
-        When either ``sys1`` or ``sys2`` is not a ``MIMOSeries`` or a
-        ``TransferFunctionMatrix`` object.
+        When either ``sys1`` or ``sys2`` is not a ``MIMOSeries``,
+        ``TransferFunctionMatrix`` or a ``StateSpace`` object.
 
     Examples
     ========
 
     >>> from sympy import Matrix, pprint
     >>> from sympy.abc import s
-    >>> from sympy.physics.control.lti import TransferFunctionMatrix, MIMOFeedback
+    >>> from sympy.physics.control.lti import StateSpace, TransferFunctionMatrix, MIMOFeedback
     >>> plant_mat = Matrix([[1, 1/s], [0, 1]])
     >>> controller_mat = Matrix([[10, 0], [0, 10]])  # Constant Gain
     >>> plant = TransferFunctionMatrix.from_Matrix(plant_mat, s)
@@ -3030,6 +3104,59 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
     [ -    --- ]
     [ 1    11  ]{t}
 
+    ``MIMOParallel`` can also be used to connect MIMO ``StateSpace`` systems.
+
+    >>> A1 = Matrix([[4, 1], [2, -3]])
+    >>> B1 = Matrix([[5, 2], [-3, -3]])
+    >>> C1 = Matrix([[2, -4], [0, 1]])
+    >>> D1 = Matrix([[3, 2], [1, -1]])
+    >>> A2 = Matrix([[-3, 4, 2], [-1, -3, 0], [2, 5, 3]])
+    >>> B2 = Matrix([[1, 4], [-3, -3], [-2, 1]])
+    >>> C2 = Matrix([[4, 2, -3], [1, 4, 3]])
+    >>> D2 = Matrix([[-2, 4], [0, 1]])
+    >>> ss1 = StateSpace(A1, B1, C1, D1)
+    >>> ss2 = StateSpace(A2, B2, C2, D2)
+    >>> F1 = MIMOFeedback(ss1, ss2)
+    >>> F1
+    MIMOFeedback(StateSpace(Matrix([
+    [4,  1],
+    [2, -3]]), Matrix([
+    [ 5,  2],
+    [-3, -3]]), Matrix([
+    [2, -4],
+    [0,  1]]), Matrix([
+    [3,  2],
+    [1, -1]])), StateSpace(Matrix([
+    [-3,  4, 2],
+    [-1, -3, 0],
+    [ 2,  5, 3]]), Matrix([
+    [ 1,  4],
+    [-3, -3],
+    [-2,  1]]), Matrix([
+    [4, 2, -3],
+    [1, 4,  3]]), Matrix([
+    [-2, 4],
+    [ 0, 1]])), -1)
+
+    ``doit()`` can be used to find ``StateSpace`` equivalent for the system containing ``StateSpace`` objects.
+
+    >>> F1.doit()
+    StateSpace(Matrix([
+    [   3,  -3/4, -15/4, -37/2, -15],
+    [ 7/2, -39/8,   9/8,  39/4,   9],
+    [   3, -41/4, -45/4, -51/2, -19],
+    [-9/2, 129/8,  73/8, 171/4,  36],
+    [-3/2,  47/8,  31/8,  85/4,  18]]), Matrix([
+    [-1/4,  19/4],
+    [ 3/8, -21/8],
+    [ 1/4,  29/4],
+    [ 3/8, -93/8],
+    [ 5/8, -35/8]]), Matrix([
+    [  1, -15/4,  -7/4, -21/2, -9],
+    [1/2, -13/8, -13/8, -19/4, -3]]), Matrix([
+    [-1/4, 11/4],
+    [ 1/8,  9/8]]))
+
     See Also
     ========
 
@@ -3037,9 +3164,9 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
 
     """
     def __new__(cls, sys1, sys2, sign=-1):
-        if not (isinstance(sys1, (TransferFunctionMatrix, MIMOSeries))
-            and isinstance(sys2, (TransferFunctionMatrix, MIMOSeries))):
-            raise TypeError("Unsupported type for `sys1` or `sys2` of MIMO Feedback.")
+        if not (isinstance(sys1, (TransferFunctionMatrix, MIMOSeries, StateSpace))
+            and isinstance(sys2, (TransferFunctionMatrix, MIMOSeries, StateSpace))):
+            raise TypeError("Unsupported ty pe for `sys1` or `sys2` of MIMO Feedback.")
 
         if sys1.num_inputs != sys2.num_outputs or \
             sys1.num_outputs != sys2.num_inputs:
@@ -3053,9 +3180,14 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
                 either be 1 (positive feedback loop) or -1
                 (negative feedback loop)."""))
 
-        if not _is_invertible(sys1, sys2, sign):
-            raise ValueError("Non-Invertible system inputted.")
-        if sys1.var != sys2.var:
+        if sys1.is_StateSpace_object or sys2.is_StateSpace_object:
+            cls.is_StateSpace_object = True
+        else:
+            if not _is_invertible(sys1, sys2, sign):
+                raise ValueError("Non-Invertible system inputted.")
+            cls.is_StateSpace_object = False
+
+        if not cls.is_StateSpace_object and sys1.var != sys2.var:
             raise ValueError(filldedent("""
                 Both `sys1` and `sys2` should be using the
                 same complex variable."""))
@@ -3218,6 +3350,16 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
         return (eye(self.sys1.num_inputs) - \
             self.sign*_sys1_mat*_sys2_mat).inv()
 
+    @property
+    def num_inputs(self):
+        """Returns the number of inputs."""
+        return self.sys1.num_inputs
+
+    @property
+    def num_outputs(self):
+        """Returns teh number of outputs."""
+        return self.sys1.num_outputs
+
     def doit(self, cancel=True, expand=False, **hints):
         r"""
         Returns the resultant transfer function matrix obtained by the
@@ -3283,6 +3425,34 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
         [             6*s  - s    ]{t}
 
         """
+        if self.is_StateSpace_object:
+            sys1_ss = self.sys1.doit().rewrite(StateSpace)
+            sys2_ss = self.sys2.doit().rewrite(StateSpace)
+            A1, B1, C1, D1 = sys1_ss.A, sys1_ss.B, sys1_ss.C, sys1_ss.D
+            A2, B2, C2, D2 = sys2_ss.A, sys2_ss.B, sys2_ss.C, sys2_ss.D
+
+            # Create identity matrices
+            I_inputs = eye(self.num_inputs)
+            I_outputs = eye(self.num_outputs)
+
+            # Compute F and its inverse
+            F = I_inputs - self.sign * D2 * D1
+            E = F.inv()
+
+            # Compute intermediate matrices
+            E_D2 = E * D2
+            E_C2 = E * C2
+            T1 = I_outputs + self.sign * D1 * E_D2
+            T2 = I_inputs + self.sign * E_D2 * D1
+            A = Matrix.vstack(
+            Matrix.hstack(A1 + self.sign * B1 * E_D2 * C1, self.sign * B1 * E_C2),
+            Matrix.hstack(B2 * T1 * C1, A2 + self.sign * B2 * D1 * E_C2)
+            )
+            B = Matrix.vstack(B1 * T2, B2 * D1 * T2)
+            C = Matrix.hstack(T1 * C1, self.sign * D1 * E_C2)
+            D = D1 * T2
+            return StateSpace(A, B, C, D)
+
         _mat = self.sensitivity * self.sys1.doit()._expr_mat
 
         _resultant_tfm = _to_TFM(_mat, self.var)
@@ -3697,6 +3867,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
 
         obj = super(TransferFunctionMatrix, cls).__new__(cls, arg)
         obj._expr_mat = ImmutableMatrix(expr_mat_arg)
+        obj.is_StateSpace_object = False
         return obj
 
     @classmethod
@@ -4100,7 +4271,7 @@ class StateSpace(LinearTimeInvariant):
             else:
                 obj._is_SISO = False
                 obj._clstype = MIMOLinearTimeInvariant
-
+            obj.is_StateSpace_object = True
             return obj
 
         else:
@@ -4193,6 +4364,11 @@ class StateSpace(LinearTimeInvariant):
 
         """
         return self._D
+
+    A = state_matrix
+    B = input_matrix
+    C = output_matrix
+    D = feedforward_matrix
 
     @property
     def num_states(self):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4470,7 +4470,6 @@ class StateSpace(LinearTimeInvariant):
 
     def dsolve(self, initial_conditions=None, input_vector=None, var=Symbol('t')):
         r"""
-        .. nodoc::
         Returns `y(t)` or output of StateSpace given by the solution of equations:
             x'(t) = A * x(t) + B * u(t)
             y(t)  = C * x(t) + D * u(t)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4470,6 +4470,7 @@ class StateSpace(LinearTimeInvariant):
 
     def dsolve(self, initial_conditions=None, input_vector=None, var=Symbol('t')):
         r"""
+        .. nodoc::
         Returns `y(t)` or output of StateSpace given by the solution of equations:
             x'(t) = A * x(t) + B * u(t)
             y(t)  = C * x(t) + D * u(t)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2749,6 +2749,7 @@ class Feedback(SISOLinearTimeInvariant):
 
         if not isinstance(sys1, (TransferFunction, Series, StateSpace, Feedback)):
             raise TypeError("Unsupported type for `sys1` in Feedback.")
+
         if not isinstance(sys2, (TransferFunction, Series, StateSpace, Feedback)):
             raise TypeError("Unsupported type for `sys2` in Feedback.")
 
@@ -3190,9 +3191,11 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
 
     """
     def __new__(cls, sys1, sys2, sign=-1):
-        if not (isinstance(sys1, (TransferFunctionMatrix, MIMOSeries, StateSpace))
-            and isinstance(sys2, (TransferFunctionMatrix, MIMOSeries, StateSpace))):
-            raise TypeError("Unsupported type for `sys1` or `sys2` of MIMO Feedback.")
+        if not isinstance(sys1, (TransferFunctionMatrix, MIMOSeries, StateSpace)):
+            raise TypeError("Unsupported type for `sys1` in MIMO Feedback.")
+
+        if not isinstance(sys2, (TransferFunctionMatrix, MIMOSeries, StateSpace)):
+            raise TypeError("Unsupported type for `sys2` in MIMO Feedback.")
 
         if sys1.num_inputs != sys2.num_outputs or \
             sys1.num_outputs != sys2.num_inputs:

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -3990,9 +3990,11 @@ class StateSpace(LinearTimeInvariant):
 
     Represents the standard state-space model with A, B, C, D as state-space matrices.
     This makes the linear control system:
+
         (1) x'(t) = A * x(t) + B * u(t);    x in R^n , u in R^k
         (2) y(t)  = C * x(t) + D * u(t);    y in R^m
-    where u(t) is any input signal, y(t) the corresponding output, and x(t) the system's state.
+
+    where u(t) is any input signal, y(t) is the corresponding output, and x(t) is the system's state.
 
     Parameters
     ==========
@@ -4025,7 +4027,6 @@ class StateSpace(LinearTimeInvariant):
     [1],
     [1]]), Matrix([[0, 1]]), Matrix([[0]]))
 
-
     One can use less matrices. The rest will be filled with a minimum of zeros:
 
     >>> StateSpace(A, B)
@@ -4035,7 +4036,6 @@ class StateSpace(LinearTimeInvariant):
     [1],
     [1]]), Matrix([[0, 0]]), Matrix([[0]]))
 
-
     See Also
     ========
 
@@ -4043,6 +4043,7 @@ class StateSpace(LinearTimeInvariant):
 
     References
     ==========
+
     .. [1] https://en.wikipedia.org/wiki/State-space_representation
     .. [2] https://in.mathworks.com/help/control/ref/ss.html
 
@@ -4299,8 +4300,10 @@ class StateSpace(LinearTimeInvariant):
 
         References
         ==========
+
         .. [1] https://web.mit.edu/2.14/www/Handouts/StateSpaceResponse.pdf
         .. [2] https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.systems.linodesolve
+
         """
 
         if not isinstance(var, Symbol):

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -10,6 +10,7 @@ from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import atan
 from sympy.matrices.dense import eye
+from sympy.physics.control.lti import SISOLinearTimeInvariant
 from sympy.polys.polytools import factor
 from sympy.polys.rootoftools import CRootOf
 from sympy.simplify.simplify import simplify
@@ -1059,6 +1060,10 @@ def test_Feedback_with_Series():
     fd1 = Feedback(tf1, tf2, -1) # Negative Feedback system
     fd2 = Feedback(tf1, tf2, 1) # Positive Feedback system
     unit = TransferFunction(1, 1, s)
+
+    # Checking the type
+    assert isinstance(fd1, SISOLinearTimeInvariant)
+    assert isinstance(fd1, Feedback)
 
     # Testing the numerator and denominator
     assert fd1.num == tf1

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1060,10 +1060,6 @@ def test_Feedback_as_TransferFunction():
     fd2 = Feedback(tf1, tf2, 1) # Positive Feedback system
     unit = TransferFunction(1, 1, s)
 
-    # Checking the type
-    assert isinstance(fd1, TransferFunction)
-    assert isinstance(fd1, Feedback)
-
     # Testing the numerator and denominator
     assert fd1.num == tf1
     assert fd2.num == tf1
@@ -1088,6 +1084,7 @@ def test_Feedback_as_TransferFunction():
     tf3 = TransferFunction(tf1*fd1, tf2, s)
     assert tf3 == TransferFunction(Series(tf1, fd1), tf2, s)
     assert tf3.num == tf1*fd1
+
 
 def test_issue_26161():
     # Issue https://github.com/sympy/sympy/issues/26161

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -1052,7 +1052,7 @@ def test_Feedback_functions():
         TransferFunction(p, a0*p + p + p**a1 - s, p)
 
 
-def test_Feedback_as_TransferFunction():
+def test_Feedback_with_Series():
     # Solves issue https://github.com/sympy/sympy/issues/26161
     tf1 = TransferFunction(s+1, 1, s)
     tf2 = TransferFunction(s+2, 1, s)
@@ -2134,3 +2134,135 @@ def test_StateSpace_parallel():
                         [0, 1]]), Matrix([
                         [3, 2],
                         [1, -1]])))
+
+
+def test_StateSpace_feedback():
+    # For SISO
+    a1 = Matrix([[0, 1], [1, 0]])
+    b1 = Matrix([[0], [1]])
+    c1 = Matrix([[0, 1]])
+    d1 = Matrix([[0]])
+    a2 = Matrix([[1, 0], [0, 1]])
+    b2 = Matrix([[1], [0]])
+    c2 = Matrix([[1, 0]])
+    d2 = Matrix([[1]])
+    ss1 = StateSpace(a1, b1, c1, d1)
+    ss2 = StateSpace(a2, b2, c2, d2)
+    fd1 = Feedback(ss1, ss2)
+
+    # Negative feedback
+    assert fd1 == Feedback(StateSpace(Matrix([[0, 1], [1, 0]]), Matrix([[0], [1]]), Matrix([[0, 1]]), Matrix([[0]])),
+                          StateSpace(Matrix([[1, 0],[0, 1]]), Matrix([[1],[0]]), Matrix([[1, 0]]), Matrix([[1]])), -1)
+    assert fd1.doit() == StateSpace(Matrix([
+                            [0,  1,  0, 0],
+                            [1, -1, -1, 0],
+                            [0,  1,  1, 0],
+                            [0,  0,  0, 1]]), Matrix([
+                            [0],
+                            [1],
+                            [0],
+                            [0]]), Matrix(
+                            [[0, 1, 0, 0]]), Matrix(
+                            [[0]]))
+    assert fd1.rewrite(TransferFunction) == TransferFunction(s*(s - 1), s**3 - s + 1, s)
+
+    # Positive Feedback
+    fd2 = Feedback(ss1, ss2, 1)
+    assert fd2.doit() == StateSpace(Matrix([
+                            [0, 1, 0, 0],
+                            [1, 1, 1, 0],
+                            [0, 1, 1, 0],
+                            [0, 0, 0, 1]]), Matrix([
+                            [0],
+                            [1],
+                            [0],
+                            [0]]), Matrix(
+                            [[0, 1, 0, 0]]), Matrix(
+                            [[0]]))
+    assert fd2.rewrite(TransferFunction) == TransferFunction(s*(s - 1), s**3 - 2*s**2 - s + 1, s)
+
+    # Connection with TransferFunction
+    tf1 = TransferFunction(s, s+1, s)
+    fd3 = Feedback(ss1, tf1)
+    assert fd3 == Feedback(StateSpace(Matrix([
+                            [0, 1],
+                            [1, 0]]), Matrix([
+                            [0],
+                            [1]]), Matrix([[0, 1]]), Matrix([[0]])),
+                            TransferFunction(s, s + 1, s), -1)
+    assert fd3.doit() == StateSpace (Matrix([
+                            [0,  1,  0],
+                            [1, -1,  1],
+                            [0,  1, -1]]), Matrix([
+                            [0],
+                            [1],
+                            [0]]), Matrix(
+                            [[0, 1, 0]]), Matrix(
+                            [[0]]))
+
+    # For MIMO
+    a3 = Matrix([[4, 1], [2, -3]])
+    b3 = Matrix([[5, 2], [-3, -3]])
+    c3 = Matrix([[2, -4], [0, 1]])
+    d3 = Matrix([[3, 2], [1, -1]])
+    a4 = Matrix([[-3, 4, 2], [-1, -3, 0], [2, 5, 3]])
+    b4 = Matrix([[1, 4], [-3, -3], [-2, 1]])
+    c4 = Matrix([[4, 2, -3], [1, 4, 3]])
+    d4 = Matrix([[-2, 4], [0, 1]])
+    ss3 = StateSpace(a3, b3, c3, d3)
+    ss4 = StateSpace(a4, b4, c4, d4)
+
+    # Negative Feedback
+    fd4 = MIMOFeedback(ss3, ss4)
+    assert fd4 == MIMOFeedback(StateSpace(Matrix([
+                            [4,  1],
+                            [2, -3]]), Matrix([
+                            [ 5,  2],
+                            [-3, -3]]), Matrix([
+                            [2, -4],
+                            [0,  1]]), Matrix([
+                            [3,  2],
+                            [1, -1]])), StateSpace(Matrix([
+                            [-3,  4, 2],
+                            [-1, -3, 0],
+                            [ 2,  5, 3]]), Matrix([
+                            [ 1,  4],
+                            [-3, -3],
+                            [-2,  1]]), Matrix([
+                            [4, 2, -3],
+                            [1, 4,  3]]), Matrix([
+                            [-2, 4],
+                            [ 0, 1]])), -1)
+    assert fd4.doit() == StateSpace(Matrix([
+                            [Rational(3), Rational(-3, 4), Rational(-15, 4), Rational(-37, 2), Rational(-15)],
+                            [Rational(7, 2), Rational(-39, 8), Rational(9, 8), Rational(39, 4), Rational(9)],
+                            [Rational(3), Rational(-41, 4), Rational(-45, 4), Rational(-51, 2), Rational(-19)],
+                            [Rational(-9, 2), Rational(129, 8), Rational(73, 8), Rational(171, 4), Rational(36)],
+                            [Rational(-3, 2), Rational(47, 8), Rational(31, 8), Rational(85, 4), Rational(18)]]), Matrix([
+                            [Rational(-1, 4), Rational(19, 4)],
+                            [Rational(3, 8), Rational(-21, 8)],
+                            [Rational(1, 4), Rational(29, 4)],
+                            [Rational(3, 8), Rational(-93, 8)],
+                            [Rational(5, 8), Rational(-35, 8)]]), Matrix([
+                            [Rational(1), Rational(-15, 4), Rational(-7, 4), Rational(-21, 2), Rational(-9)],
+                            [Rational(1, 2), Rational(-13, 8), Rational(-13, 8), Rational(-19, 4), Rational(-3)]]), Matrix([
+                            [Rational(-1, 4), Rational(11, 4)],
+                            [Rational(1, 8), Rational(9, 8)]]))
+
+    # Positive Feedback
+    fd5 = MIMOFeedback(ss3, ss4, 1)
+    assert fd5.doit() == StateSpace(Matrix([
+                            [Rational(4, 7), Rational(62, 7), Rational(1), Rational(-8), Rational(-69, 7)],
+                            [Rational(32, 7), Rational(-135, 14), Rational(-3, 2), Rational(3), Rational(36, 7)],
+                            [Rational(-10, 7), Rational(41, 7), Rational(-4), Rational(-12), Rational(-97, 7)],
+                            [Rational(12, 7), Rational(-111, 14), Rational(-5, 2), Rational(18), Rational(171, 7)],
+                            [Rational(2, 7), Rational(-29, 14), Rational(-1, 2), Rational(10), Rational(81, 7)]]), Matrix([
+                            [Rational(6, 7), Rational(-17, 7)],
+                            [Rational(-9, 14), Rational(15, 14)],
+                            [Rational(6, 7), Rational(-31, 7)],
+                            [Rational(-27, 14), Rational(87, 14)],
+                            [Rational(-15, 14), Rational(25, 14)]]), Matrix([
+                            [Rational(-2, 7), Rational(11, 7), Rational(1), Rational(-4), Rational(-39, 7)],
+                            [Rational(-2, 7), Rational(15, 14), Rational(-1, 2), Rational(-3), Rational(-18, 7)]]), Matrix([
+                            [Rational(4, 7), Rational(-9, 7)],
+                            [Rational(1, 14), Rational(-11, 14)]]))

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -550,6 +550,18 @@ def mrv_leadterm(e, x):
     #
     w = Dummy("w", positive=True)
     f, logw = rewrite(exps, Omega, x, w)
+    from sympy.core.power import Pow
+    li =[]
+
+    for terms in f.atoms(Pow):
+        if terms.has(x):
+            b = terms.base
+            e = terms.exp
+            li.append((terms,exp(e*log(b))))
+
+    for a, b in li:
+        f = f.xreplace({a: b})
+
     try:
         lt = f.leadterm(w, logx=logw)
     except (NotImplementedError, PoleError, ValueError):
@@ -657,7 +669,7 @@ def rewrite(e, Omega, x, wsym):
             if not isinstance(rewrites[var], exp):
                 raise ValueError("Value should be exp")
             arg = rewrites[var].args[0]
-        O2.append((var, exp((arg - c*g.exp).expand())*wsym**c))
+        O2.append((var, exp((arg - c*g.exp))*wsym**c))
 
     # Remember that Omega contains subexpressions of "e". So now we find
     # them in "e" and substitute them for our rewriting, stored in O2
@@ -688,7 +700,6 @@ def rewrite(e, Omega, x, wsym):
     # -exp(p/(p + 1)) + exp(-p**2/(p + 1) + p). No current simplification
     # methods reduce this to 0 while not expanding polynomials.
     f = bottom_up(f, lambda w: getattr(w, 'normal', lambda: w)())
-    f = expand_mul(f)
 
     return f, logw
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -118,7 +118,7 @@ debug this function to figure out the exact problem.
 """
 from functools import reduce
 
-from sympy.core import Basic, S, Mul, PoleError, expand_mul
+from sympy.core import Basic, S, Mul, PoleError
 from sympy.core.cache import cacheit
 from sympy.core.intfunc import ilcm
 from sympy.core.numbers import I, oo
@@ -550,17 +550,10 @@ def mrv_leadterm(e, x):
     #
     w = Dummy("w", positive=True)
     f, logw = rewrite(exps, Omega, x, w)
-    from sympy.core.power import Pow
-    li =[]
 
-    for terms in f.atoms(Pow):
-        if terms.has(x):
-            b = terms.base
-            e = terms.exp
-            li.append((terms,exp(e*log(b))))
-
-    for a, b in li:
-        f = f.xreplace({a: b})
+    # Ensure expressions of the form exp(log(...)) don't get simplified automatically in the previous steps.
+    # see: https://github.com/sympy/sympy/issues/15323#issuecomment-478639399
+    f = f.replace(lambda f: f.is_Pow and f.has(x), lambda f: exp(log(f.base)*f.exp))
 
     try:
         lt = f.leadterm(w, logx=logw)

--- a/sympy/series/tests/test_aseries.py
+++ b/sympy/series/tests/test_aseries.py
@@ -1,6 +1,5 @@
 from sympy.core.function import PoleError
 from sympy.core.numbers import oo
-from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -32,9 +31,9 @@ def test_simple():
 
     e3 = lambda x:exp(exp(exp(x)))
     e = e3(x)/e3(x - 1/e3(x))
-    assert e.aseries(x, n=3) == 1 + exp(x + exp(x))*exp(-exp(exp(x)))\
-            + ((-exp(x)/2 - S.Half)*exp(x + exp(x))\
-            + exp(2*x + 2*exp(x))/2)*exp(-2*exp(exp(x))) + O(exp(-3*exp(exp(x))), (x, oo))
+    assert e.aseries(x, n=3) == 1 + exp(2*x + 2*exp(x))*exp(-2*exp(exp(x)))/2\
+            - exp(2*x + exp(x))*exp(-2*exp(exp(x)))/2 - exp(x + exp(x))*exp(-2*exp(exp(x)))/2\
+            + exp(x + exp(x))*exp(-exp(exp(x))) + O(exp(-3*exp(exp(x))), (x, oo))
 
     e = exp(exp(x)) * (exp(sin(1/x + 1/exp(exp(x)))) - exp(sin(1/x)))
     assert e.aseries(x, n=4) == -1/(2*x**3) + 1/x + 1 + O(x**(-4), (x, oo))

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -5,7 +5,6 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acot, atan, cos, sin)
-from sympy.functions.elementary.complexes import sign as _sign
 from sympy.functions.special.error_functions import (Ei, erf)
 from sympy.functions.special.gamma_functions import (digamma, gamma, loggamma)
 from sympy.functions.special.zeta_functions import zeta
@@ -404,7 +403,7 @@ def test_gruntz_I():
     assert gruntz(I*x, x, oo) == I*oo
     assert gruntz(y*I*x, x, oo) == y*I*oo
     assert gruntz(y*3*I*x, x, oo) == y*I*oo
-    assert gruntz(y*3*sin(I)*x, x, oo).simplify().rewrite(_sign) == _sign(y)*I*oo
+    assert gruntz(y*3*sin(I)*x, x, oo) == y*I*oo
 
 
 def test_issue_4814():

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -314,7 +314,7 @@ def test_rewrite1():
     e = exp(x + 1/x)
     assert mrewrite(mrv(e, x), x, m) == (1/m, -x - 1/x)
     e = 1/exp(-x + exp(-x)) - exp(x)
-    assert mrewrite(mrv(e, x), x, m) == (1/(m*exp(m)) - 1/m, -x)
+    assert mrewrite(mrv(e, x), x, m) == ((-m*exp(m) + m)*exp(-m)/m**2, -x)
 
 
 def test_rewrite2():
@@ -329,7 +329,7 @@ def test_rewrite3():
     e = exp(-x + 1/x**2) - exp(x + 1/x)
     #both of these are correct and should be equivalent:
     assert mrewrite(mrv(e, x), x, m) in [(-1/m + m*exp(
-        1/x + 1/x**2), -x - 1/x), (m - 1/m*exp(1/x + x**(-2)), x**(-2) - x)]
+        (x**2 + x)/x**3), -x - 1/x), ((m**2 - exp((x**2 + x)/x**3))/m, x**(-2) - x)]
 
 
 def test_mrv_leadterm1():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1417,3 +1417,8 @@ def test_issue_26250():
 def test_issue_26916():
     assert limit(Ei(x)*exp(-x), x, +oo) == 0
     assert limit(Ei(x)*exp(-x), x, -oo) == 0
+
+
+def test_issue_22982_15323():
+    assert limit((log(E + 1/x) - 1)**(1 - sqrt(E + 1/x)), x, oo) == oo
+    assert limit((1 - 1/x)**x*(log(1 - 1/x) + 1/(x*(1 - 1/x))), x, 1, dir='+') == 1

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1422,3 +1422,5 @@ def test_issue_26916():
 def test_issue_22982_15323():
     assert limit((log(E + 1/x) - 1)**(1 - sqrt(E + 1/x)), x, oo) == oo
     assert limit((1 - 1/x)**x*(log(1 - 1/x) + 1/(x*(1 - 1/x))), x, 1, dir='+') == 1
+    assert limit((log(E + 1/x) )**(1 - sqrt(E + 1/x)), x, oo) == 1
+    assert limit((log(E + 1/x) - 1)**(- sqrt(E + 1/x)), x, oo) == oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1412,3 +1412,8 @@ def test_issue_26250():
     e1 = ((1-3*x**2)*e**2/2 - (x**2-2*x+1)*e*k/2)
     e2 = pi**2*(x**8 - 2*x**7 - x**6 + 4*x**5 - x**4 - 2*x**3 + x**2)
     assert limit(e1/e2, x, 0) == -S(1)/8
+
+
+def test_issue_26916():
+    assert limit(Ei(x)*exp(-x), x, +oo) == 0
+    assert limit(Ei(x)*exp(-x), x, -oo) == 0

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -402,3 +402,7 @@ def test_issue_24266():
     #type3: f(y)**g(x)
     assert ((y)**(I*pi*(2*x+1))).series(x, 0, 2) == exp(I*pi*log(y)) + 2*I*pi*x*exp(I*pi*log(y))*log(y) + O(x**2)
     assert ((I*y)**(I*pi*(2*x+1))).series(x, 0, 2) == exp(I*pi*log(I*y)) + 2*I*pi*x*exp(I*pi*log(I*y))*log(I*y) + O(x**2)
+
+
+def test_issue_26856():
+    raises(ValueError, lambda: (2**x).series(x, oo, -1))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -826,10 +826,9 @@ def solve(f, *symbols, **flags):
 
     See Also
     ========
-    
-    - :func:`sympy.solvers.recurrence.rsolve`: For solving recurrence relationships
-    - `For solving ordinary differential equations. <https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.dsolve>`_
 
+    rsolve: For solving recurrence relationships
+    sympy.solvers.ode.dsolve: For solving differential equations
 
     """
     from .inequalities import reduce_inequalities

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -826,9 +826,10 @@ def solve(f, *symbols, **flags):
 
     See Also
     ========
+    
+    - :func:`sympy.solvers.recurrence.rsolve`: For solving recurrence relationships
+    - `For solving ordinary differential equations. <https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.dsolve>`_
 
-    - `rsolve`: For solving recurrence relationships (make sure to add the full path if it's a function or method)
-    - :py:meth:`~sympy.solvers.ode.dsolve`: For solving ordinary differential equations.
 
     """
     from .inequalities import reduce_inequalities

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -828,7 +828,7 @@ def solve(f, *symbols, **flags):
     ========
 
     rsolve: For solving recurrence relationships
-    dsolve: For solving differential equations
+    :py:meth:`~sympy.solvers.ode.dsolve`
 
     """
     from .inequalities import reduce_inequalities

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -828,7 +828,7 @@ def solve(f, *symbols, **flags):
     ========
 
     rsolve: For solving recurrence relationships
-    :py:meth:`~sympy.solvers.ode.dsolve`
+    dsolve: For solving differential equations
 
     """
     from .inequalities import reduce_inequalities

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -827,8 +827,8 @@ def solve(f, *symbols, **flags):
     See Also
     ========
 
-    rsolve: For solving recurrence relationships
-    :func: `sympy.solvers.ode.dsolve`
+    - `rsolve`: For solving recurrence relationships (make sure to add the full path if it's a function or method)
+    - :py:meth:`~sympy.solvers.ode.dsolve`: For solving ordinary differential equations.
 
     """
     from .inequalities import reduce_inequalities

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -828,7 +828,7 @@ def solve(f, *symbols, **flags):
     ========
 
     rsolve: For solving recurrence relationships
-    dsolve: For solving differential equations
+    :func: `sympy.solvers.ode.dsolve`
 
     """
     from .inequalities import reduce_inequalities


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Added `StateSpace` and `PIDController` to the offical documentation of
`sympy.physics.control`.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->