### PR TITLE
Fix: Correct substitution behavior in Quantity._eval_subs

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -106,8 +106,18 @@ class Quantity(AtomicExpr):
         return self
 
     def _eval_subs(self, old, new):
+        # If `new` is a Quantity and `self` is not `old`, preserve current behavior
         if isinstance(new, Quantity) and self != old:
             return self
+        # Use parent class substitution
+        expr = super()._eval_subs(old, new)
+        # If the substitution results in None, return self
+        if expr is None:
+            return self
+        # Handle cases where the substitution leaves `old` inside unit expressions
+        if old in expr.free_symbols:
+            expr = expr.xreplace({old: new})
+        return expr
 
     def _latex(self, printer):
         if self._latex_repr:

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -111,12 +111,9 @@ class Quantity(AtomicExpr):
             return self
         # Use parent class substitution
         expr = super()._eval_subs(old, new)
-        # If the substitution results in None, return self
-        if expr is None:
+        # Prevent substitution in unit symbols directly
+        if isinstance(self, Quantity):
             return self
-        # Handle cases where the substitution leaves `old` inside unit expressions
-        if old in expr.free_symbols:
-            expr = expr.xreplace({old: new})
         return expr
 
     def _latex(self, printer):

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -28,6 +28,8 @@ from sympy.physics.units.prefixes import PREFIXES, kilo
 from sympy.physics.units.quantities import PhysicalConstant, Quantity
 from sympy.physics.units.systems import SI
 from sympy.testing.pytest import raises
+import sympy.physics.units as u
+from sympy import symbols, latex
 
 k = PREFIXES["k"]
 
@@ -573,3 +575,15 @@ def test_physics_constant():
 
     assert not meter.is_physical_constant
     assert not joule.is_physical_constant
+
+
+def test_quantity_substitution():
+    # Define symbol m and quantity expressions
+    m = symbols('m')
+    h = 10 * u.m
+    U = m * u.acceleration_due_to_gravity * h
+    # Substitute m with 10 * u.kg
+    result = U.subs(m, 10 * u.kg)
+    # latex output is as expected
+    expected_latex = '100 \\text{g} \\text{kg} \\text{m}'
+    assert latex(result) == expected_latex, f"Expected: {expected_latex}, got: {latex(result)}"

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -29,7 +29,7 @@ from sympy.physics.units.quantities import PhysicalConstant, Quantity
 from sympy.physics.units.systems import SI
 from sympy.testing.pytest import raises
 import sympy.physics.units as u
-from sympy import symbols, latex
+from sympy import latex
 
 k = PREFIXES["k"]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27180
#### Brief description of what is fixed or changed
This PR addresses a bug in the Quantity._eval_subs method, which previously caused AttributeError when substitutions left symbols inside unit expressions. @oscarbenjamin @sylee957 

#### Other comments
The fix improves compatibility with unit-related computations and ensures robust behavior for substitutions involving Quantity objects.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units

    * Fixed a bug in Quantity._eval_subs that caused AttributeError during substitutions involving symbols within units.
      
<!-- END RELEASE NOTES -->
