### PR TITLE
more lenient BooleanFunction.equals

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -121,6 +121,7 @@ class Boolean(Basic):
         False
 
         """
+        from sympy.logic.inference import satisfiable
         from sympy.core.symbol import Symbol
 
         def ok(f):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -105,7 +105,8 @@ class Boolean(Basic):
     def equals(self, other):
         """
         Returns ``True`` if the given formulas have the same truth table.
-        For two formulas to be equal they must have the same literals.
+        For two formulas to be equal one must have the all the literals
+        of the other.
 
         Examples
         ========
@@ -125,7 +126,11 @@ class Boolean(Basic):
 
         if self.has(Relational) or other.has(Relational):
             raise NotImplementedError('handling of relationals')
-        return self.atoms() == other.atoms() and \
+        more = self.atoms()
+        less = other.atoms()
+        if len(more) < len(less):
+            more, less = less, more
+        return not less - more and \
             not satisfiable(Not(Equivalent(self, other)))
 
     def to_nnf(self, simplify=True):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -124,8 +124,8 @@ class Boolean(Basic):
         from sympy.logic.inference import satisfiable
         from sympy.core.relational import Relational
 
-        if self.has(Relational) or other.has(Relational):
-            raise NotImplementedError('handling of relationals')
+        if not all(is_literal(i) for i in (self, other)):
+            raise NotImplementedError('non-literal BooleanFunction')
         more = self.atoms()
         less = other.atoms()
         if len(more) < len(less):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -15,7 +15,6 @@ from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
-from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
@@ -122,7 +121,7 @@ class Boolean(Basic):
         False
 
         """
-        from sympy.logic.inference import satisfiable
+        from sympy.core.symbol import Symbol
 
         def ok(f):
             return isinstance(f, (BooleanFunction, Symbol)) and (not f.args or

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -15,6 +15,7 @@ from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
+from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -123,7 +123,10 @@ class Boolean(Basic):
         """
         from sympy.logic.inference import satisfiable
 
-        if not all(is_literal(i) for i in (self, other)):
+        def ok(f):
+            return isinstance(f, (BooleanFunction, Symbol)) and (not f.args or
+                all(ok(a) for a in f.args))
+        if not ok(self) or not ok(other):
             raise NotImplementedError('non-literal BooleanFunction')
         more = self.atoms()
         less = other.atoms()

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -122,7 +122,6 @@ class Boolean(Basic):
 
         """
         from sympy.logic.inference import satisfiable
-        from sympy.core.relational import Relational
 
         if not all(is_literal(i) for i in (self, other)):
             raise NotImplementedError('non-literal BooleanFunction')

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -308,6 +308,7 @@ def test_simplification_boolalg():
     b = (~x & ~y & ~z) | (~x & ~y & z)
     e = And(A, b)
     assert simplify_logic(e) == A & ~x & ~y
+    assert e.equals(A & ~x & ~y)
     raises(ValueError, lambda: simplify_logic(A & (B | C), form='blabla'))
     assert simplify(Or(x <= y, And(x < y, z))) == (x <= y)
     assert simplify(Or(x <= y, And(y > x, z))) == (x <= y)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -309,6 +309,10 @@ def test_simplification_boolalg():
     e = And(A, b)
     assert simplify_logic(e) == A & ~x & ~y
     assert e.equals(A & ~x & ~y)
+    a1 = Contains(x, Interval(1, 2))
+    a2 = Contains(x, Interval(2, 3))
+    a3 =  Contains(x, Interval(1, 3))
+    raises(NotImplementedError, lambda: (a1 | a2).equals(a3))
     raises(ValueError, lambda: simplify_logic(A & (B | C), form='blabla'))
     assert simplify(Or(x <= y, And(x < y, z))) == (x <= y)
     assert simplify(Or(x <= y, And(y > x, z))) == (x <= y)


### PR DESCRIPTION
Allow two expressions to compare equal as long as
one has all the symbols of the other and the truth tables are the same.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #27310

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * two boolean functions will compare equal if the logic is the same and one's free symbols are a subset of the others
<!-- END RELEASE NOTES -->
