### PR TITLE
test(quality): Add missing ruff rules that are checked by flake8

### DIFF
--- a/.ci/parse_durations_log.py
+++ b/.ci/parse_durations_log.py
@@ -15,7 +15,7 @@ def read_log():
         if start_token_seen:
             try:
                 dur, kind, test_id = line.split()
-            except:
+            except ValueError:
                 return
             else:
                 if dur[0] not in '0123456789':

--- a/bin/ask_update.py
+++ b/bin/ask_update.py
@@ -16,7 +16,6 @@ $ python bin/ask_update.py
 # hook in-tree SymPy into Python path, if possible
 import os
 import sys
-import pprint
 
 isympy_path = os.path.abspath(__file__)
 isympy_dir = os.path.dirname(isympy_path)

--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -27,7 +27,6 @@ def sympy_dir():
 
 # put sympy on the path
 sys.path.insert(0, str(sympy_dir()))
-import sympy
 from sympy.utilities.misc import filldedent
 from sympy.external.importtools import version_tuple
 

--- a/bin/sympy_time.py
+++ b/bin/sympy_time.py
@@ -32,7 +32,7 @@ def new_import(name, globals={}, locals={}, fromlist=[]):
 old_import = __builtins__.__import__
 
 __builtins__.__import__ = new_import
-from sympy import *
+from sympy import * # noqa: F403
 
 parents = {}
 is_parent = {}

--- a/bin/test_import.py
+++ b/bin/test_import.py
@@ -4,6 +4,6 @@ from timeit import default_timer as clock
 from get_sympy import path_hack
 path_hack()
 t = clock()
