### PR TITLE
Added getO and removeO to Mul

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1081,6 +1081,7 @@ Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
+Noah McGlothlin <2004.nbm@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -818,6 +818,13 @@ class Mul(Expr, AssocOp):
         else:
             return args[0], self._new_rawargs(*args[1:])
 
+    def removeO(self):
+        from .function import expand
+        return expand(self).removeO()
+    def getO(self):
+        from .function import expand
+        return expand(self).getO()
+
     @cacheit
     def as_coeff_mul(self, *deps, rational=True, **kwargs):
         if deps:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -501,3 +501,13 @@ def test_issue_22836():
     assert O(2**x + factorial(x), (x, oo)) == O(factorial(x), (x, oo))
     assert O(2**x + factorial(x) + x**x, (x, oo)) == O(exp(x*log(x)), (x, oo))
     assert O(x + factorial(x), (x, oo)) == O(factorial(x), (x, oo))
+
+def test_issue_27031():
+    assert ((1 + O(x)) * exp(x)).getO() == O(x)
+    assert ((1 + O(x)) * exp(x)).removeO() == exp(x)
+    assert ((1 + O(x * y) - O(x - 1, (x, 1))) * exp(y)).getO() == O(x*y) + O(x - 1, (x, 1))
+    assert ((1 + O(x * y) - O(x - 1, (x, 1))) * exp(y)).removeO() == exp(y)
+    assert ((x**2 + O(x**3) ) * (exp(x) + x + O(x) + O(y))).getO() == O(x**3) + O(y)
+    assert ((x**2 + O(x**3) ) * (exp(x) + x + O(x) + O(y))).removeO() == x**2 * exp(x)
+    assert ((1 + x**2 + O(x**3)) * (-1 + O(x))).getO() == O(x)
+    assert ((1 + x**2 + O(x**3)) * (-1 + O(x))).removeO() == -1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27031 

#### Brief description of what is fixed or changed

Added getO() and removeO() to Mul class. Now returns the 
expected value instead of None.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * No longer need to expand Mul expressions before calling getO() or removeO().
<!-- END RELEASE NOTES -->
