### PR TITLE
add functions to boolalg

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -125,6 +125,7 @@ class Boolean(Basic):
 
         """
         from sympy.logic.inference import satisfiable
+        from sympy.core.symbol import Symbol
 
         def ok(f):
             return isinstance(f, (BooleanFunction, Symbol)) and (not f.args or

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -105,7 +105,8 @@ class Boolean(Basic):
     def equals(self, other):
         """
         Returns ``True`` if the given formulas have the same truth table.
-        For two formulas to be equal they must have the same literals.
+        For two formulas to be equal one must have the all the literals
+        of the other.
 
         Examples
         ========
@@ -125,7 +126,11 @@ class Boolean(Basic):
 
         if self.has(Relational) or other.has(Relational):
             raise NotImplementedError('handling of relationals')
-        return self.atoms() == other.atoms() and \
+        more = self.atoms()
+        less = other.atoms()
+        if len(more) < len(less):
+            more, less = less, more
+        return not less - more and \
             not satisfiable(Not(Equivalent(self, other)))
 
     def to_nnf(self, simplify=True):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -134,7 +134,7 @@ class Boolean(Basic):
             raise NotImplementedError('non-literal BooleanFunction')
 
         # simplification can remove redundant symbols
-        args = [simplify_logic(simpler(i)) for i in (self, other)]
+        args = [simplify_logic(i) for i in (self, other)]
         return not satisfiable(Not(Equivalent(*args)))
 
     def to_nnf(self, simplify=True):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -134,7 +134,7 @@ class Boolean(Basic):
             raise NotImplementedError('non-literal BooleanFunction')
 
         # simplification can remove redundant symbols
-        args = simpler(self), simpler(other)
+        args = [simplify_logic(simpler(i)) for i in (self, other)]
         return not satisfiable(Not(Equivalent(*args)))
 
     def to_nnf(self, simplify=True):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -126,8 +126,8 @@ class Boolean(Basic):
 
         if self.has(Relational) or other.has(Relational):
             raise NotImplementedError('handling of relationals')
-        more = self.atoms()
-        less = other.atoms()
+        more = self.free_symbols
+        less = other.free_symbols
         if len(more) < len(less):
             more, less = less, more
         return not less - more and \
@@ -2799,7 +2799,9 @@ def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
             form_ok = is_dnf(expr)
 
         if form_ok and all(is_literal(a)
-                for a in expr.args):
+                for a in expr.args) and not any(
+                ~v in ao.args for ao in expr.atoms(And, Or)
+                for v in ao.args):
             return expr
     from sympy.core.relational import Relational
     if deep:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -108,6 +108,10 @@ class Boolean(Basic):
         For two formulas to be equal one must have the all the literals
         of the other.
 
