### PR TITLE
Implement series expansion for non-integer order for BesselY

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -278,6 +278,7 @@ class besselj(BesselBase):
 
         return super(besselj, self)._eval_nseries(x, n, logx, cdir)
 
+
 class bessely(BesselBase):
     r"""
     Bessel function of the second kind.
@@ -334,9 +335,9 @@ class bessely(BesselBase):
         if z in (S.Infinity, S.NegativeInfinity):
             return S.Zero
         if z == I*S.Infinity:
-            return exp(I*pi*(nu + 1)/2)*S.Infinity
+            return exp(I*pi*(nu + 1)/2) * S.Infinity
         if z == I*S.NegativeInfinity:
-            return exp(-I*pi*(nu + 1)/2)*S.Infinity
+            return exp(-I*pi*(nu + 1)/2) * S.Infinity
 
         if nu.is_integer:
             if nu.could_extract_minus_sign():
@@ -352,7 +353,7 @@ class bessely(BesselBase):
             return aj.rewrite(besseli)
 
     def _eval_rewrite_as_yn(self, nu, z, **kwargs):
-        return sqrt(2*z/pi)*yn(nu - S.Half, self.argument)
+        return sqrt(2*z/pi) * yn(nu - S.Half, self.argument)
 
     def _eval_as_leading_term(self, x, logx, cdir):
         nu, z = self.args
@@ -436,7 +437,7 @@ class bessely(BesselBase):
                     term = p*(digamma(k + nu + 1) + digamma(k + 1))
                     c.append(term)
                 return a - Add(*b) - Add(*c)  # Order term comes from a
-            else:
+            elif nu.is_noninteger:
                 # Reference - https://functions.wolfram.com/Bessel-TypeFunctions/BesselY/06/01/04/01/01/0003/
                 newn_a = ceiling((n + nu)/exp)
                 newn_b = ceiling((n - nu)/exp)
@@ -446,8 +447,11 @@ class bessely(BesselBase):
                 b = [_mexpand(-gamma(-nu)*cos(nu*pi)*(-1)**k*r**(2*k + nu)/(pi*RisingFactorial(nu + 1, k)*\
                     factorial(k))) for k in range((newn_b + 1)//2)]
                 return Add(*a) + Add(*b) + o
+            else:
+                raise NotImplementedError("besselk expansion is only implemented for real order")
 
         return super(bessely, self)._eval_nseries(x, n, logx, cdir)
+
 
 class besseli(BesselBase):
     r"""

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -381,8 +381,8 @@ class bessely(BesselBase):
                 # asymptotic approximation of bessely function.
                return sqrt(2)*(-sin(pi*nu/2 - z + pi/4) + 3*cos(pi*nu/2 - z + pi/4)/(8*z))*sqrt(1/z)/sqrt(pi)
             return self
-
-        return super(bessely, self)._eval_as_leading_term(x, logx=logx, cdir=cdir)
+        else:
+            return self.func(nu, arg)
 
     def _eval_is_extended_real(self):
         nu, z = self.args
@@ -420,11 +420,7 @@ class bessely(BesselBase):
                     term = r**(-nu)*factorial(nu - 1)/pi
                     b.append(term)
                     for k in range(1, nu):
-                        denom = (nu - k)*k
-                        if denom == S.Zero:
-                            term *= t/k
-                        else:
-                            term *= t/denom
+                        term *= t/((nu - k)*k)
                         term = (_mexpand(term) + o).removeO()
                         b.append(term)
 
