### PR TITLE
Add Documentation for Checking Square Free Numbers using factorint

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1360,15 +1360,14 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     If ``verbose`` is set to ``True``, detailed progress is printed.
 
-    Checking if a number is k-th power free:
+    Square-Free Number:
 
-    A k-th power free number is a number where no prime factor in its factorization has an exponent >= k.Returns True if the number is k-th power free; otherwise, returns False.
+    A square-free number is a number where no prime factor in its factorization has an exponent >= 2. Returns True if the number is square-free; otherwise, returns False.
 
+    Example
     >>> from sympy.ntheory import factorint
-    >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is 2nd power free (square-free)
+    >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is square-free
     True
-    >>> all(exp < 3 for exp in factorint(72).values()) # Check if 72 is 3rd power free
-    False
 
     See Also
     ========

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1360,6 +1360,21 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     If ``verbose`` is set to ``True``, detailed progress is printed.
 
+    Checking if a number is k-th power free:
+
+    To check if an integer is k-th power free, verify that no prime factor in its prime factorization has an exponent greater than or equal to k. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of factorint(n).The result will be True if the number is k-th power free, and False otherwise.
+
+    >>> from sympy.ntheory import factorint
+
+    >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is 2nd power free (square-free)
+    True
+
+    >>> all(exp < 2 for exp in factorint(36).values()) # Check if 36 is 2nd power free (square-free)
+    False
+
+    >>> all(exp < 3 for exp in factorint(60).values()) # Check if 60 is 3rd power free
+    True
+
     See Also
     ========
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1362,18 +1362,13 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     Checking if a number is k-th power free:
 
-    To check if an integer is k-th power free, verify that no prime factor in its prime factorization has an exponent greater than or equal to k. A k-th power free number is one where no prime factor has an exponent of k or more in its factorization. This can be easily determined by examining the exponents in the output of factorint(n).The result will be True if the number is k-th power free, and False otherwise.
+    A k-th power free number is a number where no prime factor in its factorization has an exponent >= k.Returns True if the number is k-th power free; otherwise, returns False.
 
     >>> from sympy.ntheory import factorint
-
     >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is 2nd power free (square-free)
     True
-
-    >>> all(exp < 2 for exp in factorint(36).values()) # Check if 36 is 2nd power free (square-free)
+    >>> all(exp < 3 for exp in factorint(72).values()) # Check if 72 is 3rd power free
     False
-
-    >>> all(exp < 3 for exp in factorint(60).values()) # Check if 60 is 3rd power free
-    True
 
     See Also
     ========

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1365,6 +1365,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     A square-free number is a number where no prime factor in its factorization has an exponent >= 2. Returns True if the number is square-free; otherwise, returns False.
 
     Example
+
     >>> from sympy.ntheory import factorint
     >>> all(exp < 2 for exp in factorint(30).values()) # Check if 30 is square-free
     True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
issue #27271
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added documentation for checking whether a number is square free using factorint in the sympy library. This includes an explanation of how to determine if a number is free of prime factors raised to an exponent greater than or equal to k

#### Other comments
This documentation update helps users easily understand how to check if a number is square free using the factorint function.
No changes to the code were made, only improvements to the documentation for clarity.

#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
