### PR TITLE
 Fixed handling of integer exponentiation in rational assumptions

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -154,7 +154,7 @@ def _(expr, assumptions):
                 return True
             if ask(Q.eq(expr.base,0),assumptions) and ask(Q.positive(expr.exp)) is True:
                 return True
-            return 
+            return
         return is_base_rational
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -151,9 +151,10 @@ def _(expr, assumptions):
     if is_exp_integer:
         is_base_rational = ask(Q.rational(expr.base),assumptions)
         if is_base_rational is True:
-            if ask(Q.ne(expr.base,0),assumptions):
+            is_base_zero = ask(Q.zero(expr.base),assumptions)
+            if is_base_zero is False:
                 return True
-            if ask(Q.eq(expr.base,0),assumptions) and ask(Q.positive(expr.exp)) is True:
+            if is_base_zero is True and ask(Q.positive(expr.exp)) is True:
                 return True
         return
     elif ask(Q.rational(expr.exp), assumptions):
@@ -163,7 +164,7 @@ def _(expr, assumptions):
             return False
         if ask(Q.eq(expr.base,1) | Q.eq(expr.base,-1)):
             return True
-        if ask(Q.eq(expr.base,0)) and ask(Q.positive(expr.exp)) is True:
+        if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)) is True:
             return True
 
 @RationalPredicate.register_many(asin, atan, cos, sin, tan)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -163,9 +163,9 @@ def _(expr, assumptions):
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:
             return False
-        if ask(Q.eq(expr.base,1) | Q.eq(expr.base,-1)):
-            return True
         if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)) is True:
+            return True
+        if ask(Q.eq(expr.base,1)):
             return True
 
 @RationalPredicate.register_many(asin, atan, cos, sin, tan)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -159,6 +159,8 @@ def _(expr, assumptions):
                 return True
         if ask(Q.algebraic(expr.base),assumptions) is False:
             return ask(Q.zero(expr.exp), assumptions)
+        if ask(Q.irrational(expr.base),assumptions) and ask(Q.eq(expr.exp,-1)):
+            return False
         return
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -147,17 +147,17 @@ def _(expr, assumptions):
         if ask(Q.rational(x), assumptions):
             return ask(~Q.nonzero(x), assumptions)
         return
-    if ask(Q.integer(expr.exp), assumptions):
+    is_exp_integer = ask(Q.integer(expr.exp), assumptions)
+    if is_exp_integer:
         is_base_rational = ask(Q.rational(expr.base),assumptions)
         if is_base_rational is True:
             if ask(Q.ne(expr.base,0),assumptions):
                 return True
             if ask(Q.eq(expr.base,0),assumptions) and ask(Q.positive(expr.exp)) is True:
                 return True
-            return
-        return is_base_rational
+        return
     elif ask(Q.rational(expr.exp), assumptions):
-        if ask(Q.prime(expr.base), assumptions):
+        if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:
             return False
         if ask(Q.rational(expr.base),assumptions) is False:
             return False

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -163,7 +163,7 @@ def _(expr, assumptions):
             return False
         if ask(Q.eq(expr.base,1) | Q.eq(expr.base,-1)):
             return True
-        if ask(Q.eq(expr.base,0)) & ask(Q.positive(expr.exp)) is True:
+        if ask(Q.eq(expr.base,0)) and ask(Q.positive(expr.exp)) is True:
             return True
 
 @RationalPredicate.register_many(asin, atan, cos, sin, tan)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -158,7 +158,7 @@ def _(expr, assumptions):
             if is_base_zero is True and ask(Q.positive(expr.exp)) is True:
                 return True
         if ask(Q.algebraic(expr.base),assumptions) is False:
-            return False
+            return ask(~Q.nonzero(expr.exp), assumptions)
         return
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -145,25 +145,25 @@ def _(expr, assumptions):
     if expr.base == E:
         x = expr.exp
         if ask(Q.rational(x), assumptions):
-            return ask(~Q.nonzero(x), assumptions)
+            return ask(Q.zero(x), assumptions)
         return
 
     is_exp_integer = ask(Q.integer(expr.exp), assumptions)
     if is_exp_integer:
         is_base_rational = ask(Q.rational(expr.base),assumptions)
