### PR TITLE
types(core): add type hints in core for better inference

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -6,9 +6,12 @@ Core
 
 sympify
 -------
+
 .. module:: sympy.core.sympify
 
 .. autofunction:: sympify
+
+.. py:class:: Tbasic
 
 assumptions
 -----------

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -184,7 +184,7 @@ class AccumulationBounds(Expr):
     is_extended_real = True
     is_number = False
 
-    def __new__(cls, min, max):
+    def __new__(cls, min, max) -> Expr: # type: ignore
 
         min = _sympify(min)
         max = _sympify(max)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,4 +1,6 @@
-from typing import Tuple as tTuple
+from __future__ import annotations
+
+from typing import Tuple as tTuple, TYPE_CHECKING
 from collections import defaultdict
 from functools import reduce
 from operator import attrgetter
@@ -12,6 +14,12 @@ from .intfunc import ilcm, igcd
 from .expr import Expr
 from .kind import UndefinedKind
 from sympy.utilities.iterables import is_sequence, sift
+
+
+if TYPE_CHECKING:
+    from sympy.core.numbers import Number
+    from sympy.series.order import Order
+
 
 def _could_extract_minus_sign(expr):
     # assume expr is Add-like
@@ -171,14 +179,14 @@ class Add(Expr, AssocOp):
 
     __slots__ = ()
 
-    args: tTuple[Expr, ...]
+    args: tTuple[Expr, ...] # type: ignore
 
     is_Add = True
 
     _args_type = Expr
 
     @classmethod
-    def flatten(cls, seq):
+    def flatten(cls, seq: list[Expr]) -> tuple[list[Expr], list[Expr], None]:
         """
         Takes the sequence "seq" of nested Adds and returns a flatten list.
 
@@ -197,7 +205,7 @@ class Add(Expr, AssocOp):
         """
         from sympy.calculus.accumulationbounds import AccumBounds
         from sympy.matrices.expressions import MatrixExpr
-        from sympy.tensor.tensor import TensExpr
+        from sympy.tensor.tensor import TensExpr, TensAdd
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -211,29 +219,28 @@ class Add(Expr, AssocOp):
                     return rv
                 return [], rv[0], None
 
-        terms = {}      # term -> coeff
-                        # e.g. x**2 -> 5   for ... + 5*x**2 + ...
+        # term -> coeff
+        # e.g. x**2 -> 5   for ... + 5*x**2 + ...
+        terms: dict[Expr, Number] = {}
 
-        coeff = S.Zero  # coefficient (Number or zoo) to always be in slot 0
-                        # e.g. 3 + ...
-        order_factors = []
+        # coefficient (Number or zoo) to always be in slot 0
+        # e.g. 3 + ...
+        coeff: Expr = S.Zero
 
-        extra = []
+        order_factors: list[Order] = []
+
+        extra: list[MatrixExpr] = []
 
         for o in seq:
 
             # O(x)
             if o.is_Order:
-                if o.expr.is_zero:
+                if o.expr.is_zero: # type: ignore
                     continue
-                for o1 in order_factors:
-                    if o1.contains(o):
-                        o = None
-                        break
-                if o is None:
+                if any(o1.contains(o) for o1 in order_factors):
                     continue
-                order_factors = [o] + [
-                    o1 for o1 in order_factors if not o.contains(o1)]
+                order_factors = [o1 for o1 in order_factors if not o.contains(o1)] # type: ignore
+                order_factors = [o] + order_factors # type: ignore
                 continue
 
             # 3 or NaN
@@ -259,7 +266,7 @@ class Add(Expr, AssocOp):
                 continue
 
             elif isinstance(o, TensExpr):
-                coeff = o.__add__(coeff) if coeff else o
+                coeff = TensAdd(o, coeff).doit(deep=False)
                 continue
 
             elif o is S.ComplexInfinity:
