### PR TITLE
Improving sympy.printing.pretty.stringpict API

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -825,6 +825,7 @@ João Moura <operte@gmail.com>
 Juan Barbosa <js.barbosa10@uniandes.edu.co>
 Juan Felipe Osorio <jfosorio@gmail.com>
 Juan Luis Cano Rodríguez <juanlu001@gmail.com>
+Juan Mauricio Matera <matera@fisica.unlp.edu.ar>
 Juha Remes <jremes@outlook.com>
 Julien Palard <julien@palard.fr>
 Julien Rioux <julien.rioux@gmail.com>

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -141,7 +141,7 @@ class AntiCommutator(Expr):
         pform = printer._print(self.args[0], *args)
         pform = pform.right(prettyForm(','))
         pform = pform.right(printer._print(self.args[1], *args))
-        pform = pform.parens(left='{', right='}')
+        pform = pform.parenthesis(left='{', right='}')
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -139,9 +139,9 @@ class AntiCommutator(Expr):
 
     def _pretty(self, printer, *args):
         pform = printer._print(self.args[0], *args)
-        pform = prettyForm(*pform.right(prettyForm(',')))
-        pform = prettyForm(*pform.right(printer._print(self.args[1], *args)))
-        pform = prettyForm(*pform.parens(left='{', right='}'))
+        pform = pform.right(prettyForm(','))
+        pform = pform.right(printer._print(self.args[1], *args))
+        pform = pform.parens(left='{', right='}')
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -143,7 +143,7 @@ class Wigner3j(Expr):
             for _ in range(vsep):
                 D = D.below(' ')
             D = D.below(D_row)
-        D = D.parens()
+        D = D.parenthesis()
         return D
 
     def _latex(self, printer, *args):
@@ -318,7 +318,7 @@ class Wigner6j(Expr):
             for _ in range(vsep):
                 D = D.below(' ')
             D = D.below(D_row)
-        D = D.parens(left='{', right='}')
+        D = D.parenthesis(left='{', right='}')
         return D
 
     def _latex(self, printer, *args):
@@ -422,7 +422,7 @@ class Wigner9j(Expr):
             for _ in range(vsep):
                 D = D.below(' ')
             D = D.below(D_row)
-        D = D.parens(left='{', right='}')
+        D = D.parenthesis(left='{', right='}')
         return D
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -16,7 +16,7 @@ from sympy.core.symbol import (Wild, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.printing.pretty.stringpict import prettyForm, stringPict
+from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.wigner import clebsch_gordan, wigner_3j, wigner_6j, wigner_9j
@@ -129,21 +129,21 @@ class Wigner3j(Expr):
                 wleft = wdelta //2
                 wright = wdelta - wleft
 
-                s = prettyForm(*s.right(' '*wright))
-                s = prettyForm(*s.left(' '*wleft))
+                s = s.right(' '*wright)
+                s = s.left(' '*wleft)
 
                 if D_row is None:
                     D_row = s
                     continue
-                D_row = prettyForm(*D_row.right(' '*hsep))
-                D_row = prettyForm(*D_row.right(s))
+                D_row = D_row.right(' '*hsep)
+                D_row = D_row.right(s)
             if D is None:
                 D = D_row
                 continue
             for _ in range(vsep):
-                D = prettyForm(*D.below(' '))
-            D = prettyForm(*D.below(D_row))
-        D = prettyForm(*D.parens())
+                D = D.below(' ')
+            D = D.below(D_row)
+        D = D.parens()
         return D
 
     def _latex(self, printer, *args):
@@ -226,16 +226,16 @@ class CG(Wigner3j):
         top = printer._print_seq((self.j3, self.m3), delimiter=',')
 
         pad = max(top.width(), bot.width())
-        bot = prettyForm(*bot.left(' '))
-        top = prettyForm(*top.left(' '))
+        bot = bot.left(' ')
+        top = top.left(' ')
 
         if not pad == bot.width():
-            bot = prettyForm(*bot.right(' '*(pad - bot.width())))
+            bot = bot.right(' '*(pad - bot.width()))
         if not pad == top.width():
-            top = prettyForm(*top.right(' '*(pad - top.width())))
-        s = stringPict('C' + ' '*pad)
-        s = prettyForm(*s.below(bot))
-        s = prettyForm(*s.above(top))
+            top = top.right(' '*(pad - top.width()))
+        s = prettyForm('C' + ' '*pad)
+        s = s.below(bot)
+        s = s.above(top)
         return s
 
     def _latex(self, printer, *args):
@@ -304,21 +304,21 @@ class Wigner6j(Expr):
                 wleft = wdelta //2
                 wright = wdelta - wleft
 
-                s = prettyForm(*s.right(' '*wright))
-                s = prettyForm(*s.left(' '*wleft))
+                s = s.right(' '*wright)
+                s = s.left(' '*wleft)
 
                 if D_row is None:
                     D_row = s
                     continue
-                D_row = prettyForm(*D_row.right(' '*hsep))
-                D_row = prettyForm(*D_row.right(s))
+                D_row = D_row.right(' '*hsep)
+                D_row = D_row.right(s)
             if D is None:
                 D = D_row
                 continue
             for _ in range(vsep):
-                D = prettyForm(*D.below(' '))
-            D = prettyForm(*D.below(D_row))
-        D = prettyForm(*D.parens(left='{', right='}'))
+                D = D.below(' ')
+            D = D.below(D_row)
+        D = D.parens(left='{', right='}')
         return D
 
     def _latex(self, printer, *args):
@@ -408,21 +408,21 @@ class Wigner9j(Expr):
                 wleft = wdelta //2
                 wright = wdelta - wleft
 
-                s = prettyForm(*s.right(' '*wright))
-                s = prettyForm(*s.left(' '*wleft))
+                s = s.right(' '*wright)
+                s = s.left(' '*wleft)
 
                 if D_row is None:
                     D_row = s
                     continue
-                D_row = prettyForm(*D_row.right(' '*hsep))
-                D_row = prettyForm(*D_row.right(s))
+                D_row = D_row.right(' '*hsep)
+                D_row = D_row.right(s)
             if D is None:
                 D = D_row
                 continue
             for _ in range(vsep):
-                D = prettyForm(*D.below(' '))
-            D = prettyForm(*D.below(D_row))
-        D = prettyForm(*D.parens(left='{', right='}'))
+                D = D.below(' ')
+            D = D.below(D_row)
+        D = D.parens(left='{', right='}')
         return D
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -229,9 +229,9 @@ class Commutator(Expr):
 
     def _pretty(self, printer, *args):
         pform = printer._print(self.args[0], *args)
-        pform = prettyForm(*pform.right(prettyForm(',')))
-        pform = prettyForm(*pform.right(printer._print(self.args[1], *args)))
-        pform = prettyForm(*pform.parens(left='[', right=']'))
+        pform = pform.right(prettyForm(','))
+        pform = pform.right(printer._print(self.args[1], *args))
+        pform = pform.parens(left='[', right=']')
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -231,7 +231,7 @@ class Commutator(Expr):
         pform = printer._print(self.args[0], *args)
         pform = pform.right(prettyForm(','))
         pform = pform.right(printer._print(self.args[1], *args))
-        pform = pform.parens(left='[', right=']')
+        pform = pform.parenthesis(left='[', right=']')
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -26,7 +26,7 @@ from sympy.core.singleton import S as _S
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import _sympify
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.printing.pretty.stringpict import prettyForm, stringPict
+from sympy.printing.pretty.stringpict import stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
@@ -431,7 +431,7 @@ class CGate(Gate):
         gate_name = stringPict(self.gate_name)
         first = self._print_subscript_pretty(gate_name, controls)
         gate = self._print_parens_pretty(gate)
-        final = prettyForm(*first.right(gate))
+        final = first.right(gate)
         return final
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -414,7 +414,7 @@ class TensorProductHilbertSpace(HilbertSpace):
             next_pform = printer._print(self.args[i], *args)
             if isinstance(self.args[i], (DirectSumHilbertSpace,
                           TensorProductHilbertSpace)):
-                next_pform = next_pform.parens(left='(', right=')')
+                next_pform = next_pform.parenthesis(left='(', right=')')
             pform = pform.right(next_pform)
             if i != length - 1:
                 if printer._use_unicode:
@@ -522,7 +522,7 @@ class DirectSumHilbertSpace(HilbertSpace):
             next_pform = printer._print(self.args[i], *args)
             if isinstance(self.args[i], (DirectSumHilbertSpace,
                           TensorProductHilbertSpace)):
-                next_pform = next_pform.parens(left='(', right=')')
+                next_pform = next_pform.parenthesis(left='(', right=')')
             pform = pform.right(next_pform)
             if i != length - 1:
                 if printer._use_unicode:

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -414,15 +414,13 @@ class TensorProductHilbertSpace(HilbertSpace):
             next_pform = printer._print(self.args[i], *args)
             if isinstance(self.args[i], (DirectSumHilbertSpace,
                           TensorProductHilbertSpace)):
-                next_pform = prettyForm(
-                    *next_pform.parens(left='(', right=')')
-                )
-            pform = prettyForm(*pform.right(next_pform))
+                next_pform = next_pform.parens(left='(', right=')')
+            pform = pform.right(next_pform)
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(' ' + '\N{N-ARY CIRCLED TIMES OPERATOR}' + ' '))
+                    pform = pform.right(' ' + '\N{N-ARY CIRCLED TIMES OPERATOR}' + ' ')
                 else:
-                    pform = prettyForm(*pform.right(' x '))
+                    pform = pform.right(' x ')
         return pform
 
     def _latex(self, printer, *args):
@@ -524,15 +522,13 @@ class DirectSumHilbertSpace(HilbertSpace):
             next_pform = printer._print(self.args[i], *args)
             if isinstance(self.args[i], (DirectSumHilbertSpace,
                           TensorProductHilbertSpace)):
-                next_pform = prettyForm(
-                    *next_pform.parens(left='(', right=')')
-                )
-            pform = prettyForm(*pform.right(next_pform))
+                next_pform = next_pform.parens(left='(', right=')')
+            pform = pform.right(next_pform)
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(' \N{CIRCLED PLUS} '))
+                    pform = pform.right(' \N{CIRCLED PLUS} ')
                 else:
-                    pform = prettyForm(*pform.right(' + '))
+                    pform = pform.right(' + ')
         return pform
 
     def _latex(self, printer, *args):
@@ -641,9 +637,9 @@ class TensorPowerHilbertSpace(HilbertSpace):
     def _pretty(self, printer, *args):
         pform_exp = printer._print(self.exp, *args)
         if printer._use_unicode:
-            pform_exp = prettyForm(*pform_exp.left(prettyForm('\N{N-ARY CIRCLED TIMES OPERATOR}')))
+            pform_exp = pform_exp.left(prettyForm('\N{N-ARY CIRCLED TIMES OPERATOR}'))
         else:
-            pform_exp = prettyForm(*pform_exp.left(prettyForm('x')))
+            pform_exp = pform_exp.left(prettyForm('x'))
         pform_base = printer._print(self.base, *args)
         return pform_base**pform_exp
 

--- a/sympy/physics/quantum/innerproduct.py
+++ b/sympy/physics/quantum/innerproduct.py
@@ -2,7 +2,6 @@
 
 from sympy.core.expr import Expr
 from sympy.functions.elementary.complexes import conjugate
-from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.state import KetBase, BraBase
 
@@ -111,10 +110,10 @@ class InnerProduct(Expr):
         lbracket, _ = self.bra._pretty_brackets(height, use_unicode)
         cbracket, rbracket = self.ket._pretty_brackets(height, use_unicode)
         # Build innerproduct
-        pform = prettyForm(*bra.left(lbracket))
-        pform = prettyForm(*pform.right(cbracket))
-        pform = prettyForm(*pform.right(ket))
-        pform = prettyForm(*pform.right(rbracket))
+        pform = bra.left(lbracket)
+        pform = pform.right(cbracket)
+        pform = pform.right(ket)
+        pform = pform.right(rbracket)
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -136,7 +136,7 @@ class Operator(QExpr):
         else:
             pform = self._print_operator_name_pretty(printer, *args)
             label_pform = self._print_label_pretty(printer, *args)
-            label_pform = label_pform.parens(left='(', right=')')
+            label_pform = label_pform.parenthesis(left='(', right=')')
             pform = pform.right(label_pform)
             return pform
 
@@ -649,7 +649,7 @@ class DifferentialOperator(Operator):
         pform = self._print_operator_name_pretty(printer, *args)
         label_pform = self._print_label_pretty(printer, *args)
         label_pform = prettyForm(
-            *label_pform.parens(left='(', right=')')
+            *label_pform.parenthesis(left='(', right=')')
         )
         pform = pform.right(label_pform)
         return pform

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -136,10 +136,8 @@ class Operator(QExpr):
         else:
             pform = self._print_operator_name_pretty(printer, *args)
             label_pform = self._print_label_pretty(printer, *args)
-            label_pform = prettyForm(
-                *label_pform.parens(left='(', right=')')
-            )
-            pform = prettyForm(*pform.right(label_pform))
+            label_pform = label_pform.parens(left='(', right=')')
+            pform = pform.right(label_pform)
             return pform
 
     def _print_contents_latex(self, printer, *args):
@@ -479,7 +477,7 @@ class OuterProduct(Operator):
 
     def _pretty(self, printer, *args):
         pform = self.ket._pretty(printer, *args)
-        return prettyForm(*pform.right(self.bra._pretty(printer, *args)))
+        return pform.right(self.bra._pretty(printer, *args))
 
     def _latex(self, printer, *args):
         k = printer._print(self.ket, *args)
@@ -653,5 +651,5 @@ class DifferentialOperator(Operator):
         label_pform = prettyForm(
             *label_pform.parens(left='(', right=')')
         )
-        pform = prettyForm(*pform.right(label_pform))
+        pform = pform.right(label_pform)
         return pform

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -227,22 +227,23 @@ class QExpr(Expr):
     def _print_sequence_pretty(self, seq, sep, printer, *args):
         pform = printer._print(seq[0], *args)
         for item in seq[1:]:
-            pform = prettyForm(*pform.right(sep))
-            pform = prettyForm(*pform.right(printer._print(item, *args)))
+            pform = pform.right(sep)
+            pform = pform.right(printer._print(item, *args))
         return pform
 
     # Utilities for printing: these operate prettyForm objects
 
     def _print_subscript_pretty(self, a, b):
