### PR TITLE
Doc: Shorten the hyperlink of functions in Simplification document 

### DIFF
--- a/doc/src/tutorials/intro-tutorial/simplification.rst
+++ b/doc/src/tutorials/intro-tutorial/simplification.rst
@@ -17,7 +17,7 @@ Now let's jump in and do some interesting mathematics.  One of the most useful
 features of a symbolic manipulation system is the ability to simplify
 mathematical expressions.  SymPy has dozens of functions to perform various
 kinds of simplification.  There is also one general function called
-:func:~sympy.simplify.simplify.simplify()` that attempts to apply
+:func:`~sympy.simplify.simplify.simplify` that attempts to apply
 all of these functions in an intelligent
 way to arrive at the simplest form of an expression.  Here are some examples
 
@@ -30,10 +30,10 @@ way to arrive at the simplest form of an expression.  Here are some examples
 
 Here, ``gamma(x)`` is `\Gamma(x)`, the `gamma function
 <https://en.wikipedia.org/wiki/Gamma_function>`_.  We see that
-:func:`~sympy.simplify.simplify.simplify()`
+:func:`~sympy.simplify.simplify.simplify`
 is capable of handling a large class of expressions.
 
-But :func:`~sympy.simplify.simplify.simplify()` has a pitfall.  It
+But :func:`~sympy.simplify.simplify.simplify` has a pitfall.  It
 just applies all the major
 simplification operations in SymPy, and uses heuristics to determine the
 simplest result. But "simplest" is not a well-defined term.  For example, say
@@ -44,10 +44,10 @@ we wanted to "simplify" `x^2 + 2x + 1` into `(x + 1)^2`:
     x  + 2⋅x + 1
 
 We did not get what we want.  There is a function to perform this
-simplification, called :func:`~sympy.polys.polytools.factor()`, which
+simplification, called :func:`~sympy.polys.polytools.factor`, which
 will be discussed below.
 
-Another pitfall to :func:`~sympy.simplify.simplify.simplify()` is
+Another pitfall to :func:`~sympy.simplify.simplify.simplify` is
 that it can be unnecessarily slow, since
 it tries many kinds of simplifications before picking the best one.  If you
 already know exactly what kind of simplification you are after, it is better
@@ -55,21 +55,21 @@ to apply the specific simplification function(s) that apply those
 simplifications.
 
 Applying specific simplification functions instead of
-:func:`~sympy.simplify.simplify.simplify()` also has
+:func:`~sympy.simplify.simplify.simplify` also has
 the advantage that specific functions have certain guarantees about the form
 of their output.  These will be discussed with each function below.  For
-example, :func:`~sympy.polys.polytools.factor()`, when called on a
+example, :func:`~sympy.polys.polytools.factor`, when called on a
 polynomial with rational coefficients,
 is guaranteed to factor the polynomial into irreducible factors.
-:func:`~sympy.simplify.simplify.simplify()` has no guarantees.  It is
+:func:`~sympy.simplify.simplify.simplify` has no guarantees.  It is
 entirely heuristical, and, as we saw
 above, it may even miss a possible type of simplification that SymPy is
 capable of doing.
 
-:func:`~sympy.simplify.simplify.simplify()` is best when used
+:func:`~sympy.simplify.simplify.simplify` is best when used
 interactively, when you just want to whittle
 down an expression to a simpler form.  You may then choose to apply specific
-functions once you see what :func:`~sympy.simplify.simplify.simplify()`
+functions once you see what :func:`~sympy.simplify.simplify.simplify`
 returns, to get a more precise result. It is also useful when you have no idea
 what form an expression will take, and you need a catchall function to simplify it.
 
@@ -79,7 +79,7 @@ Polynomial/Rational Function Simplification
 expand
 ------
 
-:func:`~sympy.core.function.expand()` is one of the most common simplification
+:func:`~sympy.core.function.expand` is one of the most common simplification
 functions in SymPy. Although it has a lot of scopes, for now, we will consider
 its function in expanding polynomial expressions. For example:
 
@@ -90,13 +90,13 @@ its function in expanding polynomial expressions. For example:
      2
     x  - x - 6
 
-Given a polynomial, :func:`~sympy.core.function.expand()` will put it into
+Given a polynomial, :func:`~sympy.core.function.expand` will put it into
 a canonical form of a sum of monomials.
 
-:func:`~sympy.core.function.expand()` may not sound like a simplification
+:func:`~sympy.core.function.expand` may not sound like a simplification
 function.  After all, by its very name, it makes expressions bigger, not
 smaller.  Usually this is the case, but often an expression will become
-smaller upon calling on :func:`~sympy.core.function.expand()`
+smaller upon calling on :func:`~sympy.core.function.expand`
 it due to cancellation.
 
     >>> expand((x + 1)*(x - 2) - (x - 1)*x)
@@ -105,7 +105,7 @@ it due to cancellation.
 factor
 ------
 
-:func:`~sympy.polys.polytools.factor()` takes a polynomial and factors
+:func:`~sympy.polys.polytools.factor` takes a polynomial and factors
 it into irreducible factors over
 the rational numbers.  For example:
 
@@ -116,11 +116,11 @@ the rational numbers.  For example:
                2
     z⋅(x + 2⋅y)
 
-For polynomials, :func:`~sympy.polys.polytools.factor()` is the opposite of
-:func:`~sympy.core.function.expand()`.  :func:`~sympy.polys.polytools.factor()`
+For polynomials, :func:`~sympy.polys.polytools.factor` is the opposite of
+:func:`~sympy.core.function.expand`.  :func:`~sympy.polys.polytools.factor`
 uses a complete multivariate factorization algorithm over the rational
 numbers, which means that each of the factors returned by
-:func:`~sympy.polys.polytools.factor()` is
+:func:`~sympy.polys.polytools.factor` is
 guaranteed to be irreducible.
 
 If you are interested in the factors themselves, ``factor_list`` returns a
@@ -129,8 +129,8 @@ more structured output.
     >>> factor_list(x**2*z + 4*x*y*z + 4*y**2*z)
     (1, [(z, 1), (x + 2⋅y, 2)])
 
