### PR TITLE
fix(matrices): Matrix([[], []]) -> Matrix(2, 0, [])

### DIFF
--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3895,8 +3895,14 @@ class MatrixBase(Printable):
                     if isinstance(dat, (list, tuple)):
                         dat = [make_explicit_row(row) for row in dat]
 
-                if dat in ([], [[]]):
+                if len(dat) == 0:
                     rows = cols = 0
+                    flat_list = []
+                elif all(raw(i) for i in dat) and len(dat[0]) == 0:
+                    if not all(len(i) == 0 for i in dat):
+                        raise ValueError('mismatched dimensions')
+                    rows = len(dat)
+                    cols = 0
                     flat_list = []
                 elif not any(raw(i) or ismat(i) for i in dat):
                     # a column as a list of values

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -749,7 +749,10 @@ def test_creation():
     with raises(IndexError):
         Matrix((1, 2))[3] = 5
 
-    assert Matrix() == Matrix([]) == Matrix([[]]) == Matrix(0, 0, [])
+    assert Matrix() == Matrix([]) == Matrix(0, 0, [])
+    assert Matrix([[]]) == Matrix(1, 0, [])
+    assert Matrix([[], []]) == Matrix(2, 0, [])
+
     # anything used to be allowed in a matrix
     with warns_deprecated_sympy():
         assert Matrix([[[1], (2,)]]).tolist() == [[[1], (2,)]]
@@ -2761,7 +2764,7 @@ def test_from_ndarray():
         lambda: Matrix(array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])))
     assert Matrix([array([1, 2]), array([3, 4])]) == Matrix([[1, 2], [3, 4]])
     assert Matrix([array([1, 2]), [3, 4]]) == Matrix([[1, 2], [3, 4]])
-    assert Matrix([array([]), array([])]) == Matrix([])
+    assert Matrix([array([]), array([])]) == Matrix(2, 0, []) != Matrix(0, 0, [])
 
 def test_17522_numpy():
     from sympy.matrices.common import _matrixify

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -1506,7 +1506,10 @@ def test_creation():
     with raises(IndexError):
         Matrix((1, 2))[3] = 5
 
-    assert Matrix() == Matrix([]) == Matrix([[]]) == Matrix(0, 0, [])
+    assert Matrix() == Matrix([]) == Matrix(0, 0, [])
+    assert Matrix([[]]) == Matrix(1, 0, [])
+    assert Matrix([[], []]) == Matrix(2, 0, [])
+
     # anything used to be allowed in a matrix
     with warns_deprecated_sympy():
         assert Matrix([[[1], (2,)]]).tolist() == [[[1], (2,)]]
@@ -3457,7 +3460,7 @@ def test_from_ndarray():
         lambda: Matrix(array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])))
     assert Matrix([array([1, 2]), array([3, 4])]) == Matrix([[1, 2], [3, 4]])
     assert Matrix([array([1, 2]), [3, 4]]) == Matrix([[1, 2], [3, 4]])
-    assert Matrix([array([]), array([])]) == Matrix([])
+    assert Matrix([array([]), array([])]) == Matrix(2, 0, []) != Matrix([])
 
 
 def test_17522_numpy():

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -85,7 +85,7 @@ def test_DiscreteMarkovChain():
     assert Y.number_of_states == ceiling((t-1)/2)
 
     # pass name and transition_probabilities
-    chains = [DiscreteMarkovChain("Y", trans_probs=Matrix([[]])),
+    chains = [DiscreteMarkovChain("Y", trans_probs=Matrix([])),
               DiscreteMarkovChain("Y", trans_probs=Matrix([[0, 1], [1, 0]])),
               DiscreteMarkovChain("Y", trans_probs=Matrix([[pi, 1-pi], [sym, 1-sym]]))]
     for Z in chains:
@@ -169,12 +169,12 @@ def test_DiscreteMarkovChain():
                                                             [Rational(-14, 75), Rational(1, 25), Rational(86, 75)]])
 
     # test for zero-sized matrix functionality
-    X = DiscreteMarkovChain('X', trans_probs=Matrix([[]]))
+    X = DiscreteMarkovChain('X', trans_probs=Matrix([]))
     assert X.number_of_states == 0
     assert X.stationary_distribution() == Matrix([[]])
     assert X.communication_classes() == []
-    assert X.canonical_form() == ([], Matrix([[]]))
-    assert X.decompose() == ([], Matrix([[]]), Matrix([[]]), Matrix([[]]))
+    assert X.canonical_form() == ([], Matrix([]))
+    assert X.decompose() == ([], Matrix([]), Matrix([]), Matrix([]))
     assert X.is_regular() == False
     assert X.is_ergodic() == False
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-27064

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * Handle matrices of zero columns correctly in the `Matrix` constructor. In SymPy 1.12 these produced empty matrices of the wrong shape and in 1.13 they resulted in an error. Now `Matrix([[], []]).shape == (2,0)`.
<!-- END RELEASE NOTES -->