-import sympy
+import sympy # noqa: F401
 t = clock() - t
 print(t)

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -131,7 +131,7 @@ doctest_list = [
 # This is just needed for the numpy nightly job which does not have matplotlib
 # Otherwise these could be added to doctest_list above
 try:
-    import matplotlib
+    import matplotlib # noqa: F401
     doctest_list.extend([
         'doc/src/tutorials/biomechanics/biomechanical-model-example.rst',
         'doc/src/tutorials/biomechanics/biomechanics.rst',

--- a/bin/test_py2_import.py
+++ b/bin/test_py2_import.py
@@ -15,7 +15,7 @@ parentdir = os.path.normpath(os.path.join(thisdir, '..'))
 sys.path.append(parentdir)
 
 try:
-    import sympy
+    import sympy # noqa: F401
 except ImportError as exc:
     message = str(exc)
     # e.g. "Python version 3.5 or above is required for SymPy."

--- a/doc/api/conf.py
+++ b/doc/api/conf.py
@@ -10,11 +10,11 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
-import sys
 import sympy
 
 # If your extensions are in another directory, add it here.
-#sys.path.append('some/directory')
+# import sys
+# sys.path.append('some/directory')
 
 # General configuration
 # ---------------------

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -464,7 +464,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = str(inspect.signature(func))
                 argspec = argspec.replace('*', r'\*')
                 signature = '{}{}'.format(func_name, argspec)
-            except TypeError as e:
+            except TypeError:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -480,7 +480,6 @@ class FunctionDoc(NumpyDocString):
         out = ''
 
         func, func_name = self.get_func()
-        signature = self['Signature'].replace('*', r'\*')
 
         roles = {'func': 'function',
                  'meth': 'method'}

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -7,7 +7,6 @@ import textwrap
 import re
 import pydoc
 from collections.abc import Mapping
-import sys
 
 
 class Reader:

--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -1,10 +1,8 @@
-import sys
 import re
 import inspect
 import textwrap
 import pydoc
 import sphinx
-import collections
 
 from docscrape import NumpyDocString, FunctionDoc, ClassDoc
 

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -17,7 +17,6 @@ It will:
 
 """
 
-import sys
 import re
 import pydoc
 import sphinx
@@ -47,10 +46,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
         doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
-        if sys.version_info[0] >= 3:
-            doc = str(doc)
-        else:
-            doc = unicode(doc)
+        doc = str(doc)
         lines[:] = doc.split(u_NL)
 
     if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -99,7 +99,6 @@ redirects = {
     "modules/physics/mechanics/symsystem": "../explanation/modules/physics/mechanics/symsystem.html",
     "modules/physics/mechanics/linearize": "../explanation/modules/physics/mechanics/linearize.html",
     "modules/physics/mechanics/sympy_mechanics_for_autolev_uses": "../explanation/modules/physics/mechanics/sympy_mechanics_for_autolev_uses.html",
-    "modules/physics/mechanics/examples": "../tutorials/physics/mechanics.html",
     "tutorials/physics/biomechanics/biomechanics": "../explanation/modules/physics/biomechanics/biomechanics.html",
 
 }
@@ -477,7 +476,7 @@ if not commit_hash:
         commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
         commit_hash = commit_hash.decode('ascii')
         commit_hash = commit_hash.rstrip()
-    except:
+    except Exception:
         import warnings
         warnings.warn(
             "Failed to get the git commit hash as the command " \

--- a/doc/src/tutorials/physics/control/generate_plots.py
+++ b/doc/src/tutorials/physics/control/generate_plots.py
@@ -1,4 +1,4 @@
-from sympy import Matrix, laplace_transform, inverse_laplace_transform, exp, cos, sqrt, sin
+from sympy import Matrix, laplace_transform, exp, cos, sqrt, sin
 from sympy.abc import s, t
 from sympy.physics.control import *
 

--- a/doc/src/tutorials/physics/control/generate_plots.py
+++ b/doc/src/tutorials/physics/control/generate_plots.py
@@ -1,6 +1,14 @@
 from sympy import Matrix, laplace_transform, exp, cos, sqrt, sin
 from sympy.abc import s, t
-from sympy.physics.control import *
+from sympy.physics.control import (
+    TransferFunction,
+    TransferFunctionMatrix,
+    Series,
+    Feedback,
+    pole_zero_plot,
+    bode_magnitude_plot,
+    step_response_plot
+)
 
 def main_q3():
     g =  Matrix([[exp(-t)*(1 - t), exp(-2*t)], [5*exp((-2*t))-exp((-t)), (cos((sqrt(3)*t)/2) - 3*sqrt(3)*sin((sqrt(3)*t)/2))*exp(-t/2)]])

--- a/isympy.py
+++ b/isympy.py
@@ -305,7 +305,7 @@ def main() -> None:
         ipython = session == 'ipython'
     else:
         try:
-            import IPython
+            import IPython # noqa: F401
             ipython = True
         except ImportError:
             if not options.quiet:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,18 +56,9 @@ lint.ignore = [
     "E713",  # Test for membership should be `not in`
     "E714",  # Test for object identity should be `is not`
     "E721",  # Do not compare types, use `isinstance()`
-    "E722",  # Do not use bare `except`
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "E741",  # Ambiguous variable name: `<VARIABLE>`
     "E743",  # Ambiguous function name: `<FUNCTION>`
-    "F403",  # `from <MODULE> import *` used; unable to detect undefined names
-    "F405",  # `<TYPE>` may be undefined, or defined from star imports: `<MODULE>`
-    "F523",  # `.format` call has unused arguments at position(s): <INDEX>
-    "F601",  # Dictionary key literal `'<KEY>'` repeated
-    "F811",  # Redefinition of unused `<VARIABLE>` from line <LINE>
-    "F821",  # Undefined name `VARIABLE`
-    "F823",  # Local variable `VARIABLE` referenced before assignment
-    "F841",  # Local variable `VARIABLE` is assigned to but never used
 ]
 
 # Exclude paths currently excluded in the flake8 configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ lint.ignore = [
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "E741",  # Ambiguous variable name: `<VARIABLE>`
     "E743",  # Ambiguous function name: `<FUNCTION>`
-    "F401",  # `<TYPE>` imported but unused
     "F403",  # `from <MODULE> import *` used; unable to detect undefined names
     "F405",  # `<TYPE>` may be undefined, or defined from star imports: `<MODULE>`
     "F523",  # `.format` call has unused arguments at position(s): <INDEX>

--- a/release/authors.py
+++ b/release/authors.py
@@ -43,6 +43,10 @@ def blue(text):
     return "\033[34m%s\033[0m" % text
 
 
+def red(text):
+    return "\033[31m%s\033[0m" % text
+
+
 def get_authors(version, prevversion):
     """
     Get the list of authors since the previous release
@@ -118,7 +122,7 @@ def get_previous_version_tag(version):
             # never happens, so just error
             cmdline = f'git rev-list --parents -n 1 {curtag}'
             print(cmdline)
-            parents = check_output(cmdline.split()).decode('utf-8').strip().split()
+            check_output(cmdline.split()).decode('utf-8').strip().split()
             # rev-list prints the current commit and then all its parents
             # If the tagged commit *is* a merge commit, just comment this
             # out, and manually make sure `get_previous_version_tag` is correct

--- a/release/authors.py
+++ b/release/authors.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import os
 from pathlib import Path
 from subprocess import check_output
 import unicodedata

--- a/release/build_docs.py
+++ b/release/build_docs.py
@@ -2,7 +2,7 @@
 
 
 import os
-from os.path import dirname, join, basename, normpath
+from os.path import dirname, join
 from os import chdir
 import shutil
 

--- a/release/github_release.py
+++ b/release/github_release.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
 
 import os
+import stat
 import json
 from subprocess import check_output
 from collections import OrderedDict, defaultdict
 from collections.abc import Mapping
 import glob
 from contextlib import contextmanager
+from getpass import getpass
 
 import requests
+from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth2
 
 

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ class sdist_sympy(sdist):
             commit_hash = commit_hash.rstrip()
             print('Commit hash found : {}.'.format(commit_hash))
             print('Writing it to {}.'.format(commit_hash_filepath))
-        except:
+        except Exception:
             pass
 
         if commit_hash:
@@ -308,7 +308,7 @@ with open(os.path.join(dir_setup, 'sympy', 'release.py')) as f:
 
 if __name__ == '__main__':
     setup(name='sympy',
-          version=__version__,
+          version=__version__, # noqa: F821
           description='Computer algebra system (CAS) in Python',
           long_description=(Path(__file__).parent / 'README.md').read_text("UTF-8"),
           long_description_content_type='text/markdown',

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -983,7 +983,6 @@ class MathematicaParser:
         "Log": lambda *a: log(*reversed(a)),
         "Log2": lambda x: log(x, 2),
         "Log10": lambda x: log(x, 10),
-        "Rational": Rational,
         "Exp": exp,
         "Sqrt": sqrt,
 

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -163,7 +163,6 @@ def test_all_implicit_steps():
         'pi': 'pi',  # don't mess with constants
         'None': 'None',
         'ln sin x': 'ln(sin(x))',  # multiple implicit function applications
-        'factorial': 'factorial',  # don't add parentheses
         'sin x**2': 'sin(x**2)',  # implicit application to an exponential
         'alpha': 'Symbol("alpha")',  # don't split Greek letters/subscripts
         'x_2': 'Symbol("x_2")',

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -9,4 +9,4 @@ sympy_deprecation_warning("The sympy.utilities.pytest submodule is deprecated. U
     deprecated_since_version="1.6",
     active_deprecations_target="deprecated-sympy-utilities-submodules")
 
-from sympy.testing.pytest import *  # noqa:F401
+from sympy.testing.pytest import *  # noqa:F401,F403

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -9,4 +9,4 @@ sympy_deprecation_warning("The sympy.utilities.randtest submodule is deprecated.
     deprecated_since_version="1.6",
     active_deprecations_target="deprecated-sympy-utilities-submodules")
 
-from sympy.core.random import *  # noqa:F401
+from sympy.core.random import *  # noqa:F401,F403

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -10,4 +10,4 @@ sympy_deprecation_warning("The sympy.utilities.runtests submodule is deprecated.
     deprecated_since_version="1.6",
     active_deprecations_target="deprecated-sympy-utilities-submodules")
 
-from sympy.testing.runtests import *  # noqa:F401
+from sympy.testing.runtests import * # noqa: F401,F403

--- a/sympy/utilities/tmpfiles.py
+++ b/sympy/utilities/tmpfiles.py
@@ -9,4 +9,4 @@ sympy_deprecation_warning("The sympy.utilities.tmpfiles submodule is deprecated.
     deprecated_since_version="1.6",
     active_deprecations_target="deprecated-sympy-utilities-submodules")
 
-from sympy.testing.tmpfiles import *  # noqa:F401
+from sympy.testing.tmpfiles import *  # noqa:F401,F403


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

Add rule F401 to ruff checks. Note that this rule is already checked by flake8 for the contents of the sympy code directory. The rule is basically `x is imported but not used` which means that a redundant import should be deleted. This is the most common reason that someone ends up pushing a second commit to fix the code quality CI checks but is currently not checked by running `ruff check`.

Adding this rule to ruff is useful because ruff can run the checks much faster than flake8 and can also fix these automatically most of the time. For example if I add an unnecessary import like:
```console
$ time ruff check 
sympy/core/add.py:12:17: F401 [*] `foo.bar` imported but unused
   |
10 | from .cache import cacheit
11 | from .numbers import equal_valued
12 | from foo import bar
   |                 ^^^ F401
13 | from .intfunc import ilcm, igcd
14 | from .expr import Expr
   |
   = help: Remove unused import: `foo.bar`

Found 1 error.
[*] 1 fixable with the `--fix` option.

real	0m0.159s
user	0m0.185s
sys	0m0.073s
```
Note that this checked the entire codebase in 0.2 seconds. It also says that it can fix the problem e.g.:
```console
$ ruff check --fix
Found 1 error (1 fixed, 0 remaining).
$ git diff
diff --git a/sympy/core/add.py b/sympy/core/add.py
index effbb4cd77..f09051ed8b 100644
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -9,7 +9,6 @@
 from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
 from .numbers import equal_valued
-from foo import bar
 from .intfunc import ilcm, igcd
 from .expr import Expr
 from .kind import UndefinedKind
```
I don't usually run flake8 before pushing because it is too slow on the SymPy codebase. Running ruff is fast enough to be worthwhile.

#### Other comments

The ruff checks are set up to run in the whole codebase unlike the flake8 checks that only apply to the sympy package directory. Adding this rule to ruff checks means that it also applies to files outside the sympy package directory which is why I have removed some imports and added some noqa comments.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
