### PR TITLE
0*(x+zoo) not 0

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -377,6 +377,10 @@ class Mul(Expr, AssocOp):
                 coeff = S.ComplexInfinity
                 continue
 
+            elif not coeff and isinstance(o, Add) and o.has(S.ComplexInfinity):
+                # 0 * (x + zoo) = NaN
+                return [S.NaN], [], None
+
             elif o is S.ImaginaryUnit:
                 neg1e += S.Half
                 continue

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2355,6 +2355,11 @@ def test_Mul_does_not_distribute_infinity():
     assert ((1 - I)*z).expand() is oo
 
 
+def test_Mul_does_not_let_0_trump_zoo():
+    assert Mul(*[0, a + zoo]) is S.NaN
+    Mul(*[0,zoo+x])
+
+
 def test_issue_8247_8354():
     from sympy.functions.elementary.trigonometric import tan
     z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2357,7 +2357,6 @@ def test_Mul_does_not_distribute_infinity():
 
 def test_Mul_does_not_let_0_trump_zoo():
     assert Mul(*[0, a + zoo]) is S.NaN
-    Mul(*[0,zoo+x])
 
 
 def test_issue_8247_8354():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * 0*f(zoo) is no longer 0 (it is nan)
<!-- END RELEASE NOTES -->
