### PR TITLE
Fixes classify_ode to simplify substituted expressions in power series checks

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -848,7 +848,7 @@ Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
-Karan Anand <anandkarancompsci@gmail.com> anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>
+Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -848,7 +848,7 @@ Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
-Karan Anand <anandkarancompsci@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com> anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
@@ -1610,7 +1610,6 @@ aditisingh2362 <aditisingh2362@gmail.com>
 alejandro <amartinhernan@gmail.com>
 alijosephine <alijosephine@gmail.com>
 amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
-anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>
 arooshiverma <av22@iitbbs.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -1610,6 +1610,7 @@ aditisingh2362 <aditisingh2362@gmail.com>
 alejandro <amartinhernan@gmail.com>
 alijosephine <alijosephine@gmail.com>
 amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
+anandkaranubc <119553199+anandkaranubc@users.noreply.github.com>
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>
 arooshiverma <av22@iitbbs.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -848,6 +848,7 @@ Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com>
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1082,7 +1082,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
             check1 = check.subs({x: point, y: value}).simplify()
             if not check1.has(oo) and not check1.has(zoo) and \
                 not check1.has(nan) and not check1.has(-oo):
-                check2 = (check1.diff(x)).subs({x: point, y: value})
+                check2 = check.diff(x).subs({x: point, y: value}).simplify()
                 if not check2.has(oo) and not check2.has(zoo) and \
                     not check2.has(nan) and not check2.has(-oo):
                     rseries = r.copy()

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1079,7 +1079,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
             point = boundary.get('f0', 0)
             value = boundary.get('f0val', C1)
             check = cancel(r[d]/r[e])
-            check1 = check.subs({x: point, y: value})
+            check1 = check.subs({x: point, y: value}).simplify()
             if not check1.has(oo) and not check1.has(zoo) and \
                 not check1.has(nan) and not check1.has(-oo):
                 check2 = (check1.diff(x)).subs({x: point, y: value})

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1079,10 +1079,10 @@ def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta
             point = boundary.get('f0', 0)
             value = boundary.get('f0val', C1)
             check = cancel(r[d]/r[e])
-            check1 = check.subs({x: point, y: value}).simplify()
+            check1 = cancel(check.subs({x: point, y: value}))
             if not check1.has(oo) and not check1.has(zoo) and \
                 not check1.has(nan) and not check1.has(-oo):
-                check2 = check.diff(x).subs({x: point, y: value}).simplify()
+                check2 = cancel(check.diff(x).subs({x: point, y: value}))
                 if not check2.has(oo) and not check2.has(zoo) and \
                     not check2.has(nan) and not check2.has(-oo):
                     rseries = r.copy()

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -1,5 +1,5 @@
 from sympy.core.function import (Derivative, Function, Subs, diff)
-from sympy.core.numbers import (E, I, Rational, pi)
+from sympy.core.numbers import (E, I, Rational, pi, oo)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -789,6 +789,15 @@ def test_issue_4825():
     assert classify_ode(f(x).diff(x), f(y), dict=True) == \
         {'order': 0, 'default': None, 'ordered_hints': ()}
 
+def test_issue_27392():
+    # See also issue 27403
+    bcs = {f(x).subs(x, oo): C1, f(x).diff(x).subs(x, oo): C2}
+
+    eq1 = f(x).diff(x) + C3 * f(x) / x
+    assert '1st_power_series' in classify_ode(eq1, x0=oo, n=3, ics=bcs)
+
+    eq2 = f(x).diff(x) + C3 * f(x) / (x * (C3 + C4))
+    assert '1st_power_series' in classify_ode(eq2, x0=oo, n=3, ics=bcs)
 
 def test_constant_renumber_order_issue_5308():
     from sympy.utilities.iterables import variations


### PR DESCRIPTION
**Fix #27390 `classify_ode` to simplify expressions before checking for infinities**

As suggested by @pashilkar

In the `classify_ode` function, expressions were being checked for infinite values (like `oo`) after substitution, but without simplifying them first. This could lead to cases where valid expressions were mistakenly flagged as invalid because they weren’t in their simplest form.

Now, the function simplifies substituted expressions using `.simplify()` before checking for infinities.

This change ensures the `classify_ode` function works correctly in all cases, especially for power series checks. It’s a small but important fix to improve accuracy.

### Release Notes
<!-- BEGIN RELEASE NOTES -->

* solvers
  * Fixed a bug in `classify_ode` where substituted expressions were not simplified before checking for infinities. This ensures valid cases are not incorrectly excluded.

<!-- END RELEASE NOTES -->

--- 