### PR TITLE
Update _eval_integral, making it handle limit case where the exponent's coefficient becomes zero

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1168,33 +1168,49 @@ class Integral(AddWithLimits):
                 conds = kwargs.get('conds', 'piecewise')
                 current_expr = f
                 for integration_limit in self.limits:
-                    result = self._handle_single_limit(current_expr, integration_limit, meijerg, risch, manual, heurisch, conds)
+                    result = self._handle_single_limit(current_expr, integration_limit,
+                                                     meijerg, risch, manual, heurisch, conds)
                     if result is None:
                         return self.func(current_expr, integration_limit[0])
+                    try:
+                        if hasattr(result, 'doit'):
+                            result = result.doit()
+                        if hasattr(result, 'simplify'):
+                            result = result.simplify()
+                    except Exception:
+                        pass
                     current_expr = result
                     if current_expr == f:
                         break
                 return current_expr
             def _handle_single_limit(self, expr, integration_limit, meijerg, risch, manual, heurisch, conds):
                 """Handle integration for a single limit"""
-                if len(integration_limit) == 3:
-                    var, a, b = integration_limit
-                    return integrate(expr, (var, a, b),
-                                   meijerg=meijerg, risch=risch,
-                                   manual=manual, heurisch=heurisch,
-                                   conds=conds)
-                elif len(integration_limit) == 2:
-                    var, b = integration_limit
-                    return integrate(expr, (var, None, b),
-                                   meijerg=meijerg, risch=risch,
-                                   manual=manual, heurisch=heurisch,
-                                   conds=conds)
-                else:
-                    var = integration_limit[0]
-                    return integrate(expr, var,
-                                   meijerg=meijerg, risch=risch,
-                                   manual=manual, heurisch=heurisch,
-                                   conds=conds)
+                try:
+                    if len(integration_limit) == 3:
+                        var, a, b = integration_limit
+                        result = integrate(expr, (var, a, b),
+                                       meijerg=meijerg, risch=risch,
+                                       manual=manual, heurisch=heurisch,
+                                       conds=conds)
+                    elif len(integration_limit) == 2:
+                        var, b = integration_limit
+                        result = integrate(expr, (var, None, b),
+                                       meijerg=meijerg, risch=risch,
+                                       manual=manual, heurisch=heurisch,
+                                       conds=conds)
+                    else:
+                        var = integration_limit[0]
+                        result = integrate(expr, var,
+                                       meijerg=meijerg, risch=risch,
+                                       manual=manual, heurisch=heurisch,
+                                       conds=conds)
+                    if hasattr(result, 'doit'):
+                        result = result.doit()
+                    if hasattr(result, 'simplify'):
+                        result = result.simplify()
+                    return result
+                except Exception:
+                    return None
     def _eval_lseries(self, x, logx=None, cdir=0):
         expr = self.as_dummy()
         symb = x

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1160,16 +1160,16 @@ class Integral(AddWithLimits):
             else:
                 return None
             current_expr = f
-            for limit in self.limits:
-                if len(limit) == 3:
-                    var, a, b = limit
+            for lim in self.limits:
+                if len(lim) == 3:
+                    var, a, b = lim
                     is_definite = True
-                elif len(limit) == 2:
-                    var, b = limit
+                elif len(lim) == 2:
+                    var, b = lim
                     a = None
                     is_definite = True
                 else:
-                    var = limit[0]
+                    var = lim[0]
                     a = b = None
                     is_definite = False
                 if is_definite and a is not None and b is not None:
@@ -1196,7 +1196,7 @@ class Integral(AddWithLimits):
                         if attempted is not None:
                             current_expr = attempted
                         else:
-                            current_expr = self.func(*([function] + [xab]))
+                            current_expr = self.func(current_expr, var)
             return current_expr
 
     def _eval_lseries(self, x, logx=None, cdir=0):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -30,7 +30,7 @@ from sympy.tensor.functions import shape
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.misc import filldedent
-
+from sympy import re, exp, Eq
 
 class Integral(AddWithLimits):
     """Represents unevaluated integral."""
@@ -1169,7 +1169,6 @@ class Integral(AddWithLimits):
                 var, b = limit
                 a = None
             else:
