### PR TITLE
26637: include wrt in free symbols

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -1,7 +1,7 @@
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
-from sympy.core.function import AppliedUndef, UndefinedFunction
+from sympy.core.function import AppliedUndef, UndefinedFunction, Derivative
 from sympy.core.mul import Mul
 from sympy.core.relational import Equality, Relational
 from sympy.core.singleton import S
@@ -61,7 +61,7 @@ def _common_new(cls, function, *symbols, discrete, **assumptions):
                 limits[i] = Tuple(*li[:-1])
     else:
         # symbol not provided -- we can still try to compute a general form
-        free = function.free_symbols
+        free = (function.expr if isinstance(function, Derivative) else function).free_symbols
         if len(free) != 1:
             raise ValueError(
                 "specify dummy variables for %s" % function)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1659,8 +1659,8 @@ class Derivative(Expr):
     def free_symbols(self):
         ret = self.expr.free_symbols
         # Add symbolic counts to free_symbols
-        for _, count in self.variable_count:
-            ret.update(count.free_symbols)
+        for v, count in self.variable_count:
+            ret.update(count.free_symbols|v.free_symbols)
         return ret
 
     @property

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1394,6 +1394,7 @@ def test_Derivative_free_symbols():
     f = Function('f')
     n = Symbol('n', integer=True, positive=True)
     assert diff(f(x), (x, n)).free_symbols == {n, x}
+    assert t in Derivative(f(x), t).free_symbols
 
 
 def test_issue_20683():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -61,7 +61,7 @@ def test_issue_5223():
     assert D(x**2 + x**3*y**2, x, 2, y, 1).series(x).doit() == 12*x*y
     assert next(D(cos(x), x).lseries()) == D(1, x)
     assert D(
-        exp(x), x).series(n=3) == D(1, x) + D(x, x) + D(x**2/2, x) + D(x**3/6, x) + O(x**3)
+        exp(x), x).series(n=3) == D(x, x) + D(x**2/2, x) + D(x**3/6, x) + O(x**3)
 
     assert Integral(x, (x, 1, 3), (y, 1, x)).series(x) == -4 + 4*x
 
@@ -106,10 +106,7 @@ def test_issue_11313():
     assert Derivative(x**3, y).as_leading_term(x) == 0
     assert Derivative(sin(x), x).as_leading_term(x) == 1
     assert Derivative(cos(x), x).as_leading_term(x) == -x
-
-    # This result is equivalent to zero, zero is not return because
-    # `Expr.series` doesn't currently detect an `x` in its `free_symbol`s.
-    assert Derivative(1, x).as_leading_term(x) == Derivative(1, x)
+    assert Derivative(1, x).as_leading_term(x) == 0
 
     assert Derivative(exp(x), x).series(x).doit() == exp(x).series(x)
     assert 1 + Integral(exp(x), x).series(x) == exp(x).series(x)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -337,7 +337,7 @@ def _free_symbols(eq):
     >>> Derivative(1, x).free_symbols
     {x}
     >>> _free_symbols(Derivative(1, x))
-    {}
+    set()
     >>> _free_symbols([y + Derivative(1, x)])
     {y}
     """

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -341,7 +341,7 @@ def _free_symbols(eq):
     >>> _free_symbols([y + Derivative(1, x)])
     {y}
     """
-    if type(eq) is not list:
+    if not hasattr(eq, 'free_symbols'):
         eq = [eq]
     derivs = {}
     for eq in eq:

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -341,7 +341,7 @@ def _free_symbols(eq):
     >>> _free_symbols([y + Derivative(1, x)])
     {y}
     """
-    if not hasattr(eq, 'free_symbols'):
+    if hasattr(eq, 'free_symbols'):  # else it must be iterable
         eq = [eq]
     derivs = {}
     for eq in eq:

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -149,9 +149,10 @@ class SingleODEProblem:
 
     @cached_property
     def is_autonomous(self):
+        from sympy.solvers.ode.ode import _free_symbols
         u = Dummy('u')
         x = self.sym
-        syms = self.eq.subs(self.func, u).free_symbols
+        syms = _free_symbols(self.eq.subs(self.func, u))
         return x not in syms
 
     def get_linear_coefficients(self, eq, func, order):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #26637


#### Brief description of what is fixed or changed

`Derivative(y, x).free_symbols` is now `{x, y}` instead of `{y}`.

#### Other comments

To get the old behavior, the function `sympy.solvers.ode.ode._free_symbols` can be used.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * variables of differentiation are now included in free symbols so Derivative(y, x).free_symbols is {y, x}, not {y}
<!-- END RELEASE NOTES -->
