### PR TITLE
Refactoring of `SievePolynomial`

### DIFF
--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -22,10 +22,9 @@ def test_qs_1():
 def test_qs_2() -> None:
     n = 10009202107
     M = 50
-    # a = 10, b = 15, modified_coeff = [a**2, 2*a*b, b**2 - N]
-    sieve_poly = SievePolynomial([100,  1600, -10009195707], 10, 80)
-    assert sieve_poly.eval(10) == -10009169707
-    assert sieve_poly.eval(5) == -10009185207
+    sieve_poly = SievePolynomial(10, 80, n)
+    assert sieve_poly.eval_v(10) == sieve_poly.eval_u(10)**2 - n == -10009169707
+    assert sieve_poly.eval_v(5) == sieve_poly.eval_u(5)**2 - n == -10009185207
 
     idx_1000, idx_5000, factor_base = _generate_factor_base(2000, n)
     assert idx_1000 == 82


### PR DESCRIPTION
The `__init__` method takes `modified_coeff` as an argument, but it can be computed internally.
Additionally, the `eval` method uses a for loop for evaluation, but since the polynomial degree is fixed, it can be expanded.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
This fix is part of #27636 but does not resolve any of the existing issues with `qs`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
