### PR TITLE
Fixed some broken links in the index.rst file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -410,6 +410,7 @@ Bill Flynn <wflynny@gmail.com>
 Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
+Blossom Goyal <blossom9915998399@gmail.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1595,6 +1595,7 @@ anutosh491 <andersonbhat491@gmail.com> anutosh491 <87052487+anutosh491@users.nor
 arooshiverma <av22@iitbbs.ac.in>
 atharvParlikar <atharvparlikar@gmail.com>
 bharatAmeria <21001019007@jcboseust.ac.in> bharatAmeria <147488804+bharatAmeria@users.noreply.github.com>
+blossomgoyal <81066741+blossomgoyal@users.noreply.github.com>
 bluebrook <perl4logic@gmail.com>
 carstimon <carstimon@gmail.com>
 ck Lux <lux.r.ck@gmail.com>

--- a/doc/src/guides/physics/index.rst
+++ b/doc/src/guides/physics/index.rst
@@ -11,6 +11,6 @@ Physics, Optics, Quantum Mechanics, Units and Vector algebra.
 
 For physics tutorials, please check out:
 
-* `Biomechanics Tutorials <../../tutorials/physics/biomechanics/index.html>`_
-* `Mechanics Tutorials <../../tutorials/physics/mechanics/index.html>`_
-* `Control Tutorials <../../tutorials/physics/control/index.html>`_
+* `Biomechanics Tutorials <../../tutorials/physics/biomechanics/index.rst>`_
+* `Mechanics Tutorials <../../tutorials/physics/mechanics/index.rst>`_
+* `Control Tutorials <../../tutorials/physics/control/index.rst>`_

--- a/setup.py
+++ b/setup.py
@@ -323,6 +323,7 @@ if __name__ == '__main__':
           # Set upper bound when making the release branch.
           install_requires=[
               'mpmath >= 1.1.0',
+               'linkify-it-py',
           ],
           py_modules=['isympy'],
           packages=['sympy'] + modules + tests,


### PR DESCRIPTION
I have fixed some broken links. These are in the (guides/physics/index) directory.

Fixes #24140 

Previously, when I run the command "make linkcheck". It shows something like this:

![image](https://github.com/user-attachments/assets/1e2339e8-f5b0-4eed-a80e-cf25c2583d52)

Now, after I have made these changes, it looks like this:

![image](https://github.com/user-attachments/assets/68550e1c-cd13-469a-95e9-804044634d6d)

<!-- BEGIN RELEASE NOTES -->

NO ENTRY
<!-- END RELEASE NOTES -->

