### PR TITLE
Removed redundant Poly.unit method in favour of Poly.one

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -443,11 +443,6 @@ class Poly(Basic):
         """Return one polynomial with ``self``'s properties. """
         return self.new(self.rep.one(self.rep.lev, self.rep.dom), *self.gens)
 
-    @property
-    def unit(self):
-        """Return unit polynomial with ``self``'s properties. """
-        return self.new(self.rep.unit(self.rep.lev, self.rep.dom), *self.gens)
-
     def unify(f, g):
         """
         Make ``f`` and ``g`` belong to the same domain.

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3941,10 +3941,3 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
-
-
-def test_issue_21314():
-    x = Symbol('x')
-    p = Poly([1, 2, 3], x)
-    poly = p.one
-    assert poly == Poly(1, x, domain=ZZ)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3941,3 +3941,10 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_issue_21314():
+    x = Symbol('x')
+    p = Poly([1, 2, 3], x)
+    poly = p.one
+    assert poly == Poly(1, x, domain=ZZ)


### PR DESCRIPTION

#### Brief description of what is fixed or changed
This PR addresses issue by removing the redundant `Poly.unit` method, as `Poly.one` already provides the same functionality.

#### Other comments
Deleted the unit method from the Poly class.

Fixes #21314

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Removed `Poly.unit` which has same functionality as `Poly.one`.
<!-- END RELEASE NOTES -->
