### PR TITLE
Ensure wigner_3j compatibility with numpy floats

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1272,6 +1272,7 @@ Roman Inflianskas <infroma@gmail.com>
 Ronan Lamy <ronan.lamy@gmail.com> <Ronan.Lamy@normalesup.org>
 Rudr Tiwari <rudrtiwari@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com> RushabhMehta2005 <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>

--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -61,6 +61,9 @@ def test_clebsch_gordan_numpy():
     except ImportError:
         skip("numpy not installed")
     assert clebsch_gordan(*np.zeros(6).astype(np.int64)) == 1
+    assert wigner_3j(2, np.float64(6.0), 4.0, 0, 0, 0) == sqrt(715)/143
+    assert wigner_3j(0, 0.5, 0.5, 0, 0.5, -0.5) == sqrt(2)/2
+    raises(ValueError, lambda: wigner_3j(2.1, 6, 4, 0, 0, 0))
 
 
 def test_wigner():

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -216,14 +216,9 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     - Jens Rasch (2009-03-24): initial version
     """
 
-    j_1 = sympify(j_1)
-    j_2 = sympify(j_2)
-    j_3 = sympify(j_3)
-    m_1 = sympify(m_1)
-    m_2 = sympify(m_2)
-    m_3 = sympify(m_3)
-
-    j_1, j_2, j_3, m_1, m_2, m_3 = map(_int_or_halfint, [j_1, j_2, j_3, m_1, m_2, m_3])
+    j_1, j_2, j_3, m_1, m_2, m_3 = \
+        map(_int_or_halfint, map(sympify,
+            [j_1, j_2, j_3, m_1, m_2, m_3]))
 
     if m_1 + m_2 + m_3 != 0:
         return S.Zero

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -216,8 +216,12 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
     - Jens Rasch (2009-03-24): initial version
     """
 
-    j_1, j_2, j_3, m_1, m_2, m_3 = map(_int_or_halfint,
-                                       [j_1, j_2, j_3, m_1, m_2, m_3])
+    j_1 = sympify(j_1)
+    j_2 = sympify(j_2)
+    j_3 = sympify(j_3)
+    m_1 = sympify(m_1)
+    m_2 = sympify(m_2)
+    m_3 = sympify(m_3)
 
     if m_1 + m_2 + m_3 != 0:
         return S.Zero

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -215,13 +215,15 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-
+    
     j_1 = sympify(j_1)
     j_2 = sympify(j_2)
     j_3 = sympify(j_3)
     m_1 = sympify(m_1)
     m_2 = sympify(m_2)
     m_3 = sympify(m_3)
+
+    j_1, j_2, j_3, m_1, m_2, m_3 = map(_int_or_halfint, [j_1, j_2, j_3, m_1, m_2, m_3])
 
     if m_1 + m_2 + m_3 != 0:
         return S.Zero

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -215,7 +215,7 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-    
+
     j_1 = sympify(j_1)
     j_2 = sympify(j_2)
     j_3 = sympify(j_3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27219 

#### Brief description of what is fixed or changed
Modified the wigner_3j function to ensure compatibility with numpy floats by adding calls to sympify for the input params. This solves the issue where it previously raised a ValueError when encountered with a numpy float.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
  * Numpy floats can be used with wigner_3j

<!-- END RELEASE NOTES -->
