### PR TITLE
Refactor: Replace '.func is' with 'isinstance()' for code quality

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -767,6 +767,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1314,4 +1314,3 @@ Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 Dean Price <dean1357price1357@gmail.com>
 Hugo Kerstens <hugo@kerstens.me>
-Jatin Bhardwaj <bhardwajjatin@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1314,3 +1314,4 @@ Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 Dean Price <dean1357price1357@gmail.com>
 Hugo Kerstens <hugo@kerstens.me>
+Jatin Bhardwaj <bhardwajjatin@gmail.com>

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -174,7 +174,7 @@ def test_isnan_isinf():
     assert isinf(S.Pi) == False
     isinfx = isinf(x)
     assert isinfx not in (False, True)
-    assert isinfx.func is isinf
+    assert isinstance(isinfx, isinf)
     assert isinfx.args == (x,)
 
     # isnan
@@ -182,5 +182,5 @@ def test_isnan_isinf():
     assert isnan(S.Pi) == False
     isnanx = isnan(x)
     assert isnanx not in (False, True)
-    assert isnanx.func is isnan
+    assert isinstance(isnanx, isnan)
     assert isnanx.args == (x,)

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -200,7 +200,7 @@ def test_simple_products():
 
     assert product(1, (n, 1, oo)) == 1  # issue 8301
     assert product(2, (n, 1, oo)) is oo
-    assert product(-1, (n, 1, oo)).func is Product
+    assert isinstance(product(-1, (n, 1, oo)), Product)
 
 
 def test_multiple_products():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1826,7 +1826,7 @@ def test_issue_5919():
 
 
 def test_Mod():
-    assert isinstance(Mod(3, 2), Integer)
+    assert isinstance(Mod(x, 1), Mod)
     assert pi % pi is S.Zero
     assert Mod(5, 3) == 2
     assert Mod(-5, 3) == 1

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1667,13 +1667,13 @@ def test_suppressed_evaluation():
     b = Mul(1, 3, 2, evaluate=False)
     c = Pow(3, 2, evaluate=False)
     assert a != 6
-    assert a.func is Add
+    assert isinstance(a, Add)
     assert a.args == (0, 3, 2)
     assert b != 6
-    assert b.func is Mul
+    assert isinstance(b, Mul)
     assert b.args == (1, 3, 2)
     assert c != 9
-    assert c.func is Pow
+    assert isinstance(c, Pow)
     assert c.args == (3, 2)
 
 
@@ -1682,13 +1682,13 @@ def test_AssocOp_doit():
     b = Mul(y,y, evaluate=False)
     c = Add(b,b, evaluate=False)
     d = Mul(a,a, evaluate=False)
-    assert c.doit(deep=False).func == Mul
+    assert isinstance(c.doit(deep=False), Mul)
     assert c.doit(deep=False).args == (2,y,y)
-    assert c.doit().func == Mul
+    assert isinstance(c.doit(), Mul)
     assert c.doit().args == (2, Pow(y,2))
-    assert d.doit(deep=False).func == Pow
+    assert isinstance(d.doit(deep=False), Pow)
     assert d.doit(deep=False).args == (a, 2*S.One)
-    assert d.doit().func == Mul
+    assert isinstance(d.doit(), Mul)
     assert d.doit().args == (4*S.One, Pow(x,2))
 
 
@@ -1826,7 +1826,7 @@ def test_issue_5919():
 
 
 def test_Mod():
-    assert Mod(x, 1).func is Mod
+    assert isinstance(Mod(3, 2), Integer)
     assert pi % pi is S.Zero
     assert Mod(5, 3) == 2
     assert Mod(-5, 3) == 1
@@ -1847,8 +1847,8 @@ def test_Mod():
 
     k = Symbol('k', integer=True)
     m = Symbol('m', integer=True, positive=True)
-    assert (x**m % x).func is Mod
-    assert (k**(-m) % k).func is Mod
+    assert isinstance((x**m % x), Mod)
+    assert isinstance((k**(-m) % k), Mod)
     assert k**m % k == 0
     assert (-2*k)**m % k == 0
 
