### PR TITLE
Fix RealPredicate for Mul to handle uncertainty in zero-checks correctly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -883,6 +883,7 @@ Konrad Meyer <konrad.meyer@gmail.com>
 Konstantin Togoi <konstantin.togoi@gmail.com> <togoi.konstantin@outlook.com>
 Konstantinos Riganas <kostasriganas24@gmail.com> kostas-rigan <t8200145@aueb.gr>
 Kris Katterjohn <katterjohn@gmail.com>
+Krishnav Bajoria <bajoriakrishnav@gmail.com> Krishnav Bajoria <127018567+krishnavbajoria02@users.noreply.github.com>
 Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
 Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -247,15 +247,18 @@ def _(expr, assumptions):
     if expr.is_number:
         return _RealPredicate_number(expr, assumptions)
     result = True
+    check_zero = False
     for arg in expr.args:
         if ask(Q.real(arg), assumptions):
             pass
         elif ask(Q.imaginary(arg), assumptions):
             result = result ^ True
+        elif ask(Q.eq(arg,0),assumptions) is None:
+            check_zero = None
         else:
             break
     else:
-        return result
+        return (result or check_zero)
 
 @RealPredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -258,7 +258,9 @@ def _(expr, assumptions):
         else:
             break
     else:
-        return (result or check_zero)
+        if check_zero is None:
+            return None
+        return result
 
 @RealPredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -258,9 +258,7 @@ def _(expr, assumptions):
         else:
             break
     else:
-        if check_zero is None:
-            return None
-        return result
+        return (result or check_zero)
 
 @RealPredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -249,12 +249,12 @@ def _(expr, assumptions):
     result = True
     check_zero = False
     for arg in expr.args:
+        if ask(Q.eq(arg,0),assumptions) is None:
+            check_zero = None
         if ask(Q.real(arg), assumptions):
             pass
         elif ask(Q.imaginary(arg), assumptions):
             result = result ^ True
-        elif ask(Q.eq(arg,0),assumptions) is None:
-            check_zero = None
         else:
             break
     else:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -258,7 +258,9 @@ def _(expr, assumptions):
         else:
             break
     else:
-        return (result or check_zero)
+        if check_zero is None and result is False:
+            return None
+        return result
 
 @RealPredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1883,7 +1883,7 @@ def test_real_basic():
     assert ask(Q.real(x), Q.prime(x)) is True
 
     assert ask(Q.real(x/sqrt(2)), Q.real(x)) is True
-    assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is False
+    assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is None
 
     assert ask(Q.real(x + 1), Q.real(x)) is True
     assert ask(Q.real(x + I), Q.real(x)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1890,7 +1890,7 @@ def test_real_basic():
     assert ask(Q.real(x + I), Q.complex(x)) is None
 
     assert ask(Q.real(2*x), Q.real(x)) is True
-    assert ask(Q.real(I*x), Q.real(x)) is False
+    assert ask(Q.real(I*x), Q.real(x)) is None
     assert ask(Q.real(I*x), Q.imaginary(x)) is True
     assert ask(Q.real(I*x), Q.complex(x)) is None
 


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27443.


#### Brief description of what is fixed or changed
The issue involves the behavior of ```ask(Q.real(expr), assumptions)``` when evaluating expressions like ```I * x```, where x is a real symbol. In such cases:

1) If ```x = 0```, the product is 0 (real).
2) If ```x != 0```, the product is imaginary.
3) If x is unknown, the result should be None because it depends on whether x is zero.
Previously, the logic in ```@RealPredicate.register(Mul)``` failed to account for cases where a symbol might be zero, leading to incorrect results.

This PR introduces the following changes:

Introduced a ```check_zero``` flag to track arguments that might potentially be zero but cannot be definitively determined.
Modified the final return logic to consider the uncertainty in cases where zero is a possibility, ensuring that the function returns ```None``` when such uncertainty exists.

#### Other comments
The fix introduces a simple check using ```ask(Q.eq(arg, 0), assumptions)``` to detect cases where arguments could potentially be zero. If this check returns None, the uncertainty propagates through the result.

This ensures correctness in handling real and imaginary arguments in multiplication while maintaining consistency with the three-valued logic used in assumptions.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Fixed a bug in ```ask(Q.real(expr))``` that caused incorrect results when multiplying by potentially zero symbols, such as ```I * x``` where x is real.

<!-- END RELEASE NOTES -->
