### PR TITLE
allow ( or $ to anchor test name

### DIFF
--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -1368,7 +1368,10 @@ class SymPyTests:
         if not self._kw:
             return True
         for kw in self._kw:
-            if x.__name__.lower().find(kw.lower()) != -1:
+            if len(kw) > 1 and kw[-1] in "$(":
+                if x.__name__.lower().endswith(kw.lower()[:-1]):
+                    return True
+            elif x.__name__.lower().find(kw.lower()) != -1:
                 return True
         return False
 


### PR DESCRIPTION
`test(kw='cancel')` will run test_cancel and test_cancellation
`test(kw='cancel$')` will (now) run only test_cancel -- in master it would run nothing

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #8358 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* testing
  * to run tests that end with some text, use suffix "(" or "$": `test(kw='cancel$')` will tests functions ending in "cancel"
<!-- END RELEASE NOTES -->
