### PR TITLE
Fix inconsistent behavior of primitive method for zero polynomial

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2218,6 +2218,8 @@ class DUP_Flint(DMP):
     def primitive(f):
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
+        if f.is_zero:
+            return f.dom.zero, f
         prim = f._exquo_ground(cont)
         return cont, prim
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2218,6 +2218,8 @@ class DUP_Flint(DMP):
     def primitive(f):
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
+        if cont == f.ring.domain.zero:
+            return (cont, f)
         prim = f._exquo_ground(cont)
         return cont, prim
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2218,8 +2218,6 @@ class DUP_Flint(DMP):
     def primitive(f):
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
-        if cont == f.ring.domain.zero:
-            return (cont, f)
         prim = f._exquo_ground(cont)
         return cont, prim
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1974,8 +1974,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def primitive(f):
         """Returns content and a primitive polynomial. """
         cont = f.content()
-        if cont == f.ring.domain.zero:
-            return (cont, f)
         return cont, f.quo_ground(cont)
 
     def monic(f):
@@ -2012,6 +2010,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def quo_ground(f, x):
         domain = f.ring.domain
 
+        if not x:
+            return f.ring.zero
         if not x:
             raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2012,6 +2012,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         if not x:
             return f.ring.zero
+        if not x:
+            raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:
             return f
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2012,8 +2012,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         if not x:
             return f.ring.zero
-        if not x:
-            raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:
             return f
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1974,6 +1974,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def primitive(f):
         """Returns content and a primitive polynomial. """
         cont = f.content()
+        if cont == f.ring.domain.zero:
+            return (cont, f)
         return cont, f.quo_ground(cont)
 
     def monic(f):

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1974,6 +1974,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def primitive(f):
         """Returns content and a primitive polynomial. """
         cont = f.content()
+        if cont == f.ring.domain.zero:
+            return (cont, f)
         return cont, f.quo_ground(cont)
 
     def monic(f):
@@ -2010,8 +2012,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def quo_ground(f, x):
         domain = f.ring.domain
 
-        if not x:
-            return f.ring.zero
         if not x:
             raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -586,3 +586,16 @@ def test_ANP_unify():
     assert b.unify_ANP(a)[-1] == QQ
     assert a.unify_ANP(a)[-1] == QQ
     assert b.unify_ANP(b)[-1] == ZZ
+
+
+def test_zero_poly():
+    from sympy import Symbol
+    x = Symbol('x')
+
+    R_old = ZZ.old_poly_ring(x)
+    zero_poly_old = R_old(0)
+    cont_old, prim_old = zero_poly_old.primitive()
+
+    assert cont_old == 0
+    assert prim_old == zero_poly_old
+    assert prim_old.is_primitive is False

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1588,3 +1588,10 @@ def test_zero_polynomial_primitive():
     assert cont == 0
     assert prim == zero_poly
     assert prim.is_primitive is False
+
+    R_old = ZZ.old_poly_ring(x)
+    zero_poly_old = R_old(0)
+    cont_old, prim_old = zero_poly_old.primitive()
+    assert cont_old == 0
+    assert prim_old == zero_poly_old
+    assert prim_old.is_primitive is False

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1576,3 +1576,22 @@ def test_issue_21410():
     R, x = ring('x', FF(2))
     p = x**6 + x**5 + x**4 + x**3 + 1
     assert p._pow_multinomial(4) == x**24 + x**20 + x**16 + x**12 + 1
+
+
+def test_zero_polynomial_primitive():
+
+    x = symbols('x')
+
+    R = ZZ[x]
+    zero_poly = R(0)
+    cont, prim = zero_poly.primitive()
+    assert cont == 0
+    assert prim == zero_poly
+    assert prim.is_primitive is False
+
+    R_old = ZZ.old_poly_ring(x)
+    zero_poly_old = R_old(0)
+    cont_old, prim_old = zero_poly_old.primitive()
+    assert cont_old == 0
+    assert prim_old == zero_poly_old
+    assert prim_old.is_primitive is False

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1588,10 +1588,3 @@ def test_zero_polynomial_primitive():
     assert cont == 0
     assert prim == zero_poly
     assert prim.is_primitive is False
-
-    R_old = ZZ.old_poly_ring(x)
-    zero_poly_old = R_old(0)
-    cont_old, prim_old = zero_poly_old.primitive()
-    assert cont_old == 0
-    assert prim_old == zero_poly_old
-    assert prim_old.is_primitive is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Brief description of what is fixed or changed
This PR fixes the inconsistent behaviour of the `primitive` method for the zero polynomial. Previously, calling `primitive` on the zero polynomial would either raise a `ZeroDivisionError`. This PR ensures that the method consistently returns `(0, 0)` for the zero polynomial and marks it as non-primitive.

#### Other comments
Modified the `primitive` method to handle the zero polynomial case.

Fixes #21319
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed inconsistent behavior of the `primitive` method for the zero polynomial.
<!-- END RELEASE NOTES -->
