### PR TITLE
Removal of the reaction forces from the dynamic part of the EOMs

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -296,7 +296,6 @@ class KanesMethod(_Methods):
             raise ValueError('There must be an equal number of dependent '
                              'speeds and acceleration constraints.')
         if vel:
-            print('guten morgen')
             # When calling kanes_equations, another class instance will be
             # created if auxiliary u's are present. In this case, the
             # computation of kinetic differential equation matrices will be

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -230,22 +230,25 @@ class KanesMethod(_Methods):
 
         self._forcelist = forcelist
         self._bodylist = bodies
-        self._reaction_forces = reaction_forces
 
         self.explicit_kinematics = explicit_kinematics
         self._constraint_solver = constraint_solver
         self._initialize_vectors(q_ind, q_dependent, u_ind, u_dependent,
-                u_auxiliary)
+                u_auxiliary, reaction_forces)
         _validate_coordinates(self.q, self.u)
         self._initialize_kindiffeq_matrices(kd_eqs, kd_eqs_solver)
         self._initialize_constraint_matrices(
             configuration_constraints, velocity_constraints,
             acceleration_constraints, constraint_solver)
 
-    def _initialize_vectors(self, q_ind, q_dep, u_ind, u_dep, u_aux):
+    def _initialize_vectors(self, q_ind, q_dep, u_ind, u_dep, u_aux,
+                        reaction_forces):
         """Initialize the coordinate and speed vectors."""
 
         none_handler = lambda x: Matrix(x) if x else Matrix()
+
+        # Initialize reaction_forces
+        self._reaction_forces = none_handler(reaction_forces)
 
         # Initialize generalized coordinates
         q_dep = none_handler(q_dep)

--- a/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
+++ b/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
@@ -70,4 +70,3 @@ def test_removal_of_reaction_forces():
     eom_d_DS = me.find_dynamicsymbols(eom_d)
     for i in reaction_forces + aux:
         assert i not in eom_d_DS, f"{i} found in eom_d_DS"
-

--- a/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
+++ b/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
@@ -53,11 +53,8 @@ def test_removal_of_reaction_forces():
         velocity_constraints=speed_constr,
     )
 
-    (fr, frstar) = KM.kanes_equations(BODY, FL)
-    fr + frstar
+    fr, frstar = KM.kanes_equations(BODY, FL)
     force = KM.forcing_full
-
-    fr+frstar
 
     force_DS = me.find_dynamicsymbols(force)
     for i in reaction_forces + aux:

--- a/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
+++ b/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
@@ -1,0 +1,82 @@
+# %%
+import sympy as sm
+import sympy.physics.mechanics as me
+
+def test_removal_of_reaction_forces():
+    """
+    This function test whether the reaction forces are removed from the
+    dynamic parts of (fr + frstar) and from the forcing vector.
+    It is a simple pendulum where the foot is moving in the x direction.
+    """
+    t = me.dynamicsymbols._t
+    N, A = me.ReferenceFrame('N'), me.ReferenceFrame('A')
+    O, P, P1 = me.Point('O'), me.Point('P'), me.Point('P1')
+    O.set_vel(N, 0)
+
+    m, l, g = sm.symbols('m l g')
+    q, x, y, u, ux, uy = me.dynamicsymbols('q x y u ux uy')
+    x1, ux1 = me.dynamicsymbols('x1 u1')
+
+    auxx, auxy, fx, fy, F = me.dynamicsymbols('auxx auxy fx fy F')
+
+    A.orient_axis(N, q, N.z)
+    A.set_ang_vel(N, u * N.z)
+    P1.set_pos(O, x1 * N.x)
+    P1.set_vel(N, ux*N.x + auxx*N.x + auxy*N.y)
+    P.set_pos(P1, -l * A.y)
+    P.v2pt_theory(P1, N, A)
+
+    BODY = [me.Particle('body', P, m)]
+    FL = [(P, -m * g * N.y), (P1, F*N.x + fx * N.x + fy * N.y)]
+
+    kd = [u - q.diff(t), ux - x.diff(t), uy - y.diff(t), ux1 - x1.diff(t)]
+    config_constr = [x - x1 - l * sm.sin(q), y - l * sm.cos(q)]
+    speed_constr = [ux - ux1 - l * q.diff(t) * sm.cos(q),
+        uy - l * q.diff(t) * sm.sin(q)]
+    q_ind = [q, x1]
+    q_dep = [x, y]
+    u_ind = [u, ux1]
+    u_dep = [ux, uy]
+    aux = [auxx, auxy]
+
+    reaction_forces = [fx, fy]
+
+    KM = me.KanesMethod(
+        N,
+        q_ind=q_ind,
+        q_dependent=q_dep,
+        u_ind=u_ind,
+        u_dependent=u_dep,
+        u_auxiliary=aux,
+        reaction_forces = reaction_forces,
+        kd_eqs=kd,
+        configuration_constraints=config_constr,
+        velocity_constraints=speed_constr,
+    )
+
+    (fr, frstar) = KM.kanes_equations(BODY, FL)
+    fr + frstar
+    force = KM.forcing_full
+
+    fr+frstar
+    force_DS = me.find_dynamicsymbols(force)
+    for i in reaction_forces + aux:
+        assert i not in force_DS
+
+    eom_dynamic = sm.Matrix([(fr+frstar)[0], (fr+frstar)[1]])
+    eom_DS = me.find_dynamicsymbols(eom_dynamic)
+    for i in reaction_forces + aux:
+        assert i not in eom_DS
+
+    eom_dynamic = KM._form_eoms()
+    eom_d = sm.Matrix([eom_dynamic[0], eom_dynamic[1]])
+    eom_d_DS = me.find_dynamicsymbols(eom_d)
+    for i in reaction_forces + aux:
+        assert i not in eom_d_DS
+
+test = test_removal_of_reaction_forces()
+
+# %% [markdown]
+#
+
+

--- a/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
+++ b/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
@@ -58,17 +58,19 @@ def test_removal_of_reaction_forces():
     force = KM.forcing_full
 
     fr+frstar
+
     force_DS = me.find_dynamicsymbols(force)
     for i in reaction_forces + aux:
-        assert i not in force_DS
+        assert i not in force_DS, f"{i} found in force_DS"
 
     eom_dynamic = sm.Matrix([(fr+frstar)[0], (fr+frstar)[1]])
     eom_DS = me.find_dynamicsymbols(eom_dynamic)
     for i in reaction_forces + aux:
-        assert i not in eom_DS
+        assert i not in eom_DS, f"{i} found in eom_DS"
 
     eom_dynamic = KM._form_eoms()
     eom_d = sm.Matrix([eom_dynamic[0], eom_dynamic[1]])
     eom_d_DS = me.find_dynamicsymbols(eom_d)
     for i in reaction_forces + aux:
-        assert i not in eom_d_DS
+        assert i not in eom_d_DS, f"{i} found in eom_d_DS"
+

--- a/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
+++ b/sympy/physics/mechanics/tests/test_removal_of_reaction_forces.py
@@ -1,4 +1,3 @@
-# %%
 import sympy as sm
 import sympy.physics.mechanics as me
 
@@ -73,10 +72,3 @@ def test_removal_of_reaction_forces():
     eom_d_DS = me.find_dynamicsymbols(eom_d)
     for i in reaction_forces + aux:
         assert i not in eom_d_DS
-
-test = test_removal_of_reaction_forces()
-
-# %% [markdown]
-#
-
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


####

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics 
  * remove reaction forces.

<!-- END RELEASE NOTES -->
