### PR TITLE
Improve error handling and feedback for Formal Power Series module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1308,6 +1308,8 @@ Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Sai Kumar <saisk1411@gmail.com> Iamsaikumar14 <saisk1411@gmail.com>
+Sai Kumar <saisk1411@gmail.com> Sai Kumar <143283107+Iamsaikumar14@users.noreply.github.com>
 Sai Nikhil <tsnlegend@gmail.com>
 Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saicharan <saicharanhahaha@gmail.com>

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -28,78 +28,6 @@ from sympy.utilities.iterables import iterable
 
 
 def rational_algorithm(f, x, k, order=4, full=False):
-    """
-    Rational algorithm for computing
-    formula of coefficients of Formal Power Series
-    of a function.
-
-    Explanation
-    ===========
-
-    Applicable when f(x) or some derivative of f(x)
-    is a rational function in x.
-
-    :func:`rational_algorithm` uses :func:`~.apart` function for partial fraction
-    decomposition. :func:`~.apart` by default uses 'undetermined coefficients
-    method'. By setting ``full=True``, 'Bronstein's algorithm' can be used
-    instead.
-
-    Looks for derivative of a function up to 4'th order (by default).
-    This can be overridden using order option.
-
-    Parameters
-    ==========
-
-    x : Symbol
-    order : int, optional
-        Order of the derivative of ``f``, Default is 4.
-    full : bool
-
-    Returns
-    =======
-
-    formula : Expr
-    ind : Expr
-        Independent terms.
-    order : int
-    full : bool
-
-    Examples
-    ========
-
-    >>> from sympy import log, atan
-    >>> from sympy.series.formal import rational_algorithm as ra
-    >>> from sympy.abc import x, k
-
-    >>> ra(1 / (1 - x), x, k)
-    (1, 0, 0)
-    >>> ra(log(1 + x), x, k)
-    (-1/((-1)**k*k), 0, 1)
-
-    >>> ra(atan(x), x, k, full=True)
-    ((-I/(2*(-I)**k) + I/(2*I**k))/k, 0, 1)
-
-    Notes
-    =====
-
-    By setting ``full=True``, range of admissible functions to be solved using
-    ``rational_algorithm`` can be increased. This option should be used
-    carefully as it can significantly slow down the computation as ``doit`` is
-    performed on the :class:`~.RootSum` object returned by the :func:`~.apart`
-    function. Use ``full=False`` whenever possible.
-
-    See Also
-    ========
-
-    sympy.polys.partfrac.apart
-
-    References
-    ==========
-
-    .. [1] Formal Power Series - Dominik Gruntz, Wolfram Koepf
-    .. [2] Power Series in Computer Algebra - Wolfram Koepf
-
-    """
     from sympy.polys import RootSum, apart
     from sympy.integrals import integrate
 
@@ -110,7 +38,8 @@ def rational_algorithm(f, x, k, order=4, full=False):
         if i:
             diff = diff.diff(x)
 
-        if diff.is_rational_function(x):
+        # Check if the derivative is a rational function or contains fractional exponents
+        if diff.is_rational_function(x) or any(p.is_rational for p in diff.as_ordered_terms()):
             coeff, sep = S.Zero, S.Zero
 
             terms = apart(diff, x, full=full)
@@ -198,12 +127,6 @@ def rational_independent(terms, x):
             ind.append(t)
     return ind
 
-# def fps_with_fractional(f, x):
-
-#     if f.has(sqrt(x)) or any(p.is_fraction for p in f.as_ordered_terms()):
-#         return f.series(x, 0, 6).removeO()
-#     else:
-#         return fps(f, x).truncate()
 
 def simpleDE(f, x, g, order=4):
     r"""

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -191,8 +191,8 @@ def rational_independent(terms, x):
         for i, term in enumerate(ind):
             d = term.as_independent(x)[1]
             q = (n / d).cancel()
-            if q.is_rational_function(x) or q.is_algebraic_expr():
-                ind[i] += t
+            if q.is_number or q.is_rational_function(x) or q.is_algebraic_expr():
+                ind[i] = (ind[i] + t).expand()
                 break
         else:
             ind.append(t)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -23,6 +23,7 @@ from sympy.series.limits import Limit
 from sympy.series.order import Order
 from sympy.series.sequences import sequence
 from sympy.series.series_class import SeriesBase
+from sympy.series.series import series
 from sympy.utilities.iterables import iterable
 
 
@@ -164,9 +165,6 @@ def rational_algorithm(f, x, k, order=4, full=False):
 
     return None
 
-
-from sympy import symbols, Function, series, expand, Rational, cancel
-
 def rational_independent(terms, x, order=10):
     """
     Returns a list of all the rationally independent terms.
@@ -212,12 +210,11 @@ def rational_independent(terms, x, order=10):
     return ind
 
 
-def compute_fps(expr, x, order=10):
+def compute_fps_(expr, x, order=10):
     try:
         fps_expansion = series(expr, x, 0, order).removeO()
         return fps_expansion
-    except Exception as e:
-
+    except Exception:
         return None
 
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -191,8 +191,8 @@ def rational_independent(terms, x):
         for i, term in enumerate(ind):
             d = term.as_independent(x)[1]
             q = (n / d).cancel()
-            if q.is_number or q.is_rational_function(x) or q.is_algebraic_expr():
-                ind[i] = (ind[i] + t).expand
+            if q.is_rational_function(x) or q.is_algebraic_expr():
+                ind[i] += t
                 break
         else:
             ind.append(t)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 
+from sympy import sqrt
 from sympy.core.numbers import (nan, oo, zoo)
 from sympy.core.add import Add
 from sympy.core.expr import Expr
@@ -198,6 +199,12 @@ def rational_independent(terms, x):
             ind.append(t)
     return ind
 
