### PR TITLE
Change some wording in the solveset FAQ to clarify solve is not being…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -863,6 +863,7 @@ Keno Goertz <keno@goertz-berlin.com>
 Keval Shah <kevalshah_96@yahoo.co.in>
 Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
+Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>

--- a/doc/src/modules/solvers/solvers.rst
+++ b/doc/src/modules/solvers/solvers.rst
@@ -56,6 +56,11 @@ is the symbol that we want to solve the equation for.
 
 .. autofunction:: sympy.solvers.solvers::unrad
 
+Univariate Equations
+--------------------
+
+See :ref:`solveset`.
+
 Ordinary Differential equations (ODEs)
 --------------------------------------
 

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -476,9 +476,9 @@ What is the plan for solve and solveset?
 
 There are still a few things ``solveset`` can't do, which ``solve`` can, such
 as solving nonlinear multivariate & LambertW type equations.  Hence, it's not
-yet a perfect replacement for ``solve``. As the algorithms in ``solveset``
+ a perfect replacement for ``solve``. As the algorithms in ``solveset``
 mature, ``solveset`` may be able to be used within ``solve`` to replace some of
-its algorithms.
+its algorithms. However, there are no current plans to remove ``solve``.
 
 How are symbolic parameters handled in solveset?
 ------------------------------------------------

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -14,31 +14,44 @@ equations.
    For a beginner-friendly guide focused on solving common types of equations,
    refer to :ref:`solving-guide`.
 
-What's wrong with solve():
---------------------------
+How solve() is different from solveset()
+----------------------------------------
 
-SymPy already has a pretty powerful ``solve`` function. But it has some
-deficiencies. For example:
+SymPy already has a pretty powerful ``solve`` function. But it has different
+goals. For example:
 
-1. It doesn't have a consistent output for various types of solutions
+1. It has a generalized output to handle various types of solutions.
    It needs to return a lot of types of solutions consistently:
 
    * Single solution : `x = 1`
    * Multiple solutions: `x^2 = 1`
    * No Solution: `x^2 + 1 = 0 ; x \in \mathbb{R}`
    * Interval of solution: `\lfloor x \rfloor = 0`
-   * Infinitely many solutions: `\sin(x) = 0`
+   * Finite list (even though there are infinitely many solutions): `\sin(x) = 0`
+
+     *Compare the* ``solve`` *output of* `[0, \pi ]` *to the* ``solveset`` *output shown in the* :ref:`why-solveset` *section below.*
+
    * Multivariate functions with point solutions: `x^2 + y^2 = 0`
    * Multivariate functions with non-point solution: `x^2 + y^2 = 1`
    * System of equations: `x + y = 1` and `x - y = 0`
    * Relational: `x > 0`
    * And the most important case: "We don't Know"
 
-2. The input API has a lot of parameters and it can be difficult to use.
+2. The input API has a lot of parameters. It is a facade around
+   more specialized solvers. *It is analogous to how* ``simplify``
+   *is a facade around more specialized simplification functions.*
 
 3. There are cases like finding the maxima and minima of function using
    critical points where it is important to know if it has returned all the
    solutions. ``solve`` does not guarantee this.
+
+The main differences are the ability to provide a finite list of substitutions
+without introducing new symbols; provides solutions for multivariate
+systems of equations and acts as an on ramp to using the SymPy
+``solver`` sub-system.
+
+Please see the `solving guide </guides/solving/>`_ for more details on using SymPy solvers.
+
 
 .. _why-solveset:
 

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -81,6 +81,22 @@ Why Solveset?
   the set of all solutions, that is `\{2 n i \pi | n \in \mathbb{Z}\}`, whereas
   if `x` is to be solved in the real domain then only `\{0\}` is returned.
 
