### PR TITLE
Add floor_simplify() function for simplifying expressions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1712,3 +1712,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -770,6 +770,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
@@ -1712,4 +1713,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Jatin Bhardwaj <bhardwajjatin093@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -770,7 +770,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
-Jatin Bhardwaj <bhardwajjatin093@gmail.com>
+Jatin Bhardwaj <148186488+Jatinbhardwaj-093@users.noreply.github.com> <bhardwajjatin093@gmail.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1000,7 +1000,7 @@ def floor_simplify(expr):
             return floor(num_numerator / Mul(num_denominator, denominator))
         return expr
 
-    choices = set([expr])
+    choices = {expr}
     floor_atoms = set(expr.atoms(floor))
     sorted_floor_atoms = sorted(floor_atoms, key=lambda x: count_ops(x), reverse=True)
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -24,7 +24,7 @@ from sympy.functions.combinatorial.factorials import CombinatorialFunction
 from sympy.functions.elementary.complexes import unpolarify, Abs, sign
 from sympy.functions.elementary.exponential import ExpBase
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
-from sympy.functions.elementary.integers import ceiling
+from sympy.functions.elementary.integers import ceiling,floor
 from sympy.functions.elementary.piecewise import (Piecewise, piecewise_fold,
                                                   piecewise_simplify)
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
@@ -625,6 +625,8 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         if not expr.args:  # simplified to atomic
             return expr
 
+    if isinstance(expr, Expr) and expr.has(floor):
+        expr = floor_simplify(expr)
     # do deep simplification
     handled = Add, Mul, Pow, ExpBase
     expr = expr.replace(
@@ -959,6 +961,60 @@ def product_mul(self, other, method=0):
 
     return Mul(self, other)
 
+def floor_simplify(expr):
+    """
+    Simplifies a given expression involving the floor function.
+    Parameters:
+        expr: The expression to simplify, which may contain floor functions.
+    Returns:
+        A simplified expression with the floor functions reduced where possible.
+    """
+    def helper_floor_simplify(expr):
+        if isinstance(expr, floor):
+            numerator, denominator = expr.args[0].as_numer_denom()
+            # Simplify numerator
+            if isinstance(numerator, floor):
+                num_numerator, num_denominator = helper_floor_simplify(numerator).args[0].as_numer_denom()
+            elif isinstance(numerator, Mul):
+                num_numerator = numerator
+                num_denominator = 1
+                terms = Mul.make_args(numerator)
+                f_t = []  # floor terms
+                o_t = []  # other terms
+                for term in terms:
+                    if isinstance(term, floor):
+                        f_t.append(helper_floor_simplify(term))
+                    else:
+                        o_t.append(term)
+                num_numerator = Mul(*o_t)
+                for t in f_t:
+                    n, d = t.args[0].as_numer_denom()
+                    num_numerator = Mul(n, num_numerator)
+                    num_denominator = Mul(d, num_denominator)
+            else:
+                num_numerator = numerator
+                num_denominator = 1
+            # Simplify denominator
+            if isinstance(denominator, floor):
+                denominator = helper_floor_simplify(denominator)
+            return floor(num_numerator / Mul(num_denominator, denominator))
+        return expr
+
+    choices = set([expr])
+    floor_atoms = set(expr.atoms(floor))
+    sorted_floor_atoms = sorted(floor_atoms, key=lambda x: count_ops(x), reverse=True)
+
+    for a in sorted_floor_atoms:
+        if a.has(floor):
+            collapse = helper_floor_simplify(a)
+            if collapse != a:
+                temp = set()
+                for choice in choices:
+                    temp.add(choice.xreplace({a: collapse}))
+                choices |= temp
+
+    choices = list(choices)
+    return min(choices, key=count_ops)
 
 def _nthroot_solve(p, n, prec):
     """

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -11,6 +11,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import (binomial, factorial)
+from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.complexes import (Abs, sign)
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (cosh, csch, sinh)
@@ -142,6 +143,18 @@ def test_simplify_expr():
 
     assert simplify(hyper([], [], x)) == exp(x)
 
+
+def test_simplify_floor():
+    x, y, a, b, c, d = symbols('x,y,a,b,c,d')
+    # Noramal case
+    assert simplify(floor(floor(x/y)/a)) == floor(x/(a*y))
+    #deep case
+    assert simplify(tan(sin(x//y//z))) == tan(sin(floor(x/(y*z))))
+    assert simplify(floor((floor(x/y/a))/ (b/(c*d)))) == floor(c*d*x/(a*b*y))
+    assert simplify((6+ floor(floor(x/y)/a)) / floor(floor(floor(x/y)/a)/d)) == \
+            (floor(x/(a*y)) + 6)/floor(x/(a*d*y))
+    assert simplify((6+(x//y)//(a/(b/c//d)))//(x//y//a//b//c//d)) == \
+            floor((floor(b*x/(a*c*d*y)) + 6)/floor(x/(a*b*c*d*y)))
 
 def test_issue_3557():
     f_1 = x*a + y*b + z*c - 1


### PR DESCRIPTION
## Fixes #27400

#### Brief description of what is fixed or changed
Added a floor_simplify function that simplifies floor operations in an expression at an atomic level. This functionality iterates through all floor atoms in the expression and simplifies them individually to reduce computational complexity.


#### Other comments
This enhancement optimizes expressions containing nested or multiple floor functions and has been tested on representative cases for correctness and efficiency.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* simplify
  * Added a `floor_simplify()` function to simplify floor operations in expressions at an atomic level.

<!-- END RELEASE NOTES -->
