### PR TITLE
Remove unnecessary `:func:` parentheses from reST content

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -963,6 +963,7 @@ Matt Bogosian <matt@bogosian.net>
 Matt Curry <mattjcurry@gmail.com>
 Matt Habel <habelinc@gmail.com>
 Matt Rajca <matt.rajca@me.com>
+Matt Wang <mattwang44@gmail.com>
 Matthew Brett <matthew.brett@gmail.com>
 Matthew Craven <clyring@users.noreply.github.com>
 Matthew Davis <davisml.md@gmail.com> <mlda065@cse.unsw.edu.au>

--- a/doc/src/modules/holonomic/uses.rst
+++ b/doc/src/modules/holonomic/uses.rst
@@ -36,9 +36,9 @@ should have a hypergeometric series at ``x0``.
 ``Frobenius method`` when the solutions need to have `\log` terms. This happens
 when at least one pair of the roots of the indicial equation differ by an integer and
 frobenius method yields linearly dependent series solutions. Since we use this while converting
-to expressions, sometimes :func:`~HolonomicFunction.to_expr()` fails.
+to expressions, sometimes :func:`~HolonomicFunction.to_expr` fails.
 
-3. There doesn't seem to be a way for computing indefinite integrals, so :func:`~HolonomicFunction.integrate()`
+3. There doesn't seem to be a way for computing indefinite integrals, so :func:`~HolonomicFunction.integrate`
 basically computes `\int_{x_0}^{x} f(x)dx` if no limits are given, where `x_0` is the point at
 which initial conditions for the integrand are stored. Sometimes this gives an additional constant in the result.
 For instance:

--- a/doc/src/modules/plotting.rst
+++ b/doc/src/modules/plotting.rst
@@ -286,7 +286,7 @@ origin and of radius 2 units.
     >>> x,y = symbols('x y')
     >>> plot_implicit(Eq(x**2+y**2, 4))
 
-Similarly, :func:`~.plot_implicit()` may be used to plot any 2-D geometric structure from
+Similarly, :func:`~.plot_implicit` may be used to plot any 2-D geometric structure from
 its implicit equation.
 
 Plotting polygons (Polygon, RegularPolygon, Triangle) are not supported

--- a/doc/src/tutorials/intro-tutorial/matrices.rst
+++ b/doc/src/tutorials/intro-tutorial/matrices.rst
@@ -59,7 +59,7 @@ Here are some basic operations on ``Matrix``.
 Shape
 -----
 
-To get the shape of a matrix, use :func:`~.shape()` function.
+To get the shape of a matrix, use :func:`~.shape` function.
 
     >>> from sympy import shape
     >>> M = Matrix([[1, 2, 3], [-2, 0, 4]])

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -374,7 +374,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     This function evaluates the proposition to ``True`` or ``False`` if
     the truth value can be determined. If not, it returns ``None``.
 
-    It should be discerned from :func:`~.refine()` which, when applied to a
+    It should be discerned from :func:`~.refine` which, when applied to a
     proposition, simplifies the argument to symbolic ``Boolean`` instead of
     Python built-in ``True``, ``False`` or ``None``.
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -15,13 +15,13 @@ def refine(expr, assumptions=True):
     Explanation
     ===========
 
-    Unlike :func:`~.simplify()` which performs structural simplification
+    Unlike :func:`~.simplify` which performs structural simplification
     without any assumption, this function transforms the expression into
     the form which is only valid under certain assumptions. Note that
     ``simplify()`` is generally not done in refining process.
 
     Refining boolean expression involves reducing it to ``S.true`` or
-    ``S.false``. Unlike :func:`~.ask()`, the expression will not be reduced
+    ``S.false``. Unlike :func:`~.ask`, the expression will not be reduced
     if the truth value cannot be determined.
 
     Examples

--- a/sympy/assumptions/relation/equality.py
+++ b/sympy/assumptions/relation/equality.py
@@ -32,7 +32,7 @@ class EqualityPredicate(BinaryRelation):
     use :obj:`~.Eq()` instead to construct the equality expression.
 
     Evaluating this predicate to ``True`` or ``False`` is done by
-    :func:`~.core.relational.is_eq()`
+    :func:`~.core.relational.is_eq`
 
     Examples
     ========
@@ -76,7 +76,7 @@ class UnequalityPredicate(BinaryRelation):
     use :obj:`~.Ne()` instead to construct the inequation expression.
 
     Evaluating this predicate to ``True`` or ``False`` is done by
