### PR TITLE
Refactor all function arguments with mutable defaults

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -267,7 +267,10 @@ class FindInSphinx(HTMLParser):
         if tag == "div" and a.get('class', None) == "viewcode-block":
             self.is_imported.append(a['id'])
 
-def find_sphinx(name, mod_path, found={}):
+def find_sphinx(name, mod_path, found=None):
+    if found is None:
+        found = {}
+
     if mod_path in found: # Cache results
         return name in found[mod_path]
 

--- a/bin/sympy_time.py
+++ b/bin/sympy_time.py
@@ -12,7 +12,13 @@ parent = None
 children = {}
 
 
-def new_import(name, globals={}, locals={}, fromlist=[]):
+def new_import(name, globals=None, locals=None, fromlist=None):
+    if globals is None:
+        globals = {}
+    if locals is None:
+        locals = {}
+    if fromlist is None:
+        fromlist = []
     global level, parent
     if name in seen:
         return old_import(name, globals, locals, fromlist)

--- a/bin/sympy_time_cache.py
+++ b/bin/sympy_time_cache.py
@@ -94,7 +94,13 @@ pp = TreeNode(None)  # We have to use pp since there is a sage function
 seen = set()
 
 
-def new_import(name, globals={}, locals={}, fromlist=[]):
+def new_import(name, globals=None, locals=None, fromlist=None):
+    if globals is None:
+        globals = {}
+    if locals is None:
+        locals = {}
+    if fromlist is None:
+        fromlist = []
     global pp
     if name in seen:
         return old_import(name, globals, locals, fromlist)

--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -10,7 +10,10 @@ from docscrape import NumpyDocString, FunctionDoc, ClassDoc
 
 
 class SphinxDocString(NumpyDocString):
-    def __init__(self, docstring, config={}):
+    def __init__(self, docstring, config=None):
+        if config is None:
+            config = {}
+
         NumpyDocString.__init__(self, docstring, config=config)
         self.load_config(config)
 
@@ -243,25 +246,37 @@ class SphinxDocString(NumpyDocString):
 
 
 class SphinxFunctionDoc(SphinxDocString, FunctionDoc):
-    def __init__(self, obj, doc=None, config={}):
+    def __init__(self, obj, doc=None, config=None):
+        if config is None:
+            config = {}
+
         self.load_config(config)
         FunctionDoc.__init__(self, obj, doc=doc, config=config)
 
 
 class SphinxClassDoc(SphinxDocString, ClassDoc):
-    def __init__(self, obj, doc=None, func_doc=None, config={}):
+    def __init__(self, obj, doc=None, func_doc=None, config=None):
+        if config is None:
+            config = {}
+
         self.load_config(config)
         ClassDoc.__init__(self, obj, doc=doc, func_doc=None, config=config)
 
 
 class SphinxObjDoc(SphinxDocString):
-    def __init__(self, obj, doc=None, config={}):
+    def __init__(self, obj, doc=None, config=None):
+        if config is None:
+            config = {}
+
         self._f = obj
         self.load_config(config)
         SphinxDocString.__init__(self, doc, config=config)
 
 
-def get_doc_object(obj, what=None, doc=None, config={}):
+def get_doc_object(obj, what=None, doc=None, config=None):
+    if config is None:
+        config = {}
+
     if inspect.isclass(obj):
         what = 'class'
     elif inspect.ismodule(obj):

--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -457,7 +457,7 @@ def _strip(g, base, orbits, transversals):
     return _af_new(h), base_len + 1
 
 
-def _strip_af(h, base, orbits, transversals, j, slp=[], slps={}):
+def _strip_af(h, base, orbits, transversals, j, slp=None, slps=None):
     """
     optimized _strip, with h, transversals and result in array form
     if the stripped elements is the identity, it returns False, base_len + 1
@@ -465,6 +465,10 @@ def _strip_af(h, base, orbits, transversals, j, slp=[], slps={}):
     j    h[base[i]] == base[i] for i <= j
 
     """
