### PR TITLE
Fix hypersimp function and refactor piecewise._eval_nseries() to use wrapper function.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -907,6 +907,7 @@ Lee Johnston <lee.johnston.100@gmail.com>
 Lejla Metohajrova <l.metohajrova@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu>
 Leo Battle <leowbattle@gmail.com>
+Leonardo Mangani <leomangani4@gmail.com> leomanga <leomangani4@gmail.com>
 Leonid Blouvshtein <leonidbl91@gmail.com>
 Leonid Kovalev <leonidvkovalev@gmail.com> <leonid.traveling@gmail.com>
 Leonid Kovalev <leonidvkovalev@gmail.com> <normalhuman@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -907,7 +907,7 @@ Lee Johnston <lee.johnston.100@gmail.com>
 Lejla Metohajrova <l.metohajrova@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu>
 Leo Battle <leowbattle@gmail.com>
-Leonardo Mangani <leomangani4@gmail.com> leomanga <leomangani4@gmail.com>
+Leonardo Mangani <leomangani4@gmail.com> Leonardo Mangani <88255254+leomanga@users.noreply.github.com>
 Leonid Blouvshtein <leonidbl91@gmail.com>
 Leonid Kovalev <leonidvkovalev@gmail.com> <leonid.traveling@gmail.com>
 Leonid Kovalev <leonidvkovalev@gmail.com> <normalhuman@users.noreply.github.com>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -748,7 +748,7 @@ class Piecewise(DefinedFunction):
         return True, list(uniq(int_expr))
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        args = [(ec.expr._eval_nseries(x, n, logx), ec.cond) for ec in self.args]
+        args = [(ec.expr.nseries(x=x, n=n, logx=logx), ec.cond) for ec in self.args]
         return self.func(*args)
 
     def _eval_power(self, s):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -324,6 +324,15 @@ def hypersimp(f, k):
     g = expand_func(g)
     g = powsimp(g, deep=True, combine='exp')
 
+    # Check if the expression contains symbols other than k. This is needed because
+    # expand_func does not always simplify expressions optimally when other symbols
+    # are present. By detecting this case, we apply additional expansion and processing
+    # to achieve better simplification.
+    has_other_symbols = any(symbol != k for symbol in g.free_symbols)
+    if has_other_symbols:
+        g = expand(g, multinomial=False)
+        g = powsimp(g, deep=True, combine='exp')
+
     if g.is_rational_function(k):
         return simplify(g, ratio=S.Infinity)
     else:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #27256

#### Brief description of what is fixed or changed
I tried to better expand functions in `simplify.hypersimp()` with multiple symbols because `expand_func(g)` is not able to simplify every function sufficiently to be recognized as a rational function.

##### Example:
Expected:
```python
In [1]: hypersimp(exp(x*y), x)
Out[1]: 
 y
ℯ 
```
Current behavior:
```python
In [1]: print(hypersimp(exp(x*y), x))
Out[1]: None
```

During tests I also had an error caused by `args = [(ec.expr._eval_nseries(x, n, logx), ec.cond) for ec in self.args]` as `._eval_nseries()` requires the `cdir`. I resolved this by using the wrapper as indicated in the docstring.

#### Other comments
The best way to solve the problem in `hypersimp` would be to find a new heuristic for the `expand`.
I'm open to discussing new ideas.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `hypersimp`
<!-- END RELEASE NOTES -->