### PR TITLE
printing.mathematica: fix output arg order for two-arg ArcTan (atan2)

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -27,7 +27,6 @@ known_functions = {
     "acot": [(lambda x: True, "ArcCot")],
     "asec": [(lambda x: True, "ArcSec")],
     "acsc": [(lambda x: True, "ArcCsc")],
-    "atan2": [(lambda *x: True, "ArcTan")],
     "sinh": [(lambda x: True, "Sinh")],
     "cosh": [(lambda x: True, "Cosh")],
     "tanh": [(lambda x: True, "Tanh")],
@@ -314,6 +313,10 @@ class MCodePrinter(CodePrinter):
         if len(expr.args) == 1:
             return "ProductLog[{}]".format(self._print(expr.args[0]))
         return "ProductLog[{}, {}]".format(
+            self._print(expr.args[1]), self._print(expr.args[0]))
+
+    def _print_atan2(self, expr):
+        return "ArcTan[{}, {}]".format(
             self._print(expr.args[1]), self._print(expr.args[0]))
 
     def _print_Integral(self, expr):

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -45,7 +45,7 @@ def test_Function():
     assert mcode(f(x, y, z)) == "f[x, y, z]"
     assert mcode(sin(x) ** cos(x)) == "Sin[x]^Cos[x]"
     assert mcode(sec(x) * acsc(x)) == "ArcCsc[x]*Sec[x]"
-    assert mcode(atan2(x, y)) == "ArcTan[x, y]"
+    assert mcode(atan2(y, x)) == "ArcTan[x, y]"
     assert mcode(conjugate(x)) == "Conjugate[x]"
     assert mcode(Max(x, y, z)*Min(y, z)) == "Max[x, y, z]*Min[y, z]"
     assert mcode(fresnelc(x)) == "FresnelC[x]"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The argument order for a two-argument `ArcTan[x, y]` in Mathematica differs from the order for `atan2(y, x)` in Sympy, but the printing module prints `atan2(y, x)` as `ArcTan[y, x]` (with the same argument order).

This commit fixes the argument order when printing a two-argument `ArcTan` expression.  This also fixes an existing test that was added in commit 285fd9b233bbc483b006bac409e9c4934a3f1950.

#### Other comments

The parsing module does swap the argument order as expected:

```
>>> from sympy.parsing.mathematica import parse_mathematica
>>> parse_mathematica("ArcTan[x, y]")
atan2(y, x)
```

Other references:
* https://reference.wolfram.com/language/ref/ArcTan.html
* https://functions.wolfram.com/ElementaryFunctions/ArcTan2/

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Fixed the argument order when printing a two-argument ArcTan Mathematica expression

<!-- END RELEASE NOTES -->