-    :func:`~.core.relational.is_neq()`
+    :func:`~.core.relational.is_neq`
 
     Examples
     ========
@@ -120,7 +120,7 @@ class StrictGreaterThanPredicate(BinaryRelation):
     use :obj:`~.Gt()` instead to construct the equality expression.
 
     Evaluating this predicate to ``True`` or ``False`` is done by
-    :func:`~.core.relational.is_gt()`
+    :func:`~.core.relational.is_gt`
 
     Examples
     ========
@@ -168,7 +168,7 @@ class GreaterThanPredicate(BinaryRelation):
     use :obj:`~.Ge()` instead to construct the equality expression.
 
     Evaluating this predicate to ``True`` or ``False`` is done by
-    :func:`~.core.relational.is_ge()`
+    :func:`~.core.relational.is_ge`
 
     Examples
     ========
@@ -216,7 +216,7 @@ class StrictLessThanPredicate(BinaryRelation):
     use :obj:`~.Lt()` instead to construct the equality expression.
 
     Evaluating this predicate to ``True`` or ``False`` is done by
-    :func:`~.core.relational.is_lt()`
+    :func:`~.core.relational.is_lt`
 
     Examples
     ========
@@ -264,7 +264,7 @@ class LessThanPredicate(BinaryRelation):
     use :obj:`~.Le()` instead to construct the equality expression.
 
     Evaluating this predicate to ``True`` or ``False`` is done by
-    :func:`~.core.relational.is_le()`
+    :func:`~.core.relational.is_le`
 
     Examples
     ========

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -589,7 +589,7 @@ def match_real_imag(expr):
 
     ``match_real_imag`` returns a tuple containing the real and imaginary
     parts of expr or ``(None, None)`` if direct matching is not possible. Contrary
-    to :func:`~.re()`, :func:`~.im()``, and ``as_real_imag()``, this helper will not force things
+    to :func:`~.re`, :func:`~.im``, and ``as_real_imag()``, this helper will not force things
     by returning expressions themselves containing ``re()`` or ``im()`` and it
     does not expand its argument either.
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -377,11 +377,11 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         printer will only print SymPy types.
     str_printer : function, optional, default=None
         A custom string printer function. This should mimic
-        :func:`~.sstrrepr()`.
+        :func:`~.sstrrepr`.
     pretty_printer : function, optional, default=None
-        A custom pretty printer. This should mimic :func:`~.pretty()`.
+        A custom pretty printer. This should mimic :func:`~.pretty`.
     latex_printer : function, optional, default=None
-        A custom LaTeX printer. This should mimic :func:`~.latex()`.
+        A custom LaTeX printer. This should mimic :func:`~.latex`.
     scale : float, optional, default=1.0
         Scale the LaTeX output when using the ``'png'`` or ``'svg'`` backends.
         Useful for high dpi screens.

--- a/sympy/plotting/backends/base_backend.py
+++ b/sympy/plotting/backends/base_backend.py
@@ -51,7 +51,7 @@ class Plot:
     which implements the necessary functionalities in order to use SymPy
     plotting functions.
 
-    For interactive work the function :func:`plot()` is better suited.
+    For interactive work the function :func:`plot` is better suited.
 
     This class permits the plotting of SymPy expressions using numerous
     backends (:external:mod:`matplotlib`, textplot, the old pyglet module for SymPy, Google

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -562,7 +562,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
     :obj:`~.Eq()` or :obj:`~.Or()`), simplification will return ``True`` or
     ``False`` if truth value can be determined. If the expression is not
     evaluated by default (such as :obj:`~.Predicate()`), simplification will
-    not reduce it and you should use :func:`~.refine()` or :func:`~.ask()`
+    not reduce it and you should use :func:`~.refine` or :func:`~.ask`
     function. This inconsistency will be resolved in future version.
 
     See Also


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

resolve #27022

#### Brief description of what is fixed or changed

Remove `:func:` role's parentheses as Sphinx will add them to the rendered output.


#### Other comments

We're introducing a new rule to the sphinx-lint ([issue](https://github.com/sphinx-contrib/sphinx-lint/issues/114) & [PR](https://github.com/sphinx-contrib/sphinx-lint/pull/115)) and, since sphinx-lint utilizes Sympy doc content in the CI, we'd like to also fix the issue in doc.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
