### PR TITLE
polys: Check if extension is True when constructing polys

### DIFF
--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -232,6 +232,8 @@ def _parallel_dict_from_expr_if_gens(exprs, opt):
                     except KeyError:
                         if not factor.has_free(*opt.gens):
                             coeff.append(factor)
+                        elif opt.extension is True and factor.is_algebraic:
+                            coeff.append(factor)
                         else:
                             raise PolynomialError("%s contains an element of "
                                                   "the set of generators." % factor)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#26785 (this bug came up while testing code from it)

#### Brief description of what is fixed or changed

In _parallel_dict_from_expr_if_gens(), added a check if extension is True, and if the factor is algebraic, then this is a valid factor. Previously, this would give an error if, e.g., CRootOf objects were given. 

Example:

```
Poly(CRootOf(x**5+x**3-1,0)*x+1, x, extension=True)
```

would yield an error: `PolynomialError: CRootOf(x**5 + x**3 - 1, 0) contains an element of the set of generators.`. But, the following, without gens, would work:

```
Poly(CRootOf(x**5+x**3-1,0)*x+1, extension=True)
```

This is a minor pesky bug that came up while implementing cylindrical algebraic decomposition (#26785). Now, it should work:

```
In [3]: Poly(CRootOf(x**5 + x**3 - 1, 0) * x + 1, x, extension=True)
Out[3]: Poly(CRootOf(x**5 + x**3 - 1, 0)*x + 1, x, domain='QQ<CRootOf(x**5 + x**3 - 1, 0)>')

In [4]: Poly(CRootOf(x**5 + x**3 - 1, 0) * x + 1, extension=True)
Out[4]: Poly(CRootOf(x**5 + x**3 - 1, 0)*x + 1, x, domain='QQ<CRootOf(x**5 + x**3 - 1, 0)>')
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed constructing a polynomial with a given generator with coefficients being root objects.
<!-- END RELEASE NOTES -->
