### PR TITLE
Refactored sympify Calls to Use map for Improved Readability

### DIFF
--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -324,12 +324,7 @@ def clebsch_gordan(j_1, j_2, j_3, m_1, m_2, m_3):
 
     - Jens Rasch (2009-03-24): initial version
     """
-    j_1 = sympify(j_1)
-    j_2 = sympify(j_2)
-    j_3 = sympify(j_3)
-    m_1 = sympify(m_1)
-    m_2 = sympify(m_2)
-    m_3 = sympify(m_3)
+    j_1, j_2, j_3, m_1, m_2, m_3 = map(sympify, [j_1, j_2, j_3, m_1, m_2, m_3])
 
     w = wigner_3j(j_1, j_2, j_3, m_1, m_2, -m_3)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR refactors the code where multiple sympify calls were made individually on the j and m values in the clebsch_gordan function. I used the map function to apply the sympify function on all the variables in a more concise and readable manner.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
