### PR TITLE
types(core): add type hints for Basic.atoms

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -831,6 +831,8 @@ class AppliedUndef(Function):
 
     is_number = False
 
+    name: str
+
     def __new__(cls, *args, **options) -> Expr:  # type: ignore
         args = tuple(map(sympify, args))
         u = [a.name for a in args if isinstance(a, UndefinedFunction)]

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Iterator
+
 from .basic import Basic
 from .sorting import ordered
 from .sympify import sympify
@@ -156,7 +160,7 @@ class preorder_traversal:
     def __next__(self):
         return next(self._pt)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Basic]:
         return self
 
 

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -559,11 +559,11 @@ def _auto_infer_smtlib_types(
     }, float)
 
     # EQUALITY RELATION RULE
-    rels = [rel for expr in exprs for rel in expr.atoms(Equality)]
+    rels_eq = [rel for expr in exprs for rel in expr.atoms(Equality)]
     rels = [
-               (rel.lhs, rel.rhs) for rel in rels if rel.lhs.is_Symbol
+               (rel.lhs, rel.rhs) for rel in rels_eq if rel.lhs.is_Symbol
            ] + [
-               (rel.rhs, rel.lhs) for rel in rels if rel.rhs.is_Symbol
+               (rel.rhs, rel.lhs) for rel in rels_eq if rel.rhs.is_Symbol
            ]
     for infer, reltd in rels:
         inference = (


### PR DESCRIPTION
This enables a type checker to infer the types returned by e.g. expr.atoms() or expr.atoms(Pow).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
