### PR TITLE
Add MPa and Celsius physics units.

### DIFF
--- a/sympy/physics/units/definitions/unit_definitions.py
+++ b/sympy/physics/units/definitions/unit_definitions.py
@@ -49,6 +49,8 @@ A = ampere = amperes = Quantity("ampere", abbrev='A')
 ampere.set_global_dimension(current)
 K = kelvin = kelvins = Quantity("kelvin", abbrev='K')
 kelvin.set_global_dimension(temperature)
+degC = degree_celsius = Quantity("degree_celsius", abbrev='degC', latex_repr=r"^\circC")
+degree_celsius.set_global_dimension(temperature)
 mol = mole = moles = Quantity("mole", abbrev="mol")
 mole.set_global_dimension(amount_of_substance)
 cd = candela = candelas = Quantity("candela", abbrev="cd")
@@ -307,6 +309,8 @@ atmosphere = atmospheres = atm = Quantity("atmosphere", abbrev="atm")
 
 kPa = kilopascal = Quantity("kilopascal", abbrev="kPa")
 kilopascal.set_global_relative_scale_factor(kilo, Pa)
+MPa = megapascal = Quantity("megapascal", abbrev="MPa")
+megapascal.set_global_relative_scale_factor(mega, Pa)
 
 bar = bars = Quantity("bar", abbrev="bar")
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Add MPa and Celsius physics units.

#### Other comments
No other comments.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Add MPa and Celsius physics units.
<!-- END RELEASE NOTES -->
