### PR TITLE
cancel now more strict

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -7352,7 +7352,7 @@ def cancel(f, *gens, _signsimp=True, **args):
     if 'polys' in args:
         opt['polys'] = args['polys']
 
-    if not isinstance(f, (tuple, Tuple)):
+    if not isinstance(f, Tuple):
         if f.is_Number or isinstance(f, Relational) or not isinstance(f, Expr):
             return f
         f = factor_terms(f, radical=True)
@@ -7365,8 +7365,6 @@ def cancel(f, *gens, _signsimp=True, **args):
             opt['domain'] = p.domain
             opt['polys'] = opt.get('polys', True)
         p, q = p.as_expr(), q.as_expr()
-    elif isinstance(f, Tuple):
-        return factor_terms(f)
     else:
         raise ValueError('unexpected argument: %s' % f)
 
@@ -7376,7 +7374,7 @@ def cancel(f, *gens, _signsimp=True, **args):
             raise PolynomialError()
         R, (F, G) = sring((p, q), *gens, **args)
         if not R.ngens:
-            if not isinstance(f, (tuple, Tuple)):
+            if not isinstance(f, Tuple):
                 return f.expand()
             else:
                 return S.One, p, q
@@ -7395,8 +7393,7 @@ def cancel(f, *gens, _signsimp=True, **args):
             pot = preorder_traversal(f)
             next(pot)
             for e in pot:
-                # XXX: This should really skip anything that's not Expr.
-                if isinstance(e, (tuple, Tuple, BooleanAtom)):
+                if isinstance(e, BooleanAtom) or not isinstance(e, Expr):
                     continue
                 try:
                     reps.append((e, cancel(e)))
@@ -7409,7 +7406,7 @@ def cancel(f, *gens, _signsimp=True, **args):
     if opt.get('polys', False) and 'gens' not in opt:
         opt['gens'] = R.symbols
 
-    if not isinstance(f, (tuple, Tuple)):
+    if not isinstance(f, Tuple):
         return c*(P.as_expr()/Q.as_expr())
     else:
         P, Q = P.as_expr(), Q.as_expr()

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3298,9 +3298,15 @@ def test_cancel():
 
     assert cancel(oo) is oo
 
-    assert cancel((2, 3)) == (1, 2, 3)
+    raises(ValueError, lambda: cancel((1, 2, 3)))
 
-    assert cancel((1, 0), x) == (1, 1, 0)
+    # test first tuple returnr
+    assert (t:=cancel((2, 3))) == (1, 2, 3)
+    assert isinstance(t, tuple)
+
+    # tests 2nd tuple return
+    assert (t:=cancel((1, 0), x)) == (1, 1, 0)
+    assert isinstance(t, tuple)
     assert cancel((0, 1), x) == (1, 0, 1)
 
     f, g, p, q = 4*x**2 - 4, 2*x - 2, 2*x + 2, 1
@@ -3310,7 +3316,9 @@ def test_cancel():
     assert cancel((f, g)) == (1, p, q)
     assert cancel((f, g), x) == (1, p, q)
     assert cancel((f, g), (x,)) == (1, p, q)
-    assert cancel((F, G)) == (1, P, Q)
+    # tests 3rd tuple return
+    assert (t:=cancel((F, G))) == (1, P, Q)
+    assert isinstance(t, tuple)
     assert cancel((f, g), polys=True) == (1, P, Q)
     assert cancel((F, G), polys=False) == (1, p, q)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * `cancel` can accept a tuple or Tuple but it must now be of length 2; any other length will raise an error
<!-- END RELEASE NOTES -->