-Note that the input to :func:`~sympy.polys.polytools.factor()` and
-:func:`~sympy.core.function.expand()` need not be polynomials in
+Note that the input to :func:`~sympy.polys.polytools.factor` and
+:func:`~sympy.core.function.expand` need not be polynomials in
 the strict sense.  They will intelligently factor or expand any kind of
 expression (though note that the factors may not be irreducible if the input
 is no longer a polynomial over the rationals).
@@ -145,7 +145,7 @@ is no longer a polynomial over the rationals).
 collect
 -------
 
-:func:`~sympy.simplify.radsimp.collect()` collects common powers of a
+:func:`~sympy.simplify.radsimp.collect` collects common powers of a
 term in an expression.  For example
 
     >>> expr = x*y + x - 3 + 2*x**2 - z*x**2 + x**3
@@ -157,8 +157,8 @@ term in an expression.  For example
      3    2
     x  + x ⋅(2 - z) + x⋅(y + 1) - 3
 
-:func:`~sympy.simplify.radsimp.collect()` is particularly useful in
-conjunction with the :func:`~sympy.core.expr.Expr.coeff()`
+:func:`~sympy.simplify.radsimp.collect` is particularly useful in
+conjunction with the :func:`~sympy.core.expr.Expr.coeff`
 method.  ``expr.coeff(x, n)`` gives the coefficient of ``x**n`` in ``expr``:
 
     >>> collected_expr.coeff(x, 2)
@@ -170,7 +170,7 @@ method.  ``expr.coeff(x, n)`` gives the coefficient of ``x**n`` in ``expr``:
 cancel
 ------
 
-:func:`~sympy.polys.polytools.cancel()` will take any rational function
+:func:`~sympy.polys.polytools.cancel` will take any rational function
 and put it into the standard
 canonical form, `\frac{p}{q}`, where `p` and `q` are expanded polynomials with
 no common factors, and the leading coefficients of `p` and `q` do not have
@@ -208,7 +208,7 @@ denominators (i.e., are integers).
     ───────────────
          x - 1
 
-Note that since :func:`~sympy.polys.polytools.factor()` will completely
+Note that since :func:`~sympy.polys.polytools.factor` will completely
 factorize both the numerator and
 the denominator of an expression, it can also be used to do the same thing:
 
@@ -219,13 +219,13 @@ the denominator of an expression, it can also be used to do the same thing:
      x - 1
 
 However, if you are only interested in making sure that the expression is in
-canceled form, :func:`~sympy.polys.polytools.cancel()` is more
-efficient than :func:`~sympy.polys.polytools.factor()`.
+canceled form, :func:`~sympy.polys.polytools.cancel` is more
+efficient than :func:`~sympy.polys.polytools.factor`.
 
 apart
 -----
 
-:func:`~sympy.polys.partfrac.apart()` performs a `partial fraction
+:func:`~sympy.polys.partfrac.apart` performs a `partial fraction
 decomposition
 <https://en.wikipedia.org/wiki/Partial_fraction_decomposition>`_ on a rational
 function.
@@ -251,7 +251,7 @@ Trigonometric Simplification
    SymPy follows Python's naming conventions for inverse trigonometric
    functions, which is to append an ``a`` to the front of the function's
    name.  For example, the inverse cosine, or arc cosine, is called
-   :func:`~sympy.functions.elementary.trigonometric.acos()`.
+   :func:`~sympy.functions.elementary.trigonometric.acos`.
 
    >>> acos(x)
    acos(x)
@@ -269,7 +269,7 @@ trigsimp
 --------
 
 To simplify expressions using trigonometric identities, use
-:func:`~sympy.simplify.trigsimp.trigsimp()`.
+:func:`~sympy.simplify.trigsimp.trigsimp`.
 
     >>> trigsimp(sin(x)**2 + cos(x)**2)
     1
@@ -281,7 +281,7 @@ To simplify expressions using trigonometric identities, use
        2
     sin (x)
 
-:func:`~sympy.simplify.trigsimp.trigsimp()` also works with
+:func:`~sympy.simplify.trigsimp.trigsimp` also works with
 hyperbolic trig functions.
 
     >>> trigsimp(cosh(x)**2 + sinh(x)**2)
@@ -289,8 +289,8 @@ hyperbolic trig functions.
     >>> trigsimp(sinh(x)/tanh(x))
     cosh(x)
 
-Much like :func:`~sympy.simplify.simplify.simplify()`,
-:func:`~sympy.simplify.trigsimp.trigsimp()` applies various
+Much like :func:`~sympy.simplify.simplify.simplify`,
+:func:`~sympy.simplify.trigsimp.trigsimp` applies various
 trigonometric identities to
 the input expression, and then uses a heuristic to return the "best" one.
 
@@ -298,7 +298,7 @@ expand_trig
 -----------
 
 To expand trigonometric functions, that is, apply the sum or double angle
-identities, use :func:`~sympy.core.function.expand_trig()`.
+identities, use :func:`~sympy.core.function.expand_trig`.
 
     >>> expand_trig(sin(x + y))
     sin(x)⋅cos(y) + sin(y)⋅cos(x)
@@ -308,10 +308,10 @@ identities, use :func:`~sympy.core.function.expand_trig()`.
            2
     1 - tan (x)
 
-Because :func:`~sympy.core.function.expand_trig()` tends to make trigonometric
-expressions larger, and :func:`~sympy.simplify.trigsimp.trigsimp()` tends to
+Because :func:`~sympy.core.function.expand_trig` tends to make trigonometric
+expressions larger, and :func:`~sympy.simplify.trigsimp.trigsimp` tends to
 make them smaller, these identities can be applied in
-reverse using :func:`~sympy.simplify.trigsimp.trigsimp()`
+reverse using :func:`~sympy.simplify.trigsimp.trigsimp`
 
     >>> trigsimp(sin(x)*cos(y) + sin(y)*cos(x))
     sin(x + y)
@@ -372,7 +372,7 @@ but for now, all we need to know are the following.
   expression with a given Symbol unless it holds for all complex numbers.
 
 - Symbols can be given different assumptions by passing the assumption to
-  :func:`~sympy.core.symbol.symbols()`.  For the rest of this section,
+  :func:`~sympy.core.symbol.symbols`.  For the rest of this section,
   we will be assuming that ``x``
   and ``y`` are positive, and that ``a`` and ``b`` are real.  We will leave
   ``z``, ``t``, and ``c`` as arbitrary complex Symbols to demonstrate what
