### PR TITLE
Corrected restructuredtext formatting in linear_eq_to_matrix docstring.

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2765,30 +2765,36 @@ def linear_coeffs(eq, *syms, dict=False):
 
 def linear_eq_to_matrix(equations, *symbols):
     r"""
-    Converts a given System of Equations into Matrix form.
-    Here `equations` must be a linear system of equations in
-    `symbols`. Element ``M[i, j]`` corresponds to the coefficient
-    of the jth symbol in the ith equation.
+    Converts a given System of Equations into Matrix form. Here ``equations``
+    must be a linear system of equations in ``symbols``. Element ``M[i, j]``
+    corresponds to the coefficient of the jth symbol in the ith equation.
 
-    The Matrix form corresponds to the augmented matrix form.
-    For example:
+    The Matrix form corresponds to the augmented matrix form. For example:
 
-    .. math:: 4x + 2y + 3z  = 1
-    .. math:: 3x +  y +  z  = -6
-    .. math:: 2x + 4y + 9z  = 2
+    .. math::
 
-    This system will return $A$ and $b$ as:
+       4x + 2y + 3z & = 1 \\
+       3x +  y +  z & = -6 \\
+       2x + 4y + 9z & = 2
 
-    $$ A = \left[\begin{array}{ccc}
-        4 & 2 & 3 \\
-        3 & 1 & 1 \\
-        2 & 4 & 9
-        \end{array}\right] \ \  b = \left[\begin{array}{c}
-        1 \\ -6 \\ 2
-        \end{array}\right] $$
+    This system will return :math:`A` and :math:`b` as:
+
+    .. math::
+
+       A = \left[\begin{array}{ccc}
+       4 & 2 & 3 \\
+       3 & 1 & 1 \\
+       2 & 4 & 9
+       \end{array}\right] \\
+
+    .. math::
+
+       b = \left[\begin{array}{c}
+       1 \\ -6 \\ 2
+       \end{array}\right]
 
     The only simplification performed is to convert
-    ``Eq(a, b)`` $\Rightarrow a - b$.
+    ``Eq(a, b)`` :math:`\Rightarrow a - b`.
 
     Raises
     ======
@@ -2807,39 +2813,40 @@ def linear_eq_to_matrix(equations, *symbols):
     The coefficients (numerical or symbolic) of the symbols will
     be returned as matrices:
 
-        >>> eqns = [c*x + z - 1 - c, y + z, x - y]
-        >>> A, b = linear_eq_to_matrix(eqns, [x, y, z])
-        >>> A
-        Matrix([
-        [c,  0, 1],
-        [0,  1, 1],
-        [1, -1, 0]])
-        >>> b
-        Matrix([
-        [c + 1],
-        [    0],
-        [    0]])
+    >>> eqns = [c*x + z - 1 - c, y + z, x - y]
+    >>> A, b = linear_eq_to_matrix(eqns, [x, y, z])
+    >>> A
+    Matrix([
+    [c,  0, 1],
+    [0,  1, 1],
+    [1, -1, 0]])
+    >>> b
+    Matrix([
+    [c + 1],
+    [    0],
+    [    0]])
 
     This routine does not simplify expressions and will raise an error
     if nonlinearity is encountered:
 
-            >>> eqns = [
-            ...     (x**2 - 3*x)/(x - 3) - 3,
-            ...     y**2 - 3*y - y*(y - 4) + x - 4]
-            >>> linear_eq_to_matrix(eqns, [x, y])
-            Traceback (most recent call last):
-            ...
-            NonlinearError:
-            symbol-dependent term can be ignored using `strict=False`
+    >>> eqns = [
+    ...     (x**2 - 3*x)/(x - 3) - 3,
+    ...     y**2 - 3*y - y*(y - 4) + x - 4]
+    >>> linear_eq_to_matrix(eqns, [x, y])
+    Traceback (most recent call last):
+    ...
+    NonlinearError:
+    symbol-dependent term can be ignored using `strict=False`
 
-        Simplifying these equations will discard the removable singularity
-        in the first and reveal the linear structure of the second:
+    Simplifying these equations will discard the removable singularity in the
+    first and reveal the linear structure of the second:
 
-            >>> [e.simplify() for e in eqns]
-            [x - 3, x + y - 4]
+    >>> [e.simplify() for e in eqns]
+    [x - 3, x + y - 4]
 
-        Any such simplification needed to eliminate nonlinear terms must
-        be done *before* calling this routine.
+    Any such simplification needed to eliminate nonlinear terms must be done
+    *before* calling this routine.
+
     """
     if not symbols:
         raise ValueError(filldedent('''


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I noticed that the docstring of this function was not rendering correctly in HTML, mostly the math. I've corrected the RestructuredText formatting to obtain correct HTML rendering.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
