### PR TITLE
Fix: Return None in finite predicate Mul expression when a finite argument’s nonzero status is indeterminate

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -771,7 +771,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
-Jatin Bhardwaj <bhardwajjatin093@gmail.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -771,6 +771,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -503,12 +503,9 @@ def ask(proposition, assumptions=True, context=global_assumptions):
         return bool(res)
 
     # using satask (still costly)
-    try:
-        res = satask(proposition, assumptions=assumptions, context=context)
-        if res is not None:
-            return res
-    except ValueError:
-        pass
+    res = satask(proposition, assumptions=assumptions, context=context)
+    if res is not None:
+        return res
 
     try:
         res = lra_satask(proposition, assumptions=assumptions, context=context)

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -503,9 +503,12 @@ def ask(proposition, assumptions=True, context=global_assumptions):
         return bool(res)
 
     # using satask (still costly)
-    res = satask(proposition, assumptions=assumptions, context=context)
-    if res is not None:
-        return res
+    try:
+        res = satask(proposition, assumptions=assumptions, context=context)
+        if res is not None:
+            return res
+    except ValueError:
+        pass
 
     try:
         res = lra_satask(proposition, assumptions=assumptions, context=context)

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -158,8 +158,7 @@ def _(expr, assumptions):
             if ask(Q.zero(arg), assumptions) is not False:
                 if result is False:
                     return None
-                else:
-                    possible_zero = None
+                possible_zero = None
         elif _bounded is None:
             if result is None:
                 return None
@@ -170,11 +169,8 @@ def _(expr, assumptions):
         else:
             if possible_zero is None:
                 return None