@@ -395,7 +395,7 @@ but for now, all we need to know are the following.
 powsimp
 -------
 
-:func:`~sympy.simplify.powsimp.powsimp()` applies identities 1 and 2
+:func:`~sympy.simplify.powsimp.powsimp` applies identities 1 and 2
 from above, from left to right.
 
 
@@ -406,7 +406,7 @@ from above, from left to right.
         a
    (x⋅y)
 
-Notice that ::func:`~sympy.simplify.powsimp.powsimp()` refuses to do
+Notice that ::func:`~sympy.simplify.powsimp.powsimp` refuses to do
 the simplification if it is not valid.
 
     >>> powsimp(t**c*z**c)
@@ -431,8 +431,8 @@ rational numbers, and identity 2 holds, it will be applied automatically.
     √x⋅√y
 
 This means that it will be impossible to undo this identity with
-:func:`~sympy.simplify.powsimp.powsimp()`, because even if
-:func:`~sympy.simplify.powsimp.powsimp()` were to put the bases
+:func:`~sympy.simplify.powsimp.powsimp`, because even if
+:func:`~sympy.simplify.powsimp.powsimp` were to put the bases
 together,
 they would be automatically split apart again.
 
@@ -445,8 +445,8 @@ they would be automatically split apart again.
 expand_power_exp / expand_power_base
 ------------------------------------
 
-:func:`~sympy.core.function.expand_power_exp()` and
-:func:`~sympy.core.function.expand_power_base()` apply identities 1 and 2
+:func:`~sympy.core.function.expand_power_exp` and
+:func:`~sympy.core.function.expand_power_base` apply identities 1 and 2
 from right to left, respectively.
 
     >>> expand_power_exp(x**(a + b))
@@ -457,14 +457,14 @@ from right to left, respectively.
      a  a
     x ⋅y
 
-As with :func:`~sympy.simplify.powsimp.powsimp()`, identity 2 is not
+As with :func:`~sympy.simplify.powsimp.powsimp`, identity 2 is not
 applied if it is not valid.
 
     >>> expand_power_base((z*t)**c)
          c
     (t⋅z)
 
-And as with :func:`~sympy.simplify.powsimp.powsimp()`, you can force
+And as with :func:`~sympy.simplify.powsimp.powsimp`, you can force
 the expansion to happen without
 fiddling with assumptions by using ``force=True``.
 
@@ -473,7 +473,7 @@ fiddling with assumptions by using ``force=True``.
     t ⋅z
 
 As with identity 2, identity 1 is applied automatically if the power is a
-number, and hence cannot be undone with :func:`~sympy.core.function.expand_power_exp()`.
+number, and hence cannot be undone with :func:`~sympy.core.function.expand_power_exp`.
 
    >>> x**2*x**3
      5
@@ -485,7 +485,7 @@ number, and hence cannot be undone with :func:`~sympy.core.function.expand_power
 powdenest
 ---------
 
-:func:`~sympy.simplify.powsimp.powdenest()` applies identity 3, from
+:func:`~sympy.simplify.powsimp.powdenest` applies identity 3, from
 left to right.
 
     >>> powdenest((x**a)**b)
@@ -549,7 +549,7 @@ expand_log
 ----------
 
 To apply identities 1 and 2 from left to right, use
-:func:`~sympy.core.function.expand_log()`.  As always, the identities
+:func:`~sympy.core.function.expand_log`.  As always, the identities
 will not be applied unless they are valid.
 
     >>> expand_log(log(x*y))
@@ -563,9 +563,9 @@ will not be applied unless they are valid.
     >>> expand_log(log(z*t))
     log(t⋅z)
 
-As with :func:`~sympy.simplify.powsimp.powsimp()` and
-:func:`~sympy.simplify.powsimp.powdenest()`,
-:func:`~sympy.core.function.expand_log()` has a ``force``
+As with :func:`~sympy.simplify.powsimp.powsimp` and
+:func:`~sympy.simplify.powsimp.powdenest`,
+:func:`~sympy.core.function.expand_log` has a ``force``
 option that can be used to ignore assumptions.
 
     >>> expand_log(log(z**2))
@@ -578,7 +578,7 @@ logcombine
 ----------
 
 To apply identities 1 and 2 from right to left, use
-:func:`~sympy.simplify.simplify.logcombine()`.
+:func:`~sympy.simplify.simplify.logcombine`.
 
     >>> logcombine(log(x) + log(y))
     log(x⋅y)
@@ -588,7 +588,7 @@ To apply identities 1 and 2 from right to left, use
     >>> logcombine(n*log(z))
     n⋅log(z)
 
-:func:`~sympy.simplify.simplify.logcombine()` also has a ``force``
+:func:`~sympy.simplify.simplify.logcombine` also has a ``force``
 option that can be used to ignore assumptions.
 
     >>> logcombine(n*log(z), force=True)
@@ -615,7 +615,7 @@ assumptions we put on them in the previous section.  We will also define ``k``,
     >>> k, m, n = symbols('k m n')
 
 The `factorial <https://en.wikipedia.org/wiki/Factorial>`_ function is
-:class:`~sympy.functions.combinatorial.factorials.factorial()`.
+:class:`~sympy.functions.combinatorial.factorials.factorial`.
 ``factorial(n)`` represents `n!= 1\cdot2\cdots(n - 1)\cdot
 n`. `n!` represents the number of permutations of `n` distinct items.
 
@@ -624,7 +624,7 @@ n`. `n!` represents the number of permutations of `n` distinct items.
 
 The `binomial coefficient
 <https://en.wikipedia.org/wiki/Binomial_coefficient>`_ function is
-:class:`~sympy.functions.combinatorial.factorials.binomial()`.
+:class:`~sympy.functions.combinatorial.factorials.binomial`.
 ``binomial(n, k)`` represents `\binom{n}{k}`, the number of ways to
 choose `k` items from a set of `n` distinct items.  It is also often
 written as `nCk`, and is pronounced "`n` choose `k`".
@@ -636,7 +636,7 @@ written as `nCk`, and is pronounced "`n` choose `k`".
 
 The factorial function is closely related to the `gamma function
 <https://en.wikipedia.org/wiki/Gamma_function>`_,
