### PR TITLE
Add _eval_rewrite_as_Integral for Shi and Chi functions

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2188,6 +2188,11 @@ class Shi(TrigonometricIntegral):
         # XXX should we polarify z?
         return (E1(z) - E1(exp_polar(I*pi)*z))/2 - I*pi/2
 
+    def _eval_rewrite_as_Integral(self, z, **kwargs):
+        from sympy.integrals.integrals import Integral
+        t = Dummy(uniquely_named_symbol('t', [z]).name)
+        return Integral(sinh(t) / t, (t, 0, z))
+
     def _eval_is_zero(self):
         z = self.args[0]
         if z.is_zero:
@@ -2303,6 +2308,11 @@ class Chi(TrigonometricIntegral):
 
     def _eval_rewrite_as_expint(self, z, **kwargs):
         return -I*pi/2 - (E1(z) + E1(exp_polar(I*pi)*z))/2
+
+    def _eval_rewrite_as_Integral(self, z, **kwargs):
+        from sympy.integrals.integrals import Integral
+        t = Dummy(uniquely_named_symbol('t', [z]).name)
+        return S.EulerGamma + log(z) + Integral((cosh(t) - 1) / t, (t, 0, z))
 
     def _eval_as_leading_term(self, x, logx, cdir):
         arg = self.args[0].as_leading_term(x, logx=logx, cdir=cdir)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -656,6 +656,7 @@ def test_si():
 
     t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc).dummy_eq(Integral(sinc(t), (t, 0, x)))
+    assert Shi(x).rewrite(Integral).dummy_eq(Integral(sinh(t) / t, (t, 0, x)))
 
     assert limit(Shi(x), x, S.Infinity) == S.Infinity
     assert limit(Shi(x), x, S.NegativeInfinity) == S.NegativeInfinity
@@ -714,6 +715,9 @@ def test_ci():
                                         expint(1, x*exp_polar(I*pi/2))/2
     raises(ArgumentIndexError, lambda: Ci(x).fdiff(2))
 
+    t = Symbol('t', Dummy=True)
+    assert Ci(x).rewrite(Integral).dummy_eq(EulerGamma + log(x) - Integral((1 - cos(t)) / t, (t, 0, x)))
+    assert Chi(x).rewrite(Integral).dummy_eq(EulerGamma + log(x) + Integral((cosh(t) - 1) / t, (t, 0, x)))
 
 def test_fresnel():
     assert fresnels(0) is S.Zero


### PR DESCRIPTION
### Brief Description of Changes

This PR adds the _eval_rewrite_as_Integral method for the Shi (Hyperbolic Sine Integral) and Chi (Hyperbolic Cosine Integral) functions in SymPy.

- Shi function now rewrites as:
  ```bash
   Shi(z) = ∫₀ᶻ (sinh(t) / t) dt
  ```
- Chi function now rewrites as:
  ```bash
    Chi(z) = γ + ln(z) + ∫₀ᶻ (cosh(t) - 1) / t dt
  ```
### Changes Made:

- Implemented _eval_rewrite_as_Integral in Shi and Chi.
- Added corresponding test cases in test_error_functions.py.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->