### PR TITLE
maint(ci): only run ruff on the sympy package

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -30,7 +30,7 @@ jobs:
         run: bin/test quality
 
       - name: Run Ruff on the sympy package
-        run: ruff check .
+        run: ruff check sympy
 
       - name: Run flake8 on the sympy package
         run: flake8 sympy


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-26964
Alternative to gh-26968. See https://github.com/sympy/sympy/pull/26968#issuecomment-2293795390

#### Brief description of what is fixed or changed

Only run ruff in the sympy package directory.

#### Other comments

When the flake8 checks were added they were added only for the sympy package like:
```
flake8 sympy
```
However the ruff checks were added like:
```
ruff check .
```
This means that they check other files like setup.py and the notebooks in examples, etc. The change here is just that we only run this in CI:
```
ruff check sympy
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