-        top = prettyForm(*b.left(' '*a.width()))
-        bot = prettyForm(*a.right(' '*b.width()))
-        return prettyForm(binding=prettyForm.POW, *bot.below(top))
+        result = b.left(' '*a.width())
+        result = a.right(' '*b.width()).below(result)
+        result.binding = prettyForm.POW
+        return result
 
     def _print_superscript_pretty(self, a, b):
         return a**b
 
     def _print_parens_pretty(self, pform, left='(', right=')'):
-        return prettyForm(*pform.parens(left=left, right=right))
+        return pform.parens(left=left, right=right)
 
     # Printing of labels (i.e. args)
 

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -243,7 +243,7 @@ class QExpr(Expr):
         return a**b
 
     def _print_parens_pretty(self, pform, left='(', right=')'):
-        return pform.parens(left=left, right=right)
+        return pform.parenthesis(left=left, right=right)
 
     # Printing of labels (i.e. args)
 

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -851,7 +851,7 @@ class WignerD(Expr):
 
             s = prettyForm('D' + ' '*pad)
 
-        args = args.parens()
+        args = args.parenthesis()
         s = s.above(top)
         s = s.below(bot)
         s = s.right(args)

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -16,7 +16,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.simplify.simplify import simplify
 from sympy.matrices import zeros
-from sympy.printing.pretty.stringpict import prettyForm, stringPict
+from sympy.printing.pretty.stringpict import prettyForm
 from sympy.printing.pretty.pretty_symbology import pretty_symbol
 
 from sympy.physics.quantum.qexpr import QExpr
@@ -91,8 +91,8 @@ class SpinOpBase:
         return '%s%s' % (self.name, self._coord)
 
     def _print_contents_pretty(self, printer, *args):
-        a = stringPict(str(self.name))
-        b = stringPict(self._coord)
+        a = prettyForm(str(self.name))
+        b = prettyForm(self._coord)
         return self._print_subscript_pretty(a, b)
 
     def _print_contents_latex(self, printer, *args):
@@ -841,7 +841,7 @@ class WignerD(Expr):
             bot = prettyForm(*bot.right(' '*(pad - bot.width())))
         if self.alpha == 0 and self.gamma == 0:
             args = printer._print(self.beta)
-            s = stringPict('d' + ' '*pad)
+            s = prettyForm('d' + ' '*pad)
         else:
             args = printer._print(self.alpha)
             args = prettyForm(*args.right(','))
@@ -849,12 +849,12 @@ class WignerD(Expr):
             args = prettyForm(*args.right(','))
             args = prettyForm(*args.right(printer._print(self.gamma)))
 
-            s = stringPict('D' + ' '*pad)
+            s = prettyForm('D' + ' '*pad)
 
-        args = prettyForm(*args.parens())
-        s = prettyForm(*s.above(top))
-        s = prettyForm(*s.below(bot))
-        s = prettyForm(*s.right(args))
+        args = args.parens()
+        s = s.above(top)
+        s = s.below(bot)
+        s = s.right(args)
         return s
 
     def doit(self, **hints):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -183,14 +183,13 @@ class StateBase(QExpr):
         return '%s%s%s' % (getattr(self, 'lbracket', ""), contents, getattr(self, 'rbracket', ""))
 
     def _pretty(self, printer, *args):
-        from sympy.printing.pretty.stringpict import prettyForm
         # Get brackets
         pform = self._print_contents_pretty(printer, *args)
         lbracket, rbracket = self._pretty_brackets(
             pform.height(), printer._use_unicode)
         # Put together state
-        pform = prettyForm(*pform.left(lbracket))
-        pform = prettyForm(*pform.right(rbracket))
+        pform = pform.left(lbracket)
+        pform = pform.right(rbracket)
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -7,7 +7,6 @@ from sympy.core.power import Pow
 from sympy.core.sympify import sympify
 from sympy.matrices.dense import DenseMatrix as Matrix
 from sympy.matrices.immutable import ImmutableDenseMatrix as ImmutableMatrix
-from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import QuantumError
 from sympy.physics.quantum.dagger import Dagger
@@ -177,19 +176,18 @@ class TensorProduct(Expr):
                 length_i = len(self.args[i].args)
                 for j in range(length_i):
                     part_pform = printer._print(self.args[i].args[j], *args)
-                    next_pform = prettyForm(*next_pform.right(part_pform))
+                    next_pform = next_pform.right(part_pform)
                     if j != length_i - 1:
-                        next_pform = prettyForm(*next_pform.right(', '))
+                        next_pform = next_pform.right(', ')
 
                 if len(self.args[i].args) > 1:
-                    next_pform = prettyForm(
-                        *next_pform.parens(left='{', right='}'))
-                pform = prettyForm(*pform.right(next_pform))
+                    next_pform = next_pform.parens(left='{', right='}')
+                pform = pform.right(next_pform)
                 if i != length - 1:
-                    pform = prettyForm(*pform.right(',' + ' '))
+                    pform = pform.right(',' + ' ')
 
-            pform = prettyForm(*pform.left(self.args[0].lbracket))
-            pform = prettyForm(*pform.right(self.args[0].rbracket))
+            pform = pform.left(self.args[0].lbracket)
+            pform = pform.right(self.args[0].rbracket)
             return pform
 
         length = len(self.args)
@@ -197,15 +195,13 @@ class TensorProduct(Expr):
         for i in range(length):
             next_pform = printer._print(self.args[i], *args)
             if isinstance(self.args[i], (Add, Mul)):
-                next_pform = prettyForm(
-                    *next_pform.parens(left='(', right=')')
-                )
-            pform = prettyForm(*pform.right(next_pform))
+                next_pform = next_pform.parens(left='(', right=')')
+            pform = pform.right(next_pform)
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right('\N{N-ARY CIRCLED TIMES OPERATOR}' + ' '))
+                    pform = pform.right('\N{N-ARY CIRCLED TIMES OPERATOR}' + ' ')
                 else:
-                    pform = prettyForm(*pform.right('x' + ' '))
+                    pform = pform.right('x' + ' ')
         return pform
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -181,7 +181,7 @@ class TensorProduct(Expr):
                         next_pform = next_pform.right(', ')
 
                 if len(self.args[i].args) > 1:
-                    next_pform = next_pform.parens(left='{', right='}')
+                    next_pform = next_pform.parenthesis(left='{', right='}')
                 pform = pform.right(next_pform)
                 if i != length - 1:
                     pform = pform.right(',' + ' ')
@@ -195,7 +195,7 @@ class TensorProduct(Expr):
         for i in range(length):
             next_pform = printer._print(self.args[i], *args)
             if isinstance(self.args[i], (Add, Mul)):
-                next_pform = next_pform.parens(left='(', right=')')
+                next_pform = next_pform.parenthesis(left='(', right=')')
             pform = pform.right(next_pform)
             if i != length - 1:
                 if printer._use_unicode:

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -235,7 +235,7 @@ class Dyadic(Printable, EvalfMixin):
                     elif v[0] != 0:
                         if isinstance(v[0], Add):
                             arg_str = mpp._print(
-                                v[0]).parens()[0]
+                                v[0]).parenthesis()[0]
                         else:
                             arg_str = mpp.doprint(v[0])
                         if arg_str.startswith("-"):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -265,7 +265,7 @@ class Vector(Printable, EvalfMixin):
             pa = printer._print(a)
             pb = printer._print(b)
             if a.is_Add:
-                pa = prettyForm(*pa.parens())
+                pa = prettyForm(*pa.parenthesis())
             return printer._print_seq([pa, pb], delimiter=' ')
 
         for M, N in self.args:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -77,7 +77,7 @@ class PrettyPrinter(Printer):
         return prettyForm(e)
 
     def _print_atan2(self, e):
-        pform = self._print_seq(e.args).parens()
+        pform = self._print_seq(e.args).parenthesis()
         pform = pform.left('atan2')
         return pform
 
@@ -185,7 +185,7 @@ class PrettyPrinter(Printer):
         pform = self._print(x)
         # Add parentheses if needed
         if not ((x.is_Integer and x.is_nonnegative) or x.is_Symbol):
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform.left('!')
         return pform
 
@@ -194,7 +194,7 @@ class PrettyPrinter(Printer):
         pform = self._print(x)
         # Add parentheses if needed
         if not ((x.is_Integer and x.is_nonnegative) or x.is_Symbol):
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform.right('!')
         return pform
 
@@ -203,7 +203,7 @@ class PrettyPrinter(Printer):
         pform = self._print(x)
         # Add parentheses if needed
         if not ((x.is_Integer and x.is_nonnegative) or x.is_Symbol):
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform.right('!!')
         return pform
 
@@ -217,7 +217,7 @@ class PrettyPrinter(Printer):
 
         pform = k_pform.above(bar)
         pform = pform.above(n_pform)
-        pform = pform.parens('(', ')')
+        pform = pform.parenthesis('(', ')')
 
         pform.baseline = (pform.baseline + 1)//2
 
@@ -242,7 +242,7 @@ class PrettyPrinter(Printer):
                 return self._print_Implies(arg, altchar=pretty_atom('NotArrow'))
 
             if arg.is_Boolean and not arg.is_Not:
-                pform = pform.parens()
+                pform = pform.parenthesis()
 
             return pform.left(pretty_atom('Not'))
         else:
@@ -256,13 +256,13 @@ class PrettyPrinter(Printer):
         pform = self._print(arg)
 
         if arg.is_Boolean and not arg.is_Not:
-            pform = pform.parens()
+            pform = pform.parenthesis()
 
         for arg in args[1:]:
             pform_arg = self._print(arg)
 
             if arg.is_Boolean and not arg.is_Not:
-                pform_arg = pform_arg.parens()
+                pform_arg = pform_arg.parenthesis()
 
             pform = pform.right(' %s ' % char)
             pform = pform.right(pform_arg)
@@ -317,13 +317,13 @@ class PrettyPrinter(Printer):
 
     def _print_Abs(self, e):
         pform = self._print(e.args[0])
-        pform = pform.parens('|', '|')
+        pform = pform.parenthesis('|', '|')
         return pform
 
     def _print_floor(self, e):
         if self._use_unicode:
             pform = self._print(e.args[0])
-            pform = pform.parens('lfloor', 'rfloor')
+            pform = pform.parenthesis('lfloor', 'rfloor')
             return pform
         else:
             return self._print_Function(e)
@@ -331,7 +331,7 @@ class PrettyPrinter(Printer):
     def _print_ceiling(self, e):
         if self._use_unicode:
             pform = self._print(e.args[0])
-            pform = pform.parens('lceil', 'rceil')
+            pform = pform.parenthesis('lceil', 'rceil')
             return pform
         else:
             return self._print_Function(e)
@@ -358,7 +358,7 @@ class PrettyPrinter(Printer):
                 x = x.right(' ')
                 x = x.right(ds)
 
-        f = self._print(deriv.expr).parens()
+        f = self._print(deriv.expr).parenthesis()
         f.binding=prettyForm.FUNC
 
         pform = prettyForm(deriv_symbol)
@@ -378,13 +378,13 @@ class PrettyPrinter(Printer):
         # for Empty Cycle
         if dc == Cycle():
             cyc = stringPict('')
-            return cyc.parens()
+            return cyc.parenthesis()
 
         dc_list = Permutation(dc.list()).cyclic_form
         # for Identity Cycle
         if dc_list == []:
             cyc = self._print(dc.size - 1)
-            return cyc.parens()
+            return cyc.parenthesis()
 
         cyc = stringPict('')
         for i in dc_list:
@@ -426,7 +426,7 @@ class PrettyPrinter(Printer):
             else:
                 col = col.left(" ")
             result = result.right(col)
-        return result.parens()
+        return result.parenthesis()
 
 
     def _print_Integral(self, integral):
@@ -437,7 +437,7 @@ class PrettyPrinter(Printer):
         prettyF = self._print(f)
         # XXX generalize parens
         if f.is_Add:
-            prettyF = prettyF.parens()
+            prettyF = prettyF.parenthesis()
 
         # dx dy dz ...
         arg = prettyF
@@ -445,7 +445,7 @@ class PrettyPrinter(Printer):
             prettyArg = self._print(x[0])
             # XXX qparens (parens if needs-parens)
             if prettyArg.width() > 1:
-                prettyArg = prettyArg.parens()
+                prettyArg = prettyArg.parenthesis()
 
             arg = arg.right(' d', prettyArg)
 
@@ -620,7 +620,7 @@ class PrettyPrinter(Printer):
         prettyF = self._print(f)
 
         if f.is_Add:  # add parens
-            prettyF = prettyF.parens()
+            prettyF = prettyF.parenthesis()
 
         H = prettyF.height() + 2
 
@@ -672,7 +672,7 @@ class PrettyPrinter(Printer):
 
         E = self._print(e)
         if precedence(e) <= PRECEDENCE["Mul"]:
-            E = E.parens('(', ')')
+            E = E.parenthesis('(', ')')
         Lim = prettyForm('lim')
 
         LimArg = self._print(z)
@@ -766,7 +766,7 @@ class PrettyPrinter(Printer):
     def _print_MatrixBase(self, e, lparens='[', rparens=']'):
         D = self._print_matrix_contents(e)
         D.baseline = D.height()//2
-        D = D.parens(lparens, rparens)
+        D = D.parenthesis(lparens, rparens)
         return D
 
     def _print_Determinant(self, e):
@@ -777,7 +777,7 @@ class PrettyPrinter(Printer):
                 return self._print_MatrixBase(mat.blocks, lparens='|', rparens='|')
             D = self._print(mat)
             D.baseline = D.height()//2
-            return D.parens('|', '|')
+            return D.parenthesis('|', '|')
         else:
             return self._print_MatrixBase(mat, lparens='|', rparens='|')
 
@@ -801,7 +801,7 @@ class PrettyPrinter(Printer):
 
     def _print_Trace(self, e):
         D = self._print(e.arg)
-        D = D.parens('(',')')
+        D = D.parenthesis('(',')')
         D.baseline = D.height()//2
         D = D.left('\n'*(0) + 'tr')
         return D
@@ -815,9 +815,9 @@ class PrettyPrinter(Printer):
                     Symbol(expr.parent.name + '_%d%d' % (expr.i, expr.j)))
         else:
             prettyFunc = self._print(expr.parent)
