### PR TITLE
fix(matrices): Fix Matrix.inv_mod for composite modulus

### DIFF
--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -47,3 +47,16 @@ def test_matrix_inv_mod():
     raises(ValueError, lambda: A.inv_mod(2))
     A = Matrix([[1, 2], [3, 4]])
     raises(TypeError, lambda: A.inv_mod(Rational(1, 2)))
+    # https://github.com/sympy/sympy/issues/27663
+    M = Matrix([
+        [2, 3, 1, 4],
+        [1, 5, 3, 2],
+        [3, 2, 4, 1],
+        [4, 1, 2, 5],
+    ])
+    assert M.inv_mod(26) == Matrix([
+        [7, 21, 10, 10],
+        [1, 7, 19, 3],
+        [14, 1, 15, 1],
+        [25, 23, 3, 12],
+    ])

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -232,6 +232,14 @@ class FiniteField(Field, SimpleDomain):
     def tp(self):
         return self._tp
 
+    @property
+    def is_Field(self):
+        is_field = getattr(self, '_is_field', None)
+        if is_field is None:
+            from sympy.ntheory.primetest import isprime
+            self._is_field = is_field = isprime(self.mod)
+        return is_field
+
     def __str__(self):
         return 'GF(%s)' % self.mod
 

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -506,6 +506,19 @@ def test_issue_14433():
     assert ((x - y) in QQ.frac_field(x, 1/y)) is True
 
 
+def test_Domain_is_field():
+    assert ZZ.is_Field is False
+    assert GF(5).is_Field is True
+    assert GF(6).is_Field is False
+    assert QQ.is_Field is True
+    assert RR.is_Field is True
+    assert CC.is_Field is True
+    assert EX.is_Field is True
+    assert ALG.is_Field is True
+    assert QQ[x].is_Field is False
+    assert ZZ.frac_field(x).is_Field is True
+
+
 def test_Domain_get_ring():
     assert ZZ.has_assoc_Ring is True
     assert QQ.has_assoc_Ring is True

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -790,6 +790,12 @@ def test_DomainMatrix_inv():
     Aninv = DomainMatrix([[QQ(1), QQ(2)], [QQ(3), QQ(6)]], (2, 2), QQ)
     raises(DMNonInvertibleMatrixError, lambda: Aninv.inv())
 
+    Z3 = FF(3)
+    assert DM([[1, 2], [3, 4]], Z3).inv() == DM([[1, 1], [0, 1]], Z3)
+
+    Z6 = FF(6)
+    raises(DMNotAField, lambda: DM([[1, 2], [3, 4]], Z6).inv())
+
 
 def test_DomainMatrix_det():
     A = DomainMatrix([], (0, 0), ZZ)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1639,7 +1639,7 @@ class Distribution(Basic):
                 import pymc3 as pymc
 
             with pymc.Model():
-                if do_sample_pymc(self):
+                if do_sample_pymc(self) is not None:
                     samps = pymc.sample(draws=prod(size), chains=1, compute_convergence_checks=False,
                             progressbar=False, random_seed=seed, return_inferencedata=False)[:]['X']
                     samps = samps.reshape(size)


### PR DESCRIPTION
In the case of composite m the inverse of a matrix modulus m may exist even if the standard Gaussian elimination would encounter zero divisors. Compute instead the adjugate and determinant. If the determinant is invertible then the inverse mod m exists.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-27663

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * A regression in Matrix.inv_mod was fixed. In versions before 1.12 inv_mod could compute the inverse of a matrix modulo a composite number if it exists. This would potentially fail in 1.12 and 1.13 due to the inverse algorithm encountering zero divisors even if the inverse matrix does exist. Now if the determinant is invertible mod m then the inverse of the matrix mod m is always computed.
<!-- END RELEASE NOTES -->
