### PR TITLE
Fix bug in TensAdd.contract_delta

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2666,7 +2666,7 @@ class TensAdd(TensExpr, AssocOp):
             return self.data[item]
 
     def contract_delta(self, delta):
-        args = [contract_delta(x, delta) for x in self.args]
+        args = [x.contract_delta(delta) if isinstance(x, TensExpr) else x for x in self.args]
         t = TensAdd(*args).doit(deep=False)
         return canon_bp(t)
 
@@ -5234,12 +5234,6 @@ def contract_metric(t, g):
     if isinstance(t, TensExpr):
         return t.contract_metric(g)
     return t
-
-def contract_delta(t, delta):
-    if isinstance(t, TensExpr):
-        return t.contract_delta(delta)
-    else:
-        return t
 
 def perm2tensor(t, g, is_canon_bp=False):
     """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2666,7 +2666,7 @@ class TensAdd(TensExpr, AssocOp):
             return self.data[item]
 
     def contract_delta(self, delta):
-        args = [x.contract_delta(delta) for x in self.args]
+        args = [contract_delta(x, delta) for x in self.args]
         t = TensAdd(*args).doit(deep=False)
         return canon_bp(t)
 
@@ -5235,6 +5235,11 @@ def contract_metric(t, g):
         return t.contract_metric(g)
     return t
 
+def contract_delta(t, delta):
+    if isinstance(t, TensExpr):
+        return t.contract_delta(delta)
+    else:
+        return t
 
 def perm2tensor(t, g, is_canon_bp=False):
     """

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1096,6 +1096,16 @@ def test_contract_delta1():
     t1 = t.contract_delta(delta)
     assert t1.equals(n**2 - 1)
 
+def test_contract_delta2():
+    R3 = TensorIndexType('R3', dim=3)
+    p, q = tensor_indices("p q", R3)
+    delta = R3.delta
+    K = TensorHead("K", [R3])
+
+    #Check if TensAdd.contract_delta can handle the case when the TensAdd has non-TensExpr args.
+    expr = 1 + K(p)*K(q)*delta(-p,-q)
+    assert expr.contract_delta(delta) == 1 + K(p)*K(-p)
+
 def test_fun():
     with warns_deprecated_sympy():
         D = Symbol('D')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title.

#### References to other Issues or PRs -->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The current implementation of `TensAdd.contract_delta` assumes that a TensAdd cannot have non-TensExpr arguments. A counter-example is `1 + K(p)*K(q)*delta(-p,-q)`. This PR allows such expressions to be handled without raising an error.

#### Other comments
I have added a function `contract_delta` (sympy.tensor.tensor.contract_delta). The rationale is similar to that for the existing `contract_metric` function.

Suggested reviewers: @Upabjojr 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * `TensAdd.contract_delta` no longer raises an error for non-TensExpr arguments
  * A `contract_delta` function has been added that will call `contract_delta` only if the argument is a `TensExpr`
<!-- END RELEASE NOTES -->