-:class:`~sympy.functions.special.gamma_functions.gamma()`  ``gamma(z)``
+:class:`~sympy.functions.special.gamma_functions.gamma`  ``gamma(z)``
 represents `\Gamma(z) = \int_0^\infty t^{z - 1}e^{-t}\,dt`, which for positive
 integer
 `z` is the same as `(z - 1)!`.
@@ -646,7 +646,7 @@ integer
 
 The `generalized hypergeometric function
 <https://en.wikipedia.org/wiki/Generalized_hypergeometric_function>`_ is
-:class:`~sympy.functions.special.hyper.hyper()`.
+:class:`~sympy.functions.special.hyper.hyper`.
 ``hyper([a_1, ..., a_p], [b_1, ..., b_q], z)`` represents
 `{}_pF_q\left(\begin{matrix} a_1, \cdots, a_p \\ b_1, \cdots, b_q \end{matrix}
 \middle| z \right)`.  The most common case is `{}_2F_1`, which is often
@@ -682,7 +682,7 @@ expand_func
 -----------
 
 To expand special functions in terms of some identities, use
-:func:`~sympy.core.function.expand_func()`.  For example
+:func:`~sympy.core.function.expand_func`.  For example
 
     >>> expand_func(gamma(x + 3))
     x⋅(x + 1)⋅(x + 2)⋅Γ(x)
@@ -691,14 +691,14 @@ hyperexpand
 -----------
 
 To rewrite ``hyper`` in terms of more standard functions, use
-:func:`~sympy.simplify.hyperexpand.hyperexpand()`.
+:func:`~sympy.simplify.hyperexpand.hyperexpand`.
 
     >>> hyperexpand(hyper([1, 1], [2], z))
     -log(1 - z)
     ────────────
          z
 
-:func:`~sympy.simplify.hyperexpand.hyperexpand()` also works on
+:func:`~sympy.simplify.hyperexpand.hyperexpand` also works on
 the more general Meijer G-function (see
 :class:`~sympy.functions.special.hyper.meijerg` for more
 information).
@@ -718,7 +718,7 @@ combsimp
 --------
 
 To simplify combinatorial expressions, use
-:func:`~sympy.simplify.combsimp.combsimp()`.
+:func:`~sympy.simplify.combsimp.combsimp`.
 
     >>> n, k = symbols('n k', integer = True)
     >>> combsimp(factorial(n)/factorial(n - 3))
@@ -732,7 +732,7 @@ gammasimp
 ---------
 
 To simplify expressions with gamma functions or combinatorial functions with
-non-integer argument, use :func:`~sympy.core.expr.Expr.gammasimp()`.
+non-integer argument, use :func:`~sympy.core.expr.Expr.gammasimp`.
 
     >>> gammasimp(gamma(x)*gamma(1 - x))
        π
@@ -786,7 +786,7 @@ SymPy object, even if we only pass in Python ints.
 
 Every finite continued fraction is a rational number, but we are interested in
 symbolics here, so let's create a symbolic continued fraction.  The
-:func:`~sympy.core.symbol.symbols()` function that we have been using
+:func:`~sympy.core.symbol.symbols` function that we have been using
 has a shortcut to create
 numbered symbols.  ``symbols('a0:5')`` will create the symbols ``a0``, ``a1``,
 ..., ``a4``.
@@ -809,7 +809,7 @@ numbered symbols.  ``symbols('a0:5')`` will create the symbols ``a0``, ``a1``,
 
 This form is useful for understanding continued fractions, but lets put it
 into standard rational function form using
-:func:`~sympy.polys.polytools.cancel()`.
+:func:`~sympy.polys.polytools.cancel`.
 
     >>> frac = cancel(frac)
     >>> frac
@@ -819,7 +819,7 @@ into standard rational function form using
 
 Now suppose we were given ``frac`` in the above canceled form. In fact, we
 might be given the fraction in any form, but we can always put it into the
-above canonical form with :func:`~sympy.polys.polytools.cancel()`.
+above canonical form with :func:`~sympy.polys.polytools.cancel`.
 Suppose that we knew that it could be
 rewritten as a continued fraction.  How could we do this with SymPy?  A
 continued fraction is recursively `c + \frac{1}{f}`, where `c` is an integer
@@ -830,8 +830,8 @@ could then get a continued fraction with our ``list_to_frac()`` function.
 The key observation here is that we can convert an expression to the form `c +
 \frac{1}{f}` by doing a partial fraction decomposition with respect to
 `c`. This is because `f` does not contain `c`.  This means we need to use the
-:func:`~sympy.polys.partfrac.apart()` function.  We use
-:func:`~sympy.polys.partfrac.apart()` to pull the term out, then
+:func:`~sympy.polys.partfrac.apart` function.  We use
+:func:`~sympy.polys.partfrac.apart` to pull the term out, then
 subtract it from the expression, and take the reciprocal to get the `f` part.
 
     >>> l = []
