### PR TITLE
not all 0*f(oo) are 0

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -377,8 +377,12 @@ class Mul(Expr, AssocOp):
                 coeff = S.ComplexInfinity
                 continue
 
-            elif not coeff and isinstance(o, Add) and o.has(S.ComplexInfinity):
-                # 0 * (x + zoo) = NaN
+            elif not coeff and isinstance(o, Add) and any(
+                    _ in (S.NegativeInfinity, S.ComplexInfinity, S.Infinity)
+                    for __ in o.args for _ in Mul.make_args(__)):
+                # e.g 0 * (x + oo) = NaN but not
+                # 0 * (1 + Integral(x, (x, 0, oo))) which is
+                # treated like 0 * x -> 0
                 return [S.NaN], [], None
 
             elif o is S.ImaginaryUnit:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -14,6 +14,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import (Max, sqrt)
 from sympy.functions.elementary.trigonometric import (atan, cos, sin)
+from sympy.integrals.integrals import Integral
 from sympy.polys.polytools import Poly
 from sympy.sets.sets import FiniteSet
 
@@ -2355,8 +2356,12 @@ def test_Mul_does_not_distribute_infinity():
     assert ((1 - I)*z).expand() is oo
 
 
-def test_Mul_does_not_let_0_trump_zoo():
+def test_Mul_does_not_let_0_trump_inf():
     assert Mul(*[0, a + zoo]) is S.NaN
+    assert Mul(*[0, a + oo]) is S.NaN
+    assert Mul(*[0, a + Integral(1/x**2, (x, 1, oo))]) is S.Zero
+    # Integral is treated like an unknown like 0*x -> 0
+    assert Mul(*[0, a + Integral(x, (x, 1, oo))]) is S.Zero
 
 
 def test_issue_8247_8354():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
This is a follow-up to #27053, @haru-44 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