+* As mentioned above, ``solveset`` will return a ``ConditionSet`` where not all
+  parts of an equation can be solved. Consider this example.
+
+  ``expr = (x**2 - 1) * (x**5 + y*x + 1)`` where ``x`` and ``y`` are defined as being
+  in `\mathbb{C}`.
+
+  ``solve(expr, [x], dict=True)`` gives us the solutions it can find. However it gives
+  us no indication that there may be more solutions that it did not return.
+
+  ``[{x: -1},{x: 1}]``
+
+  However, with ``solveset(expr, x)`` the partial solution becomes clear. The quadratic factor
+  was solved, but the quintic factor is not solvable and so a ``ConditionSet`` is returned.
+
+  `\displaystyle \left\{-1, 1\right\} \cup \left\{x\; \middle|\; x \in \mathbb{C} \wedge x^{5} + x y + 1 = 0 \right\}`
+
 
 .. _why-set-output:
 

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -18,10 +18,11 @@ How solveset() is different from solve()
 SymPy already has a pretty powerful ``solve`` function. But it has different
 goals. For example:
 
-* It has a generalized output to handle various types of solutions.
-  It needs to return a lot of types of solutions consistently. It can deal with
-  univariate as well as multivariate equations as well as various other sorts
-  of variability in the system of equations passed into it.
+* It has a generalized output interface to handle various types of solutions.
+  It needs to return many types of solutions consistently. It can deal with
+  univariate as well as multivariate equations as well as other kinds
+  of variability due to the system of equations and options passed into it,
+  producing associated outputs. See :ref:`solve_output` for more details.
 
 * The input API has a lot of parameters. It is a facade around
   more specialized solvers. *This feature of* ``solve`` *could be viewed as analogous
@@ -30,10 +31,10 @@ goals. For example:
   See :func:`~sympy.solvers.solvers.solve` for more details about the available parameters
   and output options.
 
-* There are cases where :func:`~sympy.solvers.solvers.solve` returns an empty list.
+* There are cases where ``solve`` returns an empty list.
 
   This might mean that there are no solutions or no solution could be found
-  given its current supported feature set. In other cases, there is no way
+  given its currently supported features. In other cases, there is no way
   (given the output interface of ``solve``) to communicate whether or not:
 
   * all possible solutions to the system were found
@@ -41,11 +42,11 @@ goals. For example:
   * or that the real set of solutions are finite or infinite
   * etc.
 
-* :func:`~sympy.solvers.solvers.solve` may return a few solutions
-  when more solutions (potentially infinitely many) also exist.
+* ``solve`` may return a few solutions when more solutions (potentially
+  infinitely many) also exist.
 
-  It is to some extent inherent to the API of :func:`~sympy.solvers.solvers.solve`
-  that it does not have a way to represent these different cases distinctly.
+  It is to some extent inherent to the API of ``solve`` that it does not
+  have a way to represent these different cases distinctly.
 
 Whereas ``solveset`` returns a ``Set`` representing all of the solutions
 of a univariate equation.
@@ -56,11 +57,11 @@ of a univariate equation.
 Why Solveset?
 -------------
 
-* ``solveset`` has an alternative consistent input and output interface:
-  ``solveset`` returns a set object that takes
-  care of all types of output.
+``solveset`` has a consistent input and output interface:
 
-  For cases where it does not "know" all the solutions a ``ConditionSet``
+* ``solveset`` returns a ``Set`` object in a way that takes care of all types of output.
+
+  For cases where it does not "know" all of the solutions a ``ConditionSet``
   with a partial solution is returned.
 
   For input it only takes the equation, the variables to solve for and the optional
@@ -491,16 +492,6 @@ How do we deal with cases where only some of the solutions are known?
  We can represent it as:
 
  `\{-2, 2\} ∪ \{x | x \in \mathbb{R} ∧ x + \sin(x) = 0\}`
-
-
-What is the plan for solve and solveset?
-----------------------------------------
-
-Since the goals for ``solveset`` are different from ``solve``,
-``solveset`` is not intended to be a perfect replacement
-for ``solve``. Rather, ``solveset`` should be viewed as complimentary.
-
-As such, there are no current plans to remove ``solve``.
 
 
 How are symbolic parameters handled in solveset?

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -474,13 +474,11 @@ How do we deal with cases where only some of the solutions are known?
 What is the plan for solve and solveset?
 ----------------------------------------
 
