### PR TITLE
Add additional ruff SLOT checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ lint.select = [
     "PLE",
     "PLR1736",
     "SIM101",
+    "SLOT",
     "TRY002",
 ]
 

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -353,6 +353,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
     `FreeGroup` class.
 
     """
+    __slots__ = ()
     is_assoc_word = True
 
     def new(self, init):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1633,6 +1633,8 @@ def test_issue_3531():
     # https://github.com/sympy/sympy/issues/3531
     # https://github.com/sympy/sympy/pull/18116
     class MightyNumeric(tuple):
+        __slots__ = ()
+
         def __rtruediv__(self, other):
             return "something"
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -2292,7 +2292,7 @@ class primepi(DefinedFunction):
 
 
 class _MultisetHistogram(tuple):
-    pass
+    __slots__ = ()
 
 
 _N = -1

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -120,6 +120,8 @@ class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
     ((N.x|N.x) + (N.y|N.y) + (N.z|N.z), Po)
 
     """
+    __slots__ = ()
+
     def __new__(cls, dyadic, point):
         # Switch order if given in the wrong order
         if isinstance(dyadic, Point) and isinstance(point, Dyadic):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Adds additional SLOT checks in ruff that does additional checks to the
slotcheck linter. Ensures that builtin subclasses do not accidentally
increase memory of often used objects for immutable builtin types.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
