### PR TITLE
Modified the code to handle the negative base in the RealPredicate handler.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -620,6 +620,7 @@ G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
+Gagan Mishra <simonsimple305@gmail.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <36567889+czgdp1807@users.noreply.github.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <czgdp1807@gmail.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <gdp.1807@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -620,7 +620,7 @@ G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
-Gagan Mishra <simonsimple305@gmail.com>
+Gagan Mishra <simonsimple305@gmail.com> Gagan Mishra <70949548+GaganMishra305@users.noreply.github.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <36567889+czgdp1807@users.noreply.github.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <czgdp1807@gmail.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <gdp.1807@gmail.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -262,7 +262,7 @@ def _(expr, assumptions):
     """
     * Real**Integer              -> Real
     * Positive**Real             -> Real
-    * Negative**Real             -> ? e.g. -2**2 is real whereas -2**3 is imaginary
+    * Negative**Real             -> Depends on power e.g. -2**2 is real whereas -2**3 is imaginary
     * Real**(Integer/Even)       -> Real if base is nonnegative
     * Real**(Integer/Odd)        -> Real
     * Imaginary**(Integer/Even)  -> Real
@@ -320,7 +320,7 @@ def _(expr, assumptions):
             elif ask(Q.positive(expr.base), assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
-                return None
+                return ask(Q.even(expr.exp), assumptions)
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -262,7 +262,7 @@ def _(expr, assumptions):
     """
     * Real**Integer              -> Real
     * Positive**Real             -> Real
-    * Negative**Real             -> Depends on power e.g. -2**2 is real whereas -2**3 is imaginary
+    * Negative**Real             -> ?
     * Real**(Integer/Even)       -> Real if base is nonnegative
     * Real**(Integer/Odd)        -> Real
     * Imaginary**(Integer/Even)  -> Real
@@ -321,7 +321,10 @@ def _(expr, assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
                 if ask(Q.rational(expr.exp), assumptions):
-                    return False
+                    if ask(Q.even(expr.exp.args[1].args[0]), assumptions): # if the denominator of the rational is-even then it can't 2, 4, 6
+                        return False
+                    else:
+                        return None # otherwise we don't know
                 else:
                     return None
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -321,11 +321,6 @@ def _(expr, assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
                 if ask(Q.rational(expr.exp), assumptions):
-                    if ask(Q.even(expr.exp.args[1].args[0]), assumptions): # if the denominator of the rational is-even then it can't 2, 4, 6
-                        return False
-                    else:
-                        return None # otherwise we don't know
-                else:
                     return None
 
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -319,7 +319,7 @@ def _(expr, assumptions):
                 return True
             elif ask(Q.positive(expr.base), assumptions):
                 return True
-            elif ask(Q.negative(expr.base), assumptions):
+            else:
                 return None
 
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -319,9 +319,6 @@ def _(expr, assumptions):
                 return True
             elif ask(Q.positive(expr.base), assumptions):
                 return True
-            else:
-                return None
-
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -320,8 +320,7 @@ def _(expr, assumptions):
             elif ask(Q.positive(expr.base), assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
-                if ask(Q.rational(expr.exp), assumptions):
-                    return None
+                return None
 
 
 @RealPredicate.register_many(cos, sin)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -262,6 +262,7 @@ def _(expr, assumptions):
     """
     * Real**Integer              -> Real
     * Positive**Real             -> Real
+    * Negative**Real             -> ? e.g. -2**2 is real whereas -2**3 is imaginary
     * Real**(Integer/Even)       -> Real if base is nonnegative
     * Real**(Integer/Odd)        -> Real
     * Imaginary**(Integer/Even)  -> Real
@@ -319,7 +320,7 @@ def _(expr, assumptions):
             elif ask(Q.positive(expr.base), assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
-                return False
+                return None
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -324,7 +324,7 @@ def _(expr, assumptions):
                     return False
                 else:
                     return None
-                    
+
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -320,10 +320,11 @@ def _(expr, assumptions):
             elif ask(Q.positive(expr.base), assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
-                if ask(Q.integer(expr.exp), assumptions) and ask(Q.even(expr.exp), assumptions):
-                    return True
-                else:
+                if ask(Q.rational(expr.exp), assumptions):
                     return False
+                else:
+                    return None
+                    
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -320,7 +320,10 @@ def _(expr, assumptions):
             elif ask(Q.positive(expr.base), assumptions):
                 return True
             elif ask(Q.negative(expr.base), assumptions):
-                return ask(Q.even(expr.exp), assumptions)
+                if ask(Q.integer(expr.exp), assumptions) and ask(Q.even(expr.exp), assumptions):
+                    return True
+                else:
+                    return False
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2416,6 +2416,7 @@ def test_issue_25221():
     assert ask(Q.transcendental(x), Q.algebraic(x) | (0 > y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.gt(0,y)) is None
 
+
 def test_issue_27485():
     n = Symbol('n', negative=True)
     p = Symbol('p', positive=True)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1907,7 +1907,7 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.odd(y)) is False
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.even(y)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.rational(y/z) & Q.even(z) & Q.positive(x)) is True
-    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.rational(y/z) & Q.even(z) & Q.negative(x)) is False
+    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.rational(y/z) & Q.even(z) & Q.negative(x)) is None
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.integer(y/z)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.positive(x)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.negative(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1917,6 +1917,9 @@ def test_real_pow():
     assert ask(Q.real(x**i), Q.imaginary(i)) is None  # x could be 0
     assert ask(Q.real(x**(I*pi/log(x))), Q.real(x)) is True
 
+    # https://github.com/sympy/sympy/issues/27485
+    assert ask(Q.real(n**p), Q.negative(n) & Q.positive(p)) is None
+
 
 @_both_exp_pow
 def test_real_functions():
@@ -2415,10 +2418,3 @@ def test_issue_25221():
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.positive(y,y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | (0 > y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.gt(0,y)) is None
-
-
-def test_issue_27485():
-    n = Symbol('n', negative=True)
-    p = Symbol('p', positive=True)
-    exp = n**p
-    assert ask(Q.real(exp)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2415,3 +2415,9 @@ def test_issue_25221():
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.positive(y,y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | (0 > y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.gt(0,y)) is None
+
+def test_issue_27485():
+    n = Symbol('n', negative=True)
+    p = Symbol('p', positive=True)
+    exp = n**p
+    assert ask(Q.real(exp)) is None 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2420,4 +2420,4 @@ def test_issue_27485():
     n = Symbol('n', negative=True)
     p = Symbol('p', positive=True)
     exp = n**p
-    assert ask(Q.real(exp)) is None 
+    assert ask(Q.real(exp)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1910,7 +1910,7 @@ def test_real_pow():
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.rational(y/z) & Q.even(z) & Q.negative(x)) is False
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.integer(y/z)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.positive(x)) is True
-    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.negative(x)) is False
+    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.negative(x)) is None
     assert ask(Q.real((-I)**i), Q.imaginary(i)) is True
     assert ask(Q.real(I**i), Q.imaginary(i)) is True
     assert ask(Q.real(i**i), Q.imaginary(i)) is None  # i might be 2*I


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Fixes #27485 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed the case where the number can be real even if the base is negative.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Make ```ask(Q.real(n**p), Q.positive(p) & Q.negative(n))``` give ```None``` instead of incorrectly giving ```False```
<!-- END RELEASE NOTES -->
