### PR TITLE
Fixed broken links in docs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -345,6 +345,7 @@ Anurag Sharma <anurags92@gmail.com> <sharmaan@iitk.ac.in>
 Anutosh Bhat <andersonbhat491@gmail.com> Anutosh Bhat <87052487+anutosh491@users.noreply.github.com>
 Anutosh Bhat <andersonbhat491@gmail.com> anutosh491 <87052487+anutosh491@users.noreply.github.com>
 Anutosh Bhat <andersonbhat491@gmail.com> anutosh491 <andersonbhat491@gmail.com>
+Anvay Madhekar <anvays06@gmail.com>
 Anway De <anway1756@gmail.com>
 Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
 Arafat Dad Khan <arafat.da.khan@gmail.com>
@@ -915,6 +916,7 @@ Liwei Cai <cai.lw123@gmail.com>
 Ljubiša Moćić <3rdslasher@gmail.com>
 Lokesh Sharma <lokeshhsharma@gmail.com> <your_email@youremail.com>
 Longqi Wang <iqgnol@gmail.com>
+LordAnvayM <83640698+LordAnvayM@users.noreply.github.com>
 Lorenz Winkler <lorenz.winkler@tuwien.ac.at>
 Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.noreply.github.com>
 Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>

--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -259,7 +259,7 @@ To get a full list of all default names in SymPy do:
 If you have `IPython <https://ipython.org/>`_ installed and
 use :command:`isympy`, you can also press the TAB key to get a list of
 all built-in names and to autocomplete.  Also, see `this page
-<https://kogs-www.informatik.uni-hamburg.de/~meine/python_tricks>`_ for a
+<https://docs.python.org/3/library/readline.html#completion>`_ for a
 trick for getting tab completion in the regular Python console.
 
 .. note::

--- a/doc/src/modules/simplify/fu.rst
+++ b/doc/src/modules/simplify/fu.rst
@@ -247,4 +247,4 @@ References
     https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=718d67a8d1ce0a23808c1cc265612f81977357e4
 
 .. [2] A formula sheet for trigonometric functions.
-    http://www.sosmath.com/trig/Trig5/trig5/pdf/pdf.html
+    https://www.geeksforgeeks.org/trigonometry-formulas/

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -730,10 +730,10 @@ def is_convex(f, *syms, domain=S.Reals):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Convex_function
-    .. [2] http://www.ifp.illinois.edu/~angelia/L3_convfunc.pdf
-    .. [3] https://en.wikipedia.org/wiki/Logarithmically_convex_function
-    .. [4] https://en.wikipedia.org/wiki/Logarithmically_concave_function
-    .. [5] https://en.wikipedia.org/wiki/Concave_function
+    .. [2] https://en.wikipedia.org/wiki/Logarithmically_convex_function
+    .. [3] https://en.wikipedia.org/wiki/Logarithmically_concave_function
+    .. [4] https://en.wikipedia.org/wiki/Concave_function
+    .. [5] https://www.dropbox.com/scl/fi/g54vwyb1n2wb3jyj0gq5x/convexity_summary.pdf?rlkey=ip8ukw15insufm0qf7sieloxo&e=1
 
     """
     if len(syms) > 1 :

--- a/sympy/polys/matrices/dense.py
+++ b/sympy/polys/matrices/dense.py
@@ -463,10 +463,10 @@ def ddm_idet(a, K):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Bareiss_algorithm
-    .. [2] https://www.math.usm.edu/perry/Research/Thesis_DRL.pdf
+    .. [2] https://aquila.usm.edu/masters_theses/1/
     """
     # Bareiss algorithm
-    # https://www.math.usm.edu/perry/Research/Thesis_DRL.pdf
+    # https://aquila.usm.edu/masters_theses/1/
 
     # a is (m x n)
     m = len(a)


### PR DESCRIPTION
I have fixed broken links in docs with appropriate substitute links. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Issue ref: #24140
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
