### PR TITLE
Reset Visited List Color to Default

### DIFF
--- a/doc/src/_static/custom.css
+++ b/doc/src/_static/custom.css
@@ -146,11 +146,13 @@ This can be removed once https://github.com/executablebooks/mdit-py-plugins/issu
 
 /* Override visited link color in Furo */
 a:visited {
-    color: var(--color-link); 
+    color: var(--color-link);
+    text-decoration-color: var(--color-link);
 }
 
 /* Ensure visited links don't turn purple on hover */
 a:visited:hover {
     color: var(--color-link);
+    text-decoration-color: var(--color-link);
 }
 

--- a/doc/src/_static/custom.css
+++ b/doc/src/_static/custom.css
@@ -146,6 +146,11 @@ This can be removed once https://github.com/executablebooks/mdit-py-plugins/issu
 
 /* Override visited link color in Furo */
 a:visited {
-    color: var(--color-link); /* Use the default link color */
+    color: var(--color-link); 
+}
+
+/* Ensure visited links don't turn purple on hover */
+a:visited:hover {
+    color: var(--color-link);
 }
 

--- a/doc/src/_static/custom.css
+++ b/doc/src/_static/custom.css
@@ -143,3 +143,9 @@ This can be removed once https://github.com/executablebooks/mdit-py-plugins/issu
 .task-list-item-checkbox {
     margin: 0 0.2em 0.25em -1.4em;
 }
+
+/* Override visited link color in Furo */
+a:visited {
+    color: var(--color-link); /* Use the default link color */
+}
+


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix:   #26599
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed visited link styling in the Furo theme by ensuring the text color, underline color, and hover effect match the default link color, preventing the unwanted purple styling.
Restored the default visited link color by removing the custom :visited style override.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
