### PR TITLE
printing.julia: fix the printing of sinc (Julia's is normalized)

### DIFF
--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -25,7 +25,7 @@ known_fcns_src1 = ["sin", "cos", "tan", "cot", "sec", "csc",
                    "asin", "acos", "atan", "acot", "asec", "acsc",
                    "sinh", "cosh", "tanh", "coth", "sech", "csch",
                    "asinh", "acosh", "atanh", "acoth", "asech", "acsch",
-                   "sinc", "atan2", "sign", "floor", "log", "exp",
+                   "atan2", "sign", "floor", "log", "exp",
                    "cbrt", "sqrt", "erf", "erfc", "erfi",
                    "factorial", "gamma", "digamma", "trigamma",
                    "polygamma", "beta",
@@ -417,6 +417,9 @@ class JuliaCodePrinter(CodePrinter):
         expr2 = sqrt(S.Pi/(2*x))*bessely(expr.order + S.Half, x)
         return self._print(expr2)
 
+    def _print_sinc(self, expr):
+        # Julia has the normalized sinc function
+        return "sinc({})".format(self._print(expr.args[0] / S.Pi))
 
     def _print_Piecewise(self, expr):
         if expr.args[-1].cond != True:

--- a/sympy/printing/tests/test_julia.py
+++ b/sympy/printing/tests/test_julia.py
@@ -1,7 +1,7 @@
 from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
                         Tuple, Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda, Mul, Pow
-from sympy.functions import Piecewise, sqrt, ceiling, exp, sin, cos
+from sympy.functions import Piecewise, sqrt, ceiling, exp, sin, cos, sinc
 from sympy.testing.pytest import raises
 from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
@@ -147,6 +147,10 @@ def test_boolean():
     assert julia_code((x & y) | z) == "z || x && y"
     assert julia_code((x | y) & z) == "z && (x || y)"
 
+def test_sinc():
+    assert julia_code(sinc(x)) == 'sinc(x / pi)'
+    assert julia_code(sinc(x + 3)) == 'sinc((x + 3) / pi)'
+    assert julia_code(sinc(pi * (x + 3))) == 'sinc(x + 3)'
 
 def test_Matrices():
     assert julia_code(Matrix(1, 1, [10])) == "[10]"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

In Julia `sinc` is the normalized sinc function, while in SymPy `sinc` is the unnormalized sinc function.  However, the printing module has been printing `sinc(x)` as `sinc(x)` for Julia.

This commit fixes the printing of the `sinc` function by dividing the argument by pi.  The added tests are based on the analogous ones for Octave printing, since Octave's `sinc` is also normalized.

#### Other comments

```
julia> sinc(1)
0
```

Reference:
* https://docs.julialang.org/en/v1/base/math/#Base.Math.sinc

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Fixed the printing of Julia sinc expressions

<!-- END RELEASE NOTES -->