-            prettyFunc = prettyFunc.parens()
+            prettyFunc = prettyFunc.parenthesis()
             prettyIndices = self._print_seq((expr.i, expr.j), delimiter=', '
-                    ).parens(left='[', right=']')
+                    ).parenthesis(left='[', right=']')
             pform = prettyForm(binding=prettyForm.FUNC,
                     *stringPict.next(prettyFunc, prettyIndices))
 
@@ -833,7 +833,7 @@ class PrettyPrinter(Printer):
         from sympy.matrices import MatrixSymbol
         prettyFunc = self._print(m.parent)
         if not isinstance(m.parent, MatrixSymbol):
-            prettyFunc = prettyFunc.parens()
+            prettyFunc = prettyFunc.parenthesis()
         def ppslice(x, dim):
             x = list(x)
             if x[2] == 1:
@@ -844,7 +844,7 @@ class PrettyPrinter(Printer):
                 x[1] = ''
             return self._print_seq(x, delimiter=':')
         prettyArgs = str(self._print_seq((ppslice(m.rowslice, m.parent.rows),
-            ppslice(m.colslice, m.parent.cols)), delimiter=', ').parens(left='[', right=']'))
+            ppslice(m.colslice, m.parent.cols)), delimiter=', ').parenthesis(left='[', right=']'))
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
@@ -861,7 +861,7 @@ class PrettyPrinter(Printer):
         from sympy.matrices import MatrixSymbol, BlockMatrix
         if (not isinstance(mat, MatrixSymbol) and
             not isinstance(mat, BlockMatrix) and mat.is_MatrixExpr):
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform**(prettyForm('T'))
         return pform
 
@@ -875,7 +875,7 @@ class PrettyPrinter(Printer):
         from sympy.matrices import MatrixSymbol, BlockMatrix
         if (not isinstance(mat, MatrixSymbol) and
             not isinstance(mat, BlockMatrix) and mat.is_MatrixExpr):
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform**dag
         return pform
 
@@ -909,7 +909,7 @@ class PrettyPrinter(Printer):
         for i, a in enumerate(args):
             if (isinstance(a, (Add, MatAdd, HadamardProduct, KroneckerProduct))
                     and len(expr.args) > 1):
-                args[i] = self._print(a).parens()
+                args[i] = self._print(a).parenthesis()
             else:
                 args[i] = self._print(a)
 
@@ -944,7 +944,7 @@ class PrettyPrinter(Printer):
         pform = self._print(expr.base)
         from sympy.matrices import MatrixSymbol
         if not isinstance(expr.base, MatrixSymbol) and expr.base.is_MatrixExpr:
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform**(self._print(expr.exp))
         return pform
 
@@ -968,7 +968,7 @@ class PrettyPrinter(Printer):
         pretty_base = self._print(expr.base)
         pretty_exp = self._print(expr.exp)
         if precedence(expr.exp) < PRECEDENCE["Mul"]:
-            pretty_exp = pretty_exp.parens()
+            pretty_exp = pretty_exp.parenthesis()
         pretty_circ_exp = prettyForm(
             binding=prettyForm.LINE,
             *stringPict.next(circ, pretty_exp)
@@ -987,7 +987,7 @@ class PrettyPrinter(Printer):
 
     def _print_FunctionMatrix(self, X):
         D = self._print(X.lamda.expr)
-        D = D.parens('[', ']')
+        D = D.parenthesis('[', ']')
         return D
 
     def _print_TransferFunction(self, expr):
@@ -1001,7 +1001,7 @@ class PrettyPrinter(Printer):
     def _print_Series(self, expr):
         args = list(expr.args)
         for i, a in enumerate(expr.args):
-            args[i] = self._print(a).parens()
+            args[i] = self._print(a).parenthesis()
         return prettyForm.__mul__(*args)
 
     def _print_MIMOSeries(self, expr):
@@ -1012,7 +1012,7 @@ class PrettyPrinter(Printer):
             if (isinstance(a, MIMOParallel) and len(expr.args) > 1):
                 expression = self._print(a)
                 expression.baseline = expression.height()//2
-                pretty_args.append(expression.parens())
+                pretty_args.append(expression.parenthesis())
             else:
                 expression = self._print(a)
                 expression.baseline = expression.height()//2
@@ -1093,7 +1093,7 @@ class PrettyPrinter(Printer):
         _feedback = prettyForm(*stringPict.next(inv_mat))
         _feedback = stringPict.right(prettyForm("I + "), _feedback)  if expr.sign == -1 \
             else stringPict.right(prettyForm("I - "), _feedback)
-        _feedback = stringPict.parens(_feedback)
+        _feedback = stringPict.parenthesis(_feedback)
         _feedback.baseline = 0
         _feedback = stringPict.right(_feedback, stringPict('-1 '))
         _feedback.baseline = _feedback.height()//2
@@ -1151,7 +1151,7 @@ class PrettyPrinter(Printer):
                     #We always wrap the measure numbers in
                     #parentheses
                     arg_str = str(self._print(
-                        v).parens())
+                        v).parenthesis())
 
                     o1.append(arg_str + ' ' + k._pretty_form)
                 vectstrs.append(k._pretty_form)
@@ -1303,7 +1303,7 @@ class PrettyPrinter(Printer):
     def _print_TensMul(self, expr):
         sign, args = expr._get_args_for_traditional_printer()
         args = [
-            self._print(i).parens() if
+            self._print(i).parenthesis() if
             precedence_traditional(i) < PRECEDENCE["Mul"] else self._print(i)
             for i in args
         ]
@@ -1315,7 +1315,7 @@ class PrettyPrinter(Printer):
 
     def _print_TensAdd(self, expr):
         args = [
-            self._print(i).parens() if
+            self._print(i).parenthesis() if
             precedence_traditional(i) < PRECEDENCE["Mul"] else self._print(i)
             for i in expr.args
         ]
@@ -1344,7 +1344,7 @@ class PrettyPrinter(Printer):
                 x = x.right(' ')
                 x = x.right(ds)
 
-        f = self._print(deriv.expr).parens()
+        f = self._print(deriv.expr).parenthesis()
         f.binding = prettyForm.FUNC
 
         pform = prettyForm(deriv_symbol)
@@ -1409,7 +1409,7 @@ class PrettyPrinter(Printer):
 
             D = D.below(D_row)
 
-        D = D.parens('{', '')
+        D = D.parenthesis('{', '')
         D.baseline = D.height()//2
         D.binding = prettyForm.OPEN
         return D
@@ -1471,7 +1471,7 @@ class PrettyPrinter(Printer):
         D = self._hprint_vseparator(D, P)
 
         # add parens
-        D = D.parens('(', ')')
+        D = D.parenthesis('(', ')')
 
         # create the F symbol
         above = D.height()//2 - 1
@@ -1532,7 +1532,7 @@ class PrettyPrinter(Printer):
         D = self._hprint_vseparator(D, P)
 
         # add parens
-        D = D.parens('(', ')')
+        D = D.parenthesis('(', ')')
 
         # create the G symbol
         above = D.height()//2 - 1
@@ -1613,7 +1613,7 @@ class PrettyPrinter(Printer):
         if func_name:
             prettyFunc = self._print(Symbol(func_name))
         else:
-            prettyFunc = self._print(func).parens()
+            prettyFunc = self._print(func).parenthesis()
 
         if elementwise:
             if self._use_unicode:
@@ -1626,7 +1626,7 @@ class PrettyPrinter(Printer):
                 *stringPict.next(prettyFunc, circ)
             )
 
-        prettyArgs = self._print_seq(args, delimiter=delimiter).parens(
+        prettyArgs = self._print_seq(args, delimiter=delimiter).parenthesis(
                                                  left=left, right=right)
 
         pform = prettyForm(
@@ -1691,7 +1691,7 @@ class PrettyPrinter(Printer):
     def _print_Heaviside(self, e):
         func_name = greek_unicode['theta'] if self._use_unicode else 'Heaviside'
         if e.args[1] is S.Half:
-            pform = self._print(e.args[0]).parens()
+            pform = self._print(e.args[0]).parenthesis()
             pform = pform.left(func_name)
             return pform
         else:
@@ -1760,7 +1760,7 @@ class PrettyPrinter(Printer):
                 pform = pform.right(self._print(expr.point))
             else:
                 pform = pform.right(self._print(expr.point[0]))
-        pform = pform.parens()
+        pform = pform.parenthesis()
         pform = pform.left("O")
         return pform
 
@@ -1808,15 +1808,15 @@ class PrettyPrinter(Printer):
             if len(e.args) == 2:
                 a = prettyForm(greek_unicode['delta'])
                 b = self._print(e.args[1])
-                b = b.parens()
+                b = b.parenthesis()
                 c = self._print(e.args[0])
-                c = c.parens()
+                c = c.parenthesis()
                 pform = a**b
                 pform = pform.right(' ')
                 pform = pform.right(c)
                 return pform
             pform = self._print(e.args[0])
-            pform = pform.parens()
+            pform = pform.parenthesis()
             pform = pform.left(greek_unicode['delta'])
             return pform
         else:
@@ -1832,7 +1832,7 @@ class PrettyPrinter(Printer):
         # This needs a special case since otherwise it comes out as greek
         # letter chi...
         prettyFunc = prettyForm("Chi")
-        prettyArgs = self._print_seq(e.args).parens()
+        prettyArgs = self._print_seq(e.args).parenthesis()
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
@@ -1850,13 +1850,13 @@ class PrettyPrinter(Printer):
         else:
             pforma1 = self._print(e.args[1])
             pform = self._hprint_vseparator(pforma0, pforma1)
-        pform = pform.parens()
+        pform = pform.parenthesis()
         pform = pform.left('E')
         return pform
 
     def _print_elliptic_k(self, e):
         pform = self._print(e.args[0])
-        pform = pform.parens()
+        pform = pform.parenthesis()
         pform = pform.left('K')
         return pform
 
@@ -1864,7 +1864,7 @@ class PrettyPrinter(Printer):
         pforma0 = self._print(e.args[0])
         pforma1 = self._print(e.args[1])
         pform = self._hprint_vseparator(pforma0, pforma1)
-        pform = pform.parens()
+        pform = pform.parenthesis()
         pform = pform.left('F')
         return pform
 
@@ -1879,7 +1879,7 @@ class PrettyPrinter(Printer):
             pforma = self._hprint_vseparator(pforma1, pforma2, ifascii_nougly=False)
             pforma = pforma.left('; ')
             pform = pforma.left(pforma0)
-        pform = pform.parens()
+        pform = pform.parenthesis()
         pform = pform.left(name)
         return pform
 
@@ -1899,7 +1899,7 @@ class PrettyPrinter(Printer):
     def _print_Mod(self, expr):
         pform = self._print(expr.args[0])
         if pform.binding > prettyForm.MUL:
-            pform = pform.parens()
+            pform = pform.parenthesis()
         pform = pform.right(' mod ')
         pform = pform.right(self._print(expr.args[1]))
         pform.binding = prettyForm.OPEN
@@ -1922,7 +1922,7 @@ class PrettyPrinter(Printer):
 
             if (pform.binding > prettyForm.NEG
                 or pform.binding == prettyForm.ADD):
-                p = pform.parens()
+                p = pform.parenthesis()
             else:
                 p = pform
             p = stringPict.next(pform_neg, p)
@@ -1946,7 +1946,7 @@ class PrettyPrinter(Printer):
                 pform = self._print(-term)
                 pforms.append(pretty_negative(pform, i))
             elif term.is_Relational:
-                pforms.append(self._print(term).parens())
+                pforms.append(self._print(term).parenthesis())
             else:
                 pforms.append(self._print(term))
 
@@ -2070,7 +2070,7 @@ class PrettyPrinter(Printer):
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 
         if b.is_Relational:
-            return self._print(b).parens().__pow__(self._print(e))
+            return self._print(b).parenthesis().__pow__(self._print(e))
 
         return self._print(b)**self._print(e)
 
@@ -2251,7 +2251,7 @@ class PrettyPrinter(Printer):
             cond = self._print(ts.condition)
             if self._use_unicode:
                 cond = self._print(cond)
-                cond = cond.parens()
+                cond = cond.parenthesis()
 
         if ts.base_set is S.UniversalSet:
             return self._hprint_vseparator(variables, cond, left="{",
@@ -2300,7 +2300,7 @@ class PrettyPrinter(Printer):
         return self._print_Add(s.infinite)
 
     def _print_SetExpr(self, se):
-        pretty_set = self._print(se.set).parens()
+        pretty_set = self._print(se.set).parenthesis()
         pretty_name = self._print(Symbol("SetExpr"))
         return pretty_name.right(pretty_set)
 
@@ -2336,7 +2336,7 @@ class PrettyPrinter(Printer):
         for item in seq:
             pform = self._print(item)
             if parenthesize(item):
-                pform = pform.parens()
+                pform = pform.parenthesis()
             if pforms:
                 pforms.append(delimiter)
             pforms.append(pform)
@@ -2346,7 +2346,7 @@ class PrettyPrinter(Printer):
         else:
             s = prettyForm(*stringPict.next(*pforms))
 
-        s = s.parens(left, right, ifascii_nougly=ifascii_nougly)
+        s = s.parenthesis(left, right, ifascii_nougly=ifascii_nougly)
         return s
 
     def join(self, delimiter, args):
@@ -2370,7 +2370,7 @@ class PrettyPrinter(Printer):
     def _print_tuple(self, t):
         if len(t) == 1:
             ptuple = prettyForm(*stringPict.next(self._print(t[0]), ','))
-            return ptuple.parens('(', ')', ifascii_nougly=True)
+            return ptuple.parenthesis('(', ')', ifascii_nougly=True)
         else:
             return self._print_seq(t, '(', ')')
 
@@ -2398,7 +2398,7 @@ class PrettyPrinter(Printer):
             return prettyForm('set()')
         items = sorted(s, key=default_sort_key)
         pretty = self._print_seq(items)
-        pretty = pretty.parens('{', '}', ifascii_nougly=True)
+        pretty = pretty.parenthesis('{', '}', ifascii_nougly=True)
         return pretty
 
     def _print_frozenset(self, s):
@@ -2406,8 +2406,8 @@ class PrettyPrinter(Printer):
             return prettyForm('frozenset()')
         items = sorted(s, key=default_sort_key)
         pretty = self._print_seq(items)
-        pretty = pretty.parens('{', '}', ifascii_nougly=True)
-        pretty = pretty.parens('(', ')', ifascii_nougly=True)
+        pretty = pretty.parenthesis('{', '}', ifascii_nougly=True)
+        pretty = pretty.parenthesis('(', ')', ifascii_nougly=True)
         pretty = prettyForm(*stringPict.next(type(s).__name__, pretty))
         return pretty
 
@@ -2440,7 +2440,7 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexRootOf(self, expr):
         args = [self._print_Add(expr.expr, order='lex'), expr.index]
-        pform = self._print_seq(args).parens()
+        pform = self._print_seq(args).parenthesis()
         pform = pform.left('CRootOf')
         return pform
 
@@ -2450,7 +2450,7 @@ class PrettyPrinter(Printer):
         if expr.fun is not S.IdentityFunction:
             args.append(self._print(expr.fun))
 
-        pform = self._print_seq(args).parens()
+        pform = self._print_seq(args).parenthesis()
         pform = pform.left('RootSum')
 
         return pform
@@ -2533,7 +2533,7 @@ class PrettyPrinter(Printer):
     def _print_GroebnerBasis(self, basis):
         exprs = [ self._print_Add(arg, order=basis.order)
                   for arg in basis.exprs ]
-        exprs = self.join(", ", exprs).parens(left="[", right="]")
+        exprs = self.join(", ", exprs).parenthesis(left="[", right="]")
 
         gens = [ self._print(gen) for gen in basis.gens ]
 
@@ -2542,14 +2542,14 @@ class PrettyPrinter(Printer):
 
         pform = self.join(", ", [exprs] + gens + [domain, order])
 
-        pform = pform.parens()
+        pform = pform.parenthesis()
         pform = pform.left(basis.__class__.__name__)
 
         return pform
 
     def _print_Subs(self, e):
         pform = self._print(e.expr)
-        pform = pform.parens()
+        pform = pform.parenthesis()
 
         h = pform.height() if pform.height() > 1 else 2
         rvert = stringPict(vobj('|', h), baseline=pform.baseline)
@@ -2577,7 +2577,7 @@ class PrettyPrinter(Printer):
         m, x = e.args
         # TODO: copy-pasted from _print_Function: can we do better?
         prettyFunc = pform
-        prettyArgs = self._print_seq([x]).parens()
+        prettyArgs = self._print_seq([x]).parenthesis()
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
         pform.prettyFunc = prettyFunc
@@ -2778,7 +2778,7 @@ class PrettyPrinter(Printer):
             return self._print(d + ' ' + pretty_symbol(string))
         else:
             pform = self._print(field)
-            pform = pform.parens()
+            pform = pform.parenthesis()
             return pform.left(d)
 
     def _print_Tr(self, p):
@@ -2790,7 +2790,7 @@ class PrettyPrinter(Printer):
 
     def _print_primenu(self, e):
         pform = self._print(e.args[0])
-        pform = pform.parens()
+        pform = pform.parenthesis()
         if self._use_unicode:
             pform = pform.left(greek_unicode['nu'])
         else:
@@ -2799,7 +2799,7 @@ class PrettyPrinter(Printer):
 
     def _print_primeomega(self, e):
         pform = self._print(e.args[0])
-        pform = pform.parens()
+        pform = pform.parenthesis()
         if self._use_unicode:
             pform = pform.left(greek_unicode['Omega'])
         else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -27,6 +27,10 @@ pprint_use_unicode = pretty_use_unicode
 pprint_try_use_unicode = pretty_try_use_unicode
 
 
+# TODO: use high-level methods from stringPict
+# instead of stack/next methods to simplify
+# this code.
+
 class PrettyPrinter(Printer):
     """Printer, which converts an expression into 2D ASCII-art figure."""
     printmethod = "_pretty"
@@ -2044,39 +2048,13 @@ class PrettyPrinter(Printer):
                  or (base.is_Integer and base.is_nonnegative))):
             return bpretty.left(nth_root[2])
 
-        # Construct root sign, start with the \/ shape
-        _zZ = xobj('/', 1)
-        rootsign = xobj('\\', 1) + _zZ
-        # Constructing the number to put on root
         rpretty = self._print(root)
-        # roots look bad if they are not a single line
         if rpretty.height() != 1:
             return self._print(base)**self._print(1/root)
-        # If power is half, no number should appear on top of root sign
-        exp = '' if root == 2 else str(rpretty).ljust(2)
-        if len(exp) > 2:
-            rootsign = ' '*(len(exp) - 2) + rootsign
-        # Stack the exponent
-        rootsign = stringPict(exp + '\n' + rootsign)
-        rootsign.baseline = 0
-        # Diagonal: length is one less than height of base
-        linelength = bpretty.height() - 1
-        diagonal = stringPict('\n'.join(
-            ' '*(linelength - i - 1) + _zZ + ' '*i
-            for i in range(linelength)
-        ))
-        # Put baseline just below lowest line: next to exp
-        diagonal.baseline = linelength - 1
-        # Make the root symbol
-        rootsign = rootsign.right(diagonal)
-        # Det the baseline to match contents to fix the height
-        # but if the height of bpretty is one, the rootsign must be one higher
-        rootsign.baseline = max(1, bpretty.baseline)
-        #build result
-        s = prettyForm(hobj('_', 2 + bpretty.width()))
-        s = bpretty.above(s)
-        s = s.left(rootsign)
-        return s
+
+        if root == 2:
+            return bpretty.root()
+        return bpretty.root(rpretty)
 
     def _print_Pow(self, power):
         from sympy.simplify.simplify import fraction

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -73,8 +73,8 @@ class PrettyPrinter(Printer):
         return prettyForm(e)
 
     def _print_atan2(self, e):
-        pform = prettyForm(*self._print_seq(e.args).parens())
-        pform = prettyForm(*pform.left('atan2'))
+        pform = self._print_seq(e.args).parens()
+        pform = pform.left('atan2')
         return pform
 
     def _print_Symbol(self, e, bold_name=False):
@@ -96,58 +96,58 @@ class PrettyPrinter(Printer):
         vec1 = e._expr1
         vec2 = e._expr2
         pform = self._print(vec2)
-        pform = prettyForm(*pform.left('('))
-        pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('MULTIPLICATION SIGN'))))
-        pform = prettyForm(*pform.left(')'))
-        pform = prettyForm(*pform.left(self._print(vec1)))
-        pform = prettyForm(*pform.left('('))
+        pform = pform.left('(')
+        pform = pform.right(')')
+        pform = pform.left(self._print(U('MULTIPLICATION SIGN')))
+        pform = pform.left(')')
+        pform = pform.left(self._print(vec1))
+        pform = pform.left('(')
         return pform
 
     def _print_Curl(self, e):
         vec = e._expr
         pform = self._print(vec)
