### PR TITLE
Fix mypy error: type-checking for prev_i index 

### DIFF
--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -395,10 +395,10 @@ def _(expr: ArrayTensorProduct):
             elif pending == k:
                 prev = newargs[-1]
                 if prev.shape[0] == 1:
-                    d1 = cumul[prev_i]
+                    d1 = cumul[prev_i]  # type: ignore
                     prev = _a2m_transpose(prev)
                 else:
-                    d1 = cumul[prev_i] + 1
+                    d1 = cumul[prev_i] + 1  # type: ignore
                 if arg.shape[1] == 1:
                     d2 = cumul[i] + 1
                     arg = _a2m_transpose(arg)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



#### Brief description of what is fixed or changed
This PR fixes a `mypy` error introduced by a recent update `(1.15.0)` to `mypy`. The error occurs because `prev_i` is of type `int | None`, and `mypy` cannot guarantee that `prev_i` is not `None` when it is used as an index for the `cumul` list.

The fix uses `# type: ignore` for the type-checking error for two of these lines.

#### Other comments
Added `# type: ignore` to fix the mypy error in `from_array_to_matrix.py` and it is added in line `398` and `401`.

Fixes #27556

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
