### PR TITLE
Ensure that calling math.trunc on a sympy expression has an int return type

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -368,7 +368,7 @@ class Expr(Basic, EvalfMixin):
         if not self.is_number:
             raise TypeError("Cannot truncate symbols and expressions")
         else:
-            return Integer(self)
+            return int(self)
 
     def __format__(self, format_spec: str):
         if self.is_number:


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Per issue #26206, currently the return types of math functions on sympy objects are inconsistent. Since `math.floor` and `math.ceil` seems to be implemented in C, there's no easy way to change their behaviors. However, `math.trunc` simply calls the `__trunc__` function defined by the input object, so I changed its return type to a normal python int.



#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * `Expr.__trunc__` will now return an int instead of a sympy Integer, ensuring that math.trunc will have an int return type. 
<!-- END RELEASE NOTES -->
