### PR TITLE
lambdify: functools.reduce and numpy.maximum for sympy.Max

### DIFF
--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -227,7 +227,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return f"{_reduce}({op}, [{', '.join(s_args)}])"
 
     def _print_Min(self, expr):
-        return '{}({}.asarray([{}]), axis=0)'.format(self._module_format(self._module + '.amin'), self._module_format(self._module), ','.join(self._print(i) for i in expr.args))
+        return self._print_minimum(expr)
 
     def _print_amin(self, expr):
         return '{}({}, axis={})'.format(self._module_format(self._module + '.amin'), self._print(expr.array), self._print(expr.axis))
@@ -237,7 +237,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
         return self._helper_minimum_maximum(op, *expr.args)
 
     def _print_Max(self, expr):
-        return '{}({}.asarray([{}]), axis=0)'.format(self._module_format(self._module + '.amax'), self._module_format(self._module), ','.join(self._print(i) for i in expr.args))
+        return self._print_maximum(expr)
 
     def _print_amax(self, expr):
         return '{}({}, axis={})'.format(self._module_format(self._module + '.amax'), self._print(expr.array), self._print(expr.axis))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1071,6 +1071,7 @@ def test_Min_Max():
     assert lambdify((x, y, z), Min(x, y, z))(1, 2, 3) == 1
     assert lambdify((x, y, z), Max(x, y, z))(1, 2, 3) == 3
 
+
 def test_amin_amax_minimum_maximum():
     if not numpy:
         skip("numpy not installed")
@@ -1106,6 +1107,11 @@ def test_amin_amax_minimum_maximum():
     min_, max_ = lambdify((x,), [amin(x, axis=0), amax(x, axis=1)])(A)
     assert numpy.all(min_ == numpy.amin(A, axis=0))
     assert numpy.all(max_ == numpy.amax(A, axis=1))
+
+    # see gh-25659
+    assert numpy.all(lambdify((x, y), Max(x, y))([1, 2, 3], [3, 2, 1]) == [3, 2, 3])
+    assert numpy.all(lambdify((x), Min(2, x))([1, 2, 3]) == [1, 2, 2])
+
 
 
 def test_Indexed():


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Follow up of #27481

#### Brief description of what is fixed or changed
Try to map SymPy's `Min` and `Max` to `numpy.minimum` and `numpy.maximum`.

#### Other comments
I fear that this a has back-comp issues. If so, we would need a deprecation cycle, but it is not immediately obvious to me how we would go about that.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * lambdify now maps Min and Max to the numpy functions minimum and maximum.
<!-- END RELEASE NOTES -->