@@ -448,7 +444,7 @@ class bessely(BesselBase):
                     factorial(k))) for k in range((newn_b + 1)//2)]
                 return Add(*a) + Add(*b) + o
             else:
-                raise NotImplementedError("besselk expansion is only implemented for real order")
+                raise NotImplementedError("bessely expansion is only implemented for real order")
 
         return super(bessely, self)._eval_nseries(x, n, logx, cdir)
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -10,7 +10,7 @@ from sympy.core.numbers import Rational, pi, I
 from sympy.core.power import Pow
 from sympy.core.symbol import Dummy, uniquely_named_symbol, Wild
 from sympy.core.sympify import sympify
-from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 from sympy.functions.elementary.trigonometric import sin, cos, csc, cot
 from sympy.functions.elementary.integers import ceiling
 from sympy.functions.elementary.exponential import exp, log
@@ -278,7 +278,6 @@ class besselj(BesselBase):
 
         return super(besselj, self)._eval_nseries(x, n, logx, cdir)
 
-
 class bessely(BesselBase):
     r"""
     Bessel function of the second kind.
@@ -335,9 +334,9 @@ class bessely(BesselBase):
         if z in (S.Infinity, S.NegativeInfinity):
             return S.Zero
         if z == I*S.Infinity:
-            return exp(I*pi*(nu + 1)/2) * S.Infinity
+            return exp(I*pi*(nu + 1)/2)*S.Infinity
         if z == I*S.NegativeInfinity:
-            return exp(-I*pi*(nu + 1)/2) * S.Infinity
+            return exp(-I*pi*(nu + 1)/2)*S.Infinity
 
         if nu.is_integer:
             if nu.could_extract_minus_sign():
@@ -353,7 +352,7 @@ class bessely(BesselBase):
             return aj.rewrite(besseli)
 
     def _eval_rewrite_as_yn(self, nu, z, **kwargs):
-        return sqrt(2*z/pi) * yn(nu - S.Half, self.argument)
+        return sqrt(2*z/pi)*yn(nu - S.Half, self.argument)
 
     def _eval_as_leading_term(self, x, logx, cdir):
         nu, z = self.args
@@ -364,18 +363,22 @@ class bessely(BesselBase):
         c, e = arg.as_coeff_exponent(x)
 
         if e.is_positive:
-            term_one = ((2/pi)*log(z/2)*besselj(nu, z))
-            term_two = -(z/2)**(-nu)*factorial(nu - 1)/pi if (nu).is_positive else S.Zero
-            term_three = -(z/2)**nu/(pi*factorial(nu))*(digamma(nu + 1) - S.EulerGamma)
-            arg = Add(*[term_one, term_two, term_three]).as_leading_term(x, logx=logx)
-            return arg
+            # Refer https://functions.wolfram.com/Bessel-TypeFunctions/BesselY/06/01/04/01/03/
+            if nu.is_zero:
+                term = 2*(log(z/2) + S.EulerGamma)/pi
+            elif nu.is_nonzero:
+                term = -gamma(Abs(nu))*(z/2)**(-Abs(nu))/pi
+            else:
+                raise NotImplementedError(f"Cannot proceed without knowing if {nu} is zero or not.")
+
+            return term.as_leading_term(x, logx=logx)
         elif e.is_negative:
             cdir = 1 if cdir == 0 else cdir
             sign = c*cdir**e
             if not sign.is_negative:
                 # Refer Abramowitz and Stegun 1965, p. 364 for more information on
                 # asymptotic approximation of bessely function.
-                return sqrt(2)*(-sin(pi*nu/2 - z + pi/4) + 3*cos(pi*nu/2 - z + pi/4)/(8*z))*sqrt(1/z)/sqrt(pi)
+               return sqrt(2)*(-sin(pi*nu/2 - z + pi/4) + 3*cos(pi*nu/2 - z + pi/4)/(8*z))*sqrt(1/z)/sqrt(pi)
             return self
 
         return super(bessely, self)._eval_as_leading_term(x, logx=logx, cdir=cdir)
@@ -398,42 +401,53 @@ class bessely(BesselBase):
         except (ValueError, NotImplementedError):
             return self
 
-        if exp.is_positive and nu.is_integer:
-            newn = ceiling(n/exp)
-            bn = besselj(nu, z)
-            a = ((2/pi)*log(z/2)*bn)._eval_nseries(x, n, logx, cdir)
-
-            b, c = [], []
-            o = Order(x**n, x)
+        if exp.is_positive:
             r = (z/2)._eval_nseries(x, n, logx, cdir).removeO()
             if r is S.Zero:
-                return o
-            t = (_mexpand(r**2) + o).removeO()
+                return Order(z**(-nu) + z**nu, x)
 
-            if nu > S.Zero:
-                term = r**(-nu)*factorial(nu - 1)/pi
-                b.append(term)
-                for k in range(1, nu):
-                    denom = (nu - k)*k
-                    if denom == S.Zero:
-                        term *= t/k
-                    else:
-                        term *= t/denom
-                    term = (_mexpand(term) + o).removeO()
+            o = Order(x**n, x)
+            if nu.is_integer:
+                # Reference: https://functions.wolfram.com/Bessel-TypeFunctions/BesselY/06/01/04/01/02/0008/ (only for integer order)
+                newn = ceiling(n/exp)
+                bn = besselj(nu, z)
+                a = ((2/pi)*log(z/2)*bn)._eval_nseries(x, n, logx, cdir)
+                b, c = [], []
+                t = (_mexpand(r**2) + o).removeO()
+
+                if nu > S.Zero:
+                    term = r**(-nu)*factorial(nu - 1)/pi
                     b.append(term)
+                    for k in range(1, nu):
+                        denom = (nu - k)*k
+                        if denom == S.Zero:
+                            term *= t/k
+                        else:
+                            term *= t/denom
+                        term = (_mexpand(term) + o).removeO()
+                        b.append(term)
 
-            p = r**nu/(pi*factorial(nu))
-            term = p*(digamma(nu + 1) - S.EulerGamma)
-            c.append(term)
-            for k in range(1, (newn + 1)//2):
-                p *= -t/(k*(k + nu))
-                p = (_mexpand(p) + o).removeO()
-                term = p*(digamma(k + nu + 1) + digamma(k + 1))
+                p = r**nu/(pi*factorial(nu))
+                term = p*(digamma(nu + 1) - S.EulerGamma)
                 c.append(term)
-            return a - Add(*b) - Add(*c) # Order term comes from a
+                for k in range(1, (newn + 1)//2):
+                    p *= -t/(k*(k + nu))
+                    p = (_mexpand(p) + o).removeO()
+                    term = p*(digamma(k + nu + 1) + digamma(k + 1))
+                    c.append(term)
+                return a - Add(*b) - Add(*c)  # Order term comes from a
+            else:
+                # Reference - https://functions.wolfram.com/Bessel-TypeFunctions/BesselY/06/01/04/01/01/0003/
+                newn_a = ceiling((n + nu)/exp)
+                newn_b = ceiling((n - nu)/exp)
+
+                a = [_mexpand(-gamma(nu)*(-1)**k*r**(2*k - nu)/(pi*RisingFactorial(1 - nu, k)*\
+                    factorial(k))) for k in range((newn_a + 1)//2)]
+                b = [_mexpand(-gamma(-nu)*cos(nu*pi)*(-1)**k*r**(2*k + nu)/(pi*RisingFactorial(nu + 1, k)*\
+                    factorial(k))) for k in range((newn_b + 1)//2)]
+                return Add(*a) + Add(*b) + o
 
         return super(bessely, self)._eval_nseries(x, n, logx, cdir)
-
 
 class besseli(BesselBase):
     r"""

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -57,6 +57,7 @@ def test_bessely_leading_term():
     assert bessely(0, x).as_leading_term(x) == (2*log(x) - 2*log(2) + 2*S.EulerGamma)/pi
     assert bessely(1, sin(x)).as_leading_term(x) == -2/(pi*x)
     assert bessely(1, 2*sqrt(x)).as_leading_term(x) == -1/(pi*sqrt(x))
+    assert bessely(S(5)/3, x).as_leading_term(x) == -2*2**(S(2)/3)*gamma(S(5)/3)/(pi*x**(S(5)/3))
 
 
 def test_besseli_leading_term():
@@ -124,6 +125,17 @@ def test_bessely_series():
         (S(5)/2 - 2*S.EulerGamma)/(2*pi)) + x**(S(5)/2)*(log(x)/(12*pi) - \
         (S(10)/3 - 2*S.EulerGamma)/(12*pi)) + O(x**3*log(x))
     assert bessely(-2, sin(x)).series(x, n=4) == bessely(2, sin(x)).series(x, n=4)
