### PR TITLE
Improve `sympy.factorint` worst-case ECM performance

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1329,6 +1329,7 @@ Samesh Lakhotia <samesh.lakhotia@gmail.com> Samesh Lakhotia <samesh.lakhotia@gma
 Samith Karunathilake <55777141+samithkavishke@users.noreply.github.com> samithkavishke <55777141+samithkavishke@users.noreply.github.com>
 Samnan Rahee <namanush.rsr.16@gmail.com>
 Sampad Kumar Saha <sampadsaha5@gmail.com>
+Samuel Li <github@samuelj.li>
 Samyak Jain <samyak.jain2016a@vitstudent.ac.in> Samyak Jain <samtan106@gmail.com>
 Sandeep Murthy <smurthy@protonmail.ch>
 Sandeep Veethu <sandeep.veethu@gmail.com>
@@ -1712,4 +1713,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Samuel Li <github@samuelj.li>

--- a/.mailmap
+++ b/.mailmap
@@ -1712,3 +1712,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Samuel Li <github@samuelj.li>

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1624,9 +1624,9 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
             break
         low, high = high, high*2
 
-    B1 = 10000
+    B1 = 500
     B2 = 100*B1
-    num_curves = 50
+    num_curves = 4
     while(1):
         if verbose:
             print(ecm_msg % (B1, B2, num_curves))
@@ -1645,6 +1645,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
             if _check_termination(factors, n, limit, use_trial,
                                   use_rho, use_pm1, verbose, next_p):
                 return factors
+            continue
         B1 *= 5
         B2 = 100*B1
         num_curves *= 4


### PR DESCRIPTION
The default ECM parameter choices in `sympy.factorint` perform badly when `n` is a highly smooth number.
The parameters have been updated to greatly improve the worst-case performance while negligibly affecting typical performance.

#### References to other Issues or PRs
Fixes #27424 

#### Brief description of what is fixed or changed
The best ECM parameters depend on the smallest prime factor of `n`. The default initial parameters are too large, "skipping over" all factors when `n` is smooth, and leading to poor worst-case performance.

This PR adds a few very small curves, and only increases the curve bounds if no factors are found. The small curves add negligible work.

#### Other comments
For `n = 2020944952270513292896118700011239662562107339425514309019773820116389914458023658364832304` on my machine, the PR brings total factorization time down from 180 seconds to <1 second.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Changed default ECM parameters to improve worst-case performance of `sympy.factorint`
<!-- END RELEASE NOTES -->