### PR TITLE
make cancel canonical for a given expression

### DIFF
--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -744,7 +744,7 @@ def test_to_meijerg():
     p = hyper((Rational(-1, 2), -3), (), x)
     assert from_hyper(p).to_meijerg() == hyperexpand(p)
     p = hyper((S.One, S(3)), (S(2), ), x)
-    assert (hyperexpand(from_hyper(p).to_meijerg()) - hyperexpand(p)).expand() == 0
+    assert (hyperexpand(from_hyper(p).to_meijerg()) - hyperexpand(p)).cancel() == 0
     p = from_hyper(hyper((-2, -3), (S.Half, ), x))
     s = hyperexpand(hyper((-2, -3), (S.Half, ), x))
     C_0 = Symbol('C_0')

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -180,8 +180,8 @@ def test_laurent_series():
     F = Poly(t**2 - 1, t)
     n = 2
     assert laurent_series(a, d, F, n, DE) == \
-        (Poly(-3*t**3 + 3*t**2 - 6*t - 8, t), Poly(t**5 + t**4 - 2*t**3 - 2*t**2 + t + 1, t),
-        [Poly(-3*t**3 - 6*t**2, t, domain='QQ'), Poly(2*t**6 + 6*t**5 - 8*t**3, t, domain='QQ')])
+        (Poly((-3*t**3 + 3*t**2 - 6*t - 8)/36, t), Poly(t**5 + t**4 - 2*t**3 - 2*t**2 + t + 1, t),
+        [Poly((-3*t**3 - 6*t**2)/36, t, domain='QQ'), Poly((2*t**6 + 6*t**5 - 8*t**3)/36, t, domain='QQ')]),laurent_series(a, d, F, n, DE)
 
 
 def test_recognize_derivative():

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1861,7 +1861,7 @@ def dup_cancel(f, g, K, include=True):
 
 def dmp_ZZ_gcd(f, K):
         from sympy.core.intfunc import igcd
-        assert not f or set([type(i) for i in f]) in [{int},{list}],f
+        assert not f or {type(i) for i in f} in [{int}, {list}], f
         def flat(i):
             if type(i) is list:
                 for i in i:

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1880,6 +1880,7 @@ def dmp_cancel(f, g, u, K, include=True):
 
         cq, f = dmp_clear_denoms(f, u, K0, K, convert=True)
         cp, g = dmp_clear_denoms(g, u, K0, K, convert=True)
+        # domain is now K
     else:
         cp, cq = K.one, K.one
 
@@ -1903,10 +1904,12 @@ def dmp_cancel(f, g, u, K, include=True):
     elif q_neg:
         cp, q = -cp, dmp_neg(q, u, K)
 
+    if include or (c:=(cp,cq)).count(1) == 1 and c.count(-1) == 0:
+        p = dmp_mul_ground(p, cp, u, K)
+        q = dmp_mul_ground(q, cq, u, K)
+        cp = cq = 1
+
     if not include:
         return cp, cq, p, q
-
-    p = dmp_mul_ground(p, cp, u, K)
-    q = dmp_mul_ground(q, cq, u, K)
 
     return p, q

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1929,12 +1929,10 @@ def dmp_cancel(f, g, u, K, include=True):
     elif q_neg:
         cp, q = -cp, dmp_neg(q, u, K)
 
-    if include:
-        p = dmp_mul_ground(p, cp, u, K)
-        q = dmp_mul_ground(q, cq, u, K)
-        cp = cq = 1
-
     if not include:
         return cp, cq, p, q
+
+    p = dmp_mul_ground(p, cp, u, K)
+    q = dmp_mul_ground(q, cq, u, K)
 
     return p, q

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1859,27 +1859,6 @@ def dup_cancel(f, g, K, include=True):
     return dmp_cancel(f, g, 0, K, include=include)
 
 
