### PR TITLE
ask: Fix prime handler for integer exponentiation

### DIFF
--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -63,7 +63,14 @@ def _(expr, assumptions):
         return _PrimePredicate_number(expr, assumptions)
     if ask(Q.integer(expr.exp), assumptions) and \
             ask(Q.integer(expr.base), assumptions):
-        return False
+        prime_base = ask(Q.prime(expr.base), assumptions)
+        if prime_base is False:
+            return False
+        is_exp_one = ask(Q.eq(expr.exp, 1), assumptions)
+        if is_exp_one is False:
+            return False
+        if prime_base is True and is_exp_one is True:
+            return True
 
 @PrimePredicate.register(Integer)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1790,7 +1790,21 @@ def test_prime():
 
     assert ask(Q.prime(x**2), Q.integer(x)) is False
     assert ask(Q.prime(x**2), Q.prime(x)) is False
-    assert ask(Q.prime(x**y), Q.integer(x) & Q.integer(y)) is False
+
+    # https://github.com/sympy/sympy/issues/27446
+    assert ask(Q.prime(4**x), Q.integer(x)) is False
+    assert ask(Q.prime(p**x), Q.prime(p) & Q.integer(x) & Q.ne(x, 1)) is False
+    assert ask(Q.prime(n**x), Q.integer(x) & Q.composite(n)) is False
+    assert ask(Q.prime(x**y), Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.prime(2**x), Q.integer(x)) is None
+    assert ask(Q.prime(p**x), Q.prime(p) & Q.integer(x)) is None
+
+    # Ideally, these should return True since the base is prime and the exponent is one,
+    # but currently, they return None.
+    assert ask(Q.prime(x**y), Q.prime(x) & Q.eq(y,1)) is None
+    assert ask(Q.prime(x**y), Q.prime(x) & Q.integer(y) & Q.gt(y,0) & Q.lt(y,2)) is None
+
+    assert ask(Q.prime(Pow(x,1, evaluate=False)), Q.prime(x)) is True
 
 
 @_both_exp_pow


### PR DESCRIPTION
#### References to other Issues or PRs
 <!-- Fixes #27446 -->
 Fixes #27446

#### Brief description of what is fixed or changed
This PR addresses an issue in the primality check for expressions of the form x**y, where both x and y are integers. The problem arises when the exponent is 1, and the base is a prime number. In such cases, the primality check should only depend on whether the base is prime.

The fix involves:

Modifying the handler for Pow to check if the exponent is 1.
If the exponent is 1, the handler will return the result of ask(Q.prime(expr.base)), which correctly checks if the base is prime.

#### Other comments
Test cases have been added to cover cases with x**1, ensuring correct behavior when the base is prime and the exponent is 1.
The fix improves the correctness and consistency of the primality checks in symbolic expressions.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Make ```ask(Q.prime(x**y),Q.integer(x) & Q.integer(y))``` give ```None``` instead of incorrectly giving ```False``` .

<!-- END RELEASE NOTES -->