@@ -905,7 +905,7 @@ peeking (you can check your answer at the end by calling
 comparing it to ``orig_frac``.
 
 See if you can think of a way to figure out what symbol to pass to
-:func:`~sympy.polys.partfrac.apart()`
+:func:`~sympy.polys.partfrac.apart`
 at each stage (hint: think of what happens to `a_0` in the formula `a_0 +
 \frac{1}{a_1 + \cdots}` when it is canceled).
 

--- a/doc/src/tutorials/intro-tutorial/simplification.rst
+++ b/doc/src/tutorials/intro-tutorial/simplification.rst
@@ -17,7 +17,7 @@ Now let's jump in and do some interesting mathematics.  One of the most useful
 features of a symbolic manipulation system is the ability to simplify
 mathematical expressions.  SymPy has dozens of functions to perform various
 kinds of simplification.  There is also one general function called
-:func:`simplify() <sympy.simplify.simplify.simplify>` that attempts to apply
+:func:~sympy.simplify.simplify.simplify()` that attempts to apply
 all of these functions in an intelligent
 way to arrive at the simplest form of an expression.  Here are some examples
 
@@ -30,10 +30,10 @@ way to arrive at the simplest form of an expression.  Here are some examples
 
 Here, ``gamma(x)`` is `\Gamma(x)`, the `gamma function
 <https://en.wikipedia.org/wiki/Gamma_function>`_.  We see that
-:func:`simplify() <sympy.simplify.simplify.simplify>`
+:func:`~sympy.simplify.simplify.simplify()`
 is capable of handling a large class of expressions.
 
-But :func:`simplify() <sympy.simplify.simplify.simplify>` has a pitfall.  It
+But :func:`~sympy.simplify.simplify.simplify()` has a pitfall.  It
 just applies all the major
 simplification operations in SymPy, and uses heuristics to determine the
 simplest result. But "simplest" is not a well-defined term.  For example, say
@@ -44,35 +44,34 @@ we wanted to "simplify" `x^2 + 2x + 1` into `(x + 1)^2`:
     x  + 2⋅x + 1
 
 We did not get what we want.  There is a function to perform this
-simplification, called :func:`factor() <sympy.polys.polytools.factor>`, which
+simplification, called :func:`~sympy.polys.polytools.factor()`, which
 will be discussed below.
 
-Another pitfall to :func:`simplify() <sympy.simplify.simplify.simplify>` is
+Another pitfall to :func:`~sympy.simplify.simplify.simplify()` is
 that it can be unnecessarily slow, since
 it tries many kinds of simplifications before picking the best one.  If you
 already know exactly what kind of simplification you are after, it is better
 to apply the specific simplification function(s) that apply those
 simplifications.
 
-Applying specific simplification functions instead of :func:`simplify()
-<sympy.simplify.simplify.simplify>` also has
+Applying specific simplification functions instead of
+:func:`~sympy.simplify.simplify.simplify()` also has
 the advantage that specific functions have certain guarantees about the form
 of their output.  These will be discussed with each function below.  For
-example, :func:`factor() <sympy.polys.polytools.factor>`, when called on a
+example, :func:`~sympy.polys.polytools.factor()`, when called on a
 polynomial with rational coefficients,
 is guaranteed to factor the polynomial into irreducible factors.
-:func:`simplify() <sympy.simplify.simplify.simplify>` has no guarantees.  It is
+:func:`~sympy.simplify.simplify.simplify()` has no guarantees.  It is
 entirely heuristical, and, as we saw
 above, it may even miss a possible type of simplification that SymPy is
 capable of doing.
 
-:func:`simplify() <sympy.simplify.simplify.simplify>` is best when used
+:func:`~sympy.simplify.simplify.simplify()` is best when used
 interactively, when you just want to whittle
 down an expression to a simpler form.  You may then choose to apply specific
-functions once you see what :func:`simplify()
-<sympy.simplify.simplify.simplify>` returns, to get a more precise
-result.  It is also useful when you have no idea what form an expression will
-take, and you need a catchall function to simplify it.
+functions once you see what :func:`~sympy.simplify.simplify.simplify()`
+returns, to get a more precise result. It is also useful when you have no idea
+what form an expression will take, and you need a catchall function to simplify it.
 
 Polynomial/Rational Function Simplification
 ===========================================
@@ -80,9 +79,9 @@ Polynomial/Rational Function Simplification
 expand
 ------
 
-``expand()`` is one of the most common simplification functions in SymPy.
-Although it has a lot of scopes, for now, we will consider its function in
-expanding polynomial expressions. For example:
+:func:`~sympy.core.function.expand()` is one of the most common simplification
+functions in SymPy. Although it has a lot of scopes, for now, we will consider
+its function in expanding polynomial expressions. For example:
 
     >>> expand((x + 1)**2)
      2
@@ -91,12 +90,13 @@ expanding polynomial expressions. For example:
      2
     x  - x - 6
 
-Given a polynomial, ``expand()`` will put it into a canonical form of a sum of
-monomials.
+Given a polynomial, :func:`~sympy.core.function.expand()` will put it into
+a canonical form of a sum of monomials.
 
-``expand()`` may not sound like a simplification function.  After all, by its
-very name, it makes expressions bigger, not smaller.  Usually this is the
-case, but often an expression will become smaller upon calling ``expand()`` on
+:func:`~sympy.core.function.expand()` may not sound like a simplification
+function.  After all, by its very name, it makes expressions bigger, not
+smaller.  Usually this is the case, but often an expression will become
+smaller upon calling on :func:`~sympy.core.function.expand()`
 it due to cancellation.
 
     >>> expand((x + 1)*(x - 2) - (x - 1)*x)
@@ -105,7 +105,7 @@ it due to cancellation.
 factor
 ------
 
-:func:`factor() <sympy.polys.polytools.factor>` takes a polynomial and factors
+:func:`~sympy.polys.polytools.factor()` takes a polynomial and factors
 it into irreducible factors over
 the rational numbers.  For example:
 
@@ -116,11 +116,11 @@ the rational numbers.  For example:
                2
     z⋅(x + 2⋅y)
 
-For polynomials, :func:`factor() <sympy.polys.polytools.factor>` is the
-opposite of ``expand()``.  :func:`factor() <sympy.polys.polytools.factor>`
+For polynomials, :func:`~sympy.polys.polytools.factor()` is the opposite of
+:func:`~sympy.core.function.expand()`.  :func:`~sympy.polys.polytools.factor()`
 uses a complete multivariate factorization algorithm over the rational
-numbers, which means that each of the factors returned by :func:`factor()
-<sympy.polys.polytools.factor>` is
+numbers, which means that each of the factors returned by
+:func:`~sympy.polys.polytools.factor()` is
 guaranteed to be irreducible.
 
 If you are interested in the factors themselves, ``factor_list`` returns a
@@ -129,7 +129,8 @@ more structured output.
     >>> factor_list(x**2*z + 4*x*y*z + 4*y**2*z)
     (1, [(z, 1), (x + 2⋅y, 2)])
 
-Note that the input to ``factor`` and ``expand`` need not be polynomials in
+Note that the input to :func:`~sympy.polys.polytools.factor()` and
+:func:`~sympy.core.function.expand()` need not be polynomials in
 the strict sense.  They will intelligently factor or expand any kind of
 expression (though note that the factors may not be irreducible if the input
 is no longer a polynomial over the rationals).
@@ -144,7 +145,7 @@ is no longer a polynomial over the rationals).
 collect
 -------
 
-:func:`collect() <sympy.simplify.radsimp.collect>` collects common powers of a
+:func:`~sympy.simplify.radsimp.collect()` collects common powers of a
 term in an expression.  For example
 
     >>> expr = x*y + x - 3 + 2*x**2 - z*x**2 + x**3
