### PR TITLE
Fixing Float zero divison error

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1033,6 +1033,7 @@ Mohit Gupta <mohitgupta@gmail.com>
 Mohit Shah <mohitshah3111999@gmail.com>
 Morten Olsen Lysgaard <morten@lysgaard.no>
 Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
+MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4041,8 +4041,8 @@ def _mag(x):
     except (ValueError, OverflowError):
         mag_first_dig = int(ceil(Float(mpf_log(xpos._mpf_, 53))/log(10)))
     # check that we aren't off by 1
-    if (xpos/10**mag_first_dig) >= 1:
-        assert 1 <= (xpos/10**mag_first_dig) < 10
+    if (xpos/S(10)**mag_first_dig) >= 1:
+        assert 1 <= (xpos/S(10)**mag_first_dig) < 10
         mag_first_dig += 1
     return mag_first_dig
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2299,5 +2299,6 @@ def test__unevaluated_Mul():
     assert _unevaluated_Mul(-x*A*B, S(2), A).args == (-2, x, A, B, A)
 
 
+# issue 27165
 def test_Float_zero_division_error():
     assert Float('1.7567e-1417').round(15) == Float(0)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2297,3 +2297,7 @@ def test__unevaluated_Mul():
     A, B = symbols('A B', commutative=False)
     assert _unevaluated_Mul(x, A, B, S(2), A).args == (2, x, A, B, A)
     assert _unevaluated_Mul(-x*A*B, S(2), A).args == (-2, x, A, B, A)
+
+
+def test_Float_zero_division_error():
+    assert Float('1.7567e-1417').round(15) == Float(0)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2299,6 +2299,6 @@ def test__unevaluated_Mul():
     assert _unevaluated_Mul(-x*A*B, S(2), A).args == (-2, x, A, B, A)
 
 
-# issue 27165
 def test_Float_zero_division_error():
+    # issue 27165
     assert Float('1.7567e-1417').round(15) == Float(0)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #27165

#### Brief description of what is fixed or changed
In expr file the function named _mag(x) it contains the following line
if (xpos/10**mag_first_dig) >= 1:

for very small numbers the mag_first_dig is very large negative integer so when python tries to do 10**mag_first_dig it handles it as float so returns zero which leaves zero int the denominator causing ZeroDivisionError

so by changing 10 to S(10) we avoided python default conversion to float.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug with Float. Formerly, `ZeroDivisionError` as using python built-in types caused result to be zero in the denominator
<!-- END RELEASE NOTES -->