+    if slp is None:
+        slp = []
+    if slps is None:
+        slps = {}
     base_len = len(base)
     for i in range(j+1, base_len):
         beta = h[base[i]]

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -160,7 +160,7 @@ class preorder_traversal:
         return self
 
 
-def use(expr, func, level=0, args=(), kwargs={}):
+def use(expr, func, level=0, args=(), kwargs=None):
     """
     Use ``func`` to transform ``expr`` at the given level.
 
@@ -178,6 +178,9 @@ def use(expr, func, level=0, args=(), kwargs={}):
     x**3 + 2*x**2*y + x*y**2 + 1
 
     """
+    if kwargs is None:
+        kwargs = {}
+
     def _use(expr, level):
         if not level:
             return func(expr, *args, **kwargs)

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -270,7 +270,9 @@ class CoordSystem(Basic):
     .. [1] https://en.wikipedia.org/wiki/Coordinate_system
 
     """
-    def __new__(cls, name, patch, symbols=None, relations={}, **kwargs):
+    def __new__(cls, name, patch, symbols=None, relations=None, **kwargs):
+        if relations is None:
+            relations = {}
         if not isinstance(name, Str):
             name = Str(name)
 

--- a/sympy/holonomic/recurrence.py
+++ b/sympy/holonomic/recurrence.py
@@ -305,7 +305,9 @@ class HolonomicSequence:
     is Holonomic if and only if its generating function is a Holonomic Function.
     """
 
-    def __init__(self, recurrence, u0=[]):
+    def __init__(self, recurrence, u0=None):
+        if u0 is None:
+            u0 = []
         self.recurrence = recurrence
         if not isinstance(u0, list):
             self.u0 = [u0]

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -229,8 +229,10 @@ def enable_automatic_symbols(shell):
     shell.set_custom_exc((NameError,), _handler)
 
 
-def init_ipython_session(shell=None, argv=[], auto_symbols=False, auto_int_to_Integer=False):
+def init_ipython_session(shell=None, argv=None, auto_symbols=False, auto_int_to_Integer=False):
     """Construct new IPython session. """
+    if argv is None:
+        argv = []
     import IPython
 
     if version_tuple(IPython.__version__) >= version_tuple('0.11'):

--- a/sympy/logic/algorithms/dpll.py
+++ b/sympy/logic/algorithms/dpll.py
@@ -143,7 +143,7 @@ def dpll_int_repr(clauses, symbols, model):
 ### helper methods for DPLL
 
 
-def pl_true_int_repr(clause, model={}):
+def pl_true_int_repr(clause, model=None):
     """
     Lightweight version of pl_true.
     Argument clause represents the set of args of an Or clause. This is used
@@ -155,6 +155,9 @@ def pl_true_int_repr(clause, model={}):
     False
 
     """
+    if model is None:
+        model = {}
+
     result = False
     for lit in clause:
         if lit < 0:

