### PR TITLE
Updated sympy/interactive/printing.py

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -485,7 +485,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
 
     if pretty_print:
         if pretty_printer is not None:
-            stringify_func = pretty_printer
+            stringify_func = lambda expr: pretty_printer(expr,**settings)
         else:
             from sympy.printing import pretty as stringify_func
     else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26979 bug

#### Brief description of what is fixed or changed
Changed Line no 488 of [printing.py](https://github.com/sympy/sympy/blob/master/sympy/interactive/printing.py)
function `init_printing` from` stringify_func = pretty_printer` to `stringify_func = lambda expr:pretty_printer(expr, **settings)`
to solve the bug mentioned in #26979

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