@@ -1904,7 +1904,7 @@ def test_Mod():
     assert Mod(-p - 5, p + 3) == p + 1
     assert Mod(p + 5, -p - 3) == -p - 1
     assert Mod(-p - 5, -p - 3) == -2
-    assert Mod(p + 1, p - 1).func is Mod
+    assert isinstance(Mod(p + 1, p - 1), Mod)
 
     # handling sums
     assert (x + 3) % 1 == Mod(x, 1)
@@ -1946,7 +1946,7 @@ def test_Mod():
     n = Symbol('n', integer=True, positive=True)
     assert factorial(n) % n == 0
     assert factorial(n + 2) % n == 0
-    assert (factorial(n + 4) % (n + 5)).func is Mod
+    assert isinstance((factorial(n + 4) % (n + 5)), Mod)
 
     # Wilson's theorem
     assert factorial(18042, evaluate=False) % 18043 == 18042

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -91,8 +91,8 @@ def test_diff_no_eval_derivative():
             return Expr.__new__(cls, x)
 
     # My doesn't have its own _eval_derivative method
-    assert My(x).diff(x).func is Derivative
-    assert My(x).diff(x, 3).func is Derivative
+    assert isinstance(My(x).diff(x), Derivative)
+    assert isinstance(My(x).diff(x, 3), Derivative)
     assert re(x).diff(x, 2) == Derivative(re(x), (x, 2))  # issue 15518
     assert diff(NDimArray([re(x), im(x)]), (x, 2)) == NDimArray(
         [Derivative(re(x), (x, 2)), Derivative(im(x), (x, 2))])

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -494,7 +494,7 @@ def test_func_deriv():
 def test_suppressed_evaluation():
     a = sin(0, evaluate=False)
     assert a != 0
-    assert a.func is sin
+    assert isinstance(a, sin)
     assert a.args == (0,)
 
 

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -325,7 +325,7 @@ def test_issue_6100_12942_4473():
     # if the following gets distributed as a Mul (x**1.0*y**1.0 then
     # __eq__ methods could be added to Symbol and Pow to detect the
     # power-of-1.0 case.
-    assert ((x*y)**1.0).func is Pow
+    assert isinstance(((x*y)**1.0), Pow)
 
 
 def test_issue_6208():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -907,7 +907,7 @@ def test_issue_10401():
     zero = symbols('z', zero=True)
     nonzero = symbols('nz', zero=False, finite=True)
 
-    assert Eq(1/(1/x + 1), 1).func is Eq
+    assert isinstance(Eq(1/(1/x + 1), 1), Eq)
     assert Eq(1/(1/x + 1), 1).subs(x, S.ComplexInfinity) is S.true
     assert Eq(1/(1/fin + 1), 1) is S.false
 

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -327,13 +327,13 @@ def test_sign():
     eq = -sqrt(10 + 6*sqrt(3)) + sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3))
     # if there is a fast way to know when and when you cannot prove an
     # expression like this is zero then the equality to zero is ok
-    assert sign(eq).func is sign or sign(eq) == 0
+    assert isinstance(sign(eq), sign) or sign(eq) == 0
     # but sometimes it's hard to do this so it's better not to load
     # abs down with tests that will be very slow
     q = 1 + sqrt(2) - 2*sqrt(3) + 1331*sqrt(6)
     p = expand(q**3)**Rational(1, 3)
     d = p - q
-    assert sign(d).func is sign or sign(d) == 0
+    assert isinstance(sign(d), sign) or sign(d) == 0
 
 
 def test_as_real_imag():
@@ -385,7 +385,7 @@ def test_Abs():
 
     x, y = symbols('x,y')
     assert sign(sign(x)) == sign(x)
-    assert sign(x*y).func is sign
+    assert isinstance(sign(x*y), sign)
     assert Abs(0) == 0
     assert Abs(1) == 1
     assert Abs(-1) == 1
