### PR TITLE
Minor fixes to `groups_count`

### DIFF
--- a/sympy/combinatorics/group_numbers.py
+++ b/sympy/combinatorics/group_numbers.py
@@ -220,7 +220,7 @@ def groups_count(n):
     ValueError
         Number of groups of order ``n`` is unknown or not implemented.
         For example, gnu(`2^{11}`) is not yet known.
-        On the other hand, gnu(12) is known to be 5,
+        On the other hand, gnu(99) is known to be 2,
         but this has not yet been implemented in this function.
 
     Examples
@@ -289,8 +289,6 @@ def groups_count(n):
             return small[n]
         raise ValueError("Number of groups of order n is unknown or not implemented")
     if len(factors) == 2: # n is squarefree semiprime
-        p, q = list(factors.keys())
-        if p > q:
-            p, q = q, p
+        p, q = sorted(factors.keys())
         return 2 if q % p == 1 else 1
     return _holder_formula(set(factors.keys()))


### PR DESCRIPTION
- The docstring corrections were missed.
  - c.f., #25947
- Using sorting is more concise than using an if statement.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