-There are still a few things ``solveset`` can't do, which ``solve`` can, such
-as solving nonlinear multivariate & LambertW type equations.  Hence, it's not
-a perfect replacement for ``solve``. As the algorithms in ``solveset`` mature,
-``solveset`` may be able to be used within ``solve`` to replace some of
-its algorithms.
+Since the goals for ``solveset`` are different from ``solve``,
+``solveset`` is not intended to be a perfect replacement
+for ``solve``. Rather, ``solveset`` should be viewed as complimentary.
 
-However, there are no current plans to remove ``solve``.
+As such, there are no current plans to remove ``solve``.
 
 
 How are symbolic parameters handled in solveset?

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -475,10 +475,12 @@ What is the plan for solve and solveset?
 ----------------------------------------
 
 There are still a few things ``solveset`` can't do, which ``solve`` can, such
-as solving nonlinear multivariate & LambertW type equations.  Hence, it's not
- a perfect replacement for ``solve``. As the algorithms in ``solveset``
+as solving nonlinear multivariate & LambertW type equations.  Hence, it's not a
+perfect replacement for ``solve``. As the algorithms in ``solveset``
 mature, ``solveset`` may be able to be used within ``solve`` to replace some of
-its algorithms. However, there are no current plans to remove ``solve``.
+its algorithms.
+
+However, there are no current plans to remove ``solve``.
 
 How are symbolic parameters handled in solveset?
 ------------------------------------------------

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -475,12 +475,13 @@ What is the plan for solve and solveset?
 ----------------------------------------
 
 There are still a few things ``solveset`` can't do, which ``solve`` can, such
-as solving nonlinear multivariate & LambertW type equations.  Hence, it's not a
-perfect replacement for ``solve``. As the algorithms in ``solveset``
-mature, ``solveset`` may be able to be used within ``solve`` to replace some of
+as solving nonlinear multivariate & LambertW type equations.  Hence, it's not
+a perfect replacement for ``solve``. As the algorithms in ``solveset`` mature,
+``solveset`` may be able to be used within ``solve`` to replace some of
 its algorithms.
 
 However, there are no current plans to remove ``solve``.
+
 
 How are symbolic parameters handled in solveset?
 ------------------------------------------------

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -6,51 +6,49 @@ Solveset
 .. module:: sympy.solvers.solveset
 
 This is the official documentation of the ``solveset`` module in solvers.
-It contains the frequently asked questions about our new module to solve
-equations.
 
 .. note::
 
    For a beginner-friendly guide focused on solving common types of equations,
    refer to :ref:`solving-guide`.
 
-How solve() is different from solveset()
+How solveset() is different from solve()
 ----------------------------------------
 
 SymPy already has a pretty powerful ``solve`` function. But it has different
 goals. For example:
 
-1. It has a generalized output to handle various types of solutions.
-   It needs to return a lot of types of solutions consistently:
+* It has a generalized output to handle various types of solutions.
+  It needs to return a lot of types of solutions consistently. It can deal with
+  univariate as well as multivariate equations as well as various other sorts
+  of variability in the system of equations passed into it.
 
-   * Single solution : `x = 1`
-   * Multiple solutions: `x^2 = 1`
-   * No Solution: `x^2 + 1 = 0 ; x \in \mathbb{R}`
-   * Interval of solution: `\lfloor x \rfloor = 0`
-   * Finite list (even though there are infinitely many solutions): `\sin(x) = 0`
+* The input API has a lot of parameters. It is a facade around
+  more specialized solvers. *This feature of* ``solve`` *could be viewed as analogous
+  to how* ``simplify`` *is a facade around more specialized simplification functions.*
 
-     *Compare the* ``solve`` *output of* `[0, \pi ]` *to the* ``solveset`` *output shown in the* :ref:`why-solveset` *section below.*
+  See :func:`~sympy.solvers.solvers.solve` for more details about the available parameters
+  and output options.
 