-        pform = prettyForm(*pform.left('('))
-        pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('MULTIPLICATION SIGN'))))
-        pform = prettyForm(*pform.left(self._print(U('NABLA'))))
+        pform = pform.left('(')
+        pform = pform.right(')')
+        pform = pform.left(self._print(U('MULTIPLICATION SIGN')))
+        pform = pform.left(self._print(U('NABLA')))
         return pform
 
     def _print_Divergence(self, e):
         vec = e._expr
         pform = self._print(vec)
-        pform = prettyForm(*pform.left('('))
-        pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('DOT OPERATOR'))))
-        pform = prettyForm(*pform.left(self._print(U('NABLA'))))
+        pform = pform.left('(')
+        pform = pform.right(')')
+        pform = pform.left(self._print(U('DOT OPERATOR')))
+        pform = pform.left(self._print(U('NABLA')))
         return pform
 
     def _print_Dot(self, e):
         vec1 = e._expr1
         vec2 = e._expr2
         pform = self._print(vec2)
-        pform = prettyForm(*pform.left('('))
-        pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('DOT OPERATOR'))))
-        pform = prettyForm(*pform.left(')'))
-        pform = prettyForm(*pform.left(self._print(vec1)))
-        pform = prettyForm(*pform.left('('))
+        pform = pform.left('(')
+        pform = pform.right(')')
+        pform = pform.left(self._print(U('DOT OPERATOR')))
+        pform = pform.left(')')
+        pform = pform.left(self._print(vec1))
+        pform = pform.left('(')
         return pform
 
     def _print_Gradient(self, e):
         func = e._expr
         pform = self._print(func)
-        pform = prettyForm(*pform.left('('))
-        pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('NABLA'))))
+        pform = pform.left('(')
+        pform = pform.right(')')
+        pform = pform.left(self._print(U('NABLA')))
         return pform
 
     def _print_Laplacian(self, e):
         func = e._expr
         pform = self._print(func)
-        pform = prettyForm(*pform.left('('))
-        pform = prettyForm(*pform.right(')'))
-        pform = prettyForm(*pform.left(self._print(U('INCREMENT'))))
+        pform = pform.left('(')
+        pform = pform.right(')')
+        pform = pform.left(self._print(U('INCREMENT')))
         return pform
 
     def _print_Atom(self, e):
@@ -181,8 +181,8 @@ class PrettyPrinter(Printer):
         pform = self._print(x)
         # Add parentheses if needed
         if not ((x.is_Integer and x.is_nonnegative) or x.is_Symbol):
-            pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left('!'))
+            pform = pform.parens()
+        pform = pform.left('!')
         return pform
 
     def _print_factorial(self, e):
@@ -190,8 +190,8 @@ class PrettyPrinter(Printer):
         pform = self._print(x)
         # Add parentheses if needed
         if not ((x.is_Integer and x.is_nonnegative) or x.is_Symbol):
-            pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.right('!'))
+            pform = pform.parens()
+        pform = pform.right('!')
         return pform
 
     def _print_factorial2(self, e):
@@ -199,8 +199,8 @@ class PrettyPrinter(Printer):
         pform = self._print(x)
         # Add parentheses if needed
         if not ((x.is_Integer and x.is_nonnegative) or x.is_Symbol):
-            pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.right('!!'))
+            pform = pform.parens()
+        pform = pform.right('!!')
         return pform
 
     def _print_binomial(self, e):
@@ -211,9 +211,9 @@ class PrettyPrinter(Printer):
 
         bar = ' '*max(n_pform.width(), k_pform.width())
 
-        pform = prettyForm(*k_pform.above(bar))
-        pform = prettyForm(*pform.above(n_pform))
-        pform = prettyForm(*pform.parens('(', ')'))
+        pform = k_pform.above(bar)
+        pform = pform.above(n_pform)
+        pform = pform.parens('(', ')')
 
         pform.baseline = (pform.baseline + 1)//2
 
@@ -238,9 +238,9 @@ class PrettyPrinter(Printer):
                 return self._print_Implies(arg, altchar=pretty_atom('NotArrow'))
 
             if arg.is_Boolean and not arg.is_Not:
-                pform = prettyForm(*pform.parens())
+                pform = pform.parens()
 
-            return prettyForm(*pform.left(pretty_atom('Not')))
+            return pform.left(pretty_atom('Not'))
         else:
             return self._print_Function(e)
 
@@ -252,16 +252,16 @@ class PrettyPrinter(Printer):
         pform = self._print(arg)
 
         if arg.is_Boolean and not arg.is_Not:
-            pform = prettyForm(*pform.parens())
+            pform = pform.parens()
 
         for arg in args[1:]:
             pform_arg = self._print(arg)
 
             if arg.is_Boolean and not arg.is_Not:
-                pform_arg = prettyForm(*pform_arg.parens())
+                pform_arg = pform_arg.parens()
 
-            pform = prettyForm(*pform.right(' %s ' % char))
-            pform = prettyForm(*pform.right(pform_arg))
+            pform = pform.right(' %s ' % char)
+            pform = pform.right(pform_arg)
 
         return pform
 
@@ -309,17 +309,17 @@ class PrettyPrinter(Printer):
 
     def _print_conjugate(self, e):
         pform = self._print(e.args[0])
-        return prettyForm( *pform.above( hobj('_', pform.width())) )
+        return pform.above( hobj('_', pform.width()))
 
     def _print_Abs(self, e):
         pform = self._print(e.args[0])
-        pform = prettyForm(*pform.parens('|', '|'))
+        pform = pform.parens('|', '|')
         return pform
 
     def _print_floor(self, e):
         if self._use_unicode:
             pform = self._print(e.args[0])
-            pform = prettyForm(*pform.parens('lfloor', 'rfloor'))
+            pform = pform.parens('lfloor', 'rfloor')
             return pform
         else:
             return self._print_Function(e)
@@ -327,7 +327,7 @@ class PrettyPrinter(Printer):
     def _print_ceiling(self, e):
         if self._use_unicode:
             pform = self._print(e.args[0])
-            pform = prettyForm(*pform.parens('lceil', 'rceil'))
+            pform = pform.parens('lceil', 'rceil')
             return pform
         else:
             return self._print_Function(e)
@@ -342,7 +342,7 @@ class PrettyPrinter(Printer):
 
         for sym, num in reversed(deriv.variable_count):
             s = self._print(sym)
-            ds = prettyForm(*s.left(deriv_symbol))
+            ds = s.left(deriv_symbol)
             count_total_deriv += num
 
             if (not num.is_Integer) or (num > 1):
@@ -351,18 +351,18 @@ class PrettyPrinter(Printer):
             if x is None:
                 x = ds
             else:
-                x = prettyForm(*x.right(' '))
-                x = prettyForm(*x.right(ds))
+                x = x.right(' ')
+                x = x.right(ds)
 
-        f = prettyForm(
-            binding=prettyForm.FUNC, *self._print(deriv.expr).parens())
+        f = self._print(deriv.expr).parens()
+        f.binding=prettyForm.FUNC
 
         pform = prettyForm(deriv_symbol)
 
         if (count_total_deriv > 1) != False:
             pform = pform**prettyForm(str(count_total_deriv))
 
-        pform = prettyForm(*pform.below(stringPict.LINE, x))
+        pform = pform.below(stringPict.LINE, x)
         pform.baseline = pform.baseline + 1
         pform = prettyForm(*stringPict.next(pform, f))
         pform.binding = prettyForm.MUL
@@ -374,18 +374,18 @@ class PrettyPrinter(Printer):
         # for Empty Cycle
         if dc == Cycle():
             cyc = stringPict('')
