### PR TITLE
Test against Pyodide version 0.27.2 for Emscripten CI

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -27,12 +27,12 @@ jobs:
         splits: [4] # keep in sync with number of groups below
         group: [1, 2, 3, 4]
     env:
-      PYODIDE_VERSION: 0.27.0a2
+      PYODIDE_VERSION: 0.27.2
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.
       # The appropriate versions can be found in the Pyodide repodata.json
       # "info" field, or in Makefile.envs:
-      # https://github.com/pyodide/pyodide/blob/main/Makefile.envs#L2
-      PYTHON_VERSION: 3.12.1
+      # https://github.com/pyodide/pyodide/blob/d85f9cda735e47f16b3f032832fab73bd1c12a30/Makefile.envs#L1-L3
+      PYTHON_VERSION: 3.12 # any Python 3.12.x version works
       EMSCRIPTEN_VERSION: 3.1.58
       NODE_VERSION: 20
     steps:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

In the time #27149 undergoes review(s), this PR updates the Pyodide version for the Emscripten/WASM CI tests to [`0.27.2`](https://github.com/pyodide/pyodide/releases/tag/0.27.2), which we released on 24/01/2025.

#### Brief description of what is fixed or changed

I updated the `PYODIDE_VERSION:` environment variable in `.github/workflows/emscripten.yaml` from 0.27.0a2 to 0.27.2

#### Other comments

N/A

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
