### PR TITLE
fix(quantum): sympify inputs to clebsch_gordan

### DIFF
--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -8,7 +8,7 @@ from sympy.functions.special.spherical_harmonics import Ynm
 from sympy.matrices.dense import Matrix
 from sympy.physics.wigner import (clebsch_gordan, wigner_9j, wigner_6j, gaunt,
         real_gaunt, racah, dot_rot_grad_Ynm, wigner_3j, wigner_d_small, wigner_d)
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, skip
 
 # for test cases, refer : https://en.wikipedia.org/wiki/Table_of_Clebsch%E2%80%93Gordan_coefficients
 
@@ -53,6 +53,14 @@ def test_clebsch_gordan():
     assert clebsch_gordan(p, h, n, p, 1, n) == 1
     assert clebsch_gordan(p, h, p, p, 0, p) == sqrt(5)/sqrt(7)
     assert clebsch_gordan(p, h, l, k, 1, l) == 1/sqrt(15)
+
+
+def test_clebsch_gordan_numpy():
+    try:
+        import numpy as np
+    except ImportError:
+        skip("numpy not installed")
+    assert clebsch_gordan(*np.zeros(6).astype(np.int64)) == 1
 
 
 def test_wigner():

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -323,9 +323,16 @@ def clebsch_gordan(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-    res = (-1) ** sympify(j_1 - j_2 + m_3) * sqrt(2 * j_3 + 1) * \
-        wigner_3j(j_1, j_2, j_3, m_1, m_2, -m_3)
-    return res
+    j_1 = sympify(j_1)
+    j_2 = sympify(j_2)
+    j_3 = sympify(j_3)
+    m_1 = sympify(m_1)
+    m_2 = sympify(m_2)
+    m_3 = sympify(m_3)
+
+    w = wigner_3j(j_1, j_2, j_3, m_1, m_2, -m_3)
+
+    return (-1) ** (j_1 - j_2 + m_3) * sqrt(2 * j_3 + 1) * w
 
 
 def _big_delta_coeff(aa, bb, cc, prec=None):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-27012

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
   * NumPy numbers can be used with `clebsch_gordan`. Fixes a regression introduced in SymPy 1.13.0.
<!-- END RELEASE NOTES -->
