### PR TITLE
Show how to index wigner_d* matrices; note Euler angle difference

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1034,6 +1034,7 @@ Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
 Mihail Tarigradschi <m.tarigradschi@gmail.com>
 Mihir Wadwekar <m.mihirw@gmail.com>
 Mike Boyle <boyle@astro.cornell.edu>
+Mike Boyle <boyle@astro.cornell.edu> Mike Boyle <moble@users.noreply.github.com>
 Mikel Rouco <mikel.mrm@gmail.com>
 Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.noreply.github.com>
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -1014,6 +1014,8 @@ Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>
+Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <moble@users.noreply.github.com>
 Michael Chu <michael02chu@gmail.com>
 Michael Gallaspy <gallaspy.michael@gmail.com>
 Michael Greminger <michael.greminger@gmail.com> mgreminger <michael.greminger@gmail.com>
@@ -1033,8 +1035,6 @@ Miha Marolt <tloramus@gmail.com>
 Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
 Mihail Tarigradschi <m.tarigradschi@gmail.com>
 Mihir Wadwekar <m.mihirw@gmail.com>
-Mike Boyle <boyle@astro.cornell.edu>
-Mike Boyle <boyle@astro.cornell.edu> Mike Boyle <moble@users.noreply.github.com>
 Mikel Rouco <mikel.mrm@gmail.com>
 Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.noreply.github.com>
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>

--- a/AUTHORS
+++ b/AUTHORS
@@ -286,7 +286,7 @@ David Joyner <wdjoyner@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
 Alkiviadis G. Akritas <akritas@uth.gr>
 Vinit Ravishankar <vinit.ravishankar@gmail.com>
-Mike Boyle <boyle@astro.cornell.edu>
+Michael Boyle <michael.oliver.boyle@gmail.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
 Pablo Puente <ppuedom@gmail.com>
 James Fiedler <jrfiedler@gmail.com>
@@ -406,7 +406,6 @@ Lucas Jones <lucas@lucasjones.co.uk>
 Gregory Ashton <gash789@gmail.com>
 Jennifer White <jcrw122@googlemail.com>
 Renato Orsino <renato.orsino@gmail.com>
-Michael Boyle <michael.oliver.boyle@gmail.com>
 Alistair Lynn <arplynn@gmail.com>
 Govind Sahai <gsiitbhu@gmail.com>
 Adam Bloomston <adam@glitterfram.es>

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -1022,6 +1022,11 @@ def wigner_d_small(J, beta):
     .. math ::
         \\mathcal{d}_{\\beta} = \\exp\\big( \\frac{i\\beta}{\\hbar} J_y\\big)
 
+    such that
+
+    .. math ::
+        d^{(J)}_{m',m}(\\beta) = \\mathtt{wigner_d_small(J,beta)[J-mprime,J-m]}
+
     The components are calculated using the general form [Edmonds74]_,
     equation 4.1.15.
 
@@ -1118,6 +1123,8 @@ def wigner_d_small(J, beta):
     """
     M = [J-i for i in range(2*J+1)]
     d = zeros(2*J+1)
+
+    # Mi corresponds to Edmonds' $m'$, and Mj to $m$.
     for i, Mi in enumerate(M):
         for j, Mj in enumerate(M):
 
@@ -1149,13 +1156,14 @@ def wigner_d(J, alpha, beta, gamma):
         An integer, half-integer, or SymPy symbol for the total angular
         momentum of the angular momentum space being rotated.
     alpha, beta, gamma - Real numbers representing the Euler.
-        Angles of rotation about the so-called vertical, line of nodes, and
-        figure axes. See [Edmonds74]_.
+        Angles of rotation about the so-called figure axis, line of nodes,
+        and vertical. See [Edmonds74]_, however note that the symbols alpha
+        and gamma are swapped in this implementation.
 
     Returns
     =======
 
-    A matrix representing the corresponding Euler angle rotation( in the basis
+    A matrix representing the corresponding Euler angle rotation (in the basis
     of eigenvectors of `J_z`).
 
     .. math ::
@@ -1164,8 +1172,15 @@ def wigner_d(J, alpha, beta, gamma):
         \\exp\\big( \\frac{i\\beta}{\\hbar} J_y\\big)
         \\exp\\big( \\frac{i\\gamma}{\\hbar} J_z\\big)
 
+    such that
+
+    .. math ::
+        \\mathcal{D}^{(J)}_{m',m}(\\alpha, \\beta, \\gamma) =
+        \\mathtt{wigner_d(J, alpha, beta, gamma)[J-mprime,J-m]}
+
     The components are calculated using the general form [Edmonds74]_,
-    equation 4.1.12.
+    equation 4.1.12, however note that the angles alpha and gamma are swapped
+    in this implementation.
 
     Examples
     ========
@@ -1192,6 +1207,7 @@ def wigner_d(J, alpha, beta, gamma):
     """
     d = wigner_d_small(J, beta)
     M = [J-i for i in range(2*J+1)]
+    # Mi corresponds to Edmonds' $m'$, and Mj to $m$.
     D = [[exp(I*Mi*alpha)*d[i, j]*exp(I*Mj*gamma)
           for j, Mj in enumerate(M)] for i, Mi in enumerate(M)]
     return ImmutableMatrix(D)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

It was not at all clear from the documentation what the matrices output by `wigner_d_small` and `wigner_d` represented — specifically their indices.  This PR adds that information.

Also, comparing to the reference from which these expressions were taken, it is clear that there has been a swapping of the arguments for `wigner_d`.  Specifically, the docstring previously just said:

> A matrix representing the corresponding Euler angle rotation (in the basis of eigenvectors of `J_z`).

$$
\mathcal{D}_{\alpha \beta \gamma} =
\exp\big( \frac{i\alpha}{\hbar} J_z\big)
\exp\big( \frac{i\beta}{\hbar} J_y\big)
\exp\big( \frac{i\gamma}{\hbar} J_z\big)
$$

> The components are calculated using the general form [Edmonds74]_, equation 4.1.12.

This equation is implemented as (essentially)
```python
exp(I*mprime*alpha)*d[i, j]*exp(I*m*gamma)
```

But that reference actually says

<img width="1240" alt="D_screenshot" src="https://github.com/user-attachments/assets/26d9fb67-4b1f-4ade-a060-0e6bc4f2172c" />

Somehow, in both the docstring reproducing equation 4.1.9 and the implementation of equation 4.1.12 $\alpha$ and $\gamma$ have been swapped in `wigner_d` compared to the cited reference.  The implementation of `wigner_d_small` is not affected.

This is a surprising discrepancy, and a change may be warranted, but I wanted to keep this PR small and less controversial.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.wigner
  * Explained how to index the matrices output by `wigner_d` and `wigner_d_small`.
  * Noted discrepancy in angles compared to cited reference.

<!-- END RELEASE NOTES -->
