### PR TITLE
maint(ci): Use python-flint nightly wheels in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -197,13 +197,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: sudo apt-get update
-      - run: sudo apt-get install libgmp-dev libmpfr-dev libmpc-dev libflint-dev
-      - run: pip install git+https://github.com/flintlib/python-flint.git@master
-      - run: pip install git+https://github.com/aleaxit/gmpy.git@master
+      - run: pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
-      - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-      - run: pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
+      - run: |
+          python -m pip install \
+              --pre \
+              --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+              --upgrade --only-binary=:all: \
+                          python-flint      \
+                          numpy             \
+                          scipy             \
+                          #
+
       - run: pip install -r requirements-dev.txt
       - run: pip install .
       - run: pytest -n auto
@@ -222,32 +227,8 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint
-      # Test the modules that most directly use python-flint
-      - run: >-
-          pytest
-          sympy/crypto
-          sympy/integrals
-          sympy/holonomic
-          sympy/matrices
-          sympy/ntheory
-          sympy/polys
-          sympy/solvers
-      - run: >-
-          bin/doctest
-          sympy/integrals
-          sympy/holonomic
-          sympy/matrices
-          sympy/ntheory
-          sympy/polys
-          sympy/printing
-          doc/src/modules/integrals
-          doc/src/modules/holonomic
-          doc/src/modules/matrices
-          doc/src/modules/ntheory.rst
-          doc/src/modules/polys
-          doc/src/modules/printing.rst
-          doc/src/tutorials/intro-tutorial/
-
+      - run: pip install .
+      - run: pytest -n auto
 
   # -------------------- FLINT+gmpy2 ------------------------------ #
 
@@ -263,36 +244,8 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint gmpy2
-      # Test the modules that most directly use python-flint
-      - run: pytest sympy/polys sympy/ntheory sympy/matrices
-        env:
-          SYMPY_GROUND_TYPES: flint
-      # Test the modules that most directly use python-flint
-      - run: >-
-          pytest
-          sympy/crypto
-          sympy/integrals
-          sympy/holonomic
-          sympy/matrices
-          sympy/ntheory
-          sympy/polys
-          sympy/solvers
-      - run: >-
-          bin/doctest
-          sympy/integrals
-          sympy/holonomic
-          sympy/matrices
-          sympy/ntheory
-          sympy/polys
-          sympy/printing
-          doc/src/modules/integrals
-          doc/src/modules/holonomic
-          doc/src/modules/matrices
-          doc/src/modules/ntheory.rst
-          doc/src/modules/polys
-          doc/src/modules/printing.rst
-          doc/src/tutorials/intro-tutorial/
-
+      - run: pip install .
+      - run: pytest -n auto
 
   # -------------------- Tensorflow tests -------------------------- #
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/scientific-python/upload-nightly-action/issues/111

#### Brief description of what is fixed or changed

Use python-flint nightly wheels instead of building python-flint from git in CI.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
