### PR TITLE
Avoid recursion with `nextprime`

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -437,12 +437,8 @@ def prime(nth):
             b = mid
         else:
             a = mid + 1
-    n_primes = _primepi(a - 1)
-    while n_primes < n:
-        if isprime(a):
-            n_primes += 1
-        a += 1
-    return a - 1
+    return nextprime(a - 1, n - _primepi(a - 1))
+
 
 @deprecated("""\
 The `sympy.ntheory.generate.primepi` has been moved to `sympy.functions.combinatorial.numbers.primepi`.""",
@@ -685,30 +681,35 @@ def nextprime(n, ith=1):
         l, _ = sieve.search(n)
         if l + i - 1 < len(sieve._list):
             return sieve._list[l + i - 1]
-        return nextprime(sieve._list[-1], l + i - len(sieve._list))
-    if 1 < i:
-        for _ in range(i):
-            n = nextprime(n)
-        return n
+        n = sieve._list[-1]
+        i += l - len(sieve._list)
     nn = 6*(n//6)
     if nn == n:
         n += 1
         if isprime(n):
-            return n
+            i -= 1
+            if not i:
+                return n
         n += 4
     elif n - nn == 5:
         n += 2
         if isprime(n):
-            return n
+            i -= 1
+            if not i:
+                return n
         n += 4
     else:
         n = nn + 5
     while 1:
         if isprime(n):
-            return n
+            i -= 1
+            if not i:
+                return n
         n += 2
         if isprime(n):
-            return n
+            i -= 1
+            if not i:
+                return n
         n += 4
 
 


### PR DESCRIPTION
When `ith` is greater than 1, I stopped calling `nextprime` recursively. `prime` calls `nextprime` internally.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
This is a PR stemming from #27034, but it does not fundamentally resolve the issue.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
