### PR TITLE
polytools: fix cancel() to output simplified term

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4050,7 +4050,23 @@ class Poly(Basic):
             cp = dom.to_sympy(cp)
             cq = dom.to_sympy(cq)
 
-            return cp/cq, per(p), per(q)
+            quo = cp / cq
+
+            if quo.is_rational:
+                numerator, denominator = quo.as_numer_denom()
+
+                p = per(p) * numerator
+                q = per(q) * denominator
+
+                try:
+                    p = p.set_domain('ZZ')
+                    q = q.set_domain('ZZ')
+                except Exception as e:
+                    pass
+
+                quo = 1
+
+            return quo, p, q
         else:
             return tuple(map(per, result))
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4061,7 +4061,7 @@ class Poly(Basic):
                 try:
                     p = p.set_domain('ZZ')
                     q = q.set_domain('ZZ')
-                except Exception as e:
+                except Exception:
                     pass
 
                 quo = 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27096

#### Brief description of what is fixed or changed
Expresses the results of cancel over QQ as a cancel over ZZ if applicable. Does so by multiplying out the numerator and denominator of the cancel coefficient and then changing the domains to ZZ if possible.


#### Other comments
Tried to ensure that this change won't mess up the results of cancel on untargeted domains

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Converts cancel over QQ to equivalent cancel over ZZ when possible
<!-- END RELEASE NOTES -->
