### PR TITLE
Fix numpy printing of `NDimArray`

### DIFF
--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -240,11 +240,11 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
 
     def _print_MatrixBase(self, expr):
         if 0 in expr.shape:
-            func = self._module_format(self._module + '.zeros')
+            func = self._module_format(f'{self._module}.{self._zeros}')
             return f"{func}({self._print(expr.shape)})"
         func = self.known_functions.get(expr.__class__.__name__, None)
         if func is None:
-            func = self._module_format(self._module + '.array')
+            func = self._module_format(f'{self._module}.array')
         return "%s(%s)" % (func, self._print(expr.tolist()))
 
     def _print_Identity(self, expr):
@@ -260,12 +260,12 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
 
     def _print_NDimArray(self, expr):
         if expr.rank() == 0:
-            func = self._module_format(self._module + '.array')
+            func = self._module_format(f'{self._module}.array')
             return f"{func}({self._print(expr[()])})"
         if 0 in expr.shape:
-            func = self._module_format(self._module + '.zeros')
+            func = self._module_format(f'{self._module}.{self._zeros}')
             return f"{func}({self._print(expr.shape)})"
-        func = self._module_format(self._module + '.array')
+        func = self._module_format(f'{self._module}.array')
         return f"{func}({self._print(expr.tolist())})"
 
     _add = "add"

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -239,6 +239,9 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return "%s(%s)" % (self._module_format(self._module + '.sinc'), self._print(expr.args[0]/S.Pi))
 
     def _print_MatrixBase(self, expr):
+        if 0 in expr.shape:
+            func = self._module_format(self._module + '.zeros')
+            return f"{func}({self._print(expr.shape)})"
         func = self.known_functions.get(expr.__class__.__name__, None)
         if func is None:
             func = self._module_format(self._module + '.array')
@@ -256,12 +259,14 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
                                  self._print(expr.args[0].tolist()))
 
     def _print_NDimArray(self, expr):
-        if len(expr.shape) == 1:
-            return self._module + '.array(' + self._print(expr.args[0]) + ')'
-        if len(expr.shape) == 2:
-            return self._print(expr.tomatrix())
-        # Should be possible to extend to more dimensions
-        return super()._print_not_supported(self, expr)
+        if expr.rank() == 0:
+            func = self._module_format(self._module + '.array')
+            return f"{func}({self._print(expr[()])})"
+        if 0 in expr.shape:
+            func = self._module_format(self._module + '.zeros')
+            return f"{func}({self._print(expr.shape)})"
+        func = self._module_format(self._module + '.array')
+        return f"{func}({self._print(expr.tolist())})"
 
     _add = "add"
     _einsum = "einsum"

--- a/sympy/printing/tests/test_jax.py
+++ b/sympy/printing/tests/test_jax.py
@@ -334,7 +334,7 @@ def test_issue_17006():
 
 def test_jax_array():
     assert JaxPrinter().doprint(Array(((1, 2), (3, 5)))) == 'jax.numpy.array([[1, 2], [3, 5]])'
-    assert JaxPrinter().doprint(Array((1, 2))) == 'jax.numpy.array((1, 2))'
+    assert JaxPrinter().doprint(Array((1, 2))) == 'jax.numpy.array([1, 2])'
 
 
 def test_jax_known_funcs_consts():

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -6,6 +6,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.gamma_functions import polygamma
 from sympy.functions.special.error_functions import (Si, Ci)
+from sympy.matrices import Matrix
 from sympy.matrices.expressions.blockmatrix import BlockMatrix
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
@@ -329,8 +330,23 @@ def test_jax_tuple_compatibility():
     assert np.allclose(func(*input_tuple2), func(*input_array2))
 
 def test_numpy_array():
