### PR TITLE
Clear garbage collected lambdified functions from the linecache

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,6 +1,7 @@
 from itertools import product
 import math
 import inspect
+import linecache
 
 import mpmath
 
@@ -980,6 +981,15 @@ def test_lambdify_docstring():
     ).splitlines()
     assert func.__doc__.splitlines()[:len(ref)] == ref
 
+
+def test_lambdify_linecache():
+    func = lambdify(x, x + 1)
+    assert inspect.getsource(func) == 'def _lambdifygenerated(x):\n    return x + 1\n'
+    filename = inspect.getsourcefile(func)
+    assert filename.startswith('<lambdifygenerated-')
+    assert filename in linecache.cache
+    del func
+    assert filename not in linecache.cache
 
 #================== Test special printers ==========================
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -984,10 +984,12 @@ def test_lambdify_docstring():
 
 def test_lambdify_linecache():
     func = lambdify(x, x + 1)
-    assert inspect.getsource(func) == 'def _lambdifygenerated(x):\n    return x + 1\n'
+    source = 'def _lambdifygenerated(x):\n    return x + 1\n'
+    assert inspect.getsource(func) == source
     filename = inspect.getsourcefile(func)
     assert filename.startswith('<lambdifygenerated-')
     assert filename in linecache.cache
+    assert linecache.cache[filename] == (len(source), None, source.splitlines(True), filename)
     del func
     assert filename not in linecache.cache
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2,6 +2,7 @@ from itertools import product
 import math
 import inspect
 import linecache
+import gc
 
 import mpmath
 
@@ -991,6 +992,7 @@ def test_lambdify_linecache():
     assert filename in linecache.cache
     assert linecache.cache[filename] == (len(source), None, source.splitlines(True), filename)
     del func
+    gc.collect()
     assert filename not in linecache.cache
 
 #================== Test special printers ==========================


### PR DESCRIPTION
This fixes an otherwise memory leak that was caused from lambdifying many functions.

Fixes #27216

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
  - Fix a memory leak from lambdifying too many functions. 
<!-- END RELEASE NOTES -->