@@ -156,8 +157,8 @@ term in an expression.  For example
      3    2
     x  + x ⋅(2 - z) + x⋅(y + 1) - 3
 
-:func:`collect() <sympy.simplify.radsimp.collect>` is particularly useful in
-conjunction with the ``.coeff()``
+:func:`~sympy.simplify.radsimp.collect()` is particularly useful in
+conjunction with the :func:`~sympy.core.expr.Expr.coeff()`
 method.  ``expr.coeff(x, n)`` gives the coefficient of ``x**n`` in ``expr``:
 
     >>> collected_expr.coeff(x, 2)
@@ -169,7 +170,7 @@ method.  ``expr.coeff(x, n)`` gives the coefficient of ``x**n`` in ``expr``:
 cancel
 ------
 
-:func:`cancel() <sympy.polys.polytools.cancel>` will take any rational function
+:func:`~sympy.polys.polytools.cancel()` will take any rational function
 and put it into the standard
 canonical form, `\frac{p}{q}`, where `p` and `q` are expanded polynomials with
 no common factors, and the leading coefficients of `p` and `q` do not have
@@ -207,7 +208,7 @@ denominators (i.e., are integers).
     ───────────────
          x - 1
 
-Note that since :func:`factor() <sympy.polys.polytools.factor>` will completely
+Note that since :func:`~sympy.polys.polytools.factor()` will completely
 factorize both the numerator and
 the denominator of an expression, it can also be used to do the same thing:
 
@@ -218,13 +219,13 @@ the denominator of an expression, it can also be used to do the same thing:
      x - 1
 
 However, if you are only interested in making sure that the expression is in
-canceled form, :func:`cancel() <sympy.polys.polytools.cancel>` is more
-efficient than :func:`factor() <sympy.polys.polytools.factor>`.
+canceled form, :func:`~sympy.polys.polytools.cancel()` is more
+efficient than :func:`~sympy.polys.polytools.factor()`.
 
 apart
 -----
 
-:func:`apart() <sympy.polys.partfrac.apart>` performs a `partial fraction
+:func:`~sympy.polys.partfrac.apart()` performs a `partial fraction
 decomposition
 <https://en.wikipedia.org/wiki/Partial_fraction_decomposition>`_ on a rational
 function.
@@ -250,7 +251,7 @@ Trigonometric Simplification
    SymPy follows Python's naming conventions for inverse trigonometric
    functions, which is to append an ``a`` to the front of the function's
    name.  For example, the inverse cosine, or arc cosine, is called
-   :func:`acos() <sympy.functions.elementary.trigonometric.acos>`.
+   :func:`~sympy.functions.elementary.trigonometric.acos()`.
 
    >>> acos(x)
    acos(x)
@@ -267,8 +268,8 @@ Trigonometric Simplification
 trigsimp
 --------
 
-To simplify expressions using trigonometric identities, use :func:`trigsimp()
-<sympy.simplify.trigsimp.trigsimp>`.
+To simplify expressions using trigonometric identities, use
+:func:`~sympy.simplify.trigsimp.trigsimp()`.
 
     >>> trigsimp(sin(x)**2 + cos(x)**2)
     1
@@ -280,7 +281,7 @@ To simplify expressions using trigonometric identities, use :func:`trigsimp()
        2
     sin (x)
 
-:func:`trigsimp() <sympy.simplify.trigsimp.trigsimp>` also works with
+:func:`~sympy.simplify.trigsimp.trigsimp()` also works with
 hyperbolic trig functions.
 
     >>> trigsimp(cosh(x)**2 + sinh(x)**2)
@@ -288,8 +289,8 @@ hyperbolic trig functions.
     >>> trigsimp(sinh(x)/tanh(x))
     cosh(x)
 
-Much like :func:`simplify() <sympy.simplify.simplify.simplify>`,
-:func:`trigsimp() <sympy.simplify.trigsimp.trigsimp>` applies various
+Much like :func:`~sympy.simplify.simplify.simplify()`,
+:func:`~sympy.simplify.trigsimp.trigsimp()` applies various
 trigonometric identities to
 the input expression, and then uses a heuristic to return the "best" one.
 
@@ -297,7 +298,7 @@ expand_trig
 -----------
 
 To expand trigonometric functions, that is, apply the sum or double angle
-identities, use ``expand_trig()``.
+identities, use :func:`~sympy.core.function.expand_trig()`.
 
     >>> expand_trig(sin(x + y))
     sin(x)⋅cos(y) + sin(y)⋅cos(x)
@@ -307,10 +308,10 @@ identities, use ``expand_trig()``.
            2
     1 - tan (x)
 
-Because ``expand_trig()`` tends to make trigonometric expressions larger, and
-:func:`trigsimp() <sympy.simplify.trigsimp.trigsimp>` tends to make them
-smaller, these identities can be applied in
-reverse using :func:`trigsimp() <sympy.simplify.trigsimp.trigsimp>`
+Because :func:`~sympy.core.function.expand_trig()` tends to make trigonometric
+expressions larger, and :func:`~sympy.simplify.trigsimp.trigsimp()` tends to
+make them smaller, these identities can be applied in
+reverse using :func:`~sympy.simplify.trigsimp.trigsimp()`
 
     >>> trigsimp(sin(x)*cos(y) + sin(y)*cos(x))
     sin(x + y)
@@ -371,7 +372,7 @@ but for now, all we need to know are the following.
   expression with a given Symbol unless it holds for all complex numbers.
 
 - Symbols can be given different assumptions by passing the assumption to
-  :func:`symbols() <sympy.core.symbol.symbols>`.  For the rest of this section,
+  :func:`~sympy.core.symbol.symbols()`.  For the rest of this section,
   we will be assuming that ``x``
   and ``y`` are positive, and that ``a`` and ``b`` are real.  We will leave
   ``z``, ``t``, and ``c`` as arbitrary complex Symbols to demonstrate what
@@ -394,7 +395,7 @@ but for now, all we need to know are the following.
 powsimp
 -------
 
-:func:`powsimp() <sympy.simplify.powsimp.powsimp>` applies identities 1 and 2
+:func:`~sympy.simplify.powsimp.powsimp()` applies identities 1 and 2
 from above, from left to right.
 
 
@@ -405,7 +406,7 @@ from above, from left to right.
         a
    (x⋅y)
 
-Notice that :func:`powsimp() <sympy.simplify.powsimp.powsimp>` refuses to do
+Notice that ::func:`~sympy.simplify.powsimp.powsimp()` refuses to do
 the simplification if it is not valid.
 
     >>> powsimp(t**c*z**c)
@@ -430,8 +431,8 @@ rational numbers, and identity 2 holds, it will be applied automatically.
     √x⋅√y
 
 This means that it will be impossible to undo this identity with
-:func:`powsimp() <sympy.simplify.powsimp.powsimp>`, because even if
-:func:`powsimp() <sympy.simplify.powsimp.powsimp>` were to put the bases
+:func:`~sympy.simplify.powsimp.powsimp()`, because even if
+:func:`~sympy.simplify.powsimp.powsimp()` were to put the bases
 together,
 they would be automatically split apart again.
 
@@ -444,7 +445,8 @@ they would be automatically split apart again.
 expand_power_exp / expand_power_base
 ------------------------------------
 
-``expand_power_exp()`` and ``expand_power_base()`` apply identities 1 and 2
+:func:`~sympy.core.function.expand_power_exp()` and
+:func:`~sympy.core.function.expand_power_base()` apply identities 1 and 2
 from right to left, respectively.
 
     >>> expand_power_exp(x**(a + b))
@@ -455,14 +457,14 @@ from right to left, respectively.
      a  a
     x ⋅y
 
-As with :func:`powsimp() <sympy.simplify.powsimp.powsimp>`, identity 2 is not
+As with :func:`~sympy.simplify.powsimp.powsimp()`, identity 2 is not
 applied if it is not valid.
 
     >>> expand_power_base((z*t)**c)
          c
     (t⋅z)
 
-And as with :func:`powsimp() <sympy.simplify.powsimp.powsimp>`, you can force
+And as with :func:`~sympy.simplify.powsimp.powsimp()`, you can force
 the expansion to happen without
 fiddling with assumptions by using ``force=True``.
 
@@ -471,7 +473,7 @@ fiddling with assumptions by using ``force=True``.
     t ⋅z
 
 As with identity 2, identity 1 is applied automatically if the power is a
-number, and hence cannot be undone with ``expand_power_exp()``.
+number, and hence cannot be undone with :func:`~sympy.core.function.expand_power_exp()`.
 
    >>> x**2*x**3
      5
@@ -483,7 +485,7 @@ number, and hence cannot be undone with ``expand_power_exp()``.
 powdenest
 ---------
 
-:func:`powdenest() <sympy.simplify.powsimp.powdenest>` applies identity 3, from
+:func:`~sympy.simplify.powsimp.powdenest()` applies identity 3, from
 left to right.
 
     >>> powdenest((x**a)**b)
@@ -546,8 +548,9 @@ example, `\log{\left(e^{x + 2\pi i}\right)} = \log{\left(e^x\right)} = x
 expand_log
 ----------
 
