### PR TITLE
Fix stats.NegativeBinomial parameter p to represent success probability

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -451,19 +451,19 @@ class NegativeBinomialDistribution(SingleDiscreteDistribution):
         r = self.r
         p = self.p
 
-        return binomial(k + r - 1, k) * (1 - p)**r * p**k
+        return binomial(k + r - 1, k) * (1 - p)**k * p**r
 
     def _characteristic_function(self, t):
         r = self.r
         p = self.p
 
-        return ((1 - p) / (1 - p * exp(I*t)))**r
+        return (p / (1 - (1 - p) * exp(I*t)))**r
 
     def _moment_generating_function(self, t):
         r = self.r
         p = self.p
 
-        return ((1 - p) / (1 - p * exp(t)))**r
+        return (p / (1 - (1 - p) * exp(t)))**r
 
 def NegativeBinomial(name, r, p):
     r"""
@@ -475,13 +475,15 @@ def NegativeBinomial(name, r, p):
     The density of the Negative Binomial distribution is given by
 
     .. math::
-        f(k) := \binom{k + r - 1}{k} (1 - p)^r p^k
+        f(k) := \binom{k + r - 1}{k} (1 - p)^k p^r
 
     Parameters
     ==========
 
     r : A positive value
+        Number of successes until the experiment is stopped.
     p : A value between 0 and 1
+        Probability of success.
 
     Returns
     =======
@@ -495,19 +497,19 @@ def NegativeBinomial(name, r, p):
     >>> from sympy import Symbol, S
 
     >>> r = 5
-    >>> p = S.One / 5
+    >>> p = S.One / 3
     >>> z = Symbol("z")
 
     >>> X = NegativeBinomial("x", r, p)
 
     >>> density(X)(z)
-    1024*binomial(z + 4, z)/(3125*5**z)
+    (2/3)**z*binomial(z + 4, z)/243
 
     >>> E(X)
-    5/4
+    10
 
     >>> variance(X)
-    25/16
+    30
 
     References
     ==========

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -131,10 +131,10 @@ def test_negative_binomial():
     r = 5
     p = S.One / 3
     x = NegativeBinomial('x', r, p)
-    assert E(x) == p*r / (1-p)
+    assert E(x) == r * (1 - p) / p
     # This hangs when run with the cache disabled:
-    assert variance(x) == p*r / (1-p)**2
-    assert E(x**5 + 2*x + 3) == Rational(9207, 4)
+    assert variance(x) == r * (1 - p) / p**2
+    assert E(x**5 + 2*x + 3) == E(x**5) + 2*E(x) + 3 == Rational(796473, 1)
     assert isinstance(E(x, evaluate=False), Expectation)
 
 
@@ -257,7 +257,7 @@ def test_moment_generating_functions():
 
     negative_binomial_mgf = moment_generating_function(
         NegativeBinomial('n', 5, Rational(1, 3)))(t)
-    assert negative_binomial_mgf.diff(t).subs(t, 0) == Rational(5, 2)
+    assert negative_binomial_mgf.diff(t).subs(t, 0) == Rational(10, 1)
 
     poisson_mgf = moment_generating_function(Poisson('p', 5))(t)
     assert poisson_mgf.diff(t).subs(t, 0) == 5


### PR DESCRIPTION



#### Brief description of what is fixed or changed
This PR fixes the implementation of the NegativeBinomial distribution in sympy.stats to align with the standard definition where the parameter p represents the probability of success, not failure. The changes include:
Revised the correct PMF formula to (1 - p)^k * p^r (where p is the success probability).

#### Other comments
Changes Done - 
Updated NegativeBinomialDistribution Class in which Modified the pdf, _characteristic_function, and _moment_generating_function methods to treat p as the probability of success.
Clarified in the docstring that p represents the probability of success.
Updated the expected values in the test cases to match the corrected formulas.

Fixes #27203

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
