### PR TITLE
added the test case of the logscale plotting issue

### DIFF
--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -1342,3 +1342,21 @@ def test_plot3d_parametric_surface_arguments():
     assert p[1].ranges[1][1:] == (-4, 5)
     assert p[1].get_label(False) == "test"
     assert p[1].rendering_kw == {}
+
+
+def test_logscale_plotting():
+    # https://github.com/sympy/sympy/issues/25190
+    if not matplotlib:
+        skip("Matplotlib is not in the default backend")
+
+    x = Symbol("x")
+    p1 = plot(sin(log(x)), (x, .001, 10), xscale="log", show=False)
+    p2 = plot(sin(log(x)), (x, .001, 10), xscale="log", show=False, adaptive=False)
+
+    assert len(p1._series) == len(p2._series)
+
+    assert p1[0].get_data()[0][0] == p2[0].get_data()[0][0]
+    assert p1[0].get_data()[0][-1] == p2[0].get_data()[0][-1]
+
+    assert round(p1[0].get_data()[1][0], 4) == round(p2[0].get_data()[1][0], 4)
+    assert round(p1[0].get_data()[1][-1], 4) == round(p2[0].get_data()[1][-1], 4)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



#### Brief description of what is fixed or changed
Add on of test case in test_plot.py for the issue of logscale plotting uses incorrect x range for adaptive=False that was already fixed and present in the master branch.

#### Other comments
The PR for the issue was already solved in the master branch but there were no test cases. This PR includes the test case of the issue #25190 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