-                var = limit[0]
                 a = b = None
         else:
             raise NotImplementedError(

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1160,6 +1160,32 @@ class Integral(AddWithLimits):
                 parts.append(coeff * h)
             else:
                 return None
+        # Extract integration limits 
+        if len(self.limits) == 1:
+            limit = self.limits[0]
+            if len(limit) == 3:
+                var, a, b = limit
+            elif len(limit) == 2:
+                var, b = limit 
+                a = None
+            else:
+                var = limit[0]
+                a = b = None
+        else:
+            raise NotImplementedError(
+                "Multiple integration limits not implemented")
+
+        if a is not None and b is not None:
+            diff_re = re(b) - re(a)
+            if diff_re.is_zero:
+                result = (b - a) * exp(re(a))
+            else:
+                result = (b - a) * (exp(re(b)) - exp(re(a))) / diff_re
+            
+            return Piecewise(
+                ((b - a) * exp(re(a)), Eq(re(a), re(b))),
+                (result, True)
+            )
 
         return Add(*parts)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -10,14 +10,14 @@ from sympy.core.function import diff
 from sympy.core.logic import fuzzy_bool
 from sympy.core.mul import Mul
 from sympy.core.numbers import oo, pi
-from sympy.core.relational import Ne, Eq
+from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, Wild)
 from sympy.core.sympify import sympify
 from sympy.functions import Piecewise, sqrt, piecewise_fold, tan, cot, atan
-from sympy.functions.elementary.exponential import log, exp
+from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.complexes import Abs, sign, re
+from sympy.functions.elementary.complexes import Abs, sign
 from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.functions.special.singularity_functions import Heaviside
 from .rationaltools import ratint
@@ -30,7 +30,6 @@ from sympy.tensor.functions import shape
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.misc import filldedent
-
 
 class Integral(AddWithLimits):
     """Represents unevaluated integral."""

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1172,9 +1172,10 @@ class Integral(AddWithLimits):
                     var = lim[0]
                     a = b = None
                     is_definite = False
+            
                 if is_definite and a is not None and b is not None:
                     attempted = integrate(current_expr, (var, a, b), meijerg=meijerg, risch=risch,
-                                                                   manual=manual, heurisch=heurisch, conds=conds)
+                                       manual=manual, heurisch=heurisch, conds=conds)
                     current_expr = attempted
                 else:
                     if is_definite and (a is None or b is None):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1193,7 +1193,7 @@ class Integral(AddWithLimits):
                     var = limit[0]
                     return integrate(expr, var,
                                    meijerg=meijerg, risch=risch,
-                                   manual=manual, heurisch=heurisch, 
+                                   manual=manual, heurisch=heurisch,
                                    conds=conds)
     def _eval_lseries(self, x, logx=None, cdir=0):
         expr = self.as_dummy()

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1159,7 +1159,6 @@ class Integral(AddWithLimits):
                 parts.append(coeff * h)
             else:
                 return None
-            
             def _eval_integral(self, f, **kwargs):
                 """Helper method to evaluate the integral"""
                 meijerg = kwargs.get('meijerg', None)
@@ -1167,7 +1166,6 @@ class Integral(AddWithLimits):
                 manual = kwargs.get('manual', None)
                 heurisch = kwargs.get('heurisch', None)
                 conds = kwargs.get('conds', 'piecewise')
-            
                 current_expr = f
                 for lim in self.limits:
                     result = self._handle_single_limit(current_expr, lim, meijerg, risch, manual, heurisch, conds)
@@ -1177,19 +1175,18 @@ class Integral(AddWithLimits):
                     if current_expr == f:
                         break
                 return current_expr
-            
             def _handle_single_limit(self, expr, limit, meijerg, risch, manual, heurisch, conds):
                 """Handle integration for a single limit"""
                 if len(limit) == 3:
                     var, a, b = limit
-                    return integrate(expr, (var, a, b), 
+                    return integrate(expr, (var, a, b),
                                    meijerg=meijerg, risch=risch,
-                                   manual=manual, heurisch=heurisch, 
+                                   manual=manual, heurisch=heurisch,
                                    conds=conds)
                 elif len(limit) == 2:
                     var, b = limit
                     return integrate(expr, (var, None, b),
-                                   meijerg=meijerg, risch=risch, 
+                                   meijerg=meijerg, risch=risch,
                                    manual=manual, heurisch=heurisch,
                                    conds=conds)
                 else:
@@ -1198,7 +1195,6 @@ class Integral(AddWithLimits):
                                    meijerg=meijerg, risch=risch,
                                    manual=manual, heurisch=heurisch, 
                                    conds=conds)
