### PR TITLE
Resolves error caused due to the unhandled None value of residual.

### DIFF
--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -90,7 +90,10 @@ def _generate_factor_base(prime_bound, n):
                 idx_1000 = len(factor_base) - 1
             if prime > 5000 and idx_5000 is None:
                 idx_5000 = len(factor_base) - 1
-            residue = _sqrt_mod_prime_power(n, prime, 1)[0]
+            candidate_residue = _sqrt_mod_prime_power(n, prime, 1)
+            if candidate_residue is None:
+                continue
+            residue = candidate_residue[0]
             log_p = round(log(prime)*2**10)
             factor_base.append(FactorBaseElem(prime, residue, log_p))
     return idx_1000, idx_5000, factor_base


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Fixes #27616 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Resolved the error caused due to sub-scripting of a None value in the nthoery/qs.py module.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Make  ``` qs(9804659461513846513 + 1 , 5000, 20000) ```  give ```{2, 633762691, 13, 15470553254}``` instead of raising  this error : ```TypeError: 'NoneType' object is not subscriptable```
<!-- END RELEASE NOTES -->
