### PR TITLE
polytools: Added subresultant polynomials and coefficients

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2778,7 +2778,7 @@ class Poly(Basic):
 
         >>> Poly((x-1)*(x-2), x).subresultant_polys(Poly((x-1)*(x-2)*x, x))
         [Poly(0, x, domain='ZZ'),
-        Poly(1, x, domain='ZZ'),
+        Poly(0, x, domain='ZZ'),
         Poly(x**2 - 3*x + 2, x, domain='ZZ')]
 
         The coefficients are, in order, the coefficient of x^0, x^1, and x^2 in
@@ -5635,7 +5635,7 @@ def subresultant_coeffs(f, g, *gens, **args):
 
     >>> from sympy.polys.polytools import subresultant_polys
     >>> subresultant_polys((x-1)*(x-2), (x-1)*(x-2)*x)
-    [0, 1, x**2 - 3*x + 2]
+    [0, 0, x**2 - 3*x + 2]
 
     The coefficients are, in order, the coefficient of x^0, x^1, and x^2 in
     the polynomials above.

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2739,7 +2739,7 @@ class Poly(Basic):
             # so we need to first append enough 0s
             # only if not already computed (happens if deg(f) = deg(g))
             if len(subres_polys) != e:
-                subres_polys.extend([f.zero] * (e - len(subres_polys) - 1))
+                subres_polys.extend([zero] * (e - len(subres_polys) - 1))
                 subres_polys.append(p)
 
             # if there is a "degree jump"
@@ -2751,7 +2751,7 @@ class Poly(Basic):
                 subres_polys[d] = p * p.LC() ** jump
 
         # should be length m+1 so pad 0s
-        subres_polys.extend([f.zero] * (m - len(subres_polys)))
+        subres_polys.extend([zero] * (m - len(subres_polys)))
         subres_polys.append(g * g.LC() ** (n - m - 1))
 
         return subres_polys

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2669,7 +2669,6 @@ class Poly(Basic):
 
         return list(map(per, result))
 
-
     def subresultant_polys(f, g):
         """
         Computes the subresultant polynomials of two polynomials ``f`` and ``g``.
@@ -2736,7 +2735,6 @@ class Poly(Basic):
 
         return subres_polys
 
-
     def subresultant_coeffs(f, g):
         """
         Computes the subresultant coefficients of two polynomials ``f`` and ``g``.
@@ -2785,7 +2783,6 @@ class Poly(Basic):
         subres_coeffs = [subres_polys[i].nth(i) for i in range(len(subres_polys))]
 
         return subres_coeffs
-
 
     def resultant(f, g, includePRS=False):
         """

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2659,6 +2659,12 @@ class Poly(Basic):
          Poly(x**2 - 1, x, domain='ZZ'),
          Poly(-2, x, domain='ZZ')]
 
+        See also
+        ========
+
+        subresultant_polys
+        subresultant_coeffs
+
         """
         _, per, F, G = f._unify(g)
 
@@ -2695,6 +2701,12 @@ class Poly(Basic):
 
         >>> Poly(x**2 + 1, x).resultant(Poly(x**2 - 1, x))
         4
+
+        See also
+        ========
+
+        subresultants
+        subresultant_coeffs
 
         """
 
@@ -2775,6 +2787,11 @@ class Poly(Basic):
         The coefficients are, in order, the coefficient of x^0, x^1, and x^2 in
         the polynomials above.
 
+        See also
+        ========
+
+        subresultants
+        subresultant_polys
 
         """
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5541,6 +5541,12 @@ def subresultants(f, g, *gens, **args):
     >>> subresultants(x**2 + 1, x**2 - 1)
     [x**2 + 1, x**2 - 1, -2]
 
