### PR TITLE
avoid Max(x, evaluate=False) => x

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -399,7 +399,7 @@ class MinMaxBase(Expr, LatticeOp):
         if not args:
             return cls.identity
 
-        if len(args) == 1:
+        if len(args) == 1 and evaluate:
             return list(args).pop()
 
         # base creation

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -494,6 +494,10 @@ def test_minmax_no_evaluate():
     assert Max(0, p, evaluate=False).args == (0, p)
     assert Min(0, p, evaluate=False) != 0
     assert Min(0, p, evaluate=False).args == (0, p)
+    assert Min(p, evaluate=False).func == Min
+    assert Min(p, evaluate=False).args == (p,)
+    assert Max(p, evaluate=False).func == Max
+    assert Max(p, evaluate=False).args == (p,)
 
     with evaluate(False):
         assert Max(1, 3) != 3
@@ -502,3 +506,7 @@ def test_minmax_no_evaluate():
         assert Max(0, p).args == (0, p)
         assert Min(0, p) != 0
         assert Min(0, p).args == (0, p)
+        assert Min(p).func == Min
+        assert Min(p).args == (p,)
+        assert Max(p).func == Max
+        assert Max(p).args == (p,)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Currently, if I want to create a function using `lambdify` that takes to maximum value of a vector,
one natural approach could e.g. be:
```python
>>> lambdify([x], Max(x))
```
but this wont work since Max auto-simplified to it arguments if a single argument is passed. Typically we work around this by passing `evaluate=False`, however this is currently not supported. This PR aims to add support for this use case.

#### Other comments
TODO:
- [ ] add test to `test_lambdify.py` demonstrating its use with numpy (primarily).

I intend to also explore an alternative: introduce new classes Maximum and Minimum in the `.codegen` submodule, this might be less invasive than changing Min/Max.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Min and Max no longer autosimplifies single arguments when `evaluate=False` is passed.
<!-- END RELEASE NOTES -->