-            return prettyForm(*cyc.parens())
+            return cyc.parens()
 
         dc_list = Permutation(dc.list()).cyclic_form
         # for Identity Cycle
         if dc_list == []:
             cyc = self._print(dc.size - 1)
-            return prettyForm(*cyc.parens())
+            return cyc.parens()
 
         cyc = stringPict('')
         for i in dc_list:
             l = self._print(str(tuple(i)).replace(',', ''))
-            cyc = prettyForm(*cyc.right(l))
+            cyc = cyc.right(l)
         return cyc
 
     def _print_Permutation(self, expr):
@@ -416,13 +416,13 @@ class PrettyPrinter(Printer):
         for u, l in zip(upper, lower):
             s1 = self._print(u)
             s2 = self._print(l)
-            col = prettyForm(*s1.below(s2))
+            col = s1.below(s2)
             if first:
                 first = False
             else:
-                col = prettyForm(*col.left(" "))
-            result = prettyForm(*result.right(col))
-        return prettyForm(*result.parens())
+                col = col.left(" ")
+            result = result.right(col)
+        return result.parens()
 
 
     def _print_Integral(self, integral):
@@ -433,7 +433,7 @@ class PrettyPrinter(Printer):
         prettyF = self._print(f)
         # XXX generalize parens
         if f.is_Add:
-            prettyF = prettyForm(*prettyF.parens())
+            prettyF = prettyF.parens()
 
         # dx dy dz ...
         arg = prettyF
@@ -441,9 +441,9 @@ class PrettyPrinter(Printer):
             prettyArg = self._print(x[0])
             # XXX qparens (parens if needs-parens)
             if prettyArg.width() > 1:
-                prettyArg = prettyForm(*prettyArg.parens())
+                prettyArg = prettyArg.parens()
 
-            arg = prettyForm(*arg.right(' d', prettyArg))
+            arg = arg.right(' d', prettyArg)
 
         # \int \int \int ...
         firstterm = True
@@ -479,24 +479,24 @@ class PrettyPrinter(Printer):
                     # Add spacing so that endpoint can more easily be
                     # identified with the correct integral sign
                     spc = max(1, 3 - prettyB.width())
-                    prettyB = prettyForm(*prettyB.left(' ' * spc))
+                    prettyB = prettyB.left(' ' * spc)
 
                     spc = max(1, 4 - prettyA.width())
-                    prettyA = prettyForm(*prettyA.right(' ' * spc))
+                    prettyA = prettyA.right(' ' * spc)
 
-                pform = prettyForm(*pform.above(prettyB))
-                pform = prettyForm(*pform.below(prettyA))
+                pform = pform.above(prettyB)
+                pform = pform.below(prettyA)
 
             if not ascii_mode:  # XXX hack
-                pform = prettyForm(*pform.right(' '))
+                pform = pform.right(' ')
 
             if firstterm:
                 s = pform   # first term
                 firstterm = False
             else:
-                s = prettyForm(*s.left(pform))
+                s = s.left(pform)
 
-        pform = prettyForm(*arg.left(s))
+        pform = arg.left(s)
         pform.binding = prettyForm.MUL
         return pform
 
@@ -536,8 +536,8 @@ class PrettyPrinter(Printer):
             if first:
                 sign_height = pretty_sign.height()
 
-            pretty_sign = prettyForm(*pretty_sign.above(pretty_upper))
-            pretty_sign = prettyForm(*pretty_sign.below(pretty_lower))
+            pretty_sign = pretty_sign.above(pretty_upper)
+            pretty_sign = pretty_sign.below(pretty_lower)
 
             if first:
                 pretty_func.baseline = 0
@@ -546,9 +546,9 @@ class PrettyPrinter(Printer):
             height = pretty_sign.height()
             padding = stringPict('')
             padding = prettyForm(*padding.stack(*[' ']*(height - 1)))
-            pretty_sign = prettyForm(*pretty_sign.right(padding))
+            pretty_sign = pretty_sign.right(padding)
 
-            pretty_func = prettyForm(*pretty_sign.right(pretty_func))
+            pretty_func = pretty_sign.right(pretty_func)
 
         pretty_func.baseline = max_upper + sign_height//2
         pretty_func.binding = prettyForm.MUL
@@ -616,7 +616,7 @@ class PrettyPrinter(Printer):
         prettyF = self._print(f)
 
         if f.is_Add:  # add parens
-            prettyF = prettyForm(*prettyF.parens())
+            prettyF = prettyF.parens()
 
         H = prettyF.height() + 2
 
@@ -639,8 +639,8 @@ class PrettyPrinter(Printer):
             if first:
                 sign_height = prettySign.height()
 
-            prettySign = prettyForm(*prettySign.above(prettyUpper))
-            prettySign = prettyForm(*prettySign.below(prettyLower))
+            prettySign = prettySign.above(prettyUpper)
+            prettySign = prettySign.below(prettyLower)
 
             if first:
                 # change F baseline so it centers on the sign
@@ -651,9 +651,9 @@ class PrettyPrinter(Printer):
             # put padding to the right
             pad = stringPict('')
             pad = prettyForm(*pad.stack(*[' ']*h))
-            prettySign = prettyForm(*prettySign.right(pad))
+            prettySign = prettySign.right(pad)
             # put the present prettyF to the right
-            prettyF = prettyForm(*prettySign.right(prettyF))
+            prettyF = prettySign.right(prettyF)
 
         # adjust baseline of ascii mode sigma with an odd height so that it is
         # exactly through the center
@@ -668,15 +668,15 @@ class PrettyPrinter(Printer):
 
         E = self._print(e)
         if precedence(e) <= PRECEDENCE["Mul"]:
-            E = prettyForm(*E.parens('(', ')'))
+            E = E.parens('(', ')')
         Lim = prettyForm('lim')
 
         LimArg = self._print(z)
         if self._use_unicode:
-            LimArg = prettyForm(*LimArg.right(f"{xobj('-', 1)}{pretty_atom('Arrow')}"))
+            LimArg = LimArg.right(f"{xobj('-', 1)}{pretty_atom('Arrow')}")
         else:
-            LimArg = prettyForm(*LimArg.right('->'))
-        LimArg = prettyForm(*LimArg.right(self._print(z0)))
+            LimArg = LimArg.right('->')
+        LimArg = LimArg.right(self._print(z0))
 
         if str(dir) == '+-' or z0 in (S.Infinity, S.NegativeInfinity):
             dir = ""
@@ -684,10 +684,11 @@ class PrettyPrinter(Printer):
             if self._use_unicode:
                 dir = pretty_atom('SuperscriptPlus') if str(dir) == "+" else pretty_atom('SuperscriptMinus')
 
-        LimArg = prettyForm(*LimArg.right(self._print(dir)))
+        LimArg = LimArg.right(self._print(dir))
 
-        Lim = prettyForm(*Lim.below(LimArg))
-        Lim = prettyForm(*Lim.right(E), binding=prettyForm.MUL)
+        Lim = Lim.below(LimArg)
+        Lim = Lim.right(E)
+        Lim.binding=prettyForm.MUL
 
         return Lim
 
@@ -729,8 +730,8 @@ class PrettyPrinter(Printer):
                 # XXX this is not good in all cases -- maybe introduce vbaseline?
                 left, right = center_pad(s.width(), maxw[j])
 
-                s = prettyForm(*s.right(right))
-                s = prettyForm(*s.left(left))
+                s = s.right(right)
+                s = s.left(left)
 
                 # we don't need vcenter cells -- this is automatically done in
                 # a pretty way because when their baselines are taking into
@@ -740,8 +741,8 @@ class PrettyPrinter(Printer):
                     D_row = s   # first box in a row
                     continue
 
-                D_row = prettyForm(*D_row.right(' '*hsep))  # h-spacer
-                D_row = prettyForm(*D_row.right(s))
+                D_row = D_row.right(' '*hsep)  # h-spacer
+                D_row = D_row.right(s)
 
             if D is None:
                 D = D_row       # first row in a picture
@@ -749,9 +750,9 @@ class PrettyPrinter(Printer):
 
             # v-spacer
             for _ in range(vsep):
-                D = prettyForm(*D.below(' '))
+                D = D.below(' ')
 
-            D = prettyForm(*D.below(D_row))
+            D = D.below(D_row)
 
         if D is None:
             D = prettyForm('')  # Empty Matrix
@@ -761,7 +762,7 @@ class PrettyPrinter(Printer):
     def _print_MatrixBase(self, e, lparens='[', rparens=']'):
         D = self._print_matrix_contents(e)
         D.baseline = D.height()//2
-        D = prettyForm(*D.parens(lparens, rparens))
+        D = D.parens(lparens, rparens)
         return D
 
     def _print_Determinant(self, e):
@@ -772,7 +773,7 @@ class PrettyPrinter(Printer):
                 return self._print_MatrixBase(mat.blocks, lparens='|', rparens='|')
             D = self._print(mat)
             D.baseline = D.height()//2
-            return prettyForm(*D.parens('|', '|'))
+            return D.parens('|', '|')
         else:
             return self._print_MatrixBase(mat, lparens='|', rparens='|')
 
@@ -796,9 +797,9 @@ class PrettyPrinter(Printer):
 
     def _print_Trace(self, e):
         D = self._print(e.arg)
-        D = prettyForm(*D.parens('(',')'))
+        D = D.parens('(',')')
         D.baseline = D.height()//2
-        D = prettyForm(*D.left('\n'*(0) + 'tr'))
+        D = D.left('\n'*(0) + 'tr')
         return D
 
 
@@ -810,9 +811,9 @@ class PrettyPrinter(Printer):
                     Symbol(expr.parent.name + '_%d%d' % (expr.i, expr.j)))
         else:
             prettyFunc = self._print(expr.parent)
-            prettyFunc = prettyForm(*prettyFunc.parens())
+            prettyFunc = prettyFunc.parens()
             prettyIndices = self._print_seq((expr.i, expr.j), delimiter=', '
-                    ).parens(left='[', right=']')[0]
+                    ).parens(left='[', right=']')
             pform = prettyForm(binding=prettyForm.FUNC,
                     *stringPict.next(prettyFunc, prettyIndices))
 
@@ -828,7 +829,7 @@ class PrettyPrinter(Printer):
         from sympy.matrices import MatrixSymbol
         prettyFunc = self._print(m.parent)
         if not isinstance(m.parent, MatrixSymbol):
-            prettyFunc = prettyForm(*prettyFunc.parens())
+            prettyFunc = prettyFunc.parens()
         def ppslice(x, dim):
             x = list(x)
             if x[2] == 1:
@@ -837,9 +838,9 @@ class PrettyPrinter(Printer):
                 x[0] = ''
             if x[1] == dim:
                 x[1] = ''
-            return prettyForm(*self._print_seq(x, delimiter=':'))
-        prettyArgs = self._print_seq((ppslice(m.rowslice, m.parent.rows),
-            ppslice(m.colslice, m.parent.cols)), delimiter=', ').parens(left='[', right=']')[0]
+            return self._print_seq(x, delimiter=':')
+        prettyArgs = str(self._print_seq((ppslice(m.rowslice, m.parent.rows),
+            ppslice(m.colslice, m.parent.cols)), delimiter=', ').parens(left='[', right=']'))
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
@@ -856,7 +857,7 @@ class PrettyPrinter(Printer):
         from sympy.matrices import MatrixSymbol, BlockMatrix
         if (not isinstance(mat, MatrixSymbol) and
             not isinstance(mat, BlockMatrix) and mat.is_MatrixExpr):
-            pform = prettyForm(*pform.parens())
+            pform = pform.parens()
         pform = pform**(prettyForm('T'))
         return pform
 
@@ -870,7 +871,7 @@ class PrettyPrinter(Printer):
         from sympy.matrices import MatrixSymbol, BlockMatrix
         if (not isinstance(mat, MatrixSymbol) and
             not isinstance(mat, BlockMatrix) and mat.is_MatrixExpr):
-            pform = prettyForm(*pform.parens())
+            pform = pform.parens()
         pform = pform**dag
         return pform
 
@@ -888,10 +889,10 @@ class PrettyPrinter(Printer):
             else:
                 coeff = item.as_coeff_mmul()[0]
                 if S(coeff).could_extract_minus_sign():
-                    s = prettyForm(*stringPict.next(s, ' '))
+                    s = prettyForm(*stringPict.next(s, prettyForm(' ')))
                     pform = self._print(item)
                 else:
-                    s = prettyForm(*stringPict.next(s, ' + '))
+                    s = prettyForm(*stringPict.next(s, prettyForm(' + ')))
                 s = prettyForm(*stringPict.next(s, pform))
 
         return s
@@ -904,7 +905,7 @@ class PrettyPrinter(Printer):
         for i, a in enumerate(args):
             if (isinstance(a, (Add, MatAdd, HadamardProduct, KroneckerProduct))
                     and len(expr.args) > 1):
-                args[i] = prettyForm(*self._print(a).parens())
+                args[i] = self._print(a).parens()
             else:
                 args[i] = self._print(a)
 
@@ -939,7 +940,7 @@ class PrettyPrinter(Printer):
         pform = self._print(expr.base)
         from sympy.matrices import MatrixSymbol
         if not isinstance(expr.base, MatrixSymbol) and expr.base.is_MatrixExpr:
-            pform = prettyForm(*pform.parens())
+            pform = pform.parens()
         pform = pform**(self._print(expr.exp))
         return pform
 
@@ -963,7 +964,7 @@ class PrettyPrinter(Printer):
         pretty_base = self._print(expr.base)
         pretty_exp = self._print(expr.exp)
         if precedence(expr.exp) < PRECEDENCE["Mul"]:
