### PR TITLE
Fix Ratio test to check if limit ratio is NaN

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -536,7 +536,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         ratio = combsimp(powsimp(next_sequence_term/sequence_term))
         try:
             lim_ratio = limit_seq(ratio, sym)
-            if lim_ratio is not None and lim_ratio.is_number:
+            if lim_ratio is not None and lim_ratio.is_number and lim_ratio is not S.NaN:
                 if abs(lim_ratio) > 1:
                     return S.false
                 if abs(lim_ratio) < 1:

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1057,6 +1057,7 @@ def test_is_convergent():
     assert Sum((-1)**n*n, (n, 3, oo)).is_convergent() is S.false
     assert Sum((-1)**n, (n, 1, oo)).is_convergent() is S.false
     assert Sum(log(1/n), (n, 2, oo)).is_convergent() is S.false
+    assert Sum(sin(n), (n, 1, oo)).is_convergent() is S.false
 
     # Raabe's test --
     assert Sum(Product((3*m),(m,1,n))/Product((3*m+4),(m,1,n)),(n,1,oo)).is_convergent() is S.true
@@ -1155,6 +1156,11 @@ def test_issue_10156():
 
 def test_issue_10973():
     assert Sum((-n + (n**3 + 1)**(S(1)/3))/log(n), (n, 1, oo)).is_convergent() is S.true
+
+
+def test_issue_14103():
+    assert Sum(sin(n)**2 + cos(n)**2 - 1, (n, 1, oo)).is_convergent() is S.true
+    assert Sum(sin(pi*n), (n, 1, oo)).is_convergent() is S.true
 
 
 def test_issue_14129():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #14103
Closes #22200 

#### Brief description of what is fixed or changed
Add a check for NaN in the ratio test
```
>>> Sum(sin(n)**2 + cos(n)**2 - 1, (n, 1, oo)).is_convergent()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\91989\sympy\sympy\sympy\concrete\summations.py", line 540, in is_convergent
    if abs(lim_ratio) > 1:
  File "C:\Users\91989\sympy\sympy\sympy\core\decorators.py", line 236, in _func
    return func(self, other)
  File "C:\Users\91989\sympy\sympy\sympy\core\expr.py", line 360, in __gt__
    return StrictGreaterThan(self, other)
  File "C:\Users\91989\sympy\sympy\sympy\core\relational.py", line 848, in __new__
    raise TypeError("Invalid NaN comparison")
TypeError: Invalid NaN comparison
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  * Fix Ratio test to check if limit ratio is NaN.
<!-- END RELEASE NOTES -->
