### PR TITLE
Fix infinite recursion error when vectors are defined incorrectly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1285,7 +1285,7 @@ Roman Inflianskas <infroma@gmail.com>
 Ronan Lamy <ronan.lamy@gmail.com> <Ronan.Lamy@normalesup.org>
 Rudr Tiwari <rudrtiwari@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
-Rushabh Mehta <mehtarushabh2005@gmail.com> RushabhMehta2005 <139112780+RushabhMehta2005@users.noreply.github.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -272,8 +272,10 @@ class BasisDependentMul(BasisDependent, Mul):
             elif isinstance(arg, Vector):
                 try:
                     arg.components
-                except AttributeError:
-                    raise ValueError("Wrong way of defining a vector.")
+                except AttributeError as exc:
+                    raise ValueError(
+                        "Invalid vector definition, object does not have components."
+                    ) from exc
             else:
                 measure_number *= arg
         # Make sure incompatible types weren't multiplied

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -245,7 +245,7 @@ class BasisDependentMul(BasisDependent, Mul):
 
     @classmethod
     def _new(cls, *args, **options):
-        from sympy.vector import Cross, Dot, Curl, Gradient
+        from sympy.vector import Cross, Dot, Curl, Gradient, Vector
         count = 0
         measure_number = S.One
         zeroflag = False
@@ -269,6 +269,11 @@ class BasisDependentMul(BasisDependent, Mul):
                 expr = arg
             elif isinstance(arg, (Cross, Dot, Curl, Gradient)):
                 extra_args.append(arg)
+            elif isinstance(arg, Vector):
+                try:
+                    arg.components
+                except AttributeError:
+                    raise ValueError("Wrong way of defining a vector.")
             else:
                 measure_number *= arg
         # Make sure incompatible types weren't multiplied

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -340,3 +340,6 @@ def test_scalar():
     assert v1.is_scalar is False
     assert (v1.dot(v2)).is_scalar is True
     assert (v1.cross(v2)).is_scalar is False
+
+def test_issue_27439():
+    raises(ValueError, lambda: 1*Vector(*symbols('a b c')))


### PR DESCRIPTION
#### References to other Issues or PRs  
Fixes #27439  

#### Brief description of what is fixed or changed  
This PR addresses a bug where incorrectly defining a `Vector` caused an infinite recursion error.  
The correct way to define a vector is documented in the [[SymPy documentation](https://docs.sympy.org/latest/modules/vector/basics.html#coordinate-systems-and-vectors)](https://docs.sympy.org/latest/modules/vector/basics.html#coordinate-systems-and-vectors), as highlighted by @oscarbenjamin in [[this comment](https://github.com/sympy/sympy/issues/27439#issuecomment-2571602853)](https://github.com/sympy/sympy/issues/27439#issuecomment-2571602853).  

A regression test has been added to ensure this issue does not reoccur.  

#### Other comments  
Feedback and constructive criticism are highly appreciated! I am currently learning about SymPy and its codebase by tackling issues I can contribute to.  

#### Release Notes  

<!-- BEGIN RELEASE NOTES -->  
* vector  
  * Fixed a bug where incorrectly defining vectors caused an infinite recursion error.  
<!-- END RELEASE NOTES -->  
