### PR TITLE
Added cmath support for lambdify and implemented CmathPrinter 

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -633,6 +633,68 @@ def pycode(expr, **settings):
     return PythonCodePrinter(settings).doprint(expr)
 
 
+from itertools import chain
+from sympy.printing.pycode import PythonCodePrinter
+
+_known_functions_cmath = {
+    'exp': 'exp',
+    'sqrt': 'sqrt',
+    'log': 'log',
+    'cos': 'cos',
+    'sin': 'sin',
+    'tan': 'tan',
+    'acos': 'acos',
+    'asin': 'asin',
+    'atan': 'atan',
+    'cosh': 'cosh',
+    'sinh': 'sinh',
+    'tanh': 'tanh',
+    'acosh': 'acosh',
+    'asinh': 'asinh',
+    'atanh': 'atanh',
+}
+
+_known_constants_cmath = {
+    'Pi': 'pi',
+    'E': 'e',
+    'Infinity': 'inf',
+    'NegativeInfinity': '-inf',
+}
+
+class CmathPrinter(PythonCodePrinter):
+    """ Printer for Python's cmath module """
+    printmethod = "_cmathcode"
+    language = "Python with cmath"
+
+    _kf = dict(chain(
+        _known_functions_cmath.items()
+    ))
+
+    _kc = {k: 'cmath.' + v for k, v in _known_constants_cmath.items()}
+
+    def _print_Pow(self, expr, rational=False):
+        return self._hprint_Pow(expr, rational=rational, sqrt='cmath.sqrt')
+
+    def _print_Float(self, e):
+        return '{func}({val})'.format(func=self._module_format('cmath.mpf'), val=self._print(e))
+
+    def _print_known_func(self, expr):
+        func_name = expr.func.__name__
+        if func_name in self._kf:
+            return f"cmath.{self._kf[func_name]}({', '.join(map(self._print, expr.args))})"
+        return super()._print_Function(expr)
+
+    def _print_known_const(self, expr):
+        return self._kc[expr.__class__.__name__]
+
+
+for k in CmathPrinter._kf:
+    setattr(CmathPrinter, '_print_%s' % k, CmathPrinter._print_known_func)
+
+for k in _known_constants_cmath:
+    setattr(CmathPrinter, '_print_%s' % k, CmathPrinter._print_known_const)
+
+
 _not_in_mpmath = 'log1p log2'.split()
 _in_mpmath = [(k, v) for k, v in _known_functions_math.items() if k not in _not_in_mpmath]
 _known_functions_mpmath = dict(_in_mpmath, **{

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -686,6 +686,14 @@ class CmathPrinter(PythonCodePrinter):
 
     def _print_known_const(self, expr):
         return self._kc[expr.__class__.__name__]
+    
+    def _print_re(self, expr):
+        """Prints `re(z)` as `z.real`"""
+        return f"({self._print(expr.args[0])}).real"
+
+    def _print_im(self, expr):
+        """Prints `im(z)` as `z.imag`"""
+        return f"({self._print(expr.args[0])}).imag"
 
 
 for k in CmathPrinter._kf:

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -686,7 +686,7 @@ class CmathPrinter(PythonCodePrinter):
 
     def _print_known_const(self, expr):
         return self._kc[expr.__class__.__name__]
-    
+
     def _print_re(self, expr):
         """Prints `re(z)` as `z.real`"""
         return f"({self._print(expr.args[0])}).real"

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -8,13 +8,13 @@ from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.function import Derivative
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth, sec
+from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth, sec, log, sin, cos, tan, asin, atan, sinh, cosh, tanh, asinh, acosh, atanh
 from sympy.functions.elementary.trigonometric import atan2
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
 from sympy.printing.codeprinter import PrintMethodNotImplementedError
 from sympy.printing.pycode import (
-    MpmathPrinter, PythonCodePrinter, pycode, SymPyPrinter
+    MpmathPrinter, CmathPrinter, PythonCodePrinter, pycode, SymPyPrinter
 )
 from sympy.printing.tensorflow import TensorflowPrinter
 from sympy.printing.numpy import NumPyPrinter, SciPyPrinter
@@ -23,6 +23,7 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayDiagonal, ArrayContraction, ZeroArray, OneArray
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import loggamma
+
 
 
 x, y, z = symbols('x y z')
@@ -80,6 +81,29 @@ def test_PythonCodePrinter_standard():
     assert prntr.standard == 'python3'
 
     raises(ValueError, lambda: PythonCodePrinter({'standard':'python4'}))
+
+
+def test_CmathPrinter():
+    p = CmathPrinter()
+
+    assert p.doprint(sqrt(x)) == 'cmath.sqrt(x)'
+    assert p.doprint(log(x)) == 'cmath.log(x)'
+
+    assert p.doprint(sin(x)) == 'cmath.sin(x)'
+    assert p.doprint(cos(x)) == 'cmath.cos(x)'
+    assert p.doprint(tan(x)) == 'cmath.tan(x)'
+
+    assert p.doprint(asin(x)) == 'cmath.asin(x)'
+    assert p.doprint(acos(x)) == 'cmath.acos(x)'
+    assert p.doprint(atan(x)) == 'cmath.atan(x)'
+
+    assert p.doprint(sinh(x)) == 'cmath.sinh(x)'
+    assert p.doprint(cosh(x)) == 'cmath.cosh(x)'
+    assert p.doprint(tanh(x)) == 'cmath.tanh(x)'
+
+    assert p.doprint(asinh(x)) == 'cmath.asinh(x)'
+    assert p.doprint(acosh(x)) == 'cmath.acosh(x)'
+    assert p.doprint(atanh(x)) == 'cmath.atanh(x)'
 
 
 def test_MpmathPrinter():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -779,7 +779,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
                 # Use either numpy (if available) or python.math where possible.
                 # XXX: This leads to different behaviour on different systems and
                 #      might be the reason for irreproducible errors.
-                modules = ["math", "cmath", "mpmath", "sympy"]
+                modules = ["math", "mpmath", "sympy"]
             else:
                 modules = ["numpy"]
         else:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -61,23 +61,7 @@ MATH_TRANSLATIONS = {
     "ln": "log",
 }
 
-CMATH_TRANSLATIONS = {
-    "exp": "exp",
-    "log": "log",
-    "sqrt": "sqrt",
-    "sin": "sin",
-    "cos": "cos",
-    "tan": "tan",
-    "asin": "asin",
-    "acos": "acos",
-    "atan": "atan",
-    "sinh": "sinh",
-    "cosh": "cosh",
-    "tanh": "tanh",
-    "asinh": "asinh",
-    "acosh": "acosh",
-    "atanh": "atanh"
-}
+CMATH_TRANSLATIONS = {}
 
 # NOTE: This dictionary is reused in Function._eval_evalf to allow subclasses
 # of Function to automatically evalf.
@@ -830,8 +814,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     if printer is None:
         if _module_present('mpmath', namespaces):
             from sympy.printing.pycode import MpmathPrinter as Printer # type: ignore
-        elif _module_present('cmath', namespaces):
-            from sympy.printing.pycode import CmathPrinter as Printer # type: ignore
         elif _module_present('scipy', namespaces):
             from sympy.printing.numpy import SciPyPrinter as Printer # type: ignore
         elif _module_present('numpy', namespaces):
@@ -846,6 +828,8 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
             from sympy.printing.tensorflow import TensorflowPrinter as Printer # type: ignore
         elif _module_present('sympy', namespaces):
             from sympy.printing.pycode import SymPyPrinter as Printer # type: ignore
+        elif _module_present('cmath', namespaces):
+            from sympy.printing.pycode import CmathPrinter as Printer # type: ignore
         else:
             from sympy.printing.pycode import PythonCodePrinter as Printer # type: ignore
         user_functions = {}

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -61,7 +61,7 @@ MATH_TRANSLATIONS = {
     "ln": "log",
 }
 
-CMATH_TRANSLATIONS = {}
+CMATH_TRANSLATIONS: dict[str, str] = {}
 
 # NOTE: This dictionary is reused in Function._eval_evalf to allow subclasses
 # of Function to automatically evalf.

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -28,6 +28,7 @@ __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 # Default namespaces, letting us define translations that can't be defined
 # by simple variable maps, like I => 1j
 MATH_DEFAULT: dict[str, Any] = {}
+CMATH_DEFAULT: dict[str,Any] = {}
 MPMATH_DEFAULT: dict[str, Any] = {}
 NUMPY_DEFAULT: dict[str, Any] = {"I": 1j}
 SCIPY_DEFAULT: dict[str, Any] = {"I": 1j}
@@ -42,6 +43,7 @@ NUMEXPR_DEFAULT: dict[str, Any] = {}
 # throughout this file, whereas the defaults should remain unmodified.
 
 MATH = MATH_DEFAULT.copy()
+CMATH = CMATH_DEFAULT.copy()
 MPMATH = MPMATH_DEFAULT.copy()
 NUMPY = NUMPY_DEFAULT.copy()
 SCIPY = SCIPY_DEFAULT.copy()
@@ -57,6 +59,24 @@ MATH_TRANSLATIONS = {
     "ceiling": "ceil",
     "E": "e",
     "ln": "log",
+}
+
+CMATH_TRANSLATIONS = {
+    "exp": "exp",
+    "log": "log",
+    "sqrt": "sqrt",
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "asin": "asin",
+    "acos": "acos",
+    "atan": "atan",
+    "sinh": "sinh",
+    "cosh": "cosh",
+    "tanh": "tanh",
+    "asinh": "asinh",
+    "acosh": "acosh",
+    "atanh": "atanh"
 }
 
 # NOTE: This dictionary is reused in Function._eval_evalf to allow subclasses
@@ -109,6 +129,7 @@ NUMEXPR_TRANSLATIONS: dict[str, str] = {}
 # Available modules:
 MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
+    "cmath": (CMATH, CMATH_DEFAULT, CMATH_TRANSLATIONS, ("import cmath; from cmath import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
@@ -128,7 +149,7 @@ def _import(module, reload=False):
     """
     Creates a global translation dictionary for module.
 
-    The argument module has to be one of the following strings: "math",
+    The argument module has to be one of the following strings: "math","cmath"
     "mpmath", "numpy", "sympy", "tensorflow", "jax".
     These dictionaries map names of Python functions to their equivalent in
     other modules.
@@ -312,15 +333,15 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
         - ``["scipy", "numpy"]`` if SciPy is installed
         - ``["numpy"]`` if only NumPy is installed
-        - ``["math", "mpmath", "sympy"]`` if neither is installed.
+        - ``["math","cmath", "mpmath", "sympy"]`` if neither is installed.
 
         That is, SymPy functions are replaced as far as possible by
         either ``scipy`` or ``numpy`` functions if available, and Python's
-        standard library ``math``, or ``mpmath`` functions otherwise.
+        standard library ``math`` and ``cmath``, or ``mpmath`` functions otherwise.
 
         *modules* can be one of the following types:
 
-        - The strings ``"math"``, ``"mpmath"``, ``"numpy"``, ``"numexpr"``,
+        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"numpy"``, ``"numexpr"``,
           ``"scipy"``, ``"sympy"``, or ``"tensorflow"`` or ``"jax"``. This uses the
           corresponding printer and namespace mapping for that module.
         - A module (e.g., ``math``). This uses the global namespace of the
@@ -774,7 +795,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
                 # Use either numpy (if available) or python.math where possible.
                 # XXX: This leads to different behaviour on different systems and
                 #      might be the reason for irreproducible errors.
-                modules = ["math", "mpmath", "sympy"]
+                modules = ["math", "cmath", "mpmath", "sympy"]
             else:
                 modules = ["numpy"]
         else:
@@ -809,6 +830,8 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     if printer is None:
         if _module_present('mpmath', namespaces):
             from sympy.printing.pycode import MpmathPrinter as Printer # type: ignore
+        elif _module_present('cmath', namespaces):
+            from sympy.printing.pycode import CmathPrinter as Printer # type: ignore
         elif _module_present('scipy', namespaces):
             from sympy.printing.numpy import SciPyPrinter as Printer # type: ignore
         elif _module_present('numpy', namespaces):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -372,6 +372,7 @@ def test_cmath_asin():
     assert abs(f(1) - cmath.asin(1)) < 1e-15
     assert abs(f(-1) - cmath.asin(-1)) < 1e-15
     assert abs(f(2) - cmath.asin(2)) < 1e-15
+    assert abs(f(1j) - cmath.asin(1j)) < 1e-15
 
 
 def test_cmath_acos():
@@ -379,6 +380,7 @@ def test_cmath_acos():
     assert abs(f(1) - cmath.acos(1)) < 1e-15
     assert abs(f(-1) - cmath.acos(-1)) < 1e-15
     assert abs(f(2) - cmath.acos(2)) < 1e-15
+    assert abs(f(1j) - cmath.acos(1j)) < 1e-15
 
 
 def test_cmath_atan():
@@ -387,6 +389,7 @@ def test_cmath_atan():
     assert abs(f(1) - cmath.atan(1)) < 1e-15
     assert abs(f(-1) - cmath.atan(-1)) < 1e-15
     assert abs(f(2) - cmath.atan(2)) < 1e-15
+    assert abs(f(2j) - cmath.atan(2j)) < 1e-15
 
 
 def test_cmath_asinh():
@@ -395,12 +398,15 @@ def test_cmath_asinh():
     assert abs(f(1) - cmath.asinh(1)) < 1e-15
     assert abs(f(-1) - cmath.asinh(-1)) < 1e-15
     assert abs(f(2) - cmath.asinh(2)) < 1e-15
+    assert abs(f(2j) - cmath.asinh(2j)) < 1e-15
 
 
 def test_cmath_acosh():
     f = lambdify(x, acosh(x), "cmath")
     assert abs(f(1) - cmath.acosh(1)) < 1e-15
     assert abs(f(2) - cmath.acosh(2)) < 1e-15
+    assert abs(f(-1) - cmath.acosh(-1)) < 1e-15
+    assert abs(f(2j) - cmath.acosh(2j)) < 1e-15
 
 
 def test_cmath_atanh():
@@ -409,6 +415,8 @@ def test_cmath_atanh():
     assert abs(f(0.5) - cmath.atanh(0.5)) < 1e-15
     assert abs(f(-0.5) - cmath.atanh(-0.5)) < 1e-15
     assert abs(f(2) - cmath.atanh(2)) < 1e-15
+    assert abs(f(-2) - cmath.atanh(-2)) < 1e-15
+    assert abs(f(2j) - cmath.atanh(2j)) < 1e-15
 
 
 def test_cmath_complex_identities():
@@ -441,7 +449,7 @@ def test_cmath_complex_identities():
     assert abs(func_sin(hpi + 1j * hpi)) < 4e-16
 
     # Complex Hyperbolic Cosine Identity: cosh(z) = cosh(Re(z)) * cos(Im(z)) + i*sinh(Re(z)) * sin(Im(z))
-    func_cosh = lambdify([z], cosh(z) - (cosh(re(z)) * cos(im(z)) + I * sinh(re(z)) * sin(im(z))),
+    func_cosh_1 = lambdify([z], cosh(z) - (cosh(re(z)) * cos(im(z)) + I * sinh(re(z)) * sin(im(z))),
                          modules=["cmath", "math"])
     assert abs(func_cosh(hpi + 1j * hpi)) < 4e-16
 
@@ -451,7 +459,7 @@ def test_cmath_complex_identities():
     assert abs(func_sinh(hpi + 1j * hpi)) < 4e-16
 
     # cosh(z) = (e^z + e^(-z)) / 2
-    func_cosh = lambdify([z], cosh(z) - (exp(z) + exp(-z)) / 2, modules=["cmath", "math"])
+    func_cosh_2 = lambdify([z], cosh(z) - (exp(z) + exp(-z)) / 2, modules=["cmath", "math"])
     assert abs(func_cosh(hpi)) < 4e-16
 
     # Additional expressions testing log and exp with real and imaginary parts

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -458,7 +458,7 @@ def test_lambdify_complex_identities():
     expr1 = log(re(z)) + log(im(z)) - log(re(z) * im(z))
     expr2 = exp(re(z)) * exp(im(z) * I) - exp(z)
     expr3 = log(exp(re(z))) - re(z)
-    expr4 = exp(log(re(z))) - re(z) 
+    expr4 = exp(log(re(z))) - re(z)
     expr5 = log(exp(re(z) + im(z))) - (re(z) + im(z))
     expr6 = exp(log(re(z) + im(z))) - (re(z) + im(z))
     func1 = lambdify([z], expr1, modules=["sympy", "cmath", "math"])

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -451,7 +451,7 @@ def test_cmath_complex_identities():
     # Complex Hyperbolic Cosine Identity: cosh(z) = cosh(Re(z)) * cos(Im(z)) + i*sinh(Re(z)) * sin(Im(z))
     func_cosh_1 = lambdify([z], cosh(z) - (cosh(re(z)) * cos(im(z)) + I * sinh(re(z)) * sin(im(z))),
                          modules=["cmath", "math"])
-    assert abs(func_cosh(hpi + 1j * hpi)) < 4e-16
+    assert abs(func_cosh_1(hpi + 1j * hpi)) < 4e-16
 
     # Complex Hyperbolic Sine Identity: sinh(z) = sinh(Re(z)) * cos(Im(z)) + i*cosh(Re(z)) * sin(Im(z))
     func_sinh = lambdify([z], sinh(z) - (sinh(re(z)) * cos(im(z)) + I * cosh(re(z)) * sin(im(z))),
@@ -460,7 +460,7 @@ def test_cmath_complex_identities():
 
     # cosh(z) = (e^z + e^(-z)) / 2
     func_cosh_2 = lambdify([z], cosh(z) - (exp(z) + exp(-z)) / 2, modules=["cmath", "math"])
-    assert abs(func_cosh(hpi)) < 4e-16
+    assert abs(func_cosh_2(hpi)) < 4e-16
 
     # Additional expressions testing log and exp with real and imaginary parts
     expr1 = log(re(z)) + log(im(z)) - log(re(z) * im(z))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -411,13 +411,13 @@ def test_cmath_atanh():
     assert abs(f(2) - cmath.atanh(2)) < 1e-15
 
 
-def test_lambdify_complex_identities():
+def test_cmath_complex_identities():
     # Define symbol
     z = symbols('z')
 
     # Trigonometric identity using re(z) and im(z)
     expr = cos(z) - cos(re(z)) * cosh(im(z)) + I * sin(re(z)) * sinh(im(z))
-    func = lambdify([z], expr, modules=["sympy", "cmath", "math"])
+    func = lambdify([z], expr, modules=["cmath", "math"])
     hpi = math.pi / 2
     assert abs(func(hpi + 1j * hpi)) < 4e-16
 
@@ -427,27 +427,27 @@ def test_lambdify_complex_identities():
 
     # Exponential Identity: e^z = e^(Re(z)) * (cos(Im(z)) + i*sin(Im(z)))
     func_exp = lambdify([z], exp(z) - exp(re(z)) * (cos(im(z)) + I * sin(im(z))),
-                        modules=["sympy", "cmath", "math"])
+                        modules=["cmath", "math"])
     assert abs(func_exp(hpi + 1j * hpi)) < 4e-16
 
     # Complex Cosine Identity: cos(z) = cos(Re(z)) * cosh(Im(z)) - i*sin(Re(z)) * sinh(Im(z))
     func_cos = lambdify([z], cos(z) - (cos(re(z)) * cosh(im(z)) - I * sin(re(z)) * sinh(im(z))),
-                        modules=["sympy", "cmath", "math"])
+                        modules=["cmath", "math"])
     assert abs(func_cos(hpi + 1j * hpi)) < 4e-16
 
     # Complex Sine Identity: sin(z) = sin(Re(z)) * cosh(Im(z)) + i*cos(Re(z)) * sinh(Im(z))
     func_sin = lambdify([z], sin(z) - (sin(re(z)) * cosh(im(z)) + I * cos(re(z)) * sinh(im(z))),
-                        modules=["sympy", "cmath", "math"])
+                        modules=["cmath", "math"])
     assert abs(func_sin(hpi + 1j * hpi)) < 4e-16
 
     # Complex Hyperbolic Cosine Identity: cosh(z) = cosh(Re(z)) * cos(Im(z)) + i*sinh(Re(z)) * sin(Im(z))
     func_cosh = lambdify([z], cosh(z) - (cosh(re(z)) * cos(im(z)) + I * sinh(re(z)) * sin(im(z))),
-                         modules=["sympy", "cmath", "math"])
+                         modules=["cmath", "math"])
     assert abs(func_cosh(hpi + 1j * hpi)) < 4e-16
 
     # Complex Hyperbolic Sine Identity: sinh(z) = sinh(Re(z)) * cos(Im(z)) + i*cosh(Re(z)) * sin(Im(z))
     func_sinh = lambdify([z], sinh(z) - (sinh(re(z)) * cos(im(z)) + I * cosh(re(z)) * sin(im(z))),
-                         modules=["sympy", "cmath", "math"])
+                         modules=["cmath", "math"])
     assert abs(func_sinh(hpi + 1j * hpi)) < 4e-16
 
     # cosh(z) = (e^z + e^(-z)) / 2
@@ -461,12 +461,12 @@ def test_lambdify_complex_identities():
     expr4 = exp(log(re(z))) - re(z)
     expr5 = log(exp(re(z) + im(z))) - (re(z) + im(z))
     expr6 = exp(log(re(z) + im(z))) - (re(z) + im(z))
-    func1 = lambdify([z], expr1, modules=["sympy", "cmath", "math"])
-    func2 = lambdify([z], expr2, modules=["sympy", "cmath", "math"])
-    func3 = lambdify([z], expr3, modules=["sympy", "cmath", "math"])
-    func4 = lambdify([z], expr4, modules=["sympy", "cmath", "math"])
-    func5 = lambdify([z], expr5, modules=["sympy", "cmath", "math"])
-    func6 = lambdify([z], expr6, modules=["sympy", "cmath", "math"])
+    func1 = lambdify([z], expr1, modules=["cmath", "math"])
+    func2 = lambdify([z], expr2, modules=["cmath", "math"])
+    func3 = lambdify([z], expr3, modules=["cmath", "math"])
+    func4 = lambdify([z], expr4, modules=["cmath", "math"])
+    func5 = lambdify([z], expr5, modules=["cmath", "math"])
+    func6 = lambdify([z], expr6, modules=["cmath", "math"])
     test_value = 3 + 4j
     assert abs(func1(test_value)) < 4e-16
     assert abs(func2(test_value)) < 4e-16

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -5,6 +5,7 @@ import linecache
 import gc
 
 import mpmath
+import cmath
 
 from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy.concrete.summations import Sum
@@ -17,12 +18,13 @@ from sympy.functions.combinatorial.factorials import (RisingFactorial, factorial
 from sympy.functions.combinatorial.numbers import bernoulli, harmonic
 from sympy.functions.elementary.complexes import Abs, sign
 from sympy.functions.elementary.exponential import exp, log
-from sympy.functions.elementary.hyperbolic import acosh
+from sympy.functions.elementary.hyperbolic import asinh,acosh,atanh
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (acos, cos, cot, sin,
+from sympy.functions.elementary.trigonometric import (asin, acos, atan, cos, cot, sin,
                                                       sinc, tan)
+from sympy.functions import sinh,cosh,tanh
 from sympy.functions.special.bessel import (besseli, besselj, besselk, bessely, jn, yn)
 from sympy.functions.special.beta_functions import (beta, betainc, betainc_regularized)
 from sympy.functions.special.delta_functions import (Heaviside)
@@ -299,6 +301,157 @@ def test_numexpr_printer():
         args = arg_tuple[:nargs]
         f = lambdify(args, ssym(*args), modules='numexpr')
         assert f(*(1, )*nargs) is not None
+
+
+def test_cmath_sqrt():
+    f = lambdify(x, sqrt(x), "cmath")
+    assert f(0) == 0
+    assert f(1) == 1
+    assert f(4) == 2
+    assert abs(f(2) - 1.414) < 0.001
+    assert f(-1) == 1j
+    assert f(-4) == 2j
+
+
+def test_cmath_log():
+    f = lambdify(x, log(x), "cmath")
+    assert abs(f(1) - 0) < 1e-15
+    assert abs(f(cmath.e) - 1) < 1e-15
+    assert abs(f(-1) - cmath.log(-1)) < 1e-15
+
+
+def test_cmath_sinh():
+    f = lambdify(x, sinh(x), "cmath")
+    assert abs(f(0) - cmath.sinh(0)) < 1e-15
+    assert abs(f(pi) - cmath.sinh(pi)) < 1e-15
+    assert abs(f(-pi) - cmath.sinh(-pi)) < 1e-15
+    assert abs(f(1j) - cmath.sinh(1j)) < 1e-15
+
+
+def test_cmath_cosh():
+    f = lambdify(x, cosh(x), "cmath")
+    assert abs(f(0) - cmath.cosh(0)) < 1e-15
+    assert abs(f(pi) - cmath.cosh(pi)) < 1e-15
+    assert abs(f(-pi) - cmath.cosh(-pi)) < 1e-15
+    assert abs(f(1j) - cmath.cosh(1j)) < 1e-15
+
+
+def test_cmath_tanh():
+    f = lambdify(x, tanh(x), "cmath")
+    assert abs(f(0) - cmath.tanh(0)) < 1e-15
+    assert abs(f(pi) - cmath.tanh(pi)) < 1e-15
+    assert abs(f(-pi) - cmath.tanh(-pi)) < 1e-15
+    assert abs(f(1j) - cmath.tanh(1j)) < 1e-15
+
+
+def test_cmath_sin():
+    f = lambdify(x, sin(x), "cmath")
+    assert abs(f(0) - cmath.sin(0)) < 1e-15
+    assert abs(f(pi) - cmath.sin(pi)) < 1e-15
+    assert abs(f(-pi) - cmath.sin(-pi)) < 1e-15
+    assert abs(f(1j) - cmath.sin(1j)) < 1e-15
+
+
+def test_cmath_cos():
+    f = lambdify(x, cos(x), "cmath")
+    assert abs(f(0) - cmath.cos(0)) < 1e-15
+    assert abs(f(pi) - cmath.cos(pi)) < 1e-15
+    assert abs(f(-pi) - cmath.cos(-pi)) < 1e-15
+    assert abs(f(1j) - cmath.cos(1j)) < 1e-15
+
+
+def test_cmath_tan():
+    f = lambdify(x, tan(x), "cmath")
+    assert abs(f(0) - cmath.tan(0)) < 1e-15
+    assert abs(f(1j) - cmath.tan(1j)) < 1e-15
+
+
+def test_cmath_asin():
+    f = lambdify(x, asin(x), "cmath")
+    assert abs(f(0) - cmath.asin(0)) < 1e-15
+    assert abs(f(1) - cmath.asin(1)) < 1e-15
+    assert abs(f(-1) - cmath.asin(-1)) < 1e-15
+    assert abs(f(2) - cmath.asin(2)) < 1e-15
+
+
+def test_cmath_acos():
+    f = lambdify(x, acos(x), "cmath")
+    assert abs(f(1) - cmath.acos(1)) < 1e-15
+    assert abs(f(-1) - cmath.acos(-1)) < 1e-15
+    assert abs(f(2) - cmath.acos(2)) < 1e-15
+
+
+def test_cmath_atan():
+    f = lambdify(x, atan(x), "cmath")
+    assert abs(f(0) - cmath.atan(0)) < 1e-15
+    assert abs(f(1) - cmath.atan(1)) < 1e-15
+    assert abs(f(-1) - cmath.atan(-1)) < 1e-15
+    assert abs(f(2) - cmath.atan(2)) < 1e-15
+
+
+def test_cmath_asinh():
+    f = lambdify(x, asinh(x), "cmath")
+    assert abs(f(0) - cmath.asinh(0)) < 1e-15
+    assert abs(f(1) - cmath.asinh(1)) < 1e-15
+    assert abs(f(-1) - cmath.asinh(-1)) < 1e-15
+    assert abs(f(2) - cmath.asinh(2)) < 1e-15
+
+
+def test_cmath_acosh():
+    f = lambdify(x, acosh(x), "cmath")
+    assert abs(f(1) - cmath.acosh(1)) < 1e-15
+    assert abs(f(2) - cmath.acosh(2)) < 1e-15
+
+
+def test_cmath_atanh():
+    f = lambdify(x, atanh(x), "cmath")
+    assert abs(f(0) - cmath.atanh(0)) < 1e-15
+    assert abs(f(0.5) - cmath.atanh(0.5)) < 1e-15
+    assert abs(f(-0.5) - cmath.atanh(-0.5)) < 1e-15
+    assert abs(f(2) - cmath.atanh(2)) < 1e-15
+
+
+def test_lambdify_complex_identities():
+    # Define symbol
+    z = symbols('z')
+    # Explicit mappings for re and im
+    custom_mappings = {"re": lambda z: z.real, "im": lambda z: z.imag}
+    expr = cos(z) - cos(re(z)) * cosh(im(z)) + I * sin(re(z)) * sinh(im(z))
+    func = lambdify([z], expr, modules=[custom_mappings, "cmath", "math"])
+    hpi = math.pi / 2
+    assert func(hpi + 1j * hpi) == 0j
+
+    # Euler's Formula
+    func = lambdify([z], exp(I * z) - (cos(z) + I * sin(z)), modules=["cmath", "math"])
+    assert func(hpi) == 0j
+
+    # Exponential Identity: e^z = e^(Re(z)) * (cos(Im(z)) + i sin(Im(z)))
+    func_exp = lambdify([z], exp(z) - exp(re(z)) * (cos(im(z)) + I * sin(im(z))),
+                        modules=[custom_mappings, "cmath", "math"])
+    assert func_exp(hpi + 1j * hpi) == 0j
+
+    # Complex Cosine Identity: cos(z) = cos(Re(z)) * cosh(Im(z)) - i sin(Re(z)) * sinh(Im(z))
+    func_cos = lambdify([z], cos(z) - (cos(re(z)) * cosh(im(z)) - I * sin(re(z)) * sinh(im(z))),
+                        modules=[custom_mappings, "cmath", "math"])
+    assert func_cos(hpi + 1j * hpi) == 0j
+
+    # Complex Sine Identity: sin(z) = sin(Re(z)) * cosh(Im(z)) + i cos(Re(z)) * sinh(Im(z))
+    func_sin = lambdify([z], sin(z) - (sin(re(z)) * cosh(im(z)) + I * cos(re(z)) * sinh(im(z))),
+                        modules=[custom_mappings, "cmath", "math"])
+    assert func_sin(hpi + 1j * hpi) == 0j
+
+    # Complex Hyperbolic Cosine Identity: cosh(z) = cosh(Re(z)) * cos(Im(z)) + i sinh(Re(z)) * sin(Im(z))
+    func_cosh = lambdify([z], cosh(z) - (cosh(re(z)) * cos(im(z)) + I * sinh(re(z)) * sin(im(z))),
+                         modules=[custom_mappings, "cmath", "math"])
+    assert func_cosh(hpi + 1j * hpi) == 0j
+
+    # Complex Hyperbolic Sine Identity: sinh(z) = sinh(Re(z)) * cos(Im(z)) + i cosh(Re(z)) * sin(Im(z))
+    func_sinh = lambdify([z], sinh(z) - (sinh(re(z)) * cos(im(z)) + I * cosh(re(z)) * sin(im(z))),
+                         modules=[custom_mappings, "cmath", "math"])
+    assert func_sinh(hpi + 1j * hpi) == 0j
+
+    func_cosh = lambdify([z], cosh(z) - (exp(z) + exp(-z)) / 2, modules=["cmath", "math"])
+    assert func_cosh(hpi) == 0j
 
 
 def test_issue_9334():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -414,44 +414,66 @@ def test_cmath_atanh():
 def test_lambdify_complex_identities():
     # Define symbol
     z = symbols('z')
-    # Explicit mappings for re and im
-    custom_mappings = {"re": lambda z: z.real, "im": lambda z: z.imag}
+
+    # Trigonometric identity using re(z) and im(z)
     expr = cos(z) - cos(re(z)) * cosh(im(z)) + I * sin(re(z)) * sinh(im(z))
-    func = lambdify([z], expr, modules=[custom_mappings, "cmath", "math"])
+    func = lambdify([z], expr, modules=["sympy", "cmath", "math"])
     hpi = math.pi / 2
-    assert func(hpi + 1j * hpi) == 0j
+    assert abs(func(hpi + 1j * hpi)) < 4e-16
 
-    # Euler's Formula
+    # Euler's Formula: e^(i*z) = cos(z) + i*sin(z)
     func = lambdify([z], exp(I * z) - (cos(z) + I * sin(z)), modules=["cmath", "math"])
-    assert func(hpi) == 0j
+    assert abs(func(hpi)) < 4e-16
 
-    # Exponential Identity: e^z = e^(Re(z)) * (cos(Im(z)) + i sin(Im(z)))
+    # Exponential Identity: e^z = e^(Re(z)) * (cos(Im(z)) + i*sin(Im(z)))
     func_exp = lambdify([z], exp(z) - exp(re(z)) * (cos(im(z)) + I * sin(im(z))),
-                        modules=[custom_mappings, "cmath", "math"])
-    assert func_exp(hpi + 1j * hpi) == 0j
+                        modules=["sympy", "cmath", "math"])
+    assert abs(func_exp(hpi + 1j * hpi)) < 4e-16
 
-    # Complex Cosine Identity: cos(z) = cos(Re(z)) * cosh(Im(z)) - i sin(Re(z)) * sinh(Im(z))
+    # Complex Cosine Identity: cos(z) = cos(Re(z)) * cosh(Im(z)) - i*sin(Re(z)) * sinh(Im(z))
     func_cos = lambdify([z], cos(z) - (cos(re(z)) * cosh(im(z)) - I * sin(re(z)) * sinh(im(z))),
-                        modules=[custom_mappings, "cmath", "math"])
-    assert func_cos(hpi + 1j * hpi) == 0j
+                        modules=["sympy", "cmath", "math"])
+    assert abs(func_cos(hpi + 1j * hpi)) < 4e-16
 
-    # Complex Sine Identity: sin(z) = sin(Re(z)) * cosh(Im(z)) + i cos(Re(z)) * sinh(Im(z))
+    # Complex Sine Identity: sin(z) = sin(Re(z)) * cosh(Im(z)) + i*cos(Re(z)) * sinh(Im(z))
     func_sin = lambdify([z], sin(z) - (sin(re(z)) * cosh(im(z)) + I * cos(re(z)) * sinh(im(z))),
-                        modules=[custom_mappings, "cmath", "math"])
-    assert func_sin(hpi + 1j * hpi) == 0j
+                        modules=["sympy", "cmath", "math"])
+    assert abs(func_sin(hpi + 1j * hpi)) < 4e-16
 
-    # Complex Hyperbolic Cosine Identity: cosh(z) = cosh(Re(z)) * cos(Im(z)) + i sinh(Re(z)) * sin(Im(z))
+    # Complex Hyperbolic Cosine Identity: cosh(z) = cosh(Re(z)) * cos(Im(z)) + i*sinh(Re(z)) * sin(Im(z))
     func_cosh = lambdify([z], cosh(z) - (cosh(re(z)) * cos(im(z)) + I * sinh(re(z)) * sin(im(z))),
-                         modules=[custom_mappings, "cmath", "math"])
-    assert func_cosh(hpi + 1j * hpi) == 0j
+                         modules=["sympy", "cmath", "math"])
+    assert abs(func_cosh(hpi + 1j * hpi)) < 4e-16
 
-    # Complex Hyperbolic Sine Identity: sinh(z) = sinh(Re(z)) * cos(Im(z)) + i cosh(Re(z)) * sin(Im(z))
+    # Complex Hyperbolic Sine Identity: sinh(z) = sinh(Re(z)) * cos(Im(z)) + i*cosh(Re(z)) * sin(Im(z))
     func_sinh = lambdify([z], sinh(z) - (sinh(re(z)) * cos(im(z)) + I * cosh(re(z)) * sin(im(z))),
-                         modules=[custom_mappings, "cmath", "math"])
-    assert func_sinh(hpi + 1j * hpi) == 0j
+                         modules=["sympy", "cmath", "math"])
+    assert abs(func_sinh(hpi + 1j * hpi)) < 4e-16
 
+    # cosh(z) = (e^z + e^(-z)) / 2
     func_cosh = lambdify([z], cosh(z) - (exp(z) + exp(-z)) / 2, modules=["cmath", "math"])
-    assert func_cosh(hpi) == 0j
+    assert abs(func_cosh(hpi)) < 4e-16
+
+    # Additional expressions testing log and exp with real and imaginary parts
+    expr1 = log(re(z)) + log(im(z)) - log(re(z) * im(z))
+    expr2 = exp(re(z)) * exp(im(z) * I) - exp(z)
+    expr3 = log(exp(re(z))) - re(z)
+    expr4 = exp(log(re(z))) - re(z) 
+    expr5 = log(exp(re(z) + im(z))) - (re(z) + im(z))
+    expr6 = exp(log(re(z) + im(z))) - (re(z) + im(z))
+    func1 = lambdify([z], expr1, modules=["sympy", "cmath", "math"])
+    func2 = lambdify([z], expr2, modules=["sympy", "cmath", "math"])
+    func3 = lambdify([z], expr3, modules=["sympy", "cmath", "math"])
+    func4 = lambdify([z], expr4, modules=["sympy", "cmath", "math"])
+    func5 = lambdify([z], expr5, modules=["sympy", "cmath", "math"])
+    func6 = lambdify([z], expr6, modules=["sympy", "cmath", "math"])
+    test_value = 3 + 4j
+    assert abs(func1(test_value)) < 4e-16
+    assert abs(func2(test_value)) < 4e-16
+    assert abs(func3(test_value)) < 4e-16
+    assert abs(func4(test_value)) < 4e-16
+    assert abs(func5(test_value)) < 4e-16
+    assert abs(func6(test_value)) < 4e-16
 
 
 def test_issue_9334():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->Fixes #24828 


#### Brief description of what is fixed or changed
This PR introduces cmath support to the lambdify functionality, which includes:

1)Implementation of CmathPrinter for proper printing of cmath functions.
2)Added functionality to lambdify to use cmath functions seamlessly in complex expressions.
3)Regression tests were added to ensure that cmath-related lambdified expressions work as expected.

#### Other comments

1)This PR enhances the lambdify system by integrating complex number handling via the cmath module, expanding its versatility for users working with symbolic expressions that involve complex math.
2)The addition of CmathPrinter ensures that expressions using cmath functions are correctly represented in the generated code, maintaining accuracy when transitioning between symbolic and numerical evaluations.
3)The regression tests help ensure that existing functionality remains unaffected and that the new cmath support behaves as expected across various test cases.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * CmathPrinter was implemented to print cmath functions correctly in lambdified code.
* utilities
  * Enhanced lambdify to support Python's built-in cmath module.
<!-- END RELEASE NOTES -->
