### PR TITLE
logic: Improve speed of Z3 wrapper 17x by using faster SMT-LIB parser

### DIFF
--- a/sympy/logic/algorithms/z3_wrapper.py
+++ b/sympy/logic/algorithms/z3_wrapper.py
@@ -77,10 +77,10 @@ def encoded_cnf_to_z3_solver(enc_cnf, z3):
     for sym in symbols:
         declarations.append(f"(declare-const {sym} Real)")
 
-    declarations = "\n".join(declarations)
-    assertions = "\n".join(assertions)
-    s.from_string(declarations)
-    s.from_string(assertions)
+    declarations = z3.parse_smt2_string("\n".join(declarations))
+    assertions = z3.parse_smt2_string("\n".join(assertions))
+    s.add(declarations)
+    s.add(assertions)
 
     return s
 


### PR DESCRIPTION
Switched from `Solver.from_string()` to `parse_smt2_string()`, significantly improving performance. The `test_z3_vs_lra_dpll2 ` test  now runs 17x faster, reducing execution time from ~30 seconds to ~1.7 seconds.

Not sure why the `Solver.from_string()` api exists if using `parse_smt2_string()` is so much faster. Given this speedup it may be more worth it to consider adding Z3 as a hard dependency.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
