### PR TITLE
Improve documentation for working with FormalPowerSeries Object in fps function.

### DIFF
--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1819,6 +1819,45 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
         See :func:`rational_algorithm` for details. By default it is set to
         False.
 
+    Returns
+    =======
+
+    FormalPowerSeries
+        An object representing the formal power series of the input function.
+
+    Working with FormalPowerSeries Objects
+    ======================================
+
+    The returned FormalPowerSeries object can be manipulated and interrogated:
+
+    1. Accessing the Structure:
+        Use ``.args`` to access the internal structure:
+
+        >>> from sympy import fps, exp
+        >>> from sympy.abc import x
+        >>> series = fps(exp(x))
+        >>> series.args
+        (exp(x), x, 0, 1, (SeqFormula(Piecewise((1/factorial(_k), Eq(Mod(_k, 1), 0)),
+        (0, True)), (_k, 1, oo)), SeqFormula(x**_k, (_k, 0, oo)), 1))
+
+    2. Accessing Coefficients:
+        The coefficient sequence is a SeqFormula object:
+
+        >>> coeff_seq = series.args[4][0]
+        >>> type(coeff_seq)
+        <class 'sympy.series.sequences.SeqFormula'>
+        >>> coeff_seq[3]
+        1/24
+
+    3. Accessing Sequence:
+        The power sequence is a SeqFormula object:
+
+        >>> power_seq = series.args[4][1]
+        >>> type(power_seq)
+        <class 'sympy.series.sequences.SeqFormula'>
+        >>> power_seq[3]
+        x**3
+
     Examples
     ========
 


### PR DESCRIPTION
## Improve the documentation for the `fps` function in `formal.py`

### Reference Issue #26824

### Brief description of what is fixed or changed:
Added detailed documentation on working with the `FormalPowerSeries` object in SymPy. This includes examples of how to access the internal structure, coefficients, and sequences of a formal power series using the `fps` function.

### Other comments:
This update enhances the understanding of how to manipulate and extract components from a `FormalPowerSeries` object, such as the coefficient and power sequences. The added examples provide clear, executable code snippets for users, helping them work with `fps` more effectively.

### Release Notes:
<!-- BEGIN RELEASE NOTES -->
- series
  - Added documentation for working with the `FormalPowerSeries` object in the `fps` function in `formal.py`
<!-- END RELEASE NOTES -->
