### PR TITLE
add cache for constructor post processing

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -122,6 +122,7 @@ def _cmp_name(x: type, y: type) -> int:
     return (i1 > i2) - (i1 < i2)
 
 
+
 @cacheit
 def _get_postprocessors(clsname, arg_type):
     # Since only Add, Mul, Pow can be clsname, this cache
@@ -139,7 +140,7 @@ def _get_postprocessors(clsname, arg_type):
 
 @cacheit
 def _get_postprocessors_for_type(arg_type):
-    return (
+    return tuple(
         Basic._constructor_postprocessor_mapping[cls]
         for cls in arg_type.mro()
         if cls in Basic._constructor_postprocessor_mapping

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -128,14 +128,11 @@ def _get_postprocessors(clsname, arg_type):
     # Since only Add, Mul, Pow can be clsname, this cache
     # is not quadratic.
     postprocessors = set()
-    try:
-        mappings = _get_postprocessors_for_type(arg_type)
-        for mapping in mappings:
-            f = mapping.get(clsname, None)
-            if f is not None:
-                postprocessors.update(f)
-    except TypeError:
-        pass
+    mappings = _get_postprocessors_for_type(arg_type)
+    for mapping in mappings:
+        f = mapping.get(clsname, None)
+        if f is not None:
+            postprocessors.update(f)
     return postprocessors
 
 @cacheit

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,9 +1,8 @@
 """Base class for all the objects in SymPy"""
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Mapping
-from itertools import chain, zip_longest
+from itertools import zip_longest
 from functools import cmp_to_key
 
 from .assumptions import _prepare_class_assumptions
@@ -121,6 +120,30 @@ def _cmp_name(x: type, y: type) -> int:
     if i1 == UNKNOWN and i2 == UNKNOWN:
         return (n1 > n2) - (n1 < n2)
     return (i1 > i2) - (i1 < i2)
+
+
+@cacheit
+def _get_postprocessors(clsname, arg_type):
+    # Since only Add, Mul, Pow can be clsname, this cache
+    # is not quadratic.
+    postprocessors = set()
+    try:
+        mappings = _get_postprocessors_for_type(arg_type)
+        for mapping in mappings:
+            f = mapping.get(clsname, None)
+            if f is not None:
+                postprocessors.update(f)
+    except TypeError:
+        pass
+    return postprocessors
+
+@cacheit
+def _get_postprocessors_for_type(arg_type):
+    return (
+        Basic._constructor_postprocessor_mapping[cls]
+        for cls in arg_type.mro()
+        if cls in Basic._constructor_postprocessor_mapping
+    )
 
 
 class Basic(Printable):
@@ -2130,20 +2153,12 @@ class Basic(Printable):
         # functions for matching expression node names.
 
         clsname = obj.__class__.__name__
-        postprocessors = defaultdict(list)
+        postprocessors = set()
         for i in obj.args:
-            try:
-                postprocessor_mappings = (
-                    Basic._constructor_postprocessor_mapping[cls].items()
-                    for cls in type(i).mro()
-                    if cls in Basic._constructor_postprocessor_mapping
-                )
-                for k, v in chain.from_iterable(postprocessor_mappings):
-                    postprocessors[k].extend([j for j in v if j not in postprocessors[k]])
-            except TypeError:
-                pass
+            for f in _get_postprocessors(clsname, type(i)):
+                postprocessors.add(f)
 
-        for f in postprocessors.get(clsname, []):
+        for f in postprocessors:
             obj = f(obj)
 
         return obj


### PR DESCRIPTION
This makes the last line from following script go from 0.735s to 0.673s

```python
  from sympy import *
  a = symbols("a0:100000")
  b = Add(*a);
  b + a[0]
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