-   * Multivariate functions with point solutions: `x^2 + y^2 = 0`
-   * Multivariate functions with non-point solution: `x^2 + y^2 = 1`
-   * System of equations: `x + y = 1` and `x - y = 0`
-   * Relational: `x > 0`
-   * And the most important case: "We don't Know"
+* There are cases where :func:`~sympy.solvers.solvers.solve` returns an empty list.
 
-2. The input API has a lot of parameters. It is a facade around
-   more specialized solvers. *It is analogous to how* ``simplify``
-   *is a facade around more specialized simplification functions.*
+  This might mean that there are no solutions or no solution could be found
+  given its current supported feature set. In other cases, there is no way
+  (given the output interface of ``solve``) to communicate whether or not:
 
-3. There are cases like finding the maxima and minima of function using
-   critical points where it is important to know if it has returned all the
-   solutions. ``solve`` does not guarantee this.
+  * all possible solutions to the system were found
+  * or that there are provably no solutions
+  * or that the real set of solutions are finite or infinite
+  * etc.
 
-The main differences are the ability to provide a finite list of substitutions
-without introducing new symbols; provides solutions for multivariate
-systems of equations and acts as an on ramp to using the SymPy
-``solver`` sub-system.
+* :func:`~sympy.solvers.solvers.solve` may return a few solutions
+  when more solutions (potentially infinitely many) also exist.
 
-Please see the `solving guide </guides/solving/>`_ for more details on using SymPy solvers.
+  It is to some extent inherent to the API of :func:`~sympy.solvers.solvers.solve`
+  that it does not have a way to represent these different cases distinctly.
+
+Whereas ``solveset`` returns a ``Set`` representing all of the solutions
+of a univariate equation.
 
 
 .. _why-solveset:
@@ -59,21 +57,31 @@ Why Solveset?
 -------------
 
 * ``solveset`` has an alternative consistent input and output interface:
-  ``solveset`` returns a set object and a set object takes care of all types of
-  output. For cases where it does not "know" all the solutions a
-  ``ConditionSet`` with a partial solution is returned. For input it only takes
-  the equation, the variables to solve for and the optional argument ``domain``
-  over which the equation is to be solved.
+  ``solveset`` returns a set object that takes
+  care of all types of output.
+
+  For cases where it does not "know" all the solutions a ``ConditionSet``
+  with a partial solution is returned.
+
+  For input it only takes the equation, the variables to solve for and the optional
+  argument ``domain`` over which the equation is to be solved.
+
+  See :ref:`solveset-input-api` for more details about the available
+  parameters and :ref:`why-set-output` below for more about ``Set`` output.
 
 * ``solveset`` can return infinitely many solutions. For example solving for
   `\sin{(x)} = 0` returns `\{2 n \pi | n \in \mathbb{Z}\} \cup \{2 n \pi + \pi | n \in \mathbb{Z}\}`,
   whereas ``solve`` only returns `[0, \pi]`.
 
-* There is a clear code level and interface level separation between solvers
-  for equations in the complex domain and the real domain. For example
-  solving `e^x = 1` when `x` is to be solved in the complex domain, returns
+* ``solveset`` has a clear code level and interface level separation between solvers
+  for equations in the complex and real domains.
+
+  For example solving `e^x = 1` when `x` is to be solved in the complex domain, returns
   the set of all solutions, that is `\{2 n i \pi | n \in \mathbb{Z}\}`, whereas
   if `x` is to be solved in the real domain then only `\{0\}` is returned.
+
+
+.. _why-set-output:
 
 Why do we use Sets as an output type?
 -------------------------------------
@@ -231,6 +239,7 @@ Why not use dicts as output?
     a disk of radius 1 in the Argand Plane. This problem is solved using
     complex sets implemented as ``ComplexRegion``.
 
+.. _solveset-input-api:
 
 Input API of ``solveset``
 -------------------------


### PR DESCRIPTION
… removed

* full docs review is pending
* pushing this now to get the PR created and linked to issue 27332

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27332 

#### Brief description of what is fixed or changed
This is a documentation change only. No code changes should be expected.

Change some wording suggesting that `solve` will be replaced by `solveset`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * clarify wording in the docs that there are no current plans to remove `solve`
<!-- END RELEASE NOTES -->
