### PR TITLE
Added a setting 'dps' in StrPrinter to control decimal places of floats

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -27,6 +27,7 @@ class StrPrinter(Printer):
         "perm_cyclic": True,
         "min": None,
         "max": None,
+        "dps" : None
     }
 
     _relationals: dict[str, str] = {}
@@ -736,10 +737,13 @@ class StrPrinter(Printer):
 
     def _print_Float(self, expr):
         prec = expr._prec
-        if prec < 5:
-            dps = 0
+        if self._settings['dps'] :
+            dps = self._settings['dps'] 
         else:
-            dps = prec_to_dps(expr._prec)
+            if prec < 5:
+                dps = 0
+            else:
+                dps = prec_to_dps(expr._prec)
         if self._settings["full_prec"] is True:
             strip = False
         elif self._settings["full_prec"] is False:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #27033

#### Brief description of what is fixed or changed
Added a {"dps" : None} pair in _default_settings in StrPrinter and accordingly made some change in the _print_Float method . 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* str
  * Added a {"dps" : None} in _default_settings in StrPrinter class. 
  * Added an if condition in _print_Float method. 
<!-- END RELEASE NOTES -->
