### PR TITLE
Cache assumption creation in Symbol

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -713,6 +713,7 @@ Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>
 Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
 Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>
+Isuru Fernando <isuruf@gmail.com> <ifernando@quansight.com>
 Itay4 <31018228+Itay4@users.noreply.github.com>
 Ivan Petuhov <ivan@ostrovok.ru>
 Ivan Petukhov <satels@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -712,8 +712,8 @@ Ishan Pandhare <ishan9096137017@gmail.com>
 Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>
 Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
-Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>
 Isuru Fernando <isuruf@gmail.com> <ifernando@quansight.com>
+Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>
 Itay4 <31018228+Itay4@users.noreply.github.com>
 Ivan Petuhov <ivan@ostrovok.ru>
 Ivan Petukhov <satels@gmail.com>

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -329,11 +329,10 @@ class Symbol(AtomicExpr, Boolean):
         cls._sanitize(assumptions, cls)
         return Symbol.__xnew_cached_(cls, name, **assumptions)
 
-    @staticmethod
-    def __xnew__(cls, name, **assumptions):  # never cached (e.g. dummy)
-        if not isinstance(name, str):
-            raise TypeError("name should be a string, not %s" % repr(type(name)))
 
+    @staticmethod
+    @cacheit
+    def _canonical_assumptions(**assumptions):
         # This is retained purely so that srepr can include commutative=True if
         # that was explicitly specified but not if it was not. Ideally srepr
         # should not distinguish these cases because the symbols otherwise
@@ -349,8 +348,18 @@ class Symbol(AtomicExpr, Boolean):
         assumptions_kb = StdFactKB(assumptions)
         assumptions0 = dict(assumptions_kb)
 
+        return assumptions_kb, assumptions_orig, assumptions0
+
+    @staticmethod
+    def __xnew__(cls, name, **assumptions):  # never cached (e.g. dummy)
+        if not isinstance(name, str):
+            raise TypeError("name should be a string, not %s" % repr(type(name)))
+
+
         obj = Expr.__new__(cls)
         obj.name = name
+
+        assumptions_kb, assumptions_orig, assumptions0 = Symbol._canonical_assumptions(**assumptions)
 
         obj._assumptions = assumptions_kb
         obj._assumptions_orig = assumptions_orig

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -224,9 +224,10 @@ class ReprPrinter(Printer):
         return "%s(%s)" % (s.__class__.__name__, self._print(s.name))
 
     def _print_Symbol(self, expr):
-        d = expr._assumptions_orig.copy()
+        d = expr._assumptions_orig
         # print the dummy_index like it was an assumption
         if expr.is_Dummy:
+            d = d.copy()
             d['dummy_index'] = expr.dummy_index
 
         if d == {}:

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -224,7 +224,7 @@ class ReprPrinter(Printer):
         return "%s(%s)" % (s.__class__.__name__, self._print(s.name))
 
     def _print_Symbol(self, expr):
-        d = expr._assumptions_orig
+        d = expr._assumptions_orig.copy()
         # print the dummy_index like it was an assumption
         if expr.is_Dummy:
             d['dummy_index'] = expr.dummy_index


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This makes the following code 3 times faster

```python
import sympy
sympy.symbols("x0:10000")
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Cache assumption canonicalization in SymPy.

<!-- END RELEASE NOTES -->
