### PR TITLE
Define a missing symbol in an intro example.

### DIFF
--- a/doc/src/tutorials/intro-tutorial/intro.rst
+++ b/doc/src/tutorials/intro-tutorial/intro.rst
@@ -153,6 +153,7 @@ Solve `x^2 - 2 = 0`.
 
 Solve the differential equation `y'' - y = e^t`.
 
+ >>> t = Symbol('t')
  >>> y = Function('y')
  >>> dsolve(Eq(y(t).diff(t, t) - y(t), exp(t)), y(t))
             -t   ⎛     t⎞  t


### PR DESCRIPTION
The differential equation example in the tutorial at intro.html currently crashes with NameError. The independent variable "t" has not been defined. This just adds the missing definition.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

None

#### Brief description of what is fixed or changed

Added a missing symbol definition to an example in the intro tutorial.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