@@ -272,7 +279,8 @@ class Add(Expr, AssocOp):
             # Add([...])
             elif o.is_Add:
                 # NB: here we assume Add is always commutative
-                seq.extend(o.args)  # TODO zerocopy?
+                o_args: tuple[Expr, ...] = o.args # type: ignore
+                seq.extend(o_args)  # TODO zerocopy?
                 continue
 
             # Mul([...])
@@ -327,7 +335,7 @@ class Add(Expr, AssocOp):
                     #
                     # XXX: This breaks VectorMul unless it overrides
                     # _new_rawargs
-                    cs = s._new_rawargs(*((c,) + s.args))
+                    cs = s._new_rawargs(*((c,) + s.args)) # type: ignore
                     newseq.append(cs)
                 elif s.is_Add:
                     # we just re-create the unevaluated Mul
@@ -361,15 +369,10 @@ class Add(Expr, AssocOp):
         if order_factors:
             newseq2 = []
             for t in newseq:
-                for o in order_factors:
-                    # x + O(x) -> O(x)
-                    if o.contains(t):
-                        t = None
-                        break
-                # x + O(x**2) -> x + O(x**2)
-                if t is not None:
+                # x + O(x) -> O(x)
+                if not any(o.contains(t) for o in order_factors):
                     newseq2.append(t)
-            newseq = newseq2 + order_factors
+            newseq = newseq2 + order_factors # type: ignore
             # 1 + O(1) -> O(1)
             for o in order_factors:
                 if o.contains(coeff):
@@ -436,41 +439,41 @@ class Add(Expr, AssocOp):
             return coeff, notrat + self.args[1:]
         return S.Zero, self.args
 
-    def as_coeff_Add(self, rational=False, deps=None):
+    def as_coeff_Add(self, rational=False, deps=None) -> tuple[Number, Expr]:
         """
         Efficiently extract the coefficient of a summation.
         """
         coeff, args = self.args[0], self.args[1:]
 
         if coeff.is_Number and not rational or coeff.is_Rational:
-            return coeff, self._new_rawargs(*args)
+            return coeff, self._new_rawargs(*args) # type: ignore
         return S.Zero, self
 
     # Note, we intentionally do not implement Add.as_coeff_mul().  Rather, we
     # let Expr.as_coeff_mul() just always return (S.One, self) for an Add.  See
     # issue 5524.
 
-    def _eval_power(self, e):
+    def _eval_power(self, expt):
         from .evalf import pure_complex
         from .relational import is_eq
         if len(self.args) == 2 and any(_.is_infinite for _ in self.args):
-            if e.is_zero is False and is_eq(e, S.One) is False:
+            if expt.is_zero is False and is_eq(expt, S.One) is False:
                 # looking for literal a + I*b
                 a, b = self.args
                 if a.coeff(S.ImaginaryUnit):
                     a, b = b, a
                 ico = b.coeff(S.ImaginaryUnit)
                 if ico and ico.is_extended_real and a.is_extended_real:
-                    if e.is_extended_negative:
+                    if expt.is_extended_negative:
                         return S.Zero
-                    if e.is_extended_positive:
+                    if expt.is_extended_positive:
                         return S.ComplexInfinity
             return
-        if e.is_Rational and self.is_number:
+        if expt.is_Rational and self.is_number:
             ri = pure_complex(self)
             if ri:
                 r, i = ri
-                if e.q == 2:
+                if expt.q == 2:
                     from sympy.functions.elementary.miscellaneous import sqrt
                     D = sqrt(r**2 + i**2)
                     if D.is_Rational:
@@ -478,11 +481,11 @@ class Add(Expr, AssocOp):
                         from sympy.functions.elementary.complexes import sign
                         from .function import expand_multinomial
                         # (r, i, D) is a Pythagorean triple
