### PR TITLE
Removal of the inner function `_find_conditions`

### DIFF
--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -2099,39 +2099,25 @@ def from_hyper(func, x0=0, evalf=False):
     if simp in (Infinity, NegativeInfinity):
         return HolonomicFunction(sol, x).composition(z)
 
-    def _find_conditions(simp, x, x0, order, evalf=False):
-        y0 = []
-        for i in range(order):
-            if evalf:
-                val = simp.subs(x, x0).evalf()
-            else:
-                val = simp.subs(x, x0)
-            # return None if it is Infinite or NaN
-            if val.is_finite is False or isinstance(val, NaN):
-                return None
-            y0.append(val)
-            simp = simp.diff(x)
-        return y0
-
     # if the function is known symbolically
     if not isinstance(simp, hyper):
-        y0 = _find_conditions(simp, x, x0, sol.order)
+        y0 = _find_conditions(simp, x, x0, sol.order, use_limit=False)
         while not y0:
             # if values don't exist at 0, then try to find initial
             # conditions at 1. If it doesn't exist at 1 too then
             # try 2 and so on.
             x0 += 1
-            y0 = _find_conditions(simp, x, x0, sol.order)
+            y0 = _find_conditions(simp, x, x0, sol.order, use_limit=False)
 
         return HolonomicFunction(sol, x).composition(z, x0, y0)
 
     if isinstance(simp, hyper):
         x0 = 1
         # use evalf if the function can't be simplified
-        y0 = _find_conditions(simp, x, x0, sol.order, evalf)
+        y0 = _find_conditions(simp, x, x0, sol.order, evalf, use_limit=False)
         while not y0:
             x0 += 1
-            y0 = _find_conditions(simp, x, x0, sol.order, evalf)
+            y0 = _find_conditions(simp, x, x0, sol.order, evalf, use_limit=False)
         return HolonomicFunction(sol, x).composition(z, x0, y0)
 
     return HolonomicFunction(sol, x).composition(z)
@@ -2183,34 +2169,21 @@ def from_meijerg(func, x0=0, evalf=False, initcond=True, domain=QQ):
     if simp in (Infinity, NegativeInfinity):
         return HolonomicFunction(sol, x).composition(z)
 
-    def _find_conditions(simp, x, x0, order, evalf=False):
-        y0 = []
-        for i in range(order):
-            if evalf:
-                val = simp.subs(x, x0).evalf()
-            else:
-                val = simp.subs(x, x0)
-            if val.is_finite is False or isinstance(val, NaN):
-                return None
-            y0.append(val)
-            simp = simp.diff(x)
-        return y0
-
     # computing initial conditions
     if not isinstance(simp, meijerg):
-        y0 = _find_conditions(simp, x, x0, sol.order)
+        y0 = _find_conditions(simp, x, x0, sol.order, use_limit=False)
         while not y0:
             x0 += 1
-            y0 = _find_conditions(simp, x, x0, sol.order)
+            y0 = _find_conditions(simp, x, x0, sol.order, use_limit=False)
 
         return HolonomicFunction(sol, x).composition(z, x0, y0)
 
     if isinstance(simp, meijerg):
         x0 = 1
-        y0 = _find_conditions(simp, x, x0, sol.order, evalf)
+        y0 = _find_conditions(simp, x, x0, sol.order, evalf, use_limit=False)
         while not y0:
             x0 += 1
-            y0 = _find_conditions(simp, x, x0, sol.order, evalf)
+            y0 = _find_conditions(simp, x, x0, sol.order, evalf, use_limit=False)
 
         return HolonomicFunction(sol, x).composition(z, x0, y0)
 
@@ -2777,11 +2750,13 @@ def _create_table(table, domain=QQ):
     add(Shi(x_1), -x_1*Dx + 2*Dx**2 + x_1*Dx**3, x_1)
 
 
-def _find_conditions(func, x, x0, order):
+def _find_conditions(func, x, x0, order, evalf=False, use_limit=True):
     y0 = []
-    for i in range(order):
+    for _ in range(order):
         val = func.subs(x, x0)
-        if isinstance(val, NaN):
+        if evalf:
+            val = val.evalf()
+        if use_limit and isinstance(val, NaN):
             val = limit(func, x, x0)
         if val.is_finite is False or isinstance(val, NaN):
             return None


### PR DESCRIPTION
The inner function `_find_conditions` in `from_hyper` and `from_meijerg` is very similar to `_find_conditions`. The inner function has been removed, and `_find_conditions` is now used instead.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
