### PR TITLE
Handling Piecewise limit for ">=" functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -689,6 +689,7 @@ Harsh Kasat <hkasat@waymore.io>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>
+Harshit Gupta <harshithigh2001@gmail.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
 Haruki Moriguchi <harukimoriguchi@gmail.com>
 HeeJae Chang <hechang@microsoft.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3526,8 +3526,7 @@ class Expr(Basic, EvalfMixin):
             raise ValueError('expecting a Symbol but got %s' % x)
         if x not in self.free_symbols:
             return self
-        obj = self
-
+        obj = self._eval_as_leading_term(x, logx=logx, cdir=cdir)
         if obj is not None:
             from sympy.simplify.powsimp import powsimp
             return powsimp(obj, deep=True, combine='exp')

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3526,7 +3526,8 @@ class Expr(Basic, EvalfMixin):
             raise ValueError('expecting a Symbol but got %s' % x)
         if x not in self.free_symbols:
             return self
-        obj = self._eval_as_leading_term(x, logx=logx, cdir=cdir)
+        obj = self
+
         if obj is not None:
             from sympy.simplify.powsimp import powsimp
             return powsimp(obj, deep=True, combine='exp')

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -226,6 +226,12 @@ class Piecewise(DefinedFunction):
         for e, c in self.args:
             if c == True or c.subs(x, 0) == True:
                 return e.as_leading_term(x)
+            elif cdir == -1 and c.subs(x, 0) == False:
+                if c.func == Lt and c.lhs==x:
+                    return e.as_leading_term(x)
+            elif cdir == 1 and c.subs(x, 0) == False:
+                if c.func == Gt and c.lhs==x:
+                    return e.as_leading_term(x)
 
     def _eval_adjoint(self):
         return self.func(*[(e.adjoint(), c) for e, c in self.args])

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -162,6 +162,12 @@ def test_piecewise2():
     assert limit(func2, x, 0) == 0
     assert limit(func3, x, -1) == 2
 
+def test_issue_27236():
+    func1 = Piecewise((1, x < 0), (-1, x >= 0))
+
+    assert limit(func1, x, 0, '+') == -1
+    assert limit(func1, x, 0, '-') == 1
+
 
 def test_basic5():
     class my(Function):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27236


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Updated how piecewise is evaluated as leading term based on approaching direction.
* series
  * Added a test for piecewise limits

<!-- END RELEASE NOTES -->