-        if is_base_rational is True:
+        if is_base_rational:
             is_base_zero = ask(Q.zero(expr.base),assumptions)
             if is_base_zero is False:
                 return True
-            if is_base_zero is True and ask(Q.positive(expr.exp)) is True:
+            if is_base_zero and ask(Q.positive(expr.exp)):
                 return True
         if ask(Q.algebraic(expr.base),assumptions) is False:
-            return ask(~Q.nonzero(expr.exp), assumptions)
+            return ask(Q.zero(expr.exp), assumptions)
         return
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:
             return False
-        if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)) is True:
+        if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)):
             return True
         if ask(Q.eq(expr.base,1)):
             return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -147,6 +147,7 @@ def _(expr, assumptions):
         if ask(Q.rational(x), assumptions):
             return ask(~Q.nonzero(x), assumptions)
         return
+
     is_exp_integer = ask(Q.integer(expr.exp), assumptions)
     if is_exp_integer:
         is_base_rational = ask(Q.rational(expr.base),assumptions)
@@ -156,6 +157,8 @@ def _(expr, assumptions):
                 return True
             if is_base_zero is True and ask(Q.positive(expr.exp)) is True:
                 return True
+        if ask(Q.algebraic(expr.base),assumptions) is False:
+            return False
         return
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -147,12 +147,24 @@ def _(expr, assumptions):
         if ask(Q.rational(x), assumptions):
             return ask(~Q.nonzero(x), assumptions)
         return
-
     if ask(Q.integer(expr.exp), assumptions):
-        return ask(Q.rational(expr.base), assumptions)
+        is_base_rational = ask(Q.rational(expr.base),assumptions)
+        if is_base_rational is True:
+            if ask(Q.ne(expr.base,0),assumptions):
+                return True
+            if ask(Q.eq(expr.base,0),assumptions) and ask(Q.positive(expr.exp)) is True:
+                return True
+            return 
+        return is_base_rational
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions):
             return False
+        if ask(Q.rational(expr.base),assumptions) is False:
+            return False
+        if ask(Q.eq(expr.base,1) | Q.eq(expr.base,-1)):
+            return True
+        if ask(Q.eq(expr.base,0)) & ask(Q.positive(expr.exp)) is True:
+            return True
 
 @RationalPredicate.register_many(asin, atan, cos, sin, tan)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -160,8 +160,6 @@ def _(expr, assumptions):
     elif ask(Q.rational(expr.exp), assumptions):
         if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:
             return False
-        if ask(Q.rational(expr.base),assumptions) is False:
-            return False
         if ask(Q.eq(expr.base,1) | Q.eq(expr.base,-1)):
             return True
         if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)) is True:

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1391,6 +1391,8 @@ def test_rational():
     assert ask(Q.rational(Pow(-1, x, evaluate=False), Q.rational(x))) is None
     assert ask(Q.rational(x**y), Q.integer(y) & ~Q. algebraic(x)) is None
     assert ask(Q.rational(x**y), Q.integer(y) & ~Q. algebraic(x) & ~Q.zero(x)) is None
+    assert ask(Q.rational(x**y), Q.integer(y) & ~Q.algebraic(x) & Q.complex(x) & ~Q.real(x)) is None
+    assert ask(Q.rational(x**y), Q.integer(y) & ~Q.algebraic(x) & Q.complex(x)) is None
 
 
 def test_hermitian():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1345,8 +1345,8 @@ def test_rational():
     assert ask(Q.rational(1/x), Q.irrational(x)) is False
 
     assert ask(Q.rational(2/x), Q.rational(x)) is None
-    assert ask(Q.rational(2/x), Q.integer(x)) is True
-    assert ask(Q.rational(2/x), Q.even(x)) is True
+    assert ask(Q.rational(2/x), Q.integer(x)) is None
+    assert ask(Q.rational(2/x), Q.even(x)) is None
     assert ask(Q.rational(2/x), Q.odd(x)) is True
     assert ask(Q.rational(2/x), Q.irrational(x)) is False
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -401,7 +401,7 @@ def test_pi():
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
     assert ask(Q.rational(z)) is None
-    assert ask(Q.algebraic(z)) is None
+    assert ask(Q.algebraic(z)) is False
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
     assert ask(Q.irrational(z)) is True
