### PR TITLE
when use_latex=True, only add _repr_latex_ and nothing else

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -247,7 +247,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         Printable._repr_svg_ = Printable._repr_disabled
 
     png_formatter = ip.display_formatter.formatters['image/png']
-    if use_latex in (True, 'png'):
+    if use_latex == 'png':
         debug("init_printing: using png formatter")
         for cls in printable_types:
             png_formatter.for_type(cls, _print_latex_png)


### PR DESCRIPTION
#### References to other Issues or PRs
This doesn't fix #18155, but now it would impact only users explicitly setting use_latex='png'

#### Brief description of what is fixed or changed
When use_latex=True, only send latex code to kernel, do not try to generate images


#### Release Notes
<!-- BEGIN RELEASE NOTES -->

* printing
  * init_printing default value `use_latex=None` and `use_latex=True` would only add latex representation of printable objects (and would not generate images of expressions like `use_latex='png'` is doing)

<!-- END RELEASE NOTES -->