-To apply identities 1 and 2 from left to right, use ``expand_log()``.  As
-always, the identities will not be applied unless they are valid.
+To apply identities 1 and 2 from left to right, use
+:func:`~sympy.core.function.expand_log()`.  As always, the identities
+will not be applied unless they are valid.
 
     >>> expand_log(log(x*y))
     log(x) + log(y)
@@ -560,9 +563,9 @@ always, the identities will not be applied unless they are valid.
     >>> expand_log(log(z*t))
     log(t⋅z)
 
-As with :func:`powsimp() <sympy.simplify.powsimp.powsimp>` and
-:func:`powdenest() <sympy.simplify.powsimp.powdenest>`, ``expand_log()`` has a
-``force``
+As with :func:`~sympy.simplify.powsimp.powsimp()` and
+:func:`~sympy.simplify.powsimp.powdenest()`,
+:func:`~sympy.core.function.expand_log()` has a ``force``
 option that can be used to ignore assumptions.
 
     >>> expand_log(log(z**2))
@@ -574,7 +577,8 @@ option that can be used to ignore assumptions.
 logcombine
 ----------
 
-To apply identities 1 and 2 from right to left, use ``logcombine()``.
+To apply identities 1 and 2 from right to left, use
+:func:`~sympy.simplify.simplify.logcombine()`.
 
     >>> logcombine(log(x) + log(y))
     log(x⋅y)
@@ -584,8 +588,8 @@ To apply identities 1 and 2 from right to left, use ``logcombine()``.
     >>> logcombine(n*log(z))
     n⋅log(z)
 
-``logcombine()`` also has a ``force`` option that can be used to ignore
-assumptions.
+:func:`~sympy.simplify.simplify.logcombine()` also has a ``force``
+option that can be used to ignore assumptions.
 
     >>> logcombine(n*log(z), force=True)
        ⎛ n⎞
@@ -611,7 +615,8 @@ assumptions we put on them in the previous section.  We will also define ``k``,
     >>> k, m, n = symbols('k m n')
 
 The `factorial <https://en.wikipedia.org/wiki/Factorial>`_ function is
-``factorial``.  ``factorial(n)`` represents `n!= 1\cdot2\cdots(n - 1)\cdot
+:class:`~sympy.functions.combinatorial.factorials.factorial()`.
+``factorial(n)`` represents `n!= 1\cdot2\cdots(n - 1)\cdot
 n`. `n!` represents the number of permutations of `n` distinct items.
 
     >>> factorial(n)
@@ -619,8 +624,9 @@ n`. `n!` represents the number of permutations of `n` distinct items.
 
 The `binomial coefficient
 <https://en.wikipedia.org/wiki/Binomial_coefficient>`_ function is
-``binomial``.  ``binomial(n, k)`` represents `\binom{n}{k}`, the number of
-ways to choose `k` items from a set of `n` distinct items.  It is also often
+:class:`~sympy.functions.combinatorial.factorials.binomial()`.
+``binomial(n, k)`` represents `\binom{n}{k}`, the number of ways to
+choose `k` items from a set of `n` distinct items.  It is also often
 written as `nCk`, and is pronounced "`n` choose `k`".
 
     >>> binomial(n, k)