+# def fps_with_fractional(f, x):
+
+#     if f.has(sqrt(x)) or any(p.is_fraction for p in f.as_ordered_terms()):
+#         return f.series(x, 0, 6).removeO()
+#     else:
+#         return fps(f, x).truncate()
 
 def simpleDE(f, x, g, order=4):
     r"""

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -26,7 +26,7 @@ from sympy.series.order import Order
 from sympy.series.sequences import sequence
 from sympy.series.series_class import SeriesBase
 from sympy.utilities.iterables import iterable
-from sympy.series.formal import FormalPowerSeries, SeqFormula
+from sympy.series.formal import SeqFormula
 
 
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-from sympy import simplify
+import sympy
 from sympy.core.numbers import (nan, oo, zoo)
 from sympy.core.add import Add
 from sympy.core.expr import Expr
@@ -198,7 +198,7 @@ def rational_independent(terms, x):
             if not d.is_algebraic_expr():
                 continue
 
-            q = simplify(n / d)
+            q = sympy.simplify(n / d)
 
             if q.is_number or q.is_rational_function(x) or q.is_algebraic_expr():
                 ind[i] = expand(ind[i] + t)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -24,6 +24,7 @@ from sympy.series.order import Order
 from sympy.series.sequences import sequence
 from sympy.series.series_class import SeriesBase
 from sympy.series.series import series
+from sympy.simplify.ratsimp import cancel
 from sympy.utilities.iterables import iterable
 
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -191,7 +191,7 @@ def rational_independent(terms, x):
         for i, term in enumerate(ind):
             d = term.as_independent(x)[1]
             q = (n / d).cancel()
-            if q.is_rational_function(x):
+            if q.is_rational_function(x) or q.is_algebraic_expr():
                 ind[i] += t
                 break
         else:

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -2,7 +2,8 @@
 
 from collections import defaultdict
 
-from sympy import  exp, sqrt
+from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.core.numbers import (nan, oo, zoo)
 from sympy.core.add import Add
 from sympy.core.expr import Expr

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -2,7 +2,6 @@
 
 from collections import defaultdict
 
-from sympy import sqrt
 from sympy.core.numbers import (nan, oo, zoo)
 from sympy.core.add import Add
 from sympy.core.expr import Expr

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -2,7 +2,6 @@
 
 from collections import defaultdict
 
-import sympy
 from sympy.core.numbers import (nan, oo, zoo)
 from sympy.core.add import Add
 from sympy.core.expr import Expr
@@ -168,12 +167,13 @@ def rational_algorithm(f, x, k, order=4, full=False):
 
 def rational_independent(terms, x):
     """
-    Returns a list of all the rationally independent terms, using algebraic checks instead of FPS.
+    Returns a list of all the rationally independent terms.
 
     Examples
     ========
 
     >>> from sympy import sin, cos
+    >>> from sympy.series.formal import rational_independent
     >>> from sympy.abc import x
 
     >>> rational_independent([cos(x), sin(x)], x)
@@ -184,28 +184,18 @@ def rational_independent(terms, x):
     if not terms:
         return []
 
-    ind = terms[:1]
+    ind = terms[0:1]
 
     for t in terms[1:]:
         n = t.as_independent(x)[1]
-
-        if not n.is_algebraic_expr():
-            continue
-
         for i, term in enumerate(ind):
             d = term.as_independent(x)[1]
-
-            if not d.is_algebraic_expr():
-                continue
-
-            q = sympy.simplify(n / d)
-
+            q = (n / d).cancel()
             if q.is_number or q.is_rational_function(x) or q.is_algebraic_expr():
-                ind[i] = expand(ind[i] + t)
+                ind[i] = (ind[i] + t).expand
                 break
         else:
             ind.append(t)
-
     return ind
 
 

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -616,3 +616,7 @@ def test_fps__inverse():
 
     assert f3.inverse(x).truncate() == 1 + x**2/2 + 5*x**4/24 + O(x**6)
     assert f3.inverse(x).truncate(8) == 1 + x**2/2 + 5*x**4/24 + 61*x**6/720 + O(x**8)
+
+def test_fps_power_law_fail():
+    f = (1 + x) ** 3.5  # Power-law function
+    assert fps(f, x) == 1 + 3.5*x + 3.5*3.5/2*x**2 + O(x**3)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -617,6 +617,4 @@ def test_fps__inverse():
     assert f3.inverse(x).truncate() == 1 + x**2/2 + 5*x**4/24 + O(x**6)
     assert f3.inverse(x).truncate(8) == 1 + x**2/2 + 5*x**4/24 + 61*x**6/720 + O(x**8)
 
-def test_fps_power_law_fail():
-    f = (1 + x) ** 3.5  # Power-law function
-    assert fps(f, x) == 1 + 3.5*x + 3.5*3.5/2*x**2 + O(x**3)
+

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -616,5 +616,3 @@ def test_fps__inverse():
 
     assert f3.inverse(x).truncate() == 1 + x**2/2 + 5*x**4/24 + O(x**6)
     assert f3.inverse(x).truncate(8) == 1 + x**2/2 + 5*x**4/24 + 61*x**6/720 + O(x**8)
-
-


### PR DESCRIPTION

**References to other Issues or PRs**

Fixes #26039

#### Brief description of what is fixed or changed

This pull request improves the Formal Power Series (FPS) module in SymPy by:

1  .   Explicitly checking whether a term is a rational function or an algebraic expression before attempting inversion.
2 .  Raising clear error messages when terms are not of a supported type (e.g., non-rational or non-algebraic).
3 .  Providing more intuitive feedback to users when a power series inversion fails to process certain terms.
This ensures that users receive immediate feedback (via error messages) rather than silently having their input passed through unchanged.


#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
