### PR TITLE
Fix lambdify for Sum employing nested loops

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -253,7 +253,7 @@ class AbstractPythonCodePrinter(CodePrinter):
                 i=self._print(i),
                 a=self._print(a),
                 b=self._print(b))
-            for i, a, b in expr.limits)
+            for i, a, b in expr.limits[::-1])
         return '(builtins.sum({function} {loops}))'.format(
             function=self._print(expr.function),
             loops=' '.join(loops))

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -181,7 +181,7 @@ def test_multiple_sums():
     s = Sum(i * x + j, (i, a, b), (j, c, d))
 
     l = lambdarepr(s)
-    assert l == "(builtins.sum(i*x + j for i in range(a, b+1) for j in range(c, d+1)))"
+    assert l == "(builtins.sum(i*x + j for j in range(c, d+1) for i in range(a, b+1)))"
 
     args = x, a, b, c, d
     f = lambdify(args, s)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1068,6 +1068,12 @@ def test_Indexed():
     b = numpy.array([[1, 2], [3, 4]])
     assert lambdify(a, Sum(a[x, y], (x, 0, 1), (y, 0, 1)))(b) == 10
 
+def test_Sum():
+    e = Sum(z, (y, 0, x), (x, 0, 10))
+    ref = 66*z
+    assert e.doit() == ref
+    assert lambdify([z], e)(7) == ref.subs(z, 7)
+
 def test_Idx():
     # Issue 26888
     a = IndexedBase('a')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes the `lambdify` part of gh-27112

#### Brief description of what is fixed or changed
Generated in-line for loops by `PythonCodePrinter` needed to use reverse order of `.args` in `Sum`.

#### Other comments
`.evalf()` on `Sum` with multiple indices is not addressed by this PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * `lambdify` now generates correct code for `Sum` instances running over multiple summation indices (nested sums).
<!-- END RELEASE NOTES -->
