### PR TITLE
[GSoC] Included documentation of StateSpace and PIDController to docs.

### DIFF
--- a/doc/src/modules/physics/control/control.rst
+++ b/doc/src/modules/physics/control/control.rst
@@ -14,6 +14,14 @@ with ``TransferFunctionMatrix`` as the base class for representing one. ``MIMOSe
 ``MIMOParallel``  and ``MIMOFeedback`` are MIMO equivalent of ``Series``, ``Parallel``
 and ``Feedback`` classes.
 
+Alongside ``TransferFunction`` representations, the ``StateSpace`` class can be used
+to model state-space systems. These representations are more general and can handle
+both continuous-time and discrete-time systems. The ``StateSpace`` class supports
+various methods for analyzing and manipulating systems, such as controllability,
+observability, and transformations between state-space and transfer function
+representations. MIMO state-space systems are also supported, making this module
+versatile for dealing with a wide range of control system problems.
+
 The advantage of this symbolic Control system package is that the solutions obtained
 from it are highly accurate and do not rely on numerical methods to approximate the
 solutions. Symbolic solutions obtained are also in a compact form that can be used for

--- a/doc/src/modules/physics/control/control.rst
+++ b/doc/src/modules/physics/control/control.rst
@@ -15,8 +15,7 @@ with ``TransferFunctionMatrix`` as the base class for representing one. ``MIMOSe
 and ``Feedback`` classes.
 
 Alongside ``TransferFunction`` representations, the ``StateSpace`` class can be used
-to model state-space systems. These representations are more general and can handle
-both continuous-time and discrete-time systems. The ``StateSpace`` class supports
+to model state-space systems. The ``StateSpace`` class supports
 various methods for analyzing and manipulating systems, such as controllability,
 observability, and transformations between state-space and transfer function
 representations. MIMO state-space systems are also supported, making this module

--- a/doc/src/modules/physics/control/lti.rst
+++ b/doc/src/modules/physics/control/lti.rst
@@ -22,6 +22,9 @@ lti
 .. autoclass:: TransferFunctionMatrix
    :members:
 
+.. autoclass:: PIDController
+   :members:
+
 .. autoclass:: MIMOSeries
    :members:
 
@@ -29,6 +32,9 @@ lti
    :members:
 
 .. autoclass:: MIMOFeedback
+   :members:
+
+.. autoclass:: StateSpace
    :members:
 
 .. autofunction:: gbt

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4243,6 +4243,7 @@ class StateSpace(LinearTimeInvariant):
 
     References
     ==========
+
     .. [1] https://en.wikipedia.org/wiki/State-space_representation
     .. [2] https://in.mathworks.com/help/control/ref/ss.html
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4505,6 +4505,7 @@ class StateSpace(LinearTimeInvariant):
         ==========
         .. [1] https://web.mit.edu/2.14/www/Handouts/StateSpaceResponse.pdf
         .. [2] https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.systems.linodesolve
+    
         """
 
         if not isinstance(var, Symbol):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4192,6 +4192,7 @@ class StateSpace(LinearTimeInvariant):
     This makes the linear control system:
         (1) x'(t) = A * x(t) + B * u(t);    x in R^n , u in R^k
         (2) y(t)  = C * x(t) + D * u(t);    y in R^m
+
     where u(t) is any input signal, y(t) the corresponding output, and x(t) the system's state.
 
     Parameters

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4505,7 +4505,7 @@ class StateSpace(LinearTimeInvariant):
         ==========
         .. [1] https://web.mit.edu/2.14/www/Handouts/StateSpaceResponse.pdf
         .. [2] https://docs.sympy.org/latest/modules/solvers/ode.html#sympy.solvers.ode.systems.linodesolve
-    
+
         """
 
         if not isinstance(var, Symbol):

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4225,7 +4225,6 @@ class StateSpace(LinearTimeInvariant):
     [1],
     [1]]), Matrix([[0, 1]]), Matrix([[0]]))
 
-
     One can use less matrices. The rest will be filled with a minimum of zeros:
 
     >>> StateSpace(A, B)
@@ -4234,7 +4233,6 @@ class StateSpace(LinearTimeInvariant):
     [1, 0]]), Matrix([
     [1],
     [1]]), Matrix([[0, 0]]), Matrix([[0]]))
-
 
     See Also
     ========

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4190,6 +4190,7 @@ class StateSpace(LinearTimeInvariant):
 
     Represents the standard state-space model with A, B, C, D as state-space matrices.
     This makes the linear control system:
+
         (1) x'(t) = A * x(t) + B * u(t);    x in R^n , u in R^k
         (2) y(t)  = C * x(t) + D * u(t);    y in R^m
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -828,7 +828,7 @@ def solve(f, *symbols, **flags):
     ========
 
     rsolve: For solving recurrence relationships
-    dsolve: For solving differential equations
+    sympy.solvers.ode.dsolve: For solving differential equations
 
     """
     from .inequalities import reduce_inequalities


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Added `StateSpace` and `PIDController` to the offical documentation of
`sympy.physics.control`.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->