### PR TITLE
Added test for "Definite integral variant fails" in test_integrals.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1456,6 +1456,7 @@ Taylan Sahin <info@taylansahin.net>
 Ted Dokos <tdokos@gmail.com> <t.dokos@gmail.com>
 Ted Horst <ted.horst@earthlink.net>
 Tejaswini Sanapathi <sastejaswini2002@gmail.com>
+Temi <ytemiloluwa@gmail.com> ytemiloluwa <ytemiloluwa@gmail.com>
 Theodore Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2160,3 +2160,19 @@ def test_integral_issue_26566():
 
     # Assert that the symbolic result matches the correct value
     assert simplify(numeric_symbolic_result - numeric_correct_result) == 0
+
+
+def test_definite_integral_with_floats_issue_27231():
+    # Define the symbol and the integral expression
+    x = symbols('x', real=True)
+    integral_expr = sqrt(1 - 0.5625 * (x + 0.333333333333333) ** 2)
+
+    # Perform the definite integral with the known limits
+    result_symbolic = integrate(integral_expr, (x, -1, 1))
+    result_numeric = result_symbolic.evalf()
+
+    # Expected result with higher precision
+    expected_result = sqrt(3) / 6 + 4 * pi / 9
+
+    # Verify that the result is approximately equal within a larger tolerance
+    assert abs(result_numeric - expected_result.evalf()) < 1e-8


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27231

#### Brief description of what is fixed or changed
This PR adds a regression test to verify the proper evaluation of a definite integral involving floating-point values, which previously resulted in incorrect evaluations. The test has been included in `sympy/integrals/tests/test_integrals.py` and it checks the integral's outcome against an expected result with a tolerance of 1e-8. @oscarbenjamin

#### Other comments

- Adjusted the tolerance level to 1e-8 in the test to prevent false negatives due to minimal floating-point precision errors.
- Ran all relevant test suites (193 selected ) and it passed. 
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals

   *  Added a regression test for a specific floating-point Definite integral variant  #27231 to prevent future discrepancies      in evaluation.


<!-- END RELEASE NOTES -->