@@ -435,13 +435,13 @@ def test_Abs():
     eq = -sqrt(10 + 6*sqrt(3)) + sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3))
     # if there is a fast way to know when you can and when you cannot prove an
     # expression like this is zero then the equality to zero is ok
-    assert abs(eq).func is Abs or abs(eq) == 0
+    assert isinstance(abs(eq), Abs) or abs(eq) == 0
     # but sometimes it's hard to do this so it's better not to load
     # abs down with tests that will be very slow
     q = 1 + sqrt(2) - 2*sqrt(3) + 1331*sqrt(6)
     p = expand(q**3)**Rational(1, 3)
     d = p - q
-    assert abs(d).func is Abs or abs(d) == 0
+    assert isinstance(abs(d), Abs) or abs(d) == 0
 
     assert Abs(4*exp(pi*I/4)) == 4
     assert Abs(3**(2 + I)) == 9
@@ -974,10 +974,10 @@ def test_principal_branch():
     assert N_equals(principal_branch((1 + I)**2, 1*pi), 2*I)
 
     # test argument sanitization
-    assert principal_branch(x, I).func is principal_branch
-    assert principal_branch(x, -4).func is principal_branch
-    assert principal_branch(x, -oo).func is principal_branch
-    assert principal_branch(x, zoo).func is principal_branch
+    assert isinstance(principal_branch(x, I), principal_branch)
+    assert isinstance(principal_branch(x, -4), principal_branch)
+    assert isinstance(principal_branch(x, -oo), principal_branch)
+    assert isinstance(principal_branch(x, zoo), principal_branch)
 
 
 @XFAIL

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -266,8 +266,8 @@ def test_log_values():
     assert exp(-log(3))**(-1) == 3
 
     assert log(S.Half) == -log(2)
-    assert log(2*3).func is log
-    assert log(2*3**2).func is log
+    assert isinstance(log(2*3), log)
+    assert isinstance(log(2*3**2),  log)
 
 
 def test_match_real_imag():
@@ -379,8 +379,8 @@ def test_log_symbolic():
 
     assert (log(x**-5)**-1).expand() != -1/log(x)/5
     assert (log(p**-5)**-1).expand() == -1/log(p)/5
-    assert log(-x).func is log and log(-x).args[0] == -x
-    assert log(-p).func is log and log(-p).args[0] == -p
+    assert isinstance(log(-x), log) and log(-x).args[0] == -x
+    assert isinstance(log(-p), log) and log(-p).args[0] == -p
 
 
 def test_log_exp():
@@ -459,13 +459,13 @@ def test_log_hashing():
     assert log(x) != log(log(log(x)))
 
     e = 1/log(log(x) + log(log(x)))
-    assert e.base.func is log
+    assert isinstance(e.base, log)
     e = 1/log(log(x) + log(log(log(x))))
-    assert e.base.func is log
+    assert isinstance(e.base, log)
 
     e = log(log(x))
-    assert e.func is log
-    assert x.func is not log
+    assert isinstance(e, log)
+    assert not isinstance(x, log)
     assert hash(log(log(x))) != hash(x)
     assert e != x
 

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -61,7 +61,7 @@ def test_floor():
     assert floor(I) == I
     assert floor(-I) == -I
     e = floor(i)
-    assert e.func is floor and e.args[0] == i
+    assert isinstance(e, floor) and e.args[0] == i
 
     assert floor(oo*I) == oo*I
     assert floor(-oo*I) == -oo*I
@@ -248,7 +248,7 @@ def test_ceiling():
     assert ceiling(I) == I
     assert ceiling(-I) == -I
     e = ceiling(i)
-    assert e.func is ceiling and e.args[0] == i
+    assert isinstance(e, ceiling) and e.args[0] == i
 
     assert ceiling(oo*I) == oo*I
     assert ceiling(-oo*I) == -oo*I

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -80,10 +80,10 @@ def test_Min():
     assert Min(oo, p) == p
     assert Min(oo, oo) is oo
 
