### PR TITLE
Add Fraction-Free LU Decomposition for DomainMatrix

### DIFF
--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -958,6 +958,111 @@ class DDM(list):
 
         return L, U, swaps
 
+    def _fflu(self):
+        """
+        Private method for Phase 1 of fraction-free LU decomposition.
+        Performs row operations and elimination to compute U and permutation indices.
+
+        Returns:
+            LU : decomposition as a single matrix.
+            perm (list): Permutation indices for row swaps.
+        """
+        rows, cols = self.shape
+        K = self.domain
+
+        LU = self.copy()
+        perm = list(range(rows))
+        rank = 0
+
+        for j in range(min(rows, cols)):
+            # Skip columns where all entries are zero
+            if all(LU[i][j] == K.zero for i in range(rows)):
+                continue
+
+            # Find the first non-zero pivot in the current column
+            pivot_row = -1
+            for i in range(rank, rows):
+                if LU[i][j] != K.zero:
+                    pivot_row = i
+                    break
+
+            # If no pivot is found, skip column
+            if pivot_row == -1:
+                continue
+
+            # Swap rows to bring the pivot to the current rank
+            if pivot_row != rank:
+                LU[rank], LU[pivot_row] = LU[pivot_row], LU[rank]
+                perm[rank], perm[pivot_row] = perm[pivot_row], perm[rank]
+
+            # Found pivot - (Gauss-Bareiss elimination)
+            pivot = LU[rank][j]
+            for i in range(rank + 1, rows):
+                multiplier = LU[i][j]
+                # Denominator is previous pivot or 1
+                denominator = LU[rank - 1][rank - 1] if rank > 0 else K.one
+                for k in range(j + 1, cols):
+                    LU[i][k] = K.exquo(pivot * LU[i][k] - LU[rank][k] * multiplier, denominator)
+                # Keep the multiplier for L matrix
+                LU[i][j] = multiplier
+            rank += 1
+
+        return LU, perm
+
+    def fflu(self):
+        """
+        Fraction-free LU decomposition of DDM.
+
+        See Also
+        ========
+
+        sympy.polys.matrices.domainmatrix.DomainMatrix.fflu
+            The higher-level interface to this function.
+        """
+        rows, cols = self.shape
+        K = self.domain
+
+        # Phase 1: Perform row operations and get permutation
+        U, perm = self._fflu()
+
+        # Phase 2: Construct P, L, D matrices
+        # Create P from permutation
+        P = self.zeros((rows, rows), K)
+        for i, pi in enumerate(perm):
+            P[i][pi] = K.one
+
+        # Create L matrix
+        L = self.zeros((rows, rows), K)
+        i = j = 0
+        while i < rows and j < cols:
+            if U[i][j] != K.zero:
+                # Found non-zero pivot
+                # Diagonal entry is the pivot
+                L[i][i] = U[i][j]
+                for l in range(i + 1, rows):
+                    # Off-diagonal entries are the multipliers
+                    L[l][i] = U[l][j]
+                    # zero out the entries in U
+                    U[l][j] = K.zero
+                i += 1
+            j += 1
+
+        # Fill remaining diagonal of L with ones
+        for i in range(i, rows):
+            L[i][i] = K.one
+
+        # Create D matrix - using FLINT's approach with accumulator
+        D = self.zeros((rows, rows), K)
+        if rows >= 1:
+            D[0][0] = L[0][0]
+        di = K.one
+        for i in range(1, rows):
+            # Accumulate product of pivots
+            di = L[i - 1][i - 1] * L[i][i]
+            D[i][i] = di
+
+        return P, L, D, U
+
     def qr(self):
         """
         QR decomposition for DDM.

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -3370,6 +3370,66 @@ class DomainMatrix:
         sol = self.rep.lu_solve(rhs.rep)
         return self.from_rep(sol)
 
+    def fflu(self):
+        """
+        Fraction-free LU decomposition of DomainMatrix.
+
+        Explanation
+        ===========
+
+        This method computes the PLDU decomposition
+        using Gauss-Bareiss elimination in a fraction-free manner,
+        it ensures that all intermediate results remain in
+        the domain of the input matrix. Unlike standard
+        LU decomposition, which introduces division, this approach
+        avoids fractions, making it particularly suitable
+        for exact arithmetic over integers or polynomials.
+
+        This method satisfies the invariant:
+
+        P * A = L * inv(D) * U
+
+        Returns
+        =======
+
+        (P, L, D, U)
+            - P (Permutation matrix)
+            - L (Lower triangular matrix)
+            - D (Diagonal matrix)
+            - U (Upper triangular matrix)
+
+        Examples
+        ========
+
+        >>> from sympy import ZZ
+        >>> from sympy.polys.matrices import DomainMatrix
+        >>> A = DomainMatrix([[1, 2], [3, 4]], (2, 2), ZZ)
+        >>> P, L, D, U = A.fflu()
+        >>> P
+        DomainMatrix([[1, 0], [0, 1]], (2, 2), ZZ)
+        >>> L
+        DomainMatrix([[1, 0], [3, -2]], (2, 2), ZZ)
+        >>> D
+        DomainMatrix([[1, 0], [0, -2]], (2, 2), ZZ)
+        >>> U
+        DomainMatrix([[1, 2], [0, -2]], (2, 2), ZZ)
+        >>> L.is_lower and U.is_upper and D.is_diagonal
+        True
+        >>> L * D.to_field().inv() * U == P * A.to_field()
+        True
+        >>> I, d = D.inv_den()
+        >>> L * I * U == d * P * A
+        True
+
+        See Also
+        ========
+
+        sympy.polys.matrices.ddm.DDM.fflu
+        """
+        from_rep = self.from_rep
+        P, L, D, U = self.rep.fflu()
+        return from_rep(P), from_rep(L), from_rep(D), from_rep(U)
+
     def _solve(A, b):
         # XXX: Not sure about this method or its signature. It is just created
         # because it is needed by the holonomic module.

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -3425,6 +3425,17 @@ class DomainMatrix:
         ========
 
         sympy.polys.matrices.ddm.DDM.fflu
+
+        References
+        ==========
+
+        .. [1]  Nakos, G. C., Turner, P. R., & Williams, R. M. (1997). Fraction-free
+                algorithms for linear and polynomial equations. ACM SIGSAM Bulletin,
+                31(3), 11-19. https://doi.org/10.1145/271130.271133
+        .. [2]  Middeke, J.; Jeffrey, D.J.; Koutschan, C. (2020), "Common Factors
+                in Fraction-Free Matrix Decompositions", Mathematics in Computer Science,
+                15 (4): 589–608, arXiv:2005.12380, doi:10.1007/s11786-020-00495-9
+        .. [3]  https://en.wikipedia.org/wiki/Bareiss_algorithm
         """
         from_rep = self.from_rep
         P, L, D, U = self.rep.fflu()

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1096,6 +1096,24 @@ class SDM(dict):
         """
         return A.from_ddm(A.to_ddm().lu_solve(b.to_ddm()))
 
+    def fflu(self):
+        """
+        Fraction free LU decomposition of SDM.
+
+        Uses DDM implementation.
+
+        See Also
+        ========
+
+        sympy.polys.matrices.ddm.DDM.fflu
+        """
+        ddm_p, ddm_l, ddm_d, ddm_u = self.to_dfm_or_ddm().fflu()
+        P = ddm_p.to_sdm()
+        L = ddm_l.to_sdm()
+        D = ddm_d.to_sdm()
+        U = ddm_u.to_sdm()
+        return P, L, D, U
+
     def nullspace(A):
         """
         Nullspace of a :py:class:`~.SDM` matrix A.

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1360,3 +1360,18 @@ def test_DomainMatrix_pickling():
     assert pickle.loads(pickle.dumps(dM)) == dM
     dM = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     assert pickle.loads(pickle.dumps(dM)) == dM
