### PR TITLE
Fix measure_all_oneshot (Qubit(0)) that yields |01>

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -658,6 +658,7 @@ Grace Su <grace.duansu@gmail.com>
 Gregory Ashton <gash789@gmail.com> <ga7g08@soton.ac.uk>
 Gregory Ksionda <ksiondag846@gmail.com>
 Grzegorz Świrski <sognat@gmail.com>
+Guido Roncarolo <guido.roncarolo@gmail.com> groncarolo <53181812+groncarolo@users.noreply.github.com>
 Guillaume Gay <contact@damcb.com> <guillaume@mitotic-machine.org>
 Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
 Guo Xingjian <Seeker1995@gmail.com>

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -804,7 +804,7 @@ def measure_all_oneshot(qubit, format='sympy'):
             if total > random_number:
                 break
             result += 1
-        return Qubit(IntQubit(result, int(math.log2(max(m.shape)) + .1)))
+        return Qubit(IntQubit(result, nqubits=int(math.log2(max(m.shape)) + .1)))
     else:
         raise NotImplementedError(
             "This function cannot handle non-SymPy matrix formats yet"

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -5,7 +5,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import Matrix
-from sympy.physics.quantum.qubit import (measure_all, measure_partial,
+from sympy.physics.quantum.qubit import (measure_all, measure_all_oneshot, measure_partial,
                                          matrix_to_qubit, matrix_to_density,
                                          qubit_to_matrix, IntQubit,
                                          IntQubitBra, QubitBra)
@@ -191,6 +191,15 @@ def test_measure_all():
 
     # from issue #12585
     assert measure_all(qapply(Qubit('0'))) == [(Qubit('0'), 1)]
+
+
+def test_measure_all_oneshot():
+    random.seed(42)
+    # for issue #27092
+    assert measure_all_oneshot(Qubit('11')) == Qubit('11')
+    assert measure_all_oneshot(Qubit('1')) == Qubit('1')
+    assert measure_all_oneshot(Qubit('0')/sqrt(2) + Qubit('1')/sqrt(2)) == \
+            Qubit('0')
 
 
 def test_eval_trace():


### PR DESCRIPTION
Fixes #27092

Fix measure_all_oneshot (Qubit(0)) that yields |01>
   
Fix the following case:
```
q = Qubit(0)
measure_all_oneshot(q)
|01>
 ```
Add also the tests for this use case

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * A bug in Qubit.measure_all_oneshot was fixed. Previously measuring `measure_all_oneshot(Qubit(0))` would return incorrectly `|01>`. Now `Qubit.measure_all_oneshot(Qubit(0))` returns correct results `|0>` 
<!-- END RELEASE NOTES -->