-    assert NumPyPrinter().doprint(Array(((1, 2), (3, 5)))) == 'numpy.array([[1, 2], [3, 5]])'
-    assert NumPyPrinter().doprint(Array((1, 2))) == 'numpy.array((1, 2))'
+    p = NumPyPrinter()
+    assert p.doprint(Array([[1, 2], [3, 5]])) == 'numpy.array([[1, 2], [3, 5]])'
+    assert p.doprint(Array([1, 2])) == 'numpy.array([1, 2])'
+    assert p.doprint(Array([[[1, 2, 3]]])) == 'numpy.array([[[1, 2, 3]]])'
+    assert p.doprint(Array([], (0,))) == 'numpy.zeros((0,))'
+    assert p.doprint(Array([], (0, 0))) == 'numpy.zeros((0, 0))'
+    assert p.doprint(Array([], (0, 1))) == 'numpy.zeros((0, 1))'
+    assert p.doprint(Array([], (1, 0))) == 'numpy.zeros((1, 0))'
+    assert p.doprint(Array([1], ())) == 'numpy.array(1)'
+
+def test_numpy_matrix():
+    p = NumPyPrinter()
+    assert p.doprint(Matrix([[1, 2], [3, 5]])) == 'numpy.array([[1, 2], [3, 5]])'
+    assert p.doprint(Matrix([1, 2])) == 'numpy.array([[1], [2]])'
+    assert p.doprint(Matrix(0, 0, [])) == 'numpy.zeros((0, 0))'
+    assert p.doprint(Matrix(0, 1, [])) == 'numpy.zeros((0, 1))'
+    assert p.doprint(Matrix(1, 0, [])) == 'numpy.zeros((1, 0))'
 
 def test_numpy_known_funcs_consts():
     assert _numpy_known_constants['NaN'] == 'numpy.nan'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1168,6 +1168,10 @@ def test_NDimArray():
     assert sstr(NDimArray(1.0), full_prec=False) == '1.0'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=True) == '[1.00000000000000, 2.00000000000000]'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=False) == '[1.0, 2.0]'
+    assert sstr(NDimArray([], (0,))) == 'ImmutableDenseNDimArray([], (0,))'
+    assert sstr(NDimArray([], (0, 0))) == 'ImmutableDenseNDimArray([], (0, 0))'
+    assert sstr(NDimArray([], (0, 1))) == 'ImmutableDenseNDimArray([], (0, 1))'
+    assert sstr(NDimArray([], (1, 0))) == 'ImmutableDenseNDimArray([], (1, 0))'
 
 def test_Predicate():
     assert sstr(Q.even) == 'Q.even'

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -362,7 +362,8 @@ class NDimArray(Printable):
 
         if self.rank() == 0:
             return printer._print(self[()])
-
+        if 0 in self.shape:
+            return f"{self.__class__.__name__}([], {self.shape})"
         return f(self._loop_size, self.shape, 0, self._loop_size)
 
     def tolist(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/27151
Fixes gh-27174

#### Brief description of what is fixed or changed

Although the original issue just suggests to fix the issues with `_print_not_supported`,
I think that it is better fixed by implementing NumPy printer properly for 

I also fixed some issues with zero dimensions 

```python
p = NumPyPrinter()
print(p.doprint(Matrix(0, 0, [])))
print(p.doprint(Matrix(0, 1, [])))
print(p.doprint(Array([], (0,))))
print(p.doprint(Array([], (0, 0))))
print(p.doprint(Array([], (0, 1))))
```

So the results are corrected from

```python
numpy.array([])
numpy.array([])
numpy.array(())
numpy.array([])
numpy.array([])
```

to 

```python
numpy.zeros((0, 0))
numpy.zeros((0, 1))
numpy.zeros((0,))
numpy.zeros((0, 0))
numpy.zeros((0, 1))
```

`numpy.array([])` always gives `(0,)` shape which is not correct.

Also, `sstr` gives error for some exceptional arrays with 0 in shape, so they

The issue of `sstr` was discovered because I think that lambdify calls it somewhere. So the fix should work for lambdify as well.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed errors of `NumPyPrinter` from printing `Array` with more than 2 dimensions. For example, `NumPyPrinter().doprint(Array([[[1, 2, 3]]]))`.
  - Fixed issues that `NumPyPrinter` prints arrays with wrong shape for `Array` with some `0` in the shape. For example, `NumPyPrinter().doprint(Array([], (0, 1)))`
  - Fixed issues that `sstr` gives errors for `Array` with some `0` in the shape. For example, `sstr(Array([], (0, 1)))`.
<!-- END RELEASE NOTES -->