+
+
+def test_DomainMatrix_fflu():
+    A = DM([[1, 2], [3, 4]], ZZ)
+    P, L, D, U = A.fflu()
+    assert P.shape == A.shape
+    assert L.shape == A.shape
+    assert D.shape == A.shape
+    assert U.shape == A.shape
+    assert P == DM([[1, 0], [0, 1]], ZZ)
+    assert L == DM([[1, 0], [3, -2]], ZZ)
+    assert D == DM([[1, 0], [0, -2]], ZZ)
+    assert U == DM([[1, 2], [0, -2]], ZZ)
+    di, d = D.inv_den()
+    assert P.matmul(A).rmul(d) == L.matmul(di).matmul(U)

--- a/sympy/polys/matrices/tests/test_fflu.py
+++ b/sympy/polys/matrices/tests/test_fflu.py
@@ -1,0 +1,301 @@
+from sympy.polys.matrices import DomainMatrix, DM
+from sympy.polys.domains import ZZ, QQ
+from sympy import Matrix
+import pytest
+
+
+FFLU_EXAMPLES = [
+    (
+        'zz_2x3',
+        DM([[1, 2, 3], [4, 5, 6]], ZZ),
+        DM([[1, 0], [0, 1]], ZZ),
+        DM([[1, 0], [4, -3]], ZZ),
+        DM([[1, 0], [0, -3]], ZZ),
+        DM([[1, 2, 3], [0, -3, -6]], ZZ),
+    ),
+
+    (
+        'zz_2x2',
+        DM([[4, 3], [6, 3]], ZZ),
+        DM([[1, 0], [0, 1]], ZZ),
+        DM([[1, 0], [6, -6]], ZZ),
+        DM([[4, 0], [0, -3]], ZZ),
+        DM([[4, 3], [0, -3]], ZZ),
+    ),
+
+    (
+        'zz_3x2',
+        DM([[1, 2], [3, 4], [5, 6]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[1, 0, 0], [3, 1, 0], [5, 2, 1]], ZZ),
+        DM([[1, 0], [0, -2]], ZZ),
+        DM([[1, 2], [0, -2], [0, 0]], ZZ),
+    ),
+
+    (
+        'zz_3x3',
+        DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[1, 0, 0], [4, 1, 0], [7, 2, 1]], ZZ),
+        DM([[1, 0, 0], [0, -3, 0], [0, 0, 0]], ZZ),
+        DM([[1, 2, 3], [0, -3, -6], [0, 0, 0]], ZZ),
+    ),
+
+    (
+        'zz_zero',
+        DM([[0, 0, 0], [0, 0, 0], [0, 0, 0]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[0, 0, 0], [0, 0, 0], [0, 0, 0]], ZZ),
+        DM([[0, 0, 0], [0, 0, 0], [0, 0, 0]], ZZ),
+    ),
+
+    (
+        'zz_empty',
+        DM([], ZZ),
+        DM([], ZZ),
+        DM([], ZZ),
+        DM([], ZZ),
+        DM([], ZZ),
+    ),
+
+    (
+        'zz_empty_0x2',
+        DomainMatrix([], (0, 2), ZZ),
+        DomainMatrix([], (0, 0), ZZ),
+        DomainMatrix([], (0, 0), ZZ),
+        DomainMatrix([], (0, 0), ZZ),
+        DomainMatrix([], (0, 2), ZZ)
+    ),
+
+    (
+
+        'zz_empty_2x0',
+        DomainMatrix([[], []], (2, 0), ZZ),
+        DomainMatrix.eye((2, 2), ZZ),
+        DomainMatrix.eye((2, 2), ZZ),
+        DomainMatrix.eye((2, 2), ZZ),
+        DomainMatrix([[], []], (2, 0), ZZ)
+
+    ),
+
+    (
+        'zz_negative',
+        DM([[-1, -2], [-3, -4]], ZZ),
+        DM([[1, 0], [0, 1]], ZZ),
+        DM([[-1, 0], [-3, -2]], ZZ),
+        DM([[-1, 0], [0, 2]], ZZ),
+        DM([[-1, -2], [0, -2]], ZZ),
+    ),
+
+    (
+        'zz_mixed_signs',
+        DM([[1, -2], [-3, 4]], ZZ),
+        DM([[1, 0], [0, 1]], ZZ),
+        DM([[1, 0], [-3, 1]], ZZ),
+        DM([[1, 0], [0, -2]], ZZ),
+        DM([[1, -2], [0, -2]], ZZ),
+    ),
+
+    (
+        'zz_upper_triangular',
+        DM([[1, 2, 3], [0, 4, 5], [0, 0, 6]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[1, 0, 0], [0, 4, 0], [0, 0, 24]], ZZ),
+        DM([[1, 0, 0], [0, 4, 0], [0, 0, 96]], ZZ),
+        DM([[1, 2, 3], [0, 4, 5], [0, 0, 24]], ZZ),
+    ),
+
+    (
+        'zz_lower_triangular',
+        DM([[1, 0, 0], [2, 3, 0], [4, 5, 6]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[1, 0, 0], [2, 3, 0], [4, 5, 18]], ZZ),
+        DM([[1, 0, 0], [0, 3, 0], [0, 0, 54]], ZZ),
+        DM([[1, 0, 0], [0, 3, 0], [0, 0, 18]], ZZ),
+    ),
+
+    (
+        'zz_diagonal',
+        DM([[2, 0, 0], [0, 3, 0], [0, 0, 4]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[2, 0, 0], [0, 6, 0], [0, 0, 24]], ZZ),
+        DM([[2, 0, 0], [0, 12, 0], [0, 0, 144]], ZZ),
+        DM([[2, 0, 0], [0, 6, 0], [0, 0, 24]], ZZ)
+
+    ),
+
+    (
+        'rank_deficient_3x3',
+        DM([[1, 2, 3], [2, 4, 6], [3, 6, 9]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[1, 0, 0], [2, 1, 0], [3, 0, 1]], ZZ),
+        DM([[1, 0, 0], [0, 0, 0], [0, 0, 0]], ZZ),
+        DM([[1, 2, 3], [0, 0, 0], [0, 0, 0]], ZZ),
+    ),
+
+    (
+        'zz_1x1',
+        DM([[5]], ZZ),
+        DM([[1]], ZZ),
+        DM([[5]], ZZ),
+        DM([[5]], ZZ),
+        DM([[5]], ZZ),
+    ),
+
+    (
+        'zz_nx1_2rows',
+        DM([[81], [54]], ZZ),
+        DM([[1, 0], [0, 1]], ZZ),
+        DM([[81, 0], [54, 81]], ZZ),
+        DM([[81, 0], [0, 81]], ZZ),
+        DM([[81], [0]], ZZ),
+    ),
+
+    (
+        'zz_nx2_3rows',
+        DM([[2, 7], [7, 45], [25, 84]], ZZ),
+        DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]], ZZ),
+        DM([[2, 0, 0], [7, 82, 0], [25, 41, 41]], ZZ),
+        DM([[2, 0, 0], [0, 82, 0], [0, 0, 41]], ZZ),
+        DM([[2, 7], [0, 82], [0, 0]], ZZ),
+    ),
+
+    (
+
+        'zz_1x2',
+        DM([[0, 28]], ZZ),
+        DM([[1]], ZZ),
+        DM([[28]], ZZ),
+        DM([[28]], ZZ),
+        DM([[0, 28]], ZZ)
+    ),
+
+    (
+        'zz_nx3_4rows',
+        DM([[84, 30, 9], [20, 59, 13], [53, 46, 81], [63, 48, 29]], ZZ),
+        DM([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]], ZZ),
+        DM([[84, 0, 0, 0], [20, 365904, 0, 0], [53, 303411, 303411, 0], [63, 303411, 303411, 303411]], ZZ),
+        DM([[84, 0, 0, 0], [0, 365904, 0, 0], [0, 0, 1321658316, 0], [0, 0, 0, 303411]], ZZ),
+        DM([[84, 30, 9], [0, 365904, 13], [0, 0, 1321658316], [0, 0, 0]], ZZ),
+    ),
+
+    (
+        'fflu_row_swap',
+        DM([[0, 1, 2], [3, 4, 5], [6, 7, 8]], ZZ),
+        DM([[0, 1, 0], [1, 0, 0], [0, 0, 1]], ZZ),
+        DM([[3, 0, 0], [0, 3, 0], [6, -3, 1]], ZZ),
+        DM([[3, 0, 0], [0, 9, 0], [0, 0, 3]], ZZ),
+        DM([[3, 4, 5], [0, 3, 6], [0, 0, 0]], ZZ)
+    ),
+]
+
+
+def _check_fflu(A, P, L, D, U):
+    P_field = P.to_field().to_dense()
+    L_field = L.to_field().to_dense()
+    D_field = D.to_field().to_dense()
+    U_field = U.to_field().to_dense()
+    m, n = A.shape
+    assert P_field.shape == (m, m)
+    assert L_field.shape == (m, m)
+    assert D_field.shape == (m, m)
+    assert U_field.shape == (m, n)
+    assert L_field.is_lower
+    assert D_field.is_diagonal
+    di, d = D.inv_den()
+    assert P.matmul(A).rmul(d) == L.matmul(di).matmul(U)
+    assert U_field.is_upper
+
+
+def _to_DM(A, ans):
+    if isinstance(A, DomainMatrix):
+        return A
+    elif isinstance(A, Matrix):
+        return A.to_DM(ans.domain)
+    return DomainMatrix(A.to_list(), A.shape, A.domain)
+
+
+def _check_fflu_result(result, A, P_ans, L_ans, D_ans, U_ans):
+    P, L, D, U = result
+    P = _to_DM(P, P_ans)
+    L = _to_DM(L, L_ans)
+    D = _to_DM(D, D_ans)
+    U = _to_DM(U, U_ans)
+    A = _to_DM(A, P_ans)
+    m, n = A.shape
+    assert P.shape == (m, m)
+    assert L.shape == (m, m)
+    assert D.shape == (m, m)
+    assert U.shape == (m, n)
+    assert L.is_lower
+    assert D.is_diagonal
+    di, d = D.inv_den()
+    assert P.matmul(A).rmul(d) == L.matmul(di).matmul(U)
+    assert U.is_upper
+
+
+@pytest.mark.parametrize('name, A, P_ans, L_ans, D_ans, U_ans', FFLU_EXAMPLES)
+def test_dm_dense_fflu(name, A, P_ans, L_ans, D_ans, U_ans):
+    A = A.to_dense()
+    _check_fflu_result(A.fflu(), A, P_ans, L_ans, D_ans, U_ans)
+
+
+@pytest.mark.parametrize('name, A, P_ans, L_ans, D_ans, U_ans', FFLU_EXAMPLES)
+def test_dm_sparse_fflu(name, A, P_ans, L_ans, D_ans, U_ans):
+    A = A.to_sparse()
+    _check_fflu_result(A.fflu(), A, P_ans, L_ans, D_ans, U_ans)
+
+
+@pytest.mark.parametrize('name, A, P_ans, L_ans, D_ans, U_ans', FFLU_EXAMPLES)
+def test_ddm_fflu(name, A, P_ans, L_ans, D_ans, U_ans):
+    A = A.to_ddm()
+    _check_fflu_result(A.fflu(), A, P_ans, L_ans, D_ans, U_ans)
+
+
+@pytest.mark.parametrize('name, A, P_ans, L_ans, D_ans, U_ans', FFLU_EXAMPLES)
+def test_sdm_fflu(name, A, P_ans, L_ans, D_ans, U_ans):
+    A = A.to_sdm()
+    _check_fflu_result(A.fflu(), A, P_ans, L_ans, D_ans, U_ans)
+
+
+@pytest.mark.parametrize('name, A, P_ans, L_ans, D_ans, U_ans', FFLU_EXAMPLES)
+def test_dfm_fflu(name, A, P_ans, L_ans, D_ans, U_ans):
+    pytest.importorskip('flint')
+    if A.domain not in (ZZ, QQ) and not A.domain.is_FF:
+        pytest.skip("Domain not supported by DFM")
+    A = A.to_dfm()
+    _check_fflu_result(A.fflu(), A, P_ans, L_ans, D_ans, U_ans)
+
+
+def test_fflu_empty_matrix():
+    A = DomainMatrix([], (0, 0), ZZ)
+    P, L, D, U = A.fflu()
+    assert P.shape == (0, 0)
+    assert L.shape == (0, 0)
+    assert D.shape == (0, 0)
+    assert U.shape == (0, 0)
+
+
+def test_fflu_properties():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    P, L, D, U = A.fflu()
+    assert P.shape == (2, 2)
+    assert L.shape == (2, 2)
+    assert D.shape == (2, 2)
+    assert U.shape == (2, 2)
+    assert L.is_lower
+    assert U.is_upper
+    assert D.is_diagonal
+    di, d = D.inv_den()
+    assert P.matmul(A).rmul(d) == L.matmul(di).matmul(U)
+
+
+def test_fflu_rank_deficient():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(2), ZZ(4)]], (2, 2), ZZ)
+    P, L, D, U = A.fflu()
+    assert P.shape == (2, 2)
+    assert L.shape == (2, 2)
+    assert D.shape == (2, 2)
+    assert U.shape == (2, 2)
+    assert U.getitem_sympy(1, 1) == 0

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -755,6 +755,8 @@ def test_XXM_applyfunc(DM):
 def test_XXM_is_upper(DM):
     assert DM([[1, 2, 3], [0, 5, 6]]).is_upper() is True
     assert DM([[1, 2, 3], [4, 5, 6]]).is_upper() is False
