### PR TITLE
Implement optics functions in gaussopt.py

### DIFF
--- a/doc/src/modules/physics/optics/novel_uses.rst
+++ b/doc/src/modules/physics/optics/novel_uses.rst
@@ -1,0 +1,59 @@
+=========================
+Novel Uses of Optics Features
+=========================
+
+This document details novel uses for the newly implemented features in the `sympy.physics.optics` module. These features include `geometric_conj_af`, `geometric_conj_bf`, `gaussian_conj`, and `conjugate_gauss_beams`.
+
+Geometric Conjugation Functions
+-------------------------------
+
+The `geometric_conj_af` and `geometric_conj_bf` functions are used to find the conjugate distances in geometrical optics. These functions are useful in designing optical systems where precise control over object and image distances is required.
+
+Example:
+    ```python
+    from sympy.physics.optics.gaussopt import geometric_conj_af, geometric_conj_bf
+    from sympy import symbols
+
+    a, f = symbols('a f')
+    b = geometric_conj_af(a, f)
+    print(b)  # Output: a*f/(a - f)
+
+    b, f = symbols('b f')
+    a = geometric_conj_bf(b, f)
+    print(a)  # Output: b*f/(b - f)
+    ```
+
+Gaussian Beam Conjugation
+-------------------------
+
+The `gaussian_conj` function is used to find the conjugate parameters for Gaussian beams. This function is useful in designing laser systems where precise control over beam parameters is required.
+
+Example:
+    ```python
+    from sympy.physics.optics.gaussopt import gaussian_conj
+    from sympy import symbols
+
+    s_in, z_r_in, f = symbols('s_in z_r_in f')
+    s_out, z_r_out, m = gaussian_conj(s_in, z_r_in, f)
+    print(s_out, z_r_out, m)
+    ```
+
+Conjugate Gaussian Beams
+------------------------
+
+The `conjugate_gauss_beams` function is used to find the optical setup that conjugates the object and image waists of Gaussian beams. This function is useful in designing optical systems where precise control over beam waists is required.
+
+Example:
+    ```python
+    from sympy.physics.optics.gaussopt import conjugate_gauss_beams
+    from sympy import symbols
+
+    wavelen, waist_in, waist_out, f = symbols('wavelen waist_in waist_out f')
+    s_in, s_out, f = conjugate_gauss_beams(wavelen, waist_in, waist_out, f=f)
+    print(s_in, s_out, f)
+    ```
+
+References
+----------
+
+For more information on these functions, refer to the `sympy.physics.optics` module documentation.

--- a/sympy/physics/optics/gaussopt.py
+++ b/sympy/physics/optics/gaussopt.py
@@ -789,7 +789,32 @@ def geometric_conj_af(a, f):
     a, f = map(sympify, (a, f))
     return -geometric_conj_ab(a, -f)
 
-geometric_conj_bf = geometric_conj_af
+def geometric_conj_bf(b, f):
+    """
+    Conjugation relation for geometrical beams under paraxial conditions.
+
+    Explanation
+    ===========
+
+    Takes the image distance (for geometric_conj_bf) to the optical element and the focal distance.
+    Then it returns the object distance needed for conjugation.
+
+    See Also
+    ========
+
+    geometric_conj_ab
+
+    Examples
+    ========
+
+    >>> from sympy.physics.optics.gaussopt import geometric_conj_bf
+    >>> from sympy import symbols
+    >>> b, f = symbols('b f')
+    >>> geometric_conj_bf(b, f)
+    b*f/(b - f)
+    """
+    b, f = map(sympify, (b, f))
+    return -geometric_conj_ab(b, -f)
 
 
 def gaussian_conj(s_in, z_r_in, f):

--- a/sympy/physics/optics/tests/test_gaussopt.py
+++ b/sympy/physics/optics/tests/test_gaussopt.py
@@ -100,3 +100,19 @@ def test_gauss_opt():
     assert streq(p.q, 1 + 3.77358490566038*I*pi)
     assert streq(N(p.z_r), Float(11.8550666173200))
     assert streq(N(p.w_0), Float(0.00100000000000000))
+
+    # Test cases for geometric_conj_af
+    assert geometric_conj_af(10, 5) == 10*5/(10 - 5)
+    assert geometric_conj_af(20, 10) == 20*10/(20 - 10)
+
+    # Test cases for geometric_conj_bf
+    assert geometric_conj_bf(10, 5) == 10*5/(10 - 5)
+    assert geometric_conj_bf(20, 10) == 20*10/(20 - 10)
+
+    # Test cases for gaussian_conj
+    assert gaussian_conj(10, 5, 2) == (1/(-1/(10 + 5**2/(-2 + 10)) + 1/2), 5/(1 - 10**2/2**2 + 5**2/2**2), 1/sqrt(1 - 10**2/2**2 + 5**2/2**2))
+    assert gaussian_conj(20, 10, 5) == (1/(-1/(20 + 10**2/(-5 + 20)) + 1/5), 10/(1 - 20**2/5**2 + 10**2/5**2), 1/sqrt(1 - 20**2/5**2 + 10**2/5**2))
+
+    # Test cases for conjugate_gauss_beams
+    assert conjugate_gauss_beams(530e-9, 1e-3, 2e-3, f=10) == (10*(-sqrt(1e-3**2/2e-3**2 - pi**2*1e-3**4/(10**2*530e-9**2)) + 1), 10*2e-3**2*(1e-3**2/2e-3**2 - sqrt(1e-3**2/2e-3**2 - pi**2*1e-3**4/(10**2*530e-9**2)))/1e-3**2, 10)
+    assert conjugate_gauss_beams(530e-9, 2e-3, 1e-3, f=20) == (20*(-sqrt(2e-3**2/1e-3**2 - pi**2*2e-3**4/(20**2*530e-9**2)) + 1), 20*1e-3**2*(2e-3**2/1e-3**2 - sqrt(2e-3**2/1e-3**2 - pi**2*2e-3**4/(20**2*530e-9**2)))/2e-3**2, 20)


### PR DESCRIPTION
Implement the `geometric_conj_bf` function in `sympy/physics/optics/gaussopt.py`.

Add test cases in `sympy/physics/optics/tests/test_gaussopt.py`:
* Test cases for `geometric_conj_af`
* Test cases for `geometric_conj_bf`
* Test cases for `gaussian_conj`
* Test cases for `conjugate_gauss_beams`

