### PR TITLE
Fix : Simplification of Mod expressions 

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -46,7 +46,7 @@ from sympy.simplify.trigsimp import trigsimp, exptrigsimp
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import has_variety, sift, subsets, iterable
 from sympy.utilities.misc import as_int
-from sympy import Mod
+from sympy import Mod, symbols, simplify
 from sympy.core.logic import fuzzy_and
 import mpmath
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -46,7 +46,7 @@ from sympy.simplify.trigsimp import trigsimp, exptrigsimp
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import has_variety, sift, subsets, iterable
 from sympy.utilities.misc import as_int
-from sympy import Mod, symbols, simplify
+from sympy import Mod
 from sympy.core.logic import fuzzy_and
 import mpmath
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -450,7 +450,6 @@ def simplify_mod_addition(expr):
 
 
 def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, doit=True, **kwargs):
-    expr = simplify_mod_addition(expr)
     """Simplifies the given expression.
 
     Explanation
@@ -604,7 +603,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
     sympy.assumptions.refine.refine : Simplification using assumptions.
     sympy.assumptions.ask.ask : Query for boolean expressions using assumptions.
     """
-
+    expr = simplify_mod_addition(expr)
     def shorter(*choices):
         """
         Return the choice that has the fewest ops. In case of a tie,

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -33,6 +33,7 @@ from sympy.solvers.solvers import solve
 from sympy.testing.pytest import XFAIL, slow, _both_exp_pow
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, n
 
+from sympy import Mod
 
 def test_issue_7263():
     assert abs((simplify(30.8**2 - 82.5**2 * sin(rad(11.6))**2)).evalf() - \
@@ -1085,3 +1086,32 @@ def test_nc_recursion_coeff():
     X = symbols("X", commutative = False)
     assert (2 * cos(pi/3) * X).simplify() == X
     assert (2.0 * cos(pi/3) * X).simplify() == X
+
+
+def test_simplify_mod_issue_27304():
+    # Test case 1: Real numbers
+    a, b, c = symbols('a b c', real=True)
+    expr = Mod(a - b, c) + Mod(b - a, c)
+    result = simplify(expr)
+    # Expect c when symbols are real
+    assert result == c
+
+    # Test case 2: Complex numbers (should remain unchanged)
+    a, b, c = symbols('a b c', complex=True)
+    expr = Mod(a - b, c) + Mod(b - a, c)
+    result = simplify(expr)
+    # No simplification for complex numbers
+    assert result == expr
+
+    # Test case 3: Different moduli (should remain unchanged)
+    a, b, c1, c2 = symbols('a b c1 c2', real=True)
+    expr = Mod(a - b, c1) + Mod(b - a, c2)
+    result = simplify(expr)
+    # No simplification if moduli are different
+    assert result == expr
+
+    # Test case 4: Single Mod term (should remain unchanged)
+    a, b, c = symbols('a b c', real=True)
+    expr = Mod(a - b, c)
+    result = simplify(expr)
+    assert result == Mod(a - b, c)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27304
#### Brief description of what is fixed or changed

This PR addresses the issue with the simplification of modular expressions. Specifically, it ensures that the expression `Mod(-a + b, c) + Mod(a - b, c)` simplifies correctly when the symbols are real, returning c. Additionally, it preserves the expression when dealing with complex numbers, as no simplification is possible in that case. @oscarbenjamin @sylee957 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
     * Fixed simplification for modular arithmetic expressions with real numbers.
<!-- END RELEASE NOTES -->
