### PR TITLE
Handle multiple equations and inequalities for `parse_expr`

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -12,7 +12,7 @@ import builtins
 import types
 from typing import Tuple as tTuple, Dict as tDict, Any, Callable, \
     List, Optional, Union as tUnion
-
+from functools import reduce
 from sympy.assumptions.ask import AssumptionKeys
 from sympy.core.basic import Basic
 from sympy.core import Symbol
@@ -1128,17 +1128,31 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         ast.Eq: 'Eq'
     }
     def visit_Compare(self, node):
-        if node.ops[0].__class__ in self.relational_operators:
-            sympy_class = self.relational_operators[node.ops[0].__class__]
-            right = self.visit(node.comparators[0])
-            left = self.visit(node.left)
-            new_node = ast.Call(
-                func=ast.Name(id=sympy_class, ctx=ast.Load()),
-                args=[left, right],
-                keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
+        def reducer(acc, op_right):
+            result, left = acc
+            op, right = op_right
+            right = self.visit(right)
+            if op.__class__ not in self.relational_operators:
+                raise ValueError("Only equation or inequality operators are supported")
+            new = ast.Call(
+                func=ast.Name(
+                    id=self.relational_operators[op.__class__], ctx=ast.Load()
+                ),
+                args=[self.visit(left), self.visit(right)],
+                keywords=[ast.keyword(arg="evaluate", value=ast.Constant(value=False))],
             )
-            return new_node
-        return node
+            return result + [new], right
+
+        args, _ = reduce(
+            reducer, zip(node.ops, node.comparators), ([], node.left)
+        )
+        if len(args) == 1:
+            return args[0]
+        return ast.Call(
+            func=ast.Name(id=self.operators[ast.BitAnd], ctx=ast.Load()),
+            args=args,
+            keywords=[ast.keyword(arg="evaluate", value=ast.Constant(value=False))],
+        )
 
     def flatten(self, args, func):
         result = []

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1128,11 +1128,12 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         ast.Eq: 'Eq'
     }
     def visit_Compare(self, node):
+        if any(op.__class__ not in self.relational_operators for op in node.ops):
+            return node
+
         def reducer(acc, op_right):
             result, left = acc
             op, right = op_right
