### PR TITLE
series: Added a function pade_approximant

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -920,6 +920,7 @@ Lukas Molleman <Lukas.Molleman@gmail.com>
 Lukas Zorich <lukas.zorich@gmail.com>
 Luke Peterson <hazelnusse@gmail.com>
 Luv Agarwal <agarwal.iiit@gmail.com>
+Lyle Poley <poleylyle@gmail.com>
 Maciej Baranski <getrox.sc@gmail.com>
 Maciej Skórski <maciej.skorski@gmail.com>
 Madeleine Ball <mpball@gmail.com>

--- a/sympy/series/pade_approximant.py
+++ b/sympy/series/pade_approximant.py
@@ -1,0 +1,99 @@
+from sympy.functions.combinatorial.factorials import factorial
+from sympy.core.symbol import symbols
+from sympy.solvers.solveset import linsolve
+from sympy.utilities import public
+
+@public
+def pade_approximant(expr, x, x0, n, m=None):
+    """
+    Return the [n/m] Pade approximation p(x)/q(x) of expr around ``x = x0'',
+    where p(x) and q(x) are polynomials of order n and m respectively.
+
+    The polynomials p(x) and q(x) are found by requiring the taylor series of
+    expr and p(x)/q(x) to match up to (n + m)th order.
+
+    Parameters
+    ----------
+    expr : Expression
+           The expression whose Pade approximant is to be computed.
+
+    x   : Symbol
+        It is the variable of the expression to be calculated.
+
+    x0  : Value
+         The value around which ``x`` is calculated. Can be any value
+         from ``-oo`` to ``oo``.
+
+    n   : int
+        The order of the returned approximating polynomial `p`.
+
+    m   : int, optional
+        The order of the returned approximating polynomial `q`. Defaults to n.
+
+    Returns
+    -------
+    p(x)/q(x) : Rational Function
+        The Pade approximation of expr around ``x = x0``.
+
+    Examples
+    --------
+    >>> import sympy as sp
+    >>> x = sp.symbols('x')
+    >>> exp_pade = pade_approximant(sp.exp(x), x, 0, 2, 2)
+    >>> exp_pade
+    (x**2/12 + x/2 + 1)/(x**2/12 - x/2 + 1)
+
+    Compare the [3/4] Pade approximant of sin(x) around x=0 with sin(x)
+    >>> sin_pade = pade_approximant(sp.sin(x), x, 0, 3, 4)
+    >>> sin_pade
+    (-31*x**3/294 + x)/(11*x**4/5880 + 3*x**2/49 + 1)
+
+    >>> sp.N(sin_pade.subs(x, 1))
+    0.841465365541513
+
+    >>> sp.N(sp.sin(1))
+    0.841470984807897
+
+    """
+
+    if n < 0:
+        raise ValueError("Order of p <n> must be greater than 0.")
+    if m is None:
+        m = n
+    elif m < 0:
+        raise ValueError("Order of q <m> must be greater than 0.")
+
+    N = m + n
+    taylor_coefficients = [
+        expr.diff(x, i).subs(x, x0) / factorial(i) for i in range(N + 1)
+    ]
+
+    pq_coefficients = symbols(f"p0:{N + 1}")
+
+    A = [[1 if i == j else 0 for j in range(n + 1)] for i in range(N + 1)]
+    B = [[0 for _ in range(m)] for _ in range(N + 1)]
+
+    for row in range(1, m + 1):
+        B[row][:row] = [-f for f in taylor_coefficients[:row][::-1]]
+    for row in range(m + 1, N + 1):
+        B[row][:] = [-f for f in taylor_coefficients[row - m : row][::-1]]
+
+    C = [a + b for a, b in zip(A, B)]
+    linear_system = [
+        sum([c * pq for c, pq in zip(row, pq_coefficients)]) - f
+        for row, f in zip(C, taylor_coefficients)
+    ]
+
+    pq_solution = list(*linsolve(linear_system, *pq_coefficients))
+
+    # the linear system has no solution iff the leading terms in both p(x) and q(x) are zero
+    # in this case, the pade approximation [n/m] is the same as the pade approximation [n-1/m-1]
+    if pq_solution == []:
+        return pade_approximant(expr, x, x0, n - 1, m - 1)
+
+    p = sum([p * (x - x0) ** i for i, p in enumerate(pq_solution[: n + 1])])
+    q = 1 + sum(
+        [q * (x - x0) ** (i + 1) for i, q in enumerate(pq_solution[n + 1 :])]
+    )
+
+    return p / q