--- a/sympy/parsing/maxima.py
+++ b/sympy/parsing/maxima.py
@@ -48,7 +48,9 @@ sub_dict = {
 var_name = re.compile(r'^\s*(\w+)\s*:')
 
 
-def parse_maxima(str, globals=None, name_dict={}):
+def parse_maxima(str, globals=None, name_dict=None):
+    if name_dict is None:
+        name_dict = {}
     str = str.strip()
     str = str.rstrip('; ')
 

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -299,7 +299,7 @@ def circuit_plot(c, nqubits, **kwargs):
     """
     return CircuitPlot(c, nqubits, **kwargs)
 
-def render_label(label, inits={}):
+def render_label(label, inits=None):
     """Slightly more flexible way to render labels.
 
     >>> from sympy.physics.quantum.circuitplot import render_label
@@ -308,6 +308,9 @@ def render_label(label, inits={}):
     >>> render_label('q0', {'q0':'0'})
     '$\\\\left|q0\\\\right\\\\rangle=\\\\left|0\\\\right\\\\rangle$'
     """
+    if inits is None:
+        inits = {}
+
     init = inits.get(label)
     if init:
         return r'$\left|%s\right\rangle=\left|%s\right\rangle$' % (label, init)

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2400,7 +2400,7 @@ def evaluate_deltas(e):
         return e
 
 
-def substitute_dummies(expr, new_indices=False, pretty_indices={}):
+def substitute_dummies(expr, new_indices=False, pretty_indices=None):
     """
     Collect terms by substitution of dummy variables.
 
@@ -2465,7 +2465,8 @@ def substitute_dummies(expr, new_indices=False, pretty_indices={}):
     f(_p_0, _p_1)
 
     """
-
+    if pretty_indices is None:
+        pretty_indices = {}
     # setup the replacing dummies
     if new_indices:
         letters_above = pretty_indices.get('above', "")

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -298,7 +298,9 @@ class DimensionSystem(Basic, _QuantityMapper):
     may be omitted.
     """
 
-    def __new__(cls, base_dims, derived_dims=(), dimensional_dependencies={}):
+    def __new__(cls, base_dims, derived_dims=(), dimensional_dependencies=None):
+        if dimensional_dependencies is None:
+            dimensional_dependencies = {}
         dimensional_dependencies = dict(dimensional_dependencies)
 
         def parse_dim(dim):

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -27,7 +27,9 @@ class UnitSystem(_QuantityMapper):
 
     _unit_systems = {}  # type: tDict[str, UnitSystem]
 
-    def __init__(self, base_units, units=(), name="", descr="", dimension_system=None, derived_units: tDict[Dimension, Quantity]={}):
+    def __init__(self, base_units, units=(), name="", descr="", dimension_system=None, derived_units: tDict[Dimension, Quantity]=None):
+        if derived_units is None:
+            derived_units = {}
 
         UnitSystem._unit_systems[name] = self
 
@@ -59,13 +61,15 @@ class UnitSystem(_QuantityMapper):
     def __repr__(self):
         return '<UnitSystem: %s>' % repr(self._base_units)
 
-    def extend(self, base, units=(), name="", description="", dimension_system=None, derived_units: tDict[Dimension, Quantity]={}):
+    def extend(self, base, units=(), name="", description="", dimension_system=None, derived_units: tDict[Dimension, Quantity]=None):
         """Extend the current system into a new one.
 
         Take the base and normal units of the current system to merge
         them to the base and normal units given in argument.
         If not provided, name and description are overridden by empty strings.
         """
+        if derived_units is None:
+            derived_units = {}
 
         base = self._base_units + tuple(base)
         units = self._units + tuple(units)

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -198,8 +198,11 @@ class Options(dict):
                 raise RuntimeError(
                     "cycle detected in sympy.polys options framework")
 
-    def clone(self, updates={}):
+    def clone(self, updates=None):
         """Clone ``self`` and update specified options. """
+        if updates is None:
+            updates = {}
+
         obj = dict.__new__(self.__class__)
 
         for option, value in self.items():

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -52,7 +52,9 @@ class GLSLPrinter(CodePrinter):
         'contract': True,
     })
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -55,7 +55,9 @@ class JavascriptCodePrinter(CodePrinter):
         'contract': True,
     })
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -68,7 +68,9 @@ class JuliaCodePrinter(CodePrinter):
     # assignment (if False).  FIXME: this should be looked a more carefully
     # for Julia.
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
         super().__init__(settings)
         self.known_functions = dict(zip(known_fcns_src1, known_fcns_src1))
         self.known_functions.update(dict(known_fcns_src2))

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -135,8 +135,11 @@ class MCodePrinter(CodePrinter):
     _number_symbols: set[tuple[Expr, Float]] = set()
     _not_supported: set[Basic] = set()
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
         """Register function mappings supplied by user"""
+        if settings is None:
+            settings = {}
+
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {}).copy()

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -86,7 +86,9 @@ class OctaveCodePrinter(CodePrinter):
     # for Octave.
 
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
         super().__init__(settings)
         self.known_functions = dict(zip(known_fcns_src1, known_fcns_src1))
         self.known_functions.update(dict(known_fcns_src2))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1249,7 +1249,10 @@ class PrettyPrinter(Printer):
 
         return self._print(out_expr)
 
