### PR TITLE
Fix bug in TensAdd.canon_bp

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2632,9 +2632,12 @@ class TensAdd(TensExpr, AssocOp):
         under monoterm symmetries.
         """
         expr = self.expand()
-        args = [canon_bp(x) for x in expr.args]
-        res = TensAdd(*args).doit(deep=False)
-        return res
+        if isinstance(expr, self.func):
+            args = [canon_bp(x) for x in expr.args]
+            res = TensAdd(*args).doit(deep=False)
+            return res
+        else:
+            return canon_bp(expr)
 
     def equals(self, other):
         other = _sympify(other)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -423,6 +423,13 @@ def test_canonicalize3():
     t1 = t.canon_bp()
     assert t1 == -chi(a0)*psi(a1)
 
+def test_canonicalize4():
+    #Check whether TensAdd.canon_bp chokes on a case where the type of the expression changes on calling expand
+    Cartesian = TensorIndexType('Cartesian', dim=3)
+    p = tensor_indices("p", Cartesian)
+    K = TensorHead("K", [Cartesian])
+    expr = TensAdd( K(p) , - 2*K(p) )
+    assert expr.canon_bp() == -K(p)
 
 def test_TensorIndexType():
     D = Symbol('D')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!--#### References to other Issues or PRs-->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The earlier implementation of `TensAdd.canon_bp` assumed that the result of `TensAdd.expand()` is always a TensAdd. This is not true for something like `TensAdd( K(p) , - 2*K(p) )`

#### Other comments

On current master (isympy session),
```
In [1]: from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorHead, TensAdd

In [2]: Cartesian = TensorIndexType('Cartesian', dim=3)

In [3]: p = tensor_indices("p", Cartesian)

In [4]: K = TensorHead("K", [Cartesian])

In [5]: expr = TensAdd( K(p) , - 2*K(p) )

In [6]: assert expr.canon_bp() == -K(p)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 assert expr.canon_bp() == -K(p)

File /usr/lib/python3.12/site-packages/sympy/tensor/tensor.py:2636, in TensAdd.canon_bp(self)
   2634 expr = self.expand()
   2635 args = [canon_bp(x) for x in expr.args]
-> 2636 res = TensAdd(*args).doit(deep=False)
   2637 return res

File /usr/lib/python3.12/site-packages/sympy/tensor/tensor.py:2528, in TensAdd.doit(self, **hints)
   2525     return args[0]
   2527 # now check that all addends have the same indices:
-> 2528 TensAdd._tensAdd_check(args)
   2530 # Collect terms appearing more than once, differing by their coefficients:
   2531 args = TensAdd._tensAdd_collect_terms(args)

File /usr/lib/python3.12/site-packages/sympy/tensor/tensor.py:2576, in TensAdd._tensAdd_check(args)
   2574 list_indices = [get_indices_set(arg) for arg in args[1:]]
   2575 if not all(x == indices0 for x in list_indices):
-> 2576     raise ValueError('all tensors must have the same indices')

ValueError: all tensors must have the same indices
```

With this PR, the assert above succeeds (added as a test).

Suggested reviewers: @Upabjojr 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fix a bug where `TensAdd( K(p) , - 2*K(p) ).canon_bp()` would raise an error.
<!-- END RELEASE NOTES -->
