### PR TITLE
Fix incorrect handling of `y=1` in composite predicate logic

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -848,6 +848,7 @@ Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -106,8 +106,11 @@ def _(expr, assumptions):
                 return
             # Positive integer which is not prime is not
             # necessarily composite
-            if expr.equals(1):
+            _is_one = ask(Q.eq(expr, 1), assumptions)
+            if _is_one:
                 return False
+            if _is_one is None:
+                return None
             return not _prime
         else:
             return _integer

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1106,6 +1106,10 @@ def test_bounded():
     assert ask(Q.finite(cos(x)**2)) is True
     assert ask(Q.finite(cos(x) + sin(x))) is True
 
+def test_issue_27441():
+    # Test for issue 27441
+    # checks that a positive integer which is not prime is not necessarily composite
+    assert ask(Q.composite(y), Q.integer(y) & Q.positive(y) & ~Q.prime(y)) is None
 
 @XFAIL
 def test_bounded_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1106,10 +1106,11 @@ def test_bounded():
     assert ask(Q.finite(cos(x)**2)) is True
     assert ask(Q.finite(cos(x) + sin(x))) is True
 
+
 def test_issue_27441():
-    # Test for issue 27441
-    # checks that a positive integer which is not prime is not necessarily composite
+    # https://github.com/sympy/sympy/issues/27441
     assert ask(Q.composite(y), Q.integer(y) & Q.positive(y) & ~Q.prime(y)) is None
+
 
 @XFAIL
 def test_bounded_xfail():


### PR DESCRIPTION
<!-- Fixes #27441 -->

#### References to other Issues or PRs
Fixes #27441

#### Brief description of what is fixed or changed
The `.equals` method used in the composite predicate handler was replaced with a more appropriate condition using `ask(Q.eq(expr, 1), assumptions)`. When `ask(Q.eq(expr, 1), assumptions)` is used, it checks for both the case where the expression strictly equals `1` (where it returns `True`) or when the expression could contain `1` based on the assumptions (where it returns `None`), and thus differentiating the output in those two different cases.

The PR also adds a test case to confirm the correct output.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed incorrect output for `ask(Q.composite(x), Q.integer(y) & Q.positive(y) & ~Q.prime(y))`, making sure that a non-prime positive integer is not necessarily composite.
<!-- END RELEASE NOTES -->
