### PR TITLE
Added the test case for the Transpose MatMul issue

### DIFF
--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -184,3 +184,10 @@ def test_shape_error():
     A = MatrixSymbol('A', 2, 2)
     B = MatrixSymbol('B', 3, 3)
     raises(ShapeError, lambda: MatMul(A, B))
+
+
+def test_matmul_transpose():
+    # https://github.com/sympy/sympy/issues/9503
+    M = Matrix(2, 2, [1, 2 + I, 3, 4])
+    a = Symbol('a')
+    assert (MatMul(a, M).T).expand() == (a*Matrix([[1, 3],[2 + I, 4]])).expand()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



#### Brief description of what is fixed or changed
Added the necessary test case in test_matmul.py for the issue of transpose of MatMul(<Symbol>, <Matrix>)that was failing

#### Other comments
The PR for that issue was already solved in the master branch but there were no test cases. This PR includes the test case of the issue #9503 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
