### PR TITLE
fix(core): tests for 2-arg Mul restriction

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -211,7 +211,7 @@ jobs:
 
       - run: pip install -r requirements-dev.txt
       - run: pip install .
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- FLINT tests -------------------------------- #
 
@@ -228,7 +228,7 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint
       - run: pip install .
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- FLINT+gmpy2 ------------------------------ #
 
@@ -245,7 +245,7 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint gmpy2
       - run: pip install .
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Tensorflow tests -------------------------- #
 
@@ -322,7 +322,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Doctests older (and newer) Python --------------------- #
 
@@ -364,7 +364,7 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Build the html/latex docs ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -139,7 +139,7 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto
+      - run: pytest -n auto --timeout 595
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2007,16 +2007,18 @@ class Basic(Printable):
         >>> from sympy.abc import x
         >>> expr = cos(x) + I*sin(x)
         >>> expr.rewrite(exp)
+        (exp(I*x) - exp(-I*x))/2 + (exp(I*x) + exp(-I*x))/2
+        >>> expr.rewrite(exp).expand()
         exp(I*x)
 
         Pattern can be a type or an iterable of types.
 
         >>> expr.rewrite(sin, exp)
-        exp(I*x)/2 + cos(x) - exp(-I*x)/2
+        (exp(I*x) - exp(-I*x))/2 + cos(x)
         >>> expr.rewrite([cos,], exp)
-        exp(I*x)/2 + I*sin(x) + exp(-I*x)/2
+        (exp(I*x) + exp(-I*x))/2 + I*sin(x)
         >>> expr.rewrite([cos, sin], exp)
-        exp(I*x)
+        (exp(I*x) - exp(-I*x))/2 + (exp(I*x) + exp(-I*x))/2
 
         Rewriting behavior can be implemented by defining ``_eval_rewrite()``
         method.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1072,9 +1072,9 @@ class Derivative(Expr):
 
         >>> e = sqrt((x + 1)**2 + x)
         >>> diff(e, (x, 5), simplify=False).count_ops()
-        136
+        37
         >>> diff(e, (x, 5)).count_ops()
-        30
+        33
 
     Ordering of variables:
 
@@ -2856,7 +2856,7 @@ def expand_multinomial(expr, deep=True):
     >>> from sympy import symbols, expand_multinomial, exp
     >>> x, y = symbols('x y', positive=True)
     >>> expand_multinomial((x + exp(x + 1))**2)
-    x**2 + 2*x*exp(x + 1) + exp(2*x + 2)
+    x**2 + 2*x*exp(x + 1) + exp(2*(x + 1))
 
     """
     return sympify(expr).expand(deep=deep, mul=False, power_exp=False,

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -204,16 +204,18 @@ class Mul(Expr, AssocOp):
 
                 >>> from sympy import Mul, sqrt
                 >>> from sympy.abc import x, y, z
-                >>> 2*(x + 1) # this is the 2-arg Mul behavior
-                2*x + 2
-                >>> y*(x + 1)*2
-                2*y*(x + 1)
-                >>> 2*(x + 1)*y # 2-arg result will be obtained first
-                y*(2*x + 2)
-                >>> Mul(2, x + 1, y) # all 3 args simultaneously processed
-                2*y*(x + 1)
-                >>> 2*((x + 1)*y) # parentheses can control this behavior
-                2*y*(x + 1)
+                >>> 2*(x + 1)
+                2*(x + 1)
+                >>> -(x + 1) # this is the 2-arg Mul behavior
+                -x - 1
+                >>> y*(x + 1)*-1
+                -y*(x + 1)
+                >>> -1*(x + 1)*y # 2-arg result will be obtained first
+                y*(-x - 1)
+                >>> Mul(-1, x + 1, y) # all 3 args simultaneously processed
+                -y*(x + 1)
+                >>> -1*((x + 1)*y) # parentheses can control this behavior
+                -y*(x + 1)
 
                 Powers with compound bases may not find a single base to
                 combine with unless all arguments are processed at once.

--- a/sympy/core/parameters.py
+++ b/sympy/core/parameters.py
@@ -118,11 +118,11 @@ def distribute(x):
 
     >>> from sympy.abc import x
     >>> from sympy.core.parameters import distribute
-    >>> print(2*(x + 1))
-    2*x + 2
+    >>> print(-1*(x + 1))
+    -x - 1
     >>> with distribute(False):
-    ...     print(2*(x + 1))
-    2*(x + 1)
+    ...     print(-1*(x + 1))
+    -(x + 1)
     """
 
     old = global_parameters.distribute

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1750,7 +1750,7 @@ class Pow(Expr):
         >>> (3**((5 + y)/2)).as_content_primitive()
         (9, 3**((y + 1)/2))
         >>> eq = 3**(2 + 2*x)
