### PR TITLE
TensExpr.expand: reuse sympy.core.expand rather than an independent method

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3933,6 +3933,7 @@ class TensMul(TensExpr, AssocOp):
             return expr.canon_bp()
         if not expr.components:
             return expr
+        expr = expr.doit(deep=False) #make sure self.coeff is populated correctly
         t = expr.sorted_components()
         g, dummies, msym = t._index_structure.indices_canon_args()
         v = components_canon_args(t.components)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3853,6 +3853,12 @@ class TensMul(TensExpr, AssocOp):
             TensMul(*i) for i in itertools.product(*args1)]
         )
 
+    def _eval_expand_mul(self, **hints):
+        args1 = [arg.args if isinstance(arg, (Add, TensAdd)) else (arg,) for arg in self.args]
+        return TensAdd(*[
+            TensMul(*i).doit(deep=False) for i in itertools.product(*args1)]
+        )
+
     def __neg__(self):
         return TensMul(S.NegativeOne, self, is_canon_bp=self._is_canon_bp).doit(deep=False)
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3989,7 +3989,7 @@ class TensMul(TensExpr, AssocOp):
         >>> t.contract_metric(g).canon_bp()
         p(L_0)*q(-L_0)
         """
-        expr = self.expand()
+        expr = self.expand().doit(deep=False)
         if self != expr:
             expr = canon_bp(expr)
             return contract_metric(expr, g)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -8,6 +8,7 @@ from sympy.core import S, Rational, Symbol, Basic, Add, Wild, Function
 from sympy.core.containers import Tuple
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.integrals import integrate
 from sympy.tensor.array import Array
 from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, \
     get_symmetric_group_sgs, TensorIndex, tensor_mul, TensAdd, \
@@ -430,6 +431,16 @@ def test_canonicalize4():
     K = TensorHead("K", [Cartesian])
     expr = TensAdd( K(p) , - 2*K(p) )
     assert expr.canon_bp() == -K(p)
+
+def test_canonicalize5():
+    R3 = TensorIndexType('R3', dim=3)
+    p = tensor_indices("p", R3)
+    K = TensorHead("K", [R3])
+    f = symbols("f", cls=Function)
+    x = symbols("x")
+
+    expr = integrate(f(x), (x,0,1)) * K(p)
+    assert expr.as_dummy().canon_bp() == integrate(f(x), (x,0,1)).as_dummy() * K(p)
 
 def test_TensorIndexType():
     D = Symbol('D')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.core.numbers import Integer
 from sympy.matrices.dense import (Matrix, eye)
 from sympy.tensor.indexed import Indexed
 from sympy.combinatorics import Permutation
-from sympy.core import S, Rational, Symbol, Basic, Add, Wild
+from sympy.core import S, Rational, Symbol, Basic, Add, Wild, Function
 from sympy.core.containers import Tuple
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -1787,6 +1787,9 @@ def test_tensor_expand():
 
     A, B, C, D = tensor_heads("A B C D", [L])
 
+    F = Function("F")
+    x = Symbol("x")
+
     assert isinstance(Add(A(i), B(i)), TensAdd)
     assert isinstance(expand(A(i)+B(i)), TensAdd)
 
@@ -1830,6 +1833,21 @@ def test_tensor_expand():
 
     expr = C(-i)*(B(j)*B(-j) + B(j)*C(-j))
     assert expr.expand() == C(-i)*B(j)*B(-j) + C(-i)*B(j)*C(-j)
+
+    """
+    Test whether expand correctly handles the case where the coeff of a TensMul
+    is an add. We do not directly check expr_expand == 2*A(i) + F(x)*A(i) since
+    __add__ currently consolidates the coefficients automatically
+    """
+    expr = (2 + F(x))*A(i)
+    expr_expand = expr.expand()
+    assert isinstance(expr_expand, TensAdd)
+    assert expr_expand.args == (2*A(i), F(x)*A(i))
+
+    expr = (2 + F(x))*A(i) + B(i)
+    expr_expand = expr.expand()
+    assert isinstance(expr_expand, TensAdd)
+    assert expr_expand.args == (2*A(i), F(x)*A(i), B(i))
 
 
 def test_tensor_alternative_construction():

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1014,6 +1014,20 @@ def test_contract_metric4():
     assert expr.contract_metric(delta) == 0
 
 
+def test_contract_metric5():
+    R3 = TensorIndexType('R3', dim=3)
+    p, q, r = tensor_indices("p q r", R3)
+    delta = R3.delta
+    K = TensorHead("K", [R3])
+
+    F = Function("F")
+    x = Symbol("x")
+
+    #Check if contract_metric gets into an infinite loop when given a TensMul whose coeff is an Add
+    expr = (2+F(x))*K(-p)*K(-q)
+    assert expr.contract_metric(delta) == expr
+
+
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_name='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -442,10 +442,10 @@ def test_eval_partial_derivative_expr1():
         L.delta(L_0, -k)*A(-L_0)*A(j) +
         A(L_0)*L.metric(-L_0, -L_1)*L.delta(L_1, -k)*A(j) +
         A(L_0)*A(-L_0)*L.delta(j, -k) +
-        L.delta(L_0, -k)*H(-L_0, j))).expand() == 0
+        L.delta(L_0, -k)*H(-L_0, j))).expand().doit() == 0
 
     assert (vector_derivative.contract_metric(L.metric).contract_delta(L.delta) -
-        (tau**alpha*L.delta(j, -k) + A(L_0)*A(-L_0)*L.delta(j, -k) + H(-k, j) + 2*A(j)*A(-k))).expand() == 0
+        (tau**alpha*L.delta(j, -k) + A(L_0)*A(-L_0)*L.delta(j, -k) + H(-k, j) + 2*A(j)*A(-k))).expand().doit() == 0
 
     assert scalar_derivative - alpha*1/tau*tau**alpha*A(j) == 0
 
@@ -458,7 +458,7 @@ def test_eval_partial_derivative_mixed_scalar_tensor_expr2():
 
     vector_expression = PartialDerivative(base_expr2, A(k))._perform_derivative()
     assert  (vector_expression -
-        (L.delta(L_0, -k)*A(-L_0) + A(L_0)*L.metric(-L_0, -L_1)*L.delta(L_1, -k))).expand() == 0
+        (L.delta(L_0, -k)*A(-L_0) + A(L_0)*L.metric(-L_0, -L_1)*L.delta(L_1, -k))).expand().doit() == 0
 
     scalar_expression = PartialDerivative(base_expr2, tau)._perform_derivative()
     assert scalar_expression == 2*tau


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- #### References to other Issues or PRs -->
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier, expansion of `TensExpr` instances was done through a method independent of `sympy.core.expand`. This PR makes expansion of `TensExpr` use the same machinery as other Sympy objects. The only nontrivial expansion is done for `Tensmul`, for which I have added an `_eval_expand_mul` method.

#### Other comments
* `doit` is no longer called on the result of the expansion. This has the benefit of allowing to expand things like `(1 + x)*K(p)` (which would earlier not be expanded), but the disadvantage is that some tests need to be modified and `doit` needs to be explicitly called in some other functions where it is needed after expansion (e.g. `canon_bp`). This may break some user code, but I am not sure how to communicate it to users beyond mentioning it in the changelog
* With this change, the results of the expansion are cached (I believe the method earlier used was not cached)
* Suggested reviewers: @Upabjojr 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * `doit` is no longer automatically called on the result of `TensExpr.expand`
  * Calling `expand` on `TensMul` whose coeff is an `Add` now results in a `TensAdd` (earlier, no expansion would  be performed)
<!-- END RELEASE NOTES -->
