### PR TITLE
Simplification of outputs from Singularity Functions and Multiplication strings

### DIFF
--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -194,7 +194,7 @@ class SingularityFunction(DefinedFunction):
                     return self
         return Mul(self,other, evaluate=True)
 
-    def _eval_power(self, expt) -> Expr | None:
+    def _eval_power(self, expt):
         '''
         Modifies the singularity function exponential function, in which it will return a simplified version of the
         singularity function to a certain power only if the power for the singularity function is 0 (essentially

--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -178,7 +178,33 @@ class SingularityFunction(DefinedFunction):
                 return S.Zero
             if shift.is_zero:
                 return oo
+    def __mul__(self, other):
+        '''
+        Overwrites the singularity function multiplication to return one if an exponent is 0. It will check that the
+        shift and variable remain the same so that it can be simplified.
 
+        '''
+        if isinstance(other, SingularityFunction):
+            if self.args[1] == other.args[1] and self.args[0] == other.args[0]:
+                if self.args[2] == 0 and other.args[2] != 0:
+                    return other
+                if other.args[2] == 0 and self.args[2] != 0:
+                    return self
+                if self.args[2] == 0 and other.args[2] == 0:
+                    return self
+        return Mul(self,other, evaluate=True)
+
+    def _eval_power(self, expt) -> Expr | None:
+        '''
+        Modifies the singularity function exponential function, in which it will return a simplified version of the
+        singularity function to a certain power only if the power for the singularity function is 0 (essentially
+        discontinuity should equal 1).
+
+        '''
+        if self.args[2] == 0 and expt != 0:
+            return self
+        return super()._eval_power(expt)
+        
     def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         '''
         Converts a Singularity Function expression into its Piecewise form.

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -268,6 +268,13 @@ class StrPrinter(Printer):
         # etc so we display in a straight-forward form that fully preserves all
         # args and their order.
         args = expr.args
+        
+        # Simplifies the string representation of multiplying integers and variables.
+        if isinstance(args[0], Integer) and isinstance(args[1], Symbol):
+            beginning_part = f"{args[0]}{self._print(args[1])}"
+            remaining_part = " * ".join(self._print(arg) for arg in args[2:])
+            return beginning_part if not remaining_part else f"{beginning_part}{remaining_part}"
+            
         if args[0] is S.One or any(
                 isinstance(a, Number) or
                 a.is_Pow and all(ai.is_Integer for ai in a.args)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/issues/26700

#### Brief description of what is fixed or changed
Changed the output if the singularity function ever encountered exponents with 0. Essentially simplified the output so that it is not redundant. I also added design changes to the multiplication string output so that it looks nicer in my opinion. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added functions that simplify redundant singularity function operatives
  * Added design implementation for nicer looking multiplication output string. 
<!-- END RELEASE NOTES -->
