### PR TITLE
Second Quantization: Fixed index ordering in FermionState

### DIFF
--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -187,9 +187,9 @@ class AntiSymmetricTensor(TensorSymbol):
 
         try:
             upper, signu = _sort_anticommuting_fermions(
-                upper, key=cls._sortkey)
+                upper, key=_sqkey_index)
             lower, signl = _sort_anticommuting_fermions(
-                lower, key=cls._sortkey)
+                lower, key=_sqkey_index)
 
         except ViolationOfPauliPrinciple:
             return S.Zero
@@ -203,31 +203,6 @@ class AntiSymmetricTensor(TensorSymbol):
         else:
 
             return TensorSymbol.__new__(cls, symbol, upper, lower)
-
-    @classmethod
-    def _sortkey(cls, index):
-        """Key for sorting of indices.
-
-        particle < hole < general
-
-        FIXME: This is a bottle-neck, can we do it faster?
-        """
-        h = hash(index)
-        label = str(index)
-        if isinstance(index, Dummy):
-            if index.assumptions0.get('above_fermi'):
-                return (20, label, h)
-            elif index.assumptions0.get('below_fermi'):
-                return (21, label, h)
-            else:
-                return (22, label, h)
-
-        if index.assumptions0.get('above_fermi'):
-            return (10, label, h)
-        elif index.assumptions0.get('below_fermi'):
-            return (11, label, h)
-        else:
-            return (12, label, h)
 
     def _latex(self, printer):
         return "{%s^{%s}_{%s}}" % (
@@ -1051,7 +1026,7 @@ class FermionState(FockState):
         if len(occupations) > 1:
             try:
                 (occupations, sign) = _sort_anticommuting_fermions(
-                    occupations, key=hash)
+                    occupations, key=_sqkey_index)
             except ViolationOfPauliPrinciple:
                 return S.Zero
         else:
@@ -2228,12 +2203,37 @@ def contraction(a, b):
         raise ContractionAppliesOnlyToFermions(*t)
 
 
-def _sqkey(sq_operator):
+def _sqkey_operator(sq_operator):
     """Generates key for canonical sorting of SQ operators."""
     return sq_operator._sortkey()
 
+def _sqkey_index(index):
+    """Key for sorting of indices.
 
-def _sort_anticommuting_fermions(string1, key=_sqkey):
+    particle < hole < general
+
+    FIXME: This is a bottle-neck, can we do it faster?
+    """
+    h = hash(index)
+    label = str(index)
+    if isinstance(index, Dummy):
+        if index.assumptions0.get('above_fermi'):
+            return (20, label, h)
+        elif index.assumptions0.get('below_fermi'):
+            return (21, label, h)
+        else:
+            return (22, label, h)
+
+    if index.assumptions0.get('above_fermi'):
+        return (10, label, h)
+    elif index.assumptions0.get('below_fermi'):
+        return (11, label, h)
+    else:
+        return (12, label, h)
+
+
+
+def _sort_anticommuting_fermions(string1, key=_sqkey_operator):
     """Sort fermionic operators to canonical order, assuming all pairs anticommute.
 
     Explanation

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -301,8 +301,8 @@ def test_create_f():
     assert srepr(Fd(p)) == "CreateFermion(Symbol('p'))"
     assert latex(Fd(p)) == r'{a^\dagger_{p}}'
     assert latex(Fd(p1)) == r'{a^\dagger_{p_{1}}}'
-    tex_strings = [r"\left|\left( a, \  i\right)\right\rangle", r"- \left|\left( i, \  a\right)\right\rangle"]
-    assert latex(FKet([a,i], 1)) in tex_strings
+    assert latex(FKet([a,i], 1)) == r"\left|\left( a, \  i\right)\right\rangle"
+    assert latex(FKet([j,i,b,a], 2)) == r"\left|\left( a, \  b, \  i, \  j\right)\right\rangle"
 
 
 def test_annihilate_f():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addressing the index ordering in #26984

#### Brief description of what is fixed or changed

Different parts of ``physics.secondquant`` use the ``_sort_anticommuting_fermions`` function to either sort creation/annihilation operators or indices while keeping track of the permutation sign.

However, the sort key used is not consistent for different objects. In particular the ``FermionState`` class used the symbol hash, which made index ordering and phase change between runs.  The class ``AntiSymmetricTensor`` on the other hand had a custom sort key function, sorting first on the index type (relation to Fermi level, is Dummy and whatnot), then the symbol string, and lastly the hash.

Now the ``_sortkey`` function of ``AntiSymmetricTensor`` is removed, in favor of the new ``_sqkey_index`` function which both ``AntiSymmetricTensor`` and ``FermionState`` can use. In tandem with this, the ``_sqkey`` function is renamed to ``_sqkey_operator`` since it assumes an SQ operator instead of an index. 

#### Other comments

Tests using the ``latex`` function can now be simplified as the produced string will not be random.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