-        >>> powsimp(eq) == eq
+        >>> powsimp(eq)
         True
         >>> eq.as_content_primitive()
         (9, 3**(2*x))

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -529,7 +529,7 @@ def kernS(s):
     of an expression, but kernS will prevent that:
 
     >>> 2*(x + y), -(x + 1)
-    (2*x + 2*y, -x - 1)
+    (2*(x + y), -x - 1)
     >>> kernS('2*(x + y)')
     2*(x + y)
     >>> kernS('-(x + 1)')

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -109,7 +109,7 @@ def test_arit0():
     e = -(1 + a)
     assert e == -1 - a
     e = S.Half*(1 + a)
-    assert e == S.Half + a/2
+    assert e == Mul(S.Half, 1 + a, evaluate=False)
 
 
 def test_div():
@@ -1789,7 +1789,7 @@ def test_Add_as_content_primitive():
     # the coefficient may sort to a position other than 0
     p = 3 + x + y
     assert (2*p).expand().as_content_primitive() == (2, p)
-    assert (2.0*p).expand().as_content_primitive() == (1, 2.*p)
+    assert (2.0*p).expand().as_content_primitive() == (1, 2.0*x + 2.0*y + 6.0)
     p *= -1
     assert (2*p).expand().as_content_primitive() == (2, p)
 
@@ -1854,7 +1854,7 @@ def test_Mod():
 
     # Float handling
     point3 = Float(3.3) % 1
-    assert (x - 3.3) % 1 == Mod(1.*x + 1 - point3, 1)
+    assert (x - 3.3) % 1 == Mod(x - 3.3, 1)
     assert Mod(-3.3, 1) == 1 - point3
     assert Mod(0.7, 1) == Float(0.7)
     e = Mod(1.3, 1)
@@ -2448,7 +2448,9 @@ def test_issue_22021():
     for args in permutations((zoo, a, x)):
         e = Add(*args, evaluate=False)
         assert -e == -1*e
-    assert 2*Add(1, x, x, evaluate=False) == 4*x + 2
+    e2 = Add(1, x, x, evaluate=False)
+    assert e2.is_Add and e2.args == (1, x, x)
+    assert 2*e2 == Mul(2, e2, evaluate=False)
 
 
 def test_issue_22244():

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -213,7 +213,7 @@ def test_rewrite():
     x, y, z = symbols('x y z')
     a, b = symbols('a b')
     f1 = sin(x) + cos(x)
-    assert f1.rewrite(cos,exp) == exp(I*x)/2 + sin(x) + exp(-I*x)/2
+    assert f1.rewrite(cos,exp) == (exp(I*x) + exp(-I*x))/2 + sin(x)
     assert f1.rewrite([cos],sin) == sin(x) + sin(x + pi/2, evaluate=False)
     f2 = sin(x) + cos(y)/gamma(z)
     assert f2.rewrite(sin,exp) == -I*(exp(I*x) - exp(-I*x))/2 + cos(y)/gamma(z)

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -115,7 +115,7 @@ def test_rootcomplex():
 
 
 def test_expand_inverse():
-    assert (1/(1 + I)).expand(complex=True) == (1 - I)/2
+    assert (1/(1 + I)).expand(complex=True) == S(1)/2 - I/2
     assert ((1 + 2*I)**(-2)).expand(complex=True) == (-3 - 4*I)/25
     assert ((1 + I)**(-8)).expand(complex=True) == Rational(1, 16)
 

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -722,7 +722,7 @@ def test_issue_2877():
     def r(a, b, c):
         return factor(a*x**2 + b*x + c)
     e = r(5.0/6, 10, 5)
-    assert nsimplify(e) == 5*x**2/6 + 10*x + 5
+    assert nsimplify(e) == 10*(x**2/12 + x + S(1)/2)
 
 
 def test_issue_5910():

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1,6 +1,6 @@
 from math import prod
 
-from sympy.core import Add, S, Dummy, expand_func
+from sympy.core import Add, S, Dummy, expand_func, expand_mul
 from sympy.core.expr import Expr
 from sympy.core.function import Function, ArgumentIndexError, PoleError
 from sympy.core.logic import fuzzy_and, fuzzy_not
