### PR TITLE
Fix discrete_log for n=1 to return 0 instead of ValueError

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1625,6 +1625,10 @@ def discrete_log(n, a, b, order=None, prime_order=None):
 
     """
     from math import sqrt, log
+    if n < 1:
+        raise ValueError("n should be positive")
+    if n == 1:
+        return 0
     n, a, b = as_int(n), as_int(a), as_int(b)
     if order is None:
         # Compute the order and its factoring in one pass

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -344,3 +344,7 @@ def test_deprecated_ntheory_symbolic_functions():
         assert legendre_symbol(2, 3) == -1
     with warns_deprecated_sympy():
         assert jacobi_symbol(2, 3) == -1
+
+
+def test_discrete_log_n_equals_1():
+    assert discrete_log(1, 0, 2) == 0

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -276,6 +276,8 @@ def test_residue():
     args = 5779, 3528, 6215
     assert discrete_log(*args) == 687
     assert discrete_log(*Tuple(*args)) == 687
+    assert discrete_log(1, 0, 2) == 0
+    raises(ValueError, lambda: discrete_log(-5, 0, 2))
     assert quadratic_congruence(400, 85, 125, 1600) == [295, 615, 935, 1255, 1575]
     assert quadratic_congruence(3, 6, 5, 25) == [3, 20]
     assert quadratic_congruence(120, 80, 175, 500) == []
@@ -344,7 +346,3 @@ def test_deprecated_ntheory_symbolic_functions():
         assert legendre_symbol(2, 3) == -1
     with warns_deprecated_sympy():
         assert jacobi_symbol(2, 3) == -1
-
-
-def test_discrete_log_n_equals_1():
-    assert discrete_log(1, 0, 2) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#27612


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously, discrete_log(1, 0, n) raised a ValueError. This fix ensures that when n=1, the function correctly returns 0 instead. A test case was added to validate this behavior.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
