### PR TITLE
Fixing `prime` comments

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -373,9 +373,6 @@ def prime(nth):
     Return the nth prime number, where primes are indexed starting from 1:
     prime(1) = 2, prime(2) = 3, etc.
 
-    This function efficiently computes the nth prime using a combination of
-    direct sieving for smaller values of n(< 1000) and approximation techniques for larger values.
-
     Parameters
     ==========
 
@@ -387,14 +384,6 @@ def prime(nth):
 
     int
         The nth prime number.
-
-    Notes
-    =====
-
-    For n < 1000, an empirical approximation is used by extending a sieve to
-    find the nth prime. For larger values, the logarithmic integral function
-    li(x) is utilized to estimate an upper bound for the nth prime, after which
-    a search is conducted to locate the prime.
 
     Examples
     ========
@@ -432,8 +421,7 @@ def prime(nth):
     from sympy.functions.elementary.exponential import log
     from sympy.functions.special.error_functions import li
 
-    # Use approximations for smaller values of n to avoid li computation
-    if n < 1000:  # Threshold for approximation can be adjusted
+    if n < 1000:
         # Extend sieve up to 8*n as this is empirically sufficient
         sieve.extend(8 * n)
         return sieve[n]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27051 

#### Brief description of what is fixed or changed
I removed the comment on `prime` because it did not accurately describe the operation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
