### PR TITLE
Implemented Frobenius number in ntheory

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -122,6 +122,8 @@ Ntheory Functions Reference
 
 .. autofunction:: solve_congruence
 
+.. autofunction:: frobenius_number
+
 .. module:: sympy.ntheory.multinomial
 
 .. autofunction:: binomial_coefficients

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,4 +1,5 @@
 from math import prod
+from itertools import combinations_with_replacement
 
 from sympy.external.gmpy import gcd, gcdext
 from sympy.ntheory.primetest import isprime
@@ -289,3 +290,51 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         if symmetric:
             return symmetric_residue(n, m), m
         return n, m
+
+def frobenius_number(denominations):
+    """
+    Computes the Frobenius number for a given set of coin denominations.
+    The Frobenius number is the largest integer that cannot be expressed as a
+    non-negative integer combination of the given denominations.
+
+    Parameters:
+        denominations (list): A list of positive integers representing coin values.
+
+    Returns:
+        int: The Frobenius number if it exists, otherwise None (if GCD != 1).
+
+    Examples
+    ========
+    >>> from sympy.ntheory.modular import frobenius_number
+    >>> print(frobenius_number([6, 9, 20]))
+    43
+    >>> print(frobenius_number([3, 5]))
+    7
+    >>> print(frobenius_number([4, 6, 8])) # GCD != 1
+    None
+    """
+    if any(d <= 0 for d in denominations):
+        raise ValueError("All input numbers must be positive integers.")
+
+    if 1 in denominations:
+        raise ValueError("Frobenius number is not defined when 1 is in the set.")
+
+    if gcd(*denominations) != 1:
+        return None
+
+    if len(denominations) == 2:
+        a, b = sorted(denominations)
+        return a * b - a - b
+
+    max_value = max(denominations) * max(denominations)
+    representable = set()
+
+    for i in range(1, max_value):
+        for comb in combinations_with_replacement(denominations, i):
+            representable.add(sum(comb))
+
+    for i in range(max_value, -1, -1):
+        if i not in representable:
+            return i
+
+    return None

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -310,9 +310,10 @@ def frobenius_number(denominations):
     43
     >>> print(frobenius_number([3, 5]))
     7