-            else:
-                result = False
-    if result:
-        return result
-    return possible_zero
+            result = False
+    return result
 
 @FinitePredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -151,10 +151,12 @@ def _(expr, assumptions):
         * /s = not signed
     """
     result = True
+    possible_zero = False
     for arg in expr.args:
         _bounded = ask(Q.finite(arg), assumptions)
         if _bounded:
-            continue
+            if ask(Q.eq(arg, 0), assumptions) is None:
+                possible_zero = None
         elif _bounded is None:
             if result is None:
                 return None
@@ -164,7 +166,9 @@ def _(expr, assumptions):
                 result = None
         else:
             result = False
-    return result
+    if result:
+        return result
+    return possible_zero
 
 @FinitePredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -158,7 +158,7 @@ def _(expr, assumptions):
             if ask(Q.zero(arg), assumptions) is not False:
                 if result is False:
                     return None
-                possible_zero = None
+                possible_zero = True
         elif _bounded is None:
             if result is None:
                 return None
@@ -167,7 +167,7 @@ def _(expr, assumptions):
             if result is not False:
                 result = None
         else:
-            if possible_zero is None:
+            if possible_zero is True:
                 return None
             result = False
     return result

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -155,8 +155,11 @@ def _(expr, assumptions):
     for arg in expr.args:
         _bounded = ask(Q.finite(arg), assumptions)
         if _bounded:
-            if ask(Q.zero(arg), assumptions) is None:
-                possible_zero = None
+            if ask(Q.zero(arg), assumptions) is not False:
+                if result is False:
+                    return None
+                else:
+                    possible_zero = None
         elif _bounded is None:
             if result is None:
                 return None
@@ -165,7 +168,10 @@ def _(expr, assumptions):
             if result is not False:
                 result = None
         else:
-            result = False
+            if possible_zero is None:
+                return None
+            else:
+                result = False
     if result:
         return result
     return possible_zero

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -155,7 +155,7 @@ def _(expr, assumptions):
     for arg in expr.args:
         _bounded = ask(Q.finite(arg), assumptions)
         if _bounded:
-            if ask(Q.eq(arg, 0), assumptions) is None:
+            if ask(Q.zero(arg), assumptions) is None:
                 possible_zero = None
         elif _bounded is None:
             if result is None:

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -167,7 +167,7 @@ def _(expr, assumptions):
             if result is not False:
                 result = None
         else:
-            if possible_zero is True:
+            if possible_zero:
                 return None
             result = False
     return result

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1117,6 +1117,7 @@ def test_issue_27447():
     a = x*y
     assert ask(Q.finite(a), Q.finite(x)  & ~Q.finite(y)) is None
     assert ask(Q.finite(a), ~Q.finite(x)  & Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.zero(y)) is None
 
     a = x*y*z
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -9,7 +9,6 @@ from sympy.assumptions.handlers import AskHandler
 from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)
 from sympy.core.add import Add
-from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer, Rational, oo, zoo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
@@ -1115,8 +1114,9 @@ def test_issue_27441():
 
 def test_issue_27447():
     x,y = symbols('x y')
-    assert ask(Q.finite(Mul(x, oo)), Q.finite(x)) is None
-    assert ask(Q.finite(Mul(y, oo)), Q.finite(y) & ~Q.zero(y)) is False
+    a = x * y
+    assert ask(Q.finite(a), Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y) & ~Q.zero(x)) is False
 
 @XFAIL
 def test_bounded_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -633,17 +633,17 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y) & ~Q.positive(x)
         & ~Q.positive(y)) is True
     # B + U
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is False
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)) is False
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is False
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)) is False
     assert ask(Q.finite(a), Q.finite(x)
         & Q.positive_infinite(y)) is False
     assert ask(Q.finite(a), Q.positive(x)
         & Q.positive_infinite(y)) is False
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
         & ~Q.positive(y)) is False
     assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x)
         & Q.positive_infinite(y)) is False
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x) & ~Q.finite(y)
         & ~Q.positive(y)) is False
     # B + ?
     assert ask(Q.finite(a), Q.finite(x)) is None
@@ -658,31 +658,31 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x)
         & ~Q.positive(y)) is None
     # U + U
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.positive_infinite(x)
-        & Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x)
+        & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x)
         & Q.positive_infinite(y)) is None
     assert ask(Q.finite(a), Q.positive_infinite(x)
         & Q.positive_infinite(y)) is False
-    assert ask(Q.finite(a), Q.positive_infinite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.positive_infinite(x) & ~Q.finite(y)
         & ~Q.extended_positive(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & ~Q.extended_positive(x)
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.extended_positive(x)
         & Q.positive_infinite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & ~Q.extended_positive(x) & ~Q.extended_positive(y)) is False
     # U + ?
-    assert ask(Q.finite(a), Q.infinite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.extended_positive(x)
-        & Q.infinite(y)) is None
+        & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.positive_infinite(y)) is None
     assert ask(Q.finite(a), Q.extended_positive(x)
         & Q.positive_infinite(y)) is False
     assert ask(Q.finite(a), Q.extended_positive(x)
-        & Q.infinite(y) & ~Q.extended_positive(y)) is None
+        & ~Q.finite(y) & ~Q.extended_positive(y)) is None
     assert ask(Q.finite(a), ~Q.extended_positive(x)
         & Q.positive_infinite(y)) is None
-    assert ask(Q.finite(a), ~Q.extended_positive(x) & Q.infinite(y)
+    assert ask(Q.finite(a), ~Q.extended_positive(x) & ~Q.finite(y)
         & ~Q.extended_positive(y)) is False
     # ? + ?
     assert ask(Q.finite(a)) is None
@@ -709,7 +709,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
-        & Q.infinite(z)) is False
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
@@ -724,7 +724,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
-        & Q.infinite(z)) is False
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
@@ -737,7 +737,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
-        & Q.infinite(z)) is False
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
@@ -749,7 +749,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
-        & Q.infinite(z)) is None
+        & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
         & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
@@ -758,14 +758,14 @@ def test_bounded():
         & Q.negative_infinite(y)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
-        & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is False
@@ -793,7 +793,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
-        & Q.infinite(z)) is False
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
@@ -806,7 +806,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
-        & Q.infinite(z)) is False
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
@@ -817,7 +817,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
-        & Q.infinite(z)) is None
+        & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
         & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
@@ -826,14 +826,14 @@ def test_bounded():
         & Q.negative_infinite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
-        & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is False
@@ -859,7 +859,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
-        & Q.infinite(z)) is False
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
@@ -870,7 +870,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
-        & Q.infinite(z)) is None
+        & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
         & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
@@ -879,14 +879,14 @@ def test_bounded():
         & Q.negative_infinite(y)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
-        & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is False
@@ -910,7 +910,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.negative_infinite(y) & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.negative_infinite(y) & Q.infinite(z)) is None
+        & Q.negative_infinite(y) & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.negative_infinite(y)& Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
@@ -920,15 +920,15 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.negative_infinite(y) & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.infinite(y) & Q.infinite(z)) is None
+        & ~Q.finite(y) & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.infinite(y) & Q.positive_infinite(z)) is None
+        & ~Q.finite(y) & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.infinite(y) & Q.extended_negative(z)) is None
+        & ~Q.finite(y) & Q.extended_negative(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.infinite(y)) is None
+        & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.infinite(y) & Q.extended_positive(z)) is None
+        & ~Q.finite(y) & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.positive_infinite(y) & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
@@ -948,33 +948,33 @@ def test_bounded():
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.extended_positive(y) & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
-        & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(z)
-        & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(z)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x)
+    assert ask(Q.finite(a), ~Q.finite(x)
         & Q.positive_infinite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.extended_negative(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.extended_negative(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x)
+    assert ask(Q.finite(a), ~Q.finite(x)
         & Q.extended_negative(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.extended_negative(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.extended_negative(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x)) is None
-    assert ask(Q.finite(a), Q.infinite(x)
+    assert ask(Q.finite(a), ~Q.finite(x)) is None
+    assert ask(Q.finite(a), ~Q.finite(x)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.extended_positive(y)
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.extended_positive(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.positive_infinite(x)
         & Q.positive_infinite(y) & Q.positive_infinite(z)) is False
@@ -1023,10 +1023,10 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
     assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is False
-    assert ask(Q.finite(a), Q.infinite(x)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is False
+    assert ask(Q.finite(a), ~Q.finite(x)) is None
     assert ask(Q.finite(a), Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(y)) is None
     assert ask(Q.finite(a)) is None
     a = x*y*z
     x, y, z = a.args
@@ -1039,35 +1039,35 @@ def test_bounded():
         & Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
         & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
     assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)
         & Q.finite(z)) is None
     assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)
         & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is None
     assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
         & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
-        & Q.infinite(z)) is False
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is False
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x)) is None
     assert ask(Q.finite(a), Q.finite(y) & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(y) & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.finite(y) & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(y) & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(y) & Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(y) & Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(y) & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(z) & Q.extended_nonzero(x)
+    assert ask(Q.finite(a), ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(z) & Q.extended_nonzero(x)
         & Q.extended_nonzero(y) & Q.extended_nonzero(z)) is None
-    assert ask(Q.finite(a), Q.extended_nonzero(x) & Q.infinite(y)
-        & Q.extended_nonzero(y) & Q.infinite(z)
+    assert ask(Q.finite(a), Q.extended_nonzero(x) & ~Q.finite(y)
+        & Q.extended_nonzero(y) & ~Q.finite(z)
         & Q.extended_nonzero(z)) is False
 
     x, y, z = symbols('x,y,z')
@@ -1080,12 +1080,12 @@ def test_bounded():
     assert ask(Q.finite(S.Half ** x), Q.extended_negative(x)) is None
     assert ask(Q.finite(2**x), Q.extended_negative(x)) is True
     assert ask(Q.finite(sqrt(x))) is None
-    assert ask(Q.finite(2**x), Q.infinite(x)) is False
-    assert ask(Q.finite(x**2), Q.infinite(x)) is False
+    assert ask(Q.finite(2**x), ~Q.finite(x)) is False
+    assert ask(Q.finite(x**2), ~Q.finite(x)) is False
 
     # sign function
     assert ask(Q.finite(sign(x))) is True
-    assert ask(Q.finite(sign(x)), Q.infinite(x)) is True
+    assert ask(Q.finite(sign(x)), ~Q.finite(x)) is True
 
     # exponential functions
     assert ask(Q.finite(log(x))) is None
@@ -1099,9 +1099,9 @@ def test_bounded():
 
     # trigonometric functions
     assert ask(Q.finite(sin(x))) is True
-    assert ask(Q.finite(sin(x)), Q.infinite(x)) is True
+    assert ask(Q.finite(sin(x)), ~Q.finite(x)) is True
     assert ask(Q.finite(cos(x))) is True
-    assert ask(Q.finite(cos(x)), Q.infinite(x)) is True
+    assert ask(Q.finite(cos(x)), ~Q.finite(x)) is True
     assert ask(Q.finite(2*sin(x))) is True
     assert ask(Q.finite(sin(x)**2)) is True
     assert ask(Q.finite(cos(x)**2)) is True
@@ -1118,8 +1118,6 @@ def test_issue_27447():
     # https://github.com/sympy/sympy/issues/27447
     assert ask(Q.finite(Mul(x, oo))) is None
     assert ask(Q.finite(Mul(y, oo))) is False
-    assert ask(Q.finite(Mul(oo, oo))) is False
-    assert ask(Q.finite(Mul(0, oo))) is None
 
 @XFAIL
 def test_bounded_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1114,11 +1114,9 @@ def test_issue_27441():
 
 
 def test_issue_27447():
-    x = Symbol('x', finite=True)
-    y = Symbol('y', finite=True, nonzero=True)
-    assert ask(Q.finite(Mul(x, oo))) is None
-    assert ask(Q.finite(Mul(y, oo))) is False
-
+    x,y = symbols('x y')
+    assert ask(Q.finite(Mul(x, oo)), Q.finite(x)) is None
+    assert ask(Q.finite(Mul(y, oo)), Q.finite(y) & ~Q.zero(y)) is False
 
 @XFAIL
 def test_bounded_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1132,6 +1132,7 @@ def test_issue_27447():
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & Q.finite(z)) is None
 
+
 @XFAIL
 def test_issue_27662_xfail():
     assert ask(Q.finite(x*y), ~Q.finite(x)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1019,9 +1019,9 @@ def test_bounded():
     a = x*y
     x, y = a.args
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)) is True
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.zero(x) & ~Q.finite(y)) is False
     assert ask(Q.finite(a), Q.finite(x)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y) &~Q.zero(y)) is False
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is False
     assert ask(Q.finite(a), ~Q.finite(x)) is None
     assert ask(Q.finite(a), Q.finite(y)) is None
@@ -1031,24 +1031,24 @@ def test_bounded():
     x, y, z = a.args
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.finite(z)) is True
-    assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
-        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.zero(x) & Q.finite(y)
+        & ~Q.zero(y) & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
-        & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
-        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.zero(x) & ~Q.finite(y)
+        & Q.finite(z) & ~Q.zero(z)) is False
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.zero(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)
-        & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)
-        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y) & ~Q.zero(y)
+        & Q.finite(z) & ~Q.zero(z)) is False
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.zero(x) & Q.finite(y)
+        & ~Q.zero(y) & ~Q.finite(z)) is False
     assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
-        & Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+        & Q.finite(z) & ~Q.zero(z)) is False
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & ~Q.finite(z)) is False
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1112,12 +1112,13 @@ def test_issue_27441():
     # https://github.com/sympy/sympy/issues/27441
     assert ask(Q.composite(y), Q.integer(y) & Q.positive(y) & ~Q.prime(y)) is None
 
+
 def test_issue_27447():
     x = Symbol('x', finite=True)
     y = Symbol('y', finite=True, nonzero=True)
-    # https://github.com/sympy/sympy/issues/27447
     assert ask(Q.finite(Mul(x, oo))) is None
     assert ask(Q.finite(Mul(y, oo))) is False
+
 
 @XFAIL
 def test_bounded_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1139,6 +1139,8 @@ def test_bounded_xfail():
     """We need to support relations in ask for this to work"""
     assert ask(Q.finite(sin(x)**x)) is True
     assert ask(Q.finite(cos(x)**x)) is True
+    assert ask(Q.finite(x*y), ~Q.finite(x)
+        & Q.zero(y)) is None
 
 
 def test_commutative():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1019,9 +1019,9 @@ def test_bounded():
     a = x*y
     x, y = a.args
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)) is True
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is False
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is False
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is None
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is False
     assert ask(Q.finite(a), ~Q.finite(x)) is None
     assert ask(Q.finite(a), Q.finite(y)) is None
@@ -1032,23 +1032,23 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.finite(z)) is True
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
-        & ~Q.finite(z)) is False
+        & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
-        & Q.finite(z)) is False
+        & Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is False
+        & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(z)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
     assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)
-        & Q.finite(z)) is False
+        & Q.finite(z)) is None
     assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)
-        & ~Q.finite(z)) is False
+        & ~Q.finite(z)) is None
     assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is None
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
-        & Q.finite(z)) is False
+        & Q.finite(z)) is None
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & ~Q.finite(z)) is False
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1116,7 +1116,8 @@ def test_issue_27447():
     x,y = symbols('x y')
     a = x * y
     assert ask(Q.finite(a), Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y) & ~Q.zero(x)) is False
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.zero(x) & ~Q.finite(y)) is False
+
 
 @XFAIL
 def test_bounded_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1117,7 +1117,6 @@ def test_issue_27447():
     a = x*y
     assert ask(Q.finite(a), Q.finite(x)  & ~Q.finite(y)) is None
     assert ask(Q.finite(a), ~Q.finite(x)  & Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.zero(y)) is None
 
     a = x*y*z
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
@@ -1133,14 +1132,17 @@ def test_issue_27447():
     assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
         & Q.finite(z)) is None
 
+@XFAIL
+def test_issue_27662_xfail():
+    assert ask(Q.finite(x*y), ~Q.finite(x)
+        & Q.zero(y)) is None
+
 
 @XFAIL
 def test_bounded_xfail():
     """We need to support relations in ask for this to work"""
     assert ask(Q.finite(sin(x)**x)) is True
     assert ask(Q.finite(cos(x)**x)) is True
-    assert ask(Q.finite(x*y), ~Q.finite(x)
-        & Q.zero(y)) is None
 
 
 def test_commutative():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1113,10 +1113,24 @@ def test_issue_27441():
 
 
 def test_issue_27447():
-    x,y = symbols('x y')
-    a = x * y
-    assert ask(Q.finite(a), Q.infinite(y)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.zero(x) & ~Q.finite(y)) is False
+    x,y,z = symbols('x y z')
+    a = x*y
+    assert ask(Q.finite(a), Q.finite(x)  & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), ~Q.finite(x)  & Q.finite(y)) is None
+
+    a = x*y*z
+    assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+        & Q.finite(z) ) is None
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)
+        & Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)
+        & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+        & Q.finite(z)) is None
 
 
 @XFAIL

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -9,6 +9,7 @@ from sympy.assumptions.handlers import AskHandler
 from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)
 from sympy.core.add import Add
+from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer, Rational, oo, zoo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
@@ -632,17 +633,17 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y) & ~Q.positive(x)
         & ~Q.positive(y)) is True
     # B + U
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is False
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)) is False
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is False
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)) is False
     assert ask(Q.finite(a), Q.finite(x)
         & Q.positive_infinite(y)) is False
     assert ask(Q.finite(a), Q.positive(x)
         & Q.positive_infinite(y)) is False
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
         & ~Q.positive(y)) is False
     assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x)
         & Q.positive_infinite(y)) is False
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x) & Q.infinite(y)
         & ~Q.positive(y)) is False
     # B + ?
     assert ask(Q.finite(a), Q.finite(x)) is None
@@ -657,31 +658,31 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & ~Q.positive(x)
         & ~Q.positive(y)) is None
     # U + U
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.positive_infinite(x)
-        & ~Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x)
+        & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(x)
         & Q.positive_infinite(y)) is None
     assert ask(Q.finite(a), Q.positive_infinite(x)
         & Q.positive_infinite(y)) is False
-    assert ask(Q.finite(a), Q.positive_infinite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.positive_infinite(x) & Q.infinite(y)
         & ~Q.extended_positive(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.extended_positive(x)
+    assert ask(Q.finite(a), Q.infinite(x) & ~Q.extended_positive(x)
         & Q.positive_infinite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
         & ~Q.extended_positive(x) & ~Q.extended_positive(y)) is False
     # U + ?
-    assert ask(Q.finite(a), ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.extended_positive(x)
-        & ~Q.finite(y)) is None
+        & Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.positive_infinite(y)) is None
     assert ask(Q.finite(a), Q.extended_positive(x)
         & Q.positive_infinite(y)) is False
     assert ask(Q.finite(a), Q.extended_positive(x)
-        & ~Q.finite(y) & ~Q.extended_positive(y)) is None
+        & Q.infinite(y) & ~Q.extended_positive(y)) is None
     assert ask(Q.finite(a), ~Q.extended_positive(x)
         & Q.positive_infinite(y)) is None
-    assert ask(Q.finite(a), ~Q.extended_positive(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), ~Q.extended_positive(x) & Q.infinite(y)
         & ~Q.extended_positive(y)) is False
     # ? + ?
     assert ask(Q.finite(a)) is None
@@ -708,7 +709,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
-        & ~Q.finite(z)) is False
+        & Q.infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative(y)
@@ -723,7 +724,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
-        & ~Q.finite(z)) is False
+        & Q.infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.finite(y)
@@ -736,7 +737,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
-        & ~Q.finite(z)) is False
+        & Q.infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.positive(y)
@@ -748,7 +749,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
-        & ~Q.finite(z)) is None
+        & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
         & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
@@ -757,14 +758,14 @@ def test_bounded():
         & Q.negative_infinite(y)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.negative_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.negative(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.negative(x) & Q.infinite(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is False
@@ -792,7 +793,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
-        & ~Q.finite(z)) is False
+        & Q.infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
@@ -805,7 +806,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
-        & ~Q.finite(z)) is False
+        & Q.infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.positive(y)
@@ -816,7 +817,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
-        & ~Q.finite(z)) is None
+        & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
         & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
@@ -825,14 +826,14 @@ def test_bounded():
         & Q.negative_infinite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.negative_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is False
@@ -858,7 +859,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
-        & ~Q.finite(z)) is False
+        & Q.infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
         & Q.positive_infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.positive(y)
@@ -869,7 +870,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
         & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
-        & ~Q.finite(z)) is None
+        & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
         & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
@@ -878,14 +879,14 @@ def test_bounded():
         & Q.negative_infinite(y)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.negative_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.positive(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.positive(x) & Q.infinite(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.positive(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is False
@@ -909,7 +910,7 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.negative_infinite(y) & Q.negative_infinite(z)) is False
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & Q.negative_infinite(y) & ~Q.finite(z)) is None
+        & Q.negative_infinite(y) & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.negative_infinite(y)& Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
@@ -919,15 +920,15 @@ def test_bounded():
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.negative_infinite(y) & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & ~Q.finite(y) & ~Q.finite(z)) is None
+        & Q.infinite(y) & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & ~Q.finite(y) & Q.positive_infinite(z)) is None
+        & Q.infinite(y) & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & ~Q.finite(y) & Q.extended_negative(z)) is None
+        & Q.infinite(y) & Q.extended_negative(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & ~Q.finite(y)) is None
+        & Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
-        & ~Q.finite(y) & Q.extended_positive(z)) is None
+        & Q.infinite(y) & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.positive_infinite(y) & Q.positive_infinite(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
@@ -947,33 +948,33 @@ def test_bounded():
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.negative_infinite(x)
         & Q.extended_positive(y) & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(z)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(z)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(y)
         & Q.positive_infinite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x)
+    assert ask(Q.finite(a), Q.infinite(x)
         & Q.positive_infinite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.positive_infinite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.positive_infinite(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.extended_negative(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.extended_negative(y)
         & Q.extended_negative(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x)
+    assert ask(Q.finite(a), Q.infinite(x)
         & Q.extended_negative(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.extended_negative(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.extended_negative(y)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x)) is None
-    assert ask(Q.finite(a), ~Q.finite(x)
+    assert ask(Q.finite(a), Q.infinite(x)) is None
+    assert ask(Q.finite(a), Q.infinite(x)
         & Q.extended_positive(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.extended_positive(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.extended_positive(y)
         & Q.extended_positive(z)) is None
     assert ask(Q.finite(a), Q.positive_infinite(x)
         & Q.positive_infinite(y) & Q.positive_infinite(z)) is False
@@ -1019,54 +1020,54 @@ def test_bounded():
     a = x*y
     x, y = a.args
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)) is True
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is False
-    assert ask(Q.finite(a), ~Q.finite(x)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is False
+    assert ask(Q.finite(a), Q.infinite(x)) is None
     assert ask(Q.finite(a), Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(y)) is None
     assert ask(Q.finite(a)) is None
     a = x*y*z
     x, y, z = a.args
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
         & Q.finite(z)) is True
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)
-        & ~Q.finite(z)) is None
+        & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(y)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
         & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.finite(x) & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(x) & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.finite(x) & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.finite(x)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)
         & Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)
-        & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
+    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)
+        & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
         & Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)
-        & ~Q.finite(z)) is False
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x) & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(x)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)
+        & Q.infinite(z)) is False
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(x) & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(x)) is None
     assert ask(Q.finite(a), Q.finite(y) & Q.finite(z)) is None
-    assert ask(Q.finite(a), Q.finite(y) & ~Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.finite(y) & Q.infinite(z)) is None
     assert ask(Q.finite(a), Q.finite(y)) is None
-    assert ask(Q.finite(a), ~Q.finite(y) & Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(y) & ~Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(y)) is None
+    assert ask(Q.finite(a), Q.infinite(y) & Q.finite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(y) & Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(y)) is None
     assert ask(Q.finite(a), Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(z)) is None
-    assert ask(Q.finite(a), ~Q.finite(z) & Q.extended_nonzero(x)
+    assert ask(Q.finite(a), Q.infinite(z)) is None
+    assert ask(Q.finite(a), Q.infinite(z) & Q.extended_nonzero(x)
         & Q.extended_nonzero(y) & Q.extended_nonzero(z)) is None
-    assert ask(Q.finite(a), Q.extended_nonzero(x) & ~Q.finite(y)
-        & Q.extended_nonzero(y) & ~Q.finite(z)
+    assert ask(Q.finite(a), Q.extended_nonzero(x) & Q.infinite(y)
+        & Q.extended_nonzero(y) & Q.infinite(z)
         & Q.extended_nonzero(z)) is False
 
     x, y, z = symbols('x,y,z')
@@ -1079,12 +1080,12 @@ def test_bounded():
     assert ask(Q.finite(S.Half ** x), Q.extended_negative(x)) is None
     assert ask(Q.finite(2**x), Q.extended_negative(x)) is True
     assert ask(Q.finite(sqrt(x))) is None
-    assert ask(Q.finite(2**x), ~Q.finite(x)) is False
-    assert ask(Q.finite(x**2), ~Q.finite(x)) is False
+    assert ask(Q.finite(2**x), Q.infinite(x)) is False
+    assert ask(Q.finite(x**2), Q.infinite(x)) is False
 
     # sign function
     assert ask(Q.finite(sign(x))) is True
-    assert ask(Q.finite(sign(x)), ~Q.finite(x)) is True
+    assert ask(Q.finite(sign(x)), Q.infinite(x)) is True
 
     # exponential functions
     assert ask(Q.finite(log(x))) is None
@@ -1098,9 +1099,9 @@ def test_bounded():
 
     # trigonometric functions
     assert ask(Q.finite(sin(x))) is True
-    assert ask(Q.finite(sin(x)), ~Q.finite(x)) is True
+    assert ask(Q.finite(sin(x)), Q.infinite(x)) is True
     assert ask(Q.finite(cos(x))) is True
-    assert ask(Q.finite(cos(x)), ~Q.finite(x)) is True
+    assert ask(Q.finite(cos(x)), Q.infinite(x)) is True
     assert ask(Q.finite(2*sin(x))) is True
     assert ask(Q.finite(sin(x)**2)) is True
     assert ask(Q.finite(cos(x)**2)) is True
@@ -1111,6 +1112,14 @@ def test_issue_27441():
     # https://github.com/sympy/sympy/issues/27441
     assert ask(Q.composite(y), Q.integer(y) & Q.positive(y) & ~Q.prime(y)) is None
 
+def test_issue_27447():
+    x = Symbol('x', finite=True)
+    y = Symbol('y', finite=True, nonzero=True)
+    # https://github.com/sympy/sympy/issues/27447
+    assert ask(Q.finite(Mul(x, oo))) is None
+    assert ask(Q.finite(Mul(y, oo))) is False
+    assert ask(Q.finite(Mul(oo, oo))) is False
+    assert ask(Q.finite(Mul(0, oo))) is None
 
 @XFAIL
 def test_bounded_xfail():


### PR DESCRIPTION
## Fixes #27447

#### Brief description of what is fixed or changed
Previously, in a Mul expression, if any argument was unbounded (infinite), the result would immediately be False, ignoring cases where a finite argument could be zero. However, if the finite argument is zero, the correct result should be None (undefined).

This PR accounts for that case and ensures the correct behavior by returning None when the finite argument’s value cannot be determined as nonzero.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Make Q.finite(Mul(...)) return `None` when a finite argument’s nonzero status is indeterminate instead of `False`.

<!-- END RELEASE NOTES -->