-            pretty_exp = prettyForm(*pretty_exp.parens())
+            pretty_exp = pretty_exp.parens()
         pretty_circ_exp = prettyForm(
             binding=prettyForm.LINE,
             *stringPict.next(circ, pretty_exp)
@@ -982,7 +983,7 @@ class PrettyPrinter(Printer):
 
     def _print_FunctionMatrix(self, X):
         D = self._print(X.lamda.expr)
-        D = prettyForm(*D.parens('[', ']'))
+        D = D.parens('[', ']')
         return D
 
     def _print_TransferFunction(self, expr):
@@ -996,7 +997,7 @@ class PrettyPrinter(Printer):
     def _print_Series(self, expr):
         args = list(expr.args)
         for i, a in enumerate(expr.args):
-            args[i] = prettyForm(*self._print(a).parens())
+            args[i] = self._print(a).parens()
         return prettyForm.__mul__(*args)
 
     def _print_MIMOSeries(self, expr):
@@ -1007,7 +1008,7 @@ class PrettyPrinter(Printer):
             if (isinstance(a, MIMOParallel) and len(expr.args) > 1):
                 expression = self._print(a)
                 expression.baseline = expression.height()//2
-                pretty_args.append(prettyForm(*expression.parens()))
+                pretty_args.append(expression.parens())
             else:
                 expression = self._print(a)
                 expression.baseline = expression.height()//2
@@ -1086,11 +1087,11 @@ class PrettyPrinter(Printer):
         inv_mat = self._print(MIMOSeries(expr.sys2, expr.sys1))
         plant = self._print(expr.sys1)
         _feedback = prettyForm(*stringPict.next(inv_mat))
-        _feedback = prettyForm(*stringPict.right("I + ", _feedback)) if expr.sign == -1 \
-            else prettyForm(*stringPict.right("I - ", _feedback))
-        _feedback = prettyForm(*stringPict.parens(_feedback))
+        _feedback = stringPict.right(prettyForm("I + "), _feedback)  if expr.sign == -1 \
+            else stringPict.right(prettyForm("I - "), _feedback)
+        _feedback = stringPict.parens(_feedback)
         _feedback.baseline = 0
-        _feedback = prettyForm(*stringPict.right(_feedback, '-1 '))
+        _feedback = stringPict.right(_feedback, stringPict('-1 '))
         _feedback.baseline = _feedback.height()//2
         _feedback = prettyForm.__mul__(_feedback, prettyForm(" "))
         if isinstance(expr.sys1, TransferFunctionMatrix):
@@ -1102,7 +1103,7 @@ class PrettyPrinter(Printer):
         mat = self._print(expr._expr_mat)
         mat.baseline = mat.height() - 1
         subscript = greek_unicode['tau'] if self._use_unicode else r'{t}'
-        mat = prettyForm(*mat.right(subscript))
+        mat = mat.right(subscript)
         return mat
 
     def _print_StateSpace(self, expr):
@@ -1145,8 +1146,8 @@ class PrettyPrinter(Printer):
                 else:
                     #We always wrap the measure numbers in
                     #parentheses
-                    arg_str = self._print(
-                        v).parens()[0]
+                    arg_str = str(self._print(
+                        v).parens())
 
                     o1.append(arg_str + ' ' + k._pretty_form)
                 vectstrs.append(k._pretty_form)
@@ -1250,7 +1251,7 @@ class PrettyPrinter(Printer):
         return self._print(out_expr)
 
     def _printer_tensor_indices(self, name, indices, index_map={}):
-        center = stringPict(name)
+        center = prettyForm(name)
         top = stringPict(" "*center.width())
         bot = stringPict(" "*center.width())
 
@@ -1271,17 +1272,17 @@ class PrettyPrinter(Printer):
             else:
                 prev_map = False
             if index.is_up:
-                top = stringPict(*top.right(indpic))
-                center = stringPict(*center.right(" "*indpic.width()))
-                bot = stringPict(*bot.right(" "*indpic.width()))
+                top = top.right(indpic)
+                center = center.right(" "*indpic.width())
+                bot = bot.right(" "*indpic.width())
             else:
-                bot = stringPict(*bot.right(indpic))
-                center = stringPict(*center.right(" "*indpic.width()))
-                top = stringPict(*top.right(" "*indpic.width()))
+                bot = bot.right(indpic)
+                center = center.right(" "*indpic.width())
+                top = top.right(" "*indpic.width())
             last_valence = index.is_up
 
-        pict = prettyForm(*center.above(top))
-        pict = prettyForm(*pict.below(bot))
+        pict = center.above(top)
+        pict = pict.below(bot)
         return pict
 
     def _print_Tensor(self, expr):
@@ -1298,19 +1299,19 @@ class PrettyPrinter(Printer):
     def _print_TensMul(self, expr):
         sign, args = expr._get_args_for_traditional_printer()
         args = [
-            prettyForm(*self._print(i).parens()) if
+            self._print(i).parens() if
             precedence_traditional(i) < PRECEDENCE["Mul"] else self._print(i)
             for i in args
         ]
         pform = prettyForm.__mul__(*args)
         if sign:
-            return prettyForm(*pform.left(sign))
+            return pform.left(sign)
         else:
             return pform
 
     def _print_TensAdd(self, expr):
         args = [
-            prettyForm(*self._print(i).parens()) if
+            self._print(i).parens() if
             precedence_traditional(i) < PRECEDENCE["Mul"] else self._print(i)
             for i in expr.args
         ]
@@ -1331,23 +1332,23 @@ class PrettyPrinter(Printer):
 
         for variable in reversed(deriv.variables):
             s = self._print(variable)
-            ds = prettyForm(*s.left(deriv_symbol))
+            ds = s.left(deriv_symbol)
 
             if x is None:
                 x = ds
             else:
-                x = prettyForm(*x.right(' '))
-                x = prettyForm(*x.right(ds))
+                x = x.right(' ')
+                x = x.right(ds)
 
-        f = prettyForm(
-            binding=prettyForm.FUNC, *self._print(deriv.expr).parens())
+        f = self._print(deriv.expr).parens()
+        f.binding = prettyForm.FUNC
 
         pform = prettyForm(deriv_symbol)
 
         if len(deriv.variables) > 1:
             pform = pform**self._print(len(deriv.variables))
 
-        pform = prettyForm(*pform.below(stringPict.LINE, x))
+        pform = pform.below(stringPict.LINE, x)
         pform.baseline = pform.baseline + 1
         pform = prettyForm(*stringPict.next(pform, f))
         pform.binding = prettyForm.MUL
@@ -1362,8 +1363,7 @@ class PrettyPrinter(Printer):
             if ec.cond == True:
                 P[n, 1] = prettyForm('otherwise')
             else:
-                P[n, 1] = prettyForm(
-                    *prettyForm('for ').right(self._print(ec.cond)))
+                P[n, 1] = prettyForm('for ').right(self._print(ec.cond))
         hsep = 2
         vsep = 1
         len_args = len(pexpr.args)
@@ -1386,26 +1386,26 @@ class PrettyPrinter(Printer):
                 wleft = wdelta // 2
                 wright = wdelta - wleft
 
-                p = prettyForm(*p.right(' '*wright))
-                p = prettyForm(*p.left(' '*wleft))
+                p = p.right(' '*wright)
+                p = p.left(' '*wleft)
 
                 if D_row is None:
                     D_row = p
                     continue
 
-                D_row = prettyForm(*D_row.right(' '*hsep))  # h-spacer
-                D_row = prettyForm(*D_row.right(p))
+                D_row = D_row.right(' '*hsep)  # h-spacer
+                D_row = D_row.right(p)
             if D is None:
                 D = D_row       # first row in a picture
                 continue
 
             # v-spacer
             for _ in range(vsep):
-                D = prettyForm(*D.below(' '))
+                D = D.below(' ')
 
-            D = prettyForm(*D.below(D_row))
+            D = D.below(D_row)
 
-        D = prettyForm(*D.parens('{', ''))
+        D = D.parens('{', '')
         D.baseline = D.height()//2
         D.binding = prettyForm.OPEN
         return D
@@ -1422,8 +1422,8 @@ class PrettyPrinter(Printer):
             if D is None:
                 D = p
             else:
-                D = prettyForm(*D.right(', '))
-                D = prettyForm(*D.right(p))
+                D = D.right(', ')
+                D = D.right(p)
         if D is None:
             D = stringPict(' ')
 
@@ -1453,21 +1453,21 @@ class PrettyPrinter(Printer):
             if D is None:
                 D = D_row       # first row in a picture
             else:
-                D = prettyForm(*D.below(' '))
-                D = prettyForm(*D.below(D_row))
+                D = D.below(' ')
+                D = D.below(D_row)
 
         # make sure that the argument `z' is centred vertically
         D.baseline = D.height()//2
 
         # insert horizontal separator
-        P = prettyForm(*P.left(' '))
-        D = prettyForm(*D.right(' '))
+        P = P.left(' ')
+        D = D.right(' ')
 
         # insert separating `|`
         D = self._hprint_vseparator(D, P)
 
         # add parens
-        D = prettyForm(*D.parens('(', ')'))
+        D = D.parens('(', ')')
 
         # create the F symbol
         above = D.height()//2 - 1
@@ -1478,11 +1478,11 @@ class PrettyPrinter(Printer):
                        baseline=above + sz)
         add = (sz + 1)//2
 
-        F = prettyForm(*F.left(self._print(len(e.ap))))
-        F = prettyForm(*F.right(self._print(len(e.bq))))
+        F = F.left(self._print(len(e.ap)))
+        F = F.right(self._print(len(e.bq)))
         F.baseline = above + add
 
-        D = prettyForm(*F.right(' ', D))
+        D = F.right(' ', D)
 
         return D
 
@@ -1508,27 +1508,27 @@ class PrettyPrinter(Printer):
                 s = vp[(j, i)]
                 left = (maxw - s.width()) // 2
                 right = maxw - left - s.width()
-                s = prettyForm(*s.left(' ' * left))
-                s = prettyForm(*s.right(' ' * right))
+                s = s.left(' ' * left)
+                s = s.right(' ' * right)
                 vp[(j, i)] = s
 
-        D1 = prettyForm(*vp[(0, 0)].right('  ', vp[(0, 1)]))
-        D1 = prettyForm(*D1.below(' '))
-        D2 = prettyForm(*vp[(1, 0)].right('  ', vp[(1, 1)]))
-        D = prettyForm(*D1.below(D2))
+        D1 = vp[(0, 0)].right('  ', vp[(0, 1)])
+        D1 = D1.below(' ')
+        D2 = vp[(1, 0)].right('  ', vp[(1, 1)])
+        D = D1.below(D2)
 
         # make sure that the argument `z' is centred vertically
         D.baseline = D.height()//2
 
         # insert horizontal separator
-        P = prettyForm(*P.left(' '))
-        D = prettyForm(*D.right(' '))
+        P = P.left(' ')
+        D = D.right(' ')
 
         # insert separating `|`
         D = self._hprint_vseparator(D, P)
 
         # add parens
-        D = prettyForm(*D.parens('(', ')'))
+        D = D.parens('(', ')')
 
         # create the G symbol
         above = D.height()//2 - 1
@@ -1548,25 +1548,25 @@ class PrettyPrinter(Printer):
             if diff == 0:
                 return p1, p2
             elif diff > 0:
-                return p1, prettyForm(*p2.left(' '*diff))
+                return p1, p2.left(' '*diff)
             else:
-                return prettyForm(*p1.left(' '*-diff)), p2
+                return p1.left(' '*-diff), p2
         pp, pm = adjust(pp, pm)
         pq, pn = adjust(pq, pn)
-        pu = prettyForm(*pm.right(', ', pn))
-        pl = prettyForm(*pp.right(', ', pq))
+        pu = pm.right(', ', pn)
+        pl = pp.right(', ', pq)
 
         ht = F.baseline - above - 2
         if ht > 0:
-            pu = prettyForm(*pu.below('\n'*ht))
-        p = prettyForm(*pu.below(pl))
+            pu = pu.below('\n'*ht)
+        p = pu.below(pl)
 
         F.baseline = above
-        F = prettyForm(*F.right(p))
+        F = F.right(p)
 
         F.baseline = above + add
 
-        D = prettyForm(*F.right(' ', D))
+        D = F.right(' ', D)
 
         return D
 
@@ -1609,7 +1609,7 @@ class PrettyPrinter(Printer):
         if func_name:
             prettyFunc = self._print(Symbol(func_name))
         else:
-            prettyFunc = prettyForm(*self._print(func).parens())
+            prettyFunc = self._print(func).parens()
 
         if elementwise:
             if self._use_unicode:
@@ -1622,8 +1622,8 @@ class PrettyPrinter(Printer):
                 *stringPict.next(prettyFunc, circ)
             )
 
-        prettyArgs = prettyForm(*self._print_seq(args, delimiter=delimiter).parens(
-                                                 left=left, right=right))
+        prettyArgs = self._print_seq(args, delimiter=delimiter).parens(
+                                                 left=left, right=right)
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
@@ -1687,8 +1687,8 @@ class PrettyPrinter(Printer):
     def _print_Heaviside(self, e):
         func_name = greek_unicode['theta'] if self._use_unicode else 'Heaviside'
         if e.args[1] is S.Half:
-            pform = prettyForm(*self._print(e.args[0]).parens())
-            pform = prettyForm(*pform.left(func_name))
+            pform = self._print(e.args[0]).parens()
+            pform = pform.left(func_name)
             return pform
         else:
             return self._print_Function(e, func_name=func_name)
@@ -1743,21 +1743,21 @@ class PrettyPrinter(Printer):
         pform = self._print(expr.expr)
         if (expr.point and any(p != S.Zero for p in expr.point)) or \
            len(expr.variables) > 1:
-            pform = prettyForm(*pform.right("; "))
+            pform = pform.right("; ")
             if len(expr.variables) > 1:
-                pform = prettyForm(*pform.right(self._print(expr.variables)))
+                pform = pform.right(self._print(expr.variables))
             elif len(expr.variables):
-                pform = prettyForm(*pform.right(self._print(expr.variables[0])))
+                pform = pform.right(self._print(expr.variables[0]))
             if self._use_unicode:
-                pform = prettyForm(*pform.right(f" {pretty_atom('Arrow')} "))
+                pform = pform.right(f" {pretty_atom('Arrow')} ")
             else:
-                pform = prettyForm(*pform.right(" -> "))
+                pform = pform.right(" -> ")
             if len(expr.point) > 1:
-                pform = prettyForm(*pform.right(self._print(expr.point)))
+                pform = pform.right(self._print(expr.point))
             else:
-                pform = prettyForm(*pform.right(self._print(expr.point[0])))
-        pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left("O"))
+                pform = pform.right(self._print(expr.point[0]))
+        pform = pform.parens()
+        pform = pform.left("O")
         return pform
 
     def _print_SingularityFunction(self, e):
@@ -1765,8 +1765,8 @@ class PrettyPrinter(Printer):
             shift = self._print(e.args[0]-e.args[1])
             n = self._print(e.args[2])
             base = prettyForm("<")