+        Note: if there is a possibility that self is only a symbol, then
+        it is better to test as ``BooleanFunction.equals(self, other)``
+        otherwise the ``Expr.equals`` will return False.
+
         Examples
         ========
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -16,7 +16,7 @@ from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
-from sympy.utilities.iterables import sift, ibin, cartes
+from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
 
 
@@ -125,17 +125,12 @@ class Boolean(Basic):
 
         """
         from sympy.logic.inference import satisfiable
-        from sympy.core.symbol import Symbol
+        from sympy.core.relational import Relational
 
-        def ok(f):
-            return isinstance(f, (BooleanFunction, Symbol)) and (not f.args or
-                all(ok(a) for a in f.args))
-        if not ok(self) or not ok(other):
-            raise NotImplementedError('non-literal BooleanFunction')
-
-        # simplification can remove redundant symbols
-        args = [simplify_logic(i) for i in (self, other)]
-        return not satisfiable(Not(Equivalent(*args)))
+        if self.has(Relational) or other.has(Relational):
+            raise NotImplementedError('handling of relationals')
+        return self.atoms() == other.atoms() and \
+            not satisfiable(Not(Equivalent(self, other)))
 
     def to_nnf(self, simplify=True):
         # override where necessary

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -314,6 +314,10 @@ def test_simplification_boolalg():
     assert simplify(Or(x <= y, And(y > x, z))) == (x <= y)
     assert simplify(Or(x >= y, And(y < x, z))) == (x >= y)
 
+    # handle negated variables even when form is ok and literal
+    assert simplify_logic(x & ~x, 'cnf') == False
+    assert simplify_logic(x | ~x, 'dnf') == True
+
     # Check that expressions with nine variables or more are not simplified
     # (without the force-flag)
     a, b, c, d, e, f, g, h, j = symbols('a b c d e f g h j')

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -308,6 +308,7 @@ def test_simplification_boolalg():
     b = (~x & ~y & ~z) | (~x & ~y & z)
     e = And(A, b)
     assert simplify_logic(e) == A & ~x & ~y
+    assert e.equals(A & ~x & ~y)
     raises(ValueError, lambda: simplify_logic(A & (B | C), form='blabla'))
     assert simplify(Or(x <= y, And(x < y, z))) == (x <= y)
     assert simplify(Or(x <= y, And(y > x, z))) == (x <= y)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1377,3 +1377,14 @@ def test_issue_26985():
 
     assert result_anf == d
     assert result == d
+
+
+def test_change_form():
+    assert change_form(x) == x
+    eq = (x | y) & (x | y | z) & ~x
+    a = change_form(eq)
+    b = change_form(a)
+    assert a == (x & ~x) | (y & ~x)
+    assert b == ~x & (x | y)
+    assert eq.equals(a)
+    assert eq.equals(b)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -318,6 +318,13 @@ def test_simplification_boolalg():
     assert simplify_logic(x & ~x, 'cnf') == False
     assert simplify_logic(x | ~x, 'dnf') == True
 
+    # handle simple large cnf to dnf quickly
+    expr = And(*[Or(Dummy(''), Dummy('')) for _ in range(9)])
+    assert len(simplify_logic(expr, 'dnf', force=True).args) == 2**9
+    sy = [Dummy() for i in range(26)]
+    expr = And(*[Or(*sy[i: i + 3]) for i in range(0, len(sy), 2)])
+    assert len(simplify_logic(expr, 'dnf', force=True).args) == 2632
+
     # Check that expressions with nine variables or more are not simplified
     # (without the force-flag)
     a, b, c, d, e, f, g, h, j = symbols('a b c d e f g h j')

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -19,7 +19,7 @@ from sympy.logic.boolalg import (
     truth_table, as_Boolean, to_anf, is_anf, distribute_xor_over_and,
     anf_coeffs, ANFform, bool_minterm, bool_maxterm, bool_monomial,
     _check_pair, _convert_to_varsSOP, _convert_to_varsPOS, Exclusive,
-    gateinputcount)
+    gateinputcount, change_form)
 from sympy.assumptions.cnf import CNF
 
 from sympy.testing.pytest import raises, XFAIL, slow

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -426,6 +426,29 @@ def variations(seq, n, repetition=False):
             return product(seq, repeat=n)
 
 
+def remove_supersets(it):
+    """return a list of sets from which supersets are removed.
+
+    Examples
+    ========
+
+    >>> from symps.utilities.iterables import remove_supersets
+    >>> remove_supersets([{1}, {1, 2}])
+    [{1}]
+    """
+    s = sorted([set(i) for i in it], key=len)
+    out = []
+    while s:
+        sup = []
+        for j in range(1, len(s)):
+            if s[0] <= s[j]:
+                sup.append(j)
+        for j in sup[::-1]:
+            s.pop(j)
+        out.append(s.pop(0))
+    return out
+
+
 def subsets(seq, k=None, repetition=False):
     r"""Generates all `k`-subsets (combinations) from an `n`-element set, ``seq``.
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -432,7 +432,7 @@ def remove_supersets(it):
     Examples
     ========
 
-    >>> from symps.utilities.iterables import remove_supersets
+    >>> from sympy.utilities.iterables import remove_supersets
     >>> remove_supersets([{1}, {1, 2}])
     [{1}]
     """

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -20,7 +20,7 @@ from sympy.utilities.iterables import (
     strongly_connected_components, subsets, take, topological_sort, unflatten,
     uniq, variations, ordered_partitions, rotations, is_palindromic, iterable,
     NotIterable, multiset_derangements, signed_permutations,
-    sequence_partitions, sequence_partitions_empty)
+    sequence_partitions, sequence_partitions_empty, remove_supersets)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -943,3 +943,12 @@ def test_signed_permutations():
     assert list(signed_permutations((0, 1, 1))) == ans
     assert list(signed_permutations((1, 0, 1))) == ans
     assert list(signed_permutations((1, 1, 0))) == ans
+
+
+def test_remove_supersets():
+    assert remove_supersets([]) == []
+    assert remove_supersets([set()]) == [set()]
+    assert remove_supersets([set(), {1}]) == [set()]
+    assert remove_supersets([{1}, {1}]) == [{1}]
+    assert remove_supersets([{1}, {1, 2}]) == [{1}]
+    assert remove_supersets([{1}, {2}]) == [{1}, {2}]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #27309 


#### Brief description of what is fixed or changed


#### Other comments

[ ] This should allow `(a|b)&(b|c)&(c|d)&(d|a)` to simplify to `a&c|b&d` -- add test. `simplify_logic` does not currently recognize this.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * boolalg now contains `dual` that converts an expression to its dual form
  * boolalg now contains `change_form` that changes the form (cnf<->dnf) quickly while removing redundant clauses
  * boolalg now contains `simpler` that removes redundant clauses and identifies x,~x in And or Or; this can be done for much larger expressions than can be handled by `simplify_logic`
<!-- END RELEASE NOTES -->