@@ -158,6 +158,8 @@ class gamma(Function):
                 n = arg.p // arg.q
                 p = arg.p - n*arg.q
                 return self.func(x + n)._eval_expand_func().subs(x, Rational(p, arg.q))
+
+        arg = expand_mul(arg)
 
         if arg.is_Add:
             coeff, tail = arg.as_coeff_add()

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -452,7 +452,7 @@ def TR8(rv, first=True):
                 if rv.is_Mul and rv.args[0].is_Rational and \
                         len(rv.args) == 2 and rv.args[1].is_Add:
                     rv = Mul(*rv.as_coeff_Mul())
-            return rv
+            return expand_mul(rv)
 
         args = {cos: [], sin: [], None: []}
         for a in Mul.make_args(rv):
@@ -571,16 +571,16 @@ def TR9(rv):
             # application of rule if possible
             if iscos:
                 if n1 == n2:
-                    return gcd*n1*2*cos((a + b)/2)*cos((a - b)/2)
+                    return expand_mul(gcd*n1*2*cos((a + b)/2)*cos((a - b)/2))
                 if n1 < 0:
                     a, b = b, a
-                return -2*gcd*sin((a + b)/2)*sin((a - b)/2)
+                return expand_mul(-2*gcd*sin((a + b)/2)*sin((a - b)/2))
             else:
                 if n1 == n2:
-                    return gcd*n1*2*sin((a + b)/2)*cos((a - b)/2)
+                    return expand_mul(gcd*n1*2*sin((a + b)/2)*cos((a - b)/2))
                 if n1 < 0:
                     a, b = b, a
-                return 2*gcd*cos((a + b)/2)*sin((a - b)/2)
+                return expand_mul(2*gcd*cos((a + b)/2)*sin((a - b)/2))
 
         return process_common_addends(rv, do)  # DON'T sift by free symbols
 

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -169,7 +169,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 if m:
                     e.append(m)
                     coeff /= b**m
-            c_powers[b] = Add(*e)
+            c_powers[b] = expand_mul(Add(*e))
         if coeff is not S.One:
             if coeff in c_powers:
                 c_powers[coeff] += S.One

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -309,7 +309,7 @@ def hypersimp(f, k):
     """
     f = sympify(f)
 
-    g = f.subs(k, k + 1) / f
+    g = expand_mul(f.subs(k, k + 1)) / f
 
     g = g.rewrite(gamma)
     if g.has(Piecewise):
@@ -317,6 +317,7 @@ def hypersimp(f, k):
         g = g.args[-1][0]
     g = expand_func(g)
     g = powsimp(g, deep=True, combine='exp')
+    g = g.cancel()
 
     if g.is_rational_function(k):
         return simplify(g, ratio=S.Infinity)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -309,7 +309,7 @@ def hypersimp(f, k):
     """
     f = sympify(f)
 
-    g = expand_mul(f.subs(k, k + 1)) / f
+    g = f.subs(k, k + 1) / f
 
     g = g.rewrite(gamma)
     if g.has(Piecewise):
@@ -317,7 +317,6 @@ def hypersimp(f, k):
         g = g.args[-1][0]
     g = expand_func(g)
     g = powsimp(g, deep=True, combine='exp')
-    g = g.cancel()
 
     if g.is_rational_function(k):
         return simplify(g, ratio=S.Infinity)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -590,7 +590,10 @@ def exptrigsimp(expr):
         # functions
         choices = [e]
         if e.has(*_trigs):
-            choices.append(expand_mul(e.rewrite(exp)))
+            e_exp = e.rewrite(exp)
+            if isinstance(e_exp, Expr):
+                e_exp = expand_mul(e_exp)
+            choices.append(e_exp)
         choices.append(e.rewrite(cos))
         return min(*choices, key=count_ops)
     newexpr = bottom_up(expr, exp_trig)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -590,7 +590,7 @@ def exptrigsimp(expr):
         # functions
         choices = [e]
         if e.has(*_trigs):
-            choices.append(e.rewrite(exp))
+            choices.append(expand_mul(e.rewrite(exp)))
         choices.append(e.rewrite(cos))
         return min(*choices, key=count_ops)
     newexpr = bottom_up(expr, exp_trig)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Updates tests wrt gh-27200. This is built on top of gh-27200 to keep changes to tests separate from the actual behaviour changes.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
