### PR TITLE
Added test for symbolic integration in test_integrals.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1174,6 +1174,7 @@ Prasoon Shukla <prasoon92.iitr@gmail.com>
 Prateek Papriwal <papriwalprateek@gmail.com>
 Praveen Perumal <ppraveen98841@gmail.com> Praveen Perumal <58477724+solvedbiscuit71@users.noreply.github.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
+Prayag <v.prayag2005@gmail.com> vprayag2005 <v.prayag2005@gamil.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>
 Prey Patel <patel.prey@iitgn.ac.in>

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2192,3 +2192,4 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0
+    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2193,3 +2193,4 @@ def test_issue_27374():
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
     
+    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2192,3 +2192,5 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
+    
+    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2192,3 +2192,4 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
+    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2196,4 +2196,3 @@ def test_issue_27374():
 
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
-

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2182,15 +2182,18 @@ def test_issue_27374():
     #https://github.com/sympy/sympy/issues/27374
     # Define the symbols
     x, z, R, a = symbols('x z R a')
+
     # Define expressions
     r = sqrt(x**2 + z**2)
     u = erf(a*r/sqrt(2))/r
     Ec = diff(u, z, z).subs([(x, sqrt(R*R-z*z))])
+
     # Perform the integration
     numeric_result=simplify(integrate(Ec, (z, -R, R)))
+
     # Define expected result
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
+
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
-    
-    
+

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2176,3 +2176,24 @@ def test_definite_integral_with_floats_issue_27231():
 
     # Verify that the result is approximately equal within a larger tolerance
     assert abs(result_numeric - expected_result.evalf()) < 1e-8
+
+def test_issue_27374():
+    #https://github.com/sympy/sympy/issues/27374
+    
+    # Define the symbols
+    x, z, R, a = symbols('x z R a')
+    
+    # Define expressions
+    r = sqrt(x**2 + z**2)
+    u = erf(a*r/sqrt(2))/r
+    Ec = diff(u, z, z).subs([(x, sqrt(R*R-z*z))])
+    
+    # Perform the integration
+    numeric_result=simplify(integrate(Ec, (z, -R, R)))
+    
+    # Define expected result
+    expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
+    
+    # Assert that the difference between the expected and numeric result is zero
+    assert (expected_result-numeric_result)==0
+

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2191,3 +2191,4 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0
+    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2196,4 +2196,3 @@ def test_issue_27374():
     
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0
-

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2182,17 +2182,13 @@ def test_issue_27374():
     #https://github.com/sympy/sympy/issues/27374
     # Define the symbols
     x, z, R, a = symbols('x z R a')
-    
     # Define expressions
     r = sqrt(x**2 + z**2)
     u = erf(a*r/sqrt(2))/r
     Ec = diff(u, z, z).subs([(x, sqrt(R*R-z*z))])
-    
     # Perform the integration
     numeric_result=simplify(integrate(Ec, (z, -R, R)))
-    
     # Define expected result
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
-    
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2191,4 +2191,4 @@ def test_issue_27374():
     # Define expected result
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
-    assert (expected_result-numeric_result)==0
+    assert (expected_result-numeric_result) == 0 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2193,4 +2193,3 @@ def test_issue_27374():
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
     
-    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2177,6 +2177,7 @@ def test_definite_integral_with_floats_issue_27231():
     # Verify that the result is approximately equal within a larger tolerance
     assert abs(result_numeric - expected_result.evalf()) < 1e-8
 
+
 def test_issue_27374():
     #https://github.com/sympy/sympy/issues/27374
     # Define the symbols
@@ -2191,4 +2192,5 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0
+    
     

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2192,4 +2192,3 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0
-    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2182,13 +2182,17 @@ def test_issue_27374():
     #https://github.com/sympy/sympy/issues/27374
     # Define the symbols
     x, z, R, a = symbols('x z R a')
+    
     # Define expressions
     r = sqrt(x**2 + z**2)
     u = erf(a*r/sqrt(2))/r
     Ec = diff(u, z, z).subs([(x, sqrt(R*R-z*z))])
+    
     # Perform the integration
     numeric_result=simplify(integrate(Ec, (z, -R, R)))
+    
     # Define expected result
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
+    
     # Assert that the difference between the expected and numeric result is zero
-    assert (expected_result-numeric_result) == 0 
+    assert (expected_result-numeric_result) == 0

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2181,17 +2181,13 @@ def test_issue_27374():
     #https://github.com/sympy/sympy/issues/27374
     # Define the symbols
     x, z, R, a = symbols('x z R a')
-    
     # Define expressions
     r = sqrt(x**2 + z**2)
     u = erf(a*r/sqrt(2))/r
     Ec = diff(u, z, z).subs([(x, sqrt(R*R-z*z))])
-    
     # Perform the integration
     numeric_result=simplify(integrate(Ec, (z, -R, R)))
-    
     # Define expected result
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
-    
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2193,4 +2193,3 @@ def test_issue_27374():
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result)==0
     
-    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2192,4 +2192,3 @@ def test_issue_27374():
     expected_result=-2*sqrt(2)*R*a**3*exp(-R**2*a**2/2)/(3*sqrt(pi))
     # Assert that the difference between the expected and numeric result is zero
     assert (expected_result-numeric_result) == 0
-    

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2179,7 +2179,6 @@ def test_definite_integral_with_floats_issue_27231():
 
 def test_issue_27374():
     #https://github.com/sympy/sympy/issues/27374
-    
     # Define the symbols
     x, z, R, a = symbols('x z R a')
     


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Issue #7383 (fix implemented by others)
Issue #27374 (test cases added)
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The fix for Issue #7383 has already been implemented, and I have added the corresponding test cases as part of Issue #27374


#### Other comments
This PR doesn't make any changes to the core functionality; it only adds a new test case to maintain coverage for the previously fixed issue.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
