### PR TITLE
Ensure wigner_6j and wigner_9j compatibility with numpy floats

### DIFF
--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -67,6 +67,10 @@ def test_clebsch_gordan_numpy():
 
 
 def test_wigner():
+    try:
+        import numpy as np
+    except ImportError:
+        skip("numpy not installed")
     def tn(a, b):
         return (a - b).n(64) < S('1e-64')
     assert tn(wigner_9j(1, 1, 1, 1, 1, 1, 1, 1, 0, prec=64), Rational(1, 18))
@@ -74,6 +78,8 @@ def test_wigner():
         70)/(246960*sqrt(105)) - 365/(3528*sqrt(70)*sqrt(105))
     assert wigner_6j(5, 5, 5, 5, 5, 5) == Rational(1, 52)
     assert tn(wigner_6j(8, 8, 8, 8, 8, 8, prec=64), Rational(-12219, 965770))
+    assert wigner_6j(1, 1, 1, 1.0, np.float64(1.0), 1) == Rational(1, 6)
+    assert wigner_6j(3.0, np.float32(3), 3.0, 3, 3, 3) == Rational(-1, 14)
     # regression test for #8747
     half = S.Half
     assert wigner_9j(0, 0, 0, 0, half, half, 0, half, half) == half
@@ -89,6 +95,14 @@ def test_wigner():
                       2, 4, 4,
                       5, 7 * half, 7 * half)
             == -sqrt(Rational(3481, 5042614500)))
+    assert (wigner_9j(5, 5, 5.0,
+                      np.float64(5.0), 5, 5,
+                      5, 5, 5)
+            == 0)
+    assert (wigner_9j(1.0, 2.0, 3.0,
+                      3, 2, 1,
+                      2, 1, 3)
+            == -4*sqrt(70)/11025)
 
 
 def test_gaunt():

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -571,6 +571,8 @@ def wigner_6j(j_1, j_2, j_3, j_4, j_5, j_6, prec=None):
     algebra system [Rasch03]_.
 
     """
+    j_1, j_2, j_3, j_4, j_5, j_6 = map(sympify, \
+                [j_1, j_2, j_3, j_4, j_5, j_6])
     res = (-1) ** int(j_1 + j_2 + j_4 + j_5) * \
         racah(j_1, j_2, j_5, j_4, j_3, j_6, prec)
     return res
@@ -627,6 +629,8 @@ def wigner_9j(j_1, j_2, j_3, j_4, j_5, j_6, j_7, j_8, j_9, prec=None):
     for finite precision arithmetic and only useful for a computer
     algebra system [Rasch03]_.
     """
+    j_1, j_2, j_3, j_4, j_5, j_6, j_7, j_8, j_9 = map(sympify, \
+                [j_1, j_2, j_3, j_4, j_5, j_6, j_7, j_8, j_9])
     imax = int(min(j_1 + j_9, j_2 + j_6, j_4 + j_8) * 2)
     imin = imax % 2
     sumres = 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27285

#### Brief description of what is fixed or changed
Modified the wigner_6j and wigner_9j functions to ensure compatibility with numpy floats by adding calls to sympify for the input params. This now allows them to accept numpy floats.
Also added tests for this behaviour.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.wigner
  * Numpy floats can be used with wigner_6j and wigner_9j functions
<!-- END RELEASE NOTES -->
