### PR TITLE
type(evalf): add type hints for .evalf()

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -30,6 +30,7 @@ from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import as_int
 
 if TYPE_CHECKING:
+    from sympy.core.expr import Basic
     from sympy.core.expr import Expr
     from sympy.core.add import Add
     from sympy.core.mul import Mul
@@ -1558,6 +1559,15 @@ class EvalfMixin:
 
     __slots__ = ()  # type: tTuple[str, ...]
 
+    @overload
+    def evalf(self: Expr, n: int = 15, subs: dict[Basic, Basic | float] | None = None, # type: ignore
+              maxn: int = 100, chop: bool = False, strict: bool  = False,
+              quad: str | None = None, verbose: bool = False) -> Expr: ...
+    @overload
+    def evalf(self: Basic, n: int = 15, subs: dict[Basic, Basic | float] | None = None, # type: ignore
+              maxn: int = 100, chop: bool = False, strict: bool  = False,
+              quad: str | None = None, verbose: bool = False) -> Basic: ...
+
     def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False):
         """
         Evaluate the given formula to an accuracy of *n* digits.
@@ -1683,15 +1693,15 @@ class EvalfMixin:
 
     n = evalf
 
-    def _evalf(self, prec):
+    def _evalf(self, prec: int) -> Expr:
         """Helper for evalf. Does the same thing but takes binary precision"""
         r = self._eval_evalf(prec)
         if r is None:
-            r = self
-        return r
+            r = self # type: ignore
+        return r # type: ignore
 
-    def _eval_evalf(self, prec):
-        return
+    def _eval_evalf(self, prec: int) -> Expr | None:
+        return None
 
     def _to_mpmath(self, prec, allow_ints=True):
         # mpmath functions accept ints as input

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -79,7 +79,7 @@ class BasisDependent(Expr):
 
     evalf.__doc__ += Expr.evalf.__doc__  # type: ignore
 
-    n = evalf
+    n = evalf # type: ignore
 
     def simplify(self, **kwargs):
         """


### PR DESCRIPTION
This makes it possible for pyright to infer the type returned by evalf:
```
  from sympy import sqrt, Symbol
  x = Symbol('x')
  e = sqrt(2) + x
  f = e.evalf()
  reveal_type(f) # Expr
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

I think that together with gh-27262 this would mean that there are enough hints on basic functionality to be able to type check the methods in something like the quaternion module. That makes a reasonable demonstration of being able to type check some basic end user code.

#### Brief description of what is fixed or changed


#### Other comments

There may be a better way to do this without using `type: ignore` but the purpose for now is just to get the type inference working at least with pyright. It does not work with mypy unfortunately and I am not sure if it is possible to fix that. The EvalfMixin class complicates things because it is not a subclass of Basic or Expr but we need to be able to distinguish the fact that Expr.evalf returns Expr.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->