### PR TITLE
Implement Partition Dominance Function with Documentation and Tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1186,7 +1186,7 @@ Prateek Papriwal <papriwalprateek@gmail.com>
 Pratyksh Gupta <pratykshgupta9999@gmail.com> Pg999999 <pratykshgupta9999@gmail.com>
 Praveen Perumal <ppraveen98841@gmail.com> Praveen Perumal <58477724+solvedbiscuit71@users.noreply.github.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
-Prayag <v.prayag2005@gmail.com> vprayag2005 <v.prayag2005@gamil.com>
+Prayag V <v.prayag2005@gmail.com> vprayag2005 <v.prayag2005@gamil.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>
 Prey Patel <patel.prey@iitgn.ac.in>

--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -136,6 +136,8 @@ Ntheory Functions Reference
 
 .. autofunction:: npartitions
 
+.. autofunction:: is_partition_dominant
+
 .. module:: sympy.ntheory.primetest
 
 .. autofunction:: is_fermat_pseudoprime

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -309,7 +309,7 @@ def is_partition_dominant(lambda_:list,mu:list) -> bool:
         return False
     if(len(lambda_)!=len(mu)):
         if(len(lambda_)>len(mu)):
-            b+=[0]*(len(lambda_)-len(mu))
+            mu+=[0]*(len(lambda_)-len(mu))
         else:
             lambda_+=[0]*(len(mu)-len(lambda_))
     lambda_.sort(reverse=True)

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -276,3 +276,48 @@ def npartitions(n, verbose=False):
     """
     from sympy.functions.combinatorial.numbers import partition as func_partition
     return func_partition(n)
+
+
+def is_partition_dominant(lambda_:list,mu:list) -> bool:
+    """
+    Checks if 'lambda_' dominates 'mu' in the dominance order.
+
+    Returns True if the sums are equal and the cumulative sum of 'lambda_'
+    is greater than or equal to that of 'mu' at every index.
+
+    Args:
+        lambda_ (list): First partition.
+        mu (list): Second partition.
+
+    Returns:
+        bool: True if 'lambda_' dominates 'mu', else False.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.partitions_ import is_partition_dominant
+    >>> lambda_ = [5, 3, 2]
+    >>> mu = [4, 4, 2]
+    >>> is_partition_dominant(lambda_ ,mu)
+    True
+    >>> lambda_ = [4, 3, 2]
+    >>> mu = [5, 3, 1]
+    >>> is_partition_dominant(lambda_ ,mu)
+    False
+    """
+    if(sum(lambda_)!=sum(mu)):
+        return False
+    if(len(lambda_)!=len(mu)):
+        if(len(lambda_)>len(mu)):
+            b+=[0]*(len(lambda_)-len(mu))
+        else:
+            lambda_+=[0]*(len(mu)-len(lambda_))
+    lambda_.sort(reverse=True)
+    mu.sort(reverse=True)
+    sum_lambda_=sum_mu=0
+    for i in range(len(lambda_)):
+        sum_lambda_+=lambda_[i]
+        sum_mu+=mu[i]
+        if(sum_mu>sum_lambda_):
+            return False
+    return True

--- a/sympy/ntheory/tests/test_partitions.py
+++ b/sympy/ntheory/tests/test_partitions.py
@@ -1,4 +1,4 @@
-from sympy.ntheory.partitions_ import npartitions, _partition_rec, _partition
+from sympy.ntheory.partitions_ import npartitions, _partition_rec, _partition,is_partition_dominant
 
 
 def test__partition_rec():
@@ -26,3 +26,8 @@ def test_deprecated_ntheory_symbolic_functions():
 
     with warns_deprecated_sympy():
         assert npartitions(0) == 1
+
+
+def test_is_partition_dominant():
+    assert is_partition_dominant([5, 3, 2], [4, 4, 2]) == True
+    assert is_partition_dominant([4, 3, 2], [5, 3, 1]) == False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Implementaion for #22599
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Implement `is_partition_dominant` function to check partition dominance. Includes documentation and unit tests for validation.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * partition_dominance : Added `is_partition_dominant` function with docs and tests.
<!-- END RELEASE NOTES -->
