### PR TITLE
Add is_fermat_prime() to primetests.

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -809,7 +809,6 @@ def is_fermat_prime(num):
     True
     >>> is_fermat_prime(15)
     False
-    
     References
     ==========
     .. [1] https://oeis.org/A019434

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -5,6 +5,7 @@ Primality testing
 
 from itertools import count
 
+from sympy.core.intfunc import integer_log
 from sympy.core.sympify import sympify
 from sympy.external.gmpy import (gmpy as _gmpy, gcd, jacobi,
                                  is_square as gmpy_is_square,

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -799,7 +799,7 @@ def is_gaussian_prime(num):
 
 def is_fermat_prime(num):
     r"""
-    Test if num is a Fermat prime number (True) or not (False). 
+    Test if num is a Fermat prime number (True) or not (False).
 
     Examples
     ========
@@ -825,4 +825,3 @@ def is_fermat_prime(num):
         return True
 
     return False
-

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -817,7 +817,6 @@ def is_fermat_prime(num):
     """
 
     num = as_int(num)
-    
     FERMAT_PRIMES = (3, 5, 17, 257, 65537)
     
     if num in FERMAT_PRIMES:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -824,4 +824,12 @@ def is_fermat_prime(num):
     if num in FERMAT_PRIMES:
         return True
 
-    return False
+    e = num - 1
+    for do in range(2):
+        be = perfect_power(e)
+        if not be:
+            return False
+        b, e = be
+        if b != 2:
+            return False
+    return False if (e < 65537) else None  # it seems unlikely that any more will be found, but not proven

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -821,13 +821,12 @@ def is_fermat_prime(num):
     
     if num in FERMAT_PRIMES:
         return True
+    if num < 65537:
+        return False
 
     e = num - 1
     for do in range(2):
-        be = perfect_power(e)
-        if not be:
+        e, ok = integer_log(e, 2)
+        if not ok:
             return False
-        b, e = be
-        if b != 2:
-            return False
-    return False if (e < 65537) else None  # it seems unlikely that any more will be found, but not proven
+    return False if (e < 31) else None  # *unlikely* that more will be found

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -819,7 +819,6 @@ def is_fermat_prime(num):
 
     num = as_int(num)
     FERMAT_PRIMES = (3, 5, 17, 257, 65537)
-    
     if num in FERMAT_PRIMES:
         return True
     if num < 65537:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -795,3 +795,34 @@ def is_gaussian_prime(num):
         a = abs(a)
         return isprime(a) and a % 4 == 3
     return isprime(a**2 + b**2)
+
+
+def is_fermat_prime(num):
+    r"""
+    Test if num is a Fermat prime number (True) or not (False). 
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory import is_fermat_prime
+    >>> is_fermat_prime(3)
+    True
+    >>> is_fermat_prime(15)
+    False
+    
+    References
+    ==========
+    .. [1] https://oeis.org/A019434
+    .. [2] https://mathworld.wolfram.com/FermatPrime.html
+    .. [3] https://mathworld.wolfram.com/FermatNumber.html
+    """
+
+    num = as_int(num)
+    
+    FERMAT_PRIMES = (3, 5, 17, 257, 65537)
+    
+    if num in FERMAT_PRIMES:
+        return True
+
+    return False
+


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

I recently used this function in a project and I though it may be of use to someone else. Simple function checks if num is in list of known Fermat Primes as there are only a few known. If any more are discovered they can simply be added to the list like with is_mersenne_prime()

<!-- BEGIN RELEASE NOTES -->
* ntheory
    * Added new prime test is_fermat_prime()

<!-- END RELEASE NOTES -->
