### PR TITLE
Optimize `quadratic_congruence`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1023,6 +1023,7 @@ Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.nor
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>
+Mivik <mivikq@gmail.com>
 Mohak Malviya <mohakmalviya2000@gmail.com> Senku <mohakmalviya2000@gmail.com>
 Mohamed Rezk <mohrizq895@gmail.com>
 Mohammad Sadeq Dousti <msdousti@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1023,7 +1023,8 @@ Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.nor
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>
-Mivik <mivikq@gmail.com>
+Mivik <mivikq@gmail.com> Mivik <54128043+Mivik@users.noreply.github.com>
+Mivik <mivikq@gmail.com> Mivik <mivikq@gmail.com>
 Mohak Malviya <mohakmalviya2000@gmail.com> Senku <mohakmalviya2000@gmail.com>
 Mohamed Rezk <mohrizq895@gmail.com>
 Mohammad Sadeq Dousti <msdousti@gmail.com>

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1711,7 +1711,6 @@ def quadratic_congruence(a, b, c, n):
     polynomial_congruence : Solve the polynomial congruence
 
     """
-    from sympy.polys.polytools import gcdex
     a = as_int(a)
     b = as_int(b)
     c = as_int(c)
@@ -1742,16 +1741,10 @@ def quadratic_congruence(a, b, c, n):
         return sorted((i - b) % n for i in sqrt_mod_iter(b**2 - c, n))
     res = set()
     for i in sqrt_mod_iter(b**2 - 4*a*c, 4*a*n):
-        # Compute linear congruence for (2*a)x = i-b (mod 4*a*n)
-        la = 2*a
-        lb = i - b
-        lm = 4*a*n
-        r, _, g = gcdex(la, lm)
-        if lb % g != 0:
-            continue
+        q, rem = divmod(i - b, 2*a)
+        if rem == 0:
+            res.add(q % n)
 
-        delta = lm // g
-        res.update((r * lb // g + t * delta) % n for t in range(n // gcd(n, delta)))
     return sorted(res)
 
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1711,6 +1711,7 @@ def quadratic_congruence(a, b, c, n):
     polynomial_congruence : Solve the polynomial congruence
 
     """
+    from sympy.polys.polytools import gcdex
     a = as_int(a)
     b = as_int(b)
     c = as_int(c)
@@ -1741,7 +1742,16 @@ def quadratic_congruence(a, b, c, n):
         return sorted((i - b) % n for i in sqrt_mod_iter(b**2 - c, n))
     res = set()
     for i in sqrt_mod_iter(b**2 - 4*a*c, 4*a*n):
-        res.update(j % n for j in linear_congruence(2*a, i - b, 4*a*n))
+        # Compute linear congruence for (2*a)x = i-b (mod 4*a*n)
+        la = 2*a
+        lb = i - b
+        lm = 4*a*n
+        r, _, g = gcdex(la, lm)
+        if lb % g != 0:
+            continue
+
+        delta = lm // g
+        res.update((r * lb // g + t * delta) % n for t in range(n // gcd(n, delta)))
     return sorted(res)
 
 

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -287,6 +287,7 @@ def test_residue():
     assert quadratic_congruence(5, 10, 14, 2) == [0]
     assert quadratic_congruence(10, 17, 19, 2) == [1]
     assert quadratic_congruence(10, 14, 20, 2) == [0, 1]
+    assert quadratic_congruence(2**48-7, 2**48-1, 4, 2**48) == [8249717183797, 31960993774868]
     assert polynomial_congruence(6*x**5 + 10*x**4 + 5*x**3 + x**2 + x + 1,
         972000) == [220999, 242999, 463999, 485999, 706999, 728999, 949999, 971999]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

Optimizes quadratic_congruence by skipping congruences we don't need to check.

The old implementation computes all linear congruences, however some of them are not needed since we seek for their remainders modulo $m$.

An example is `quadratic_congruence(2**48-7, 2**48-1, 4, 2**48)`. In old implementation this ends up calling `linear_congruence(562949953421298, 163100502932882137399054259994, 316912650057049469074827902976)`, where the number of results can be up to `562949953421298`. However only the first one is needed.

#### Other comments

The forementioned test is also added.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* functions
  * Optimize `quadratic_congruence`

<!-- END RELEASE NOTES -->