-    >>> print(frobenius_number([4, 6, 8])) # GCD != 1
-    None
     """
+    if len(denominations) == 1:
+        raise ValueError("Frobenius number is undefined for a single number.")
+
     if any(d <= 0 for d in denominations):
         raise ValueError("All input numbers must be positive integers.")
 
@@ -320,7 +321,7 @@ def frobenius_number(denominations):
         raise ValueError("Frobenius number is not defined when 1 is in the set.")
 
     if gcd(*denominations) != 1:
-        return None
+        raise ValueError("The numbers must have a GCD of 1 for a finite Frobenius number.")
 
     if len(denominations) == 2:
         a, b = sorted(denominations)

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -1,4 +1,4 @@
-from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence
+from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence,frobenius_number
 from sympy.testing.pytest import raises
 
 
@@ -32,3 +32,9 @@ def test_modular():
     assert solve_congruence(*list(zip((1, 1, 2), (3, 2, 4)))) is None
     raises(
         ValueError, lambda: solve_congruence(*list(zip([3, 4, 2], [12.1, 35, 17]))))
+
+
+def test_frobenius_number():
+    assert frobenius_number([6, 9, 20]) == 43
+    assert frobenius_number([3, 5]) == 7
+    assert frobenius_number([4, 6, 8]) == None

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2218,6 +2218,8 @@ class DUP_Flint(DMP):
     def primitive(f):
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
+        if f.is_zero:
+            return f.dom.zero, f
         prim = f._exquo_ground(cont)
         return cont, prim
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2218,6 +2218,8 @@ class DUP_Flint(DMP):
     def primitive(f):
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
+        if cont == f.ring.domain.zero:
+            return (cont, f)
         prim = f._exquo_ground(cont)
         return cont, prim
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2218,8 +2218,6 @@ class DUP_Flint(DMP):
     def primitive(f):
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
-        if cont == f.ring.domain.zero:
-            return (cont, f)
         prim = f._exquo_ground(cont)
         return cont, prim
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1974,8 +1974,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def primitive(f):
         """Returns content and a primitive polynomial. """
         cont = f.content()
-        if cont == f.ring.domain.zero:
-            return (cont, f)
         return cont, f.quo_ground(cont)
 
     def monic(f):
@@ -2012,6 +2010,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def quo_ground(f, x):
         domain = f.ring.domain
 
+        if not x:
+            return f.ring.zero
         if not x:
             raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2012,6 +2012,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         if not x:
             return f.ring.zero
+        if not x:
+            raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:
             return f
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2012,8 +2012,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         if not x:
             return f.ring.zero
-        if not x:
-            raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:
             return f
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1974,6 +1974,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def primitive(f):
         """Returns content and a primitive polynomial. """
         cont = f.content()
+        if cont == f.ring.domain.zero:
+            return (cont, f)
         return cont, f.quo_ground(cont)
 
     def monic(f):

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1974,6 +1974,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def primitive(f):
         """Returns content and a primitive polynomial. """
         cont = f.content()
+        if cont == f.ring.domain.zero:
+            return (cont, f)
         return cont, f.quo_ground(cont)
 
     def monic(f):
@@ -2010,8 +2012,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def quo_ground(f, x):
         domain = f.ring.domain
 
-        if not x:
-            return f.ring.zero
         if not x:
             raise ZeroDivisionError('polynomial division')
         if not f or x == domain.one:

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -586,3 +586,16 @@ def test_ANP_unify():
     assert b.unify_ANP(a)[-1] == QQ
     assert a.unify_ANP(a)[-1] == QQ
     assert b.unify_ANP(b)[-1] == ZZ
+
+
+def test_zero_poly():
+    from sympy import Symbol
+    x = Symbol('x')
+
+    R_old = ZZ.old_poly_ring(x)
+    zero_poly_old = R_old(0)
+    cont_old, prim_old = zero_poly_old.primitive()
+
+    assert cont_old == 0
+    assert prim_old == zero_poly_old
+    assert prim_old.is_primitive is False

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1588,3 +1588,10 @@ def test_zero_polynomial_primitive():
     assert cont == 0
     assert prim == zero_poly
     assert prim.is_primitive is False
+
+    R_old = ZZ.old_poly_ring(x)
+    zero_poly_old = R_old(0)
+    cont_old, prim_old = zero_poly_old.primitive()
+    assert cont_old == 0
+    assert prim_old == zero_poly_old
+    assert prim_old.is_primitive is False

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1576,3 +1576,22 @@ def test_issue_21410():
     R, x = ring('x', FF(2))
     p = x**6 + x**5 + x**4 + x**3 + 1
     assert p._pow_multinomial(4) == x**24 + x**20 + x**16 + x**12 + 1
+
+
+def test_zero_polynomial_primitive():
+
+    x = symbols('x')
+
+    R = ZZ[x]
+    zero_poly = R(0)
+    cont, prim = zero_poly.primitive()
+    assert cont == 0
+    assert prim == zero_poly
+    assert prim.is_primitive is False
+
+    R_old = ZZ.old_poly_ring(x)
+    zero_poly_old = R_old(0)
+    cont_old, prim_old = zero_poly_old.primitive()
+    assert cont_old == 0
+    assert prim_old == zero_poly_old
+    assert prim_old.is_primitive is False

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1588,10 +1588,3 @@ def test_zero_polynomial_primitive():
     assert cont == 0
     assert prim == zero_poly
     assert prim.is_primitive is False
-
-    R_old = ZZ.old_poly_ring(x)
-    zero_poly_old = R_old(0)
-    cont_old, prim_old = zero_poly_old.primitive()
-    assert cont_old == 0
-    assert prim_old == zero_poly_old
-    assert prim_old.is_primitive is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
implementation for #17893
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added Frobenius number computation, handling special cases (GCD check, two-denomination formula) and using a brute-force approach for more than 2 numbers

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Implemented Frobenius Number
<!-- END RELEASE NOTES -->