-
     def _eval_lseries(self, x, logx=None, cdir=0):
         expr = self.as_dummy()
         symb = x

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1175,6 +1175,8 @@ class Integral(AddWithLimits):
                 if is_definite and a is not None and b is not None:
                     attempted = integrate(current_expr, (var, a, b), meijerg=meijerg, risch=risch,
                                        manual=manual, heurisch=heurisch, conds=conds)
+                    if attempted == current_expr:
+                        break
                     current_expr = attempted
                 else:
                     if is_definite and (a is None or b is None):
@@ -1186,17 +1188,20 @@ class Integral(AddWithLimits):
                                            conds=conds)
                         if attempted.has(Integral):
                             current_expr = attempted
-                        else:
-                            current_expr = attempted
+                            break
+                        current_expr = attempted
                     else:
                         attempted = integrate(current_expr, var,
                                            meijerg=meijerg, risch=risch,
                                            manual=manual, heurisch=heurisch,
                                            conds=conds)
                         if attempted is not None:
+                            if attempted == current_expr:
+                                break
                             current_expr = attempted
                         else:
                             current_expr = self.func(current_expr, var)
+                            break
             return current_expr
 
     def _eval_lseries(self, x, logx=None, cdir=0):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1181,12 +1181,10 @@ class Integral(AddWithLimits):
                 result = (b - a) * exp(re(a))
             else:
                 result = (b - a) * (exp(re(b)) - exp(re(a))) / diff_re
-            
             return Piecewise(
                 ((b - a) * exp(re(a)), Eq(re(a), re(b))),
                 (result, True)
             )
-
         return Add(*parts)
 
     def _eval_lseries(self, x, logx=None, cdir=0):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1166,7 +1166,7 @@ class Integral(AddWithLimits):
             if len(limit) == 3:
                 var, a, b = limit
             elif len(limit) == 2:
-                var, b = limit 
+                var, b = limit
                 a = None
             else:
                 var = limit[0]

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1161,7 +1161,8 @@ class Integral(AddWithLimits):
                 return None
             def _eval_integral(self, f, **kwargs):
                 """Helper method to evaluate the integral"""
-                from sympy import manualintegrate, simplify
+                from sympy.integrals.manualintegrate import manualintegrate
+                from sympy.simplify.simplify import simplify
                 meijerg = kwargs.get('meijerg', None)
                 risch = kwargs.get('risch', None)
                 manual = kwargs.get('manual', None)
@@ -1196,7 +1197,6 @@ class Integral(AddWithLimits):
                 return current_expr
             def _handle_single_limit(self, expr, integration_limit, meijerg, risch, manual, heurisch, conds):
                 """Handle integration for a single limit"""
-                from sympy import manualintegrate
                 try:
                     if len(integration_limit) == 3:
                         var, a, b = integration_limit
@@ -1206,23 +1206,22 @@ class Integral(AddWithLimits):
                                 return result
                         except Exception:
                             pass