@@ -1380,8 +1380,8 @@ def test_rational():
         assert ask(Q.rational(h(x)), Q.rational(x)) is False
 
     #https://github.com/sympy/sympy/issues/27442
-    assert ask(Q.rational(x**y),Q.irrational(x) & Q.rational(y)) is False
-    assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is False
+    assert ask(Q.rational(x**y),Q.irrational(x) & Q.rational(y)) is None
+    assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.integer(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y)) is None
     assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -400,7 +400,7 @@ def test_pi():
     z = S.Pi ** 2
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.rational(z)) is False
     assert ask(Q.algebraic(z)) is False
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
@@ -419,7 +419,7 @@ def test_pi():
     z = (1 + S.Pi) ** 2
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.rational(z)) is False
     assert ask(Q.algebraic(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
@@ -1379,7 +1379,7 @@ def test_rational():
         assert ask(Q.rational(h(7, evaluate=False))) is False
         assert ask(Q.rational(h(x)), Q.rational(x)) is False
 
-    #https://github.com/sympy/sympy/issues/27442
+    # https://github.com/sympy/sympy/issues/27442
     assert ask(Q.rational(x**y),Q.irrational(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.integer(y)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1338,9 +1338,9 @@ def test_rational():
     assert ask(Q.rational(x/2), Q.odd(x)) is True
     assert ask(Q.rational(x/2), Q.irrational(x)) is False
 
-    assert ask(Q.rational(1/x), Q.rational(x)) is None
-    assert ask(Q.rational(1/x), Q.integer(x)) is None
-    assert ask(Q.rational(1/x), Q.even(x)) is None
+    assert ask(Q.rational(1/x), Q.rational(x) & Q.nonzero(x)) is True
+    assert ask(Q.rational(1/x), Q.integer(x) & Q.nonzero(x)) is True
+    assert ask(Q.rational(1/x), Q.even(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(1/x), Q.odd(x)) is True
     assert ask(Q.rational(1/x), Q.irrational(x)) is None
 
@@ -1389,6 +1389,7 @@ def test_rational():
     assert ask(Q.rational(x**y), Q.prime(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y), ~Q.rational(x) & Q.integer(y) ) is None
     assert ask(Q.rational(Pow(-1, x, evaluate=False), Q.rational(x))) is None
+    assert ask(Q.rational(x**y), Q.integer(y) & ~Q. algebraic(x)) is None
 
 
 def test_hermitian():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1342,13 +1342,13 @@ def test_rational():
     assert ask(Q.rational(1/x), Q.integer(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(1/x), Q.even(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(1/x), Q.odd(x)) is True
-    assert ask(Q.rational(1/x), Q.irrational(x)) is None
+    assert ask(Q.rational(1/x), Q.irrational(x)) is False
 
     assert ask(Q.rational(2/x), Q.rational(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(2/x), Q.integer(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(2/x), Q.even(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(2/x), Q.odd(x)) is True
-    assert ask(Q.rational(2/x), Q.irrational(x)) is None
+    assert ask(Q.rational(2/x), Q.irrational(x)) is False
 
     assert ask(Q.rational(x), ~Q.algebraic(x)) is False
 
@@ -1358,7 +1358,7 @@ def test_rational():
     assert ask(Q.rational(y/x), Q.integer(x) & Q.rational(y) & Q.nonzero(x)) is True
     assert ask(Q.rational(y/x), Q.even(x) & Q.rational(y) & Q.nonzero(x)) is True
     assert ask(Q.rational(y/x), Q.odd(x) & Q.rational(y)) is True
-    assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y)) is None
+    assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y) & Q.nonzero(y)) is False
 
     for f in [exp, sin, tan, asin, atan, cos]:
         assert ask(Q.rational(f(7))) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -401,7 +401,7 @@ def test_pi():
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
     assert ask(Q.rational(z)) is False
-    assert ask(Q.algebraic(z)) is False
+    assert ask(Q.algebraic(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
     assert ask(Q.irrational(z)) is True
@@ -419,7 +419,7 @@ def test_pi():
     z = (1 + S.Pi) ** 2
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is False
+    assert ask(Q.rational(z)) is None
     assert ask(Q.algebraic(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
@@ -1342,13 +1342,13 @@ def test_rational():
     assert ask(Q.rational(1/x), Q.integer(x)) is None
     assert ask(Q.rational(1/x), Q.even(x)) is None
     assert ask(Q.rational(1/x), Q.odd(x)) is True
-    assert ask(Q.rational(1/x), Q.irrational(x)) is False
+    assert ask(Q.rational(1/x), Q.irrational(x)) is None
 
     assert ask(Q.rational(2/x), Q.rational(x)) is None
     assert ask(Q.rational(2/x), Q.integer(x)) is None
     assert ask(Q.rational(2/x), Q.even(x)) is None
     assert ask(Q.rational(2/x), Q.odd(x)) is True
-    assert ask(Q.rational(2/x), Q.irrational(x)) is False
+    assert ask(Q.rational(2/x), Q.irrational(x)) is None
 
     assert ask(Q.rational(x), ~Q.algebraic(x)) is False
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1384,8 +1384,8 @@ def test_rational():
     assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is False
     assert ask(Q.rational(x**y),Q.integer(x) & Q.integer(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y)) is None
-    assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is True
-    assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is True
+    assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is None
+    assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is None
 
 
 def test_hermitian():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1354,9 +1354,9 @@ def test_rational():
 
     # with multiple symbols
     assert ask(Q.rational(x*y), Q.irrational(x) & Q.irrational(y)) is None
-    assert ask(Q.rational(y/x), Q.rational(x) & Q.rational(y)) is None
-    assert ask(Q.rational(y/x), Q.integer(x) & Q.rational(y)) is None
-    assert ask(Q.rational(y/x), Q.even(x) & Q.rational(y)) is None
+    assert ask(Q.rational(y/x), Q.rational(x) & Q.rational(y) & Q.nonzero(x)) is True
+    assert ask(Q.rational(y/x), Q.integer(x) & Q.rational(y) & Q.nonzero(x)) is True
+    assert ask(Q.rational(y/x), Q.even(x) & Q.rational(y) & Q.nonzero(x)) is True
     assert ask(Q.rational(y/x), Q.odd(x) & Q.rational(y)) is True
     assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y)) is None
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1388,6 +1388,7 @@ def test_rational():
     assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is None
     assert ask(Q.rational(x**y), Q.prime(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y), ~Q.rational(x) & Q.integer(y) ) is None
+    assert ask(Q.rational(Pow(-1, x, evaluate=False), Q.rational(x))) is None
 
 
 def test_hermitian():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1379,6 +1379,15 @@ def test_rational():
         assert ask(Q.rational(h(7, evaluate=False))) is False
         assert ask(Q.rational(h(x)), Q.rational(x)) is False
 
+    #https://github.com/sympy/sympy/issues/27442
+    assert ask(Q.rational(x**y),Q.irrational(x) & Q.rational(y)) is False
+    assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is False
+    assert ask(Q.rational(x**y),Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y)) is None
+    assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y) & Q.positive(y)) is True
+    assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is True
+    assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is True
+
 
 def test_hermitian():
     assert ask(Q.hermitian(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -400,7 +400,7 @@ def test_pi():
     z = S.Pi ** 2
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is False
+    assert ask(Q.rational(z)) is None
     assert ask(Q.algebraic(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
@@ -1358,7 +1358,7 @@ def test_rational():
     assert ask(Q.rational(y/x), Q.integer(x) & Q.rational(y)) is None
     assert ask(Q.rational(y/x), Q.even(x) & Q.rational(y)) is None
     assert ask(Q.rational(y/x), Q.odd(x) & Q.rational(y)) is True
-    assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y)) is False
+    assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y)) is None
 
     for f in [exp, sin, tan, asin, atan, cos]:
         assert ask(Q.rational(f(7))) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1338,9 +1338,9 @@ def test_rational():
     assert ask(Q.rational(x/2), Q.odd(x)) is True
     assert ask(Q.rational(x/2), Q.irrational(x)) is False
 
-    assert ask(Q.rational(1/x), Q.rational(x)) is True
-    assert ask(Q.rational(1/x), Q.integer(x)) is True
-    assert ask(Q.rational(1/x), Q.even(x)) is True
+    assert ask(Q.rational(1/x), Q.rational(x)) is None
+    assert ask(Q.rational(1/x), Q.integer(x)) is None
+    assert ask(Q.rational(1/x), Q.even(x)) is None
     assert ask(Q.rational(1/x), Q.odd(x)) is True
     assert ask(Q.rational(1/x), Q.irrational(x)) is False
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1344,7 +1344,7 @@ def test_rational():
     assert ask(Q.rational(1/x), Q.odd(x)) is True
     assert ask(Q.rational(1/x), Q.irrational(x)) is False
 
-    assert ask(Q.rational(2/x), Q.rational(x)) is True
+    assert ask(Q.rational(2/x), Q.rational(x)) is None
     assert ask(Q.rational(2/x), Q.integer(x)) is True
     assert ask(Q.rational(2/x), Q.even(x)) is True
     assert ask(Q.rational(2/x), Q.odd(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1386,6 +1386,8 @@ def test_rational():
     assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y)) is None
     assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is None
     assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is None
+    assert ask(Q.rational(x**y), Q.prime(x) & Q.rational(y)) is None
+    assert ask(Q.rational(x**y), ~Q.rational(x) & Q.integer(y) ) is None
 
 
 def test_hermitian():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1344,9 +1344,9 @@ def test_rational():
     assert ask(Q.rational(1/x), Q.odd(x)) is True
     assert ask(Q.rational(1/x), Q.irrational(x)) is None
 
-    assert ask(Q.rational(2/x), Q.rational(x)) is None
-    assert ask(Q.rational(2/x), Q.integer(x)) is None
-    assert ask(Q.rational(2/x), Q.even(x)) is None
+    assert ask(Q.rational(2/x), Q.rational(x) & Q.nonzero(x)) is True
+    assert ask(Q.rational(2/x), Q.integer(x) & Q.nonzero(x)) is True
+    assert ask(Q.rational(2/x), Q.even(x) & Q.nonzero(x)) is True
     assert ask(Q.rational(2/x), Q.odd(x)) is True
     assert ask(Q.rational(2/x), Q.irrational(x)) is None
 
@@ -1390,6 +1390,7 @@ def test_rational():
     assert ask(Q.rational(x**y), ~Q.rational(x) & Q.integer(y) ) is None
     assert ask(Q.rational(Pow(-1, x, evaluate=False), Q.rational(x))) is None
     assert ask(Q.rational(x**y), Q.integer(y) & ~Q. algebraic(x)) is None
+    assert ask(Q.rational(x**y), Q.integer(y) & ~Q. algebraic(x) & ~Q.zero(x)) is None
 
 
 def test_hermitian():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1354,9 +1354,9 @@ def test_rational():
 
     # with multiple symbols
     assert ask(Q.rational(x*y), Q.irrational(x) & Q.irrational(y)) is None
-    assert ask(Q.rational(y/x), Q.rational(x) & Q.rational(y)) is True
-    assert ask(Q.rational(y/x), Q.integer(x) & Q.rational(y)) is True
-    assert ask(Q.rational(y/x), Q.even(x) & Q.rational(y)) is True
+    assert ask(Q.rational(y/x), Q.rational(x) & Q.rational(y)) is None
+    assert ask(Q.rational(y/x), Q.integer(x) & Q.rational(y)) is None
+    assert ask(Q.rational(y/x), Q.even(x) & Q.rational(y)) is None
     assert ask(Q.rational(y/x), Q.odd(x) & Q.rational(y)) is True
     assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y)) is False
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1384,7 +1384,6 @@ def test_rational():
     assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is False
     assert ask(Q.rational(x**y),Q.integer(x) & Q.integer(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y)) is None
-    assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y) & Q.positive(y)) is True
     assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is True
     assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is True
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->Fixes #27442


#### Brief description of what is fixed or changed
1)Updated the RationalPredicate.register(Pow) function to include explicit handling for these cases.
2)Added logical checks for base 0, 1, and -1.


#### Other comments
1)Handles 0^negative_integer: Now correctly returns None instead of True, as division by zero is undefined.
2)Handles 0^0 properly: Returns None as it is an indeterminate form.
3)Fixes rationality checks for irrational^rational: Now correctly returns False when the base is irrational and the exponent is rational.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Make ```ask(Q.integer(x**y), Q.integer(x) & Q.integer(y))``` give ```None``` instead of wrongly giving ```True```.
<!-- END RELEASE NOTES -->
