### PR TITLE
Fix and improve some floor/ceiling inequality simplifications

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -219,8 +219,6 @@ class floor(RoundFunction):
                 return self.args[0] >= other
             if other.is_number and other.is_real:
                 return self.args[0] >= ceiling(other)
-        if self.args[0] == other and other.is_real:
-            return S.false
         if other is S.NegativeInfinity and self.is_finite:
             return S.true
 
@@ -247,8 +245,6 @@ class floor(RoundFunction):
                 return self.args[0] < other
             if other.is_number and other.is_real:
                 return self.args[0] < ceiling(other)
-        if self.args[0] == other and other.is_real:
-            return S.false
         if other is S.Infinity and self.is_finite:
             return S.true
 
@@ -387,8 +383,6 @@ class ceiling(RoundFunction):
                 return self.args[0] > other
             if other.is_number and other.is_real:
                 return self.args[0] > floor(other)
-        if self.args[0] == other and other.is_real:
-            return S.false
         if other is S.NegativeInfinity and self.is_finite:
             return S.true
 
@@ -415,8 +409,6 @@ class ceiling(RoundFunction):
                 return self.args[0] <= other
             if other.is_number and other.is_real:
                 return self.args[0] <= floor(other)
-        if self.args[0] == other and other.is_real:
-            return S.false
         if other is S.Infinity and self.is_finite:
             return S.true
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -219,6 +219,8 @@ class floor(RoundFunction):
                 return self.args[0] >= other
             if other.is_number and other.is_real:
                 return self.args[0] >= ceiling(other)
+        if self.args[0] == other and other.is_real and other.is_noninteger:
+            return S.false
         if other is S.NegativeInfinity and self.is_finite:
             return S.true
 
@@ -245,6 +247,8 @@ class floor(RoundFunction):
                 return self.args[0] < other
             if other.is_number and other.is_real:
                 return self.args[0] < ceiling(other)
+        if self.args[0] == other and other.is_real and other.is_noninteger:
+            return S.true
         if other is S.Infinity and self.is_finite:
             return S.true
 
@@ -383,6 +387,8 @@ class ceiling(RoundFunction):
                 return self.args[0] > other
             if other.is_number and other.is_real:
                 return self.args[0] > floor(other)
+        if self.args[0] == other and other.is_real and other.is_noninteger:
+            return S.true
         if other is S.NegativeInfinity and self.is_finite:
             return S.true
 
@@ -409,6 +415,8 @@ class ceiling(RoundFunction):
                 return self.args[0] <= other
             if other.is_number and other.is_real:
                 return self.args[0] <= floor(other)
+        if self.args[0] == other and other.is_real and other.is_noninteger:
+            return S.false
         if other is S.Infinity and self.is_finite:
             return S.true
 

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -21,6 +21,7 @@ x = Symbol('x')
 i = Symbol('i', imaginary=True)
 y = Symbol('y', real=True)
 k, n = symbols('k,n', integer=True)
+b = Symbol('b', real=True, noninteger=True)
 
 
 def test_floor():
@@ -133,6 +134,10 @@ def test_floor():
     assert (floor(y) < oo) == True
     assert (floor(y) >= -oo) == True
     assert (floor(y) > -oo) == True
+    assert (floor(b) < b) == True
+    assert (floor(b) <= b) == True
+    assert (floor(b) > b) == False
+    assert (floor(b) >= b) == False
 
     assert floor(y).rewrite(frac) == y - frac(y)
     assert floor(y).rewrite(ceiling) == -ceiling(-y)
@@ -322,6 +327,10 @@ def test_ceiling():
     assert (ceiling(y) > -oo) == True
     assert (ceiling(y) <= oo) == True
     assert (ceiling(y) < oo) == True
+    assert (ceiling(b) < b) == False
+    assert (ceiling(b) <= b) == False
+    assert (ceiling(b) > b) == True
+    assert (ceiling(b) >= b) == True
 
     assert ceiling(y).rewrite(floor) == -floor(-y)
     assert ceiling(y).rewrite(frac) == y + frac(-y)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -121,10 +121,10 @@ def test_floor():
     assert floor(factorial(50)/exp(1)) == \
         11188719610782480504630258070757734324011354208865721592720336800
 
-    assert (floor(y) < y) == False
+    assert (floor(y) < y).is_Relational
     assert (floor(y) <= y) == True
     assert (floor(y) > y) == False
-    assert (floor(y) >= y) == False
+    assert (floor(y) >= y).is_Relational
     assert (floor(x) <= x).is_Relational  # x could be non-real
     assert (floor(x) > x).is_Relational
     assert (floor(x) <= y).is_Relational  # arg is not same as rhs
@@ -311,9 +311,9 @@ def test_ceiling():
         11188719610782480504630258070757734324011354208865721592720336801
 
     assert (ceiling(y) >= y) == True
-    assert (ceiling(y) > y) == False
+    assert (ceiling(y) > y).is_Relational
     assert (ceiling(y) < y) == False
-    assert (ceiling(y) <= y) == False
+    assert (ceiling(y) <= y).is_Relational
     assert (ceiling(x) >= x).is_Relational  # x could be non-real
     assert (ceiling(x) < x).is_Relational
     assert (ceiling(x) >= y).is_Relational  # arg is not same as rhs


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#17313

#### Brief description of what is fixed or changed

This fixes some incorrect inequality simplifications when comparing `floor(x)` and `ceiling(x)` to `x` when `x` is real (and this also fixes some existing incorrect tests).  This also improves simplifications when `x` is real and noninteger.

This is the current behavior for real args, where half of the results are bogus:

~~~
>>> r = symbols('r', real=True)
>>> floor(r) <= r   # ok
True
>>> floor(r) < r    # not ok: floor(1.1) < 1.1
False
>>> floor(r) > r    # ok
False
>>> floor(r) >= r   # not ok: floor(1) >= 1
False
>>> ceiling(r) <= r # not ok: ceiling(1) <= 1
False
>>> ceiling(r) < r  # ok
False
>>> ceiling(r) > r  # not ok: ceiling(1.1) > 1.1
False
>>> ceiling(r) >= r # ok
True
~~~

Here would be the new behavior for real args:

~~~
>>> r = symbols('r', real=True)
>>> floor(r) <= r
True
>>> floor(r) < r
⌊r⌋ < r
>>> floor(r) > r
False
>>> floor(r) >= r
⌊r⌋ ≥ r
>>> ceiling(r) <= r
⌈r⌉ ≤ r
>>> ceiling(r) < r
False
>>> ceiling(r) > r
⌈r⌉ > r
>>> ceiling(r) >= r
True
~~~

And here are new improvements to the simplifications for real, noninteger args:

~~~
>>> b = symbols('b', real=True, noninteger=True)
>>> floor(b) <= b
True
>>> floor(b) < b
True
>>> floor(b) > b
False
>>> floor(b) >= b
False
>>> ceiling(b) <= b
False
>>> ceiling(b) < b
False
>>> ceiling(b) > b
True
>>> ceiling(b) >= b
True
~~~

Since `b` is real and noninteger, `floor(b)` is always less than `b` and `ceiling(b)` is always greater than `b`.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* functions
  * Fixed and improved some inequality simplifications for floor and ceiling

<!-- END RELEASE NOTES -->
