### PR TITLE
remove deprecated function calculate_series,compute_leading_term from gruntz.py,expr.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -771,6 +771,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/doc/src/modules/series/series.rst
+++ b/doc/src/modules/series/series.rst
@@ -105,8 +105,6 @@ Reference
 
 .. autofunction:: sympy.series.gruntz::mrv_leadterm
 
-.. autofunction:: sympy.series.gruntz::calculate_series
-
 .. autofunction:: sympy.series.gruntz::limitinf
 
 .. autofunction:: sympy.series.gruntz::sign

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3487,46 +3487,6 @@ class Expr(Basic, EvalfMixin):
         from sympy.series.limits import limit
         return limit(self, x, xlim, dir)
 
-    def compute_leading_term(self, x, logx=None):
-        """Deprecated function to compute the leading term of a series.
-
-        as_leading_term is only allowed for results of .series()
-        This is a wrapper to compute a series first.
-        """
-        from sympy.utilities.exceptions import SymPyDeprecationWarning
-
-        SymPyDeprecationWarning(
-            feature="compute_leading_term",
-            useinstead="as_leading_term",
-            issue=21843,
-            deprecated_since_version="1.12"
-        ).warn()
-
-        from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
-        if self.has(Piecewise):
-            expr = piecewise_fold(self)
-        else:
-            expr = self
-        if self.removeO() == 0:
-            return self
-
-        from .symbol import Dummy
-        from sympy.functions.elementary.exponential import log
-        from sympy.series.order import Order
-
-        _logx = logx
-        logx = Dummy('logx') if logx is None else logx
-        res = Order(1)
-        incr = S.One
-        while res.is_Order:
-            res = expr._eval_nseries(x, n=1+incr, logx=logx).cancel().powsimp().trigsimp()
-            incr *= 2
-
-        if _logx is None:
-            res = res.subs(logx, log(x))
-
-        return res.as_leading_term(x)
-
     @cacheit
     def as_leading_term(self, *symbols, logx=None, cdir=0):
         """

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -128,7 +128,6 @@ from sympy.core.traversal import bottom_up
 
 from sympy.functions import log, exp, sign as _sign
 from sympy.series.order import Order
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import debug_decorator as debug
 from sympy.utilities.timeutils import timethis
 
@@ -481,47 +480,6 @@ def moveup2(s, x):
 
 def moveup(l, x):
     return [e.xreplace({x: exp(x)}) for e in l]
-
-
-@debug
-@timeit
-def calculate_series(e, x, logx=None):
-    """ Calculates at least one term of the series of ``e`` in ``x``.
-
-    This is a place that fails most often, so it is in its own function.
-    """
-
-    SymPyDeprecationWarning(
-        feature="calculate_series",
-        useinstead="series() with suitable n, or as_leading_term",
-        issue=21838,
-        deprecated_since_version="1.12"
-    ).warn()
-
-    from sympy.simplify.powsimp import powdenest
-
-    for t in e.lseries(x, logx=logx):
-        # bottom_up function is required for a specific case - when e is
-        # -exp(p/(p + 1)) + exp(-p**2/(p + 1) + p)
-        t = bottom_up(t, lambda w:
-            getattr(w, 'normal', lambda: w)())
-        # And the expression
-        # `(-sin(1/x) + sin((x + exp(x))*exp(-x)/x))*exp(x)`
-        # from the first test of test_gruntz_eval_special needs to
-        # be expanded. But other forms need to be have at least
-        # factor_terms applied. `factor` accomplishes both and is
-        # faster than using `factor_terms` for the gruntz suite. It
-        # does not appear that use of `cancel` is necessary.
-        # t = cancel(t, expand=False)
-        t = t.factor()
-
-        if t.has(exp) and t.has(log):
-            t = powdenest(t)
-
-        if not t.is_zero:
-            break
-
-    return t
 
 
 @debug

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -506,18 +506,6 @@ def test_issue_3934():
     assert limit((5**(1/x) + 3**(1/x))**x, x, 0) == 5
 
 
-def test_calculate_series():
-    # NOTE
-    # The calculate_series method is being deprecated and is no longer responsible
-    # for result being returned. The mrv_leadterm function now uses simple leadterm
-    # calls rather than calculate_series.
-
-    # needs gruntz calculate_series to go to n = 32
-    assert limit(x**Rational(77, 3)/(1 + x**Rational(77, 3)), x, oo) == 1
-    # needs gruntz calculate_series to go to n = 128
-    assert limit(x**101.1/(1 + x**101.1), x, oo) == 1
-
-
 def test_issue_5955():
     assert limit((x**16)/(1 + x**16), x, oo) == 1
     assert limit((x**100)/(1 + x**100), x, oo) == 1
@@ -556,6 +544,8 @@ def test_Limit_dir():
 def test_polynomial():
     assert limit((x + 1)**1000/((x + 1)**1000 + 1), x, oo) == 1
     assert limit((x + 1)**1000/((x + 1)**1000 + 1), x, -oo) == 1
+    assert limit(x ** Rational(77, 3) / (1 + x ** Rational(77, 3)), x, oo) == 1
+    assert limit(x ** 101.1 / (1 + x ** 101.1), x, oo) == 1
 
 
 def test_rational():


### PR DESCRIPTION
#### References to other Issues or PRs

#### issue #27281

#### Brief description of what is changed
Remove already deprecated functions since sympy 1.12

- compute_leading_term() from expr.py
instead use `as_leading_term`

- calculate_series() from gruntz.py
instead use `series()` with suitable n, or as_leading_term

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->