### PR TITLE
Fix some broken links in documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -364,7 +364,7 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
-Au Huishan <151558456+AkierRaee@users.noreply.github.com>
+Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -364,8 +364,8 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
-Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Au Huishan <151558456+AkierRaee@users.noreply.github.com>
+Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -364,7 +364,7 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
-Au Huishan <huishan_au@outlook.com>
+Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -364,6 +364,8 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
+Au Huishan <huishan_au@outlook.com>
+Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>

--- a/doc/src/guides/physics/index.rst
+++ b/doc/src/guides/physics/index.rst
@@ -11,6 +11,6 @@ Physics, Optics, Quantum Mechanics, Units and Vector algebra.
 
 For physics tutorials, please check out:
 
-* `Biomechanics Tutorials <../../tutorials/physics/biomechanics/index.html>`_
-* `Mechanics Tutorials <../../tutorials/physics/mechanics/index.html>`_
-* `Control Tutorials <../../tutorials/physics/control/index.html>`_
+* `Biomechanics Tutorials <../../tutorials/physics/biomechanics/index.rst>`_
+* `Mechanics Tutorials <../../tutorials/physics/mechanics/index.rst>`_
+* `Control Tutorials <../../tutorials/physics/control/index.rst>`_

--- a/doc/src/modules/simplify/fu.rst
+++ b/doc/src/modules/simplify/fu.rst
@@ -244,7 +244,7 @@ References
 .. [1] Fu, Hongguang, Xiuqin Zhong, and Zhenbing Zeng.
     "Automated and readable simplification of trigonometric expressions."
     Mathematical and computer modelling 44.11 (2006): 1169-1177.
-    https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.657.2478&rep=rep1&type=pdf
+    https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=718d67a8d1ce0a23808c1cc265612f81977357e4
 
 .. [2] A formula sheet for trigonometric functions.
     http://www.sosmath.com/trig/Trig5/trig5/pdf/pdf.html


### PR DESCRIPTION
#### References to other Issues or PRs
Fix some broken links in documentation in #24140

#### Brief description of what is fixed or changed
This PR addresses the following broken links in the documentation:
- Fixed links in doc/src/guides/physics/index.rst for Biomechanics, Mechanics, and Control tutorials, pointing them to the correct paths in the tutorials/physics directory.
- Updated a link in doc/src/modules/simplify/fu.rst to ensure the citation URL for CiteseerX functions properly.

#### Other comments

No comments

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
