### PR TITLE
DOC: show GenericDataSeries

### DIFF
--- a/doc/src/modules/plotting.rst
+++ b/doc/src/modules/plotting.rst
@@ -82,6 +82,9 @@ Series Classes
 .. autoclass:: sympy.plotting.series::ParametricSurfaceSeries
    :members:
 
+.. autoclass:: sympy.plotting.series::GenericDataSeries
+   :members:
+
 .. autoclass:: sympy.plotting.series::ImplicitSeries
    :members:
 

--- a/sympy/plotting/series.py
+++ b/sympy/plotting/series.py
@@ -2159,7 +2159,7 @@ class GenericDataSeries(BaseSeries):
        :include-source: True
 
        p = plot(cos(x), backend="matplotlib")
-       fig, ax = p._backend.fig, p._backend.ax[0]
+       fig, ax = p._backend.fig, p._backend.ax
        ax.plot([0, 1, 2], [0, 1, -1], "*")
        fig
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #27240.

#### Brief description of what is fixed or changed

This shows the documentation of the `GenericDataSeries` in the docs. The docstrings themselves were already there, they remain unchanged.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
