### PR TITLE
Use intersphinx-registry for the intersphinx mapping

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 furo
+intersphinx-registry
 linkify-it-py
 matplotlib
 matplotlib-inline

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -16,6 +16,9 @@ import os
 import subprocess
 from datetime import datetime
 
+from intersphinx_registry import get_intersphinx_mapping
+
+
 # Make sure we import sympy from git
 sys.path.insert(0, os.path.abspath('../..'))
 
@@ -453,12 +456,9 @@ texinfo_documents = [
 graphviz_output_format = 'svg'
 
 # Enable links to other packages
-intersphinx_mapping = {
-    'matplotlib': ('https://matplotlib.org/stable/', None),
-    'mpmath': ('https://mpmath.org/doc/current/', None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-}
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={"matplotlib", "mpmath", "scipy", "numpy"},
+)
 # Require :external: to reference intersphinx. Prevents accidentally linking
 # to something from matplotlib.
 intersphinx_disabled_reftypes = ['*']


### PR DESCRIPTION
This avoid having to hard-code the URLs.

CC @Carreau 
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