-                        result = integrate(expr, (var, a, b),
+                        return integrate(expr, (var, a, b),
                                        meijerg=meijerg, risch=risch,
                                        manual=manual, heurisch=heurisch,
                                        conds=conds)
                     elif len(integration_limit) == 2:
                         var, b = integration_limit
-                        result = integrate(expr, (var, None, b),
+                        return integrate(expr, (var, None, b),
                                        meijerg=meijerg, risch=risch,
                                        manual=manual, heurisch=heurisch,
                                        conds=conds)
                     else:
                         var = integration_limit[0]
-                        result = integrate(expr, var,
+                        return integrate(expr, var,
                                        meijerg=meijerg, risch=risch,
                                        manual=manual, heurisch=heurisch,
                                        conds=conds)
-                    return result
                 except Exception:
                     return None
     def _eval_lseries(self, x, logx=None, cdir=0):
@@ -1234,7 +1233,6 @@ class Integral(AddWithLimits):
                 break
         for term in expr.function.lseries(symb, logx):
             yield integrate(term, *expr.limits)
-
     def _eval_nseries(self, x, n, logx=None, cdir=0):
         symb = x
         for l in self.limits:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1172,7 +1172,6 @@ class Integral(AddWithLimits):
                     var = lim[0]
                     a = b = None
                     is_definite = False
-            
                 if is_definite and a is not None and b is not None:
                     attempted = integrate(current_expr, (var, a, b), meijerg=meijerg, risch=risch,
                                        manual=manual, heurisch=heurisch, conds=conds)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1167,30 +1167,30 @@ class Integral(AddWithLimits):
                 heurisch = kwargs.get('heurisch', None)
                 conds = kwargs.get('conds', 'piecewise')
                 current_expr = f
-                for lim in self.limits:
-                    result = self._handle_single_limit(current_expr, lim, meijerg, risch, manual, heurisch, conds)
+                for integration_limit in self.limits:
+                    result = self._handle_single_limit(current_expr, integration_limit, meijerg, risch, manual, heurisch, conds)
                     if result is None:
-                        return self.func(current_expr, lim[0])
+                        return self.func(current_expr, integration_limit[0])
                     current_expr = result
                     if current_expr == f:
                         break
                 return current_expr
-            def _handle_single_limit(self, expr, limit, meijerg, risch, manual, heurisch, conds):
+            def _handle_single_limit(self, expr, integration_limit, meijerg, risch, manual, heurisch, conds):
                 """Handle integration for a single limit"""
-                if len(limit) == 3:
-                    var, a, b = limit
+                if len(integration_limit) == 3:
+                    var, a, b = integration_limit
                     return integrate(expr, (var, a, b),
                                    meijerg=meijerg, risch=risch,
                                    manual=manual, heurisch=heurisch,
                                    conds=conds)
-                elif len(limit) == 2:
-                    var, b = limit
+                elif len(integration_limit) == 2:
+                    var, b = integration_limit
                     return integrate(expr, (var, None, b),
                                    meijerg=meijerg, risch=risch,
                                    manual=manual, heurisch=heurisch,
                                    conds=conds)
                 else:
-                    var = limit[0]
+                    var = integration_limit[0]
                     return integrate(expr, var,
                                    meijerg=meijerg, risch=risch,
                                    manual=manual, heurisch=heurisch,

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1159,9 +1159,6 @@ class Integral(AddWithLimits):
                 parts.append(coeff * h)
             else:
                 return None
-from sympy.integrals.manualintegrate import manualintegrate
-from sympy.simplify import simplify
-
 class IntegralEvaluator:
     def __init__(self, func, limits):
         self.func = func
@@ -1189,13 +1186,17 @@ class IntegralEvaluator:
             if isinstance(result, Integral):
                 # Try integrate again directly
                 try:
+            if isinstance(result, Integral):
+                # Try integrate again directly
+                try:
                     res_int = integrate(result.function, *result.limits,
-                                        meijerg=meijerg, risch=risch,
-                                        manual=manual, heurisch=heurisch, conds=conds)
+                                      meijerg=meijerg, risch=risch,
+                                      manual=manual, heurisch=heurisch, conds=conds)
                     if not isinstance(res_int, Integral):
                         result = res_int
                     else:
-                        # If still Integral, try manualintegrate
+                        # If still Integral, try manual integration
+                        from sympy.integrals.manualintegrate import manualintegrate
                         try:
                             manual_res = manualintegrate(result.function, result.limits[0])
                             if manual_res != result.function:
@@ -1203,16 +1204,14 @@ class IntegralEvaluator:
                         except Exception:
                             pass
                 except Exception:
-                    # If direct integrate fails, fallback to manualintegrate
+                    # If direct integrate fails, try manual integration
+                    from sympy.integrals.manualintegrate import manualintegrate
                     try:
                         manual_res = manualintegrate(result.function, result.limits[0])
                         if manual_res != result.function:
                             result = manual_res
                     except Exception:
                         pass
-
-            # Try 'doit' to force evaluation
-            try:
                 if hasattr(result, 'doit'):
                     result = result.doit(deep=True)
             except Exception:
@@ -1220,10 +1219,11 @@ class IntegralEvaluator:
 
             # Attempt simplification
             try:
+            try:
+                from sympy.simplify import simplify
                 result = simplify(result)
             except Exception:
                 pass
-
             current_expr = result
 
             # If no progress, break
@@ -1242,6 +1242,7 @@ class IntegralEvaluator:
                                     manual=manual, heurisch=heurisch, conds=conds)
                     if res is None or isinstance(res, Integral):
                         try:
+                            from sympy.integrals.manualintegrate import manualintegrate
                             manual_res = manualintegrate(expr, (var, a, b))
                             if manual_res is not None and manual_res != expr:
                                 return manual_res

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1161,45 +1161,45 @@ class Integral(AddWithLimits):
             else:
                 return None
             current_expr = f
-                for limit in self.limits:
-                    if len(limit) == 3:
-                        var, a, b = limit
-                        is_definite = True
-                    elif len(limit) == 2:
-                        var, b = limit
-                        a = None
-                        is_definite = True
-                    else:
-                        var = limit[0]
-                        a = b = None
-                        is_definite = False
+            for limit in self.limits:
+                if len(limit) == 3:
+                    var, a, b = limit
+                    is_definite = True
+                elif len(limit) == 2:
+                    var, b = limit
+                    a = None
+                    is_definite = True
+                else:
+                    var = limit[0]
+                    a = b = None
+                    is_definite = False
             
-                    if is_definite and a is not None and b is not None:
-                        attempted = integrate(current_expr, (var, a, b), meijerg=meijerg, risch=risch,
-                                                                       manual=manual, heurisch=heurisch, conds=conds)
-                        current_expr = attempted
-                    else:
-                        if is_definite and (a is None or b is None):
-                            A = a if a is not None else -oo
-                            B = b if b is not None else oo
-                            attempted = integrate(current_expr, (var, A, B), 
-                                               meijerg=meijerg, risch=risch,
-                                               manual=manual, heurisch=heurisch, 
-                                               conds=conds)
-                            if attempted.has(Integral):
-                                current_expr = attempted
-                            else:
-                                current_expr = attempted
+                if is_definite and a is not None and b is not None:
+                    attempted = integrate(current_expr, (var, a, b), meijerg=meijerg, risch=risch,
+                                                                   manual=manual, heurisch=heurisch, conds=conds)
+                    current_expr = attempted
+                else:
+                    if is_definite and (a is None or b is None):
+                        A = a if a is not None else -oo
+                        B = b if b is not None else oo
+                        attempted = integrate(current_expr, (var, A, B), 
+                                           meijerg=meijerg, risch=risch,
+                                           manual=manual, heurisch=heurisch, 
+                                           conds=conds)
+                        if attempted.has(Integral):
+                            current_expr = attempted
                         else:
-                            attempted = integrate(current_expr, var, 
-                                               meijerg=meijerg, risch=risch,
-                                               manual=manual, heurisch=heurisch, 
-                                               conds=conds)
-                            if attempted is not None:
-                                current_expr = attempted
-                            else:
-                                current_expr = self.func(*([function] + [xab]))
-                return current_expr
+                            current_expr = attempted
+                    else:
+                        attempted = integrate(current_expr, var, 
+                                           meijerg=meijerg, risch=risch,
+                                           manual=manual, heurisch=heurisch, 
+                                           conds=conds)
+                        if attempted is not None:
+                            current_expr = attempted
+                        else:
+                            current_expr = self.func(*([function] + [xab]))
+            return current_expr
 
     def _eval_lseries(self, x, logx=None, cdir=0):
         expr = self.as_dummy()

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1160,7 +1160,7 @@ class Integral(AddWithLimits):
                 parts.append(coeff * h)
             else:
                 return None
-        # Extract integration limits 
+      # Extract integration limits
         if len(self.limits) == 1:
             limit = self.limits[0]
             if len(limit) == 3:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1221,7 +1221,7 @@ class Integral(AddWithLimits):
                         result = integrate(expr, var,
                                        meijerg=meijerg, risch=risch,
                                        manual=manual, heurisch=heurisch,
-                                       conds=conds) 
+                                       conds=conds)
                     return result
                 except Exception:
                     return None

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1159,12 +1159,8 @@ class Integral(AddWithLimits):
                 parts.append(coeff * h)
             else:
                 return None
-class IntegralEvaluator:
-    def __init__(self, func, limits):
-        # func: a callable to reconstruct an unevaluated integral if needed
-        # limits: a list of integration limits, e.g. [(x, 0, 1), (y, 0, 2)]
-        self.func = func
-        self.limits = limits
+from sympy.integrals.manualintegrate import manualintegrate
+from sympy.simplify import simplify
 
 class IntegralEvaluator:
     def __init__(self, func, limits):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1173,7 +1173,6 @@ class Integral(AddWithLimits):
                     var = limit[0]
                     a = b = None
                     is_definite = False
-            
                 if is_definite and a is not None and b is not None:
                     attempted = integrate(current_expr, (var, a, b), meijerg=meijerg, risch=risch,
                                                                    manual=manual, heurisch=heurisch, conds=conds)
@@ -1182,18 +1181,18 @@ class Integral(AddWithLimits):
                     if is_definite and (a is None or b is None):
                         A = a if a is not None else -oo
                         B = b if b is not None else oo
-                        attempted = integrate(current_expr, (var, A, B), 
+                        attempted = integrate(current_expr, (var, A, B),
                                            meijerg=meijerg, risch=risch,
-                                           manual=manual, heurisch=heurisch, 
+                                           manual=manual, heurisch=heurisch,
                                            conds=conds)
                         if attempted.has(Integral):
                             current_expr = attempted
                         else:
                             current_expr = attempted
                     else:
-                        attempted = integrate(current_expr, var, 
+                        attempted = integrate(current_expr, var,
                                            meijerg=meijerg, risch=risch,
-                                           manual=manual, heurisch=heurisch, 
+                                           manual=manual, heurisch=heurisch,
                                            conds=conds)
                         if attempted is not None:
                             current_expr = attempted

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -159,7 +159,7 @@ def test_issue_15227():
     # assert i == -5*zeta(3)/4
 
 @XFAIL
-def test_issue_3880():
+def test_issue_3890():
     # the current limitations in the integration method is gonna make this test fail
     assert not integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3 + x**2)/(2*(x**2 + x + 1)), x).has(Integral)
 

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -158,6 +158,10 @@ def test_issue_15227():
     assert not i.has(Integral)
     # assert i == -5*zeta(3)/4
 
+@XFAIL
+def test_issue_3880():
+    # the current limitations in the integration method is gonna make this test fail
+    assert not integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3 + x**2)/(2*(x**2 + x + 1)), x).has(Integral)
 
 @XFAIL
 @slow

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -158,10 +158,6 @@ def test_issue_15227():
     assert not i.has(Integral)
     # assert i == -5*zeta(3)/4
 
