### PR TITLE
Simplify nested floor division in simplify function #27400

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1712,3 +1712,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Karan Anand <anandkarancompsci@gmail.com> anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -848,6 +848,7 @@ Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com> anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
@@ -1712,4 +1713,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Karan Anand <anandkarancompsci@gmail.com> anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -12,6 +12,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import (binomial, factorial)
 from sympy.functions.elementary.complexes import (Abs, sign)
+from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (cosh, csch, sinh)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -141,6 +142,21 @@ def test_simplify_expr():
     assert simplify(log(2*x) - log(2)) == log(x)
 
     assert simplify(hyper([], [], x)) == exp(x)
+
+    # issue 27400
+    assert simplify(floor(floor(a))) == floor(a)
+
+    expr = floor(floor(a) / 2)
+    assert simplify(expr) == floor(a / 2)
+
+    expr = floor(floor(floor(a) / b) / c)
+    assert simplify(expr) == floor(a / (b * c))
+
+    expr = floor(a) + b
+    assert simplify(expr) == floor(a) + b
+
+    expr = floor(floor(a + b) / floor(c + d))
+    assert simplify(expr) == floor((a + b) / floor(c + d))
 
 
 def test_issue_3557():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -12,7 +12,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import (binomial, factorial)
 from sympy.functions.elementary.complexes import (Abs, sign)
-from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (cosh, csch, sinh)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -144,19 +144,24 @@ def test_simplify_expr():
     assert simplify(hyper([], [], x)) == exp(x)
 
     # issue 27400
+    a_pos_int = symbols('a_pos_int', integer=True, positive=True)
+    b_pos_int = symbols('b_pos_int', integer=True, positive=True)
+
     assert simplify(floor(floor(a))) == floor(a)
+    assert simplify(floor(floor(a) / 2)) == floor(a / 2)
+    assert simplify(floor(floor(floor(a) / b) / c)) == floor(floor(floor(a) / b) / c)
+    assert simplify(floor(floor(floor(a) / a_pos_int) / b_pos_int)) == floor(a / (a_pos_int * b_pos_int))
+    assert simplify(floor(a) + b) == floor(a) + b
+    assert simplify(floor(floor(a + b) / floor(c + d))) == floor(floor(a + b) / floor(c + d))
+    assert simplify(floor(floor(a + b) / floor(a_pos_int + b_pos_int))) == floor((a + b) / floor(a_pos_int + b_pos_int))
 
-    expr = floor(floor(a) / 2)
-    assert simplify(expr) == floor(a / 2)
-
-    expr = floor(floor(floor(a) / b) / c)
-    assert simplify(expr) == floor(a / (b * c))
-
-    expr = floor(a) + b
-    assert simplify(expr) == floor(a) + b
-
-    expr = floor(floor(a + b) / floor(c + d))
-    assert simplify(expr) == floor((a + b) / floor(c + d))
+    assert simplify(ceiling(ceiling(a))) == ceiling(a)
+    assert simplify(ceiling(ceiling(a) / 2)) == ceiling(a / 2)
+    assert simplify(ceiling(ceiling(ceiling(a) / b) / c)) == ceiling(ceiling(ceiling(a) / b) / c)
+    assert simplify(ceiling(ceiling(ceiling(a) / a_pos_int) / b_pos_int)) == ceiling(a / (a_pos_int * b_pos_int))
+    assert simplify(ceiling(a) + b) == ceiling(a) + b
+    assert simplify(ceiling(ceiling(a + b) / ceiling(c + d))) == ceiling(ceiling(a + b) / ceiling(c + d))
+    assert simplify(ceiling(ceiling(a + b) / ceiling(a_pos_int + b_pos_int))) == ceiling((a + b) / ceiling(a_pos_int + b_pos_int))
 
 
 def test_issue_3557():


### PR DESCRIPTION
Fixes #27400

- Implemented the `simplify_nested_floor` function to simplify nester floor expressions
- Added test cases regarding the new implementation in `test_simplify.py`

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Added simplification rule for nested floor divisions: `floor(floor(a/b)/c)` now simplifies to `floor(a/(b*c))`.
<!-- END RELEASE NOTES --> 