-    def _printer_tensor_indices(self, name, indices, index_map={}):
+    def _printer_tensor_indices(self, name, indices, index_map=None):
+        if index_map is None:
+            index_map = {}
+
         center = stringPict(name)
         top = stringPict(" "*center.width())
         bot = stringPict(" "*center.width())

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -94,7 +94,10 @@ class RCodePrinter(CodePrinter):
 
     _relationals: dict[str, str] = {}
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
+
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -293,7 +293,10 @@ class RustCodePrinter(CodePrinter):
         'dereference': set(),
     })
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
+
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1951,7 +1951,7 @@ def hyperexpand_special(ap, bq, z):
 _collection = None
 
 
-def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
+def _hyperexpand(func, z, ops0=None, z0=Dummy('z0'), premult=1, prem=0,
                  rewrite='default'):
     """
     Try to find an expression for the hypergeometric function ``func``.
@@ -1964,6 +1964,8 @@ def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
     ``premult`` must be a*z**prem for some a independent of ``z``.
     """
 
+    if ops0 is None:
+        ops0 = []
     if z.is_zero:
         return S.One
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -46,7 +46,7 @@ from sympy.utilities.misc import as_int
 import mpmath
 
 
-def separatevars(expr, symbols=[], dict=False, force=False):
+def separatevars(expr, symbols=None, dict=False, force=False):
     """
     Separates variables in an expression, if possible.  By
     default, it separates with respect to all symbols in an
@@ -113,6 +113,9 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     True
 
     """
+
+    if symbols is None:
+        symbols = []
     expr = sympify(expr)
     if dict:
         return _separatevars_dict(_separatevars(expr, force), symbols)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -25,7 +25,7 @@ from sympy.strategies.tree import greedy
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
-def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
+def trigsimp_groebner(expr, hints=None, quick=False, order="grlex",
                       polynomial=False):
     """
     Simplify trigonometric expressions using a groebner basis algorithm.
@@ -204,6 +204,8 @@ def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
     # sin(x + y) - sin(x)*cos(y) - sin(y)*cos(x), etc. Geometric primality is
     # preserved by the same argument as before.
 
+    if hints is None:
+        hints = []
     def parse_hints(hints):
         """Split hints into (n, funcs, iterables, gens)."""
         n = 1

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -926,7 +926,7 @@ def _reduce_inequalities(inequalities, symbols):
     return And(*(poly_reduced + abs_reduced + other))
 
 
-def reduce_inequalities(inequalities, symbols=[]):
+def reduce_inequalities(inequalities, symbols=None):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples
@@ -941,6 +941,9 @@ def reduce_inequalities(inequalities, symbols=[]):
     >>> reduce_inequalities(0 <= x + y*2 - 1, [x])
     (x < oo) & (x >= 1 - 2*y)
     """
+    if symbols is None:
+        symbols = []
+
     if not iterable(inequalities):
         inequalities = [inequalities]
     inequalities = [sympify(i) for i in inequalities]

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -292,8 +292,8 @@ def _test_particular_example(our_hint, ode_example, solver_flag=False):
     return result
 
 
-def _test_all_examples_for_one_hint(our_hint, all_examples=[], runxfail=None):
-    if all_examples == []:
+def _test_all_examples_for_one_hint(our_hint, all_examples=None, runxfail=None):
+    if all_examples is None:
         all_examples = _get_all_examples()
     match_list, unsolve_list, exception_list = [], [], []
     for ode_example in all_examples:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2035,7 +2035,7 @@ def _solve_system(exprs, symbols, **flags):
     return linear, result
 
 
-def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
+def solve_linear(lhs, rhs=0, symbols=None, exclude=None):
     r"""
     Return a tuple derived from ``f = lhs - rhs`` that is one of
     the following: ``(0, 1)``, ``(0, 0)``, ``(symbol, solution)``, ``(n, d)``.
@@ -2142,6 +2142,11 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     solution.)
 
     """