-@XFAIL
-def test_issue_3890():
-    # the current limitations in the integration method is gonna make this test fail
-    assert not integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3 + x**2)/(2*(x**2 + x + 1)), x).has(Integral)
 
 @XFAIL
 @slow

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1733,7 +1733,11 @@ def test_issue_17671():
     assert integrate(log(log(x)) / x**3, [x, 1, oo]) == -log(2)/2 - EulerGamma/2
     assert integrate(log(log(x)) / x**10, [x, 1, oo]) == -log(9)/9 - EulerGamma/9
 
-
+def test_principal_value():
+    d = 1 / (x ** 2 - 1)
+    assert Integral(d, (x, -oo, oo)).principal_value() == 0
+    assert Integral(d, (x, -2, 2)).principal_value() == -log(3)
+    
 def test_issue_2975():
     w = Symbol('w')
     C = Symbol('C')

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1733,11 +1733,6 @@ def test_issue_17671():
     assert integrate(log(log(x)) / x**3, [x, 1, oo]) == -log(2)/2 - EulerGamma/2
     assert integrate(log(log(x)) / x**10, [x, 1, oo]) == -log(9)/9 - EulerGamma/9
 
-def test_principal_value():
-    d = 1 / (x ** 2 - 1)
-    assert Integral(d, (x, -oo, oo)).principal_value() == 0
-    assert Integral(d, (x, -2, 2)).principal_value() == -log(3)
-    
 def test_issue_2975():
     w = Symbol('w')
     C = Symbol('C')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #27280 

#### Brief description of what is fixed or changed
I think we need to update _eval_integral function for this. The issue seems like comes from definition not correctly handling the limit case where the exponent's coefficient becomes zero.  My solution involves adding a Piecewise condition for this, re(a) == re(b) will be special case, and if it's not it's going to use the general method.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * changed the limit case handling
<!-- END RELEASE NOTES -->