+    See also
+    ========
+
+    subresultant_polys
+    subresultant_coeffs
+
     """
     options.allowed_flags(args, ['polys'])
 
@@ -5583,6 +5589,13 @@ def subresultant_polys(f, g, *gens, **args):
     >>> from sympy import resultant
     >>> resultant(x**2 + 1, x**2 - 1)
     4
+
+    See also
+    ========
+
+    subresultants
+    subresultant_coeffs
+
     """
 
     options.allowed_flags(args, ['polys'])
@@ -5639,6 +5652,12 @@ def subresultant_coeffs(f, g, *gens, **args):
 
     The coefficients are, in order, the coefficient of x^0, x^1, and x^2 in
     the polynomials above.
+
+    See also
+    ========
+
+    subresultants
+    subresultant_polys
 
     """
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2679,7 +2679,7 @@ class Poly(Basic):
         This uses the subresultant PRS. The remainder r_i is the deg(r_{i-1})-th
         subresultant polynomial. Additionally, if deg(r_i) < deg(r_{i-1}) - 1,
         then the deg(r_i) subresultant polynomial is r_i * LC(r_i) ^ c_i, where
-        c_i = deg(r_{i-1})-deg(r_i)-1).
+        c_i = deg(r_{i-1})-deg(r_i)-1.
 
         Examples
         ========
@@ -2719,7 +2719,7 @@ class Poly(Basic):
 
             # if there is a "degree jump"
             # if deg(r_i) < deg(r_{i-1}) - 1, then the deg(r_i) subres poly
-            # is r_i * LC(r_i) ^ c_i, where c_i = deg(r_{i-1})-deg(r_i)-1)
+            # is r_i * LC(r_i) ^ c_i, where c_i = deg(r_{i-1})-deg(r_i)-1
             if prs[i].degree() < prs[i-1].degree() - 1:
                 degree_jump = prs[i-1].degree() - prs[i].degree() - 1
                 subres_polys[ prs[i].degree() ]  =\
@@ -5557,7 +5557,7 @@ def subresultant_polys(f, g, *gens, **args):
     This uses the subresultant PRS. The remainder r_i is the deg(r_{i-1})-th
     subresultant polynomial. Additionally, if deg(r_i) < deg(r_{i-1}) - 1,
     then the deg(r_i) subresultant polynomial is r_i * LC(r_i) ^ c_i, where
-    c_i = deg(r_{i-1})-deg(r_i)-1).
+    c_i = deg(r_{i-1})-deg(r_i)-1.
 
     Examples
     ========

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2724,20 +2724,23 @@ class Poly(Basic):
 
         subres_polys = [Poly(0, f.gen) for _ in range(m + 1)]
 
-        for i in reversed(range(2, len(prs))):
+        subres_polys[-1] = g * g.LC() ** (n - m - 1)
+
+        for i in range(2, len(prs)):
+            curr = prs[i]
+            prev = prs[i-1]
+            curr_deg = curr.degree()
+            prev_deg = prev.degree()
+
             # remainder r_i is the deg(r_{i-1})-th subres poly
-            subres_polys[ prs[i-1].degree() -1 ] = prs[i]
+            subres_polys[ prev_deg -1 ] = curr
 
             # if there is a "degree jump"
             # if deg(r_i) < deg(r_{i-1}) - 1, then the deg(r_i) subres poly
             # is r_i * LC(r_i) ^ c_i, where c_i = deg(r_{i-1})-deg(r_i)-1
-            if prs[i].degree() < prs[i-1].degree() - 1:
-                degree_jump = prs[i-1].degree() - prs[i].degree() - 1
-                subres_polys[ prs[i].degree() ]  =\
-                    prs[i] * prs[i].LC() ** degree_jump
-
-        # handle last one
-        subres_polys[-1] = prs[1] * g.LC() ** (n - m - 1)
+            degree_jump = prev_deg - curr_deg - 1
+            if degree_jump > 0:
+                subres_polys[curr_deg] = curr * curr.LC() ** degree_jump
 
         return subres_polys
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2722,7 +2722,7 @@ class Poly(Basic):
         if len(prs) <= 1:
             return []
 
-        subres_polys = [0] * (m + 1)
+        subres_polys = [Poly(0, f.gen) for _ in range(m + 1)]
 
         for i in reversed(range(2, len(prs))):
             # remainder r_i is the deg(r_{i-1})-th subres poly
@@ -2738,12 +2738,6 @@ class Poly(Basic):
 
         # handle last one
         subres_polys[-1] = prs[1] * g.LC() ** (n - m - 1)
-
-        # want it to always return Poly objects for consistency
-        # this basically just makes sure 0 is returned as Poly(0)
-        for i in range(len(subres_polys)):
-            if not isinstance(subres_polys[i], Poly):
-                subres_polys[i] = Poly(i, f.gen)
 
         return subres_polys
 
@@ -2796,7 +2790,6 @@ class Poly(Basic):
         """
 
         subres_polys = f.subresultant_polys(g)
