### PR TITLE
Add k-th power-free querying functions to ntheory

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -110,6 +110,14 @@ Ntheory Functions Reference
 
 .. autofunction:: find_first_n_carmichaels
 
+.. autofunction:: is_kth_power_free
+
+.. autofunction:: is_square_free
+
+.. autofunction:: kth_power_free_range
+
+.. autofunction:: square_free_range
+
 .. module:: sympy.ntheory.modular
 
 .. autofunction:: symmetric_residue

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -11,6 +11,7 @@ from .factor_ import divisors, proper_divisors, factorint, multiplicity, \
     divisor_count, proper_divisor_count, divisor_sigma, factorrat, \
     reduced_totient, primenu, primeomega, mersenne_prime_exponent, \
     is_perfect, is_abundant, is_deficient, is_amicable, is_carmichael, \
+    is_kth_power_free, is_square_free, kth_power_free_range, square_free_range, \
     abundance, dra, drm
 
 from .partitions_ import npartitions
@@ -40,6 +41,8 @@ __all__ = [
     'reduced_totient', 'primenu', 'primeomega', 'mersenne_prime_exponent',
     'is_perfect', 'is_abundant', 'is_deficient', 'is_amicable',
     'is_carmichael', 'abundance', 'dra', 'drm', 'multiplicity_in_factorial',
+    'is_kth_power_free', 'is_square_free', 'kth_power_free_range',
+    'square_free_range',
 
     'npartitions',
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2839,3 +2839,231 @@ def drm(n, b):
             mul *= r
         n = mul
     return n
+
+
+def is_kth_power_free(n, k=2):
+    r"""
+    Checks if a given integer `n` is `k`-th power-free.
+
+    A positive integer `n` is said to be k-th power-free if no prime factor
+    of `n` appears with an exponent greater than or equal to `k`. By default,
+    this function checks for square-freeness (k=2), meaning no prime factor
+    appears with an exponent of 2 or greater.
+
+    Parameters
+    ==========
+
+    n : int
+        A positive integer to be checked for k-th power-freeness.
+    k : int, optional
+        The value of `k` for k-th power-freeness. Defaults to 2.
+
+    Returns
+    =======
+
+    bool
+        True if `n` is k-th power-free, False otherwise.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory import is_kth_power_free
+    >>> is_kth_power_free(10)  # 10 = 2^1 * 5^1 (k=2)
+    True
+    >>> is_kth_power_free(12)  # 12 = 2^2 * 3^1 (k=2)
+    False
+    >>> is_kth_power_free(18, k=3)  # 18 = 2^1 * 3^2
+    True
+    >>> is_kth_power_free(16, k=3)  # 16 = 2^4
+    False
+
+    Notes
+    =====
+
+    - `n` must be a positive integer; otherwise, a `ValueError` is raised.
+    - If `k < 2`, a `ValueError` is raised as k-th power-freeness is only
+      meaningful for `k >= 2`.
+    - For `n = 1`, the function always returns True, as 1 is k-th power-free
+      for all values of `k`.
+    """
+
+    if n <= 0:
+        raise ValueError(
+            "Only positive integers can be checked for k-th power-freeness."
+        )
+    if n == 1:
+        return True
+    if k < 2:
+        raise ValueError("k must be at least 2 for meaningful k-th power-freeness.")
+
+    factors = factorint(n)
+
+    # Check if any prime factor has an exponent >= k
+    for exponent in factors.values():
+        if exponent >= k:
+            return False
+
+    return True
+
+
+def is_square_free(n):
+    r"""
+    Checks if a given integer `n` is square-free.
+
+    A positive integer `n` is said to be square-free if no prime factor
+    of `n` appears with an exponent greater than or equal to 2.
+
+    Parameters
+    ==========
+
+    n : int
+        A positive integer to be checked for square-freeness.
+
+    Returns
+    =======
+
+    bool
+        True if `n` is square-free, False otherwise.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory import is_square_free
+    >>> is_square_free(10)  # 10 = 2^1 * 5^1
+    True
+    >>> is_square_free(12)  # 12 = 2^2 * 3^1
+    False
+    >>> is_square_free(18)  # 18 = 2^1 * 3^2
+    False
+    >>> is_square_free(11)  # 11 = 11^1
+    True
+    >>> is_square_free(16)  # 16 = 2^4
+    False
+
+    Notes
+    =====
+
+    - `n` must be a positive integer; otherwise, a `ValueError` is raised.
+    - For `n = 1`, the function always returns True, as 1 is square-free.
+
+    See Also
+    ========
+
+    is_kth_power_free
+    """
+
+    if n <= 0:
+        raise ValueError("Only positive integers can be checked for square-freeness.")
+
+    if n == 1:
+        return True
+
+    return is_kth_power_free(n, k=2)
+
+
+def kth_power_free_range(a, b, k=2):
+    r"""
+    Generates a list of k-th power-free numbers in the range [a, b)
+
+    Parameters
+    ==========
+
+    a : int
+        A positive integer that is the start of the range (inclusive).
+    b : int
+        A positive integer that is the end of the range (exclusive).
+    k : int, optional
+        The value of `k` for k-th power-freeness. Defaults to 2.
+
+    Returns
+    =======
+
+    List
+        List having k-th power-free numbers in range [a, b).
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory import kth_power_free_range
+    >>> kth_power_free_range(1, 10, 2)
+    [1, 2, 3, 5, 6, 7]
+    >>> kth_power_free_range(10, 20, 3)
+    [10, 11, 12, 13, 14, 15, 17, 18, 19]
+
+    Notes
+    =====
+
+    - `a` and `b` must be positive integers; otherwise, a `ValueError` is raised.
+    - Empty list is returned if there are no k-th power free integers in given range.
+
+    See Also
+    ========
+
+    is_kth_power_free
+    """
+
+    if not (a > 0 and b > 0):
+        raise ValueError("Both 'a' and 'b' must be positive integers.")
+
+    if a >= b:
+        raise ValueError("'a' has to be less than 'b'.")
+
+    if k < 2:
+        raise ValueError("'k' must be an integer greater than or equal to 2.")
+
+    return [n for n in range(a, b) if is_kth_power_free(n, k)]
+
+
+def square_free_range(a, b):
+    r"""
+    Generates a list of square-free numbers in the range [a, b)
+
+    A square-free number is an integer that is not divisible by
+    any perfect square other than 1.
+
+    Parameters
+    ==========
+
+    a : int
+        A positive integer that is the start of the range (inclusive).
+    b : int
+        A positive integer that is the end of the range (exclusive).
+
+    Returns
+    =======
+
+    List
+        List having square-free numbers in range [a, b).
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory import square_free_range
+    >>> square_free_range(1, 10)
+    [1, 2, 3, 5, 6, 7]
+    >>> square_free_range(10, 20)
+    [10, 11, 13, 14, 15, 17, 19]
+    >>> square_free_range(15, 16)
+    [15]
+    >>> square_free_range(1, 2)
+    [1]
+
+    Notes
+    =====
+
+    - `a` and `b` must be positive integers; otherwise, a `ValueError` is raised.
+    - Empty list is returned if there are no k-th power free integers in given range.
+
+    See Also
+    ========
+
+    is_square_free
+    """
+
+    if not (a > 0 and b > 0):
+        raise ValueError("Both 'a' and 'b' must be positive integers.")
+
+    if a >= b:
+        raise ValueError("'a' has to be less than 'b'.")
+
+    return [n for n in range(a, b) if is_square_free(n)]

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -16,7 +16,8 @@ from sympy.ntheory.factor_ import (smoothness, smoothness_p, proper_divisors,
     udivisor_count, proper_divisor_count, primenu, primeomega,
     mersenne_prime_exponent, is_perfect, is_abundant,
     is_deficient, is_amicable, is_carmichael, find_carmichael_numbers_in_range,
-    find_first_n_carmichaels, dra, drm, _perfect_power, factor_cache)
+    find_first_n_carmichaels, dra, drm, _perfect_power, factor_cache,
+    is_kth_power_free, is_square_free, kth_power_free_range, square_free_range)
 
 from sympy.testing.pytest import raises, slow
 
