### PR TITLE
Clear the linecache entry instead of deleting it

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -912,7 +912,7 @@ or tuple for the function arguments.
     def cleanup_linecache(filename):
         def _cleanup():
             if filename in linecache.cache:
-                del linecache.cache[filename]
+                linecache.cache[filename] = (0, None, [], filename)
         return _cleanup
 
     func = funclocals[funcname]

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -993,7 +993,7 @@ def test_lambdify_linecache():
     assert linecache.cache[filename] == (len(source), None, source.splitlines(True), filename)
     del func
     gc.collect()
-    assert filename not in linecache.cache
+    assert linecache.cache[filename] == (0, None, [], filename)
 
 #================== Test special printers ==========================
 


### PR DESCRIPTION
This should avoid race conditions (esp. on PyPy) that lead to KeyErrors from looking up a name in the linecache.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
