### PR TITLE
Fix grammatical error in the Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ reported by contacting one of the project maintainers at asmeurer@gmail.com or
 ondrej.certik@gmail.com. All complaints will be reviewed and investigated and
 will result in a response that is deemed necessary and appropriate to the
 circumstances. The project team is obligated to maintain confidentiality with
-regard to the reporter of an incident.  Further details on specific
+regard to the reporter of an incident. Further details on specific
 enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ reported by contacting one of the project maintainers at asmeurer@gmail.com or
 ondrej.certik@gmail.com. All complaints will be reviewed and investigated and
 will result in a response that is deemed necessary and appropriate to the
 circumstances. The project team is obligated to maintain confidentiality with
-regard to the reporter of an incident.  Further details of specific
+regard to the reporter of an incident.  Further details on specific
 enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* other
  * Corrected a grammatical error in the Code of Conduct document. Changed "Further details of specific enforcement policies may be posted separately." to "Further details on specific enforcement policies may be posted separately."
<!-- END RELEASE NOTES -->
