### PR TITLE
Make `evaluate=False` work for Piecewise

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1129,6 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1129,9 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
 Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -32,7 +32,7 @@ class ExprCondPair(Tuple):
                 cond = piecewise_fold(cond)
                 if isinstance(cond, Piecewise):
                     cond = cond.rewrite(ITE)
-    
+
             if not isinstance(cond, Boolean):
                 raise TypeError(filldedent('''
                     Second argument must be a Boolean,

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -157,7 +157,7 @@ class Piecewise(DefinedFunction):
         elif len(newargs) == 1 and newargs[0].cond == True:
             return newargs[0].expr
 
-        return Basic.__new__(cls, *newargs, evaluate=evaluate)
+        return Basic.__new__(cls, *newargs)
 
     @classmethod
     def eval(cls, *_args):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -19,11 +19,10 @@ Undefined = S.NaN  # Piecewise()
 class ExprCondPair(Tuple):
     """Represents an expression, condition pair."""
 
-    def __new__(cls, expr, cond, **options):
+    def __new__(cls, expr, cond, evaluate=None):
         expr = as_Basic(expr)
 
-        evaluate = options.get('evaluate', global_parameters.evaluate)
-        if evaluate:
+        if global_parameters.evaluate if evaluate is None else evaluate:
             if cond == True:
                 return Tuple.__new__(cls, expr, true)
             elif cond == False:
@@ -132,11 +131,12 @@ class Piecewise(DefinedFunction):
     nargs = None
     is_Piecewise = True
 
-    def __new__(cls, *args, **options):
+    def __new__(cls, *args, evaluate=None):
         if len(args) == 0:
             raise TypeError("At least one (expr, cond) pair expected.")
 
-        evaluate = options.pop('evaluate', global_parameters.evaluate)
+        if evaluate is None:
+            evaluate = global_parameters.evaluate
 
         # (Try to) sympify args first
         newargs = []
@@ -157,7 +157,7 @@ class Piecewise(DefinedFunction):
         elif len(newargs) == 1 and newargs[0].cond == True:
             return newargs[0].expr
 
-        return Basic.__new__(cls, *newargs, **options)
+        return Basic.__new__(cls, *newargs, evaluate=evaluate)
 
     @classmethod
     def eval(cls, *_args):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27606

#### Brief description of what is fixed or changed

Make `evaluate=False` work for Piecewise

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* functions
  * Fixed a bug where `evaluate=False` did not work for Piecewise and ExprCondPair.

<!-- END RELEASE NOTES -->
