### PR TITLE
Fixed bug related to limits of abs

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -411,7 +411,7 @@ def sign(e, x):
             return 1
         if e.exp.is_Integer:
             return s**e.exp
-    elif isinstance(e, log):
+    elif isinstance(e, log) and e.args[0].is_positive:
         return sign(e.args[0] - 1, x)
 
     # if all else fails, do it the hard way

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -278,7 +278,7 @@ class Limit(Expr):
                     if sig.is_zero:
                         sig = limit(1/expr.args[0], z, z0, dir)
                 except NotImplementedError:
-                    pass
+                    return expr
                 else:
                     if sig.is_extended_real:
                         if (sig < 0) == True:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -273,16 +273,20 @@ class Limit(Expr):
             arg_flag = isinstance(expr, arg)
             sign_flag = isinstance(expr, sign)
             if abs_flag or sign_flag or arg_flag:
-                sig = limit(expr.args[0], z, z0, dir)
-                if sig.is_zero:
-                    sig = limit(1/expr.args[0], z, z0, dir)
-                if sig.is_extended_real:
-                    if (sig < 0) == True:
-                        return (-expr.args[0] if abs_flag else
-                                S.NegativeOne if sign_flag else S.Pi)
-                    elif (sig > 0) == True:
-                        return (expr.args[0] if abs_flag else
-                                S.One if sign_flag else S.Zero)
+                try:
+                    sig = limit(expr.args[0], z, z0, dir)
+                    if sig.is_zero:
+                        sig = limit(1/expr.args[0], z, z0, dir)
+                except NotImplementedError:
+                    pass
+                else:
+                    if sig.is_extended_real:
+                        if (sig < 0) == True:
+                            return (-expr.args[0] if abs_flag else
+                                    S.NegativeOne if sign_flag else S.Pi)
+                        elif (sig > 0) == True:
+                            return (expr.args[0] if abs_flag else
+                                    S.One if sign_flag else S.Zero)
             return expr
 
         if e.has(Float):

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1414,6 +1414,11 @@ def test_issue_26250():
     assert limit(e1/e2, x, 0) == -S(1)/8
 
 
+def test_issue_26513():
+    assert limit(abs((-n/(n+1))**n), n ,oo) == exp(-1)
+    raises (NotImplementedError, lambda: limit((-n/(n+1))**n, n, oo))
+
+
 def test_issue_26916():
     assert limit(Ei(x)*exp(-x), x, +oo) == 0
     assert limit(Ei(x)*exp(-x), x, -oo) == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1415,8 +1415,9 @@ def test_issue_26250():
 
 
 def test_issue_26513():
-    assert limit(abs((-n/(n+1))**n), n ,oo) == exp(-1)
-    raises (NotImplementedError, lambda: limit((-n/(n+1))**n, n, oo))
+    assert limit(abs((-x/(x+1))**x), x ,oo) == exp(-1)
+    assert limit((x/(x + 1))**x, x, oo) == exp(-1)
+    raises (NotImplementedError, lambda: limit((-x/(x+1))**x, x, oo))
 
 
 def test_issue_26916():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #26513 
#### Brief description of what is fixed or changed
sign function in gruntz gave erroneous results for negative logarithmic arguments. Refactored `set_signs` in limits to let pass expressions returning NotImplementedError for gruntz to operate directly on abs functions . Made this separate PR for this issue as suggested in  #26749.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed `sign` in gruntz for better handling of terms having negative bases in power expressions with symbolic exponents.
<!-- END RELEASE NOTES -->
