### PR TITLE
Fix broken links in solvers documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -500,6 +500,7 @@ Daniel Wennberg <daniel.wennberg@gmail.com>
 Danny Hermes <daniel.j.hermes@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>
 Dave Witte Morris <Dave.Morris@uleth.ca>
+Davi Laerte <davilae011@gmail.com>
 David Daly <david.daly12@kzoo.edu>
 David Hagen <david@drhagen.com>
 David Joyner <wdjoyner@gmail.com>

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -985,7 +985,7 @@ class GeneralSumOfSquares(DiophantineEquationType):
 
     .. [1] Representing an integer as a sum of three squares, [online],
         Available:
-        https://www.proofwiki.org/wiki/Integer_as_Sum_of_Three_Squares
+        https://proofwiki.org/wiki/Integer_as_Sum_of_Three_Squares
     """
 
     name = 'general_sum_of_squares'
@@ -3408,7 +3408,7 @@ def diop_general_sum_of_squares(eq, limit=1):
 
     .. [1] Representing an integer as a sum of three squares, [online],
         Available:
-        https://www.proofwiki.org/wiki/Integer_as_Sum_of_Three_Squares
+        https://proofwiki.org/wiki/Integer_as_Sum_of_Three_Squares
     """
     var, coeff, diop_type = classify_diop(eq, _dict=False)
 


### PR DESCRIPTION
**References to other Issues or PRs**
Fix broken links in documentation according https://github.com/sympy/sympy/issues/24140

**Brief description of what is fixed or changed**
This PR fix broken link to `proofwiki` in solvers documentation. The correct path now is a non-WWW domain.


**Other comments**
No comments

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->