### PR TITLE
 Handle Non-Comparable Terms During Equation Solving

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1715,3 +1715,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sai Kumar <saisk1411@gmail.com> Sai Kumar <143283107+Iamsaikumar14@users.noreply.github.com>
+Sai Kumar <saisk1411@gmail.com> Iamsaikumar14 <saisk1411@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1308,6 +1308,8 @@ Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Sai Kumar <saisk1411@gmail.com> Iamsaikumar14 <saisk1411@gmail.com>
+Sai Kumar <saisk1411@gmail.com> Sai Kumar <143283107+Iamsaikumar14@users.noreply.github.com>
 Sai Nikhil <tsnlegend@gmail.com>
 Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saicharan <saicharanhahaha@gmail.com>
@@ -1715,5 +1717,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sai Kumar <saisk1411@gmail.com> Sai Kumar <143283107+Iamsaikumar14@users.noreply.github.com>
-Sai Kumar <saisk1411@gmail.com> Iamsaikumar14 <saisk1411@gmail.com>

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1431,7 +1431,8 @@ def _solve(f, *symbols, **flags):
                     if _eval_simplify is not None:
                         # unconditionally take the simplification of v
                         v = _eval_simplify(ratio=2, measure=lambda x: 1)
-                except TypeError:
+                except (TypeError, ValueError):
+
                     # incompatible type with condition(s)
                     continue
                 if v == False:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1432,7 +1432,6 @@ def _solve(f, *symbols, **flags):
                         # unconditionally take the simplification of v
                         v = _eval_simplify(ratio=2, measure=lambda x: 1)
                 except (TypeError, ValueError):
-
                     # incompatible type with condition(s)
                     continue
                 if v == False:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2713,8 +2713,6 @@ def test_solve_Piecewise():
         (0, x < 10),  # this will simplify away
         (S.NaN,True)))
 
-from sympy import Abs, log, Symbol, solve
-
 def test_issue_27233():
 
     eq1 = (x**2 - 6*x + y**2 + 9) * log(Abs(x) - Abs(y) - 2)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2724,5 +2724,3 @@ def test_issue_27233():
     assert solutions == [
         {x: 3, y: 0}, {x: -3, y: 0}
     ]
-
-

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2715,6 +2715,8 @@ def test_solve_Piecewise():
 
 def test_issue_27233():
 
+    x, y = symbols('x y', real=True)
+
     eq1 = (x**2 - 6*x + y**2 + 9) * log(Abs(x) - Abs(y) - 2)
     eq2 = x**2 - y
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2712,3 +2712,17 @@ def test_solve_Piecewise():
         (46*x - 3*(x - 6)**2/2 - 276, (x >= 6) & (x < 10)),
         (0, x < 10),  # this will simplify away
         (S.NaN,True)))
+
+from sympy import Abs, log, Symbol, solve
+
+def test_issue_27233():
+
+    eq1 = (x**2 - 6*x + y**2 + 9) * log(Abs(x) - Abs(y) - 2)
+    eq2 = x**2 - y
+
+    solutions = solve([eq1, eq2], [x, y])
+    assert solutions == [
+        {x: 3, y: 0}, {x: -3, y: 0}
+    ]
+
+


### PR DESCRIPTION

**References to other Issues or PRs**

Fixes #27233

**Brief description of what is fixed or changed**

This change resolves an issue where solving certain symbolic systems in SymPy would raise a ValueError due to non-comparable terms, particularly when using logarithms with absolute values. The issue arises when the solver encounters expressions that involve complex or non-comparable terms. This fix improves the solver’s robustness by handling these cases without throwing exceptions.

**Other comments**

With this fix, the solver now processes the given equations properly and avoids errors related to incompatible terms. Additional tests have been added to verify that the issue is resolved, ensuring reliable behavior for similar cases in the future.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