-def dmp_ZZ_gcd(f, K):
-        from sympy.core.intfunc import igcd
-        assert not f or {type(i) for i in f} in [{int}, {list}], f
-        def flat(i):
-            if type(i) is list:
-                for i in i:
-                    for j in flat(i):
-                        yield j
-            else:
-                yield i
-        _flat = list(flat(f))
-        if not _flat:
-            return K.one, f
-        if len(_flat) == 1:
-            c = _flat[0]
-        else:
-            c = igcd(*_flat)
-        if c - 1:
-            f = [i//c for i in f] if f and type(f[0]) is int else [[i//c for i in j] for j in f]
-        return c, f
-
 def dmp_cancel(f, g, u, K, include=True):
     """
     Cancel common factors in a rational function `f/g`.
@@ -1902,12 +1881,10 @@ def dmp_cancel(f, g, u, K, include=True):
         cq, f = dmp_clear_denoms(f, u, K0, K, convert=True)
         cp, g = dmp_clear_denoms(g, u, K0, K, convert=True)
         # domain is now K
-    elif K.is_ZZ:
-        # remove gcd
-        cp, f = dmp_ZZ_gcd(f, K)
-        cq, g = dmp_ZZ_gcd(g, K)
     else:
-        cp, cq = K.one, K.one
+        # remove gcd
+        cp, f = dmp_ground_primitive(f, u, K)
+        cq, g = dmp_ground_primitive(g, u, K)
 
     _, p, q = dmp_inner_gcd(f, g, u, K)
 

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -255,9 +255,9 @@ def apart_list(f, x=None, dummies=None, **options):
     >>> f = (2*x**3 - 2*x) / (x**2 - 2*x + 1)
     >>> pfd = apart_list(f)
     >>> pfd
-    (1,
-    Poly(2*x + 4, x, domain='ZZ'),
-    [(Poly(_w - 1, _w, domain='ZZ'), Lambda(_a, 4), Lambda(_a, -_a + x), 1)])
+    (2,
+    Poly(x + 2, x, domain='ZZ'),
+    [(Poly(_w - 1, _w, domain='ZZ'), Lambda(_a, 2), Lambda(_a, -_a + x), 1)])
 
     >>> assemble_partfrac_list(pfd)
     2*x + 4 + 4/(x - 1)
@@ -267,9 +267,9 @@ def apart_list(f, x=None, dummies=None, **options):
     >>> f = (-2*x - 2*x**2) / (3*x**2 - 6*x)
     >>> pfd = apart_list(f)
     >>> pfd
-    (-1,
-    Poly(2/3, x, domain='QQ'),
-    [(Poly(_w - 2, _w, domain='ZZ'), Lambda(_a, 2), Lambda(_a, -_a + x), 1)])
+    (-2/3,
+    Poly(1, x, domain='ZZ'),
+    [(Poly(_w - 2, _w, domain='ZZ'), Lambda(_a, 3), Lambda(_a, -_a + x), 1)])
 
     >>> assemble_partfrac_list(pfd)
     -2/3 - 2/(x - 2)
@@ -293,11 +293,11 @@ def apart_list(f, x=None, dummies=None, **options):
     >>> f = 36 / (x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2)
     >>> pfd = apart_list(f)
     >>> pfd
-    (1,
+    (36,
     Poly(0, x, domain='ZZ'),
-    [(Poly(_w - 2, _w, domain='ZZ'), Lambda(_a, 4), Lambda(_a, -_a + x), 1),
-    (Poly(_w**2 - 1, _w, domain='ZZ'), Lambda(_a, -3*_a - 6), Lambda(_a, -_a + x), 2),
-    (Poly(_w + 1, _w, domain='ZZ'), Lambda(_a, -4), Lambda(_a, -_a + x), 1)])
+    [(Poly(_w - 2, _w, domain='ZZ'), Lambda(_a, 1/9), Lambda(_a, -_a + x), 1),
+    (Poly(_w**2 - 1, _w, domain='ZZ'), Lambda(_a, -_a/12 - 1/6), Lambda(_a, -_a + x), 2),
+    (Poly(_w + 1, _w, domain='ZZ'), Lambda(_a, -1/9), Lambda(_a, -_a + x), 1)])
 
     >>> assemble_partfrac_list(pfd)
     -4/(x + 1) - 3/(x + 1)**2 - 9/(x - 1)**2 + 4/(x - 2)
@@ -330,18 +330,9 @@ def apart_list(f, x=None, dummies=None, **options):
             "multivariate partial fraction decomposition")
 
     common, P, Q = P.cancel(Q)
-    if common.is_Rational:
-        Q *= common.q
-        if common < 0:
-            P *= -common.p
-            common = S.NegativeOne
-        else:
-            P *= common.p
-            common =  S.One
 
     poly, P = P.div(Q, auto=True)
     P, Q = P.rat_clear_denoms(Q)
-
     polypart = poly
 
     if dummies is None:
@@ -440,11 +431,11 @@ def assemble_partfrac_list(partial_list):
     >>> f = 36 / (x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2)
     >>> pfd = apart_list(f)
     >>> pfd
-    (1,
+    (36,
     Poly(0, x, domain='ZZ'),
-    [(Poly(_w - 2, _w, domain='ZZ'), Lambda(_a, 4), Lambda(_a, -_a + x), 1),
-    (Poly(_w**2 - 1, _w, domain='ZZ'), Lambda(_a, -3*_a - 6), Lambda(_a, -_a + x), 2),
-    (Poly(_w + 1, _w, domain='ZZ'), Lambda(_a, -4), Lambda(_a, -_a + x), 1)])
+    [(Poly(_w - 2, _w, domain='ZZ'), Lambda(_a, 1/9), Lambda(_a, -_a + x), 1),
+    (Poly(_w**2 - 1, _w, domain='ZZ'), Lambda(_a, -_a/12 - 1/6), Lambda(_a, -_a + x), 2),
+    (Poly(_w + 1, _w, domain='ZZ'), Lambda(_a, -1/9), Lambda(_a, -_a + x), 1)])
 
     >>> assemble_partfrac_list(pfd)
     -4/(x + 1) - 3/(x + 1)**2 - 9/(x - 1)**2 + 4/(x - 2)
@@ -453,10 +444,10 @@ def assemble_partfrac_list(partial_list):
 
     >>> pfd = apart_list(2/(x**2-2))
     >>> pfd
-    (1,
+    (2,
     Poly(0, x, domain='ZZ'),
     [(Poly(_w**2 - 2, _w, domain='ZZ'),
-    Lambda(_a, _a/2),
+    Lambda(_a, _a/4),
     Lambda(_a, -_a + x),
     1)])
 

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -330,6 +330,14 @@ def apart_list(f, x=None, dummies=None, **options):
             "multivariate partial fraction decomposition")
 
     common, P, Q = P.cancel(Q)
+    if common.is_Rational:
+        Q *= common.q
+        if common < 0:
+            P *= -common.p
+            common = S.NegativeOne
+        else:
+            P *= common.p
+            common =  S.One
 
     poly, P = P.div(Q, auto=True)
     P, Q = P.rat_clear_denoms(Q)

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -6,6 +6,7 @@ from sympy.external.gmpy import GROUND_TYPES
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
+from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import oo
 from sympy.core.sympify import CantSympify
 from sympy.polys.polyutils import PicklableWithSlots, _sort_factors
@@ -2171,9 +2172,10 @@ class DUP_Flint(DMP):
         if R.is_QQ:
             cG, F = f.clear_denoms()
             cF, G = g.clear_denoms()
-        else:
-            cG, F = R.one, f
-            cF, G = R.one, g
+        elif R.is_ZZ:
+            print(f,g)
+            cG, F = factor_terms(f).as_coeff_Mul()  # or similar for type of f,g
+            cF, G = factor_terms(g).as_coeff_Mul()
 
         cH = cF.gcd(cG)
         cF, cG = cF // cH, cG // cH

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -544,6 +544,7 @@ class Poly(Basic):
         Poly(y + 1, y, domain='ZZ')
 
         """
+        # mnemonic: "per" is the reverse of "rep"
         if gens is None:
             gens = f.gens
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4032,7 +4032,7 @@ class Poly(Basic):
         >>> from sympy.abc import x
 
         >>> Poly(2*x**2 - 2, x).cancel(Poly(x**2 - 2*x + 1, x))
-        (1, Poly(2*x + 2, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'))
+        (2, Poly(x + 1, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'))
 
         >>> Poly(2*x**2 - 2, x).cancel(Poly(x**2 - 2*x + 1, x), include=True)
         (Poly(2*x + 2, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'))

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4020,7 +4020,10 @@ class Poly(Basic):
 
     def cancel(f, g, include=False):
         """
-        Cancel common factors in a rational function ``f/g``.
+        Cancel common factors in a rational function ``f/g``, returning
+        ``(p/q, n, d)`` if ``include`` is False, else ``(N, D)`` where
+        ``N/D = (p*n)/(q*d)``, i.e. ``p`` and ``q`` are included in ``N``
+        and ``D``.
 
         Examples
         ========

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -662,8 +662,8 @@ def test_dup_cancel():
     p = 2*x + 2
     q = x - 1
 
-    assert R.dup_cancel(f, g) == (p, q)
-    assert R.dup_cancel(f, g, include=False) == (1, 1, p, q)
+    assert R.dup_cancel(f, g) == (p, q),R.dup_cancel(f, g)
+    assert R.dup_cancel(f, g, include=False) == (2, 1, p/2, q)
 
     f = -x - 2
     g = 3*x - 4
@@ -700,7 +700,7 @@ def test_dmp_cancel():
     q = x - 1
 
     assert R.dmp_cancel(f, g) == (p, q)
-    assert R.dmp_cancel(f, g, include=False) == (1, 1, p, q)
+    assert R.dmp_cancel(f, g, include=False) == (2, 1, p/2, q)
 
     assert R.dmp_cancel(0, 0) == (0, 0)
     assert R.dmp_cancel(0, 0, include=False) == (1, 1, 0, 0)

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -197,22 +197,22 @@ def test_apart_list():
 
     f = (-2*x - 2*x**2) / (3*x**2 - 6*x)
     got = apart_list(f, x, dummies=numbered_symbols("w"))
-    ans = (-1, Poly(Rational(2, 3), x, domain='QQ'),
-        [(Poly(w0 - 2, w0, domain='ZZ'), Lambda(_a, 2), Lambda(_a, -_a + x), 1)])
+    ans = (-Rational(2, 3), Poly(1, x, domain='ZZ'),
+        [(Poly(w0 - 2, w0, domain='ZZ'), Lambda(_a, 3), Lambda(_a, -_a + x), 1)])
     assert dummy_eq(got, ans)
 
     got = apart_list(2/(x**2-2), x, dummies=numbered_symbols("w"))
-    ans = (1, Poly(0, x, domain='ZZ'), [(Poly(w0**2 - 2, w0, domain='ZZ'),
-        Lambda(_a, _a/2),
+    ans = (2, Poly(0, x, domain='ZZ'), [(Poly(w0**2 - 2, w0, domain='ZZ'),
+        Lambda(_a, _a/4),
         Lambda(_a, -_a + x), 1)])
     assert dummy_eq(got, ans)
 
     f = 36 / (x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2)
     got = apart_list(f, x, dummies=numbered_symbols("w"))
-    ans = (1, Poly(0, x, domain='ZZ'),
-        [(Poly(w0 - 2, w0, domain='ZZ'), Lambda(_a, 4), Lambda(_a, -_a + x), 1),
-        (Poly(w1**2 - 1, w1, domain='ZZ'), Lambda(_a, -3*_a - 6), Lambda(_a, -_a + x), 2),
-        (Poly(w2 + 1, w2, domain='ZZ'), Lambda(_a, -4), Lambda(_a, -_a + x), 1)])
+    ans = (36, Poly(0, x, domain='ZZ'),
+        [(Poly(w0 - 2, w0, domain='ZZ'), Lambda(_a, 1/S(9)), Lambda(_a, -_a + x), 1),
+        (Poly(w1**2 - 1, w1, domain='ZZ'), Lambda(_a, -_a/12 - 1/S(6)), Lambda(_a, -_a + x), 2),
+        (Poly(w2 + 1, w2, domain='ZZ'), Lambda(_a, -1/S(9)), Lambda(_a, -_a + x), 1)])
     assert dummy_eq(got, ans)
 
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3301,7 +3301,7 @@ def test_ptcancel():
     raises(ValueError, lambda: cancel((1, 2, 3)))
 
     # tests first tuple return
-    assert (t:=cancel((2, 3))) == (1, 2, 3)
+    assert (t:=cancel((2, 3))) == (S(2)/3, 1, 1)
     assert isinstance(t, tuple)
 
     # tests 2nd tuple return
@@ -3311,11 +3311,11 @@ def test_ptcancel():
 
     # issue 27906
     p, q = Poly(x**2/4 - 1), Poly(x/2 - 1)
-    zz = (1, Poly(x + 2), Poly(2, x))
-    qq = (1, Poly(x + 2, domain=QQ), Poly(2, x, domain=QQ))
+    zz = (S.Half, Poly(x + 2), Poly(1, x))
+    qq = (S.Half, Poly(x + 2, domain=QQ), Poly(1, x, domain=QQ))
     assert p.cancel(q, include=False) == qq
     case1 = p.cancel(q)
-    p, q = [Poly(i) for i in (p/q).as_expr().as_numer_denom()]
+    p, q = [Poly(4*i) for i in (p, q)]
     assert p.cancel(q, include=False) == zz
     case2 = p.cancel(q)
     c,n,d = case1
@@ -3328,15 +3328,15 @@ def test_ptcancel():
     f, g, p, q = 4*x**2 - 4, 2*x - 2, 2*x + 2, 1
     F, G, P, Q = [ Poly(u, x) for u in (f, g, p, q) ]
 
-    assert F.cancel(G) == (1, P, Q)
-    assert cancel((f, g)) == (1, p, q)
-    assert cancel((f, g), x) == (1, p, q)
-    assert cancel((f, g), (x,)) == (1, p, q)
+    assert F.cancel(G) == (2, P/2, Q)
+    assert cancel((f, g)) == (2, p/2, q)
+    assert cancel((f, g), x) == (2, p/2, q)
+    assert cancel((f, g), (x,)) == (2, p/2, q)
     # tests 3rd tuple return
-    assert (t:=cancel((F, G))) == (1, P, Q)
+    assert (t:=cancel((F, G))) == (2, P/2, Q)
     assert isinstance(t, tuple)
-    assert cancel((f, g), polys=True) == (1, P, Q)
-    assert cancel((F, G), polys=False) == (1, p, q)
+    assert cancel((f, g), polys=True) == (2, P/2, Q)
+    assert cancel((F, G), polys=False) == (2, p/2, q)
 
     f = (x**2 - 2)/(x + sqrt(2))
 
@@ -3348,8 +3348,7 @@ def test_ptcancel():
     assert cancel(f) == f
     assert cancel(f, greedy=False) == x + sqrt(2)
 
-    assert cancel((x**2/4 - 1, x/2 - 1)) == (1, x + 2, 2)
-    # assert cancel((x**2/4 - 1, x/2 - 1)) == (S.Half, x + 2, 1)
+    assert cancel((x**2/4 - 1, x/2 - 1)) == (S.Half, x + 2, 1)
 
     assert cancel((x**2 - y)/(x - y)) == 1/(x - y)*(x**2 - y)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3291,7 +3291,7 @@ def test_torational_factor_list():
     assert _torational_factor_list(p, x) is None
 
 
-def test_cancel():
+def test_ptcancel():
     assert cancel(0) == 0
     assert cancel(7) == 7
     assert cancel(x) == x
@@ -3300,7 +3300,7 @@ def test_cancel():
 
     raises(ValueError, lambda: cancel((1, 2, 3)))
 
-    # test first tuple returnr
+    # tests first tuple return
     assert (t:=cancel((2, 3))) == (1, 2, 3)
     assert isinstance(t, tuple)
 
@@ -3308,6 +3308,22 @@ def test_cancel():
     assert (t:=cancel((1, 0), x)) == (1, 1, 0)
     assert isinstance(t, tuple)
     assert cancel((0, 1), x) == (1, 0, 1)
+
+    # issue 27906
+    p, q = Poly(x**2/4 - 1), Poly(x/2 - 1)
+    zz = (1, Poly(x + 2), Poly(2, x))
+    qq = (1, Poly(x + 2, domain=QQ), Poly(2, x, domain=QQ))
+    assert p.cancel(q, include=False) == qq
+    case1 = p.cancel(q)
+    p, q = [Poly(i) for i in (p/q).as_expr().as_numer_denom()]
+    assert p.cancel(q, include=False) == zz
+    case2 = p.cancel(q)
+    c,n,d = case1
+    C,N,D = case2
+    assert (c*n/d).equals(C*N/D)
+    # case1 and 2 output is consistent with their input so we don't
+    # want the following assertion
+    # assert case1 == case2
 
     f, g, p, q = 4*x**2 - 4, 2*x - 2, 2*x + 2, 1
     F, G, P, Q = [ Poly(u, x) for u in (f, g, p, q) ]

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3315,8 +3315,8 @@ def test_ptcancel():
     qq = (S.Half, Poly(x + 2, domain=QQ), Poly(1, x, domain=QQ))
     assert p.cancel(q, include=False) == qq
     case1 = p.cancel(q)
-    p, q = [Poly(4*i) for i in (p, q)]
-    assert p.cancel(q, include=False) == zz
+    p, q = [Poly(4*i.as_expr()) for i in (p, q)]
+    assert p.cancel(q, include=False) == zz,p.cancel(q, include=False)
     case2 = p.cancel(q)
     c,n,d = case1
     C,N,D = case2

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -114,14 +114,14 @@ def test_hyperexpand_bases():
         a + z**(-a + 1)*(-a**2 + 3*a + z*(a - 1) - 2)*exp(z)* \
         lowergamma(a - 1, z) - 1
     # TODO [a+1, aRational(-1, 2)], [2*a]
-    assert hyperexpand(hyper([1, 2], [3], z)) == -2/z - 2*log(-z + 1)/z**2
-    assert hyperexpand(hyper([S.Half, 2], [Rational(3, 2)], z)) == \
-        -1/(2*z - 2) + atanh(sqrt(z))/sqrt(z)/2
-    assert hyperexpand(hyper([S.Half, S.Half], [Rational(5, 2)], z)) == \
+    assert hyperexpand(hyper([1, 2], [3], z)).equals(-2/z - 2*log(-z + 1)/z**2)
+    assert hyperexpand(hyper([S.Half, 2], [Rational(3, 2)], z)).equals(
+        -1/(2*z - 2) + atanh(sqrt(z))/sqrt(z)/2)
+    assert hyperexpand(hyper([S.Half, S.Half], [Rational(5, 2)], z)).equals(
         (-3*z + 3)/4/(z*sqrt(-z + 1)) \
-        + (6*z - 3)*asin(sqrt(z))/(4*z**Rational(3, 2))
-    assert hyperexpand(hyper([1, 2], [Rational(3, 2)], z)) == -1/(2*z - 2) \
-        - asin(sqrt(z))/(sqrt(z)*(2*z - 2)*sqrt(-z + 1))
+        + (6*z - 3)*asin(sqrt(z))/(4*z**Rational(3, 2)))
+    assert hyperexpand(hyper([1, 2], [Rational(3, 2)], z)).equals(
+        -1/(2*z - 2) - asin(sqrt(z))/(sqrt(z)*(2*z - 2)*sqrt(-z + 1)))
     assert hyperexpand(hyper([Rational(-1, 2) - 1, 1, 2], [S.Half, 3], z)) == \
         sqrt(z)*(z*Rational(6, 7) - Rational(6, 5))*atanh(sqrt(z)) \
         + (-30*z**2 + 32*z - 6)/35/z - 6*log(-z + 1)/(35*z**2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #27096
#### Brief description of what is fixed or changed

The result of `p.cancel(q, include=False)` should be the same as `P.cancel(Q)` if `(p/q).equals(P/Q)`. The domain will match the unified domain of `p` and `q`, however, so may be different.

Also, any extractable Rational context will be reported; there will never be a distributed constant in numerator or denominator expressions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