-    assert Min(n, n_).func is Min
-    assert Min(nn, nn_).func is Min
-    assert Min(np, np_).func is Min
-    assert Min(p, p_).func is Min
+    assert isinstance(Min(n, n_), Min)
+    assert isinstance(Min(nn, nn_),  Min)
+    assert isinstance(Min(np, np_),  Min)
+    assert isinstance(Min(p, p_),  Min)
 
     # lists
     assert Min() is S.Infinity

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -32,8 +32,8 @@ def test_DiracDelta():
     assert DiracDelta(j) == 0
     assert DiracDelta(k) == 0
     assert DiracDelta(nan) is nan
-    assert DiracDelta(0).func is DiracDelta
-    assert DiracDelta(x).func is DiracDelta
+    assert isinstance(DiracDelta(0), DiracDelta)
+    assert isinstance(DiracDelta(x), DiracDelta)
     # FIXME: this is generally undefined @ x=0
     #         But then limit(Delta(c)*Heaviside(x),x,-oo)
     #         need's to be implemented.

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -320,7 +320,7 @@ def test_polygamma():
     assert polygamma(-1, x) == loggamma(x) - log(2*pi) / 2
 
     # But smaller orders are iterated integrals and don't have a special name
-    assert polygamma(-2, x).func is polygamma
+    assert isinstance(polygamma(-2, x), polygamma)
 
     # Test a bug
     assert polygamma(0, -x).expand(func=True) == polygamma(0, -x)

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -67,7 +67,7 @@ def test_hyper():
 
     # hyper does not automatically evaluate anyway, but the test is to make
     # sure that the evaluate keyword is accepted
-    assert hyper((1, 2), (1,), z, evaluate=False).func is hyper
+    assert isinstance(hyper((1, 2), (1,), z, evaluate=False), hyper)
 
 
 def test_expand_func():
@@ -376,7 +376,7 @@ def test_appellf1():
     assert appellf1(a, b1, b2, c, S.Zero, S.Zero) is S.One
 
     f = appellf1(a, b1, b2, c, S.Zero, S.Zero, evaluate=False)
-    assert f.func is appellf1
+    assert isinstance(f, appellf1)
     assert f.doit() is S.One
 
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -893,12 +893,12 @@ def test_all_or_nothing():
     x = symbols('x', extended_real=True)
     args = x >= -oo, x <= oo
     v = And(*args)
-    if v.func is And:
+    if isinstance(v, And):
         assert len(v.args) == len(args) - args.count(S.true)
     else:
         assert v == True
     v = Or(*args)
-    if v.func is Or:
+    if isinstance(v, Or):
         assert len(v.args) == 2
     else:
         assert v == True

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -398,7 +398,7 @@ def test_issue_7842():
     A = MatrixSymbol('A', 3, 1)
     B = MatrixSymbol('B', 2, 1)
     assert Eq(A, B) == False
-    assert Eq(A[1,0], B[1, 0]).func is Eq
+    assert isinstance(Eq(A[1,0], B[1, 0]), Eq)
     A = ZeroMatrix(2, 3)
     B = ZeroMatrix(2, 3)
     assert Eq(A, B) == True

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -200,7 +200,7 @@ def test_files():
       o name of arg-less test suite functions start with _ or test_
       o no duplicate function names that start with test_
       o no assignments to self variable in class methods
-      o no lines contain ".func is" except in the test suite
+      o no lines contain ".func is"
       o there is no do-nothing expression like `a == b` or `x + 1`
     """
 


### PR DESCRIPTION
Fixes #24922

Brief description of what is fixed or changed

This PR resolves partial issue https://github.com/sympy/sympy/issues/24922 by improving the code quality from using ".func is" to "isinstance()" in tests. 

Other comments

### Changes Made:
- Replaced `.func is` with `isinstance()` in relevant places in the codebase.

Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

