### PR TITLE
Fix laplace zero division

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -907,6 +907,7 @@ Lee Johnston <lee.johnston.100@gmail.com>
 Lejla Metohajrova <l.metohajrova@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu>
 Leo Battle <leowbattle@gmail.com>
+Leonardo Mangani <leomangani4@gmail.com> Leonardo Mangani <88255254+leomanga@users.noreply.github.com>
 Leonid Blouvshtein <leonidbl91@gmail.com>
 Leonid Kovalev <leonidvkovalev@gmail.com> <leonid.traveling@gmail.com>
 Leonid Kovalev <leonidvkovalev@gmail.com> <normalhuman@users.noreply.github.com>

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -926,15 +926,20 @@ def dmp_shift(f, a, u, K):
 
     a0, a1 = a[0], a[1:]
 
-    f = [ dmp_shift(c, a1, u-1, K) for c in f ]
-    n = len(f) - 1
+    if any(a1):
+        f = [ dmp_shift(c, a1, u-1, K) for c in f ]
+    else:
+        f = list(f)
 
-    for i in range(n, 0, -1):
-        for j in range(0, i):
-            afj = dmp_mul_ground(f[j], a0, u-1, K)
-            f[j + 1] = dmp_add(f[j + 1], afj, u-1, K)
+    if a0:
+        n = len(f) - 1
 
-    return f
+        for i in range(n, 0, -1):
+            for j in range(0, i):
+                afj = dmp_mul_ground(f[j], a0, u-1, K)
+                f[j + 1] = dmp_add(f[j + 1], afj, u-1, K)
+
+    return dmp_strip(f, u)
 
 
 def dup_transform(f, p, q, K):

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2792,6 +2792,14 @@ def test_factor():
     )
     assert factor(e) == -(y - I)**3*(y + I)*(x**2 + 2*x + y**2 + 2)/(y**2 + 1)
 
+    # issue 27506
+    e = (I*t*x*y - 3*I*t - I*x*y*z - 6*x*y + 3*I*z + 18)
+    assert factor(e) == -I*(x*y - 3)*(-t + z - 6*I)
+
+    e = (8*x**2*z**2 - 32*x**2*z*t + 24*x**2*t**2 - 4*I*x*y*z**2 + 16*I*x*y*z*t -
+         12*I*x*y*t**2 + z**4 - 8*z**3*t + 22*z**2*t**2 - 24*z*t**3 + 9*t**4)
+    assert factor(e) == (-3*t + z)*(-t + z)*(3*t**2 - 4*t*z + 8*x**2 - 4*I*x*y + z**2)
+
 
 def test_factor_large():
     f = (x**2 + 4*x + 4)**10000000*(x**2 + 1)*(x**2 + 2*x + 1)**1234567


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27498 



#### Brief description of what is fixed or changed

Updated `dmp_shift` function to handle zero elements correctly, adding checks for non-zero elements.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug in `dmp_shift` to handle zero elements correctly.
<!-- END RELEASE NOTES -->