-
         subres_coeffs = [subres_polys[i].nth(i) for i in range(len(subres_polys))]
 
         return subres_coeffs

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2729,6 +2729,8 @@ class Poly(Basic):
         if m == 0:
             return subres_polys
 
+        zero = f.zero
+
         for i in range(len(prs)-1, 1, -1):
             p, d = prs[i], prs[i].degree() # r_i and deg(r_i)
             e = prs[i-1].degree() # deg(r_{i-1})
@@ -2737,7 +2739,7 @@ class Poly(Basic):
             # so we need to first append enough 0s
             # only if not already computed (happens if deg(f) = deg(g))
             if len(subres_polys) != e:
-                subres_polys.extend([Poly(0, f.gen)] * (e - len(subres_polys) - 1))
+                subres_polys.extend([f.zero] * (e - len(subres_polys) - 1))
                 subres_polys.append(p)
 
             # if there is a "degree jump"
@@ -2749,7 +2751,7 @@ class Poly(Basic):
                 subres_polys[d] = p * p.LC() ** jump
 
         # should be length m+1 so pad 0s
-        subres_polys.extend([Poly(0, f.gen)] * (m - len(subres_polys)))
+        subres_polys.extend([f.zero] * (m - len(subres_polys)))
         subres_polys.append(g * g.LC() ** (n - m - 1))
 
         return subres_polys

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2664,6 +2664,7 @@ class Poly(Basic):
 
         subresultant_polys
         subresultant_coeffs
+        resultant
 
         """
         _, per, F, G = f._unify(g)
@@ -2707,6 +2708,7 @@ class Poly(Basic):
 
         subresultants
         subresultant_coeffs
+        resultant
 
         """
 
@@ -2797,6 +2799,7 @@ class Poly(Basic):
 
         subresultants
         subresultant_polys
+        resultant
 
         """
 
@@ -5554,6 +5557,7 @@ def subresultants(f, g, *gens, **args):
 
     subresultant_polys
     subresultant_coeffs
+    resultant
 
     """
     options.allowed_flags(args, ['polys'])
@@ -5603,6 +5607,7 @@ def subresultant_polys(f, g, *gens, **args):
 
     subresultants
     subresultant_coeffs