-                        root = sqrt(factor_terms((D - r)/2))**e.p
+                        root = sqrt(factor_terms((D - r)/2))**expt.p
                         return root*expand_multinomial((
                             # principle value
-                            (D + r)/abs(i) + sign(i)*S.ImaginaryUnit)**e.p)
-                elif e == -1:
+                            (D + r)/abs(i) + sign(i)*S.ImaginaryUnit)**expt.p)
+                elif expt == -1:
                     return _unevaluated_Mul(
                         r - i*S.ImaginaryUnit,
                         1/(r**2 + i**2))
@@ -551,7 +554,7 @@ class Add(Expr, AssocOp):
         """
         return self.args[0], self._new_rawargs(*self.args[1:])
 
-    def as_numer_denom(self):
+    def as_numer_denom(self) -> tuple[Expr, Expr]:
         """
         Decomposes an expression to its numerator part and its
         denominator part.
@@ -1032,7 +1035,7 @@ class Add(Expr, AssocOp):
         _logx = Dummy('logx') if logx is None else logx
         leading_terms = [t.as_leading_term(x, logx=_logx, cdir=cdir) for t in expr.args]
 
-        min, new_expr = Order(0), 0
+        min, new_expr = Order(0), S.Zero
 
         try:
             for term in leading_terms:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from itertools import chain, zip_longest
 from functools import cmp_to_key
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from .assumptions import _prepare_class_assumptions
 from .cache import cacheit
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
     from .assumptions import StdFactKB
     from .symbol import Symbol
+    from .expr import Expr
 
 
 def as_Basic(expr):
@@ -843,7 +844,7 @@ class Basic(Printable):
         """
         return self._eval_is_comparable()
 
-    def _eval_is_comparable(self):
+    def _eval_is_comparable(self) -> bool:
         # Expr.is_comparable overrides this
         return False
 
@@ -924,6 +925,15 @@ class Basic(Printable):
         sympy.core.expr.Expr.as_content_primitive
         """
         return S.One, self
+
+    @overload
+    def subs(self: Expr, arg1: dict[Expr, Expr | int], arg2: None=None) -> Expr: ... # type: ignore
+    @overload
+    def subs(self: Expr, arg1: Expr, arg2: Expr | int) -> Expr: ... # type: ignore
+    @overload
+    def subs(self: Basic, arg1: dict[Basic, Basic], arg2: None=None) -> Basic: ...
+    @overload
+    def subs(self: Basic, arg1: Basic, arg2: Basic) -> Basic: ...
 
     def subs(self, *args, **kwargs):
         """
@@ -1244,7 +1254,7 @@ class Basic(Printable):
             rv = fallback(self, old, new)
         return rv
 
-    def _eval_subs(self, old, new):
+    def _eval_subs(self, old, new) -> Basic | None:
         """Override this stub if you want to do anything more than
         attempt a replacement of old with new in the arguments of self.
 
@@ -1918,6 +1928,11 @@ class Basic(Printable):
         else:
             return self
 
+    @overload
+    def simplify(self: Expr, **kwargs) -> Expr: ... # type: ignore
+    @overload
+    def simplify(self: Basic, **kwargs) -> Basic: ...
+
     def simplify(self, **kwargs):
         """See the simplify function in sympy.simplify"""
         from sympy.simplify.simplify import simplify
@@ -2121,7 +2136,7 @@ class Basic(Printable):
             # call the freshly monkey-patched method
             return self._sage_()
 
-    def could_extract_minus_sign(self):
+    def could_extract_minus_sign(self) -> bool:
         return False  # see Expr.could_extract_minus_sign
 
     def is_same(a, b, approx=None):

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -6,6 +6,8 @@
     They are supposed to work seamlessly within the SymPy framework.
 """
 
+from __future__ import annotations
+
 from collections import OrderedDict
 from collections.abc import MutableSet
 from typing import Any, Callable

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -252,6 +252,9 @@ class Dict(Basic):
 
     """
 
