### PR TITLE
Minor tweak in .calculus.util.function_range

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -234,14 +234,10 @@ def function_range(f, symbol, domain):
     range_int = S.EmptySet
     if isinstance(intervals,(Interval, FiniteSet)):
         interval_iter = (intervals,)
-
     elif isinstance(intervals, Union):
         interval_iter = intervals.args
-
     else:
-            raise NotImplementedError(filldedent('''
-                Unable to find range for the given domain.
-                '''))
+        raise NotImplementedError("Unable to find range for the given domain.")
 
     for interval in interval_iter:
         if isinstance(interval, FiniteSet):
@@ -250,7 +246,6 @@ def function_range(f, symbol, domain):
                     range_int += FiniteSet(f.subs(symbol, singleton))
         elif isinstance(interval, Interval):
             vals = S.EmptySet
-            critical_points = S.EmptySet
             critical_values = S.EmptySet
             bounds = ((interval.left_open, interval.inf, '+'),
                    (interval.right_open, interval.sup, '-'))
@@ -259,20 +254,17 @@ def function_range(f, symbol, domain):
                 if is_open:
                     critical_values += FiniteSet(limit(f, symbol, limit_point, direction))
                     vals += critical_values
-
                 else:
                     vals += FiniteSet(f.subs(symbol, limit_point))
 
-            solution = solveset(f.diff(symbol), symbol, interval)
+            critical_points = solveset(f.diff(symbol), symbol, interval)
 
-            if not iterable(solution):
+            if not iterable(critical_points):
                 raise NotImplementedError(
                         'Unable to find critical points for {}'.format(f))
-            if isinstance(solution, ImageSet):
+            if isinstance(critical_points, ImageSet):
                 raise NotImplementedError(
                         'Infinite number of critical points for {}'.format(f))
-
-            critical_points += solution
 
             for critical_point in critical_points:
                 vals += FiniteSet(f.subs(symbol, critical_point))
@@ -288,9 +280,7 @@ def function_range(f, symbol, domain):
 
             range_int += Interval(vals.inf, vals.sup, left_open, right_open)
         else:
-            raise NotImplementedError(filldedent('''
-                Unable to find range for the given domain.
-                '''))
+            raise NotImplementedError("Unable to find range for the given domain.")
 
     return range_int
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Removed one local variable

#### Other comments
Avoid fillddedent in exception definition.

This patch should have no observable effect on the functionality of `function_range`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
