### PR TITLE
fix(simplify): Change a == b to a = b

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ markers = [
 [tool.ruff]
 # Enable Pyflakes `E` and `F` codes by default.
 lint.select = [
+    "B015",  # Useless comparison: a == b rather than a = b.
     "C4",
     "E",
     "F",
@@ -43,7 +44,6 @@ lint.select = [
     "SIM101",
     "SLOT",
     "TRY002",
-    "B015",  # Useless comparison: a == b rather than a = b.
 ]
 
 # Ignore rules that currently fail on the SymPy codebase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ lint.select = [
     "SIM101",
     "SLOT",
     "TRY002",
+    "B015",  # Useless comparison: a == b rather than a = b.
 ]
 
 # Ignore rules that currently fail on the SymPy codebase
@@ -66,6 +67,7 @@ lint.ignore = [
 exclude = [
     "sympy/assumptions/*generated.py",
     "sympy/core/*_generated.py",
+    "sympy/core/benchmarks/",
     "sympy/parsing/latex/_antlr/*",
     "sympy/parsing/autolev/_antlr/*",
     "sympy/parsing/autolev/test-examples/*",

--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -814,7 +814,13 @@ class CosetTable(DefaultPrinting):
                 for x in A:
                     beta = table[alpha][A_dict[x]]
                     table[gamma][A_dict[x]] = beta
-                    table[beta][A_dict_inv[x]] == gamma
+                    # XXX: The line below uses == rather than = which means
+                    # that it has no effect. It is not clear though if it is
+                    # correct simply to delete the line or to change it to
+                    # use =. Changing it causes some tests to fail.
+                    #
+                    # https://github.com/sympy/sympy/issues/27633
+                    table[beta][A_dict_inv[x]] == gamma # noqa: B015
         # all the cosets in the table are live cosets
         self.p = list(range(gamma + 1))
         # delete the useless columns

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1798,7 +1798,7 @@ def try_lerchphi(func):
             n = dep.exp
             dep = dep.base
         if dep == t:
-            a == 0
+            a = 0
         elif dep.is_Add:
             a, tmp = dep.as_independent(t)
             b = 1


### PR DESCRIPTION
Also apply ruff rule B015 to detect this sort of thing in future.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/27633

#### Brief description of what is fixed or changed



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
