### PR TITLE
Fixed missing space in translation of 'Not' in pycode printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -923,6 +923,7 @@ Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
 Luca Weihs <astronomicalcuriosity@gmail.com>
 Lucas Gallindo <lgallindo@gmail.com>
 Lucas Jones <lucas@lucasjones.co.uk>
+Lucas Kletzander <lucas.kletzander@gmail.com>
 Lucas Wiman <lucas.wiman@gmail.com>
 Lucy Mountain <lucymountain1@icloud.com> LucyMountain <lucymountain1@icloud.com>
 Luis Garcia <ppn.online@me.com>

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -557,7 +557,7 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
 
     def _print_Not(self, expr):
         PREC = precedence(expr)
-        return self._operators['not'] + self.parenthesize(expr.args[0], PREC)
+        return self._operators['not'] + ' ' + self.parenthesize(expr.args[0], PREC)
 
     def _print_IndexedBase(self, expr):
         return expr.name

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -1,3 +1,4 @@
+from sympy import Not
 from sympy.codegen import Assignment
 from sympy.codegen.ast import none
 from sympy.codegen.cfunctions import expm1, log1p
@@ -40,6 +41,7 @@ def test_PythonCodePrinter():
     assert prntr.doprint(And(x, y)) == 'x and y'
     assert prntr.doprint(Or(x, y)) == 'x or y'
     assert prntr.doprint(1/(x+y)) == '1/(x + y)'
+    assert prntr.doprint(Not(x)) == 'not x'
     assert not prntr.module_imports
 
     assert prntr.doprint(pi) == 'math.pi'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #26855

#### Brief description of what is fixed or changed
A translation of Not(x) with the pycode printer (e.g. using lambdify with the math library) would result in 'notx' instead of 'not x'. The fix adds the missing space.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* printing
  * Fixed missing space in translation of 'Not' in pycode printer.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed missing space in translation of 'Not' in pycode printer.
<!-- END RELEASE NOTES -->
