### PR TITLE
Second Quantization: Fixed TypeError in FermionState

### DIFF
--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1221,14 +1221,19 @@ class FermionState(FockState):
         return self.__class__((i,) + self.args[0], self.fermi_level)
 
     @classmethod
-    def _count_holes(cls, list):
+    def _count_holes(cls, occupations):
         """
-        Returns the number of identified hole states in list.
+        Returns the number of identified hole states in occupations list.
         """
-        return len([i for i in list if cls._only_below_fermi(i)])
+        return len([i for i in occupations if cls._only_below_fermi(i)])
 
-    def _negate_holes(self, list):
-        return tuple([-i if i <= self.fermi_level else i for i in list])
+    def _negate_holes(self, occupations):
+        """
+        Returns the occupations list where states below the fermi level have negative labels.
+
+        For symbolic state labels, no sign is included.
+        """
+        return tuple([-i if self._only_below_fermi(i) and i.is_number else i for i in occupations])
 
     def __repr__(self):
         if self.fermi_level:

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -301,7 +301,6 @@ def test_create_f():
     assert srepr(Fd(p)) == "CreateFermion(Symbol('p'))"
     assert latex(Fd(p)) == r'{a^\dagger_{p}}'
     assert latex(Fd(p1)) == r'{a^\dagger_{p_{1}}}'
-    
     tex_strings = [r"\left|\left( a, \  i\right)\right\rangle", r"- \left|\left( i, \  a\right)\right\rangle"]
     assert latex(FKet([a,i], 1)) in tex_strings
 

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -301,6 +301,9 @@ def test_create_f():
     assert srepr(Fd(p)) == "CreateFermion(Symbol('p'))"
     assert latex(Fd(p)) == r'{a^\dagger_{p}}'
     assert latex(Fd(p1)) == r'{a^\dagger_{p_{1}}}'
+    
+    tex_strings = [r"\left|\left( a, \  i\right)\right\rangle", r"- \left|\left( i, \  a\right)\right\rangle"]
+    assert latex(FKet([a,i], 1)) in tex_strings
 
 
 def test_annihilate_f():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The base class ``FermionState``, which ``FermionStateBra``/``FermionStateKet`` inherits from, had a bug in its ``_negate_holes`` function. In the case where symbolic states were used, the index could not be compared to the fermi level, raising a ``TypeError``. Fixed by using the already existing ``_only_above_fermi`` function, making sure it is a number before negating. Added a test that fails before the patch.

#### Other comments
Since ``_sort_anticommuting_fermions`` uses the symbols hash to sort the indices, the ordering will differ per runtime. Something like ``default_sort_key`` can be used instead, but I think using something like the ``_sortkey`` functions for ``AntiSymmetricTensor`` might be better, as general, particle and hole indices are treated differently. This also makes testing the above more difficult.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
