### PR TITLE
Conjugate scalars in dagger

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -967,6 +967,8 @@ Mark Jeromin <mark.jeromin@sysfrog.net>
 Mark Shoulson <mark@kli.org>
 Mark van Gelder <m.j.vangelder@student.tudelft.nl>
 Mark van Gelder <mvgmvgmvg@live.com> mvg2002 <168417631+mvg2002@users.noreply.github.com>
+Matt Ord <matthew.ord1@gmail.com>
+Matt Ord <matthew.ord1@gmail.com> Matt Ord <55235095+Matt-Ord@users.noreply.github.com>
 Markus Mohrhard <markus.mohrhard@googlemail.com>
 Markus Müller <markus.mueller.1.g@googlemail.com>
 Martha Giannoudovardi <maapxa@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -967,8 +967,6 @@ Mark Jeromin <mark.jeromin@sysfrog.net>
 Mark Shoulson <mark@kli.org>
 Mark van Gelder <m.j.vangelder@student.tudelft.nl>
 Mark van Gelder <mvgmvgmvg@live.com> mvg2002 <168417631+mvg2002@users.noreply.github.com>
-Matt Ord <matthew.ord1@gmail.com>
-Matt Ord <matthew.ord1@gmail.com> Matt Ord <55235095+Matt-Ord@users.noreply.github.com>
 Markus Mohrhard <markus.mohrhard@googlemail.com>
 Markus Müller <markus.mueller.1.g@googlemail.com>
 Martha Giannoudovardi <maapxa@gmail.com>
@@ -985,6 +983,8 @@ Mathias Louboutin <mathias.louboutin@gmail.com>
 Matt Bogosian <matt@bogosian.net>
 Matt Curry <mattjcurry@gmail.com>
 Matt Habel <habelinc@gmail.com>
+Matt Ord <matthew.ord1@gmail.com>
+Matt Ord <matthew.ord1@gmail.com> Matt Ord <55235095+Matt-Ord@users.noreply.github.com>
 Matt Rajca <matt.rajca@me.com>
 Matt Wang <mattwang44@gmail.com>
 Matthew Brett <matthew.brett@gmail.com>

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -145,12 +145,15 @@ class Dagger(Expr):
                 return Add(*tuple(map(Dagger, arg.args)))
             if arg.is_Mul:
                 return Mul(*tuple(map(Dagger, reversed(arg.args))))
-            if arg.is_Number or arg.is_scalar:
-                return conjugate(arg)
+            if arg.is_Number:
+                return arg
             if arg.is_Pow:
                 return Pow(Dagger(arg.args[0]), arg.args[1])
             if arg == I:
                 return -arg
+        if isinstance(arg, Function):
+            if all(a.is_commutative for a in arg.args):
+                return arg.func(*[Dagger(a) for a in arg.args])
         else:
             return None
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -19,7 +19,6 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
-from sympy.functions.elementary.complexes import conjugate
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.dense import zeros

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -19,6 +19,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
+from sympy.functions.elementary.complexes import conjugate
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.dense import zeros
@@ -144,8 +145,8 @@ class Dagger(Expr):
                 return Add(*tuple(map(Dagger, arg.args)))
             if arg.is_Mul:
                 return Mul(*tuple(map(Dagger, reversed(arg.args))))
-            if arg.is_Number:
-                return arg
+            if arg.is_Number or arg.is_scalar:
+                return conjugate(arg)
             if arg.is_Pow:
                 return Pow(Dagger(arg.args[0]), arg.args[1])
             if arg == I:

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -19,6 +19,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
+from sympy.functions.elementary.complexes import conjugate
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.dense import zeros
@@ -139,6 +140,8 @@ class Dagger(Expr):
         dagger = getattr(arg, '_dagger_', None)
         if dagger is not None:
             return dagger()
+        if isinstance(arg, Symbol) and arg.is_commutative:
+            return conjugate(arg)
         if isinstance(arg, Basic):
             if arg.is_Add:
                 return Add(*tuple(map(Dagger, arg.args)))

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -90,8 +90,7 @@ def test_dagger():
     assert Dagger('a') == Dagger(Symbol('a'))
     assert Dagger(Dagger('a')) == Symbol('a')
     assert Dagger(exp(2 * I)) == exp(-2 * I)
-    s = symbols('s', commutative=True)
-    assert Dagger(s) == conjugate(s)
+    assert Dagger(i) == conjugate(i)
 
 
 def test_operator():

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -1,3 +1,4 @@
+from sympy.functions.elementary.exponential import exp
 from sympy.physics.secondquant import (
     Dagger, Bd, VarBosonicBasis, BBra, B, BKet, FixedBosonicBasis,
     matrix_rep, apply_operators, InnerProduct, Commutator, KroneckerDelta,
@@ -87,6 +88,7 @@ def test_dagger():
     assert Dagger(B(n)**10) == Dagger(B(n))**10
     assert Dagger('a') == Dagger(Symbol('a'))
     assert Dagger(Dagger('a')) == Symbol('a')
+    assert Dagger(exp(2 * I)) == exp(-2 * I)
 
 
 def test_operator():

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -1,3 +1,4 @@
+from sympy.functions.elementary.complexes import conjugate
 from sympy.functions.elementary.exponential import exp
 from sympy.physics.secondquant import (
     Dagger, Bd, VarBosonicBasis, BBra, B, BKet, FixedBosonicBasis,
@@ -89,6 +90,8 @@ def test_dagger():
     assert Dagger('a') == Dagger(Symbol('a'))
     assert Dagger(Dagger('a')) == Symbol('a')
     assert Dagger(exp(2 * I)) == exp(-2 * I)
+    s = symbols('s', commutative=True)
+    assert Dagger(s) == conjugate(s)
 
 
 def test_operator():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Dagger operator does not simplify scalar expressions such as 

```
alpha = sp.symbols("alpha", complex=True)
Dagger(sp.exp(sp.I * alpha ))

```
This becomes an issue when attempting to call apply_operators on 
```
Dagger(sp.exp(sp.I * theta) * CreateBoson(0))
```
as `Dagger(sp.exp(sp.I * theta)` is non commutative. this pr is an attempt to fix this - Let me know if there is a way that is better!

<!-- BEGIN RELEASE NOTES -->
* physics.secondquant
  * Add support for Dagger of a Function

