### PR TITLE
Remove unnecessary copy for list reversal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ lint.select = [
     "C4",
     "E",
     "F",
+    "FURB187",
     "LOG",
     "PIE810",
     "PLE",

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1404,7 +1404,7 @@ class Polygon(GeometrySet):
         pts.append(pts[0])  # close it
         cw = Polygon._is_clockwise(*pts[:3])
         if cw:
-            pts = list(reversed(pts))
+            pts.reverse()
         for v, a in p.angles.items():
             i = pts.index(v)
             p1, p2 = Point._normalize_dimension(pts[i], pts[i + 1])

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -919,7 +919,7 @@ def _det_bird(M):
         for i in reversed(range(1, n)):
             total -= X[i][i]
             diag_sums.append(total)
-        diag_sums = diag_sums[::-1]
+        diag_sums.reverse()
 
         elems = [[zero] * i + [diag_sums[i]] + X_i[i + 1:] for i, X_i in
                  enumerate(X)]

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -2167,7 +2167,7 @@ def sdm_berk(M, n, K):
     # range then Tq[j] must be zero. We exploit this potential banded
     # structure and the potential sparsity of q to compute Tq more efficiently.
 
-    Tvals = Tvals[::-1]
+    Tvals.reverse()
 
     Tq = {}
 

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -418,7 +418,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
 
         for symbol in syms:
             if isinstance(symbol, Derivative) and small_first:
-                terms = list(reversed(terms))
+                terms.reverse()
                 small_first = not small_first
             result = parse_expression(terms, symbol)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -105,7 +105,7 @@ def _masked(f, *atoms):
     for i, (o, n) in enumerate(mask):
         f = f.replace(o, n)
         mask[i] = (n, o)
-    mask = list(reversed(mask))
+    mask.reverse()
     return f, mask
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* This should be a non-functional change. List has a .reverse() method which
reverse a list in place. We replaces calls which implicitly copy and
delete the list (such as calling `list(reversed(x))`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