+    elements: frozenset[Tuple]
+    _dict: dict[Basic, Basic]
+
     def __new__(cls, *args):
         if len(args) == 1 and isinstance(args[0], (dict, Dict)):
             items = [Tuple(k, v) for k, v in args[0].items()]

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     T3 = TypeVar('T3')
 
 
-def _sympifyit(arg, retval=None):
+def _sympifyit(arg, retval=None) -> Callable[[Callable[[T1, T2], T3]], Callable[[T1, T2], T3]]:
     """
     decorator to smartly _sympify function arguments
 
@@ -120,7 +120,7 @@ def call_highest_priority(method_name: str
     return priority_decorator
 
 
-def sympify_method_args(cls):
+def sympify_method_args(cls: type[T1]) -> type[T1]:
     '''Decorator for a class with methods that sympify arguments.
 
     Explanation

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1260,9 +1260,11 @@ def hypsum(expr: 'Expr', n: 'Symbol', start: int, prec: int) -> mpf:
     if h < 0:
         raise ValueError("Sum diverges like (n!)^%i" % (-h))
 
-    term = expr.subs(n, 0)
-    if not term.is_Rational:
+    eterm = expr.subs(n, 0)
+    if not eterm.is_Rational:
         raise NotImplementedError("Non rational term functionality is not implemented.")
+
+    term: Rational = eterm # type: ignore
 
     # Direct summation if geometric or faster
     if h > 0 or (h == 0 and abs(g) > 1):
@@ -1321,7 +1323,7 @@ def evalf_prod(expr: 'Product', prec: int, options: OPT_DICT) -> TMP_RES:
 def evalf_sum(expr: 'Sum', prec: int, options: OPT_DICT) -> TMP_RES:
     from .numbers import Float
     if 'subs' in options:
-        expr = expr.subs(options['subs'])
+        expr = expr.subs(options['subs']) # type: ignore
     func = expr.function
     limits = expr.limits
     if len(limits) != 1 or len(limits[0]) != 3:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -31,6 +31,7 @@ There are three types of functions implemented in SymPy:
 """
 
 from __future__ import annotations
+
 from typing import Any
 from collections.abc import Iterable
 
@@ -1958,7 +1959,7 @@ class Lambda(Expr):
     """
     is_Function = True
 
-    def __new__(cls, signature, expr):
+    def __new__(cls, signature, expr) -> Lambda:
         if iterable(signature) and not isinstance(signature, (tuple, Tuple)):
             sympy_deprecation_warning(
                 """
@@ -1969,8 +1970,8 @@ class Lambda(Expr):
                 active_deprecations_target="deprecated-non-tuple-lambda",
             )
             signature = tuple(signature)
-        sig = signature if iterable(signature) else (signature,)
-        sig = sympify(sig)
+        _sig = signature if iterable(signature) else (signature,)
+        sig: Tuple = sympify(_sig) # type: ignore
         cls._check_signature(sig)
 
         if len(sig) == 1 and sig[0] == expr:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -722,15 +722,15 @@ class Mul(Expr, AssocOp):
 
         return c_part, nc_part, order_symbols
 
-    def _eval_power(self, e):
+    def _eval_power(self, expt):
 
         # don't break up NC terms: (A*B)**3 != A**3*B**3, it is A*B*A*B*A*B
         cargs, nc = self.args_cnc(split_1=False)
 
-        if e.is_Integer:
-            return Mul(*[Pow(b, e, evaluate=False) for b in cargs]) * \
-                Pow(Mul._from_args(nc), e, evaluate=False)
-        if e.is_Rational and e.q == 2:
+        if expt.is_Integer:
+            return Mul(*[Pow(b, expt, evaluate=False) for b in cargs]) * \
+                Pow(Mul._from_args(nc), expt, evaluate=False)
+        if expt.is_Rational and expt.q == 2:
             if self.is_imaginary:
                 a = self.as_real_imag()[1]
                 if a.is_Rational:
