### PR TITLE
[feat] `apply` added as traversal

### DIFF
--- a/sympy/core/tests/test_traversal.py
+++ b/sympy/core/tests/test_traversal.py
@@ -7,7 +7,8 @@ from sympy.core.function import expand, Function
 from sympy.core.numbers import I
 from sympy.integrals.integrals import Integral
 from sympy.polys.polytools import factor
-from sympy.core.traversal import preorder_traversal, use, postorder_traversal, iterargs, iterfreeargs
+from sympy.core.traversal import (preorder_traversal, use,
+    postorder_traversal, iterargs, iterfreeargs, apply)
 from sympy.functions.elementary.piecewise import ExprCondPair, Piecewise
 from sympy.testing.pytest import warns_deprecated_sympy
 from sympy.utilities.iterables import capture
@@ -117,3 +118,10 @@ def test_deprecated_imports():
     with warns_deprecated_sympy():
         from sympy.utilities.iterables import interactive_traversal
         capture(lambda: interactive_traversal(x))
+
+
+def test_trav_apply():
+    assert apply(lambda x: 42, 1) == 42
+    assert apply(lambda x: 42, [1]) == [42]
+    assert apply(lambda x: 42, ([], 1, [2])) == ([], 42, [42])
+    assert apply(lambda x: x%2, ([], 1, (2, 3))) == ([], 1, (0, 1))

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -14,7 +14,7 @@ def apply(f, e):
     ========
 
     >>> from sympy.core.traversal import apply
-    >>> from sympy import Float, Rational, nsimplify
+    >>> from sympy import Rational, nsimplify
     >>> from sympy.core.numbers import equal_valued
 
     >>> apply(nsimplify, .1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
closes #26375

#### Brief description of what is fixed or changed

An `apply` function has been added to traversals so aribitrarily nested Python list/tuple structures can have a function applied to them while retaining their native structure.

```python
assert apply(int, [1.2, (3.14, 2.718)]) == [1, (3, 2)]
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `apply` function added to traversals which will apply a function to (possibly nested) Python containers 
<!-- END RELEASE NOTES -->
