### PR TITLE
Added test case to limits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1168,6 +1168,7 @@ Pranjal Tale <pranjaltale16@gmail.com>
 Prashant Tyagi <prashanttyagi221295@gmail.com>
 Prasoon Shukla <prasoon92.iitr@gmail.com>
 Prateek Papriwal <papriwalprateek@gmail.com>
+Praveen Perumal <ppraveen98841@gmail.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1168,7 +1168,7 @@ Pranjal Tale <pranjaltale16@gmail.com>
 Prashant Tyagi <prashanttyagi221295@gmail.com>
 Prasoon Shukla <prasoon92.iitr@gmail.com>
 Prateek Papriwal <papriwalprateek@gmail.com>
-Praveen Perumal <ppraveen98841@gmail.com>
+Praveen Perumal <ppraveen98841@gmail.com> Praveen Perumal <58477724+solvedbiscuit71@users.noreply.github.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1444,3 +1444,7 @@ def test_issue_22982_15323():
 
 def test_issue_26991():
     assert limit(x/((x - 6)*sinh(tanh(0.03*x)) + tanh(x) - 0.5), x, oo) == 1/sinh(1)
+
+def test_issue_27278():
+    expr = (1/(x*log((x + 3)/x)))**x*((x + 1)*log((x + 4)/(x + 1)))**(x + 1)/3
+    assert limit(expr, x, oo) == 1


### PR DESCRIPTION
This PR fixes #27278

The added test case checks for the following expression

```python
expr = (1/(n*log((n + 3)/n)))**n*((n + 1)*log((n + 4)/(n + 1)))**(n + 1)/3

assert limit(expr, n, oo) == 1
```

This test case cause RecursionError in 1.13 and returns `oo` in 1.12. Though it has been fixed in master, added the test case for testing future versions.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->