-            base = prettyForm(*base.right(shift))
-            base = prettyForm(*base.right(">"))
+            base = base.right(shift)
+            base = base.right(">")
             pform = base**n
             return pform
         else:
@@ -1804,16 +1804,16 @@ class PrettyPrinter(Printer):
             if len(e.args) == 2:
                 a = prettyForm(greek_unicode['delta'])
                 b = self._print(e.args[1])
-                b = prettyForm(*b.parens())
+                b = b.parens()
                 c = self._print(e.args[0])
-                c = prettyForm(*c.parens())
+                c = c.parens()
                 pform = a**b
-                pform = prettyForm(*pform.right(' '))
-                pform = prettyForm(*pform.right(c))
+                pform = pform.right(' ')
+                pform = pform.right(c)
                 return pform
             pform = self._print(e.args[0])
-            pform = prettyForm(*pform.parens())
-            pform = prettyForm(*pform.left(greek_unicode['delta']))
+            pform = pform.parens()
+            pform = pform.left(greek_unicode['delta'])
             return pform
         else:
             return self._print_Function(e)
@@ -1828,7 +1828,7 @@ class PrettyPrinter(Printer):
         # This needs a special case since otherwise it comes out as greek
         # letter chi...
         prettyFunc = prettyForm("Chi")
-        prettyArgs = prettyForm(*self._print_seq(e.args).parens())
+        prettyArgs = self._print_seq(e.args).parens()
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
@@ -1846,22 +1846,22 @@ class PrettyPrinter(Printer):
         else:
             pforma1 = self._print(e.args[1])
             pform = self._hprint_vseparator(pforma0, pforma1)
-        pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left('E'))
+        pform = pform.parens()
+        pform = pform.left('E')
         return pform
 
     def _print_elliptic_k(self, e):
         pform = self._print(e.args[0])
-        pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left('K'))
+        pform = pform.parens()
+        pform = pform.left('K')
         return pform
 
     def _print_elliptic_f(self, e):
         pforma0 = self._print(e.args[0])
         pforma1 = self._print(e.args[1])
         pform = self._hprint_vseparator(pforma0, pforma1)
-        pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left('F'))
+        pform = pform.parens()
+        pform = pform.left('F')
         return pform
 
     def _print_elliptic_pi(self, e):
@@ -1873,10 +1873,10 @@ class PrettyPrinter(Printer):
         else:
             pforma2 = self._print(e.args[2])
             pforma = self._hprint_vseparator(pforma1, pforma2, ifascii_nougly=False)
-            pforma = prettyForm(*pforma.left('; '))
-            pform = prettyForm(*pforma.left(pforma0))
-        pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left(name))
+            pforma = pforma.left('; ')
+            pform = pforma.left(pforma0)
+        pform = pform.parens()
+        pform = pform.left(name)
         return pform
 
     def _print_GoldenRatio(self, expr):
@@ -1895,9 +1895,9 @@ class PrettyPrinter(Printer):
     def _print_Mod(self, expr):
         pform = self._print(expr.args[0])
         if pform.binding > prettyForm.MUL:
-            pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.right(' mod '))
-        pform = prettyForm(*pform.right(self._print(expr.args[1])))
+            pform = pform.parens()
+        pform = pform.right(' mod ')
+        pform = pform.right(self._print(expr.args[1]))
         pform.binding = prettyForm.OPEN
         return pform
 
@@ -1918,7 +1918,7 @@ class PrettyPrinter(Printer):
 
             if (pform.binding > prettyForm.NEG
                 or pform.binding == prettyForm.ADD):
-                p = stringPict(*pform.parens())
+                p = pform.parens()
             else:
                 p = pform
             p = stringPict.next(pform_neg, p)
@@ -1942,7 +1942,7 @@ class PrettyPrinter(Printer):
                 pform = self._print(-term)
                 pforms.append(pretty_negative(pform, i))
             elif term.is_Relational:
-                pforms.append(prettyForm(*self._print(term).parens()))
+                pforms.append(self._print(term).parens())
             else:
                 pforms.append(self._print(term))
 
@@ -2042,7 +2042,7 @@ class PrettyPrinter(Printer):
             and root == 2 and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
-            return prettyForm(*bpretty.left(nth_root[2]))
+            return bpretty.left(nth_root[2])
 
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
@@ -2068,14 +2068,14 @@ class PrettyPrinter(Printer):
         # Put baseline just below lowest line: next to exp
         diagonal.baseline = linelength - 1
         # Make the root symbol
-        rootsign = prettyForm(*rootsign.right(diagonal))
+        rootsign = rootsign.right(diagonal)
         # Det the baseline to match contents to fix the height
         # but if the height of bpretty is one, the rootsign must be one higher
         rootsign.baseline = max(1, bpretty.baseline)
         #build result
         s = prettyForm(hobj('_', 2 + bpretty.width()))
-        s = prettyForm(*bpretty.above(s))
-        s = prettyForm(*s.left(rootsign))
+        s = bpretty.above(s)
+        s = s.left(rootsign)
         return s
 
     def _print_Pow(self, power):
@@ -2092,7 +2092,7 @@ class PrettyPrinter(Printer):
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 
         if b.is_Relational:
-            return prettyForm(*self._print(b).parens()).__pow__(self._print(e))
+            return self._print(b).parens().__pow__(self._print(e))
 
         return self._print(b)**self._print(e)
 
@@ -2273,7 +2273,7 @@ class PrettyPrinter(Printer):
             cond = self._print(ts.condition)
             if self._use_unicode:
                 cond = self._print(cond)
-                cond = prettyForm(*cond.parens())
+                cond = cond.parens()
 
         if ts.base_set is S.UniversalSet:
             return self._hprint_vseparator(variables, cond, left="{",
@@ -2322,9 +2322,9 @@ class PrettyPrinter(Printer):
         return self._print_Add(s.infinite)
 
     def _print_SetExpr(self, se):
-        pretty_set = prettyForm(*self._print(se.set).parens())
+        pretty_set = self._print(se.set).parens()
         pretty_name = self._print(Symbol("SetExpr"))
-        return prettyForm(*pretty_name.right(pretty_set))
+        return pretty_name.right(pretty_set)
 
     def _print_SeqFormula(self, s):
         if self._use_unicode:
@@ -2358,7 +2358,7 @@ class PrettyPrinter(Printer):
         for item in seq:
             pform = self._print(item)
             if parenthesize(item):
-                pform = prettyForm(*pform.parens())
+                pform = pform.parens()
             if pforms:
                 pforms.append(delimiter)
             pforms.append(pform)
@@ -2368,7 +2368,7 @@ class PrettyPrinter(Printer):
         else:
             s = prettyForm(*stringPict.next(*pforms))
 
-        s = prettyForm(*s.parens(left, right, ifascii_nougly=ifascii_nougly))
+        s = s.parens(left, right, ifascii_nougly=ifascii_nougly)
         return s
 
     def join(self, delimiter, args):
@@ -2378,8 +2378,8 @@ class PrettyPrinter(Printer):
             if pform is None:
                 pform = arg
             else:
-                pform = prettyForm(*pform.right(delimiter))
-                pform = prettyForm(*pform.right(arg))
+                pform = pform.right(delimiter)
+                pform = pform.right(arg)
 
         if pform is None:
             return prettyForm("")
@@ -2392,7 +2392,7 @@ class PrettyPrinter(Printer):
     def _print_tuple(self, t):
         if len(t) == 1:
             ptuple = prettyForm(*stringPict.next(self._print(t[0]), ','))
-            return prettyForm(*ptuple.parens('(', ')', ifascii_nougly=True))
+            return ptuple.parens('(', ')', ifascii_nougly=True)
         else:
             return self._print_seq(t, '(', ')')
 
@@ -2420,7 +2420,7 @@ class PrettyPrinter(Printer):
             return prettyForm('set()')
         items = sorted(s, key=default_sort_key)
         pretty = self._print_seq(items)
-        pretty = prettyForm(*pretty.parens('{', '}', ifascii_nougly=True))
+        pretty = pretty.parens('{', '}', ifascii_nougly=True)
         return pretty
 
     def _print_frozenset(self, s):
@@ -2428,8 +2428,8 @@ class PrettyPrinter(Printer):
             return prettyForm('frozenset()')
         items = sorted(s, key=default_sort_key)
         pretty = self._print_seq(items)
-        pretty = prettyForm(*pretty.parens('{', '}', ifascii_nougly=True))
-        pretty = prettyForm(*pretty.parens('(', ')', ifascii_nougly=True))
+        pretty = pretty.parens('{', '}', ifascii_nougly=True)
+        pretty = pretty.parens('(', ')', ifascii_nougly=True)
         pretty = prettyForm(*stringPict.next(type(s).__name__, pretty))
         return pretty
 
@@ -2462,8 +2462,8 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexRootOf(self, expr):
         args = [self._print_Add(expr.expr, order='lex'), expr.index]
-        pform = prettyForm(*self._print_seq(args).parens())
-        pform = prettyForm(*pform.left('CRootOf'))
+        pform = self._print_seq(args).parens()
+        pform = pform.left('CRootOf')
         return pform
 
     def _print_RootSum(self, expr):
@@ -2472,8 +2472,8 @@ class PrettyPrinter(Printer):
         if expr.fun is not S.IdentityFunction:
             args.append(self._print(expr.fun))
 
-        pform = prettyForm(*self._print_seq(args).parens())
-        pform = prettyForm(*pform.left('RootSum'))
+        pform = self._print_seq(args).parens()
+        pform = pform.left('RootSum')
 
         return pform
 
@@ -2523,11 +2523,11 @@ class PrettyPrinter(Printer):
         args = list(expr.symbols)
 
         if not expr.order.is_default:
-            order = prettyForm(*prettyForm("order=").right(self._print(expr.order)))
+            order = prettyForm("order=").right(self._print(expr.order))
             args.append(order)
 
         pform = self._print_seq(args, '[', ']')
-        pform = prettyForm(*pform.left(self._print(expr.domain)))
+        pform = pform.left(self._print(expr.domain))
 
         return pform
 
@@ -2535,11 +2535,11 @@ class PrettyPrinter(Printer):
         args = list(expr.symbols)
 
         if not expr.order.is_default:
-            order = prettyForm(*prettyForm("order=").right(self._print(expr.order)))
+            order = prettyForm("order=").right(self._print(expr.order))
             args.append(order)
 
         pform = self._print_seq(args, '(', ')')
-        pform = prettyForm(*pform.left(self._print(expr.domain)))
+        pform = pform.left(self._print(expr.domain))
 
         return pform
 
@@ -2548,42 +2548,40 @@ class PrettyPrinter(Printer):
         if str(expr.order) != str(expr.default_order):
             g = g + ("order=" + str(expr.order),)
         pform = self._print_seq(g, '[', ']')
-        pform = prettyForm(*pform.left(self._print(expr.domain)))
+        pform = pform.left(self._print(expr.domain))
 
         return pform
 
     def _print_GroebnerBasis(self, basis):
         exprs = [ self._print_Add(arg, order=basis.order)
                   for arg in basis.exprs ]
-        exprs = prettyForm(*self.join(", ", exprs).parens(left="[", right="]"))
+        exprs = self.join(", ", exprs).parens(left="[", right="]")
 
         gens = [ self._print(gen) for gen in basis.gens ]
 
-        domain = prettyForm(
-            *prettyForm("domain=").right(self._print(basis.domain)))
-        order = prettyForm(
-            *prettyForm("order=").right(self._print(basis.order)))
+        domain = prettyForm("domain=").right(self._print(basis.domain))
+        order =  prettyForm("order=").right(self._print(basis.order))
 
         pform = self.join(", ", [exprs] + gens + [domain, order])
 
-        pform = prettyForm(*pform.parens())
-        pform = prettyForm(*pform.left(basis.__class__.__name__))
+        pform = pform.parens()
+        pform = pform.left(basis.__class__.__name__)
 
         return pform
 
     def _print_Subs(self, e):
         pform = self._print(e.expr)
-        pform = prettyForm(*pform.parens())
+        pform = pform.parens()
 
         h = pform.height() if pform.height() > 1 else 2
         rvert = stringPict(vobj('|', h), baseline=pform.baseline)
-        pform = prettyForm(*pform.right(rvert))
+        pform = pform.right(rvert)
 
         b = pform.baseline
         pform.baseline = pform.height() - 1
-        pform = prettyForm(*pform.right(self._print_seq([
+        pform = pform.right(self._print_seq([
             self._print_seq((self._print(v[0]), xsym('=='), self._print(v[1])),
-                delimiter='') for v in zip(e.variables, e.point) ])))
+                delimiter='') for v in zip(e.variables, e.point) ]))
 
         pform.baseline = b
         return pform
@@ -2594,14 +2592,14 @@ class PrettyPrinter(Printer):
         pform = prettyForm(name)
         arg = self._print(e.args[0])
         pform_arg = prettyForm(" "*arg.width())
-        pform_arg = prettyForm(*pform_arg.below(arg))
-        pform = prettyForm(*pform.right(pform_arg))
+        pform_arg = pform_arg.below(arg)
+        pform = pform.right(pform_arg)
         if len(e.args) == 1:
             return pform
         m, x = e.args
         # TODO: copy-pasted from _print_Function: can we do better?
         prettyFunc = pform
-        prettyArgs = prettyForm(*self._print_seq([x]).parens())
+        prettyArgs = self._print_seq([x]).parens()
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
         pform.prettyFunc = prettyFunc
@@ -2636,31 +2634,33 @@ class PrettyPrinter(Printer):
 
     def _print_KroneckerDelta(self, e):
         pform = self._print(e.args[0])
-        pform = prettyForm(*pform.right(prettyForm(',')))
-        pform = prettyForm(*pform.right(self._print(e.args[1])))
+        pform = pform.right(prettyForm(','))
+        pform = pform.right(self._print(e.args[1]))
         if self._use_unicode:
             a = stringPict(pretty_symbol('delta'))
         else:
             a = stringPict('d')
         b = pform
-        top = stringPict(*b.left(' '*a.width()))
-        bot = stringPict(*a.right(' '*b.width()))
-        return prettyForm(binding=prettyForm.POW, *bot.below(top))
+        top = b.left(' '*a.width())
+        bot = a.right(' '*b.width())
+        bot = bot.below(top)
+        bot.binding=prettyForm.POW
+        return bot
 
     def _print_RandomDomain(self, d):
         if hasattr(d, 'as_boolean'):
             pform = self._print('Domain: ')
