### PR TITLE
Fixed bug with wrong output sign in real Gaunt coefficients

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1256,6 +1256,7 @@ Robin Richard <raisin@ecomail.fr> Nornort <francois.lalleve@laposte.net>
 Robin Richard <raisin@ecomail.fr> robinechuca <61911191+robinechuca@users.noreply.github.com>
 Robin Richard <raisin@ecomail.fr> robinechuca <raisin@ecomail.fr>
 Rodrigo Luger <rodluger@gmail.com>
+Roelof Rietbroek <r.rietbroek@utwente.nl> Roelof Rietbroek <strawpants@users.noreply.github.com>
 Rohit Jain <rohitjain3241@gmail.com>
 Rohit Rango <rohit.rango@gmail.com>
 Rohit Sharma <31184621+rohitx007@users.noreply.github.com>

--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -136,7 +136,7 @@ def test_realgaunt():
     assert real_gaunt(1, 1, 2, -1, 0, -1) == sqrt(15)/(10*sqrt(pi))
     assert real_gaunt(1, 1, 2, 0, 1, 1) == sqrt(15)/(10*sqrt(pi))
     assert real_gaunt(1, 1, 2, 1, 1, 2) == sqrt(15)/(10*sqrt(pi))
-    assert real_gaunt(1, 1, 2, -1, 1, -2) == -sqrt(15)/(10*sqrt(pi))
+    assert real_gaunt(1, 1, 2, -1, 1, -2) == sqrt(15)/(10*sqrt(pi))
     assert real_gaunt(1, 1, 2, -1, -1, 2) == -sqrt(15)/(10*sqrt(pi))
     assert real_gaunt(2, 2, 2, 0, 1, 1) == sqrt(5)/(14*sqrt(pi))
     assert real_gaunt(2, 2, 2, 1, 1, 2) == sqrt(15)/(14*sqrt(pi))

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -855,7 +855,7 @@ def real_gaunt(l_1, l_2, l_3, mu_1, mu_2, mu_3, prec=None):
     ========
     >>> from sympy.physics.wigner import real_gaunt
     >>> real_gaunt(1,1,2,-1,1,-2)
-    0.1*sqrt(15)/sqrt(pi)
+    sqrt(15)/(10*sqrt(pi))
     >>> real_gaunt(10,10,20,-9,-9,0,prec=64)
     -0.00002480019791932209313156167176797577821140084216297395518482071448
 
@@ -928,7 +928,7 @@ def real_gaunt(l_1, l_2, l_3, mu_1, mu_2, mu_3, prec=None):
     t = lambda x: 1 if x > 0 else 0
     A = lambda mu, m: t(-mu) * (s(m) * kron_del(m, mu) - kron_del(m, -mu))
     B = lambda mu, m: t(mu) * (kron_del(m, mu) + s(m) * kron_del(m, -mu))
-    U = lambda mu, m: kron_del(abs(mu), abs(m)) * (kron_del(mu, 0) * kron_del(m, 0) + (B(mu, m) + 1j * A(mu, m))/sqrt(2))
+    U = lambda mu, m: kron_del(abs(mu), abs(m)) * (kron_del(mu, 0) * kron_del(m, 0) + (B(mu, m) + I * A(mu, m))/sqrt(2))
 
     ugnt = 0
     for m1 in range(-l_1, l_1+1):

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -787,7 +787,7 @@ def gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
     return res
 
 
