### PR TITLE
Fix settings not passed to pretty printer

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -219,24 +219,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 return '$\\displaystyle %s$' % s
             return s
 
-    def _result_display(self, arg):
-        """IPython's pretty-printer display hook, for use in IPython 0.10
-
-           This function was adapted from:
-
-            ipython/IPython/hooks.py:155
-
-        """
-        if self.rc.pprint:
-            out = stringify_func(arg)
-
-            if '\n' in out:
-                print()
-
-            print(out)
-        else:
-            print(repr(arg))
-
     # Printable is our own type, so we handle it with methods instead of
     # the approach required by builtin types. This allows downstream
     # packages to override the methods in their own subclasses of Printable,

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -8,8 +8,6 @@ from sympy.utilities.misc import debug
 from sympy.printing.defaults import Printable
 from sympy.external import import_module
 
-IPython = import_module("IPython", min_module_version="1.0")
-
 
 def _init_python_printing(stringify_func, **settings):
     """Setup printing in Python interactive session. """
@@ -36,6 +34,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                            backcolor, fontsize, latex_mode, print_builtin,
                            latex_printer, scale, **settings):
     """Setup printing in IPython interactive session. """
+    IPython = import_module("IPython", min_module_version="1.0")
     try:
         from IPython.lib.latextools import latex_to_png
     except ImportError:

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -7,6 +7,9 @@ from sympy.printing.latex import latex as default_latex
 from sympy.printing.preview import preview
 from sympy.utilities.misc import debug
 from sympy.printing.defaults import Printable
+from sympy.external import import_module
+
+IPython = import_module("IPython", min_module_version="1.0")
 
 
 def _init_python_printing(stringify_func, **settings):
