### PR TITLE
Fix type error when n is even in qs function

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1186,7 +1186,7 @@ Prateek Papriwal <papriwalprateek@gmail.com>
 Pratyksh Gupta <pratykshgupta9999@gmail.com> Pg999999 <pratykshgupta9999@gmail.com>
 Praveen Perumal <ppraveen98841@gmail.com> Praveen Perumal <58477724+solvedbiscuit71@users.noreply.github.com>
 Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
-Prayag <v.prayag2005@gmail.com> vprayag2005 <v.prayag2005@gamil.com>
+Prayag V <v.prayag2005@gmail.com> vprayag2005 <v.prayag2005@gamil.com>
 Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
 Prempal Singh <prempal.42@gmail.com>
 Prey Patel <patel.prey@iitgn.ac.in>

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -474,11 +474,16 @@ def qs(N, prime_bound, M, ERROR_TERM=25, seed=1234):
     .. [2] https://www.rieselprime.de/ziki/Self-initializing_quadratic_sieve
     """
     ERROR_TERM*=2**10
-    idx_1000, idx_5000, factor_base = _generate_factor_base(prime_bound, N)
+    proper_factor = set()
     smooth_relations = []
     ith_poly = 0
     partial_relations = {}
-    proper_factor = set()
+    if N % 2 == 0:
+        proper_factor.add(2)
+        N//=2
+        while N % 2 == 0:
+            N//=2
+    idx_1000, idx_5000, factor_base = _generate_factor_base(prime_bound, N)
     threshold = 5*len(factor_base) // 100
     while True:
         if ith_poly == 0:

--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -122,3 +122,9 @@ def test_qs_3():
     factor = _find_factor(
         dependent_row, mark, gauss_matrix, 0, smooth_relations, N)
     assert factor == 23
+
+
+def test_issue_27616():
+    #https://github.com/sympy/sympy/issues/27616
+    N = 9804659461513846513 + 1
+    assert qs(N, 5000, 20000) is not None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix:#27616
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed an issue in the Quadratic Sieve (QS) implementation where even factors of N were not fully removed before proceeding. The updated code ensures that all occurrences of factor 2 are divided out from N. This prevents potential issues when generating the factor base, which previously resulted in a NoneType error due to incorrect handling of prime factors.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Resolved an issue in the Quadratic Sieve (QS) where factor 2 was not fully removed from N, causing a NoneType error in factor base generation.
<!-- END RELEASE NOTES -->
