### PR TITLE
autoexpand exp(I*pi/d)

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -32,6 +32,8 @@ from sympy.ntheory.factor_ import factorint
 # p.is_positive.]
 
 
+_cos_table_keys = (3, 5, 17, 257)
+
 class ExpBase(Function):
 
     unbranched = True
@@ -278,6 +280,7 @@ class exp(ExpBase, metaclass=ExpMeta):
         from sympy.matrices.matrixbase import MatrixBase
         from sympy.sets.setexpr import SetExpr
         from sympy.simplify.simplify import logcombine
+        from sympy.functions.elementary.trigonometric import cos, sin
         if isinstance(arg, MatrixBase):
             return arg.exp()
         elif global_parameters.exp_is_pow:
@@ -314,6 +317,8 @@ class exp(ExpBase, metaclass=ExpMeta):
                     elif (coeff + S.Half).is_odd:
                         return I
                 elif coeff.is_Rational:
+                    if coeff.q in _cos_table_keys + (4, 6, 8, 10, 12):
+                        return cos(arg/I) + I*sin(arg/I)
                     ncoeff = coeff % 2 # restrict to [0, 2pi)
                     if ncoeff > 1: # restrict to (-pi, pi]
                         ncoeff -= 2
@@ -1284,3 +1289,4 @@ def _log_atan_table():
         2 + sqrt(3): pi * Rational(5, 12),
         (1 + sqrt(3)) / (-1 + sqrt(3)): pi * Rational(5, 12)
     }
+

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1289,4 +1289,3 @@ def _log_atan_table():
         2 + sqrt(3): pi * Rational(5, 12),
         (1 + sqrt(3)) / (-1 + sqrt(3)): pi * Rational(5, 12)
     }
-

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -12,6 +12,7 @@ from sympy.functions.elementary.exponential import (LambertW, exp, exp_polar, lo
 from sympy.functions.elementary.hyperbolic import (cosh, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
+from sympy.functions.elementary._trigonometric_special import cos_table
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.polys.polytools import gcd
 from sympy.series.order import O
@@ -381,6 +382,18 @@ def test_log_symbolic():
     assert (log(p**-5)**-1).expand() == -1/log(p)/5
     assert log(-x).func is log and log(-x).args[0] == -x
     assert log(-p).func is log and log(-p).args[0] == -p
+
+
+def test_special_exp():
+    for d in tuple(cos_table()) + (4, 6, 8, 10, 12):
+        # use 13 to affirm numerator does not need to be 1
+        d/=S(13)
+        assert d != 1
+        ans = cos(pi/d) + I*sin(pi/d)
+        assert not ans.has(cos)
+        assert exp(I*pi/d) == ans
+        d = -d
+        assert exp(I*pi/d) == cos(pi/d) + I*sin(pi/d)
 
 
 def test_log_exp():

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -11,6 +11,7 @@ from sympy.functions.elementary.complexes import (arg, conjugate, im, re)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (acoth, asinh, atanh, cosh, coth, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary._trigonometric_special import cos_table
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, atan2,
                                                       cos, cot, csc, sec, sin, sinc, tan)
 from sympy.functions.special.bessel import (besselj, jn)
@@ -2242,3 +2243,8 @@ def test_issue_23843():
     assert acot(x + I).series(x, -oo) == 16/(5*x**5) + 2*I/x**4 - 4/(3*x**3) - I/x**2 + 1/x + O(x**(-6), (x, -oo))
     assert acot(x - I).series(x, oo) == 16/(5*x**5) - 2*I/x**4 - 4/(3*x**3) + I/x**2 + 1/x + O(x**(-6), (x, oo))
     assert acot(x - I).series(x, -oo) == 16/(5*x**5) - 2*I/x**4 - 4/(3*x**3) + I/x**2 + 1/x + O(x**(-6), (x, -oo))
+
+
+def test_cos_table_keys():
+    # if this fails, _cos_table_keys in exponential needs updating
+    assert tuple(cos_table().keys()) == (3, 5, 17, 257)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
closes #24677

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * exponential functions with special rational multiples of `I*pi` are now expanded like `sin` and `cos`
<!-- END RELEASE NOTES -->
