### PR TITLE
better handling of oo by solvers

### DIFF
--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -754,6 +754,8 @@ def test_solve_linear():
     eq = cos(x)**2 + sin(x)**2  # = 1
     assert solve_linear(eq) == (0, 1)
     raises(ValueError, lambda: solve_linear(Eq(x, 3), 3))
+    assert solve_linear((x + oo)*(y + oo)) == ((x + oo)*(y + oo), 1)
+    assert solve_linear(x*(y + oo)) == (x*(y + oo), 1)
 
 
 def test_solve_undetermined_coeffs():
@@ -1398,14 +1400,15 @@ def test_unrad1():
     assert unrad(eq) is None
 
 
-@slow
 def test_unrad_slow():
     # this has roots with multiplicity > 1; there should be no
     # repeats in roots obtained, however
     eq = (sqrt(1 + sqrt(1 - 4*x**2)) - x*(1 + sqrt(1 + 2*sqrt(1 - 4*x**2))))
-    assert solve(eq) == [S.Half]
+    got = solve(eq, simplify=False, check=False)
+    assert len(got) == len(set(got))
 
 
+@slow
 @XFAIL
 def test_unrad_fail():
     # this only works if we check real_root(eq.subs(x, Rational(1, 3)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #27062 by testing solutions obtained from factors of a Mul; although individual solutions are checked, their validity in the expression as a whole must still be tested


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve_linear` will no longer return `oo` as a solution
<!-- END RELEASE NOTES -->
