### PR TITLE
Add support for scalar multiplication by Symbol in waves module

### DIFF
--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -82,11 +82,11 @@ def test_twave():
     raises(ValueError, lambda:TWave(A1, f, phi1, t))
 
     A, f, phi, n, A2, f2, phi2 = symbols('A, f, phi, n, A2, f2, phi2')
-    s = symbols('s') # scaling factor
+    p = symbols('p') # scaling factor
 
     w8 = TWave(A, f, phi)
-    w9 = w8*s
-    assert w9.amplitude == A*s
+    w9 = w8*p
+    assert w9.amplitude == A*p
     assert w9.frequency == f
     assert w9.phase == phi
     assert w9.wavelength == c/(f*n)
@@ -97,9 +97,9 @@ def test_twave():
 
     w10 = TWave(A2, f2, phi2)
     w11 = w9 + w10
-    assert w11.amplitude == sqrt(A**2*s**2 + 2*A*A2*s*cos(phi- phi2) + A2**2)
+    assert w11.amplitude == sqrt(A**2*p**2 + 2*A*A2*p*cos(phi- phi2) + A2**2)
     assert w11.frequency == f
-    assert w11.phase == atan2(A*s*sin(phi) + A2*sin(phi2), A*s*cos(phi) + A2*cos(phi2))
+    assert w11.phase == atan2(A*p*sin(phi) + A2*sin(phi2), A*p*cos(phi) + A2*cos(phi2))
     assert w11.wavelength == c/(f*n)
     assert w11.time_period == 1/f
     assert w11.angular_velocity == 2*pi*f

--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -81,8 +81,8 @@ def test_twave():
     raises(ValueError, lambda:TWave(A1))
     raises(ValueError, lambda:TWave(A1, f, phi1, t))
 
-    A, f, phi, n, A2, f2, phi2 = symbols('A, f, phi, n, A2, f2, phi2')
-    p = symbols('p') # scaling factor
+    A, f, phi, n, A2, phi2 = symbols('A, f, phi, n, A2, phi2')
+    p = Symbol('p') # scaling factor
 
     w8 = TWave(A, f, phi)
     w9 = w8*p
@@ -95,7 +95,7 @@ def test_twave():
     assert w9.wavenumber == 2*pi*f*n/c
     assert w9.speed == c/n
 
-    w10 = TWave(A2, f2, phi2)
+    w10 = TWave(A2, f, phi2)
     w11 = w9 + w10
     assert w11.amplitude == sqrt(A**2*p**2 + 2*A*A2*p*cos(phi- phi2) + A2**2)
     assert w11.frequency == f

--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -80,3 +80,28 @@ def test_twave():
 
     raises(ValueError, lambda:TWave(A1))
     raises(ValueError, lambda:TWave(A1, f, phi1, t))
+
+    A, f, phi, n, A2, f2, phi2 = symbols('A, f, phi, n, A2, f2, phi2')
+    s = symbols('s') # scaling factor
+
+    w8 = TWave(A, f, phi)
+    w9 = w8*s
+    assert w9.amplitude == A*s
+    assert w9.frequency == f
+    assert w9.phase == phi
+    assert w9.wavelength == c/(f*n)
+    assert w9.time_period == 1/f
+    assert w9.angular_velocity == 2*pi*f
+    assert w9.wavenumber == 2*pi*f*n/c
+    assert w9.speed == c/n
+
+    w10 = TWave(A2, f2, phi2)
+    w11 = w9 + w10
+    assert w11.amplitude == sqrt(A**2*s**2 + 2*A*A2*s*cos(phi- phi2) + A2**2)
+    assert w11.frequency == f
+    assert w11.phase == atan2(A*s*sin(phi) + A2*sin(phi2), A*s*cos(phi) + A2*cos(phi2))
+    assert w11.wavelength == c/(f*n)
+    assert w11.time_period == 1/f
+    assert w11.angular_velocity == 2*pi*f
+    assert w11.wavenumber == 2*pi*f*n/c
+    assert w11.speed == c/n

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -304,6 +304,8 @@ class TWave(Expr):
         other = sympify(other)
         if isinstance(other, Number):
             return TWave(self.amplitude*other, *self.args[1:])
+        elif isinstance(other, Symbol):
+            return TWave(self.amplitude*other, *self.args[1:])
         else:
             raise TypeError(type(other).__name__ + " and TWave objects cannot be multiplied.")
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR implements multiplication operation of a transverse wave (TWave) with a symbolic scalar (Symbol) i.e amplitude scaling by a Symbol.
Example Usage:

```python
>>> A, f, phi= symbols('A, f, phi')
>>> s = symbols('s') # scaling factor
>>> w = TWave(A, f, phi)
>>> w2 = w*s
>>> w2
TWave(A*s, f, phi, 1/f, n)
```


Tests have also been added. 

#### Other comments
Any feedback and suggestions on improving/enhancing this implementation are appreciated.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.optics
  * Symbolic amplitude scaling of waves is now supported.
<!-- END RELEASE NOTES -->