+    if symbols is None:
+        symbols = []
+    if exclude is None:
+        exclude = []
+
     if isinstance(lhs, Eq):
         if rhs:
             raise ValueError(filldedent('''

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3174,8 +3174,8 @@ def _return_conditionset(eqs, symbols):
     return condition_set
 
 
-def substitution(system, symbols, result=[{}], known_symbols=[],
-                 exclude=[], all_symbols=None):
+def substitution(system, symbols, result=None, known_symbols=None,
+                 exclude=None, all_symbols=None):
     r"""
     Solves the `system` using substitution method. It is used in
     :func:`~.nonlinsolve`. This will be called from :func:`~.nonlinsolve` when any
@@ -3260,7 +3260,12 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
       ImageSet(Lambda(_n, sqrt(-exp(2*x) + sin(2*_n*I*pi - log(3)))), Integers))}
 
     """
-
+    if result is None:
+        result = [{}]
+    if known_symbols is None:
+        known_symbols = []
+    if exclude is None:
+        exclude = []
     if not system:
         return S.EmptySet
 

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         else:
             sorted_messages.append(msg % args)
 
-    def tracking_import(module, globals=globals(), locals=[], fromlist=None, level=-1):
+    def tracking_import(module, globals=None, locals=None, fromlist=None, level=-1):
         """__import__ wrapper - does not change imports at all, but tracks them.
 
         Default order is implemented by doing output directly.
@@ -143,6 +143,11 @@ if __name__ == "__main__":
         question was already imported.
 
         Keeps the semantics of __import__ unchanged."""
+        if globals is None:
+            globals = globals()
+        if locals is None:
+            locals = []
+
         global options, symbol_definers
         caller_frame = inspect.getframeinfo(sys._getframe(1))
         importer_filename = caller_frame.filename

--- a/sympy/unify/tests/test_unify.py
+++ b/sympy/unify/tests/test_unify.py
@@ -12,7 +12,9 @@ def is_commutative(x):
     return isinstance(x, Compound) and (x.op in ('CAdd', 'CMul'))
 
 
-def unify(a, b, s={}):
+def unify(a, b, s=None):
+    if s is None:
+        s = {}
     return core.unify(a, b, s=s, is_associative=is_associative,
                           is_commutative=is_commutative)
 

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -123,10 +123,13 @@ class CodeWrapper:
     def module_name(self):
         return "%s_%s" % (self._module_basename, CodeWrapper._module_counter)
 
-    def __init__(self, generator, filepath=None, flags=[], verbose=False):
+    def __init__(self, generator, filepath=None, flags=None, verbose=False):
         """
         generator -- the code generator to use
         """
+        if flags is None:
+            flags = []
+
         self.generator = generator
         self.filepath = filepath
         self.flags = flags

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -43,9 +43,13 @@ deprecated_attrs = {
 }
 
 
-def check(a, exclude=[], check_attr=True, deprecated=()):
+def check(a, exclude=None, check_attr=True, deprecated=()):
     """ Check that pickling and copying round-trips.
     """
+
+    if exclude is None:
+        exclude = []
+
     # Pickling with protocols 0 and 1 is disabled for Basic instances:
     if isinstance(a, Basic):
         for protocol in [0, 1]:


### PR DESCRIPTION
Previously, many functions have arguments with mutable default values, most commonly {} and []. This is not a good coding style and could lead to hidden bugs if the function modifies the object. According to python documentation, the preferred way is to set the default value to None, then explicitly test for None at the beginning of the functions. See https://docs.python.org/3/reference/compound_stmts.html#function-definitions

While it's hard to say whether any of these functions had ever experienced problems as a result, I think it's better to refactor them to prevent any potential complications.

#### References to other Issues or PRs


#### Brief description of what is fixed or changed
All sympy functions that previously have mutable objects (such as empty lists or dictionaries) as their default values have been refactored to use `None` as the default value, and will be correctly initialized inside the functions.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
