### PR TITLE
fix LU solver with noncommutative entries

### DIFF
--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -375,10 +375,7 @@ def _LUsolve(M, rhs, iszerofunc=_iszero):
             b.zip_row_op(i, j, lambda x, y: dps(x - scale * y))
 
         scale = A[i, i]
-        if scale.is_commutative:
-            b.row_op(i, lambda x, _: dps(x / scale))
-        else:
-            b.row_op(i, lambda x, _: dps(scale**-1 * x))
+        b.row_op(i, lambda x, _: dps(scale**-1 * x))
 
     return rhs.__class__(b)
 

--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -357,7 +357,7 @@ def _LUsolve(M, rhs, iszerofunc=_iszero):
     for i in range(m):
         for j in range(min(i, n)):
             scale = A[i, j]
-            b.zip_row_op(i, j, lambda x, y: dps(x - y * scale))
+            b.zip_row_op(i, j, lambda x, y: dps(x - scale * y))
 
     # consistency check for overdetermined systems
     if m > n:
@@ -372,10 +372,13 @@ def _LUsolve(M, rhs, iszerofunc=_iszero):
     for i in range(n - 1, -1, -1):
         for j in range(i + 1, n):
             scale = A[i, j]
-            b.zip_row_op(i, j, lambda x, y: dps(x - y * scale))
+            b.zip_row_op(i, j, lambda x, y: dps(x - scale * y))
 
         scale = A[i, i]
-        b.row_op(i, lambda x, _: dps(x / scale))
+        if scale.is_commutative:
+            b.row_op(i, lambda x, _: dps(x / scale))
+        else:
+            b.row_op(i, lambda x, _: dps(scale**-1 * x))
 
     return rhs.__class__(b)
 

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -121,6 +121,20 @@ def test_LUsolve():
     raises(NonInvertibleMatrixError, lambda: A.LUsolve(b))
 
 
+def test_LUsolve_noncommutative():
+    a0, a1, a2, a3 = symbols("a:4", commutative=False)
+    b0, b1 = symbols("b:2", commutative=False)
+    A = Matrix([[a0, a1], [a2, a3]])
+    check = A * A.LUsolve(Matrix([b0, b1]))
+    assert check[0, 0].expand() == b0
+    # Because sympy simplification is very limited with noncommutative expressions,
+    # perform an explicit check with the second element
+    assert check[1, 0] == (
+        a2*a0**(-1)*(-a1*(-a2*a0**(-1)*a1 + a3)**(-1)*(-a2*a0**(-1)*b0 + b1) + b0)
+        + a3*(-a2*a0**(-1)*a1 + a3)**(-1)*(-a2*a0**(-1)*b0 + b1)
+    )
+
+
 def test_QRsolve():
     A = Matrix([[2, 3, 5],
                 [3, 6, 2],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Originally pointed out at https://github.com/sympy/sympy/pull/27422#issuecomment-2571432863

#### Brief description of what is fixed or changed
The fix is straigthforward: just act with matrix entries from the correct side.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed the LU solver to correctly handle noncommutative matrix entries
<!-- END RELEASE NOTES -->