@@ -741,11 +741,11 @@ class Mul(Expr, AssocOp):
                         if t:
                             from sympy.functions.elementary.complexes import sign
                             r = sympify(n)/d
-                            return _unevaluated_Mul(r**e.p, (1 + sign(a)*S.ImaginaryUnit)**e.p)
+                            return _unevaluated_Mul(r**expt.p, (1 + sign(a)*S.ImaginaryUnit)**expt.p)
 
-        p = Pow(self, e, evaluate=False)
+        p = Pow(self, expt, evaluate=False)
 
-        if e.is_Rational or e.is_Float:
+        if expt.is_Rational or expt.is_Float:
             return p._eval_expand_power_base()
 
         return p

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import overload
+
 import numbers
 import decimal
 import fractions
@@ -440,8 +442,16 @@ class Number(AtomicExpr):
     def sort_key(self, order=None):
         return self.class_key(), (0, ()), (), self
 
+    def __neg__(self) -> Number:
+        raise NotImplementedError
+
+    @overload
+    def __add__(self, other: Number | int | float) -> Number: ...
+    @overload
+    def __add__(self, other: Expr) -> Expr: ...
+
     @_sympifyit('other', NotImplemented)
-    def __add__(self, other):
+    def __add__(self, other) -> Expr:
         if isinstance(other, Number) and global_parameters.evaluate:
             if other is S.NaN:
                 return S.NaN

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+from typing import overload, TYPE_CHECKING
+
 from operator import attrgetter
 from collections import defaultdict
 
@@ -14,6 +17,13 @@ from sympy.utilities.iterables import sift
 from sympy.multipledispatch.dispatcher import (Dispatcher,
     ambiguity_register_error_ignore_dup,
     str_signature, RaiseNotImplementedError)
+
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.core.add import Add
+    from sympy.core.mul import Mul
+    from sympy.logic.boolalg import Boolean, And, Or
 
 
 class AssocOp(Basic):
@@ -426,8 +436,21 @@ this object, use the * or + operator instead.
                 args.append(newa)
         return self.func(*args)
 
+    @overload
     @classmethod
