### PR TITLE
Asymptotic series expansions for Shi & Chi functions

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -2003,6 +2003,10 @@ class Mul(Expr, AssocOp):
                 n0 = S.Zero
             facs = [t.nseries(x, n=ceiling(n-n0), logx=logx, cdir=cdir) for t in self.args]
             from sympy.simplify.powsimp import powsimp
+            from sympy.functions.special.error_functions import Shi
+            if self.has(Shi):
+                res = powsimp(self.func(*facs), combine='exp', deep=True)
+                return res
             res = powsimp(self.func(*facs).expand(), combine='exp', deep=True)
             if res.has(Order):
                 res += Order(x**n, x)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2206,6 +2206,20 @@ class Shi(TrigonometricIntegral):
         else:
             return self
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+
+        if point is S.Infinity:
+            z = self.args[0]
+            o = Order(1/z**(n), x)
+
+            p = [factorial(2 *k)/z**(2*k+1) for k in range(n//2+1)] + [o]
+            q = [factorial(2*k+1)/z**(2*(k+1)) for k in range(n//2)] + [o]
+            result =  Add(*q)*sinh(z+o) + Add(*p)*cosh(z+o)
+
+            return result - (I*pi/2)
+        return super()._eval_aseries(n, args0, x, logx)
 
 class Chi(TrigonometricIntegral):
     r"""
@@ -2319,6 +2333,24 @@ class Chi(TrigonometricIntegral):
         else:
             return self
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy.series.order import Order
+        point = args0[0]
+        sign=S.One
+
+        if point in (S.Infinity, S.NegativeInfinity):
+            z = self.args[0]
+            o = Order(1/z**(n), x)
+
+            p = [factorial(2*k)/z**(2*k+1) for k in range(n//2+1)] + [o]
+            q = [factorial(2*k+1)/z**(2*(k+1)) for k in range(n//2)] + [o]
+            result =  Add(*q)*cosh(z+o) + Add(*p)*sinh(z+o)
+
+            if point is S.Infinity:
+                sign=S.NegativeOne
+
+            return result + sign*(I*pi/2)
+        return super()._eval_aseries(n, args0, x, logx)
 
 ###############################################################################
 #################### FRESNEL INTEGRALS ########################################

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -657,9 +657,6 @@ def test_si():
     t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc).dummy_eq(Integral(sinc(t), (t, 0, x)))
 
-    assert limit(Shi(x), x, S.Infinity) == S.Infinity
-    assert limit(Shi(x), x, S.NegativeInfinity) == S.NegativeInfinity
-
 
 def test_ci():
     m1 = exp_polar(I*pi)
@@ -713,6 +710,24 @@ def test_ci():
     assert Ci(x).rewrite(expint) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
                                         expint(1, x*exp_polar(I*pi/2))/2
     raises(ArgumentIndexError, lambda: Ci(x).fdiff(2))
+
+
+def test_shi_series():
+    assert Shi(x).series(x, oo) == (6/x**4 + x**(-2) + O(x**(-6), (x, oo)))* \
+           sinh(x + O(x**(-6), (x, oo))) + (24/x**5 + 2/x**3 + 1/x + O(x**(-6), (x, oo)))* \
+           cosh(x + O(x**(-6), (x, oo))) - I*pi/2
+    assert Shi(x).series(x, -oo) == (6/x**4 + x**(-2) + O(x**(-6), (x, -oo)))* \
+           sinh(x + O(x**(-6), (x, -oo))) - (-24/x**5 - 2/x**3 - 1/x + O(x**(-6), (x, -oo)))*\
+           cosh(x + O(x**(-6), (x, -oo))) + I*pi/2
+
+
+def test_chi_series():
+    assert Chi(x).series(x, oo) == (6/x**4 + x**(-2) + O(x**(-6), (x, oo)))* \
+           cosh(x + O(x**(-6), (x, oo))) + (24/x**5 + 2/x**3 + 1/x + O(x**(-6), (x, oo)))*\
+           sinh(x + O(x**(-6), (x, oo))) - I*pi/2
+    assert Chi(x).series(x, -oo) == (6/x**4 + x**(-2) + O(x**(-6), (x, -oo)))* \
+           cosh(x + O(x**(-6), (x, -oo))) + (24/x**5 + 2/x**3 + 1/x + O(x**(-6), (x, -oo)))* \
+           sinh(x + O(x**(-6), (x, -oo))) + I*pi/2
 
 
 def test_fresnel():


### PR DESCRIPTION
### Brief description of what is fixed or changed
Added asymptotic series expansion implementations for the Shi (hyperbolic sine integral) and Chi (hyperbolic cosine integral) functions.
New method `__eval__aseries` added for both classes.

#### Refrence issue #26208

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* series
  * `__eval__aseries` method added for `Shi` and `Chi` functions.
<!-- END RELEASE NOTES -->