--- a/sympy/series/tests/test_pade_approximant.py
+++ b/sympy/series/tests/test_pade_approximant.py
@@ -1,0 +1,41 @@
+from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.trigonometric import cos, sin
+from sympy.abc import x
+from sympy.series.pade_approximant import pade_approximant
+from sympy.simplify import simplify
+
+def test_sin_52():
+    assert pade_approximant(sin(x), x, 0, 5, 2) == \
+        (x - x**3/7 + (11*x**5)/2520)/(1 + x**2/42)
+
+def test_exp_22():
+    assert pade_approximant(exp(x), x, 0, 2, 2) == \
+        (x**2/12 + x/2 + 1)/(x**2/12 - x/2 + 1)
+
+def test_cos_24():
+    assert pade_approximant(cos(x), x, 0, 2, 4) == \
+        (1 - 61*x**2/150)/(x**4/200 + 7*x**2/75 + 1)
+
+def test_exp_cos_33():
+    assert pade_approximant(exp(cos(x)), x, 0, 3, 3) == \
+        (exp(1) - exp(1)*x**2/6)/(x**2/3 + 1)
+
+def test_log_32():
+    """
+    The below assertion evaluates to False, despite being correct.
+    assert pade_approximant(log(1 + x), x, 1, 3, 2)\
+      == ((x - 1)**3/240 + (x - 1)**2*(3*log(2)/40 + 7/40)\
+      + (x - 1)*(3*log(2)/5 + 1/2) + log(2))/(3*x/5 + 3*(x - 1)**2/40 + 2/5)
+    This assertion is mathematically equivalent to the above """
+
+    assert 0==\
+        simplify(pade_approximant(log(1 + x), x, 1, 3, 2)\
+            - ((x - 1)**3/240 + (x - 1)**2*(3*log(2)/40 + 7/40)\
+                + (x - 1)*(3*log(2)/5 + 1/2) + log(2))\
+                /(3*x/5 + 3*(x - 1)**2/40 + 2/5))
+
+def test_rational_02():
+    assert pade_approximant(1/(1 + x**2), x, 0, 0, 2) == 1/(1 + x**2)
+
+def test_rational_20():
+    assert pade_approximant(2 + x**2, x, 0, 2, 0) == 2 + x**2


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
I have not found any open issues which request this functionality.

#### Brief description of what is fixed or changed
Added a pade_approximant function. This function allows users to easily compute the [n/m] pade approximant of a given expression with a similar interface to computing a series expansion for an expression. I wrote this because I used to use the function "PadeApproximant" frequently in mathematica and found it very useful. The code for computing the approximant is adapted from the source code for scipy.interpolate.pade.


#### Other comments
The pade approximant is similar to a taylor series, although rather than approximating an expression with a polynomial of given degree, a pade approximant approximates an expression with a rational function whose numerator and denominator each have given degree.

Sorry if I have not followed the proper procedure for submitting this pull request, it's my first attempt at open source contribution.

#### Example:

In [1]: import sympy as sp

In [2]: x = sp.symbols('x')

In [3]: pade_approximant(sp.exp(x), x, 0, 2, 1)

Out [3]: (x**2/6 + 2*x/3 + 1)/(1 - x/3)

The command "pade_approximant(sp.exp(x), x, 0, 2, 1)" computes the [2/1] approximant of exp(x) around the point x = 0.



#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* series
  * added a function for computing pade approximants
<!-- END RELEASE NOTES -->
