### PR TITLE
Fix rewrite behavior for abs in sign(x) 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1709,4 +1709,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-digkioan <125358066+digkioan@users.noreply.github.com>
+Ioannis Digkas <digkasioannis@gmail.com>
+digkioan <digkioan+125358066@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1621,7 +1621,6 @@ cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>
 der-blaue-elefant <github@kklein.de>
-digkioan <125358066+digkioan@users.noreply.github.com>
 dimasvq <dimas.vq.2020@bristol.ac.uk>
 dispasha <dispasha@users.noreply.github.com>
 dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1709,3 +1709,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Ioannis Digkas <digkasioannis@gmail.com> <digkioan+125358066@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -715,6 +715,7 @@ Ian Swire <oversizedpenguin@gmail.com>
 Idan Pazi <idan.kp@gmail.com>
 Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
+Ioannis Digkas <digkasioannis@gmail.com> digkioan <125358066+digkioan@users.noreply.github.com>
 Ishan Joshi <ishanaj98@gmail.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
@@ -1620,6 +1621,7 @@ cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>
 der-blaue-elefant <github@kklein.de>
+digkioan <125358066+digkioan@users.noreply.github.com>
 dimasvq <dimas.vq.2020@bristol.ac.uk>
 dispasha <dispasha@users.noreply.github.com>
 dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.com>
@@ -1709,5 +1711,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Ioannis Digkas <digkasioannis@gmail.com>
-digkioan <125358066+digkioan@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1709,4 +1709,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Ioannis Digkas <digkasioannis@gmail.com>
+digkioan <125358066+digkioan@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1709,4 +1709,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Ioannis Digkas <digkasioannis@gmail.com> <digkioan+125358066@users.noreply.github.com>
+Ioannis Digkas <digkasioannis@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1710,4 +1710,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
 Ioannis Digkas <digkasioannis@gmail.com>
-digkioan <digkioan+125358066@users.noreply.github.com>
+digkioan <125358066+digkioan@users.noreply.github.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2075,6 +2075,11 @@ class Basic(Printable):
         pattern = args[:-1]
         rule = args[-1]
 
+        # Special case: map `abs` to `Abs`
+        if rule is abs:
+            from sympy.functions.elementary.complexes import Abs
+            rule = Abs
+
         # support old design by _eval_rewrite_as_[...] method
         if isinstance(rule, str):
             method = "_eval_rewrite_as_%s" % rule

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -348,10 +348,7 @@ def test_rewrite_abs():
     expr = Abs(x - y) + Abs(x + y)
 
     # Expected result in a more generalized form (Piecewise)
-    expected = Piecewise(
-        (2*x, Eq(y, 0)),  # Case where y = 0
-        (Abs(x - y) + Abs(x + y), True)  # General case
-    )
+    expected = Piecewise((2*x, Eq(y, 0)),(Abs(x - y) + Abs(x + y), True))
 
     # Rewrite the expression using the "abs" rule
     rewritten_expr = expr.rewrite(abs)

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -17,6 +17,7 @@ from sympy.functions.special.gamma_functions import gamma
 from sympy.integrals.integrals import Integral
 from sympy.functions.elementary.exponential import exp
 from sympy.testing.pytest import raises, warns_deprecated_sympy
+from sympy.functions.elementary.complexes import Abs, sign
 
 b1 = Basic()
 b2 = Basic(b1)
@@ -331,3 +332,32 @@ def test_generic():
 
     class B(A[T]):
         pass
+
+def test_rewrite_abs():
+    from sympy.functions.elementary.complexes import Abs
+    from sympy.core.symbol import Symbol
+    from sympy.functions.elementary.piecewise import Piecewise
+    from sympy.core.relational import Eq
+    #https://github.com/sympy/sympy/issues/27323
+
+    # Define two symbolic variables
+    x = Symbol('x')
+    y = Symbol('y')
+
+    # Create an expression involving absolute values
+    expr = Abs(x - y) + Abs(x + y)
+
+    # Expected result in a more generalized form (Piecewise)
+    expected = Piecewise(
+        (2*x, Eq(y, 0)),  # Case where y = 0
+        (Abs(x - y) + Abs(x + y), True)  # General case
+    )
+
+    # Rewrite the expression using the "abs" rule
+    rewritten_expr = expr.rewrite(abs)
+
+    # Verify that the rewritten expression still contains Abs
+    assert rewritten_expr.has(Abs), "Expression should contain Abs after rewrite"
+
+    # Check if the rewritten expression matches the original
+    assert rewritten_expr == expr, "Rewrite(abs) did not preserve the expression structure"

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -17,7 +17,7 @@ from sympy.functions.special.gamma_functions import gamma
 from sympy.integrals.integrals import Integral
 from sympy.functions.elementary.exponential import exp
 from sympy.testing.pytest import raises, warns_deprecated_sympy
-from sympy.functions.elementary.complexes import Abs, sign
+from sympy.functions.elementary.complexes import Abs
 
 b1 = Basic()
 b2 = Basic(b1)
@@ -334,10 +334,7 @@ def test_generic():
         pass
 
 def test_rewrite_abs():
-    from sympy.functions.elementary.complexes import Abs
     from sympy.core.symbol import Symbol
-    from sympy.functions.elementary.piecewise import Piecewise
-    from sympy.core.relational import Eq
     #https://github.com/sympy/sympy/issues/27323
 
     # Define two symbolic variables
@@ -346,9 +343,6 @@ def test_rewrite_abs():
 
     # Create an expression involving absolute values
     expr = Abs(x - y) + Abs(x + y)
-
-    # Expected result in a more generalized form (Piecewise)
-    expected = Piecewise((2*x, Eq(y, 0)),(Abs(x - y) + Abs(x + y), True))
 
     # Rewrite the expression using the "abs" rule
     rewritten_expr = expr.rewrite(abs)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -644,7 +644,7 @@ class MinMaxBase(Expr, LatticeOp):
         from sympy.functions.elementary.complexes import Abs
         target = kwargs.get("target", None)
         if target == abs:
-            target = Abs  
+            target = Abs
         s = (args[0] + self.func(*args[1:]))/2
         d = abs(args[0] - self.func(*args[1:]))/2
         return (s + d if isinstance(self, Max) else s - d).rewrite(Abs)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -642,6 +642,9 @@ class MinMaxBase(Expr, LatticeOp):
 
     def _eval_rewrite_as_Abs(self, *args, **kwargs):
         from sympy.functions.elementary.complexes import Abs
+        target = kwargs.get("target", None)
+        if target == abs:
+            target = Abs  
         s = (args[0] + self.func(*args[1:]))/2
         d = abs(args[0] - self.func(*args[1:]))/2
         return (s + d if isinstance(self, Max) else s - d).rewrite(Abs)


### PR DESCRIPTION
Fixes #27323.

This PR fixes the behavior of `rewrite` when called with the built-in `abs` function. Previously, `sign(x).rewrite(abs)` would return `sign(x)` without any transformation, while `sign(x).rewrite(Abs)` worked correctly. 

This inconsistency has been resolved by mapping the built-in `abs` function to the `Abs` class within `_eval_rewrite_as_Abs`.

**Key changes:**
- Updated `_eval_rewrite_as_Abs` to handle the built-in `abs` correctly.
- Added tests to verify the behavior of `rewrite` with both `abs` and `Abs`.

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug in `rewrite` for `sign(x)` where the built-in `abs` was not mapped to `Abs`.
<!-- END RELEASE NOTES -->