@@ -629,7 +635,8 @@ written as `nCk`, and is pronounced "`n` choose `k`".
     ⎝k⎠
 
 The factorial function is closely related to the `gamma function
-<https://en.wikipedia.org/wiki/Gamma_function>`_, ``gamma``.  ``gamma(z)``
+<https://en.wikipedia.org/wiki/Gamma_function>`_,
+:class:`~sympy.functions.special.gamma_functions.gamma()`  ``gamma(z)``
 represents `\Gamma(z) = \int_0^\infty t^{z - 1}e^{-t}\,dt`, which for positive
 integer
 `z` is the same as `(z - 1)!`.
@@ -639,7 +646,8 @@ integer
 
 The `generalized hypergeometric function
 <https://en.wikipedia.org/wiki/Generalized_hypergeometric_function>`_ is
-``hyper``.  ``hyper([a_1, ..., a_p], [b_1, ..., b_q], z)`` represents
+:class:`~sympy.functions.special.hyper.hyper()`.
+``hyper([a_1, ..., a_p], [b_1, ..., b_q], z)`` represents
 `{}_pF_q\left(\begin{matrix} a_1, \cdots, a_p \\ b_1, \cdots, b_q \end{matrix}
 \middle| z \right)`.  The most common case is `{}_2F_1`, which is often
 referred to as the `ordinary hypergeometric function
@@ -674,7 +682,7 @@ expand_func
 -----------
 
 To expand special functions in terms of some identities, use
-``expand_func()``.  For example
+:func:`~sympy.core.function.expand_func()`.  For example
 
     >>> expand_func(gamma(x + 3))
     x⋅(x + 1)⋅(x + 2)⋅Γ(x)
@@ -683,16 +691,16 @@ hyperexpand
 -----------
 
 To rewrite ``hyper`` in terms of more standard functions, use
-:func:`hyperexpand() <sympy.simplify.hyperexpand.hyperexpand>`.
+:func:`~sympy.simplify.hyperexpand.hyperexpand()`.
 
     >>> hyperexpand(hyper([1, 1], [2], z))
     -log(1 - z)
     ────────────
          z
 
-:func:`hyperexpand() <sympy.simplify.hyperexpand.hyperexpand>` also works on
+:func:`~sympy.simplify.hyperexpand.hyperexpand()` also works on
 the more general Meijer G-function (see
-:py:meth:`its documentation <sympy.functions.special.hyper.meijerg>` for more
+:class:`~sympy.functions.special.hyper.meijerg` for more
 information).
 
     >>> expr = meijerg([[1],[1]], [[1],[]], -z)
@@ -709,8 +717,8 @@ information).
 combsimp
 --------
 
-To simplify combinatorial expressions, use :func:`combsimp()
-<sympy.simplify.combsimp.combsimp>`.
+To simplify combinatorial expressions, use
+:func:`~sympy.simplify.combsimp.combsimp()`.
 
     >>> n, k = symbols('n k', integer = True)
     >>> combsimp(factorial(n)/factorial(n - 3))
@@ -724,7 +732,7 @@ gammasimp
 ---------
 
 To simplify expressions with gamma functions or combinatorial functions with
-non-integer argument, use ``gammasimp()``.
+non-integer argument, use :func:`~sympy.core.expr.Expr.gammasimp()`.
 
     >>> gammasimp(gamma(x)*gamma(1 - x))
        π
@@ -778,7 +786,7 @@ SymPy object, even if we only pass in Python ints.
 
 Every finite continued fraction is a rational number, but we are interested in
 symbolics here, so let's create a symbolic continued fraction.  The
-:func:`symbols() <sympy.core.symbol.symbols>` function that we have been using
+:func:`~sympy.core.symbol.symbols()` function that we have been using
 has a shortcut to create
 numbered symbols.  ``symbols('a0:5')`` will create the symbols ``a0``, ``a1``,
 ..., ``a4``.
@@ -800,8 +808,8 @@ numbered symbols.  ``symbols('a0:5')`` will create the symbols ``a0``, ``a1``,
                         a₄
 
 This form is useful for understanding continued fractions, but lets put it
-into standard rational function form using :func:`cancel()
-<sympy.polys.polytools.cancel>`.
+into standard rational function form using
+:func:`~sympy.polys.polytools.cancel()`.
 
     >>> frac = cancel(frac)
     >>> frac
@@ -811,7 +819,7 @@ into standard rational function form using :func:`cancel()
 
 Now suppose we were given ``frac`` in the above canceled form. In fact, we
 might be given the fraction in any form, but we can always put it into the
-above canonical form with :func:`cancel() <sympy.polys.polytools.cancel>`.
+above canonical form with :func:`~sympy.polys.polytools.cancel()`.
 Suppose that we knew that it could be
 rewritten as a continued fraction.  How could we do this with SymPy?  A
 continued fraction is recursively `c + \frac{1}{f}`, where `c` is an integer
@@ -822,9 +830,9 @@ could then get a continued fraction with our ``list_to_frac()`` function.
 The key observation here is that we can convert an expression to the form `c +
 \frac{1}{f}` by doing a partial fraction decomposition with respect to
 `c`. This is because `f` does not contain `c`.  This means we need to use the
-:func:`apart() <sympy.polys.partfrac.apart>` function.  We use :func:`apart()
-<sympy.polys.partfrac.apart>` to pull the term out, then subtract
-it from the expression, and take the reciprocal to get the `f` part.
+:func:`~sympy.polys.partfrac.apart()` function.  We use
+:func:`~sympy.polys.partfrac.apart()` to pull the term out, then
+subtract it from the expression, and take the reciprocal to get the `f` part.
 
     >>> l = []
     >>> frac = apart(frac, a0)
@@ -897,7 +905,7 @@ peeking (you can check your answer at the end by calling
 comparing it to ``orig_frac``.
 
 See if you can think of a way to figure out what symbol to pass to
-:func:`apart() <sympy.polys.partfrac.apart>`
+:func:`~sympy.polys.partfrac.apart()`
 at each stage (hint: think of what happens to `a_0` in the formula `a_0 +
 \frac{1}{a_1 + \cdots}` when it is canceled).
 


### PR DESCRIPTION
### References to other Issues or PRs
  #### Issue #27621 
  #### PR #27629

#### Brief description of what is fixed or changed
Shortened hyperlinks in the Simplification document under Introductory Tutorials. Also added new hyperlinks as suggested [comment](https://github.com/sympy/sympy/issues/27621#issuecomment-2678260550)


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
