### PR TITLE
Fix recursion error when applying floor to Matrix objects

### DIFF
--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -2986,7 +2986,7 @@ class MatrixBase(Printable):
 
     @call_highest_priority('__add__')
     def __radd__(self, other):
-        return self + other
+        return self.__add__(other)
 
     @call_highest_priority('__matmul__')
     def __rmatmul__(self, other):

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -8,7 +8,7 @@ from sympy import (
     ImmutableSparseMatrix, Integer, KroneckerDelta, MatPow, Matrix,
     MatrixSymbol, Max, Min, MutableDenseMatrix, MutableSparseMatrix, Poly, Pow,
     PurePoly, Q, Quaternion, Rational, RootOf, S, SparseMatrix, Symbol, Tuple,
-    Wild, banded, casoratian, cos, diag, diff, exp, expand, eye, hessian,
+    Wild, banded, casoratian, cos, diag, diff, exp, expand, eye, floor, hessian,
     integrate, log, matrix_multiply_elementwise, nan, ones, oo, pi, randMatrix,
     rot_axis1, rot_axis2, rot_axis3, rot_ccw_axis1, rot_ccw_axis2,
     rot_ccw_axis3, signsimp, simplify, sin, sqrt, sstr, symbols, sympify, tan,
@@ -3788,3 +3788,8 @@ def test_issue_23276():
     assert integrate(M, (x, 0, 1), (y, 0, 1)) == Matrix([
         [S.Half],
         [S.Half]])
+
+
+def test_issue_27225():
+    # https://github.com/sympy/sympy/issues/27225
+    raises(TypeError, lambda : floor(Matrix([1, 1, 0])))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes:#27225
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed: Recursion error when applying floor to Matrix objects.
Changed: Ensured proper handling of Matrix elements to prevent type errors.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
