### PR TITLE
Added two missing top level redirects for physics vectors and mechanics.

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -84,10 +84,12 @@ redirects = {
     "tutorial/matrices": "../tutorials/intro-tutorial/matrices.html",
     "tutorial/manipulation": "../tutorials/intro-tutorial/manipulation.html",
 
+    "modules/physics/vector": "../explanation/modules/physics/vector/index.html",
     "modules/physics/vector/vectors": "../explanation/modules/physics/vector/vectors/vectors.html",
     "modules/physics/vector/kinematics": "../explanation/modules/physics/vector/kinematics/kinematics.html",
     "modules/physics/vector/advanced": "../explanation/modules/physics/vector/advanced.html",
     "modules/physics/vector/fields": "../explanation/modules/physics/vector/fields.html",
+    "modules/physics/mechanics": "../explanation/modules/physics/mechanics/index.html",
     "modules/physics/mechanics/advanced": "../explanation/modules/physics/mechanics/advanced.html",
     "modules/physics/mechanics/autolev_parser": "../explanation/modules/physics/mechanics/autolev_parser.html",
     "modules/physics/mechanics/examples": "../tutorials/physics/mechanics/index.html",


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Redirects were not added to the primary pages of these explanation topics, so old hyper links are broken. This should fix that.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * Add a redirect to the top level explanation page from the old url in the reference section.
* physics.mechanics
  * Add a redirect to the top level explanation page from the old url in the reference section.

<!-- END RELEASE NOTES -->
