### PR TITLE
[WIP] Fixed missing cases while integrating Legendre polynomial with symbolic input

### DIFF
--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -831,7 +831,7 @@ class legendre(OrthogonalPolynomial):
         if not n.is_Number:
             # Symbolic result L_n(x)
             # L_n(-x)  --->  (-1)**n * L_n(x)
-            if x.could_extract_minus_sign():
+            if x.could_extract_minus_sign() and n.is_nonnegative:
                 return S.NegativeOne**n * legendre(n, -x)
             # L_{-n}(x)  --->  L_{n-1}(x)
             if n.could_extract_minus_sign() and not(-n - 1).could_extract_minus_sign():

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -14,6 +14,7 @@ from sympy.functions.special.hyper import hyper
 from sympy.functions.special.polynomials import (assoc_laguerre, assoc_legendre, chebyshevt, chebyshevt_root, chebyshevu, chebyshevu_root, gegenbauer, hermite, hermite_prob, jacobi, jacobi_normalized, laguerre, legendre)
 from sympy.polys.orthopolys import laguerre_poly
 from sympy.polys.polyroots import roots
+from sympy.integrals import integrate
 
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
@@ -176,7 +177,6 @@ def test_legendre():
     assert legendre(n, 1) == 1
     assert legendre(n, oo) is oo
     assert legendre(-n, x) == legendre(n - 1, x)
-    assert legendre(n, -x) == (-1)**n*legendre(n, x)
     assert unchanged(legendre, -n + k, x)
 
     assert conjugate(legendre(n, x)) == legendre(n, conjugate(x))
@@ -192,6 +192,10 @@ def test_legendre():
             x/2)**_k*(x/2 + S.Half)**(-_k + n)*binomial(n, _k)**2, (_k, 0, n)))
     raises(ArgumentIndexError, lambda: legendre(n, x).fdiff(1))
     raises(ArgumentIndexError, lambda: legendre(n, x).fdiff(3))
+
+    res = integrate(legendre(n, x), (x, -1, 1))
+    assert res.subs({n: 0}) == 2
+    assert res.subs({n: 1}) == 0
 
 
 def test_assoc_legendre():


### PR DESCRIPTION
This fixes the issue #27298 

Before this fix, Integrating the nth Legendre polynomial on symbolic input over the range [-1, 1] yields the below expression which on substituting n = 0 results in 0. This is wrong as 0th degree Legendre polynomial $P_0(x) = 1$ will result in 2.

```python
>>> integrate(legendre(n, x), (x, -1, 1))
-(-(-1)**(n - 1) + (-1)**(n + 1))/(2*n + 1)

>>> _.subs({n: 0})
0
```

After this fix, Integrating will result in a different expression on which substituting n = 0 results in 2.

```python
>>> integrate(legendre(n, x), (x, -1, 1))
-(-legendre(n - 1, -1) + legendre(n + 1, -1))/(2*n + 1)

>>> _.subs({n: 0})
2
```

<!-- BEGIN RELEASE NOTES -->
* functions
  * fixed a bug when integrating Legendre polynomial on symbolic inputs
<!-- END RELEASE NOTES -->