-def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
+def real_gaunt(l_1, l_2, l_3, mu_1, mu_2, mu_3, prec=None):
     r"""
     Calculate the real Gaunt coefficient.
 
@@ -799,23 +799,23 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
 
     .. math::
         \begin{aligned}
-        \operatorname{RealGaunt}(l_1,l_2,l_3,m_1,m_2,m_3)
-        &=\int Z^{m_1}_{l_1}(\Omega)
-         Z^{m_2}_{l_2}(\Omega) Z^{m_3}_{l_3}(\Omega) \,d\Omega \\
+        \operatorname{RealGaunt}(l_1,l_2,l_3,\mu_1,\mu_2,\mu_3)
+        &=\int Z^{\mu_1}_{l_1}(\Omega)
+         Z^{\mu_2}_{l_2}(\Omega) Z^{\mu_3}_{l_3}(\Omega) \,d\Omega \\
         \end{aligned}
 
     Alternatively, it can be defined in terms of the standard Gaunt
     coefficient by relating the real spherical harmonics to the standard
     spherical harmonics via a unitary transformation `U`, i.e.
-    `Z^{m}_{l}(\Omega)=\sum_{m'}U^{m}_{m'}Y^{m'}_{l}(\Omega)` [Homeier96]_.
+    `Z^{\mu}_{l}(\Omega)=\sum_{m'}U^{\mu}_{m'}Y^{m'}_{l}(\Omega)` [Homeier96]_.
     The real Gaunt coefficient is then defined as
 
     .. math::
         \begin{aligned}
-        \operatorname{RealGaunt}(l_1,l_2,l_3,m_1,m_2,m_3)
-        &=\int Z^{m_1}_{l_1}(\Omega)
-         Z^{m_2}_{l_2}(\Omega) Z^{m_3}_{l_3}(\Omega) \,d\Omega \\
-        &=\sum_{m'_1 m'_2 m'_3} U^{m_1}_{m'_1}U^{m_2}_{m'_2}U^{m_3}_{m'_3}
+        \operatorname{RealGaunt}(l_1,l_2,l_3,\mu_1,\mu_2,\mu_3)
+        &=\int Z^{\mu_1}_{l_1}(\Omega)
+         Z^{\mu_2}_{l_2}(\Omega) Z^{\mu_3}_{l_3}(\Omega) \,d\Omega \\
+        &=\sum_{m'_1 m'_2 m'_3} U^{\mu_1}_{m'_1}U^{\mu_2}_{m'_2}U^{\mu_3}_{m'_3}
          \operatorname{Gaunt}(l_1,l_2,l_3,m'_1,m'_2,m'_3)
         \end{aligned}
 
@@ -823,10 +823,10 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
 
     .. math::
         \begin{aligned}
-        U^m_{m'} = \delta_{|m||m'|}*(\delta_{m'0}\delta_{m0} + \frac{1}{\sqrt{2}}\big[\Theta(m)
-        \big(\delta_{m'm}+(-1)^{m'}\delta_{m'-m}\big)+i\Theta(-m)\big((-1)^{-m}
-        \delta_{m'-m}-\delta_{m'm}*(-1)^{m'-m}\big)\big])
+        U^\mu_{m} = \delta_{|\mu||m|}*(\delta_{m0}\delta_{\mu 0} + \frac{1}{\sqrt{2}}\big[\Theta(\mu)\big(\delta_{m\mu}+(-1)^{m}\delta_{m-\mu}\big)
+        +i \Theta(-\mu)\big((-1)^{m}\delta_{m\mu}-\delta_{m-\mu}\big)\big])
         \end{aligned}
+
 
     where `\delta_{ij}` is the Kronecker delta symbol and `\Theta` is a step
     function defined as
@@ -839,8 +839,8 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
     Parameters
     ==========
 
-    l_1, l_2, l_3, m_1, m_2, m_3 :
-        Integer.
+    l_1, l_2, l_3, mu_1, mu_2, mu_3 :
+        Integer degree and order
 
     prec - precision, default: ``None``.
         Providing a precision can
@@ -853,28 +853,28 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
 
     Examples
     ========
-
     >>> from sympy.physics.wigner import real_gaunt
-    >>> real_gaunt(2,2,4,-1,-1,0)
-    -2/(7*sqrt(pi))
-    >>> real_gaunt(10,10,20,-9,-9,0).n(64)
+    >>> real_gaunt(1,1,2,-1,1,-2)
+    0.1*sqrt(15)/sqrt(pi)
+    >>> real_gaunt(10,10,20,-9,-9,0,prec=64)
     -0.00002480019791932209313156167176797577821140084216297395518482071448
 
-    It is an error to use non-integer values for `l` and `m`::
+    It is an error to use non-integer values for `l` and `\mu`::
         real_gaunt(2.8,0.5,1.3,0,0,0)
         Traceback (most recent call last):
         ...
         ValueError: l values must be integer
+
         real_gaunt(2,2,4,0.7,1,-3.4)
         Traceback (most recent call last):
         ...
-        ValueError: m values must be integer
+        ValueError: mu values must be integer
 
     Notes
     =====
 
     The real Gaunt coefficient inherits from the standard Gaunt coefficient,
-    the invariance under any permutation of the pairs `(l_i, m_i)` and the
+    the invariance under any permutation of the pairs `(l_i, \mu_i)` and the
     requirement that the sum of the `l_i` be even to yield a non-zero value.
     It also obeys the following symmetry rules:
 
@@ -884,16 +884,16 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
 
       .. math::
           \begin{aligned}
-          l_{\text{min}} = \begin{cases} \kappa(l_2, l_3, m_2, m_3) & \text{if}\,
-          \kappa(l_2, l_3, m_2, m_3) + l_{\text{max}}\, \text{is even} \\
-          \kappa(l_2, l_3, m_2, m_3)+1 & \text{if}\, \kappa(l_2, l_3, m_2, m_3) +
+          l_{\text{min}} = \begin{cases} \kappa(l_2, l_3, \mu_2, \mu_3) & \text{if}\,
+          \kappa(l_2, l_3, \mu_2, \mu_3) + l_{\text{max}}\, \text{is even} \\
+          \kappa(l_2, l_3, \mu_2, \mu_3)+1 & \text{if}\, \kappa(l_2, l_3, \mu_2, \mu_3) +
           l_{\text{max}}\, \text{is odd}\end{cases}
           \end{aligned}
 
-      and `\kappa(l_2, l_3, m_2, m_3) = \max{\big(|l_2-l_3|, \min{\big(|m_2+m_3|,
-      |m_2-m_3|\big)}\big)}`
+      and `\kappa(l_2, l_3, \mu_2, \mu_3) = \max{\big(|l_2-l_3|, \min{\big(|\mu_2+\mu_3|,
+      |\mu_2-\mu_3|\big)}\big)}`
 
-    - zero for an odd number of negative `m_i`
+    - zero for an odd number of negative `\mu_i`
 
     Algorithms
     ==========
@@ -907,16 +907,16 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
     coefficient, so it is suitable for finite precision arithmetic in so far
     as the algorithm which computes the Gaunt coefficient is.
     """
