### PR TITLE
Fix perfect_power function to handle negative integers with odd exponents

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -197,6 +197,7 @@ Aaron Meurer <asmeurer@gmail.com>
 Aaron Miller <acmiller273@gmail.com>
 Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
 Aaryan Dewan <aaryandewan@yahoo.com> Aaryan Dewan <49852384+aaryandewan@users.noreply.github.com>
+Aasim Ali <aasim250205@gmail.com> Aasim Ali <94692076+aasim-maverick@users.noreply.github.com>
 Aasim Ali <aasim250205@gmail.com> aasim-maverick <aasim250205@gmail.com>
 Abbas <iamabbas7@gmail.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
 Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com> Abbas <42001049+iam-abbas@users.noreply.github.com>

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -541,15 +541,9 @@ def perfect_power(n, candidates=None, big=True, factor=True):
             qq = perfect_power(q, candidates, big, factor)
             return (S.One / qq[0], qq[1]) if qq is not None else False
 
-        pq = [perfect_power(i) for i in (p, q)]
-        if not all(pq):
-            return False
-
-        num_result, den_result = pq
-
-        if num_result and den_result:
-            num_base, num_exp = num_result
-            den_base, den_exp = den_result
+        if not all(nd := (perfect_power(i, factor=factor) for i in (p, q))):
+                return False
+        (num_base, num_exp), (den_base, den_exp) = nd
 
         def compute_tuple(exponent):
             """Helper to compute final result given an exponent"""

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -541,7 +541,6 @@ def perfect_power(n, candidates=None, big=True, factor=True):
             qq = perfect_power(q, candidates, big, factor)
             return (S.One / qq[0], qq[1]) if qq is not None else False
 
-```suggestion
         if not (pp:=perfect_power(p, factor=factor)):
                 return False
         if not (qq:=perfect_power(q, factor=factor)):

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -541,9 +541,12 @@ def perfect_power(n, candidates=None, big=True, factor=True):
             qq = perfect_power(q, candidates, big, factor)
             return (S.One / qq[0], qq[1]) if qq is not None else False
 
-        if not all(nd := (perfect_power(i, factor=factor) for i in (p, q))):
+```suggestion
+        if not (pp:=perfect_power(p, factor=factor)):
                 return False
-        (num_base, num_exp), (den_base, den_exp) = nd
+        if not (qq:=perfect_power(q, factor=factor)):
+                return False
+        (num_base, num_exp), (den_base, den_exp) = pp, qq
 
         def compute_tuple(exponent):
             """Helper to compute final result given an exponent"""

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -167,6 +167,38 @@ def test_perfect_power():
     # negatives and non-integer rationals
     assert perfect_power(-4) is False
     assert perfect_power(-8) == (-2, 3)
+    assert perfect_power(-5**15) == (-5, 15)
+    assert perfect_power(-5**15, big=False) == (-3125, 3)
+    assert perfect_power(-5**15, [15]) == (-5, 15)
+
+    n = -3 ** 60
+    assert perfect_power(n) == (-81, 15)
+    assert perfect_power(n, big=False) == (-3486784401, 3)
+    assert perfect_power(n, [3, 5], big=True) == (-531441, 5)
+    assert perfect_power(n, [3, 5], big=False) == (-3486784401, 3)
+    assert perfect_power(n, [2]) == False
+    assert perfect_power(n, [2, 15]) == (-81, 15)
+    assert perfect_power(n, [2, 13]) == False
+    assert perfect_power(n, [17]) == False
+    assert perfect_power(n, [3]) == (-3486784401, 3)
+    assert perfect_power(n + 1) == False
+
+    r = S(2) ** (2 * 5 * 7) / S(3) ** (2 * 7)
+    assert perfect_power(r) == (S(32) / 3, 14)
+    assert perfect_power(-r) == (-S(1024) / 9, 7)
+    assert perfect_power(r, big=False) == (S(34359738368) / 2187, 2)
+    assert perfect_power(r, [2, 5]) == (S(34359738368) / 2187, 2)
+    assert perfect_power(r, [5, 7]) == (S(1024) / 9, 7)
+    assert perfect_power(r, [5, 7], big=False) == (S(1024) / 9, 7)
+    assert perfect_power(r, [2, 5, 7], big=False) == (S(34359738368) / 2187, 2)
+    assert perfect_power(-r, [5, 7], big=False) == (-S(1024) / 9, 7)
+
+    assert perfect_power(-S(1) / 8) == (-S(1) / 2, 3)
+
+    assert perfect_power((-3)**60) == (3, 60)
+    assert perfect_power((-3)**61) == (-3, 61)
+
+    assert perfect_power(S(2 ** 9) / 3 ** 12) == (S(8)/81, 3)
     assert perfect_power(Rational(1, 2)**3) == (S.Half, 3)
     assert perfect_power(Rational(-3, 2)**3) == (-3*S.Half, 3)
 

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -167,6 +167,7 @@ def test_perfect_power():
     # negatives and non-integer rationals
     assert perfect_power(-4) is False
     assert perfect_power(-8) == (-2, 3)
+    assert perfect_power(-S(1)/8) == (-S(1)/2, 3)
     assert perfect_power(-5**15) == (-5, 15)
     assert perfect_power(-5**15, big=False) == (-3125, 3)
     assert perfect_power(-5**15, [15]) == (-5, 15)


### PR DESCRIPTION
This PR fixes a bug in `perfect_power` which was handling negative integers with odd powers incorrectly. 

What it did was:

- It would first find perfect power of the positive number(converting the negative int to positive)
- Then ONLY return a result if the exponent was odd
- But this missed cases where the exponent was even but could be rewritten with an odd exponent (see [comment](https://github.com/sympy/sympy/issues/27238#issue-2645983668))

Another bug caught was(see https://github.com/sympy/sympy/issues/27238#issuecomment-2466462427):

```python 
>>> perfect_power(S(2**9)/3**12)
(2, 9)
``` 

Where the expected output is `(8/81, 3)`.
The issue was that when checking the denominator, it was only looking for perfect powers with the same exponent as the numerator which is too restrictive and ultimately led to incorrect results.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27238 

#### Brief description of what is fixed or changed
The function now first checks if the input is negative. For such inputs, it finds the smallest odd factor of the exponent (if one exists), calculates the corresponding base, and makes the base negative. This allows for correct handling of cases like `perfect_power(-64)` returning now `(-4, 3)` which is the expected behavior instead of returning `False`.
And for the rational part, the approach has been made much lesser restrictive using a `gcd` approach.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * `perfect_power` returns an odd exponent, if possible, for negative n and respects key words when dealing with non-Integers
<!-- END RELEASE NOTES -->
