### PR TITLE
fix(core): cleanups in basic.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             sudo apt update
             sudo apt install imagemagick graphviz librsvg2-bin
             cd doc
-            pip install -r requirements.txt
+            pip install -r requirements.txt typing_extensions
       - run:
           name: Build docs
           no_output_timeout: 25m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: cimg/python:3.13.0
+    - image: cimg/python:3.12
   working_directory: ~/repo
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 # This is separate from the GitHub Actions build that builds the docs, which
 # also builds the docs PDF.
-version: 2
+version: 2.1
 
 # Aliases to reuse
 _defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: cimg/python:3.10.2
+    - image: cimg/python:3.13.0
   working_directory: ~/repo
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
             sudo apt update
             sudo apt install imagemagick graphviz librsvg2-bin
             cd doc
-            pip install -r requirements.txt typing_extensions
+            pip install -r requirements.txt
       - run:
           name: Build docs
           no_output_timeout: 25m

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -704,7 +704,7 @@ class Basic(Printable):
             active_deprecations_target="deprecated-expr-free-symbols")
         return set()
 
-    def as_dummy(self) -> Self:
+    def as_dummy(self) -> "Self":
         """Return the expression with any objects having structurally
         bound symbols replaced with unique, canonical symbols within
         the object in which they appear and having only the default
@@ -729,7 +729,7 @@ class Basic(Printable):
         =====
 
         Any object that has structurally bound variables should have
-        a property, `bound_symbols` that returns those symbols
+        a property, ``bound_symbols`` that returns those symbols
         appearing in the object.
         """
         from .symbol import Dummy, Symbol

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -19,8 +19,6 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable, numbered_symbols
 from sympy.utilities.misc import filldedent, func_name
 
-from inspect import getmro
-
 
 if TYPE_CHECKING:
     from typing import ClassVar
@@ -393,41 +391,6 @@ class Basic(Printable):
                 return c
         return 0
 
-    @staticmethod
-    def _compare_pretty(a, b):
-        """return -1, 0, 1 if a is canonically less, equal or
-        greater than b. This is used when 'order=old' is selected
-        for printing. This puts Order last, orders Rationals
-        according to value, puts terms in order wrt the power of
-        the last power appearing in a term. Ties are broken using
-        Basic.compare.
-        """
-        from sympy.series.order import Order
-        if isinstance(a, Order) and not isinstance(b, Order):
-            return 1
-        if not isinstance(a, Order) and isinstance(b, Order):
-            return -1
-
-        if a.is_Rational and b.is_Rational:
-            l = a.p * b.q
-            r = b.p * a.q
-            return (l > r) - (l < r)
-        else:
-            from .symbol import Wild
-            p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
-            r_a = a.match(p1 * p2**p3)
-            if r_a and p3 in r_a:
-                a3 = r_a[p3]
-                r_b = b.match(p1 * p2**p3)
-                if r_b and p3 in r_b:
-                    b3 = r_b[p3]
-                    c = Basic.compare(a3, b3)
-                    if c != 0:
-                        return c
-
-        # break ties
-        return Basic.compare(a, b)
-
     @classmethod
     def fromiter(cls, args, **assumptions):
         """
@@ -447,7 +410,7 @@ class Basic(Printable):
         return cls(*tuple(args), **assumptions)
 
     @classmethod
-    def class_key(cls):
+    def class_key(cls) -> tuple[int, int, str]:
         """Nice order of classes."""
         return 5, 0, cls.__name__
 
@@ -739,7 +702,9 @@ class Basic(Printable):
             active_deprecations_target="deprecated-expr-free-symbols")
         return set()
 
-    def as_dummy(self):
+    # XXX: The as_dummy() return type should be Self but need Python >= 3.11
+
+    def as_dummy(self) -> Basic:
         """Return the expression with any objects having structurally
         bound symbols replaced with unique, canonical symbols within
         the object in which they appear and having only the default
@@ -799,14 +764,18 @@ class Basic(Printable):
         >>> Lambda(x, 2*x).canonical_variables
         {x: _0}
         """
-        if not hasattr(self, 'bound_symbols'):
+        bound: list[Basic] | None = getattr(self, 'bound_symbols', None)
+        if bound is None:
             return {}
         dums = numbered_symbols('_')
         reps = {}
         # watch out for free symbol that are not in bound symbols;
         # those that are in bound symbols are about to get changed
-        bound = self.bound_symbols
-        names = {i.name for i in self.free_symbols - set(bound)}
+
+        # XXX: free_symbols only returns particular kinds of expressions that
+        # generally have a .name attribute. There is not a proper class/type
+        # that represents this.
+        names = {i.name for i in self.free_symbols - set(bound)} # type: ignore
         for b in bound:
             d = next(dums)
             if b.is_Symbol:
@@ -830,28 +799,13 @@ class Basic(Printable):
         >>> (x + Lambda(y, 2*y)).rcall(z)
         x + 2*z
         """
