### PR TITLE
Update primetest.py fixing Miller-Rabin for even numbers

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -248,7 +248,7 @@ def mr(n, bases):
     from sympy.polys.domains import ZZ
 
     n = as_int(n)
-    if n < 2:
+    if n < 2 or n % 2 == 0:
         return False
     # remove powers of 2 from n-1 (= t * 2**s)
     s = bit_scan1(n - 1)

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -76,6 +76,7 @@ def test_is_extra_strong_lucas_prp():
 
 @slow
 def test_prps():
+    assert [mr(i) for i in (1, 2, 4)] == [False, True, False]
     oddcomposites = [n for n in range(1, 10**5) if
         n % 2 and not isprime(n)]
     # A checksum would be better.


### PR DESCRIPTION
Update primetest.py fixing Miller-Rabin for even numbers
#### References to other Issues or PRs
Fixes #27145 
#### Brief description of what is fixed or changed
inside of primetest.py I added in addition to the preexisting check to make sure that numbers put through the Miller-Rabin function were less than 2, that they also were not divisible by two in order to remove all even numbers from the equation fixing the false positives created when running the function with even numbers such as 90.
#### Other comments
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* ntheory
  * fixed the functionality of the Miller-Rabin (mr) function.
<!-- END RELEASE NOTES -->