-    l_1, l_2, l_3, m_1, m_2, m_3 = [
-        as_int(i) for i in (l_1, l_2, l_3, m_1, m_2, m_3)]
+    l_1, l_2, l_3, mu_1, mu_2, mu_3 = [
+        as_int(i) for i in (l_1, l_2, l_3, mu_1, mu_2, mu_3)]
 
     # check for quick exits
-    if sum(1 for i in (m_1, m_2, m_3) if i < 0) % 2:
+    if sum(1 for i in (mu_1, mu_2, mu_3) if i < 0) % 2:
         return S.Zero  # odd number of negative m
     if (l_1 + l_2 + l_3) % 2:
         return S.Zero  # sum of l is odd
     lmax = l_2 + l_3
-    lmin = max(abs(l_2 - l_3), min(abs(m_2 + m_3), abs(m_2 - m_3)))
+    lmin = max(abs(l_2 - l_3), min(abs(mu_2 + mu_3), abs(mu_2 - mu_3)))
     if (lmin + lmax) % 2:
         lmin += 1
     if lmin not in range(lmax, lmin - 2, -2):
@@ -924,21 +924,20 @@ def real_gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
 
     kron_del = lambda i, j: 1 if i == j else 0
     s = lambda e: -1 if e % 2 else 1  #  (-1)**e to give +/-1, avoiding float when e<0
-    A = lambda a, b: (-kron_del(a, b)*s(a-b) + kron_del(a, -b)*
-                      s(b)) if b < 0 else 0
-    B = lambda a, b: (kron_del(a, b) + kron_del(a, -b)*s(a)) if b > 0 else 0
-    C = lambda a, b: kron_del(abs(a), abs(b))*(kron_del(a, 0)*kron_del(b, 0) +
-                                          (B(a, b) + I*A(a, b))/sqrt(2))
-    ugnt = 0
-    for i in range(-l_1, l_1+1):
-        U1 = C(i, m_1)
-        for j in range(-l_2, l_2+1):
-            U2 = C(j, m_2)
-            U3 = C(-i-j, m_3)
-            ugnt = ugnt + re(U1*U2*U3)*gaunt(l_1, l_2, l_3, i, j, -i-j)
 
-    if prec is not None:
-        ugnt = ugnt.n(prec)
+    t = lambda x: 1 if x > 0 else 0
+    A = lambda mu, m: t(-mu) * (s(m) * kron_del(m, mu) - kron_del(m, -mu))
+    B = lambda mu, m: t(mu) * (kron_del(m, mu) + s(m) * kron_del(m, -mu))
+    U = lambda mu, m: kron_del(abs(mu), abs(m)) * (kron_del(mu, 0) * kron_del(m, 0) + (B(mu, m) + 1j * A(mu, m))/sqrt(2))
+
+    ugnt = 0
+    for m1 in range(-l_1, l_1+1):
+        U1 = U(mu_1, m1)
+        for m2 in range(-l_2, l_2+1):
+            U2 = U(mu_2, m2)
+            U3 = U(mu_3,-m1-m2)
+            ugnt = ugnt + re(U1*U2*U3)*gaunt(l_1, l_2, l_3, m1, m2, -m1 - m2, prec=prec)
+
     return ugnt
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #25321

#### Brief description of what is fixed or changed
When using sympy to validate real Gaunt coefficients with `real_gaunt(...)`, I've experienced incorrect signs similar to what is reported here in this issue https://github.com/sympy/sympy/issues/25321.

This fix uses the modifications of the code of @Sunethan provided in #25321.

#### Other comments
 The documentation is corrected and updated to use the Greek letter mu to better reflect the notation used in Homeier & Steinborn 1996, and reflects the updated code.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
  * Fixed a bug with inconsistent signs of real Gaunt coefficients, occurring for certain combination of orders
<!-- END RELEASE NOTES -->
