### PR TITLE
Fixed non-iterable object in traversal

### DIFF
--- a/sympy/core/tests/test_traversal.py
+++ b/sympy/core/tests/test_traversal.py
@@ -3,7 +3,7 @@ from sympy.core.containers import Tuple
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import symbols
 from sympy.core.singleton import S
-from sympy.core.function import expand, Function
+from sympy.core.function import expand, Function, Derivative
 from sympy.core.numbers import I
 from sympy.integrals.integrals import Integral
 from sympy.polys.polytools import factor
@@ -117,3 +117,13 @@ def test_deprecated_imports():
     with warns_deprecated_sympy():
         from sympy.utilities.iterables import interactive_traversal
         capture(lambda: interactive_traversal(x))
+
+
+def test_non_iterable():
+    # issue 27163
+    f = Function('f')
+    x = symbols('x')
+    y = symbols('y')
+
+    assert Derivative(f, y).has(x) is False
+    assert Derivative(f, x).has(x) is True

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 from .basic import Basic
 from .sorting import ordered
 from .sympify import sympify
@@ -27,6 +29,8 @@ def iterargs(expr):
     args = [expr]
     for i in args:
         yield i
+        if not isinstance(i.args, Iterable):
+            continue
         args.extend(i.args)
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #27163

#### Brief description of what is fixed or changed
A bug was fixed where an object with a `property` would raise a `TypeError` ("'property' object is not iterable"). The fix adds a check to ensure that, if an object is not iterable, it is skipped rather than causing an error.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug with property of undefined function being non-iterable. Added check so that if object is not iterable skip it.
<!-- END RELEASE NOTES -->
