### PR TITLE
Fix factorial parsing for lark parser

### DIFF
--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -346,7 +346,7 @@ log: FUNC_LOG _expression
 square_root: FUNC_SQRT group_curly_parentheses
     | FUNC_SQRT group_square_brackets group_curly_parentheses
 
-factorial: _expression BANG
+factorial: _expression_func BANG
 
 conjugate: CMD_OVERLINE group_curly_parentheses
     | CMD_OVERLINE DIGIT

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -386,7 +386,8 @@ EVALUATED_FACTORIAL_EXPRESSION_PAIRS = [
     (r"(x + 1)!", factorial(x + 1)),
     (r"(x!)!", factorial(factorial(x))),
     (r"x!!!", factorial(factorial(factorial(x)))),
-    (r"5!7!", factorial(5) * factorial(7))
+    (r"5!7!", factorial(5) * factorial(7)),
+    (r"24! \times 24!", factorial(24) * factorial(24))
 ]
 
 UNEVALUATED_SUM_EXPRESSION_PAIRS = [


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27411

#### Brief description of what is fixed or changed

The issue is that $24! \times 24!$ parses to the double factorial $(24! \times 24)!$, which is $14890761641597746544640000!$.
That is quite large that modern PC can run out of memory.

I think that the easiest fix is that factorial could use stronger operator precedence than parsing add or mul, and should eliminate the choice of ambiguity. For example, $x \times y!$ isn't $(x \times y)!$ and that's quite common convention.

It also looks like trivial issue that $2! \times 2!$ is parsed to `Tree('_ambig', [24, 4])` is a bug. We should avoid `_ambig` output. 
So the problem really lies in the operator precedence. I think that using `_expression_func` is reasonable because it is limited to expressions like numbers, symbols, functions or parenthesis.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - Fixed an issue for lark parser that factorials with multiplication is parsed with ambiguity. For example, $12! \times 12!$. 
<!-- END RELEASE NOTES -->
