### PR TITLE
Fix incorrect docstring examples in TransferFunction method

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -249,7 +249,7 @@ def mr(n, bases):
     from sympy.polys.domains import ZZ
 
     n = as_int(n)
-    if n < 2:
+    if n < 2 or (n > 2 and n % 2 == 0):
         return False
     # remove powers of 2 from n-1 (= t * 2**s)
     s = bit_scan1(n - 1)

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -229,6 +229,7 @@ def test_is_gaussianprime():
     assert is_gaussian_prime(2 + 3*I)
     assert not is_gaussian_prime(2 + 2*I)
 
+
 def test_issue_27145():
     #https://github.com/sympy/sympy/issues/27145
     assert [mr(i,[2,3,5,7]) for i in (1, 2, 6)] == [False, True, False]

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -228,3 +228,7 @@ def test_is_gaussianprime():
     assert is_gaussian_prime(7)
     assert is_gaussian_prime(2 + 3*I)
     assert not is_gaussian_prime(2 + 2*I)
+
+def test_issue_27145():
+    #https://github.com/sympy/sympy/issues/27145
+    assert [mr(i,[2,3,5,7]) for i in (1, 2, 6)] == [False, True, False]

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -753,7 +753,6 @@ class TransferFunction(SISOLinearTimeInvariant):
         >>> tf = TransferFunction.from_coeff_lists(num, den, s)
         >>> tf
         TransferFunction(s**2 + 2, 3*s**3 + 2*s**2 + 2*s + 1, s)
-
         # Create a Transfer Function with more than one variable
         >>> tf1 = TransferFunction.from_coeff_lists([p, 1], [2*p, 0, 4], s)
         >>> tf1
@@ -802,12 +801,10 @@ class TransferFunction(SISOLinearTimeInvariant):
         >>> tf = TransferFunction.from_zpk(zeros, poles, gain, s)
         >>> tf
         TransferFunction(7*(s - 3)*(s - 2)*(s - 1), (s - 6)*(s - 5)*(s - 4), s)
-
         # Create a Transfer Function with variable poles and zeros
         >>> tf1 = TransferFunction.from_zpk([p, k], [p + k, p - k], 2, s)
         >>> tf1
         TransferFunction(2*(-k + s)*(-p + s), (-k - p + s)*(k - p + s), s)
-
         # Complex poles or zeros are acceptable
         >>> tf2 = TransferFunction.from_zpk([0], [1-1j, 1+1j, 2], -2, s)
         >>> tf2

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -753,8 +753,7 @@ class TransferFunction(SISOLinearTimeInvariant):
         >>> tf = TransferFunction.from_coeff_lists(num, den, s)
         >>> tf
         TransferFunction(s**2 + 2, 3*s**3 + 2*s**2 + 2*s + 1, s)
-        # Create a Transfer Function with more than one variable
-        >>> tf1 = TransferFunction.from_coeff_lists([p, 1], [2*p, 0, 4], s)
+        >>> tf1 = TransferFunction.from_coeff_lists([p, 1], [2*p, 0, 4], s) # Create a Transfer Function with more than one variable
         >>> tf1
         TransferFunction(p*s + 1, 2*p*s**2 + 4, s)
 
@@ -801,12 +800,10 @@ class TransferFunction(SISOLinearTimeInvariant):
         >>> tf = TransferFunction.from_zpk(zeros, poles, gain, s)
         >>> tf
         TransferFunction(7*(s - 3)*(s - 2)*(s - 1), (s - 6)*(s - 5)*(s - 4), s)
-        # Create a Transfer Function with variable poles and zeros
-        >>> tf1 = TransferFunction.from_zpk([p, k], [p + k, p - k], 2, s)
+        >>> tf1 = TransferFunction.from_zpk([p, k], [p + k, p - k], 2, s) # Create a Transfer Function with variable poles and zeros
         >>> tf1
         TransferFunction(2*(-k + s)*(-p + s), (-k - p + s)*(k - p + s), s)
-        # Complex poles or zeros are acceptable
-        >>> tf2 = TransferFunction.from_zpk([0], [1-1j, 1+1j, 2], -2, s)
+        >>> tf2 = TransferFunction.from_zpk([0], [1-1j, 1+1j, 2], -2, s) # Complex poles or zeros are acceptable
         >>> tf2
         TransferFunction(-2*s, (s - 2)*(s - 1.0 - 1.0*I)*(s - 1.0 + 1.0*I), s)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed incorrect or poorly formatted docstring examples in the TransferFunction method, ensuring clarity and correctness in the documentation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