+    assert bessely(2, x**2).series(x, n=2) == -4/(pi*x**4) + O(x**2)
+
+
+def test_bessely_frac_order_series():
+    assert bessely(S(1)/2, x).series(x, n=2) == -sqrt(2)/(sqrt(pi)*sqrt(x)) + sqrt(2)*x**(S(3)/2)/\
+        (2*sqrt(pi)) + O(x**2)
+    assert bessely(S(5)/3, x).series(x, n=2) == -2*2**(S(2)/3)*gamma(S(5)/3)/(pi*x**(S(5)/3)) - 3*2**(S(2)/3)*x**(S(1)/3)\
+        *gamma(S(5)/3)/(4*pi) - 2**(S(1)/3)*x**(S(5)/3)*gamma(-S(5)/3)/(8*pi) + O(x**2)
+    assert bessely(S(1)/2, sqrt(x)).series(x, n=2) == -sqrt(2)/(sqrt(pi)*x**(S(1)/4)) + sqrt(2)*x**(S(3)/4)/\
+        (2*sqrt(pi)) - sqrt(2)*x**(S(7)/4)/(24*sqrt(pi)) + O(x**2)
+    assert bessely(S(1)/2, x**2).series(x, n=2) == -sqrt(2)/(sqrt(pi)*x) + O(x**2)
 
 
 def test_besseli_series():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -58,6 +58,10 @@ def test_bessely_leading_term():
     assert bessely(1, sin(x)).as_leading_term(x) == -2/(pi*x)
     assert bessely(1, 2*sqrt(x)).as_leading_term(x) == -1/(pi*sqrt(x))
     assert bessely(S(5)/3, x).as_leading_term(x) == -2*2**(S(2)/3)*gamma(S(5)/3)/(pi*x**(S(5)/3))
