### PR TITLE
Improve hashable_content in symbol

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -363,7 +363,7 @@ class Symbol(AtomicExpr, Boolean):
 
         obj._assumptions = assumptions_kb
         obj._assumptions_orig = assumptions_orig
-        obj._assumptions0 = assumptions0
+        obj._assumptions0 = tuple(sorted(assumptions0.items()))
 
         # The three assumptions dicts are all a little different:
         #
@@ -402,8 +402,7 @@ class Symbol(AtomicExpr, Boolean):
             setattr(self, name, value)
 
     def _hashable_content(self):
-        # Note: user-specified assumptions not hashed, just derived ones
-        return (self.name,) + tuple(sorted(self.assumptions0.items()))
+        return (self.name,) + self._assumptions0
 
     def _eval_subs(self, old, new):
         if old.is_Pow:
@@ -415,7 +414,7 @@ class Symbol(AtomicExpr, Boolean):
 
     @property
     def assumptions0(self):
-        return self._assumptions0.copy()
+        return dict(self._assumptions0)
 
     @cacheit
     def sort_key(self, order=None):


### PR DESCRIPTION
This makes the last line from following script go from 0.735s to 0.617s
```python
from sympy import *
a = symbols("a0:100000")
b = Add(*a);
b + a[0]
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Cache hashable_content in symbol

<!-- END RELEASE NOTES -->