-            if op.__class__ not in self.relational_operators:
-                raise ValueError("Only equation or inequality operators are supported")
             new = ast.Call(
                 func=ast.Name(
                     id=self.relational_operators[op.__class__], ctx=ast.Load()

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1131,7 +1131,6 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         def reducer(acc, op_right):
             result, left = acc
             op, right = op_right
-            right = self.visit(right)
             if op.__class__ not in self.relational_operators:
                 raise ValueError("Only equation or inequality operators are supported")
             new = ast.Call(

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1128,12 +1128,11 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         ast.Eq: 'Eq'
     }
     def visit_Compare(self, node):
-        if any(op.__class__ not in self.relational_operators for op in node.ops):
-            return node
-
         def reducer(acc, op_right):
             result, left = acc
             op, right = op_right
+            if op.__class__ not in self.relational_operators:
+                raise ValueError("Only equation or inequality operators are supported")
             new = ast.Call(
                 func=ast.Name(
                     id=self.relational_operators[op.__class__], ctx=ast.Load()

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -280,16 +280,21 @@ def test_parse_function_issue_3539():
     assert parse_expr('f(x)') == f(x)
 
 def test_issue_24288():
-    inputs = {
-        "1 < 2": Lt(1, 2, evaluate=False),
-        "1 <= 2": Le(1, 2, evaluate=False),
-        "1 > 2": Gt(1, 2, evaluate=False),
-        "1 >= 2": Ge(1, 2, evaluate=False),
-        "1 != 2": Ne(1, 2, evaluate=False),
-        "1 == 2": Eq(1, 2, evaluate=False)
-    }
-    for text, result in inputs.items():
-        assert parse_expr(text, evaluate=False) == result
+    assert parse_expr("1 < 2", evaluate=False) == Lt(1, 2, evaluate=False)
+    assert parse_expr("1 <= 2", evaluate=False) == Le(1, 2, evaluate=False)
+    assert parse_expr("1 > 2", evaluate=False) == Gt(1, 2, evaluate=False)
+    assert parse_expr("1 >= 2", evaluate=False) == Ge(1, 2, evaluate=False)
+    assert parse_expr("1 != 2", evaluate=False) == Ne(1, 2, evaluate=False)
+    assert parse_expr("1 == 2", evaluate=False) == Eq(1, 2, evaluate=False)
+    assert parse_expr("1 < 2 < 3", evaluate=False) == And(Lt(1, 2, evaluate=False), Lt(2, 3, evaluate=False), evaluate=False)
+    assert parse_expr("1 <= 2 <= 3", evaluate=False) == And(Le(1, 2, evaluate=False), Le(2, 3, evaluate=False), evaluate=False)
+    assert parse_expr("1 < 2 <= 3 < 4", evaluate=False) == \
+        And(Lt(1, 2, evaluate=False), Le(2, 3, evaluate=False), Lt(3, 4, evaluate=False), evaluate=False)
+    # Valid Python relational operators that SymPy does not decide how to handle them yet
+    raises(ValueError, lambda: parse_expr("1 in 2", evaluate=False))
+    raises(ValueError, lambda: parse_expr("1 is 2", evaluate=False))
+    raises(ValueError, lambda: parse_expr("1 not in 2", evaluate=False))
+    raises(ValueError, lambda: parse_expr("1 is not 2", evaluate=False))
 
 def test_split_symbols_numeric():
     transformations = (

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -290,11 +290,11 @@ def test_issue_24288():
     assert parse_expr("1 <= 2 <= 3", evaluate=False) == And(Le(1, 2, evaluate=False), Le(2, 3, evaluate=False), evaluate=False)
     assert parse_expr("1 < 2 <= 3 < 4", evaluate=False) == \
         And(Lt(1, 2, evaluate=False), Le(2, 3, evaluate=False), Lt(3, 4, evaluate=False), evaluate=False)
-    # Valid Python relational operators that SymPy does not decide how to handle them yet
-    raises(ValueError, lambda: parse_expr("1 in 2", evaluate=False))
-    raises(ValueError, lambda: parse_expr("1 is 2", evaluate=False))
-    raises(ValueError, lambda: parse_expr("1 not in 2", evaluate=False))
-    raises(ValueError, lambda: parse_expr("1 is not 2", evaluate=False))
+    # parse_expr with evaluate=True also falls back to Python comparison for them
+    assert parse_expr(r"1 in {1}", evaluate=False)
+    assert parse_expr(r"1 not in {2}", evaluate=False)
+    assert parse_expr(r"1 is 1", evaluate=False)
+    assert parse_expr(r"1 is not 2", evaluate=False)
 
 def test_split_symbols_numeric():
     transformations = (

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -290,11 +290,11 @@ def test_issue_24288():
     assert parse_expr("1 <= 2 <= 3", evaluate=False) == And(Le(1, 2, evaluate=False), Le(2, 3, evaluate=False), evaluate=False)
     assert parse_expr("1 < 2 <= 3 < 4", evaluate=False) == \
         And(Lt(1, 2, evaluate=False), Le(2, 3, evaluate=False), Lt(3, 4, evaluate=False), evaluate=False)
-    # parse_expr with evaluate=True also falls back to Python comparison for them
-    assert parse_expr(r"1 in {1}", evaluate=False)
-    assert parse_expr(r"1 not in {2}", evaluate=False)
-    assert parse_expr(r"1 is 1", evaluate=False)
-    assert parse_expr(r"1 is not 2", evaluate=False)
+    # Valid Python relational operators that SymPy does not decide how to handle them yet
+    raises(ValueError, lambda: parse_expr("1 in 2", evaluate=False))
+    raises(ValueError, lambda: parse_expr("1 is 2", evaluate=False))
+    raises(ValueError, lambda: parse_expr("1 not in 2", evaluate=False))
+    raises(ValueError, lambda: parse_expr("1 is not 2", evaluate=False))
 
 def test_split_symbols_numeric():
     transformations = (


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/26834

#### Brief description of what is fixed or changed

Non-monotonic comparisons like `0 < x > 100` are possible with Python parser, so SymPy could keep them working regardless of they are possible mathematically or not.

I note that `And` sorts the arguments regardless of `evaluate=False`, maybe this can be bug in SymPy as well.

I also note that `in` or `is` are also valid Python comparison operators, and even multiple comparison is supported (for example `1 in [1] in [[1]]`), but I don't think that we have anything decided about set expressions, so I have left them raise errors.

The other thing that can lead to discussion is about raising the correctors errors, for example, we can exclude line 1135 and raise `KeyError` from dictionary naturally, but that may not be specified errors from https://docs.python.org/3/library/ast.html#ast-helpers. 
I also can't easily figure out which types of errors we should use for parsing because the documentation does not give very good hint.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - Fixed an issue that `parse_expr` with `evaluate=False` did not handle chained equation or inequality comparisons. For example, `parse_expr("0 < x < 100", evaluate=False)` should now work.
<!-- END RELEASE NOTES -->
