### PR TITLE
Implemented Frobenius number in ntheory

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -122,6 +122,8 @@ Ntheory Functions Reference
 
 .. autofunction:: solve_congruence
 
+.. autofunction:: frobenius_number
+
 .. module:: sympy.ntheory.multinomial
 
 .. autofunction:: binomial_coefficients

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -301,7 +301,7 @@ def frobenius_number(denominations):
         denominations (list): A list of positive integers representing coin values.
 
     Returns:
-        int: The Frobenius number if it exists, otherwise None (if GCD != 1).
+        If the Frobenius number exists, return the integer value. Otherwise, return an appropriate error message.
 
     Examples
     ========

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -312,31 +312,26 @@ def frobenius_number(denominations):
     >>> frobenius_number([3, 5])
     7
     """
+    denominations=sorted(denominations)
     if len(denominations) == 1:
         raise ValueError("Frobenius number is undefined for a single number.")
-
     if any(d <= 0 for d in denominations):
         raise ValueError("All input numbers must be positive integers.")
-
     if 1 in denominations:
-        raise ValueError("Frobenius number is not defined when 1 is in the set.")
-
+        return 0
     if gcd(*denominations) != 1:
         raise ValueError("The numbers must have a GCD of 1 for a finite Frobenius number.")
-
     if len(denominations) == 2:
-        a, b = sorted(denominations)
+        a, b = denominations
         return a * b - a - b
-
-    max_value = max(denominations) * max(denominations)
-    representable = set()
-
-    for i in range(1, max_value):
-        for comb in combinations_with_replacement(denominations, i):
-            representable.add(sum(comb))
-
-    for i in range(max_value, -1, -1):
-        if i not in representable:
+    max_n =denominations[0]*denominations[1]
+    reachable=[False]*(max_n+1)
+    reachable[0]=True
+    for num in denominations:
+        for i in range(num,max_n+1):
+            if reachable[i-num]:
+                reachable[i]=True
+    for i in range(max_n-1,-1,-1):
+        if not reachable[i]:
             return i
-
     return None

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,4 +1,5 @@
 from math import prod
+from itertools import combinations_with_replacement
 
 from sympy.external.gmpy import gcd, gcdext
 from sympy.ntheory.primetest import isprime
@@ -289,3 +290,53 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         if symmetric:
             return symmetric_residue(n, m), m
         return n, m
+
+
+def frobenius_number(denominations):
+    """
+    Computes the Frobenius number for a given set of coin denominations.
+    The Frobenius number is the largest integer that cannot be expressed as a
+    non-negative integer combination of the given denominations.
+
+    Parameters:
+        denominations (list): A list of positive integers representing coin values.
+
+    Returns:
+        int: The Frobenius number if it exists, otherwise None (if GCD != 1).
+
+    Examples
+    ========
+    >>> from sympy.ntheory.modular import frobenius_number
+    >>> frobenius_number([6, 9, 20])
+    43
+    >>> frobenius_number([3, 5])
+    7
+    """
+    if len(denominations) == 1:
+        raise ValueError("Frobenius number is undefined for a single number.")
+
+    if any(d <= 0 for d in denominations):
+        raise ValueError("All input numbers must be positive integers.")
+
+    if 1 in denominations:
+        raise ValueError("Frobenius number is not defined when 1 is in the set.")
+
+    if gcd(*denominations) != 1:
+        raise ValueError("The numbers must have a GCD of 1 for a finite Frobenius number.")
+
+    if len(denominations) == 2:
+        a, b = sorted(denominations)
+        return a * b - a - b
+
+    max_value = max(denominations) * max(denominations)
+    representable = set()
+
+    for i in range(1, max_value):
+        for comb in combinations_with_replacement(denominations, i):
+            representable.add(sum(comb))
+
+    for i in range(max_value, -1, -1):
+        if i not in representable:
+            return i
+
+    return None

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,5 +1,4 @@
 from math import prod
-from itertools import combinations_with_replacement
 
 from sympy.external.gmpy import gcd, gcdext
 from sympy.ntheory.primetest import isprime

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -37,3 +37,7 @@ def test_modular():
 def test_frobenius_number():
     assert frobenius_number([6, 9, 20]) == 43
     assert frobenius_number([3, 5]) == 7
+    assert frobenius_number([1,3, 5]) == 0
+    raises(ValueError,lambda:frobenius_number([3]))
+    raises(ValueError,lambda:frobenius_number([3,-5]))
+    raises(ValueError,lambda:frobenius_number([6,9]))

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -1,4 +1,4 @@
-from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence
+from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence,frobenius_number
 from sympy.testing.pytest import raises
 
 
@@ -32,3 +32,8 @@ def test_modular():
     assert solve_congruence(*list(zip((1, 1, 2), (3, 2, 4)))) is None
     raises(
         ValueError, lambda: solve_congruence(*list(zip([3, 4, 2], [12.1, 35, 17]))))
+
+
+def test_frobenius_number():
+    assert frobenius_number([6, 9, 20]) == 43
+    assert frobenius_number([3, 5]) == 7


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
implementation for issue #17893
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added Frobenius number computation, handling special cases (GCD check, two-denomination formula) and using a dynamic programming approach for more than 2 numbers

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Implemented Frobenius Number
<!-- END RELEASE NOTES -->
