### PR TITLE
typing(polys): Add a few type hints in polys

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -530,3 +530,21 @@ def linkcode_resolve(domain, info):
 
     fn = os.path.relpath(fn, start=os.path.dirname(sympy.__file__))
     return blobpath + fn + linespec
+
+
+def resolve_type_aliases(app, env, node, contnode):
+    """Resolve :class: references to our type aliases as :attr: instead."""
+    # A sphinx bug means that TypeVar doesn't work:
+    # https://github.com/sphinx-doc/sphinx/issues/10785
+    if (
+        node["refdomain"] == "py"
+        and node["reftype"] == "class"
+        and node["reftarget"] in ["sympy.utilities.decorator.T"]
+    ):
+        return app.env.get_domain("py").resolve_xref(
+            env, node["refdoc"], app.builder, "attr", node["reftarget"], node, contnode
+        )
+
+
+def setup(app):
+    app.connect("missing-reference", resolve_type_aliases)

--- a/sympy/polys/compatibility.py
+++ b/sympy/polys/compatibility.py
@@ -1,5 +1,14 @@
 """Compatibility interface between dense and sparse polys. """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.polys.domains.domain import Domain
+    from sympy.polys.orderings import MonomialOrder
+    from sympy.polys.rings import PolyElement
 
 from sympy.polys.densearith import dup_add_term
 from sympy.polys.densearith import dmp_add_term
@@ -230,11 +239,12 @@ from sympy.utilities import public
 
 @public
 class IPolys:
-    symbols = None
-    ngens = None
-    domain = None
-    order = None
-    gens = None
+
+    gens: tuple[PolyElement, ...]
+    symbols: tuple[Expr, ...]
+    ngens: int
+    domain: Domain
+    order: MonomialOrder
 
     def drop(self, gen):
         pass

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -13,15 +13,16 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import CantSympify, sympify
 from sympy.functions.elementary.exponential import ExpBase
+from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.fractionfield import FractionField
 from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.constructor import construct_domain
-from sympy.polys.orderings import lex
+from sympy.polys.orderings import lex, MonomialOrder
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.polyoptions import build_options
 from sympy.polys.polyutils import _parallel_dict_from_expr
-from sympy.polys.rings import PolyElement
+from sympy.polys.rings import PolyRing, PolyElement
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
 from sympy.utilities.iterables import is_sequence
@@ -104,8 +105,14 @@ _field_cache: dict[Any, Any] = {}
 class FracField(DefaultPrinting):
     """Multivariate distributed rational function field. """
 
+    ring: PolyRing
+    gens: tuple[FracElement, ...]
+    symbols: tuple[Expr, ...]
+    ngens: int
+    domain: Domain
+    order: MonomialOrder
+
     def __new__(cls, symbols, domain, order=lex):
-        from sympy.polys.rings import PolyRing
         ring = PolyRing(symbols, domain, order)
         symbols = ring.symbols
         ngens = ring.ngens
@@ -280,7 +287,6 @@ class FracField(DefaultPrinting):
         return FractionField(self)
 
     def to_ring(self):
-        from sympy.polys.rings import PolyRing
         return PolyRing(self.symbols, self.domain, self.order)
 
 class FracElement(DomainElement, DefaultPrinting, CantSympify):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -140,6 +140,9 @@ class DMP(CantSympify):
 
     __slots__ = ()
 
+    lev: int
+    dom: Domain
+
     def __new__(cls, rep, dom, lev=None):
 
         if lev is None:

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 __all__ = ["Options"]
 
-from sympy.core import Basic, sympify
+from sympy.core.basic import Basic
+from sympy.core.expr import Expr
+from sympy.core.sympify import sympify
 from sympy.polys.polyerrors import GeneratorsError, OptionError, FlagError
 from sympy.utilities import numbered_symbols, topological_sort, public
 from sympy.utilities.iterables import has_dups, is_sequence
@@ -122,6 +124,9 @@ class Options(dict):
 
     __order__ = None
     __options__: dict[str, type[Option]] = {}
+
+    gens: tuple[Expr, ...]
+    domain: sympy.polys.domains.Domain
 
     def __init__(self, gens, args, flags=None, strict=False):
         dict.__init__(self)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1,5 +1,6 @@
 """User-friendly public interface to polynomial functions. """
 
+from __future__ import annotations
 
 from functools import wraps, reduce
 from operator import mul