+    resultant
 
     """
 
@@ -5666,6 +5671,7 @@ def subresultant_coeffs(f, g, *gens, **args):
 
     subresultants
     subresultant_polys
+    resultant
 
     """
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -12,6 +12,7 @@ from sympy.polys.polytools import (
     div, rem, quo, exquo,
     half_gcdex, gcdex, invert,
     subresultants,
+    subresultant_polys, subresultant_coeffs,
     resultant, discriminant,
     terms_gcd, cofactors,
     gcd, gcd_list,
@@ -1991,6 +1992,103 @@ def test_subresultants():
     assert subresultants(F, G, polys=False) == [f, g, h]
 
     raises(ComputationFailed, lambda: subresultants(4, 2))
+
+
+def test_subresultant_polys():
+    # edge cases
+    assert subresultant_polys(x, 0) == []
+    assert subresultant_polys(x, 1) == [1]
+
+    # simple monic univariate examples
+    assert subresultant_polys(x**2+1, x**2-1, x) == [4, -2, -1+x**2]
+    assert subresultant_polys(x**3+1, x**2-1, x) == [0, 1+x, -1+x**2]
+
+    # should be order-invariant
+    assert subresultant_polys(x**3+1, x**2-1, x) == subresultant_polys(x**3+1, x**2-1, x)
+
+    # some univariate examples
+    f = Poly(2*x**5 - 3*x**4 + x**3 - 7*x + 5, x)
+    g = Poly(x**5 + 4*x**4 - x**3 + 2*x**2 - 3*x + 6, x)
+    assert f.subresultant_polys(g) ==\
+        [
+            Poly(45695124, x),
+            Poly(692022 - 809988*x, x),
+            Poly(1349 - 743*x - 901*x**2, x),
+            Poly(397 - 487*x + 43*x**2 - 24*x**3, x),
+            Poly(7 + x + 4*x**2 - 3*x**3 + 11*x**4, x),
+            Poly(6 - 3*x + 2*x**2 - x**3 + 4*x**4 + x**5, x)
+        ]
+
+    f = Poly(5*x**2 + 3*x - 2, x)
+    g = Poly(-x + 1, x)
+    assert f.subresultant_polys(g) ==\
+        [Poly(6, x), Poly(1-x, x)]
+
+    # some bivariate examples
+    f = Poly(2*x**3 + y**2 + 3*x*y - 4, x)
+    g = Poly(x**2 + 2*y**3 + 5*x*y, x)
+    assert f.subresultant_polys(g) ==\
+        [
+            16 + 52*y**2 + 1000*y**3 - 254*y**4 - 232*y**5 + 360*y**6 - 48*y**7 + 32*y**9,
+            -4 + 3*x*y + y**2 + 50*x*y**2 - 4*x*y**3 + 20*y**4,
+            x**2 + 5*x*y + 2*y**3
+        ]
+
+    f = Poly(y*x**2+1, x)
+    g = Poly(y**2*x**2 - 1, x)
+    assert f.subresultant_polys(g) ==\
+        [
+            y**2 + 2*y**3 + y**4,
+            -y - y**2,
+            x**2 - 1/y**2
+        ]
+    # note above it can have rational terms in the other vars!
+
+
+def test_subresultant_coeffs():
+    # edge cases
+    assert subresultant_coeffs(x, 0, x) == []
+    assert subresultant_coeffs(x, 1, x) == [1]
+
+    # simple monic univariate examples
+    assert subresultant_coeffs(x**2+1, x**2-1, x) == [4, 0, 1]
+    assert subresultant_coeffs(x**3+1, x**2-1, x) == [0, 1, 1]
+
+    # should be order-invariant
+    assert subresultant_coeffs(x**3+1, x**2-1, x) == subresultant_coeffs(x**3+1, x**2-1, x)
+
+    # first k are 0 when f and g share k common roots
+    assert subresultant_coeffs((x-1)*(x-2), (x-1)*(x-2)*x) == [0, 0, 1]
+
+    # some univariate examples
+    f = Poly(2*x**5 - 3*x**4 + x**3 - 7*x + 5, x)
+    g = Poly(x**5 + 4*x**4 - x**3 + 2*x**2 - 3*x + 6, x)
+    assert f.subresultant_coeffs(g) ==\
+        [45695124, -809988, -901, -24, 11, 1]
+
+    f = Poly(5*x**2 + 3*x - 2, x)
+    g = Poly(-x + 1, x)
+    assert f.subresultant_coeffs(g) ==\
+        [6, -1]
+
+    # some bivariate examples
+    f = Poly(2*x**3 + y**2 + 3*x*y - 4, x)
+    g = Poly(x**2 + 2*y**3 + 5*x*y, x)
+    assert f.subresultant_coeffs(g) ==\
+        [
+            16 + 52*y**2 + 1000*y**3 - 254*y**4 - 232*y**5 + 360*y**6 - 48*y**7 + 32*y**9,
+            3*y + 50*y**2 - 4*y**3,
+            1
+        ]
+
+    f = Poly(y*x**2+1, x)
+    g = Poly(y**2*x**2 - 1, x)
+    assert f.subresultant_coeffs(g) ==\
+        [
+            y**2 + 2*y**3 + y**4,
+            0,
+            1
+        ]
 
 
 def test_resultant():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2006,6 +2006,10 @@ def test_subresultant_polys():
     # should be order-invariant
     assert subresultant_polys(x**3+1, x**2-1, x) == subresultant_polys(x**3+1, x**2-1, x)
 
+    # test that 0 is still being returned as poly
+    assert Poly(x**3+1, x).subresultant_polys(Poly(x**2-1, x)) ==\
+        [Poly(0, x), Poly(1+x, x), Poly(-1+x**2, x)]
+
     # some univariate examples
     f = Poly(2*x**5 - 3*x**4 + x**3 - 7*x + 5, x)
     g = Poly(x**5 + 4*x**4 - x**3 + 2*x**2 - 3*x + 6, x)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2028,6 +2028,12 @@ def test_subresultant_polys():
     assert f.subresultant_polys(g) ==\
         [Poly(6, x), Poly(1-x, x)]
 
+    # a univariate example with a degree jump
+    f = Poly(x**5 + x**3 - 1, x)
+    g = Poly(2*x**3, x)
+    assert f.subresultant_polys(g) ==\
+        [Poly(32, x), Poly(0, x), Poly(8, x), Poly(4*x**3, x)]
+
     # some bivariate examples
     f = Poly(2*x**3 + y**2 + 3*x*y - 4, x)
     g = Poly(x**2 + 2*y**3 + 5*x*y, x)
@@ -2047,6 +2053,12 @@ def test_subresultant_polys():
             x**2 - 1/y**2
         ]
     # note above it can have rational terms in the other vars!
