### PR TITLE
Fixes to `_initialize_first_polynomial` and `_initialize_ith_poly`

### DIFF
--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -44,8 +44,6 @@ def test_qs_2() -> None:
         [0, 0, 3, 7, 13, 0, 8, 19, 9, 43, 27, 25, 63, 29, 19]
     assert [factor_base[i].soln2 for i in range(15)] == \
         [0, 1, 1, 3, 12, 16, 15, 6, 15, 1, 56, 55, 61, 58, 16]
-    assert [factor_base[i].a_inv for i in range(15)] == \
-        [1, 1, 5, 7, 3, 5, 26, 6, 40, 5, 21, 45, 4, 1, 8]
     assert [factor_base[i].b_ainv for i in range(5)] == \
         [[0, 0], [0, 2], [3, 0], [3, 9], [13, 13]]
 


### PR DESCRIPTION
- Remove `FactorBaseElem.a_inv`. This variable does not need to be stored.
- Initialize `soln1` in `_initialize_first_polynomial`. Without this, values after the first iteration become incorrect.
- Refactor `_initialize_ith_poly`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27636

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