@@ -164,7 +165,7 @@ class Poly(Basic):
     is_Poly = True
     _op_priority = 10.001
 
-    def __new__(cls, rep, *gens, **args):
+    def __new__(cls, rep, *gens, **args) -> Poly:
         """Create a new polynomial instance out of something useful. """
         opt = options.build_options(gens, args)
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -15,11 +15,12 @@ from sympy.ntheory.multinomial import multinomial_coefficients
 from sympy.polys.compatibility import IPolys
 from sympy.polys.constructor import construct_domain
 from sympy.polys.densebasic import ninf, dmp_to_dict, dmp_from_dict
+from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.heuristicgcd import heugcd
 from sympy.polys.monomials import MonomialOps
-from sympy.polys.orderings import lex
+from sympy.polys.orderings import lex, MonomialOrder
 from sympy.polys.polyerrors import (
     CoercionFailed, GeneratorsError,
     ExactQuotientFailed, MultivariatePolynomialError)
@@ -33,7 +34,7 @@ from sympy.utilities.iterables import is_sequence
 from sympy.utilities.magic import pollute
 
 @public
-def ring(symbols, domain, order=lex):
+def ring(symbols, domain, order: MonomialOrder|str = lex):
     """Construct a polynomial ring returning ``(ring, x_1, ..., x_n)``.
 
     Parameters
@@ -195,6 +196,12 @@ _ring_cache: dict[Any, Any] = {}
 
 class PolyRing(DefaultPrinting, IPolys):
     """Multivariate distributed polynomial ring. """
+
+    gens: tuple[PolyElement, ...]
+    symbols: tuple[Expr, ...]
+    ngens: int
+    domain: Domain
+    order: MonomialOrder
 
     def __new__(cls, symbols, domain, order=lex):
         symbols = tuple(_parse_symbols(symbols))

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1,6 +1,7 @@
 """Implementation of RootOf class and related tools. """
 
 
+
 from sympy.core.basic import Basic
 from sympy.core import (S, Expr, Integer, Float, I, oo, Add, Lambda,
     symbols, sympify, Rational, Dummy)

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -336,7 +336,7 @@ def sylvester(f, g, x, method = 1):
         return M
 
     # Sylvester's matrix of 1853 (a.k.a sylvester2)
-    if method >= 2:
+    else:
         if len(fp) < len(gp):
             h = []
             for i in range(len(gp) - len(fp)):

--- a/sympy/polys/tests/test_subresultants_qq_zz.py
+++ b/sympy/polys/tests/test_subresultants_qq_zz.py
@@ -1,4 +1,4 @@
-from sympy.core.symbol import var
+from sympy.core.symbol import Symbol
 from sympy.polys.polytools import (pquo, prem, sturm, subresultants)
 from sympy.matrices import Matrix
 from sympy.polys.subresultants_qq_zz import (sylvester, res, res_q, res_z, bezout,
@@ -13,7 +13,7 @@ from sympy.polys.subresultants_qq_zz import (sylvester, res, res_q, res_z, bezou
 
 
 def test_sylvester():
-    x = var('x')
+    x = Symbol('x')
 
     assert sylvester(x**3 -7, 0, x) == sylvester(x**3 -7, 0, x, 1) == Matrix([[0]])
     assert sylvester(0, x**3 -7, x) == sylvester(0, x**3 -7, x, 1) == Matrix([[0]])
@@ -37,7 +37,7 @@ def test_sylvester():
 [1, 0, -7,  7,  0,  0], [0, 3,  0, -7,  0,  0], [0, 1,  0, -7,  7,  0], [0, 0,  3,  0, -7,  0], [0, 0,  1,  0, -7,  7], [0, 0,  0,  3,  0, -7]])
 
 def test_subresultants_sylv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -52,7 +52,7 @@ def test_subresultants_sylv():
     assert subresultants_sylv(p, q, x) == euclid_amv(p, q, x)
 
 def test_modified_subresultants_sylv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -67,23 +67,23 @@ def test_modified_subresultants_sylv():
     assert modified_subresultants_sylv(-p, q, x) != sturm_amv(-p, q, x)
 
 def test_res():
-    x = var('x')
+    x = Symbol('x')
 
     assert res(3, 5, x) == 1
 
 def test_res_q():
-    x = var('x')
+    x = Symbol('x')
 
     assert res_q(3, 5, x) == 1
 
 def test_res_z():
-    x = var('x')
+    x = Symbol('x')
 
     assert res_z(3, 5, x) == 1
     assert res(3, 5, x) == res_q(3, 5, x) == res_z(3, 5, x)
 
 def test_bezout():
-    x = var('x')
+    x = Symbol('x')
 
     p = -2*x**5+7*x**3+9*x**2-3*x+1
     q = -10*x**4+21*x**2+18*x-3
@@ -92,7 +92,7 @@ def test_bezout():
     assert bezout(p, q, x, 'prs') == backward_eye(5) * bezout(p, q, x, 'bz') * backward_eye(5)
 
 def test_subresultants_bezout():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -107,7 +107,7 @@ def test_subresultants_bezout():
     assert subresultants_bezout(p, q, x) == euclid_amv(p, q, x)
 
 def test_modified_subresultants_bezout():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -122,7 +122,7 @@ def test_modified_subresultants_bezout():
     assert modified_subresultants_bezout(-p, q, x) != sturm_amv(-p, q, x)
 
 def test_sturm_pg():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -138,7 +138,7 @@ def test_sturm_pg():
     assert sturm_pg(-p, q, x) == modified_subresultants_pg(-p, q, x)
 
 def test_sturm_q():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
@@ -147,7 +147,7 @@ def test_sturm_q():
 
 
 def test_sturm_amv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -164,7 +164,7 @@ def test_sturm_amv():
 
 
 def test_euclid_pg():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**6+x**5-x**4-x**3+x**2-x+1
     q = 6*x**5+5*x**4-4*x**3-3*x**2+2*x-1
@@ -179,7 +179,7 @@ def test_euclid_pg():
 
 
 def test_euclid_q():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
@@ -187,7 +187,7 @@ def test_euclid_q():
 
 
 def test_euclid_amv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
@@ -202,7 +202,7 @@ def test_euclid_amv():
 
 
 def test_modified_subresultants_pg():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -218,7 +218,7 @@ def test_modified_subresultants_pg():
 
 
 def test_subresultants_pg():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -234,7 +234,7 @@ def test_subresultants_pg():
 
 
 def test_subresultants_amv_q():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -250,25 +250,25 @@ def test_subresultants_amv_q():
 
 
 def test_rem_z():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
     assert rem_z(p, -q, x) != prem(p, -q, x)
 
 def test_quo_z():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
     assert quo_z(p, -q, x) != pquo(p, -q, x)
 
-    y = var('y')
+    y = Symbol('y')
     q = 3*x**6 + 5*y**4 - 4*x**2 - 9*x + 21
     assert quo_z(p, -q, x) == pquo(p, -q, x)
 
 def test_subresultants_amv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -284,7 +284,7 @@ def test_subresultants_amv():
 
 
 def test_modified_subresultants_amv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -300,7 +300,7 @@ def test_modified_subresultants_amv():
 
 
 def test_subresultants_rem():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -316,7 +316,7 @@ def test_subresultants_rem():
 
 
 def test_subresultants_vv():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -332,7 +332,7 @@ def test_subresultants_vv():
 
 
 def test_subresultants_vv_2():
-    x = var('x')
+    x = Symbol('x')
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -9,7 +9,8 @@ from functools import wraps, update_wrapper
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
 
-_T = TypeVar('_T')
+T = TypeVar('T')
+"""A generic type"""
 
 
 def threaded_factory(func, use_add):
@@ -180,7 +181,7 @@ def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
     return depends_on_deco
 
 
-def public(obj: _T) -> _T:
+def public(obj: T) -> T:
     """
     Append ``obj``'s name to global ``__all__`` variable (call site).
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -1,11 +1,16 @@
 """Useful utility decorators. """
 
+from typing import TypeVar
 import sys
 import types
 import inspect
 from functools import wraps, update_wrapper
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
+
+
+_T = TypeVar('_T')
+
 
 def threaded_factory(func, use_add):
     """A factory for ``threaded`` decorators. """
@@ -175,7 +180,7 @@ def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
     return depends_on_deco
 
 
-def public(obj):
+def public(obj: _T) -> _T:
     """
     Append ``obj``'s name to global ``__all__`` variable (call site).
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

A few type hints are add in polys reducing the number of errors reported by pyright from about 10000 to about 2000. The biggest problem apparently was that pyright didn't understand the `@public` decorator.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
