### PR TITLE
Allow Pauli objects with different labels to commute and simplify when running evaluate_pauli_product.

### DIFF
--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -216,11 +216,10 @@ def evaluate_pauli_product(arg):
 
         def flatten_sigma_product():
             sigma_product = 1
-            nonlocal sigma_products_by_label
             for label in sorted(sigma_products_by_label):
                 sigma_product *= sigma_products_by_label[label]
 
-            sigma_products_by_label = {}
+            sigma_products_by_label.clear()
 
             return sigma_product
 

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -208,7 +208,7 @@ def evaluate_pauli_product(arg):
         com_product = 1
         keeper = 1
 
-        def add_sigma_product(p: Pauli):
+        def add_sigma_product(p):
             if (sigma_products_by_label.get(p.label)):
                 sigma_products_by_label[p.label] *= p
             else:

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -10,6 +10,7 @@ References
 .. [1] https://en.wikipedia.org/wiki/Pauli_matrices
 """
 
+from collections import defaultdict
 from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.core.numbers import I
@@ -204,41 +205,28 @@ def evaluate_pauli_product(arg):
         start = end
 
         tmp = start.as_coeff_mul()
-        sigma_products_by_label = {}
+        sigma_products_by_label = defaultdict(lambda: 1)
         com_product = 1
         keeper = 1
 
-        def add_sigma_product(p):
-            if (sigma_products_by_label.get(p.label)):
-                sigma_products_by_label[p.label] *= p
-            else:
-                sigma_products_by_label[p.label] = p
-
-        def flatten_sigma_product():
-            sigma_product = 1
-            for label in sorted(sigma_products_by_label):
-                sigma_product *= sigma_products_by_label[label]
-
-            sigma_products_by_label.clear()
-
-            return sigma_product
-
         for el in tmp[1]:
             if isinstance(el, Pauli):
-                add_sigma_product(el)
+                sigma_products_by_label[el.label] *= el
             elif not el.is_commutative:
                 if isinstance(el, Pow) and isinstance(el.args[0], Pauli):
                     if el.args[1].is_odd:
-                        add_sigma_product(el.args[0])
+                        sigma_products_by_label[el.args[0].label] *= el.args[0]
                 elif isinstance(el, TensorProduct):
-                    keeper = keeper*flatten_sigma_product()*\
+                    keeper = keeper*Mul(*(sigma_products_by_label[label] for label in sorted(sigma_products_by_label)))*\
                         TensorProduct(
                             *[evaluate_pauli_product(part) for part in el.args]
                         )
+                    sigma_products_by_label.clear()
                 else:
-                    keeper = keeper*flatten_sigma_product()*el
+                    keeper = keeper*Mul(*(sigma_products_by_label[label] for label in sorted(sigma_products_by_label)))*el
+                    sigma_products_by_label.clear()
             else:
                 com_product *= el
-        end = tmp[0]*keeper*flatten_sigma_product()*com_product
+        end = tmp[0]*keeper*Mul(*(sigma_products_by_label[label] for label in sorted(sigma_products_by_label)))*com_product
         if end == arg: break
     return end

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -54,21 +54,24 @@ def test_evaluate_pauli_product():
 def test_evaluate_pauli_product_ordering():
     from sympy.physics.paulialgebra import evaluate_pauli_product
 
+    a1 = Pauli(1, label = "a")
+    b3 = Pauli(3, label = "b")
+
     # Simpler case where ordering is already present
     assert evaluate_pauli_product(
-        (Pauli(1, label = "a") * Pauli(3, label = "b")) +
-        (Pauli(1, label = "a") * Pauli(3, label = "b"))
-    ) == 2 * Pauli(1, label = "a") * Pauli(3, label = "b")
+        (a1 * b3) +
+        (a1 * b3)
+    ) == 2 * a1 * b3
 
     # Issue 26745
     assert evaluate_pauli_product(
-        (Pauli(1, label = "a") * Pauli(3, label = "b")) +
-        (Pauli(3, label = "b") * Pauli(1, label = "a"))
-    ) == 2 * Pauli(1, label = "a") * Pauli(3, label = "b")
+        (a1 * b3) +
+        (b3 * a1)
+    ) == 2 * a1 * b3
 
     assert evaluate_pauli_product(
-        Pauli(1, label = "a") * Pauli(3, label = "b") * Pauli(1, label = "a")
-    ) == Pauli(3, label = "b")
+        a1 * b3 * a1
+    ) == b3
 
 @XFAIL
 def test_Pauli_should_work():

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -58,20 +58,12 @@ def test_evaluate_pauli_product_ordering():
     b3 = Pauli(3, label = "b")
 
     # Simpler case where ordering is already present
-    assert evaluate_pauli_product(
-        (a1 * b3) +
-        (a1 * b3)
-    ) == 2 * a1 * b3
+    assert evaluate_pauli_product((a1 * b3) + (a1 * b3)) == 2 * a1 * b3
 
     # Issue 26745
-    assert evaluate_pauli_product(
-        (a1 * b3) +
-        (b3 * a1)
-    ) == 2 * a1 * b3
+    assert evaluate_pauli_product((a1 * b3) + (b3 * a1)) == 2 * a1 * b3
 
-    assert evaluate_pauli_product(
-        a1 * b3 * a1
-    ) == b3
+    assert evaluate_pauli_product(a1 * b3 * a1) == b3
 
 @XFAIL
 def test_Pauli_should_work():

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -51,6 +51,24 @@ def test_evaluate_pauli_product():
         TensorProduct(I*sigma1*sigma2*sigma1*sigma2, 1)
     ) == 1 -I + I*sigma3*tau1*sigma2 - 1 - sigma3 - I*TensorProduct(1,1)
 
+def test_evaluate_pauli_product_ordering():
+    from sympy.physics.paulialgebra import evaluate_pauli_product
+
+    # Simpler case where ordering is already present
+    assert evaluate_pauli_product(
+        (Pauli(1, label = "a") * Pauli(3, label = "b")) +
+        (Pauli(1, label = "a") * Pauli(3, label = "b"))
+    ) == 2 * Pauli(1, label = "a") * Pauli(3, label = "b")
+
+    # Issue 26745
+    assert evaluate_pauli_product(
+        (Pauli(1, label = "a") * Pauli(3, label = "b")) +
+        (Pauli(3, label = "b") * Pauli(1, label = "a"))
+    ) == 2 * Pauli(1, label = "a") * Pauli(3, label = "b")
+
+    assert evaluate_pauli_product(
+        Pauli(1, label = "a") * Pauli(3, label = "b") * Pauli(1, label = "a")
+    ) == Pauli(3, label = "b")
 
 @XFAIL
 def test_Pauli_should_work():

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -65,6 +65,15 @@ def test_evaluate_pauli_product_ordering():
 
     assert evaluate_pauli_product(a1 * b3 * a1) == b3
 
+def test_evaluate_pauli_product_empty():
+    from sympy.physics.paulialgebra import evaluate_pauli_product
+
+    assert evaluate_pauli_product(1) == 1
+    a1 = Pauli(1, label = "a")
+    assert evaluate_pauli_product(a1) == a1
+    labelmissing = Pauli(1)
+    assert evaluate_pauli_product(labelmissing) == labelmissing
+
 @XFAIL
 def test_Pauli_should_work():
     assert sigma1*sigma3*sigma1 == -sigma3

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -54,8 +54,8 @@ def test_evaluate_pauli_product():
 def test_evaluate_pauli_product_ordering():
     from sympy.physics.paulialgebra import evaluate_pauli_product
 
-    a1 = Pauli(1, label = "a")
-    b3 = Pauli(3, label = "b")
+    a1 = Pauli(1, label="a")
+    b3 = Pauli(3, label="b")
 
     # Simpler case where ordering is already present
     assert evaluate_pauli_product((a1 * b3) + (a1 * b3)) == 2 * a1 * b3
@@ -69,7 +69,7 @@ def test_evaluate_pauli_product_empty():
     from sympy.physics.paulialgebra import evaluate_pauli_product
 
     assert evaluate_pauli_product(1) == 1
-    a1 = Pauli(1, label = "a")
+    a1 = Pauli(1, label="a")
     assert evaluate_pauli_product(a1) == a1
     labelmissing = Pauli(1)
     assert evaluate_pauli_product(labelmissing) == labelmissing


### PR DESCRIPTION



#### References to other Issues or PRs

Proposes a fix for https://github.com/sympy/sympy/issues/26745


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
