### PR TITLE
Implementation of Powers of `CRootOf`

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -17,7 +17,7 @@ from sympy.polys.polyfuncs import symmetrize, viete
 from sympy.polys.polyroots import (
     roots_linear, roots_quadratic, roots_binomial,
     preprocess_roots, roots)
-from sympy.polys.polytools import Poly, PurePoly, factor
+from sympy.polys.polytools import Poly, PurePoly, degree, factor, LT, LC
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import (
     dup_isolate_complex_roots_sqf,
@@ -393,6 +393,20 @@ class ComplexRootOf(RootOf):
         # whose poly attribute should be a PurePoly with no free
         # symbols
         return set()
+
+    def _eval_power(self, other):
+        if not isinstance(other, (Integer, int)):
+            return None
+        d = degree(self.expr)
+        if other < d:
+            return None
+        _x = list(self.expr.free_symbols)[0]
+        _expr = expr = (LT(self.expr) - self.expr) / LC(self.expr)
+        for _ in range(other - d):
+            _expr = (_x*_expr).expand()
+            if degree(_expr) >= d:
+                _expr += (LC(_expr) * expr).expand() - LT(_expr)
+        return _expr.subs({_x: self})
 
     def _eval_is_real(self):
         """Return ``True`` if the root is real. """

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -168,13 +168,26 @@ def test_CRootOf___eval_Eq__():
 
 def test_CRootOf_eval_power():
     r = rootof(x**3 + x + 3, 0)
+    assert r**0 == S.One
+    assert r**1 == r
     assert isinstance(r**2, Pow)
     assert r**3 == -r - 3
     assert r**4 == -r**2 - 3*r
+    for i in range(3, 5):
+        m = r**(-i)
+        assert not isinstance(m, Pow)
+        assert abs(1 - m.n() * (r**i).n()) < 1e-10
+
     r = rootof(x**5 - x + 1, 0)
+    assert r**0 == S.One
+    assert r**1 == r
     assert isinstance(r**4, Pow)
     assert r**5 == r - 1
     assert r**6 == r**2 - r
+    for i in range(5, 10):
+        m = r**(-i)
+        assert not isinstance(m, Pow)
+        assert abs(1 - m.n() * (r**i).n()) < 1e-10
 
 
 def test_CRootOf_is_real():

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -13,6 +13,7 @@ from sympy.polys.polyerrors import (
 
 from sympy.core.function import (Function, Lambda)
 from sympy.core.numbers import (Float, I, Rational)
+from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import (exp, log)
@@ -163,6 +164,17 @@ def test_CRootOf___eval_Eq__():
     assert [Eq(rootof(eq, i), j) for i in range(3) for j in sol
         ].count(True) == 3
     assert Eq(rootof(eq, 0), 1 + S.ImaginaryUnit) == False
+
+
+def test_CRootOf_eval_power():
+    r = rootof(x**3 + x + 3, 0)
+    assert isinstance(r**2, Pow)
+    assert r**3 == -r - 3
+    assert r**4 == -r**2 - 3*r
+    r = rootof(x**5 - x + 1, 0)
+    assert isinstance(r**4, Pow)
+    assert r**5 == r - 1
+    assert r**6 == r**2 - r
 
 
 def test_CRootOf_is_real():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -697,11 +697,14 @@ def solve(f, *symbols, **flags):
         >>> from sympy import real_root, S
         >>> eq = root(x, 3) - root(x, 5) + S(1)/7
         >>> solve(eq)  # this gives 2 solutions but misses a 3rd
-        [CRootOf(7*x**5 - 7*x**3 + 1, 1)**15,
-        CRootOf(7*x**5 - 7*x**3 + 1, 2)**15]
+        [-50/343 - 4*CRootOf(7*x**5 - 7*x**3 + 1, 1)**4/7 - CRootOf(7*x**5 - 7*x**3 + 1, 1)**2/7
+         + 3*CRootOf(7*x**5 - 7*x**3 + 1, 1)/49 + 52*CRootOf(7*x**5 - 7*x**3 + 1, 1)**3/49,
+         -4*CRootOf(7*x**5 - 7*x**3 + 1, 2)**4/7 - 50/343 - CRootOf(7*x**5 - 7*x**3 + 1, 2)**2/7
+         + 3*CRootOf(7*x**5 - 7*x**3 + 1, 2)/49 + 52*CRootOf(7*x**5 - 7*x**3 + 1, 2)**3/49]
+        >>> # It can also be written as [CRootOf(7*x**5 - 7*x**3 + 1, 1)**15, CRootOf(7*x**5 - 7*x**3 + 1, 2)**15]
         >>> sol = solve(eq, check=False)
-        >>> [abs(eq.subs(x,i).n(2)) for i in sol]
-        [0.48, 0.e-110, 0.e-110, 0.052, 0.052]
+        >>> sorted(abs(eq.subs(x,i).n(2)) for i in sol)
+        [0.e-110, 0.e-110, 0.052, 0.052, 0.48]
 
     The first solution is negative so ``real_root`` must be used to see that it
     satisfies the expression:


### PR DESCRIPTION
I have implemented the power function for `CRootOf`. For example, `r = CRootOf(x**3 + x + 1, 0)` is one of the roots of the equation $x^3 + x + 1 = 0$. Since $x^3 = -x - 1$, `r**3` can be calculated as `-r - 1`. Similarly, the powers of `CRootOf` can be transformed into a polynomial of degree less than the original polynomial.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Implemented power in `CRootOf`.
<!-- END RELEASE NOTES -->
