### PR TITLE
Fix polynomial scalar division to return Poly instead of Add

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4495,16 +4495,7 @@ class Poly(Basic):
 
     @_sympifyit('g', NotImplemented)
     def __truediv__(f, g):
-        try:
-            f = f.to_field()
-            g = f.domain.convert(g)
-            return f.per(f.rep * (1 / g))
-        except (CoercionFailed, TypeError):
-            result = f.as_expr() / g.as_expr()
-            if result.is_polynomial():
-                return Poly(result, f.gens, domain=f.domain)
-            else:
-                return result
+        return f.as_expr()/g.as_expr()
 
     @_sympifyit('g', NotImplemented)
     def __rtruediv__(f, g):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4495,7 +4495,16 @@ class Poly(Basic):
 
     @_sympifyit('g', NotImplemented)
     def __truediv__(f, g):
-        return f.as_expr()/g.as_expr()
+        try:
+            f = f.to_field()
+            g = f.domain.convert(g)
+            return f.per(f.rep * (1 / g))
+        except (CoercionFailed, TypeError):
+            result = f.as_expr() / g.as_expr()
+            if result.is_polynomial():
+                return Poly(result, f.gens, domain=f.domain)
+            else:
+                return result
 
     @_sympifyit('g', NotImplemented)
     def __rtruediv__(f, g):

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3974,33 +3974,3 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
-
-
-def test_all_polynomial_operations():
-    from sympy.core.symbol import symbols
-    x, y = symbols('x y')
-    p = Poly(x**2, x)
-
-    assert str(p) == "Poly(x**2, x, domain='ZZ')"
-
-    result_by_2 = p / 2
-    assert str(result_by_2) == "Poly(1/2*x**2, x, domain='QQ')"
-
-    result_by_x = p / x
-    assert str(result_by_x) == "Poly(x, x, domain='QQ')"
-
-    result_rec = 1 / p
-    assert result_rec == 1 / (x**2)
-
-    result_by_self = p / p
-    assert result_by_self == 1
-
-    p2 = Poly(x**2*y + x, x)
-    assert str(p2) == "Poly(y*x**2 + x, x, domain='ZZ[y]')"
-
-    result_p2_by_y = p2 / y
-    assert str(result_p2_by_y) == "Poly(x**2 + 1/y*x, x, domain='ZZ(y)')"
-
-    result_p2_by_exp = p2 / exp(y)
-    expected = (x**2 * y + x) * exp(-y)
-    assert result_p2_by_exp == expected

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3974,3 +3974,33 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_all_polynomial_operations():
+    from sympy.core.symbol import symbols
+    x, y = symbols('x y')
+    p = Poly(x**2, x)
+
+    assert str(p) == "Poly(x**2, x, domain='ZZ')"
+
+    result_by_2 = p / 2
+    assert str(result_by_2) == "Poly(1/2*x**2, x, domain='QQ')"
+
+    result_by_x = p / x
+    assert str(result_by_x) == "Poly(x, x, domain='QQ')"
+
+    result_rec = 1 / p
+    assert result_rec == 1 / (x**2)
+
+    result_by_self = p / p
+    assert result_by_self == 1
+
+    p2 = Poly(x**2*y + x, x)
+    assert str(p2) == "Poly(y*x**2 + x, x, domain='ZZ[y]')"
+
+    result_p2_by_y = p2 / y
+    assert str(result_p2_by_y) == "Poly(x**2 + 1/y*x, x, domain='ZZ(y)')"
+
+    result_p2_by_exp = p2 / exp(y)
+    expected = (x**2 * y + x) * exp(-y)
+    assert result_p2_by_exp == expected

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3974,3 +3974,33 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_polynomial():
+    from sympy.core.symbol import symbols
+    x, y = symbols('x y')
+    p = Poly(x**2, x)
+
+    assert str(p) == "Poly(x**2, x, domain='ZZ')"
+
+    result_by_2 = p / 2
+    assert str(result_by_2) == "Poly(1/2*x**2, x, domain='QQ')"
+
+    result_by_x = p / x
+    assert str(result_by_x) == "Poly(x, x, domain='QQ')"
+
+    result_rec = 1 / p
+    assert result_rec == 1 / (x**2)
+
+    result_by_self = p / p
+    assert result_by_self == 1
+
+    p2 = Poly(x**2*y + x, x)
+    assert str(p2) == "Poly(y*x**2 + x, x, domain='ZZ[y]')"
+
+    result_p2_by_y = p2 / y
+    assert str(result_p2_by_y) == "Poly(x**2 + 1/y*x, x, domain='ZZ(y)')"
+
+    result_p2_by_exp = p2 / exp(y)
+    expected = (x**2 * y + x) * exp(-y)
+    assert result_p2_by_exp == expected


### PR DESCRIPTION
#### Brief description of what is fixed or changed
This PR fixes issue where dividing `Poly` by an integer results in an `Add` expression instead of a `Poly`.

#### Other comments

Updated `__truediv__` function to handle scalar division by converting divisor to polynomial's domain and if divisor is scalar perform coefficient-wise division and return `Poly` otherwise divisor is non-scalar return an expression.

Fixes #19516 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * changes in `__truediv__` method ensure scalar division returns `Poly` with updated coefficients and domain.
<!-- END RELEASE NOTES -->
