### PR TITLE
fix(core): match/replace no longer treat bound symbols as wild cards

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1869,35 +1869,7 @@ class Basic(Printable):
 
         """
         pattern = sympify(pattern)
-        # match non-bound symbols
-        canonical = lambda x: x if x.is_Symbol else x.as_dummy()
-        m = canonical(pattern).matches(canonical(self), old=old)
-        if m is None:
-            return m
-        from .symbol import Wild
-        from .function import WildFunction
-        from ..tensor.tensor import WildTensor, WildTensorIndex, WildTensorHead
-        wild = pattern.atoms(Wild, WildFunction, WildTensor, WildTensorIndex, WildTensorHead)
-        # sanity check
-        if set(m) - wild:
-            raise ValueError(filldedent('''
-            Some `matches` routine did not use a copy of repl_dict
-            and injected unexpected symbols. Report this as an
-            error at https://github.com/sympy/sympy/issues'''))
-        # now see if bound symbols were requested
-        bwild = wild - set(m)
-        if not bwild:
-            return m
-        # replace free-Wild symbols in pattern with match result
-        # so they will match but not be in the next match
-        wpat = pattern.xreplace(m)
-        # identify remaining bound wild
-        w = wpat.matches(self, old=old)
-        # add them to m
-        if w:
-            m.update(w)
-        # done
-        return m
+        return pattern.matches(self, old=old)
 
     def count_ops(self, visual=None):
         """Wrapper for count_ops that returns the operation count."""

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1824,8 +1824,8 @@ class Basic(Printable):
 
         Wild symbols match all.
 
-        Return ``None`` when expression (self) does not match
-        with pattern. Otherwise return a dictionary such that::
+        Return ``None`` when expression (self) does not match with pattern.
+        Otherwise return a dictionary such that::
 
           pattern.xreplace(self.match(pattern)) == self
 
@@ -1848,25 +1848,34 @@ class Basic(Printable):
         >>> (p*q**r).xreplace(e.match(p*q**r))
         4*x**2
 
-        Structurally bound symbols are ignored during matching:
+        Since match is purely structural expressions that are equivalent up to
+        bound symbols will not match:
 
-        >>> Sum(x, (x, 1, 2)).match(Sum(y, (y, 1, p)))
-        {p_: 2}
+        >>> print(Sum(x, (x, 1, 2)).match(Sum(y, (y, 1, p))))
+        None
 
-        But they can be identified if desired:
+        An expression with bound symbols can be matched if the pattern uses
+        a distinct ``Wild`` for each bound symbol:
 
         >>> Sum(x, (x, 1, 2)).match(Sum(q, (q, 1, p)))
         {p_: 2, q_: x}
 
         The ``old`` flag will give the old-style pattern matching where
-        expressions and patterns are essentially solved to give the
-        match. Both of the following give None unless ``old=True``:
+        expressions and patterns are essentially solved to give the match. Both
+        of the following give None unless ``old=True``:
 
         >>> (x - 2).match(p - x, old=True)
         {p_: 2*x - 2}
         >>> (2/x).match(p*x, old=True)
         {p_: 2/x**2}
 
+        See Also
+        ========
+
+        matches: pattern.matches(expr) is the same as expr.match(pattern)
+        xreplace: exact structural replacement
+        replace: structural replacement with pattern matching
+        Wild: symbolic placeholders for expressions in pattern matching
         """
         pattern = sympify(pattern)
         return pattern.matches(self, old=old)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -981,6 +981,15 @@ def test_replace():
     assert S.Zero.replace(Wild('x'), 1, exact=True) == 0
 
 
+def test_replace_integral():
+    # https://github.com/sympy/sympy/issues/27142
+    q, p, s, t = symbols('q p s t', cls=Wild)
+    a, b, c, d = symbols('a b c d')
+    i = Integral(a + b, (b, c, d))
+    pattern = Integral(q, (p, s, t))
+    assert i.replace(pattern, q) == a + b
+
+
 def test_find():
     expr = (x + y + 2 + sin(3*x))
 

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -753,7 +753,7 @@ def test_match_terms():
 def test_match_bound():
     V, W = map(Wild, "VW")
     x, y = symbols('x y')
-    assert Sum(x, (x, 1, 2)).match(Sum(y, (y, 1, W))) == {W: 2}
+    assert Sum(x, (x, 1, 2)).match(Sum(y, (y, 1, W))) is None
     assert Sum(x, (x, 1, 2)).match(Sum(V, (V, 1, W))) == {W: 2, V:x}
     assert Sum(x, (x, 1, 2)).match(Sum(V, (V, 1, 2))) == {V:x}
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for gh-27142

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * BREAKING CHANGE: In SymPy 1.7 Basic.match and Basic.replace were changed to treat bound symbols in a pattern as wild cards. This change is now reverted so that patterns are matched structurally without distinguishing between free and bound symbols. This means that e.g. `Integral(x, (x, 0, 1)).match(Integral(y, (y, 0, 1)))` no longer matches if `y` is an ordinary symbol. Matching bound symbols was redundant since a Wild symbol can be used in place of any bound symbol in the pattern e.g. `Integral(x, (x, 0, 1)).match(Integral(w, (w, 0, 1)))` where `w = Wild('w')`. This change to match fixes a bug in replace where matches involving expressions with bound symbols would give incorrect expressions involving Dummy symbols.
<!-- END RELEASE NOTES -->
