### PR TITLE
Add tests for Quaternion.integrate() method

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1285,7 +1285,7 @@ Roman Inflianskas <infroma@gmail.com>
 Ronan Lamy <ronan.lamy@gmail.com> <Ronan.Lamy@normalesup.org>
 Rudr Tiwari <rudrtiwari@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
-Rushabh Mehta <mehtarushabh2005@gmail.com> RushabhMehta2005 <139112780+RushabhMehta2005@users.noreply.github.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1095,7 +1095,6 @@ class Quaternion(Expr):
         4 + 8*i + 12*j + 16*k
 
         """
-        # TODO: is this expression correct?
         return Quaternion(integrate(self.a, *args), integrate(self.b, *args),
                           integrate(self.c, *args), integrate(self.d, *args))
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -189,6 +189,15 @@ def test_quaternion_functions():
     assert integrate(Quaternion(x, x, x, x), x) == \
     Quaternion(x**2 / 2, x**2 / 2, x**2 / 2, x**2 / 2)
 
+    assert Quaternion(1, x, x**2, x**3).integrate(x) == \
+    Quaternion(x, x**2/2, x**3/3, x**4/4)
+
+    assert Quaternion(sin(x), cos(x), sin(2*x), cos(2*x)).integrate(x) == \
+    Quaternion(-cos(x), sin(x), -cos(2*x)/2, sin(2*x)/2)
+
+    assert Quaternion(x**2, y**2, z**2, x*y*z).integrate(x, y) == \
+    Quaternion(x**3*y/3, x*y**3/3, x*y*z**2, x**2*y**2*z/4)
+
     assert Quaternion.rotate_point((1, 1, 1), q1) == (S.One / 5, 1, S(7) / 5)
     n = Symbol('n')
     raises(TypeError, lambda: q1**n)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR adds tests for the `integrate` method in `Quaternion` class in the `algebras` module. The only existing test called the integrate function instead of the class method.
A TODO in the method was also removed after verification of the expression.

#### Other comments
Any advice is most welcome. I am in the process of learning about sympy.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
