### PR TITLE
Flush NamedTemporaryFile before reading

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -716,6 +716,7 @@ Islam Mansour <is3mansour@gmail.com>
 Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
 Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>
 Itay4 <31018228+Itay4@users.noreply.github.com>
+Ivan A. Melnikov <iv@altlinux.org>
 Ivan Petuhov <ivan@ostrovok.ru>
 Ivan Petukhov <satels@gmail.com>
 Ivan Tkachenko <me@ratijas.tk> ivan tkachenko <ratijas@users.noreply.github.com>

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -180,6 +180,7 @@ if cin:
             """
             file = tempfile.NamedTemporaryFile(mode = 'w+', suffix = '.cpp')
             file.write(source)
+            file.flush()
             file.seek(0)
             self.tu = self.index.parse(
                 file.name,

--- a/sympy/parsing/tests/test_custom_latex.py
+++ b/sympy/parsing/tests/test_custom_latex.py
@@ -30,6 +30,7 @@ def init_custom_parser(modification, transformer=None):
 
     with tempfile.NamedTemporaryFile() as f:
         f.write(bytes(latex_grammar, encoding="utf8"))
+        f.flush()
 
         parser = LarkLaTeXParser(grammar_file=f.name, transformer=transformer)
 


### PR DESCRIPTION
We have to flush the file to make sure that wirte is complete before we re-open it and read from it. Otherwise, we are not guaranteed to read the data back. This can lead to test failures on certain systems.

Such failure  was 100% reproducible on my loongarch64 system on tmpfs:

```
=========================== short test summary info ============================
FAILED sympy/parsing/tests/test_custom_latex.py::test_custom1 - lark.exceptions.GrammarError: Using an undefined rule: NonTerminal('latex_string')
FAILED sympy/parsing/tests/test_custom_latex.py::test_custom2 - lark.exceptions.GrammarError: Using an undefined rule: NonTerminal('latex_string')
= 2 failed, 12502 passed, 442 skipped, 197 deselected, 329 xfailed, 4 xpassed in 3006.46s (0:50:06) =
```

This PR fixes that for me.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
