### PR TITLE
Implementation of Ramanujan's congruences

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1631,6 +1631,13 @@ class partition(Function):
         if self.args[0].is_nonnegative is True:
             return True
 
+    def _eval_Mod(self, q):
+        # Ramanujan's congruences
+        n = self.args[0]
+        for p, rem in [(5, 4), (7, 5), (11, 6)]:
+            if q == p and n % q == rem:
+                return S.Zero
+
 
 class divisor_sigma(Function):
     r"""

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -574,6 +574,12 @@ def test_partition():
     assert partition(x).subs(x, 7) == 15
     assert partition(y).subs(y, 8) == 22
     raises(TypeError, lambda: partition(Rational(5, 4)))
+    assert partition(9, evaluate=False) % 5 == 0
+    assert partition(5*m + 4) % 5 == 0
+    assert partition(47, evaluate=False) % 7 == 0
+    assert partition(7*m + 5) % 7 == 0
+    assert partition(50, evaluate=False) % 11 == 0
+    assert partition(11*m + 6) % 11 == 0
 
 
 def test_divisor_sigma():


### PR DESCRIPTION
The partition function satisfy congruence relations known as Ramanujan's congruences. To achieve this, we implemented `partition._eval_Mod`.

https://en.wikipedia.org/wiki/Ramanujan%27s_congruences

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Ramanujan's congruences have been implemented. The expression `partition(5*n+4) % 5` evaluates to zero.
<!-- END RELEASE NOTES -->
