### PR TITLE
fix(core): restrict the 2-arg Mul to -1

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -211,7 +211,7 @@ jobs:
 
       - run: pip install -r requirements-dev.txt
       - run: pip install .
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- FLINT tests -------------------------------- #
 
@@ -228,7 +228,7 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint
       - run: pip install .
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- FLINT+gmpy2 ------------------------------ #
 
@@ -245,7 +245,7 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint gmpy2
       - run: pip install .
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Tensorflow tests -------------------------- #
 
@@ -322,7 +322,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Doctests older (and newer) Python --------------------- #
 
@@ -364,7 +364,7 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Build the html/latex docs ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -139,7 +139,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1,6 +1,6 @@
 from math import prod
 
-from sympy.core import Add, S, Dummy, expand_func
+from sympy.core import Add, S, Dummy, expand_func, expand_mul
 from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError, PoleError
 from sympy.core.logic import fuzzy_and, fuzzy_not
@@ -158,6 +158,8 @@ class gamma(Function):
                 n = arg.p // arg.q
                 p = arg.p - n*arg.q
                 return self.func(x + n)._eval_expand_func().subs(x, Rational(p, arg.q))
+
+        arg = expand_mul(arg)
 
         if arg.is_Add:
             coeff, tail = arg.as_coeff_add()

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -452,7 +452,7 @@ def TR8(rv, first=True):
                 if rv.is_Mul and rv.args[0].is_Rational and \
                         len(rv.args) == 2 and rv.args[1].is_Add:
                     rv = Mul(*rv.as_coeff_Mul())
-            return rv
+            return expand_mul(rv)
 
         args = {cos: [], sin: [], None: []}
         for a in Mul.make_args(rv):
@@ -571,16 +571,16 @@ def TR9(rv):
             # application of rule if possible
             if iscos:
                 if n1 == n2:
-                    return gcd*n1*2*cos((a + b)/2)*cos((a - b)/2)
+                    return expand_mul(gcd*n1*2*cos((a + b)/2)*cos((a - b)/2))
                 if n1 < 0:
                     a, b = b, a
-                return -2*gcd*sin((a + b)/2)*sin((a - b)/2)
+                return expand_mul(-2*gcd*sin((a + b)/2)*sin((a - b)/2))
             else:
                 if n1 == n2:
-                    return gcd*n1*2*sin((a + b)/2)*cos((a - b)/2)
+                    return expand_mul(gcd*n1*2*sin((a + b)/2)*cos((a - b)/2))
                 if n1 < 0:
                     a, b = b, a
-                return 2*gcd*cos((a + b)/2)*sin((a - b)/2)
+                return expand_mul(2*gcd*cos((a + b)/2)*sin((a - b)/2))
 
         return process_common_addends(rv, do)  # DON'T sift by free symbols
 

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -169,7 +169,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 if m:
                     e.append(m)
                     coeff /= b**m
-            c_powers[b] = Add(*e)
+            c_powers[b] = expand_mul(Add(*e))
         if coeff is not S.One:
             if coeff in c_powers:
                 c_powers[coeff] += S.One

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -309,7 +309,7 @@ def hypersimp(f, k):
     """
     f = sympify(f)
 
-    g = f.subs(k, k + 1) / f
+    g = expand_mul(f.subs(k, k + 1)) / f
 
     g = g.rewrite(gamma)
     if g.has(Piecewise):
@@ -317,6 +317,7 @@ def hypersimp(f, k):
         g = g.args[-1][0]
     g = expand_func(g)
     g = powsimp(g, deep=True, combine='exp')
+    g = g.cancel()
 
     if g.is_rational_function(k):
         return simplify(g, ratio=S.Infinity)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -309,7 +309,7 @@ def hypersimp(f, k):
     """
     f = sympify(f)
 
-    g = expand_mul(f.subs(k, k + 1)) / f
+    g = f.subs(k, k + 1) / f
 
     g = g.rewrite(gamma)
     if g.has(Piecewise):
@@ -317,7 +317,6 @@ def hypersimp(f, k):
         g = g.args[-1][0]
     g = expand_func(g)
     g = powsimp(g, deep=True, combine='exp')
-    g = g.cancel()
 
     if g.is_rational_function(k):
         return simplify(g, ratio=S.Infinity)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -590,7 +590,10 @@ def exptrigsimp(expr):
         # functions
         choices = [e]
         if e.has(*_trigs):
-            choices.append(expand_mul(e.rewrite(exp)))
+            e_exp = e.rewrite(exp)
+            if isinstance(e_exp, Expr):
+                e_exp = expand_mul(e_exp)
+            choices.append(e_exp)
         choices.append(e.rewrite(cos))
         return min(*choices, key=count_ops)
     newexpr = bottom_up(expr, exp_trig)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -590,7 +590,7 @@ def exptrigsimp(expr):
         # functions
         choices = [e]
         if e.has(*_trigs):
-            choices.append(e.rewrite(exp))
+            choices.append(expand_mul(e.rewrite(exp)))
         choices.append(e.rewrite(cos))
         return min(*choices, key=count_ops)
     newexpr = bottom_up(expr, exp_trig)


### PR DESCRIPTION
Since 3e835b5 from gh-716 there is the following behaviour:
```
  >>> 2*(x + y)
  2*x + 2*y
```
Specifically if there is a Mul with 2 args and one arg is a Rational and the other an Add then the Rational is distributed into the Add. More generally if there is a Mul and the arguments collapse to a number and an Add e.g. `Mul(2, 3.0, x + y)` then the coefficient is distributed into the Add.

There are various problems with this behaviour such as the fact that it breaks associativity `(a*b)*c != a*(b*c)`. Previous discussions have agreed that this should be removed (e.g. gh-4596). There have been previous attempts to remove this e.g. gh-17242 but it is not easy because so much code now depends on it.

This commit attempts a more limited change in which the 2-arg Mul is mostly removed but kept for one important special case: if we have `Mul(-1, Add(...))` then the -1 will be distributed into the Add. This special case is important because it arises when subtracting to Adds e.g.:
```
  >>> x + y - (x + y)
  0
```
It could perhaps be possible to special case negation and subtraction somehow so that negating the terms of an Add happens specifically in subtraction rather than more generally in a Mul but here we just preserve the 2-arg behaviour for -1 specifically as a more limited change to existing behaviour. Keeping this particular special case of the 2-arg Mul dramatically reduces the number of test failures seen in the test suite compared to removing automatic distribution altogether.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * BREAKING CHANGE: Multiplying a Rational and an Add no longer distributes the Rational into the Add e.g. `2*(x + y)` remains as `2*(x + y)` rather than distributing as `2*x + 2*y`. Distribution is now limited to the special case in which the multiplier is `-1` so `-(x + y)` still transforms to `-x - y` but any other coefficient will not be distributed.
<!-- END RELEASE NOTES -->
