### PR TITLE
Fix simplification issue with float 1.0 in power and division expressions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -770,6 +770,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -188,6 +188,10 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             bpos = b.is_positive or b.is_polar
             if bpos:
                 binv = 1/b
+                #Special case for float 1
+                if b.is_Float and b.equals(1):
+                    c_powers[b] = S.One
+                    continue
                 if b != binv and binv in c_powers:
                     if b.as_numer_denom()[0] is S.One:
                         c_powers.pop(b)

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -5,7 +5,7 @@ from math import prod
 from sympy.core.function import expand_log, count_ops, _coeff_isneg
 from sympy.core import sympify, Basic, Dummy, S, Add, Mul, Pow, expand_mul, factor_terms
 from sympy.core.sorting import ordered, default_sort_key
-from sympy.core.numbers import Integer, Rational
+from sympy.core.numbers import Integer, Rational, equal_valued
 from sympy.core.mul import _keep_coeff
 from sympy.core.rules import Transform
 from sympy.functions import exp_polar, exp, log, root, polarify, unpolarify
@@ -189,7 +189,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             if bpos:
                 binv = 1/b
                 #Special case for float 1
-                if b.is_Float and b.equals(1):
+                if b.is_Float and equal_valued(b, 1):
                     c_powers[b] = S.One
                     continue
                 if b != binv and binv in c_powers:

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -122,6 +122,8 @@ def test_powsimp():
     assert powsimp(x**2*y**3*(x*y**2)**Rational(3, 2)
         ) == x*y*(x*y**2)**Rational(5, 2)
 
+    #issue 27380
+    assert powsimp(1.0**(x+1)/1.0**x) == 1.0
 
 def test_powsimp_negated_base():
     assert powsimp((-x + y)/sqrt(x - y)) == -sqrt(x - y)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -232,6 +232,8 @@ def test_issue_5652():
     n = symbols('n', commutative=False)
     assert simplify(n + n**(-n)) == n + n**(-n)
 
+def test_issue_27380():
+    assert simplify(1.0**(x+1)/1.0**x) == 1.0
 
 def test_simplify_fail1():
     x = Symbol('x')


### PR DESCRIPTION
## Fixes #27380


#### Brief description of what is fixed or changed
This fix addresses an issue in the [powsimp.py](https://github.com/sympy/sympy/blob/master/sympy/simplify/powsimp.py#L189) file, specifically around the simplification logic involving 1.0 in power and division expressions. In the following code block:
```python
if bpos:
    binv = 1/b
    if b != binv and binv in c_powers:
        if b.as_numer_denom()[0] is S.One:
          c_powers.pop(b)
          c_powers[binv] -= e
        else:
        skip.add(binv)
        e = c_powers.pop(binv)
        c_powers[b] -= e
```
Line 3 checks for 1.0 in the expression (e.g., 1/1.0), where b equals binv since 1/1.0 simplifies to 1.0. The condition b != binv was returning false, causing no action to be taken. This change ensures that division by 1.0 is properly handled and doesn’t interfere with simplification.
#### Other Comments
N/A

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
