### PR TITLE
 Change wording in the solveset FAQ; clarify solve is staying

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -863,6 +863,7 @@ Keno Goertz <keno@goertz-berlin.com>
 Keval Shah <kevalshah_96@yahoo.co.in>
 Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
+Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>

--- a/doc/src/modules/solvers/solvers.rst
+++ b/doc/src/modules/solvers/solvers.rst
@@ -56,6 +56,11 @@ is the symbol that we want to solve the equation for.
 
 .. autofunction:: sympy.solvers.solvers::unrad
 
+Univariate Equations
+--------------------
+
+See :ref:`solveset`.
+
 Ordinary Differential equations (ODEs)
 --------------------------------------
 

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -6,61 +6,99 @@ Solveset
 .. module:: sympy.solvers.solveset
 
 This is the official documentation of the ``solveset`` module in solvers.
-It contains the frequently asked questions about our new module to solve
-equations.
 
 .. note::
 
    For a beginner-friendly guide focused on solving common types of equations,
    refer to :ref:`solving-guide`.
 
-What's wrong with solve():
---------------------------
+How solveset() is different from solve()
+----------------------------------------
 
-SymPy already has a pretty powerful ``solve`` function. But it has some
-deficiencies. For example:
+SymPy already has a pretty powerful ``solve`` function. But it has different
+goals. For example:
 
-1. It doesn't have a consistent output for various types of solutions
-   It needs to return a lot of types of solutions consistently:
+* It has a generalized output interface to handle various types of solutions.
+  It needs to return many types of solutions consistently. It can deal with
+  univariate as well as multivariate equations as well as other kinds
+  of variability due to the system of equations and options passed into it,
+  producing associated outputs. See :ref:`solve_output` for more details.
 
-   * Single solution : `x = 1`
-   * Multiple solutions: `x^2 = 1`
-   * No Solution: `x^2 + 1 = 0 ; x \in \mathbb{R}`
-   * Interval of solution: `\lfloor x \rfloor = 0`
-   * Infinitely many solutions: `\sin(x) = 0`
-   * Multivariate functions with point solutions: `x^2 + y^2 = 0`
-   * Multivariate functions with non-point solution: `x^2 + y^2 = 1`
-   * System of equations: `x + y = 1` and `x - y = 0`
-   * Relational: `x > 0`
-   * And the most important case: "We don't Know"
+* The input API has a lot of parameters. It is a facade around
+  more specialized solvers. *This feature of* ``solve`` *could be viewed as analogous
+  to how* ``simplify`` *is a facade around more specialized simplification functions.*
 
-2. The input API has a lot of parameters and it can be difficult to use.
+  See :func:`~sympy.solvers.solvers.solve` for more details about the available parameters
+  and output options.
 
-3. There are cases like finding the maxima and minima of function using
-   critical points where it is important to know if it has returned all the
-   solutions. ``solve`` does not guarantee this.
+* There are cases where ``solve`` returns an empty list.
+
+  This might mean that there are no solutions or no solution could be found
+  given its currently supported features. In other cases, there is no way
+  (given the output interface of ``solve``) to communicate whether or not:
+
+  * all possible solutions to the system were found
+  * or that there are provably no solutions
+  * or that the real set of solutions are finite or infinite
+  * etc.
+
+* ``solve`` may return a few solutions when more solutions (potentially
+  infinitely many) also exist.
+
+  It is to some extent inherent to the API of ``solve`` that it does not
+  have a way to represent these different cases distinctly.
+
+Whereas ``solveset`` returns a ``Set`` representing all of the solutions
+of a univariate equation.
+
 
 .. _why-solveset:
 
 Why Solveset?
 -------------
 
