### PR TITLE
Enable limits of vectors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -824,6 +824,7 @@ Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>
 José Senart <jose.senart@gmail.com>
+Jost Herkenhoff <jherkenhoff+github@mailbox.org> jherkenhoff <jherkenhoff+github@mailbox.org>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 João Moura <operte@gmail.com>
 Juan Barbosa <js.barbosa10@uniandes.edu.co>

--- a/.mailmap
+++ b/.mailmap
@@ -824,7 +824,8 @@ Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>
 José Senart <jose.senart@gmail.com>
-Jost Herkenhoff <22686781+jherkenhoff@users.noreply.github.com>
+Jost Herkenhoff <jherkenhoff@mailbox.org> jherkenhoff <jherkenhoff+github@mailbox.org>
+Jost Herkenhoff <jherkenhoff@mailbox.org> Jost Herkenhoff <22686781+jherkenhoff@users.noreply.github.com>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 João Moura <operte@gmail.com>
 Juan Barbosa <js.barbosa10@uniandes.edu.co>

--- a/.mailmap
+++ b/.mailmap
@@ -824,7 +824,7 @@ Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>
 José Senart <jose.senart@gmail.com>
-Jost Herkenhoff <jherkenhoff+github@mailbox.org> jherkenhoff <jherkenhoff+github@mailbox.org>
+Jost Herkenhoff <22686781+jherkenhoff@users.noreply.github.com>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 João Moura <operte@gmail.com>
 Juan Barbosa <js.barbosa10@uniandes.edu.co>

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -25,6 +25,7 @@ from sympy.integrals.integrals import (Integral, integrate)
 from sympy.series.limits import (Limit, limit)
 from sympy.simplify.simplify import (logcombine, simplify)
 from sympy.simplify.hyperexpand import hyperexpand
+from sympy.vector.coordsysrect import CoordSys3D
 
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.mul import Mul
@@ -1448,3 +1449,8 @@ def test_issue_26991():
 def test_issue_27278():
     expr = (1/(x*log((x + 3)/x)))**x*((x + 1)*log((x + 4)/(x + 1)))**(x + 1)/3
     assert limit(expr, x, oo) == 1
+
+def test_vector():
+    C = CoordSys3D('C')
+    assert limit(x*C.i, x, 0) == 0
+    assert limit(x*C.i + C.j, x, 0) == C.j

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1449,8 +1449,3 @@ def test_issue_26991():
 def test_issue_27278():
     expr = (1/(x*log((x + 3)/x)))**x*((x + 1)*log((x + 4)/(x + 1)))**(x + 1)/3
     assert limit(expr, x, oo) == 1
-
-def test_vector():
-    C = CoordSys3D('C')
-    assert limit(x*C.i, x, 0) == 0
-    assert limit(x*C.i + C.j, x, 0) == C.j

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -25,7 +25,6 @@ from sympy.integrals.integrals import (Integral, integrate)
 from sympy.series.limits import (Limit, limit)
 from sympy.simplify.simplify import (logcombine, simplify)
 from sympy.simplify.hyperexpand import hyperexpand
-from sympy.vector.coordsysrect import CoordSys3D
 
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.mul import Mul

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -191,6 +191,9 @@ class BasisDependentAdd(BasisDependent, Add):
 
         # Check each arg and simultaneously learn the components
         for arg in args:
+            # If argument is zero, ignore
+            if arg == S.Zero:
+                continue
             if not isinstance(arg, cls._expr_type):
                 if isinstance(arg, Mul):
                     arg = cls._mul_func(*(arg.args))
@@ -199,7 +202,7 @@ class BasisDependentAdd(BasisDependent, Add):
                 else:
                     raise TypeError(str(arg) +
                                     " cannot be interpreted correctly")
-            # If argument is zero, ignore
+            # If argument is a vector-zero-element, ignore
             if arg == cls.zero:
                 continue
             # Else, update components accordingly

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -127,6 +127,7 @@ def test_vector():
 
     assert isinstance(v1, VectorAdd)
     assert v1 - v1 == Vector.zero
+    assert v1 + 0 == v1
     assert v1 + Vector.zero == v1
     assert v1.dot(i) == a
     assert v1.dot(j) == b

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -127,7 +127,6 @@ def test_vector():
 
     assert isinstance(v1, VectorAdd)
     assert v1 - v1 == Vector.zero
-    assert v1 + 0 == v1
     assert v1 + Vector.zero == v1
     assert v1.dot(i) == a
     assert v1.dot(j) == b
@@ -341,3 +340,8 @@ def test_scalar():
     assert v1.is_scalar is False
     assert (v1.dot(v2)).is_scalar is True
     assert (v1.cross(v2)).is_scalar is False
+
+
+def test_limit():
+    v1 = a*i + b*j
+    assert v1.limit(a, 0) == b*j


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #27345


#### Brief description of what is fixed or changed
Add explicit handling of vectors being added to `S.Zero`, or simply `0`


#### Other comments
I know that the addition of a vector and a scalar is not defined/possible, but in the present case of addition to zero, e.g. doing nothing, it might make sense to handle this case explicitly? I am open for discussion.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* vector
  * taking limits of vectors is now possible
<!-- END RELEASE NOTES -->
