### PR TITLE
Fix precision loss in nroots for complex roots

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3712,11 +3712,12 @@ class Poly(Basic):
         else:
             coeffs = [coeff.evalf(n=n).as_real_imag()
                     for coeff in f.all_coeffs()]
-            try:
-                coeffs = [mpmath.mpc(*coeff) for coeff in coeffs]
-            except TypeError:
-                raise DomainError("Numerical domain expected, got %s" % \
-                        f.rep.dom)
+            with mpmath.workdps(n):
+                try:
+                    coeffs = [mpmath.mpc(*coeff) for coeff in coeffs]
+                except TypeError:
+                    raise DomainError("Numerical domain expected, got %s" % \
+                            f.rep.dom)
 
         dps = mpmath.mp.dps
         mpmath.mp.dps = n

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3202,6 +3202,12 @@ def test_nroots():
         '1.7 + 2.5*I]')
     assert str(Poly(1e-15*x**2 -1).nroots()) == ('[-31622776.6016838, 31622776.6016838]')
 
+    # https://github.com/sympy/sympy/issues/23861
+
+    i = Float('3.000000000000000000000000000000000000000000000000001')
+    [r] = nroots(x + I*i, n=300)
+    assert abs(r + I*i) < 1e-300
+
 
 def test_ground_roots():
     f = x**6 - 4*x**4 + 4*x**3 - x**2
@@ -3968,20 +3974,3 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
-
-
-def test_issue_23861():
-
-    x = Symbol('x')
-
-    imaginary_str = '3.{}1'.format('0' * 50)
-    imaginary = Float(imaginary_str)
-
-    poly = x + I * imaginary
-    roots = nroots(poly, n=300)
-    assert len(roots) == 1
-
-    root = roots[0]
-    expected = -I * imaginary
-    difference = (root - expected).evalf(300)
-    assert abs(difference) < 1e-300

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3968,3 +3968,20 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_issue_23861():
+
+    x = Symbol('x')
+
+    imaginary_str = '3.{}1'.format('0' * 50)
+    imaginary = Float(imaginary_str)
+
+    poly = x + I * imaginary
+    roots = nroots(poly, n=300)
+    assert len(roots) == 1
+
+    root = roots[0]
+    expected = -I * imaginary
+    difference = (root - expected).evalf(300)
+    assert abs(difference) < 1e-300


### PR DESCRIPTION


#### Brief description of what is fixed or changed
This PR solves loss of precision problem in `sympy.nroots` for calculating roots of polynomials that have complex coefficients. The issue was due to fact that converting coefficients to `mpmath.mpc` was not honoring specified decimal precision `(dps)`. The solution makes sure that the coefficients are converted with the right precision by invoking `mpmath.workdps`.

#### Other comments
Wrapped coefficient conversion in `mpmath.workdps(n)` to ensure correct precision is used.

Fixes #23861

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
