### PR TITLE
maint: fix .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -342,6 +342,9 @@ Anurag Bhat <bhat.1@iitj.ac.in> Anurag Bhat <90216905+faze-geek@users.noreply.gi
 Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <90216905+faze-geek@users.noreply.github.com>
 Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <bhat.1@iitj.ac.in>
 Anurag Sharma <anurags92@gmail.com> <sharmaan@iitk.ac.in>
+Anutosh Bhat <andersonbhat491@gmail.com> Anutosh Bhat <87052487+anutosh491@users.noreply.github.com>
+Anutosh Bhat <andersonbhat491@gmail.com> anutosh491 <87052487+anutosh491@users.noreply.github.com>
+Anutosh Bhat <andersonbhat491@gmail.com> anutosh491 <andersonbhat491@gmail.com>
 Anway De <anway1756@gmail.com>
 Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
 Arafat Dad Khan <arafat.da.khan@gmail.com>
@@ -1607,8 +1610,6 @@ alijosephine <alijosephine@gmail.com>
 amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>
-anutosh491 <andersonbhat491@gmail.com> Anutosh Bhat <87052487+anutosh491@users.noreply.github.com>
-anutosh491 <andersonbhat491@gmail.com> anutosh491 <87052487+anutosh491@users.noreply.github.com>
 arooshiverma <av22@iitbbs.ac.in>
 atharvParlikar <atharvparlikar@gmail.com>
 bharatAmeria <21001019007@jcboseust.ac.in> bharatAmeria <147488804+bharatAmeria@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1109,7 +1109,7 @@ Risiraj Dey <risirajdey@gmail.com>
 lastcodestanding <rohang71604@gmail.com>
 Andrey Lekar <andrey_lekar@adoriasoft.com>
 Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com>
-anutosh491 <andersonbhat491@gmail.com>
+Anutosh Bhat <andersonbhat491@gmail.com>
 Steve Kieffer <sk@skieffer.info>
 Paul Spiering <paul@spiering.org>
 Pieter Gijsbers <p.gijsbers@tue.nl>


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See e.g. https://github.com/sympy/sympy/pull/27347#issuecomment-2517898744

The problem arises after gh-27325 was merged adding a merge commit with a name that was not in the .mailmap file.

#### Brief description of what is fixed or changed

@anutosh491 can you confirm if the name and email recorded in the AUTHORS file here it what you want?

#### Other comments



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
