### PR TITLE
Ensure constant term is a unit in _series_inversion1 series inversion

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -506,7 +506,7 @@ def _series_inversion1(p, x, prec):
     if _has_constant_term(p - c, x):
         raise ValueError("p cannot contain a constant term depending on "
                          "parameters")
-    if hasattr(R.domain, 'is_unit') and not R.domain.is_unit(c):
+    if not R.domain.is_unit(c):
         raise ValueError(f"Constant term {c} must be a unit in {R.domain}")
 
     one = R(1)

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -506,11 +506,13 @@ def _series_inversion1(p, x, prec):
     if _has_constant_term(p - c, x):
         raise ValueError("p cannot contain a constant term depending on "
                          "parameters")
+    if hasattr(R.domain, 'is_unit') and not R.domain.is_unit(c):
+        raise ValueError(f"Constant term {c} must be a unit in {R.domain}")
+
     one = R(1)
     if R.domain is EX:
         one = 1
     if c != one:
-        # TODO add check that it is a unit
         p1 = R(1)/c
     else:
         p1 = R(1)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -1,4 +1,4 @@
-from sympy.polys.domains import QQ, EX, RR
+from sympy.polys.domains import ZZ, QQ, EX, RR
 from sympy.polys.rings import ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,
@@ -633,3 +633,11 @@ def test_rs_series():
     assert rs_series(log(1 + x*a**2), x, 7).as_expr() == -x**6*a**12/6 + \
                     x**5*a**10/5 - x**4*a**8/4 + x**3*a**6/3 - \
                     x**2*a**4/2 + x*a**2
+
+def test_issue_24277():
+    import pytest
+    Rx = ZZ['x']
+    x = Rx.gens[0]
+    p = Rx(2+x)
+    with pytest.raises(ValueError):
+        rs_series_inversion(p, x, 3)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -107,6 +107,10 @@ def test_inversion():
     p = R.zero
     raises(ZeroDivisionError, lambda: rs_series_inversion(p, x, 3))
 
+    R, x = ring('x', ZZ)
+    p = 2 + x
+    raises(ValueError, lambda: rs_series_inversion(p, x, 3))
+
 
 def test_series_reversion():
     R, x, y = ring('x, y', QQ)
@@ -633,11 +637,3 @@ def test_rs_series():
     assert rs_series(log(1 + x*a**2), x, 7).as_expr() == -x**6*a**12/6 + \
                     x**5*a**10/5 - x**4*a**8/4 + x**3*a**6/3 - \
                     x**2*a**4/2 + x*a**2
-
-def test_issue_24277():
-    import pytest
-    Rx = ZZ['x']
-    x = Rx.gens[0]
-    p = Rx(2+x)
-    with pytest.raises(ValueError):
-        rs_series_inversion(p, x, 3)


### PR DESCRIPTION
## Added unit check for the constant term in  `_series_inversion1`

### issue #24277

## Brief Description

Previously, `rs_series_inversion` could give a wrong result (e.g., zero) for series like `2 + x` in `ZZ[[x]]`, where the constant term 2 isn’t a unit (units in `ZZ` are `±1`). This is invalid in formal power series rings, where the constant term must be invertible.

This PR adds a unit check to `_series_inversion1` to raise a `ValueError` if the constant term isn’t a unit in the domain, preventing invalid inversions. 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

- polys
    - Added a unit check for the constant term in `_series_inversion1` function of `ring_series` to ensure valid series inversion.

<!-- END RELEASE NOTES -->
