### PR TITLE
Added NaN handler for NegativePredicate 

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -3,7 +3,7 @@ Handlers related to order relations: positive, negative, etc.
 """
 
 from sympy.assumptions import Q, ask
-from sympy.core import Add, Basic, Expr, Mul, Pow
+from sympy.core import Add, Basic, Expr, Mul, Pow, S
 from sympy.core.logic import fuzzy_not, fuzzy_and, fuzzy_or
 from sympy.core.numbers import E, ImaginaryUnit, NaN, I, pi
 from sympy.functions import Abs, acos, acot, asin, atan, exp, factorial, log
@@ -23,6 +23,10 @@ from ..predicates.order import (NegativePredicate, NonNegativePredicate,
 
 def _NegativePredicate_number(expr, assumptions):
     r, i = expr.as_real_imag()
+
+    if r == S.NaN or i == S.NaN:
+        return None
+
     # If the imaginary part can symbolically be shown to be zero then
     # we just evaluate the real part; otherwise we evaluate the imaginary
     # part to see if it actually evaluates to zero and if it does then

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2431,3 +2431,8 @@ def test_issue_25221():
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.positive(y,y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | (0 > y)) is None
     assert ask(Q.transcendental(x), Q.algebraic(x) | Q.gt(0,y)) is None
+
+
+def test_issue_27440():
+    nan = S.NaN
+    assert ask(Q.negative(nan)) is None


### PR DESCRIPTION

#### Brief description of what is fixed or changed
This PR is adding a NaN handler for NegativePredicate, as is already the case for PositivePredicate. As of now, ask(Q.negative(nan)) returns the wrong value: False instead of None.

#### Other comments
When evaluating ask(Q.negative(nan)), SymPy currently returns False, which is mathematically incorrect since we cannot determine if NaN is negative. This PR adds a NaN handler for NegativePredicate that returns None.

Fixes #27440

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Make `ask(Q.negative(S.NaN))` give `None` instead of wrongly giving `False` .
<!-- END RELEASE NOTES -->