-* ``solveset`` has an alternative consistent input and output interface:
-  ``solveset`` returns a set object and a set object takes care of all types of
-  output. For cases where it does not "know" all the solutions a
-  ``ConditionSet`` with a partial solution is returned. For input it only takes
-  the equation, the variables to solve for and the optional argument ``domain``
-  over which the equation is to be solved.
+``solveset`` has a consistent input and output interface:
+
+* ``solveset`` returns a ``Set`` object in a way that takes care of all types of output.
+
+  For cases where it does not "know" all of the solutions a ``ConditionSet``
+  with a partial solution is returned.
+
+  For input it only takes the equation, the variables to solve for and the optional
+  argument ``domain`` over which the equation is to be solved.
+
+  See :ref:`solveset-input-api` for more details about the available
+  parameters and :ref:`why-set-output` below for more about ``Set`` output.
 
 * ``solveset`` can return infinitely many solutions. For example solving for
   `\sin{(x)} = 0` returns `\{2 n \pi | n \in \mathbb{Z}\} \cup \{2 n \pi + \pi | n \in \mathbb{Z}\}`,
   whereas ``solve`` only returns `[0, \pi]`.
 
-* There is a clear code level and interface level separation between solvers
-  for equations in the complex domain and the real domain. For example
-  solving `e^x = 1` when `x` is to be solved in the complex domain, returns
+* ``solveset`` has a clear code level and interface level separation between solvers
+  for equations in the complex and real domains.
+
+  For example solving `e^x = 1` when `x` is to be solved in the complex domain, returns
   the set of all solutions, that is `\{2 n i \pi | n \in \mathbb{Z}\}`, whereas
   if `x` is to be solved in the real domain then only `\{0\}` is returned.
+
+* As mentioned above, ``solveset`` will return a ``ConditionSet`` where not all
+  parts of an equation can be solved. Consider this example.
+
+  ``expr = (x**2 - 1) * (x**5 + y*x + 1)`` where ``x`` and ``y`` are defined as being
+  in `\mathbb{C}`.
+
+  ``solve(expr, [x], dict=True)`` gives us the solutions it can find. However it gives
+  us no indication that there may be more solutions that it did not return.
+
+  ``[{x: -1},{x: 1}]``
+
+  However, with ``solveset(expr, x)`` the partial solution becomes clear. The quadratic factor
+  was solved, but the quintic factor is not solvable and so a ``ConditionSet`` is returned.
+
+  `\displaystyle \left\{-1, 1\right\} \cup \left\{x\; \middle|\; x \in \mathbb{C} \wedge x^{5} + x y + 1 = 0 \right\}`
+
+
+.. _why-set-output:
 
 Why do we use Sets as an output type?
 -------------------------------------
@@ -218,6 +256,7 @@ Why not use dicts as output?
     a disk of radius 1 in the Argand Plane. This problem is solved using
     complex sets implemented as ``ComplexRegion``.
 
+.. _solveset-input-api:
 
 Input API of ``solveset``
 -------------------------
@@ -470,15 +509,6 @@ How do we deal with cases where only some of the solutions are known?
 
  `\{-2, 2\} ∪ \{x | x \in \mathbb{R} ∧ x + \sin(x) = 0\}`
 
-
-What is the plan for solve and solveset?
-----------------------------------------
-
-There are still a few things ``solveset`` can't do, which ``solve`` can, such
-as solving nonlinear multivariate & LambertW type equations.  Hence, it's not
-yet a perfect replacement for ``solve``. As the algorithms in ``solveset``
-mature, ``solveset`` may be able to be used within ``solve`` to replace some of
-its algorithms.
 
 How are symbolic parameters handled in solveset?
 ------------------------------------------------


### PR DESCRIPTION
Change wording in the solveset FAQ; clarify solve is staying

#### References to other Issues or PRs

Fixes #27332

#### Brief description of what is fixed or changed
This is a documentation change only. No code changes should be expected.

Change some wording suggesting that `solve` will be replaced by `solveset`.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * clarify wording in the docs that there are no current plans to remove `solve`
<!-- END RELEASE NOTES -->
