### PR TITLE
Add Documentation for Checking k-th Power Free Numbers using factorint

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1359,7 +1359,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
 
     If ``verbose`` is set to ``True``, detailed progress is printed.
-    
+
     Checking if a number is k-th power free:
 
     To check if an integer is k-th power free, the function will return `True` if no prime factor has an exponent greater than or equal to `k` in its prime factorization. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of `factorint(n)`.

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1364,20 +1364,15 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     To check if an integer is k-th power free, the function will return `True` if no prime factor has an exponent greater than or equal to `k` in its prime factorization. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of `factorint(n)`.
 
-    >>> from sympy import factorint  # Importing the factorint function from sympy
-    >>> # Check if 30 is 2nd power free (square-free)
-    >>> is_kth_power_free = all(exp < 2 for exp in factorint(30).values())
-    >>> is_kth_power_free
+    >>> from sympy.ntheory import factorint  # Importing the factorint function from sympy
+
+    >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is 2nd power free (square-free)
     True  # 30 = 2 * 3 * 5 (no prime factor appears with exponent >= 2)
 
-    >>> # Check if 36 is 2nd power free (square-free)
-    >>> is_kth_power_free = all(exp < 2 for exp in factorint(36).values())
-    >>> is_kth_power_free
+    >>> all(exp < 2 for exp in factorint(36).values()) # Check if 36 is 2nd power free (square-free)
     False  # 36 = 2^2 * 3^2 (both 2 and 3 appear with exponent >= 2)
 
-    >>> # Check if 60 is 3rd power free
-    >>> is_kth_power_free = all(exp < 3 for exp in factorint(60).values())
-    >>> is_kth_power_free
+    >>> all(exp < 3 for exp in factorint(60).values()) # Check if 60 is 3rd power free
     True  # 60 = 2^2 * 3 * 5 (no prime factor appears with exponent >= 3)
 
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1359,6 +1359,29 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
 
     If ``verbose`` is set to ``True``, detailed progress is printed.
+    
+    Checking if a number is k-th power free:
+
+    To check if an integer is k-th power free, the function will return `True` if no prime factor has an exponent greater than or equal to `k` in its prime factorization. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of `factorint(n)`.
+
+    Example:
+
+    >>> from sympy import factorint  # Importing the factorint function from sympy
+    >>> # Check if 30 is 2nd power free (square-free)
+    >>> is_kth_power_free = all(exp < 2 for exp in factorint(30).values())
+    >>> is_kth_power_free
+    True  # 30 = 2 * 3 * 5 (no prime factor appears with exponent >= 2)
+
+    >>> # Check if 36 is 2nd power free (square-free)
+    >>> is_kth_power_free = all(exp < 2 for exp in factorint(36).values())
+    >>> is_kth_power_free
+    False  # 36 = 2^2 * 3^2 (both 2 and 3 appear with exponent >= 2)
+
+    >>> # Check if 60 is 3rd power free
+    >>> is_kth_power_free = all(exp < 3 for exp in factorint(60).values())
+    >>> is_kth_power_free
+    True  # 60 = 2^2 * 3 * 5 (no prime factor appears with exponent >= 3)
+
 
     See Also
     ========

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1366,14 +1366,14 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     >>> from sympy.ntheory import factorint  # Importing the factorint function from sympy
 
-    >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is 2nd power free (square-free)
-    True  # 30 = 2 * 3 * 5 (no prime factor appears with exponent >= 2)
+    >>> all(exp < 2 for exp in factorint(30).values())
+    True
 
     >>> all(exp < 2 for exp in factorint(36).values()) # Check if 36 is 2nd power free (square-free)
-    False  # 36 = 2^2 * 3^2 (both 2 and 3 appear with exponent >= 2)
+    False
 
-    >>> all(exp < 3 for exp in factorint(60).values()) # Check if 60 is 3rd power free
-    True  # 60 = 2^2 * 3 * 5 (no prime factor appears with exponent >= 3)
+    >>> all(exp < 3 for exp in factorint(60).values())
+    True
 
 
     See Also

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1364,8 +1364,6 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     To check if an integer is k-th power free, the function will return `True` if no prime factor has an exponent greater than or equal to `k` in its prime factorization. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of `factorint(n)`.
 
-    Example:
-
     >>> from sympy import factorint  # Importing the factorint function from sympy
     >>> # Check if 30 is 2nd power free (square-free)
     >>> is_kth_power_free = all(exp < 2 for exp in factorint(30).values())

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1362,17 +1362,17 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     Checking if a number is k-th power free:
 
-    To check if an integer is k-th power free, the function will return `True` if no prime factor has an exponent greater than or equal to `k` in its prime factorization. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of `factorint(n)`.
+    To check if an integer is k-th power free, verify that no prime factor in its prime factorization has an exponent greater than or equal to k. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of factorint(n).The result will be True if the number is k-th power free, and False otherwise.
 
-    >>> from sympy.ntheory import factorint  # Importing the factorint function from sympy
+    >>> from sympy.ntheory import factorint  
 
-    >>> all(exp < 2 for exp in factorint(30).values())
+    >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is 2nd power free (square-free)
     True
 
     >>> all(exp < 2 for exp in factorint(36).values()) # Check if 36 is 2nd power free (square-free)
     False
 
-    >>> all(exp < 3 for exp in factorint(60).values())
+    >>> all(exp < 3 for exp in factorint(60).values()) # Check if 60 is 3rd power free 
     True
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
issue #27271
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added documentation for checking whether a number is k-th power free using factorint in the sympy library. This includes an explanation of how to determine if a number is free of prime factors raised to an exponent greater than or equal to k

#### Other comments
This documentation update helps users easily understand how to check if a number is k-th power free using the factorint function.
No changes to the code were made, only improvements to the documentation for clarity.

#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