@@ -700,3 +701,40 @@ def test_deprecated_ntheory_symbolic_functions():
         assert divisor_sigma(3) == 4
     with warns_deprecated_sympy():
         assert udivisor_sigma(3) == 4
+
+
+def test_is_kth_power_free():
+    assert is_kth_power_free(1) == True
+    assert is_kth_power_free(10) == True
+    assert is_kth_power_free(12) == False
+    assert is_kth_power_free(18, k=3) == True
+    assert is_kth_power_free(16, k=3) == False
+    raises(ValueError, lambda: is_kth_power_free(10, k=-5))
+    raises(ValueError, lambda: is_kth_power_free(-5))
+
+
+def test_is_square_free():
+    assert is_square_free(11) == True
+    assert is_square_free(10) == True
+    assert is_square_free(12) == False
+    assert is_square_free(18) == False
+    assert is_square_free(16) == False
+    assert is_square_free(11) == True
+    raises(ValueError, lambda: is_square_free(-5))
+
+
+def test_kth_power_free_range():
+    assert kth_power_free_range(1, 10, k=2) == [1, 2, 3, 5, 6, 7]
+    assert kth_power_free_range(10, 20, k=3) == [10, 11, 12, 13, 14, 15, 17, 18, 19]
+    raises(ValueError, lambda: kth_power_free_range(-1, 5))
+    raises(ValueError, lambda: kth_power_free_range(20, 1, k=3))
+    raises(ValueError, lambda: kth_power_free_range(1, 10, k=-5))
+
+
+def test_square_free_range():
+    assert square_free_range(1, 10) == [1, 2, 3, 5, 6, 7]
+    assert square_free_range(10, 20) == [10, 11, 13, 14, 15, 17, 19]
+    assert square_free_range(15, 16) == [15]
+    assert square_free_range(1, 2) == [1]
+    raises(ValueError, lambda: square_free_range(20, 1))
+    raises(ValueError, lambda: square_free_range(-1, 5))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27271

#### Brief description of what is fixed or changed
This PR adds 4 new functions to the ntheory module in Sympy.
- Added `is_kth_power_free` to check for k-th power-freeness of a number, similarly `is_square_free` is added for special case of k = 2.
- Added `kth_power_free_range` to generate a list of k-th power free numbers in a given range, similarly for `square_free_range`.
- Added tests and docstrings for all 4 functions

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added functions to check k-th power freeness of a number and to generate them in a given range.
<!-- END RELEASE NOTES -->
