### PR TITLE
Fix non-exception errors for `curl` and `divergence`

### DIFF
--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -172,7 +172,7 @@ def curl(vect, doit=True):
         elif isinstance(vect, (Cross, Curl, Gradient)):
             return Curl(vect)
         else:
-            raise Curl(vect)
+            raise ValueError("Invalid argument for curl")
 
 
 def divergence(vect, doit=True):
@@ -239,7 +239,7 @@ def divergence(vect, doit=True):
         elif isinstance(vect, (Cross, Curl, Gradient)):
             return Divergence(vect)
         else:
-            raise Divergence(vect)
+            raise ValueError("Invalid argument for divergence")
 
 
 def gradient(scalar_field, doit=True):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Errors that are not subclass from exceptions simply does not work and shouldn't be used

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
