### PR TITLE
Remove unnecessary casts to ints

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1527,7 +1527,7 @@ def evalf(x: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
             # convert (approximately) from given tolerance;
             # the formula here will will make 1e-i rounds to 0 for
             # i in the range +/-27 while 2e-i will not be chopped
-            chop_prec = int(round(-3.321*math.log10(chop) + 2.5))
+            chop_prec = round(-3.321*math.log10(chop) + 2.5)
             if chop_prec == 3:
                 chop_prec -= 1
         r = chop_parts(r, chop_prec)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4103,9 +4103,9 @@ def _mag(x):
     if not xpos:
         return S.Zero
     try:
-        mag_first_dig = int(ceil(log10(xpos)))
+        mag_first_dig = ceil(log10(xpos))
     except (ValueError, OverflowError):
-        mag_first_dig = int(ceil(Float(mpf_log(xpos._mpf_, 53))/log(10)))
+        mag_first_dig = ceil(Float(mpf_log(xpos._mpf_, 53))/log(10))
     # check that we aren't off by 1
     if (xpos/S(10)**mag_first_dig) >= 1:
         assert 1 <= (xpos/S(10)**mag_first_dig) < 10

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -214,7 +214,7 @@ def _pi_coeff(arg: Expr, cycles: int = 1) -> tUnion[Expr, None]:
                 # recast exact binary fractions to Rationals
                 f = abs(c) % 1
                 if f != 0:
-                    p = -int(round(log(f, 2).evalf()))
+                    p = -round(log(f, 2).evalf())
                     m = 2**p
                     cm = c*m
                     i = int(cm)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -225,7 +225,7 @@ def test_matexpr_indexing():
 def test_single_indexing():
     A = MatrixSymbol('A', 2, 3)
     assert A[1] == A[0, 1]
-    assert A[int(1)] == A[0, 1]
+    assert A[(1)] == A[0, 1]
     assert A[3] == A[1, 0]
     assert list(A[:2, :2]) == [A[0, 0], A[0, 1], A[1, 0], A[1, 1]]
     raises(IndexError, lambda: A[6])

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1410,7 +1410,7 @@ def dup_revert(f, n, K):
     g = [K.revert(dup_TC(f, K))]
     h = [K.one, K.zero, K.zero]
 
-    N = int(_ceil(_log2(n)))
+    N = _ceil(_log2(n))
 
     for i in range(1, N + 1):
         a = dup_mul_ground(g, K(2), K)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -299,7 +299,7 @@ def dup_zz_hensel_lift(p, f, f_list, l, K):
 
     m = p
     k = r // 2
-    d = int(_ceil(_log2(l)))
+    d = _ceil(_log2(l))
 
     g = gf_from_int_poly([lc], p)
 
@@ -345,7 +345,7 @@ def dup_zz_zassenhaus(f, K):
     b = dup_LC(f, K)
     B = int(abs(K.sqrt(K(n + 1))*2**n*A*b))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
-    gamma = int(_ceil(2*_log2(C)))
+    gamma = _ceil(2*_log2(C))
     bound = int(2*gamma*_log(gamma))
     a = []
     # choose a prime number `p` such that `f` be square free in Z_p
@@ -367,7 +367,7 @@ def dup_zz_zassenhaus(f, K):
             break
     p, fsqf = min(a, key=lambda x: len(x[1]))
 
-    l = int(_ceil(_log(2*B + 1, p)))
+    l = _ceil(_log(2*B + 1, p))
 
     modular = [gf_to_int_poly(ff, p) for ff in fsqf]
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1984,7 +1984,7 @@ def gf_ddf_shoup(f, p, K):
 
     """
     n = gf_degree(f)
-    k = int(_ceil(_sqrt(n//2)))
+    k = _ceil(_sqrt(n//2))
     b = gf_frobenius_monomial_base(f, p, K)
     h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
     # U[i] = x**(p**i)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -450,7 +450,7 @@ def _inv_totient_estimate(m):
         b *= p - 1
 
     L = m
-    U = int(math.ceil(m*(float(a)/b)))
+    U = math.ceil(m*(float(a)/b))
 
     P = p = 2
     primes = []
@@ -466,7 +466,7 @@ def _inv_totient_estimate(m):
     for p in primes[:-1]:
         b *= p - 1
 
-    U = int(math.ceil(m*(float(P)/b)))
+    U = math.ceil(m*(float(P)/b))
 
     return L, U
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2320,7 +2320,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
                 integrand = z**s
                 for b in bm:
                     if not Mod(b, 1) and b.is_Number:
-                        b = int(round(b))
+                        b = round(b)
                     integrand *= gamma(b - s)
                 for a in an:
                     integrand *= gamma(1 - a + s)
@@ -2332,7 +2332,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
                 # Now sum the finitely many residues:
                 # XXX This speeds up some cases - is it a good idea?
                 integrand = expand_func(integrand)
-                for r in range(int(round(lu))):
+                for r in range(round(lu)):
                     resid = residue(integrand, s, b_ + r)
                     resid = apply_operators(resid, ops, lambda f: z*f.diff(z))
                     res -= resid


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
