### PR TITLE
Fix measure_partial failure for Gate * TensorProduct 26322

### DIFF
--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -6,12 +6,14 @@ TODO:
 * Document default basis functionality.
 """
 
+from sympy import log
 from sympy.core.add import Add
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.numbers import I
 from sympy.core.power import Pow
 from sympy.integrals.integrals import integrate
+from sympy.matrices.dense import MutableDenseMatrix
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.anticommutator import AntiCommutator
@@ -219,6 +221,9 @@ def represent(expr, **options):
     result = represent(expr.args[-1], **options)
     last_arg = expr.args[-1]
 
+    # add nqubits so gates get it and represent works correctly
+    if isinstance(result, MutableDenseMatrix):
+        options["nqubits"] = log(result.rows, 2)
     for arg in reversed(expr.args[:-1]):
         if isinstance(last_arg, Operator):
             options["index"] += 1

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -5,11 +5,12 @@ from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import Matrix
+from sympy.physics.quantum import TensorProduct
 from sympy.physics.quantum.qubit import (measure_all, measure_all_oneshot, measure_partial,
                                          matrix_to_qubit, matrix_to_density,
                                          qubit_to_matrix, IntQubit,
                                          IntQubitBra, QubitBra)
-from sympy.physics.quantum.gate import (HadamardGate, CNOT, XGate, YGate,
+from sympy.physics.quantum.gate import (HadamardGate, CNOT, H, XGate, YGate,
                                         ZGate, PhaseGate)
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.represent import represent
@@ -178,6 +179,12 @@ def test_measure_partial():
         [(Qubit('1000'), Rational(1, 4)),
          (Qubit('1111')/sqrt(3) + Qubit('1101')/sqrt(3) +
           Qubit('1011')/sqrt(3), Rational(3, 4))]
+
+    # Test of measuring states constructed like this: apply a quantum gate
+    # after a TensorProduct from issue 26322
+    state3 = H(0)*TensorProduct(Qubit('0'), Qubit('0'))
+    assert measure_partial(state3, [0]) == \
+        [(Qubit('00'), Rational(1, 2)), (Qubit('01'), Rational(1, 2))]
 
 
 def test_measure_all():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/26322


#### Brief description of what is fixed or changed
Fix the following case:
    
    state3 = H(0)*TensorProduct(Qubit('0'), Qubit('0'))
    measure_partial(state3, [0])


#### Other comments
Add also the tests for this use case


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * A bug in Qubit.measure_partial was fixed. 
  * Previously measuring `measure_partial(H(0)*TensorProduct(Qubit('0'), Qubit('0')), [0])` would result in an exception. 
  * Now returns correct result 
<!-- END RELEASE NOTES -->
