### PR TITLE
Add support for pickling FreeGroup

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -296,6 +296,7 @@ Aman Thakur <thakuraman22july@gmail.com> Aman Thakur <54764701+jhonsnow456@users
 Aman Thakur <thakuraman22july@gmail.com> jhonsnow456 <thakuraman22july@gmail.com>
 Amanda Dsouza <meezamanda@yahoo.com>
 Ambar Mehrotra <mehrotraambar@gmail.com>
+Amir Ebrahimi <github@aebrahimi.com>
 Amit Jamadagni <bitsjamadagni@gmail.com>
 Amit Kumar <dtu.amit@gmail.com>
 Amit Kumar <dtu.amit@gmail.com> <aktech@users.noreply.github.com>

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -161,6 +161,10 @@ class FreeGroup(DefaultPrinting):
 
         return obj
 
+    def __getnewargs__(self):
+        """Return a tuple of arguments that must be passed to __new__ in order to support pickling this object."""
+        return (self.symbols,)
+
     def _generators(group):
         """Returns the generators of the FreeGroup.
 

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -165,6 +165,10 @@ class FreeGroup(DefaultPrinting):
         """Return a tuple of arguments that must be passed to __new__ in order to support pickling this object."""
         return (self.symbols,)
 
+    def __getstate__(self):
+        # Don't pickle any fields because they are regenerated within __new__
+        return None
+
     def _generators(group):
         """Returns the generators of the FreeGroup.
 

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -15,6 +15,11 @@ def test_FreeGroup__init__():
     assert len(FreeGroup((x, y, z)).generators) == 3
 
 
+def test_FreeGroup__getnewargs__():
+    x, y, z = map(Symbol, "xyz")
+    assert FreeGroup("x, y, z").__getnewargs__() == ((x, y, z),)
+
+
 def test_free_group():
     G, a, b, c = free_group("a, b, c")
     assert F.generators == (x, y, z)

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -204,6 +204,11 @@ def test_Singletons():
         for func in copiers:
             assert func(obj) is obj
 
+#================== combinatorics ===================
+from sympy.combinatorics.free_groups import FreeGroup
+
+def test_free_group():
+    check(FreeGroup("x, y, z"), check_attr=False)
 
 #================== functions ===================
 from sympy.functions import (Piecewise, lowergamma, acosh, chebyshevu,


### PR DESCRIPTION
#### Brief description of what is fixed or changed
We use [ray,io](https://www.ray.io/), which uses `pickle` to transfer objects to task executors. Unfortunately, the `FreeGroup` class isn't pickleable because it is lacking the [__getnewargs__](https://docs.python.org/2/library/pickle.html#object.__getnewargs__) method that is used for protocol 2. This PR adds the method and an additional test.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Add pickle support to FreeGroup.
<!-- END RELEASE NOTES -->