+    assert bessely(1,cos(x)).as_leading_term(x) == bessely(1,1)
+    assert bessely(3,1/x).as_leading_term(x) == sqrt(2)*sqrt(x)*(3*x*sin(pi/4 - 1/x)/8 + cos(pi/4 - 1/x))/sqrt(pi)
+    assert bessely(3,1/sin(x)).as_leading_term(x) == sqrt(2)*(3*sin(x)*sin(pi/4 - 1/sin(x))/8 + \
+            cos(pi/4 - 1/sin(x)))*sqrt(sin(x))/sqrt(pi)
 
 
 def test_besseli_leading_term():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -58,9 +58,9 @@ def test_bessely_leading_term():
     assert bessely(1, sin(x)).as_leading_term(x) == -2/(pi*x)
     assert bessely(1, 2*sqrt(x)).as_leading_term(x) == -1/(pi*sqrt(x))
     assert bessely(S(5)/3, x).as_leading_term(x) == -2*2**(S(2)/3)*gamma(S(5)/3)/(pi*x**(S(5)/3))
-    assert bessely(1,cos(x)).as_leading_term(x) == bessely(1,1)
-    assert bessely(3,1/x).as_leading_term(x) == sqrt(2)*sqrt(x)*(3*x*sin(pi/4 - 1/x)/8 + cos(pi/4 - 1/x))/sqrt(pi)
-    assert bessely(3,1/sin(x)).as_leading_term(x) == sqrt(2)*(3*sin(x)*sin(pi/4 - 1/sin(x))/8 + \
+    assert bessely(1, cos(x)).as_leading_term(x) == bessely(1, 1)
+    assert bessely(3, 1/x).as_leading_term(x) == sqrt(2)*sqrt(x)*(3*x*sin(pi/4 - 1/x)/8 + cos(pi/4 - 1/x))/sqrt(pi)
+    assert bessely(3, 1/sin(x)).as_leading_term(x) == sqrt(2)*(3*sin(x)*sin(pi/4 - 1/sin(x))/8 + \
             cos(pi/4 - 1/sin(x)))*sqrt(sin(x))/sqrt(pi)
 
 
@@ -129,7 +129,8 @@ def test_bessely_series():
         (S(5)/2 - 2*S.EulerGamma)/(2*pi)) + x**(S(5)/2)*(log(x)/(12*pi) - \
         (S(10)/3 - 2*S.EulerGamma)/(12*pi)) + O(x**3*log(x))
     assert bessely(-2, sin(x)).series(x, n=4) == bessely(2, sin(x)).series(x, n=4)
-    assert bessely(2, x**2).series(x, n=2) == -4/(pi*x**4) + O(x**2)
+    assert bessely(2, x**2).series(x) == -4/(pi*x**4) - 1/pi + x**4*(log(x)/(2*pi) - log(2)/(4*pi) - \
+        (S(3)/2 - 2*S.EulerGamma)/(8*pi)) + O(x**6*log(x))
 
 
 def test_bessely_frac_order_series():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #25840 
#### Brief description of what is fixed or changed


#### Other comments
continues #25664 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Implemented bessely series expansion for non-integer order


<!-- END RELEASE NOTES -->