+    assert DM([]).is_upper() is True
+    assert DM([[], []]).is_upper() is True
 
 
 @pytest.mark.parametrize('DM', DMZ_all)
@@ -893,6 +895,8 @@ def test_XXM_qr_identity_matrix(DM):
     assert R == A
     assert (Q.transpose().matmul(Q)).is_diagonal
     assert R.is_upper
+    assert Q.shape == (3, 3)
+    assert R.shape == (3, 3)
 
 
 @pytest.mark.parametrize('DM', DMQ_all)
@@ -997,3 +1001,23 @@ def test_XXM_qr_empty_matrix_0x2(DM):
     assert R.is_upper
     assert Q.shape == (0, 0)
     assert R.shape == (0, 2)
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_fflu(DM):
+    A = DM([[1, 2], [3, 4]])
+    P, L, D, U = A.fflu()
+    A_field = A.convert_to(QQ)
+    P_field = P.convert_to(QQ)
+    L_field = L.convert_to(QQ)
+    D_field = D.convert_to(QQ)
+    U_field = U.convert_to(QQ)
+    assert P.shape == A.shape
+    assert L.shape == A.shape
+    assert D.shape == A.shape
+    assert U.shape == A.shape
+    assert P == DM([[1, 0], [0, 1]])
+    assert L == DM([[1, 0], [3, -2]])
+    assert D == DM([[1, 0], [0, -2]])
+    assert U == DM([[1, 2], [0, -2]])
+    assert L_field.matmul(D_field.inv()).matmul(U_field) == P_field.matmul(A_field)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27250

Extends gh-27352

#### Brief description of what is fixed or changed

- Added a fraction free LU decomposition method to DomainMatrix.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices

   * Added fraction-free LU Decomposition method for DomainMatrix.

<!-- END RELEASE NOTES -->