-        return Basic._recursive_call(self, args)
-
-    @staticmethod
-    def _recursive_call(expr_to_call, on_args):
-        """Helper for rcall method."""
-        from .symbol import Symbol
-        def the_call_method_is_overridden(expr):
-            for cls in getmro(type(expr)):
-                if '__call__' in cls.__dict__:
-                    return cls != Basic
-
-        if callable(expr_to_call) and the_call_method_is_overridden(expr_to_call):
-            if isinstance(expr_to_call, Symbol):  # XXX When you call a Symbol it is
-                return expr_to_call               # transformed into an UndefFunction
-            else:
-                return expr_to_call(*on_args)
-        elif expr_to_call.args:
-            args = [Basic._recursive_call(
-                sub, on_args) for sub in expr_to_call.args]
-            return type(expr_to_call)(*args)
+        if callable(self):
+            return self(*args)
+        elif self.args:
+            newargs = [sub.rcall(*args) for sub in self.args]
+            return self.func(*newargs)
         else:
-            return expr_to_call
+            return self
 
     def is_hypergeometric(self, k):
         from sympy.simplify.simplify import hypersimp
@@ -887,25 +841,11 @@ class Basic(Printable):
         1
 
         """
-        is_extended_real = self.is_extended_real
-        if is_extended_real is False:
-            return False
-        if not self.is_number:
-            return False
-        # don't re-eval numbers that are already evaluated since
-        # this will create spurious precision
-        n, i = [p.evalf(2) if not p.is_Number else p
-            for p in self.as_real_imag()]
-        if not (i.is_Number and n.is_Number):
-            return False
-        if i:
-            # if _prec = 1 we can't decide and if not,
-            # the answer is False because numbers with
-            # imaginary parts can't be compared
-            # so return False
-            return False
-        else:
-            return n._prec != 1
+        return self._eval_is_comparable()
+
+    def _eval_is_comparable(self):
+        # Expr.is_comparable overrides this
+        return False
 
     @property
     def func(self):
@@ -1558,7 +1498,7 @@ class Basic(Printable):
         # no success
         return False
 
-    def replace(self, query, value, map=False, simultaneous=True, exact=None):
+    def replace(self, query, value, map=False, simultaneous=True, exact=None) -> Basic:
         """
         Replace matching subexpressions of ``self`` with ``value``.
 
@@ -1814,7 +1754,7 @@ class Basic(Printable):
             return expr
 
         rv = walk(self, rec_replace)
-        return (rv, mapping) if map else rv
+        return (rv, mapping) if map else rv # type: ignore
 
     def find(self, query, group=False):
         """Find all subexpressions matching a query."""
@@ -1947,7 +1887,7 @@ class Basic(Printable):
         pattern = sympify(pattern)
         return pattern.matches(self, old=old)
 
-    def count_ops(self, visual=None):
+    def count_ops(self, visual=False):
         """Wrapper for count_ops that returns the operation count."""
         from .function import count_ops
         return count_ops(self, visual)
@@ -1999,11 +1939,13 @@ class Basic(Printable):
         if isinstance(n, (int, Integer)):
             obj = self
             for i in range(n):
-                obj2 = obj._eval_derivative(s)
-                if obj == obj2 or obj2 is None:
+                prev = obj
+                obj = obj._eval_derivative(s)
+                if obj is None:
+                    return None
+                elif obj == prev:
                     break
-                obj = obj2
-            return obj2
+            return obj
         else:
             return None
 
@@ -2171,7 +2113,7 @@ class Basic(Printable):
         This version of the method is merely a placeholder.
         """
         old_method = self._sage_
-        from sage.interfaces.sympy import sympy_init
+        from sage.interfaces.sympy import sympy_init # type: ignore
         sympy_init()  # may monkey-patch _sage_ method into self's class or superclasses
         if old_method == self._sage_:
             raise NotImplementedError('conversion to SageMath is not implemented')

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -22,7 +22,9 @@ from sympy.utilities.misc import filldedent, func_name
 
 if TYPE_CHECKING:
     from typing import ClassVar
+    from typing_extensions import Self
     from .assumptions import StdFactKB
+    from .symbol import Symbol
 
 
 def as_Basic(expr):
@@ -702,9 +704,7 @@ class Basic(Printable):
             active_deprecations_target="deprecated-expr-free-symbols")
         return set()
 
-    # XXX: The as_dummy() return type should be Self but need Python >= 3.11
-
-    def as_dummy(self) -> Basic:
+    def as_dummy(self) -> Self:
         """Return the expression with any objects having structurally
         bound symbols replaced with unique, canonical symbols within
         the object in which they appear and having only the default