-    def make_args(cls, expr):
+    def make_args(cls: type[Add], expr: Expr) -> tuple[Expr, ...]: ... # type: ignore
+    @overload
+    @classmethod
+    def make_args(cls: type[Mul], expr: Expr) -> tuple[Expr, ...]: ... # type: ignore
+    @overload
+    @classmethod
+    def make_args(cls: type[And], expr: Boolean) -> tuple[Boolean, ...]: ... # type: ignore
+    @overload
+    @classmethod
+    def make_args(cls: type[Or], expr: Boolean) -> tuple[Boolean, ...]: ... # type: ignore
+
+    @classmethod
+    def make_args(cls: type[Basic], expr: Basic) -> tuple[Basic, ...]:
         """
         Return a sequence of elements `args` such that cls(*args) == expr
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -248,13 +248,13 @@ class Pow(Expr):
             elif ask(Q.odd(e), assumptions):
                 return -Pow(-b, e)
 
-    def _eval_power(self, other):
+    def _eval_power(self, expt):
         b, e = self.as_base_exp()
         if b is S.NaN:
-            return (b**e)**other  # let __new__ handle it
+            return (b**e)**expt  # let __new__ handle it
 
         s = None
-        if other.is_integer:
+        if expt.is_integer:
             s = 1
         elif b.is_polar:  # e.g. exp_polar, besselj, var('p', polar=True)...
             s = 1
@@ -282,18 +282,18 @@ class Pow(Expr):
                     pass
             # ===================================================
             if e.is_extended_real:
-                # we need _half(other) with constant floor or
+                # we need _half(expt) with constant floor or
                 # floor(S.Half - e*arg(b)/2/pi) == 0
 
 
                 # handle -1 as special case
                 if e == -1:
                     # floor arg. is 1/2 + arg(b)/2/pi
-                    if _half(other):
+                    if _half(expt):
                         if b.is_negative is True:
-                            return S.NegativeOne**other*Pow(-b, e*other)
+                            return S.NegativeOne**expt*Pow(-b, e*expt)
                         elif b.is_negative is False:  # XXX ok if im(b) != 0?
-                            return Pow(b, -other)
+                            return Pow(b, -expt)
                 elif e.is_even:
                     if b.is_extended_real:
                         b = abs(b)
@@ -306,8 +306,8 @@ class Pow(Expr):
                     s = 1  # floor = 0
                 elif re(b).is_extended_nonnegative and (abs(e) < 2) == True:
                     s = 1  # floor = 0
-                elif _half(other):
-                    s = exp(2*S.Pi*S.ImaginaryUnit*other*floor(
+                elif _half(expt):
+                    s = exp(2*S.Pi*S.ImaginaryUnit*expt*floor(
                         S.Half - e*arg(b)/(2*S.Pi)))
                     if s.is_extended_real and _n2(sign(s) - s) == 0:
                         s = sign(s)
@@ -315,10 +315,10 @@ class Pow(Expr):
                         s = None
             else:
                 # e.is_extended_real is False requires:
-                #     _half(other) with constant floor or
+                #     _half(expt) with constant floor or
                 #     floor(S.Half - im(e*log(b))/2/pi) == 0
                 try:
-                    s = exp(2*S.ImaginaryUnit*S.Pi*other*
+                    s = exp(2*S.ImaginaryUnit*S.Pi*expt*
                         floor(S.Half - im(e*log(b))/2/S.Pi))
                     # be careful to test that s is -1 or 1 b/c sign(I) == I:
                     # so check that s is real
@@ -330,7 +330,7 @@ class Pow(Expr):
                     s = None
 
         if s is not None:
-            return s*Pow(b, e*other)
+            return s*Pow(b, e*expt)
 
     def _eval_Mod(self, q):
         r"""A dispatched function to compute `b^e \bmod q`, dispatched

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -513,7 +513,7 @@ class Relational(Boolean, EvalfMixin):
         args = (arg.expand(**kwargs) for arg in self.args)
         return self.func(*args)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         raise TypeError(
             LazyExceptionMessage(
                 lambda: f"cannot determine truth value of Relational: {self}"

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -1,8 +1,24 @@
 """Singleton mechanism"""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from .core import Registry
 from .sympify import sympify
+
+
+if TYPE_CHECKING:
+    from sympy.core.numbers import (
+        Zero as _Zero,
+        One as _One,
+        NegativeOne as _NegativeOne,
+        Half as _Half,
+        Infinity as _Infinity,
+        NegativeInfinity as _NegativeInfinity,
+        ComplexInfinity as _ComplexInfinity,
+        NaN as _NaN,
+    )
 
 
 class SingletonRegistry(Registry):
@@ -82,6 +98,15 @@ class SingletonRegistry(Registry):
 
     """
     __slots__ = ()
+
+    Zero: _Zero
+    One: _One
+    NegativeOne: _NegativeOne
+    Half: _Half
+    Infinity: _Infinity
+    NegativeInfinity: _NegativeInfinity
+    ComplexInfinity: _ComplexInfinity
+    NaN: _NaN
 
     # Also allow things like S(5)
     __call__ = staticmethod(sympify)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
     from sympy.core.numbers import Integer, Float
 
-    Tbasic = TypeVar('Tbasic', bound='Basic')
+    Tbasic = TypeVar('Tbasic', bound=Basic)
 
 
 class SympifyError(ValueError):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -1,7 +1,8 @@
 """sympify -- convert objects SymPy internal format"""
 
 from __future__ import annotations
-from typing import Any, Callable
+
+from typing import Any, Callable, overload, TYPE_CHECKING, TypeVar, Optional
 
 import mpmath.libmp as mlib
 
@@ -12,6 +13,13 @@ from sympy.core.random import choice
 from .parameters import global_parameters
 
 from sympy.utilities.iterables import iterable
+
+
+if TYPE_CHECKING:
+    from sympy.core.basic import Basic
+    from sympy.core.expr import Expr
+    from sympy.core.numbers import Integer, Float
+    Tbasic = TypeVar('Tbasic', bound=Basic)
 
 
 class SympifyError(ValueError):
@@ -94,6 +102,17 @@ def _convert_numpy_types(a, **sympify_args):
         a = mlib.from_rational(p, q, prec)
         return Float(a, precision=prec)
 
+
+@overload
+def sympify(a: int, *, strict: bool = False) -> Integer: ... # type: ignore
+@overload
+def sympify(a: float, *, strict: bool = False) -> Float: ...
+@overload
+def sympify(a: complex, *, strict: bool = False) -> Expr: ...
+@overload
+def sympify(a: Tbasic, *, strict: bool = False) -> Tbasic: ...
+@overload
+def sympify(a: Any, *, strict: bool = False) -> Basic: ...
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         evaluate=None):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, overload, TYPE_CHECKING, TypeVar, Optional
+from typing import Any, Callable, overload, TYPE_CHECKING, TypeVar
 
 import mpmath.libmp as mlib
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -16,10 +16,12 @@ from sympy.utilities.iterables import iterable
 
 
 if TYPE_CHECKING:
+
     from sympy.core.basic import Basic
     from sympy.core.expr import Expr
     from sympy.core.numbers import Integer, Float
-    Tbasic = TypeVar('Tbasic', bound=Basic)
+
+    Tbasic = TypeVar('Tbasic', bound='Basic')
 
 
 class SympifyError(ValueError):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1,4 +1,4 @@
-from typing import Tuple as tTuple
+from __future__ import annotations
 
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.core.add import Add
@@ -37,9 +37,9 @@ class Integral(AddWithLimits):
 
     __slots__ = ()
 
-    args: tTuple[Expr, Tuple]
+    args: tuple[Expr, Tuple] # type: ignore
 
-    def __new__(cls, function, *symbols, **assumptions):
+    def __new__(cls, function, *symbols, **assumptions) -> Integral:
         """Create an unevaluated integral.
 
         Explanation

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -504,7 +504,7 @@ class TrigSubstitutionRule(Rule):
             (theta, inverse)
         ]
         return Piecewise(
-            (self.substep.eval().subs(substitution).trigsimp(), self.restriction)
+                (self.substep.eval().subs(substitution).trigsimp(), self.restriction) # type: ignore
         )
 
     def contains_dont_know(self) -> bool:
@@ -1866,7 +1866,7 @@ def dirac_delta_rule(integral: IntegralInfo):
     if len(integrand.args) == 1:
         n = S.Zero
     else:
-        n = integrand.args[1]
+        n = integrand.args[1] # type: ignore
     if not n.is_Integer or n < 0:
         return
     a, b = Wild('a', exclude=[x]), Wild('b', exclude=[x, 0])

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -180,7 +180,7 @@ class Poly(Basic):
             else:
                 return cls._from_list(list(rep), opt)
         else:
-            rep = sympify(rep, evaluate=type(rep) is not str)
+            rep = sympify(rep, evaluate=type(rep) is not str) # type: ignore
 
             if rep.is_Poly:
                 return cls._from_poly(rep, opt)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -8,7 +8,7 @@ from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_not, fuzzy_or, fuzzy_and
 from sympy.core.mod import Mod
 from sympy.core.intfunc import igcd
-from sympy.core.numbers import oo, Rational
+from sympy.core.numbers import oo, Rational, Integer
 from sympy.core.relational import Eq, is_eq
 from sympy.core.kind import NumberKind
 from sympy.core.singleton import Singleton, S
@@ -100,7 +100,7 @@ class Naturals(Set, metaclass=Singleton):
     """
 
     is_iterable = True
-    _inf = S.One
+    _inf: Integer = S.One
     _sup = S.Infinity
     is_empty = False
     is_finite_set = False

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -57,7 +57,7 @@ class Set(Basic, EvalfMixin):
     :class:`EmptySet` class and available as a singleton as ``S.EmptySet``.
     """
 
-    __slots__ = ()
+    __slots__: tuple[()] = ()
 
     is_number = False
     is_iterable = False

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable
 from functools import reduce
 from collections import defaultdict

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import overload
+
 from collections import defaultdict
 
 from sympy.concrete.products import Product
@@ -416,6 +420,11 @@ def signsimp(expr, evaluate=None):
         e = e.replace(lambda x: x.is_Mul and -(-x) != x, lambda x: -(-x))
     return e
 
+
+@overload
+def simplify(expr: Expr, **kwargs) -> Expr: ...
+@overload
+def simplify(expr: Basic, **kwargs) -> Basic: ...
 
 def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, doit=True, **kwargs):
     """Simplifies the given expression.

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -14,7 +14,7 @@ from .solvers import solve, solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs, nsolve, solve_linear, checksol, \
     det_quick, inv_quick
 
-from .diophantine import diophantine
+from sympy.solvers.diophantine.diophantine import diophantine
 
 from .recurr import rsolve, rsolve_poly, rsolve_ratio, rsolve_hyper
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -2657,8 +2657,8 @@ class NthLinearEulerEqNonhomogeneousUndeterminedCoefficients(SingleODESolver):
 
         self.const_undet_instance = NthLinearConstantCoeffUndeterminedCoefficients(SingleODEProblem(eq, f(x), x))
         sol = self.const_undet_instance.get_general_solution(simplify = simplify_flag)[0]
-        sol = sol.subs(x, log(x))
-        sol = sol.subs(f(log(x)), f(x)).expand()
+        sol = sol.subs(x, log(x)) # type: ignore
+        sol = sol.subs(f(log(x)), f(x)).expand() # type: ignore
 
         return [sol]
 

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -784,7 +784,7 @@ def identify_hadamard_products(expr: tUnion[ArrayContraction, ArrayDiagonal]):
             make_trace = True
             first_element = v[0].element
             if not check_transpose(v[0].indices):
-                first_element = first_element.T
+                first_element = first_element.T # type: ignore
             hadamard_factors = v[1:]
         else:
             hadamard_factors = v

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2503,12 +2503,12 @@ class TensAdd(TensExpr, AssocOp):
         else:
             return set()
 
-    def doit(self, **hints):
+    def doit(self, **hints) -> Expr:
         deep = hints.get('deep', True)
         if deep:
             args = [arg.doit(**hints) for arg in self.args]
         else:
-            args = self.args
+            args = self.args # type: ignore
 
         # if any of the args are zero (after doit), drop them. Otherwise, _tensAdd_check will complain about non-matching indices, even though the TensAdd is correctly formed.
         args = [arg for arg in args if arg != S.Zero]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows gh-27217 (merged) and gh-27218 (outstanding).

#### Brief description of what is fixed or changed

Add more type hints so that types can be inferred for common operations with the most commonly used expression types. In particular add overloads for subs so that it is possible to distinguish between Expr and Basic. Also it is necessary in some places to distinguish Number from Expr and so some limited support for that is included e.g.:
```python
from typing import reveal_type
from sympy import Symbol, Expr

def g(a: Expr, b: Expr):
    c1, _ = a.as_coeff_Mul()
    c2, _ = b.as_coeff_Mul()
    return c1 + c2

x = Symbol('x')
v = g(2*x, 3*x - 1)

reveal_type(v) # Number
```

#### Other comments

Apart from being able to recognise basic use of polys (gh-27218) the main thing needed after this is to make it so that evalf can be understood. There are still a huge number of errors under pyright and in fact I think that the specific change here actually increases the number of errors because it means that types are inferred in more places rather than being treated as Any/Unknown.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
