### PR TITLE
is_zero = None is not necessarily 0

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -438,7 +438,7 @@ class Relational(Boolean, EvalfMixin):
                 r = r.func._eval_relation(v, S.Zero)
             r = r.canonical
             # If there is only one symbol in the expression,
-            # try to write it on a simplified form
+            # try to write it in a simplified form
             free = list(filter(lambda x: x.is_real is not False, r.free_symbols))
             if len(free) == 1:
                 try:
@@ -453,7 +453,9 @@ class Relational(Boolean, EvalfMixin):
                             r = r.func(-b / m, x)
                         else:
                             r = r.func(x, -b / m)
-                    else:
+                    elif m.is_zero is True:
+                        # not sure we can ever get here because
+                        # instantiation will detect the symbolic 0
                         r = r.func(b, S.Zero)
                 except ValueError:
                     # maybe not a linear function, try polynomial

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -802,10 +802,14 @@ def test_simplify_relational():
 
     # Test particular branches of _eval_simplify
     m = exp(1) - exp_polar(1)
-    assert simplify(m*x > 1) is S.false
     # These two test the same branch
     assert simplify(m*x + 2*m*y > 1) is S.false
     assert simplify(m*x + y > 1 + y) is S.false
+
+    # issue 26847
+    f = Function('f')
+    eq = Eq(f(1), x*f(0))
+    assert eq.simplify() == eq
 
 
 def test_equals():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #26847

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * error where univariate relational with functions simplifying incorrectly has been fixed
<!-- END RELEASE NOTES -->
