### PR TITLE
remove redundant solutions

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1772,7 +1772,8 @@ def _remove_duplicate_solutions(solutions: list[dict[Expr, Expr]]
     return solutions_new
 
 
-def _remove_redundant_solutions(s):
+def _remove_redundant_solutions(s: list[dict[Expr, Expr]]
+                                ) -> list[dict[Expr, Expr]]:
     "remove dict solutions that are implied by another"""
     if len(s) < 2:
         return s[:]
@@ -1785,7 +1786,7 @@ def _remove_redundant_solutions(s):
         # return free symbols of a dictionary (keys and values)
         return set(d)|set().union(*[v.free_symbols for v in d.values()])
 
-    rv = []
+    rv: list[dict[Expr, Expr]] = []
     for d in sorted(s, key=len):
         sd = set(d.items())
         skd = set(d)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1458,19 +1458,19 @@ def test_issue_4463():
     assert solve(x**x - 2) == [exp(LambertW(log(2)))]
     assert solve(((x - 3)*(x - 2))**((x - 3)*(x - 4))) == [2]
 
-@slow
+
 def test_issue_5114_solvers():
-    a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r = symbols('a:r')
+    a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w = symbols('a:w')
 
     # there is no 'a' in the equation set but this is how the
     # problem was originally posed
     syms = a, b, c, f, h, k, n
-    eqs = [b + r/d - c/d,
-    c*(1/d + 1/e + 1/g) - f/g - r/d,
-        f*(1/g + 1/i + 1/j) - c/g - h/i,
-        h*(1/i + 1/l + 1/m) - f/i - k/m,
-        k*(1/m + 1/o + 1/p) - h/m - n/p,
-        n*(1/p + 1/q) - k/p]
+    # the structure is the same as the original issue, but expressions
+    # involving constant sums have been replaced with a single constant
+    # since the issue was with the structure of the problem, not the symbols;
+    # the extra symbols add significant time to obtaining a solution
+    eqs = [b + c*d + e, c*g + i*f + j, c*l + m*f + o*h,
+           p*h + q*f + r*k, s*k + t*h + u*n, v*n + w*k]
     assert len(solve(eqs, syms, manual=True, check=False, simplify=False)) == 1
 
 
@@ -2576,8 +2576,8 @@ def test_issue_27001():
         8*a2*a3**2 + 2*a2*a4**2 + 8*a2*a5, 12*a1**4 + 6*a1**2*a2**2 -
         8*a1**2*a4 + 3*a2**4/4 - 2*a2**2*a4 + 4*a3**2 + a4**2 + 4*a5, 16*a1**3
         + 4*a1*a2**2 - 8*a1*a4, -8*a1**2*a2 - 2*a2**3 + 4*a2*a4]
-    sol = [{a4: 2*a1**2 + a2**2/2, a5: -a3**2}, {a1: 0, a2: 0, a5: -a3**2 - a4**2/4}]
-    assert solve(eqs, s, dict=True) == sol
+    sol = [{a4: 2*a1**2 + a2**2/2, a5: -a3**2}]
+    assert (got:=solve(eqs, s, dict=True)) == sol, (got,sol)
     assert (g:=solve(groebner(eqs, s), dict=True)) == sol, g
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Sometimes solutions which are not duplicates are, nonetheless, redundant. The modified test shows such an example:
```
[{a4: 2*a1**2 + a2**2/2, a5: -a3**2}, {a1: 0, a2: 0, a5: -a3**2 - a4**2/4}]
```
The second solution is a particular example which, when substituted into the first gives `{a4:0, a5: -a3**2}` which agrees with the second solution. So the second solution is redundant.

This PR provides a function which removes that second case.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * improved removal of redundant solutions returned when solving systems of equations
<!-- END RELEASE NOTES -->
