### PR TITLE
Fix Miller-Rabin test in primetest.py to correctly handle even numbers.

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -249,7 +249,7 @@ def mr(n, bases):
     from sympy.polys.domains import ZZ
 
     n = as_int(n)
-    if n < 2:
+    if n < 2 or (n > 2 and n % 2 == 0):
         return False
     # remove powers of 2 from n-1 (= t * 2**s)
     s = bit_scan1(n - 1)

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -229,6 +229,7 @@ def test_is_gaussianprime():
     assert is_gaussian_prime(2 + 3*I)
     assert not is_gaussian_prime(2 + 2*I)
 
+
 def test_issue_27145():
     #https://github.com/sympy/sympy/issues/27145
     assert [mr(i,[2,3,5,7]) for i in (1, 2, 6)] == [False, True, False]

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -228,3 +228,7 @@ def test_is_gaussianprime():
     assert is_gaussian_prime(7)
     assert is_gaussian_prime(2 + 3*I)
     assert not is_gaussian_prime(2 + 2*I)
+
+def test_issue_27145():
+    #https://github.com/sympy/sympy/issues/27145
+    assert [mr(i,[2,3,5,7]) for i in (1, 2, 6)] == [False, True, False]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes:#27145
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously, the check was limited to numbers less than 2. Now, it correctly handles even numbers in the Miller-Rabin primality test

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
