### PR TITLE
Fix a bug with `sympify` on infinite inputs

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -100,9 +100,14 @@ def _convert_numpy_types(a, **sympify_args):
         prec = np.finfo(a).nmant + 1
         # E.g. double precision means prec=53 but nmant=52
         # Leading bit of mantissa is always 1, so is not stored
-        p, q = a.as_integer_ratio()
-        a = mlib.from_rational(p, q, prec)
-        return Float(a, precision=prec)
+        if np.isposinf(a):
+            return Float('inf')
+        elif np.isneginf(a):
+            return Float('-inf')
+        else:
+            p, q = a.as_integer_ratio()
+            a = mlib.from_rational(p, q, prec)
+            return Float(a, precision=prec)
 
 
 @overload

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -885,5 +885,8 @@ def test_issue_21536():
     assert sympify(["x+3*x+2", "2*x+4*x+2+4"]) == [u, v]
 
 def test_issue_27284():
+    if not numpy:
+        skip("numpy not installed.")
+
     assert Float(numpy.float32(float('inf'))) == S.Infinity
     assert Float(numpy.float32(float('-inf'))) == S.NegativeInfinity

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -883,3 +883,7 @@ def test_issue_21536():
     assert u.is_Add and set(u.args) == {4*x, 2}
     assert v.is_Add and set(v.args) == {6*x, 6}
     assert sympify(["x+3*x+2", "2*x+4*x+2+4"]) == [u, v]
+
+def test_issue_27284():
+    assert Float(numpy.float32(float('inf'))) == S.Infinity
+    assert Float(numpy.float32(float('-inf'))) == S.NegativeInfinity


### PR DESCRIPTION
This PR Fixes #27284

Before this fix, the function `as_integer_ratio` throws OverflowError because infinity cannot be represented in ratio.

```python
p, q = a.as_integer_ratio() # raises OverflowError when a is `inf` or `-inf`
```

With this fix, the function check whether the value is positive or negative infinite before converting into ratio.

```python
if np.isposinf(a):
    return Float('inf')
elif np.isneginf(a):
    return Float('-inf')
else:
    # convert to ratio
```

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug with `sympify` when infinite floats are passed. For example: `sympify(np.float32('inf'))`.
<!-- END RELEASE NOTES -->
