### PR TITLE
printing.c: log10 is C89

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -872,6 +872,7 @@ Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>
 Konstantin Togoi <konstantin.togoi@gmail.com> <togoi.konstantin@outlook.com>
 Konstantinos Riganas <kostasriganas24@gmail.com> kostas-rigan <t8200145@aueb.gr>
+Kris Katterjohn <katterjohn@gmail.com>
 Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
 Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -47,6 +47,7 @@ known_functions_C89 = {
     "atan2": "atan2",
     "exp": "exp",
     "log": "log",
+    "log10": "log10",
     "sinh": "sinh",
     "cosh": "cosh",
     "tanh": "tanh",
@@ -58,7 +59,6 @@ known_functions_C89 = {
 known_functions_C99 = dict(known_functions_C89, **{
     'exp2': 'exp2',
     'expm1': 'expm1',
-    'log10': 'log10',
     'log2': 'log2',
     'log1p': 'log1p',
     'Cbrt': 'cbrt',

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -625,6 +625,7 @@ def test_C89CodePrinter():
     assert c89printer.standard == 'C89'
     assert 'void' in c89printer.reserved_words
     assert 'template' not in c89printer.reserved_words
+    assert c89printer.doprint(log10(x)) == 'log10(x)'
 
 
 def test_C99CodePrinter():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The C function `log10` is in C89, but in `printing.c` it has been treated as being introduced in C99 instead.  By default this causes an error when attempting to do the printing of `log10` with the standard set to C89.

This adds `log10` to the list of known C89 functions.

#### Other comments

References:
* https://en.cppreference.com/w/c/numeric/math/log10
* K&R

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Added log10 to the list of C89 functions

<!-- END RELEASE NOTES -->