+
+    # a bivariate example with a degree jump
+    f = Poly(x**5 + x**3 - 1, x)
+    g = Poly(y*x**3, x)
+    assert f.subresultant_polys(g) ==\
+        [Poly(y**5, x), Poly(0, x), Poly(y**3, x), Poly(y**2*x**3, x)]
 
 
 def test_subresultant_coeffs():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#26785


#### Brief description of what is fixed or changed

Added functions for subresultant polynomials and subresultant coefficients. These use the subresultant PRS (`subresultants()`) already in SymPy. The subresultant polynomials are computed from the subresultant PRS according to a certain rule, described in the comments. As for the subresultant coefficients, we simply take the coefficient of $x^{i-1}$ of the $i$-th subresultant polynomial. These functions are necessary for other tasks, including eventually for cylindrical algebraic decomposition.

For reference, the three subresultant functions line up with the following Mathematica commands:
- `subresultants` -> `SubresultantPolynomialRemainders`
- `subresultant_polys` -> `SubresultantPolynomials`
- `subresultant_coeffs` -> `Subresultants`


#### Technical details

Given the subresultant PRS, the remainder $r_i$ is the $deg(r_{i-1})$-th subresultant polynomial. Additionally, if $deg(r_i) < deg(r_{i-1}) - 1$, then the $deg(r_i)$ subresultant polynomial is $r_i * LC(r_i) ^ {c_i}$, where $c_i = deg(r_{i-1})-deg(r_i)-1$.

Given the subresultant polynomials, the coefficient of $x^{i-1}$ in the $i$-th subresultant polynomial is the $i$-th subresultant coefficient.

#### Other comments

Currently, `subresultants()` is in the main sympy namespace, i.e. it is imported when `from sympy import *`. Should these two be added to that as well? 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* polys
  * Added subresultant polynomials and subresultant coefficients.
<!-- END RELEASE NOTES -->
