### PR TITLE
Modified to avoid using `gmpy` when calculating `_partition`

### DIFF
--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -1,7 +1,6 @@
 from mpmath.libmp import (fzero, from_int, from_rational,
     fone, fhalf, bitcount, to_int, mpf_mul, mpf_div, mpf_sub,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, mpf_cos, mpf_sin)
-from sympy.external.gmpy import gcd, legendre, jacobi
 from .residue_ntheory import _sqrt_mod_prime_power, is_quad_residue
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.memoization import recurrence_memo
@@ -65,7 +64,7 @@ def _a(n, k, prec):
             arg = mpf_div(mpf_mul(
                 from_int(4*m), pi, prec), from_int(mod), prec)
             return mpf_mul(mpf_mul(
-                from_int((-1)**e*jacobi(m - 1, m)),
+                from_int((-1)**e*(2 - (m % 4))),
                 mpf_sqrt(from_int(k), prec), prec),
                 mpf_sin(arg, prec), prec)
         if p == 3:
@@ -77,14 +76,15 @@ def _a(n, k, prec):
             arg = mpf_div(mpf_mul(from_int(4*m), pi, prec),
                 from_int(mod), prec)
             return mpf_mul(mpf_mul(
-                from_int(2*(-1)**(e + 1)*legendre(m, 3)),
+                from_int(2*(-1)**(e + 1)*(3 - 2*(m % 3))),
                 mpf_sqrt(from_int(k//3), prec), prec),
                 mpf_sin(arg, prec), prec)
         v = k + v % k
+        jacobi3 = -1 if k % 12 in [5, 7] else 1
         if v % p == 0:
             if e == 1:
                 return mpf_mul(
-                    from_int(jacobi(3, k)),
+                    from_int(jacobi3),
                     mpf_sqrt(from_int(k), prec), prec)
             return fzero
         if not is_quad_residue(v, p):
@@ -96,12 +96,12 @@ def _a(n, k, prec):
             mpf_mul(from_int(4*m), pi, prec),
             from_int(k), prec)
         return mpf_mul(mpf_mul(
-            from_int(2*jacobi(3, k)),
+            from_int(2*jacobi3),
             mpf_sqrt(from_int(k), prec), prec),
             mpf_cos(arg, prec), prec)
 
     if p != 2 or e >= 3:
-        d1, d2 = gcd(k1, 24), gcd(k2, 24)
+        d1, d2 = math.gcd(k1, 24), math.gcd(k2, 24)
         e = 24//(d1*d2)
         n1 = ((d2*e*n + (k2**2 - 1)//d1)*
             pow(e*k2*k2*d2, _totient[k1] - 1, k1)) % k1

--- a/sympy/ntheory/tests/test_partitions.py
+++ b/sympy/ntheory/tests/test_partitions.py
@@ -18,6 +18,7 @@ def test__partition():
     assert _partition(2000) == 4720819175619413888601432406799959512200344166
     assert _partition(10000) % 10**10 == 6916435144
     assert _partition(100000) % 10**10 == 9421098519
+    assert _partition(10000000) % 10**10 == 7677288980
 
 
 def test_deprecated_ntheory_symbolic_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/27208#issuecomment-2448478847

#### Brief description of what is fixed or changed
The immediate issue was that `_partition(10000000)` fails when both `python-flint` and `gmpy2` are available. This occurs due to a cast from `int` to `mpz` when calculating `gcd`. Casting to `int` would minimally resolve this issue. However, there’s also the possibility of using `gmpy2` for `legendre` and `jacobi`. According to the documentation, these are supposed to return `mpz`, but they actually return `int`, so no problem arises.

One approach could be to cast everything returned by `gmpy2` functions to `int`, but since only small numbers are being used, processing with `int` shouldn’t cause any slowdown. Therefore, I decided to rewrite it to avoid using `gmpy2` altogether.

`legendre(m, 3)` is equivalent to `3 - 2*(m % 3)` when noting that `m` is not a multiple of 3. Similarly, `jacobi(m - 1, m)` and `jacobi(3, k)` can be rewritten in the same way.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * The issue where `partition(n)` would fail for large values of n in situations where both `python-flint` and `gmpy2` are available has been resolved.
<!-- END RELEASE NOTES -->
