### PR TITLE
Return unevaluated limits of UndefinedFuntion

### DIFF
--- a/sympy/calculus/tests/test_finite_diff.py
+++ b/sympy/calculus/tests/test_finite_diff.py
@@ -162,7 +162,3 @@ def test_differentiate_finite():
            + 3*g(h + x)/(2*h))/(2*h) - (2*f(x)/h - 3*f(-h + x)/(2*h) - \
            f(h + x)/(2*h))*(2*g(x)/h - 3*g(-h + x)/(2*h) - g(h + x)/(2*h))/(2*h)
     assert res5 == ref5
-
-    res6 = res5.limit(h, 0).doit()
-    ref6 = diff(res5_expr, x)
-    assert res6 == ref6

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -120,7 +120,7 @@ from functools import reduce
 
 from sympy.core import Basic, S, Mul, PoleError
 from sympy.core.cache import cacheit
-from sympy.core.function import UndefinedFunction
+from sympy.core.function import AppliedUndef
 from sympy.core.intfunc import ilcm
 from sympy.core.numbers import I, oo
 from sympy.core.symbol import Dummy, Wild
@@ -302,7 +302,7 @@ def mrv(e, x):
         else:
             s, expr = mrv(e.exp, x)
             return s, exp(expr)
-    elif isinstance(e.func, UndefinedFunction):
+    elif isinstance(e, AppliedUndef):
         raise ValueError("MRV set computation for UndefinedFunction is not allowed")
     elif e.is_Function:
         l = [mrv(a, x) for a in e.args]

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -120,6 +120,7 @@ from functools import reduce
 
 from sympy.core import Basic, S, Mul, PoleError
 from sympy.core.cache import cacheit
+from sympy.core.function import UndefinedFunction
 from sympy.core.intfunc import ilcm
 from sympy.core.numbers import I, oo
 from sympy.core.symbol import Dummy, Wild
@@ -301,6 +302,8 @@ def mrv(e, x):
         else:
             s, expr = mrv(e.exp, x)
             return s, exp(expr)
+    elif isinstance(e.func, UndefinedFunction):
+        raise ValueError("MRV set computation for UndefinedFunction is not allowed")
     elif e.is_Function:
         l = [mrv(a, x) for a in e.args]
         l2 = [s for (s, _) in l if s != SubsSet()]

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -2,7 +2,7 @@ from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import Float, _illegal
-from sympy.core.function import UndefinedFunction
+from sympy.core.function import AppliedUndef
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (Abs, sign, arg, re)
 from sympy.functions.elementary.exponential import (exp, log)
@@ -78,7 +78,7 @@ def heuristics(e, z, z0, dir):
         rv = limit(e.subs(z, 1/z), z, S.Zero, "+")
         if isinstance(rv, Limit):
             return
-    elif (e.is_Mul or e.is_Add or e.is_Pow or (e.is_Function and not isinstance(e.func, UndefinedFunction))):
+    elif (e.is_Mul or e.is_Add or e.is_Pow or (e.is_Function and not isinstance(e, AppliedUndef))):
         r = []
         from sympy.simplify.simplify import together
         for a in e.args:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -2,6 +2,7 @@ from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import Float, _illegal
+from sympy.core.function import UndefinedFunction
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (Abs, sign, arg, re)
 from sympy.functions.elementary.exponential import (exp, log)
@@ -77,7 +78,7 @@ def heuristics(e, z, z0, dir):
         rv = limit(e.subs(z, 1/z), z, S.Zero, "+")
         if isinstance(rv, Limit):
             return
-    elif e.is_Mul or e.is_Add or e.is_Pow or e.is_Function:
+    elif (e.is_Mul or e.is_Add or e.is_Pow or (e.is_Function and not isinstance(e.func, UndefinedFunction))):
         r = []
         from sympy.simplify.simplify import together
         for a in e.args:

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -478,12 +478,9 @@ def test_issue_7096():
 
 def test_issue_7391_8166():
     f = Function('f')
-    y = Symbol('y')
-    func = x*y*y / (x*x + y**4)
-    func2 = func.subs(y, f(x))
     # limit should depend on the continuity of the expression at the point passed
     raises(ValueError, lambda: gruntz(f(x), x, 4))
-    raises(ValueError, lambda: gruntz(func2, x, 0))
+    raises(ValueError, lambda: gruntz(x*f(x)**2/(x**2 + f(x)**4), x, 0))
 
 
 def test_issue_24210_25885():

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -1,4 +1,5 @@
 from sympy.core import EulerGamma
+from sympy.core.function import Function
 from sympy.core.numbers import (E, I, Integer, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
@@ -12,7 +13,7 @@ from sympy.polys.polytools import cancel
 from sympy.functions.elementary.hyperbolic import cosh, coth, sinh, tanh
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
-from sympy.testing.pytest import XFAIL, skip, slow
+from sympy.testing.pytest import XFAIL, raises, skip, slow
 
 """
 This test suite is testing the limit algorithm using the bottom up approach.
@@ -473,6 +474,17 @@ def test_issue_6682():
 def test_issue_7096():
     from sympy.functions import sign
     assert gruntz(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
+
+
+def test_issue_7391_8166():
+    f = Function('f')
+    y = Symbol('y')
+    func = x*y*y / (x*x + y**4)
+    func2 = func.subs(y, f(x))
+    # limit should depend on the continuity of the expression at the point passed
+    raises(ValueError, lambda: gruntz(f(x), x, 4))
+    raises(ValueError, lambda: gruntz(func2, x, 0))
+
 
 def test_issue_24210_25885():
     eq = exp(x)/(1+1/x)**x**2

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -694,6 +694,15 @@ def test_issue_7224():
     assert limit(x*diff(expr, x, x)/expr, x, 1).evalf() == 2.0
 
 
+def test_issue_7391_8166():
+    f = Function('f')
+    func = x*y*y / (x*x + y**4)
+    func2 = func.subs(y, f(x))
+    # limit should depend on the continuity of the expression at the point passed
+    assert limit(f(x), x, 4) == Limit(f(x), x, 4, dir='+')
+    assert limit(func2, x, 0) == Limit(x*f(x)**2/(x**2 + f(x)**4), x, 0, dir='+')
+
+
 def test_issue_8208():
     assert limit(n**(Rational(1, 1e9) - 1), n, oo) == 0
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -696,11 +696,9 @@ def test_issue_7224():
 
 def test_issue_7391_8166():
     f = Function('f')
-    func = x*y*y / (x*x + y**4)
-    func2 = func.subs(y, f(x))
     # limit should depend on the continuity of the expression at the point passed
     assert limit(f(x), x, 4) == Limit(f(x), x, 4, dir='+')
-    assert limit(func2, x, 0) == Limit(x*f(x)**2/(x**2 + f(x)**4), x, 0, dir='+')
+    assert limit(x*f(x)**2/(x**2 + f(x)**4), x, 0) == Limit(x*f(x)**2/(x**2 + f(x)**4), x, 0, dir='+')
 
 
 def test_issue_8208():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/8166
Fixes https://github.com/sympy/sympy/issues/7391
Closes #23019 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Limits of `UndefinedFuntion` will remain unevaluated.
  * `mrv` raises ValueError for `UndefinedFuntion`.
<!-- END RELEASE NOTES -->