@@ -79,7 +82,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     def _print_plain(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
         if _can_print(arg):
-            p.text(stringify_func(arg))
+            p.text(stringify_func(arg, **settings))
         else:
             p.text(IPython.lib.pretty.pretty(arg))
 
@@ -234,75 +237,69 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         else:
             print(repr(arg))
 
-    import IPython
-    if version_tuple(IPython.__version__) >= version_tuple('0.11'):
+    # Printable is our own type, so we handle it with methods instead of
+    # the approach required by builtin types. This allows downstream
+    # packages to override the methods in their own subclasses of Printable,
+    # which avoids the effects of gh-16002.
+    printable_types = [float, tuple, list, set, frozenset, dict, int]
 
-        # Printable is our own type, so we handle it with methods instead of
-        # the approach required by builtin types. This allows downstream
-        # packages to override the methods in their own subclasses of Printable,
-        # which avoids the effects of gh-16002.
-        printable_types = [float, tuple, list, set, frozenset, dict, int]
+    plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
-        plaintext_formatter = ip.display_formatter.formatters['text/plain']
+    # Exception to the rule above: IPython has better dispatching rules
+    # for plaintext printing (xref ipython/ipython#8938), and we can't
+    # use `_repr_pretty_` without hitting a recursion error in _print_plain.
+    for cls in printable_types + [Printable]:
+        plaintext_formatter.for_type(cls, _print_plain)
 
-        # Exception to the rule above: IPython has better dispatching rules
-        # for plaintext printing (xref ipython/ipython#8938), and we can't
-        # use `_repr_pretty_` without hitting a recursion error in _print_plain.
-        for cls in printable_types + [Printable]:
-            plaintext_formatter.for_type(cls, _print_plain)
-
-        svg_formatter = ip.display_formatter.formatters['image/svg+xml']
-        if use_latex in ('svg', ):
-            debug("init_printing: using svg formatter")
-            for cls in printable_types:
-                svg_formatter.for_type(cls, _print_latex_svg)
-            Printable._repr_svg_ = _print_latex_svg
-        else:
-            debug("init_printing: not using any svg formatter")
-            for cls in printable_types:
-                # Better way to set this, but currently does not work in IPython
-                #png_formatter.for_type(cls, None)
-                if cls in svg_formatter.type_printers:
-                    svg_formatter.type_printers.pop(cls)
-            Printable._repr_svg_ = Printable._repr_disabled
-
-        png_formatter = ip.display_formatter.formatters['image/png']
-        if use_latex in (True, 'png'):
-            debug("init_printing: using png formatter")
-            for cls in printable_types:
-                png_formatter.for_type(cls, _print_latex_png)
-            Printable._repr_png_ = _print_latex_png
-        elif use_latex == 'matplotlib':
-            debug("init_printing: using matplotlib formatter")
-            for cls in printable_types:
-                png_formatter.for_type(cls, _print_latex_matplotlib)
-            Printable._repr_png_ = _print_latex_matplotlib
-        else:
-            debug("init_printing: not using any png formatter")
-            for cls in printable_types:
-                # Better way to set this, but currently does not work in IPython
-                #png_formatter.for_type(cls, None)
-                if cls in png_formatter.type_printers:
-                    png_formatter.type_printers.pop(cls)
-            Printable._repr_png_ = Printable._repr_disabled
-
-        latex_formatter = ip.display_formatter.formatters['text/latex']
-        if use_latex in (True, 'mathjax'):
-            debug("init_printing: using mathjax formatter")
-            for cls in printable_types:
-                latex_formatter.for_type(cls, _print_latex_text)
-            Printable._repr_latex_ = _print_latex_text
-        else:
-            debug("init_printing: not using text/latex formatter")
-            for cls in printable_types:
-                # Better way to set this, but currently does not work in IPython
-                #latex_formatter.for_type(cls, None)
-                if cls in latex_formatter.type_printers:
-                    latex_formatter.type_printers.pop(cls)
-            Printable._repr_latex_ = Printable._repr_disabled
-
+    svg_formatter = ip.display_formatter.formatters['image/svg+xml']
+    if use_latex in ('svg', ):
+        debug("init_printing: using svg formatter")
+        for cls in printable_types:
+            svg_formatter.for_type(cls, _print_latex_svg)
+        Printable._repr_svg_ = _print_latex_svg
     else:
-        ip.set_hook('result_display', _result_display)
+        debug("init_printing: not using any svg formatter")
+        for cls in printable_types:
+            # Better way to set this, but currently does not work in IPython
+            #png_formatter.for_type(cls, None)
+            if cls in svg_formatter.type_printers:
+                svg_formatter.type_printers.pop(cls)
+        Printable._repr_svg_ = Printable._repr_disabled
+
+    png_formatter = ip.display_formatter.formatters['image/png']
+    if use_latex in (True, 'png'):
+        debug("init_printing: using png formatter")
+        for cls in printable_types:
+            png_formatter.for_type(cls, _print_latex_png)
+        Printable._repr_png_ = _print_latex_png
+    elif use_latex == 'matplotlib':
+        debug("init_printing: using matplotlib formatter")
+        for cls in printable_types:
+            png_formatter.for_type(cls, _print_latex_matplotlib)
+        Printable._repr_png_ = _print_latex_matplotlib
+    else:
+        debug("init_printing: not using any png formatter")
+        for cls in printable_types:
+            # Better way to set this, but currently does not work in IPython
+            #png_formatter.for_type(cls, None)
+            if cls in png_formatter.type_printers:
+                png_formatter.type_printers.pop(cls)
+        Printable._repr_png_ = Printable._repr_disabled
+
+    latex_formatter = ip.display_formatter.formatters['text/latex']
+    if use_latex in (True, 'mathjax'):
+        debug("init_printing: using mathjax formatter")
+        for cls in printable_types:
+            latex_formatter.for_type(cls, _print_latex_text)
+        Printable._repr_latex_ = _print_latex_text
+    else:
+        debug("init_printing: not using text/latex formatter")
+        for cls in printable_types:
+            # Better way to set this, but currently does not work in IPython
+            #latex_formatter.for_type(cls, None)
+            if cls in latex_formatter.type_printers:
+                latex_formatter.type_printers.pop(cls)
+        Printable._repr_latex_ = Printable._repr_disabled
 
 def _is_ipython(shell):
     """Is a shell instance an IPython shell?"""
@@ -509,14 +506,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
 
     if in_ipython and pretty_print:
         try:
-            import IPython
-            # IPython 1.0 deprecates the frontend module, so we import directly
-            # from the terminal module to prevent a deprecation message from being
-            # shown.
-            if version_tuple(IPython.__version__) >= version_tuple('1.0'):
-                from IPython.terminal.interactiveshell import TerminalInteractiveShell
-            else:
-                from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
+            from IPython.terminal.interactiveshell import TerminalInteractiveShell
             from code import InteractiveConsole
         except ImportError:
             pass

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -1,6 +1,5 @@
 """Tools for setting up printing in interactive sessions. """
 
-from sympy.external.importtools import version_tuple
 from io import BytesIO
 
 from sympy.printing.latex import latex as default_latex

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -9,10 +9,10 @@ from sympy.testing.pytest import raises
 
 # TODO: The code below could be made more granular with something like:
 #
-# @requires('IPython', version=">=0.11")
+# @requires('IPython', version=">=1.0")
 # def test_automatic_symbols(ipython):
 
-ipython = import_module("IPython", min_module_version="0.11")
+ipython = import_module("IPython", min_module_version="1.0")
 
 if not ipython:
     #bin/test will not execute any tests now


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/26979


#### Brief description of what is fixed or changed

```python3
from sympy import *
from sympy.printing.pretty.pretty import PrettyPrinter
from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
from sympy.core.function import AppliedUndef
from sympy.printing.conventions import requires_partial
from sympy.printing.pretty.stringpict import stringPict, prettyForm

class MyPrettyPrinter(PrettyPrinter):
    """Pretty printer customized to visualize applied undefined functions
    without arguments.
    """
    def __init__(self, settings=None):
        self._default_settings.update({
            "applied_func_with_no_args": True
        })
        super().__init__(settings)

    def _print_Function(self, expr, sort=False, func_name=None, left='(', right=')'):
        if isinstance(expr, AppliedUndef) and self._settings["applied_func_with_no_args"]:
            prettyFunc = self._print(Symbol(expr.func.__name__))
            prettyArgs = prettyForm("")
            pform = prettyForm(
                binding=prettyForm.FUNC, *stringPict.next(prettyFunc))
            # store pform parts so it can be reassembled e.g. when powered
            pform.prettyFunc = prettyFunc
            pform.prettyArgs = prettyArgs
            return pform
        
        return super()._print_Function(expr, sort=sort, func_name=func_name, left=left, right=right)

def my_pretty_printer(expr, **settings):
    pp = MyPrettyPrinter(settings)
    
    # XXX: this is an ugly hack, but at least it works
    use_unicode = pp._settings['use_unicode']
    uflag = pretty_use_unicode(use_unicode)
    
    try:
        return pp.doprint(expr)
    finally:
        pretty_use_unicode(uflag)


x, y, z = symbols('x y z')
f = Function('f')
```
```
>>> init_printing(use_latex=False, pretty_printer=my_pretty_printer, applied_func_with_no_args=True)
>>> f(x, y, z)**2
 2
f
>>> init_printing(use_latex=False, pretty_printer=my_pretty_printer, applied_func_with_no_args=True)
>>> f(x, y, z)**2
 2         
f (x, y, z)
```

The changes to pin IPython version after 1.0 is quite necessary,
It was to fix another suspected usage of `stringify_func` in `_result_display`.
And testing out `_result_display` requires IPython version before `0.11`, which is nearly impossible to install.

And also, it looks like cleaning such outdated branching of version cleans up the code significantly, so I try to clean up other related import hack (which branches over IPython `1.0`)
I note that the backward compatibility is no concern, because IPython <= 1.0 are not supported by minimal Python versions that SymPy supports.

I haven't added the tests, so the examples have to be verified manually. I took a look at `test_ipython`, but is not very clear that there are clean way to test session with custom printer, or I have to manually add dozens of lines of the example with plain strings, which can be unpleasant.

While fixing this issue, it reveals quite deep unpleasant issues of SymPy leads to more difficult changes:
(removing version hacks, very outdated packages, challenges to testing or such)
so maybe asking another new contributor to fix can be more difficult and anyway I took the issue

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- interactive
  - Fixed an issue where `init_printing` did not pass settings specific to the user-provided pretty printer. For example, when using `init_printing(use_latex=False, pretty_printer=my_pretty_printer, applied_func_with_no_args=False)`, the custom option `applied_func_with_no_args` is now correctly propagated to the custom pretty printer.
<!-- END RELEASE NOTES -->
