### PR TITLE
Tweak .core.relational._canoncial_coeff to fix gh-27538 (alt)

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -52,6 +52,8 @@ def _canonical_coeff(rel):
     rel = rel.canonical
     if not rel.is_Relational or rel.rhs.is_Boolean:
         return rel  # Eq(x, True)
+    if not isinstance(rel.lhs, Expr):
+        return rel.reversed  # e.g.: Eq(True, x) -> Eq(x, True)
     b, l = rel.lhs.as_coeff_Add(rational=True)
     m, lhs = l.as_coeff_Mul(rational=True)
     rhs = (rel.rhs - b)/m

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1335,6 +1335,17 @@ def test_Piecewise_rewrite_as_ITE():
     raises(ValueError, lambda: _ITE((a, x < 2), (b, x > 3)))
 
 
+def test_Piecewise_replace_relational_27538():
+    x, y = symbols('x, y')
+    p1 = Piecewise(
+        (0, Eq(x, True)),
+        (1, True),
+    )
+    p2 = p1.xreplace({x: y < 1})
+    assert p2.subs(y, 0) == 0
+    assert p2.subs(y, 1) == 1
+
+
 def test_issue_14052():
     assert integrate(abs(sin(x)), (x, 0, 2*pi)) == 4
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #27538


#### Brief description of what is fixed or changed
Fixes a regression involving Piecewise and Relationals:
```console-session
  File "/opt-3/cpython-v3.12-apt-deb/lib/python3.12/site-packages/sympy/core/relational.py", line 55, in _canonical_coeff
    b, l = rel.lhs.as_coeff_Add(rational=True)
           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'BooleanTrue' object has no attribute 'as_coeff_Add'
```

#### Other comments
This is an alternative to gh-27539, here we use `isinstance(..., Expr)` instead of `.is_Boolean` for `rel.lhs`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * A bug in Relational was fixed. Previously operations involving an expression like `Eq(y < 1, True)` might raise an exception.
<!-- END RELEASE NOTES -->