@@ -748,10 +748,10 @@ class Basic(Printable):
         return self.replace(
             lambda x: hasattr(x, 'bound_symbols'),
             can,
-            simultaneous=False)
+            simultaneous=False) # type:ignore
 
     @property
-    def canonical_variables(self):
+    def canonical_variables(self) -> dict[Basic, Symbol]:
         """Return a dictionary mapping any variable defined in
         ``self.bound_symbols`` to Symbols that do not clash
         with any free symbols in the expression.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -446,6 +446,40 @@ class Expr(Basic, EvalfMixin):
         """
         return all(obj.is_number for obj in self.args)
 
+    def _eval_is_comparable(self):
+        # Basic._eval_is_comparable always returns False, so we override it
+        # here
+        is_extended_real = self.is_extended_real
+        if is_extended_real is False:
+            return False
+        if not self.is_number:
+            return False
+
+        # XXX: as_real_imag() can be a very expensive operation. It should not
+        # be used here because is_comparable is used implicitly in many places.
+        # Probably this method should just return self.evalf(2).is_Number.
+
+        n, i = self.as_real_imag()
+
+        if not n.is_Number:
+            n = n.evalf(2)
+            if not n.is_Number:
+                return False
+
+        if not i.is_Number:
+            i = i.evalf(2)
+            if not i.is_Number:
+                return False
+
+        if i:
+            # if _prec = 1 we can't decide and if not,
+            # the answer is False because numbers with
+            # imaginary parts can't be compared
+            # so return False
+            return False
+        else:
+            return n._prec != 1
+
     def _random(self, n=None, re_min=-1, im_min=-1, re_max=1, im_max=1):
         """Return self evaluated, if possible, replacing free symbols with
         random complex values, if necessary.

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -342,11 +342,46 @@ class Printer:
         order = order or self.order
 
         if order == 'old':
-            return sorted(Add.make_args(expr), key=cmp_to_key(Basic._compare_pretty))
+            return sorted(Add.make_args(expr), key=cmp_to_key(self._compare_pretty))
         elif order == 'none':
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)
+
+    def _compare_pretty(self, a, b):
+        """return -1, 0, 1 if a is canonically less, equal or
+        greater than b. This is used when 'order=old' is selected
+        for printing. This puts Order last, orders Rationals
+        according to value, puts terms in order wrt the power of
+        the last power appearing in a term. Ties are broken using
+        Basic.compare.
+        """
+        from sympy.core.numbers import Rational
+        from sympy.core.symbol import Wild
+        from sympy.series.order import Order
+        if isinstance(a, Order) and not isinstance(b, Order):
+            return 1
+        if not isinstance(a, Order) and isinstance(b, Order):
+            return -1
+
+        if isinstance(a, Rational) and isinstance(b, Rational):
+            l = a.p * b.q
+            r = b.p * a.q
+            return (l > r) - (l < r)
+        else:
+            p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
+            r_a = a.match(p1 * p2**p3)
+            if r_a and p3 in r_a:
+                a3 = r_a[p3]
+                r_b = b.match(p1 * p2**p3)
+                if r_b and p3 in r_b:
+                    b3 = r_b[p3]
+                    c = Basic.compare(a3, b3)
+                    if c != 0:
+                        return c
+
+        # break ties
+        return Basic.compare(a, b)
 
 
 class _PrintFunction:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

A few cleanups in basic.py after inspecting results from `pyright sympy/core/basic.py`.

- `Basic._compare_pretty` is not really needed any more. It is only used in the printing system for `order=old` so it is moved there as there is no point in it being a static method in Basic.
- The implementation of `Basic.is_comparable` uses `Expr` methods that are not found on `Basic` so move the main implementation to `Expr`.
- `Basic.rcall` can be simplified as most of its code is outdated now since symbols are not callable any more.
- The default value of `None` for `count_ops` does not make sense as it is a boolean parameter so change the default to `False`.
- Ensure that `_eval_derivative_n_times` always returns a value even if `n=0`.
- Add a few type hints for return values of Basic methods like replace.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
