### PR TITLE
Fix: mypy 1.12 issue

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -277,8 +277,11 @@ def decompose_power_rat(expr: Expr) -> tTuple[Expr, Rational]:
     (exp(x/2), -3)
 
     """
-    _ = base, exp = expr.as_base_exp()
-    return _ if exp.is_Rational else decompose_power(expr)
+    base, exp = expr.as_base_exp()
+    if not exp.is_Rational:
+        base, exp_i = decompose_power(expr)
+        exp = Integer(exp_i)
+    return base, exp # type: ignore
 
 
 class Factors:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27160 

#### Brief description of what is fixed or changed

Modified the decompose_power_rat function to ensure that when the exponent is not rational, it correctly calls decompose_power and converts the result into an Integer before returning.
Added a # type: ignore comment to suppress type-checking issues, ensuring compatibility with mypy-1.12
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed type-checking issue in `decompose_power_rat` by ensuring non-rational exponents are handled properly.
<!-- END RELEASE NOTES -->
