### PR TITLE
Fix repeated words in docstring.rst documentation file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1410,6 +1410,7 @@ Stephen Loo <shikil@yahoo.com>
 Steve Anton <anxuiz.nx@gmail.com>
 Steve Kieffer <sk@skieffer.info>
 Steven Burns <royalstream@hotmail.com>
+Steven Esquea <steven.esquea@irreverente.net>
 Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
 Stewart Wadsworth <stewart.wadsworth@gmail.com>
 Subhash Saurabh <subhashsaurabh419@gmail.com>

--- a/doc/src/contributing/docstring.rst
+++ b/doc/src/contributing/docstring.rst
@@ -93,7 +93,7 @@ the end of this guide.
 Formatting
 -------------
 
-Docstrings are are written in `reStructuredText
+Docstrings are written in `reStructuredText
 <https://docutils.sourceforge.io/rst.html>`_ format extended by `Sphinx
 <https://www.sphinx-doc.org/en/master/>`_. Here is a concise guide to `Quick
 reStructuredText <https://docutils.sourceforge.io/docs/user/rst/quickref.html>`_. More in-depth
@@ -742,7 +742,7 @@ Here are some troubleshooting tips to fix the errors:
   names that are specific to the text at hand. In general, if the object cannot
   be accessed as ``sympy.something.something.object``, it cannot be
   cross-referenced and you should not use the ``:obj:`` syntax.
-* If you are using are using one of the `type specific
+* If you are using one of the `type specific
   <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects>`_
   identifiers like ``:func:``, be sure that the type for it is correct.
   ``:func:`` only refers to Python functions. For classes, you need to use


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Corrected the repeated word "are are" to "are" in the Formatting section
of the docstring.rst file.

Also fixed the repeated words "are using are using" to "are using" in
the Cross-Referencing section of the same file.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
