### PR TITLE
Fix: Improve Q.infinite(Expr) handling for symbolic conditions and complex infinity

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -237,8 +237,7 @@ def _(expr, assumptions):
     if assumptions is True:
         result = ask(~Q.finite(expr))
     else:
-        result = ask(~Q.finite(expr),assumptions)
-        
+        result = ask(~Q.finite(expr),assumptions)    
     return result
 
 

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -234,7 +234,10 @@ def _(expr, assumptions):
 
 @InfinitePredicate.register(Expr)
 def _(expr, assumptions):
-    return ask(~Q.finite(expr),assumptions)
+    is_finite = Q.finite(expr)._eval_ask(assumptions)
+    if is_finite is None:
+        return None
+    return not is_finite
 
 
 # PositiveInfinitePredicate

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -237,7 +237,7 @@ def _(expr, assumptions):
     if assumptions is True:
         result = ask(~Q.finite(expr))
     else:
-        result = ask(~Q.finite(expr),assumptions)    
+        result = ask(~Q.finite(expr),assumptions)
     return result
 
 

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -4,7 +4,7 @@ infinitesimal, finite, etc.
 """
 
 from sympy.assumptions import Q, ask
-from sympy.core import Add, Mul, Pow, Symbol
+from sympy.core import Expr,Add, Mul, Pow, Symbol
 from sympy.core.numbers import (NegativeInfinity, GoldenRatio,
     Infinity, Exp1, ComplexInfinity, ImaginaryUnit, NaN, Number, Pi, E,
     TribonacciConstant)
@@ -230,6 +230,16 @@ def _(expr, assumptions):
 @InfinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity)
 def _(expr, assumptions):
     return True
+
+
+@InfinitePredicate.register(Expr)
+def _(expr, assumptions):
+    if assumptions is True:
+        result = ask(~Q.finite(expr))
+    else:
+        result = ask(~Q.finite(expr),assumptions)
+        
+    return result
 
 
 # PositiveInfinitePredicate

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -234,11 +234,7 @@ def _(expr, assumptions):
 
 @InfinitePredicate.register(Expr)
 def _(expr, assumptions):
-    if assumptions is True:
-        result = ask(~Q.finite(expr))
-    else:
-        result = ask(~Q.finite(expr),assumptions)
-    return result
+    return ask(~Q.finite(expr),assumptions)
 
 
 # PositiveInfinitePredicate

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -4,7 +4,7 @@ infinitesimal, finite, etc.
 """
 
 from sympy.assumptions import Q, ask
-from sympy.core import Expr,Add, Mul, Pow, Symbol
+from sympy.core import Expr, Add, Mul, Pow, Symbol
 from sympy.core.numbers import (NegativeInfinity, GoldenRatio,
     Infinity, Exp1, ComplexInfinity, ImaginaryUnit, NaN, Number, Pi, E,
     TribonacciConstant)

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -227,11 +227,6 @@ def _(expr, assumptions):
 # InfinitePredicate
 
 
-@InfinitePredicate.register_many(ComplexInfinity, Infinity, NegativeInfinity)
-def _(expr, assumptions):
-    return True
-
-
 @InfinitePredicate.register(Expr)
 def _(expr, assumptions):
     is_finite = Q.finite(expr)._eval_ask(assumptions)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1107,8 +1107,7 @@ def test_bounded():
     assert ask(Q.finite(cos(x) + sin(x))) is True
 
 
-def test_unbounded_expr():
-    # https://github.com/sympy/sympy/issues/27610
+def test_unbounded():
     assert ask(Q.infinite(I * oo)) is True
     assert ask(Q.infinite(1 + I*oo)) is True
     assert ask(Q.infinite(3 * (I * oo))) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1107,6 +1107,21 @@ def test_bounded():
     assert ask(Q.finite(cos(x) + sin(x))) is True
 
 
+def test_unbounded_expr():
+    # https://github.com/sympy/sympy/issues/27610
+    assert ask(Q.infinite(I * oo)) is True
+    assert ask(Q.infinite(1 + I*oo)) is True
+    assert ask(Q.infinite(3 * (I * oo))) is True
+    assert ask(Q.infinite(-I * oo)) is True
+    assert ask(Q.infinite(1 + zoo)) is True
+    assert ask(Q.infinite(I * zoo)) is True
+    assert ask(Q.infinite(x / y), Q.infinite(x) & Q.finite(y) & ~Q.zero(y)) is True
+    assert ask(Q.infinite(I * oo - I * oo)) is None
+    assert ask(Q.infinite(x * I * oo)) is None
+    assert ask(Q.infinite(1 / x), Q.finite(x) & ~Q.zero(x)) is False
+    assert ask(Q.infinite(1 / (I * oo))) is False
+
+
 def test_issue_27441():
     # https://github.com/sympy/sympy/issues/27441
     assert ask(Q.composite(y), Q.integer(y) & Q.positive(y) & ~Q.prime(y)) is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->"Fixes #27610"


#### Brief description of what is fixed or changed
**Issue:**
ask(Q.infinite(I * oo)) returns None instead of True.
**Fix:**
Added Q.infinite(Expr) to handle symbolic conditions more effectively.
Ensured better handling of cases like x * oo, x + I * oo, and 1 / x under different assumptions

#### Other comments
Enhanced Q.infinite(Expr) to handle symbolic conditions correctly-

1) Fixes issue where ask(Q.infinite(I * oo)) returned None instead of True.
2) Added extensive test coverage for symbolic expressions.
3) Ensures consistency for operations involving infinity (oo, I * oo, zoo).
4) Handles cases where Expr includes symbols with Q.finite, Q.infinite, or Q.complex conditions.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * ```ask(Q.infinite(I*oo))``` now returns ```True``` instead of ```None```.

<!-- END RELEASE NOTES -->
