### PR TITLE
Fix Latex printing of logarithm with base

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -694,6 +694,7 @@ Himanshu <hs80941@gmail.com>
 Himanshu Ladia <hladia199811@gmail.com>
 Hiren Chalodiya <hirenchalodiya99@gmail.com>
 Hong Xu <hong@topbug.net>
+Hongyu Yang <brutusyhy@gmail.com>
 Hou-Rui <houruinus@gmail.com> Hou-Rui <13244639785@163.com>
 Huangduirong <huangduirong@huawei.com> Huangxiaodui <hdrong.42@163.com>
 Hubert Tsang <intsangity@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -368,7 +368,7 @@ class Expr(Basic, EvalfMixin):
         if not self.is_number:
             raise TypeError("Cannot truncate symbols and expressions")
         else:
-            return Integer(self)
+            return int(self)
 
     def __format__(self, format_spec: str):
         if self.is_number:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -368,7 +368,7 @@ class Expr(Basic, EvalfMixin):
         if not self.is_number:
             raise TypeError("Cannot truncate symbols and expressions")
         else:
-            return int(self)
+            return Integer(self)
 
     def __format__(self, format_spec: str):
         if self.is_number:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1076,7 +1076,12 @@ class LatexPrinter(Printer):
 
     def _print_log(self, expr, exp=None):
         if not self._settings["ln_notation"]:
-            tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
+            if len(expr.args) == 2:
+                argument = self._print(expr.args[0])
+                base = self._print(expr.args[1])
+                tex = r"\log_%s{\left(%s \right)}" % (base, argument)
+            else:
+                tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
         else:
             tex = r"\ln{\left(%s \right)}" % self._print(expr.args[0])
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1409,6 +1409,9 @@ def test_latex_log():
     assert latex(pow(log(x), x), ln_notation=True) == \
         r"\ln{\left(x \right)}^{x}"
 
+    # issue #26897
+    assert latex(log(x, y, evaluate=False)) == r"\log_y{\left(x \right)}"
+
 
 def test_issue_3568():
     beta = Symbol(r'\beta')


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Fixes #26897, previously `latex(log(x, y, evaluate=False))` will return `\\log{\\left(x \\right)}`, which discards the base. This fix ensures that if a base is provided, it will be included in the latex printing.

#### Other comments

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
  * Fix a bug where logarithm's base is not correctly printed in in Latex.
<!-- END RELEASE NOTES -->