-            pform = prettyForm(*pform.right(self._print(d.as_boolean())))
+            pform = pform.right(self._print(d.as_boolean()))
             return pform
         elif hasattr(d, 'set'):
             pform = self._print('Domain: ')
-            pform = prettyForm(*pform.right(self._print(d.symbols)))
-            pform = prettyForm(*pform.right(self._print(' in ')))
-            pform = prettyForm(*pform.right(self._print(d.set)))
+            pform = pform.right(self._print(d.symbols))
+            pform = pform.right(self._print(' in '))
+            pform = pform.right(self._print(d.set))
             return pform
         elif hasattr(d, 'symbols'):
             pform = self._print('Domain on ')
-            pform = prettyForm(*pform.right(self._print(d.symbols)))
+            pform = pform.right(self._print(d.symbols))
             return pform
         else:
             return self._print(None)
@@ -2685,14 +2685,13 @@ class PrettyPrinter(Printer):
 
         domain = self._print(morphism.domain)
         codomain = self._print(morphism.codomain)
-        tail = domain.right(arrow, codomain)[0]
-
-        return prettyForm(tail)
+        tail = domain.right(arrow, codomain)
+        return tail
 
     def _print_NamedMorphism(self, morphism):
         pretty_name = self._print(pretty_symbol(morphism.name))
         pretty_morphism = self._print_Morphism(morphism)
-        return prettyForm(pretty_name.right(":", pretty_morphism)[0])
+        return pretty_name.right(":", pretty_morphism)
 
     def _print_IdentityMorphism(self, morphism):
         from sympy.categories import NamedMorphism
@@ -2712,7 +2711,7 @@ class PrettyPrinter(Printer):
 
         pretty_name = self._print(component_names)
         pretty_morphism = self._print_Morphism(morphism)
-        return prettyForm(pretty_name.right(pretty_morphism)[0])
+        return pretty_name.right(pretty_morphism)
 
     def _print_Category(self, category):
         return self._print(pretty_symbol(category.name))
@@ -2730,7 +2729,7 @@ class PrettyPrinter(Printer):
             pretty_result = pretty_result.right(
                 results_arrow, pretty_conclusions)
 
-        return prettyForm(pretty_result[0])
+        return pretty_result
 
     def _print_DiagramGrid(self, grid):
         from sympy.matrices import Matrix
@@ -2769,8 +2768,8 @@ class PrettyPrinter(Printer):
     def _print_MatrixHomomorphism(self, h):
         matrix = self._print(h._sympy_matrix())
         matrix.baseline = matrix.height() // 2
-        pform = prettyForm(*matrix.right(' : ', self._print(h.domain),
-            ' %s> ' % hobj('-', 2), self._print(h.codomain)))
+        pform = matrix.right(' : ', self._print(h.domain),
+            ' %s> ' % hobj('-', 2), self._print(h.codomain))
         return pform
 
     def _print_Manifold(self, manifold):
@@ -2801,32 +2800,32 @@ class PrettyPrinter(Printer):
             return self._print(d + ' ' + pretty_symbol(string))
         else:
             pform = self._print(field)
-            pform = prettyForm(*pform.parens())
-            return prettyForm(*pform.left(d))
+            pform = pform.parens()
+            return pform.left(d)
 
     def _print_Tr(self, p):
         #TODO: Handle indices
         pform = self._print(p.args[0])
-        pform = prettyForm(*pform.left('%s(' % (p.__class__.__name__)))
-        pform = prettyForm(*pform.right(')'))
+        pform = pform.left('%s(' % (p.__class__.__name__))
+        pform = pform.right(')')
         return pform
 
     def _print_primenu(self, e):
         pform = self._print(e.args[0])
-        pform = prettyForm(*pform.parens())
+        pform = pform.parens()
         if self._use_unicode:
-            pform = prettyForm(*pform.left(greek_unicode['nu']))
+            pform = pform.left(greek_unicode['nu'])
         else:
-            pform = prettyForm(*pform.left('nu'))
+            pform = pform.left('nu')
         return pform
 
     def _print_primeomega(self, e):
         pform = self._print(e.args[0])
-        pform = prettyForm(*pform.parens())
+        pform = pform.parens()
         if self._use_unicode:
-            pform = prettyForm(*pform.left(greek_unicode['Omega']))
+            pform = pform.left(greek_unicode['Omega'])
         else:
-            pform = prettyForm(*pform.left('Omega'))
+            pform = pform.left('Omega')
         return pform
 
     def _print_Quantity(self, e):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1046,7 +1046,6 @@ class PrettyPrinter(Printer):
                 if isinstance(item, TransferFunctionMatrix):
                     s.baseline = s.height() - 1
                 s = prettyForm(*stringPict.next(s, pform))
-            # s.baseline = s.height()//2
         return s
 
     def _print_Feedback(self, expr):

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -35,7 +35,7 @@ class stringPict:
 
     @staticmethod
     def equalLengths(lines):
-        #empty lines
+        # empty lines
         if not lines:
             return ['']
 
@@ -509,7 +509,7 @@ class stringPict:
         # Join lines of each screen into sub-pictures
         pictures = ['\n'.join(picture) for picture in pictures]
 
-        #Add spacers between sub-pictures
+        # Add spacers between sub-pictures
         return "\n\n".join(pictures)
 
     def subindex(self, sub_index):
@@ -754,18 +754,9 @@ class prettyForm(stringPict):
         if use_inline_func_form:
             #         2
             #  sin  +   + (x)
-            # b.baseline = a.prettyFunc.baseline + b.height()
-            # func = a.prettyFunc.right(b)
-            # return func.right(a.prettyArgs)
             func = a.prettyFunc.superindex(b)
             return func.right(a.prettyArgs)
         else:
-            #      2    <-- top
-            # (x+y)     <-- bot
-            # top = b.left(' ' * a.width())
-            # bot = a.right(' ' * b.width())
-
-            # result = bot.above(top)
             result = a.superindex(b)
             result.binding = prettyForm.POW
             return result

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -337,34 +337,34 @@ class stringPict:
 
         >>> from sympy.printing.pretty.stringpict import stringPict, prettyForm
         >>> print(stringPict("x+3").root().right(" + a"))
-          ___
-        \\/x+3 + a
+          _____
+        \\/ x+3 + a
 
         >>> print(stringPict("x+3").root(stringPict("3")).right(" + a"))
-        3 ___
-        \\/x+3 + a
+        3 _____
+        \\/ x+3 + a
 
         >>> print((prettyForm("x")**stringPict("a")).root().right(" + a"))
-           __
-          / a
-        \\/ x + a
+           ____
+          /  a
+        \\/  x + a
 
         >>> print((prettyForm("x")**stringPict("a")).root(stringPict("3")).right(" + a"))
-           __
-        3 / a
-        \\/ x + a
+           ____
+        3 /  a
+        \\/  x + a
 
         >>> print((prettyForm("x+3")/prettyForm("y")).root().right(" + a"))
-            ___
-           /x+3
-          / --- + a
+            _____
+           / x+3
+          /  --- + a
         \\/   y
 
         >>> print((prettyForm("x+3")/prettyForm("y")).root(stringPict("3")).right(" + a"))
-            ___
-           /x+3
-        3 / --- + a
-        \\/   y
+            _____
+           / x+3
+        3 /  --- + a
+        \\/    y
 
         For indices with more than one line, use the Pow form:
 
@@ -377,39 +377,44 @@ class stringPict:
         |---|         + a
         \\ y /
         """
-        # TODO: use it in root drawing in PrettyPrinter.
-        #
-        # put line over expression
+        # Decide if using a square root symbol or
+        # an base - exponent form:
         if n is not None:
             if isinstance(n, str):
+                n = n.ljust(2)
                 n = stringPict(n)
+            elif n.width()<2:
+                n = stringPict(str(n).ljust(2))
             if n.height() > 1:
-                exponent =  n.parens().left(stringPict("1 / "))
+                exponent =  n.parens().left(stringPict("1 / "), align="c")
                 return self ** exponent
 
-        result = self.above('_' * self.width())
+        # put line over expression
+        result = self.above(hobj('_', 2 + self.width()))
         #construct right half of root symbol
         height = self.height()
-
-        root_sign = prettyForm(xobj('\\', 1))
+        _zZ = xobj('/', 1)
+        root_sign = prettyForm(xobj('\\', 1)+ _zZ)
         if n is not None:
             root_sign = root_sign.above(n, align="r")
+        if height>1:
+            slash = '\n'.join(' ' * (height - i - 2) + _zZ + ' ' * i for i in range(height-1))
+            # TODO: To improve the use of the space, consider
+            # using a vertical line instead '/', like
+            #    -
+            #   |x
+            # 20|-
+            #  \|2
+            #
+            # # remove the `.ljust.(2)` in `n` and
+            # # replace the previous line by
+            # _zZ = xobj('|', 1)
+            # slash = "\n".join(height*[_zZ])
+            #
+            # but this requires to change many tests.
+            slash = stringPict(" ").above(slash, align='l')
+            root_sign = root_sign.right(slash, align="b")
 
-        _zZ = xobj('/', 1)
-        slash = '\n'.join(' ' * (height - i - 1) + _zZ + ' ' * i for i in range(height))
-        # TODO: To improve the use of the space, consider
-        # using a vertical line instead '/', like
-        #    -
-        #   |x
-        # 20|-
-        #  \|2
-        #
-        # _zZ = xobj('|', 1)
-        # slash = "\n".join(height*[_zZ])
-        #
-        # but this requires to change many tests.
-        slash = stringPict(slash, self.baseline)
-        root_sign = root_sign.right(slash, align="b")
         return result.left(root_sign, align="b")
 
     def render(self, *args, **kwargs):

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -280,13 +280,12 @@ class stringPict:
         baseline = len(string.splitlines()) - self.height() + self.baseline
         return self.__class__(string, baseline)
 
-
     def parens(self, left="(", right=")", ifascii_nougly=False):
         """Put parentheses around self.
         Returns string, baseline arguments for stringPict.
 
         left or right can be None or empty string which means 'no paren from
-        that side'
+        that side'.
         """
 
         # TODO: Add a deprecation warning in favor of
@@ -310,10 +309,10 @@ class stringPict:
             res = res.right(rparen)
 
         return "\n".join(res.picture), res.baseline
-    
+
     def parenthesis(self, left="(", right=")", ifascii_nougly=False):
         """Returns a new object of the same type than self,
-        sorrounded by parenthesis of the type specified by 
+        sorrounded by parenthesis of the type specified by
         the arguments `left` and `right`.
 
         `left` or `right` can be None or empty string which means 'no paren from


### PR DESCRIPTION
#### References to other Issues or PRs

I am working on giving Mathics (https://github.com/Mathics3/mathics-core/pull/1155) the ability to produce prettyprint
-like output from Mathics `Expression` objects. To avoid duplicating efforts, I tried to hook on the `sympy.printing.pretty` package, but I found some problems. 
After trying to use the `PrettyPrinter`, I realized that since `mathics.core.Expression` objects behave differently than Sympy objects, the best would be to generate text blocks directly from the `sympy.printing.pretty.stringpict.prettyForm` class. A draft of it can be seen at https://github.com/Mathics3/mathics-core/pull/1162

In this journey, I found some issues in the design of `sympy.printing.pretty.stringpict` that makes me difficult to use it directly on my project. 
This PR includes the changes I need to make it work. It also probably helps with #20894.

#### Brief description of what is fixed or changed

In this PR I propose some changes in the `stringPict` API, which I hope will make it easier to use it both inside Sympy  or in in other projects, like Mathics.



  * the methods  `subindex`, `superindex`  and `subsuperindices` were added to the `stringPict` interface as high level methods to deal with indices and subindices.
  * the methods `above`, `below`, `left`, and `right` were modified to return `prettyForm` or `stringPict`
   objects depending on the class of the object over which they are called.
   * `above`, `below`, `left`,  and `right`  now support a keyword argument `align` that allow to control the relative alignment of the elements.
   * The method `parenthesis` was added, with the same functionality of `parens`, but following the pattern in `above`, `below`, `left` and `right`. `parens` is left for backward compatibility.
   * the `root` method was fixed, and used to simplify the code in `PrettyPrinter._print_nth_root()`.
   * doctests for the modified methods were added.
   * tests and the use of the modified methods were adjusted along the code.
  
The idea is that `stringPict.[above|below,left|right|subindex|superindex|subsuperindices](...)` work as high-level methods to build `stringPict` and `prettyForm` complex objects, leaving `stringPict.[stack|next]()` methods as low-level methods. High-level methods then return objects of the same type as the caller object (`stringPict|prettyForm`), while low-level methods return tuples of `(str, int)`. 
The use of the high-level methods allows us to avoid the idiom `prettyForm(*stringPict.method(...))`, which is spread all over Sympy. This behavior seems to be suggested by the implementation of `stringPict.root`, a method that didn't work in the master branch but does it here. 

Another change included is to support horizontal and vertical alignment in text blocks, which was marked as a TODO task, and which also helps to build complex stringPicts without explicitly computing the baselines on the building routines. 

The implementation of `stringPict.root`, which is working now, suggests that this organization was considered before.

#### Other comments

I tried to modify the rest of the code as little as possible to play with my project without breaking tests. I have more suggestions for improving the pretty module, but could be go in another PR.


#### Release notes

<!-- BEGIN RELEASE NOTES -->

* printing
  * the methods  `subindex`, `superindex`  and `subsuperindices` were added to the `stringPict` interface as high level methods to deal with indices and subindices.
  * the methods `above`, `below`, `left`, and `right` were modified to return `prettyForm` or `stringPict`
   objects depending on the class of the object over which they are called.
   * `above`, `below`, `left`,  and `right`  now support a keyword argument `align` that allow to control the relative alignment of the elements.
   * The method `parenthesis` was added, with the same functionality of `parens`, but following the pattern in `above`, `below`, `left` and `right`. `parens` is left for backward compatibility.
   * the `root` method was fixed, and used to simplify the code in `PrettyPrinter._print_nth_root()`.
   * doctests for the modified methods were added.
   * tests and the use of the modified methods were adjusted along the code.
   * TODO comments were included to point out how to continue.
   * Changelog-like comments in module docstrings were removed.
<!-- END RELEASE NOTES -->

