### PR TITLE
More functionality for numpy's amin & amax functions

### DIFF
--- a/sympy/codegen/numpy_nodes.py
+++ b/sympy/codegen/numpy_nodes.py
@@ -2,8 +2,10 @@ from sympy.core.function import Add, ArgumentIndexError, Function
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
+from sympy.core.sympify import sympify
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import Max, Min
+from .ast import Token, none
 
 
 def _logaddexp(x1, x2, *, evaluate=True):
@@ -111,7 +113,7 @@ class logaddexp2(Function):
             return logaddexp2(a, b)
 
 
-class amin(Function):
+class amin(Token):
     """ Minimum value along an axis.
 
     Helper class for use with e.g. numpy.amin
@@ -122,10 +124,12 @@ class amin(Function):
 
     https://numpy.org/doc/stable/reference/generated/numpy.amin.html
     """
-    nargs = 1
+    __slots__ = _fields = ('array', 'axis')
+    defaults = {'axis': none}
+    _construct_axis = staticmethod(sympify)
 
 
-class amax(Function):
+class amax(Token):
     """ Maximum value along an axis.
 
     Helper class for use with e.g. numpy.amax
@@ -136,7 +140,9 @@ class amax(Function):
 
     https://numpy.org/doc/stable/reference/generated/numpy.amax.html
     """
-    nargs = 1
+    __slots__ = _fields = ('array', 'axis')
+    defaults = {'axis': none}
+    _construct_axis = staticmethod(sympify)
 
 
 class maximum(Function):

--- a/sympy/codegen/tests/test_numpy_nodes.py
+++ b/sympy/codegen/tests/test_numpy_nodes.py
@@ -2,8 +2,10 @@ from itertools import product
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.exponential import (exp, log)
+from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.printing.repr import srepr
-from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
+from sympy.codegen.numpy_nodes import logaddexp, logaddexp2, minimum, maximum, amax, amin
+from sympy.testing.pytest import raises
 
 x, y, z = symbols('x y z')
 
@@ -48,3 +50,20 @@ def test_logaddexp2():
     assert lae2_sum_to_2.simplify() == 1
     was = logaddexp2(x, y)
     assert srepr(was) == srepr(was.simplify())  # cannot simplify with x, y
+
+
+def test_minimum_maximum():
+    for MM, mm in zip([Min, Max], [minimum, maximum]):
+        ref = MM(x, y, z)
+        m = mm(x, y, z)
+        assert m != ref
+        assert m.rewrite(MM) == ref
+
+
+def test_amin_amax():
+    for am in [amin, amax]:
+        assert am(x).array == x
+        assert am(x).axis == None
+        assert am(x, axis=3).axis == 3
+        with raises(ValueError):
+            am(x, y, z)

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -230,8 +230,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return '{}({}.asarray([{}]), axis=0)'.format(self._module_format(self._module + '.amin'), self._module_format(self._module), ','.join(self._print(i) for i in expr.args))
 
     def _print_amin(self, expr):
-        inner, = expr.args
-        return '{}({})'.format(self._module_format(self._module + '.amin'), self._print(inner))
+        return '{}({}, axis={})'.format(self._module_format(self._module + '.amin'), self._print(expr.array), self._print(expr.axis))
 
     def _print_minimum(self, expr):
         op = self._module_format(self._module + '.minimum')
@@ -241,8 +240,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return '{}({}.asarray([{}]), axis=0)'.format(self._module_format(self._module + '.amax'), self._module_format(self._module), ','.join(self._print(i) for i in expr.args))
 
     def _print_amax(self, expr):
-        inner, = expr.args
-        return '{}({})'.format(self._module_format(self._module + '.amax'), self._print(inner))
+        return '{}({}, axis={})'.format(self._module_format(self._module + '.amax'), self._print(expr.array), self._print(expr.axis))
 
     def _print_maximum(self, expr):
         op = self._module_format(self._module + '.maximum')

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,4 +1,5 @@
 from itertools import product
+import functools
 import math
 import inspect
 import linecache

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,5 +1,4 @@
 from itertools import product
-import functools
 import math
 import inspect
 import linecache
@@ -1081,10 +1080,32 @@ def test_amin_amax_minimum_maximum():
 
     a254 = numpy.array([2, 5, 4])
     a132 = numpy.array([1, 3, 2])
+    # 2 args
     assert numpy.all(lambdify((x, y), maximum(x, y))(a234, a152) == a254)
     assert numpy.all(lambdify((x, y), minimum(x, y))(a234, a152) == a132)
 
+    # 3 args
+    assert numpy.all(lambdify((x, y, z), maximum(x, y, z))(a234, a152, a234) == a254)
+    assert numpy.all(lambdify((x, y, z), minimum(x, y, z))(a234, a152, a234) == a132)
+
+    # 1 arg
+    assert numpy.all(lambdify((x,), maximum(x))(a234) == a234)
+    assert numpy.all(lambdify((x,), minimum(x))(a234) == a234)
+
+    # 4 args, mixed length
+    assert numpy.all(lambdify((x, y, z, w), maximum(x, y, z, w))(a234, a152, a234, 3) == [3, 5, 4])
+    assert numpy.all(lambdify((x, y, z, w), minimum(x, y, z, w))(a234, a152, a234, 2) == [1, 2, 2])
+
+    # amin & amax
     assert lambdify((x, y), [amin(x), amax(y)])(a234, a152) == [2, 5]
+    A = numpy.array([
+        [0, 4, 8],
+        [1, 5, 9],
+        [2, 6, 10],
+    ])
+    min_, max_ = lambdify((x,), [amin(x, axis=0), amax(x, axis=1)])(A)
+    assert numpy.all(min_ == numpy.amin(A, axis=0))
+    assert numpy.all(max_ == numpy.amax(A, axis=1))
 
 
 def test_Indexed():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Follow up PR to #27481

#### Brief description of what is fixed or changed
`numpy.amin` and `numpy.amax` both take an "axis" keyword argument. This PR adds support for setting this in the sympy object.

#### Other comments
The test coverage of numpy.minimum and numpy.maximum is also extended in this PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
