### PR TITLE
ring series: rs_series extend to work with atan

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1201,9 +1201,8 @@ def rs_atan(p, x, prec):
         return rs_puiseux(rs_atan, p, x, prec)
     R = p.ring
     const = 0
-    if _has_constant_term(p, x):
-        zm = R.zero_monom
-        c = p[zm]
+    c = _get_constant_term(p, x)
+    if c:
         if R.domain is EX:
             c_expr = c.as_expr()
             const = atan(c_expr)
@@ -1212,8 +1211,11 @@ def rs_atan(p, x, prec):
                 c_expr = c.as_expr()
                 const = R(atan(c_expr))
             except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+                R = R.add_gens([atan(c_expr)])
+                p = p.set_ring(R)
+                x = x.set_ring(R)
+                c = c.set_ring(R)
+                const = R(atan(c_expr))
         else:
             try:
                 const = R(atan(c))
@@ -1855,7 +1857,8 @@ _convert_func = {
         'cos': 'rs_cos',
         'exp': 'rs_exp',
         'tan': 'rs_tan',
-        'log': 'rs_log'
+        'log': 'rs_log',
+        'atan': 'rs_atan'
         }
 
 def rs_min_pow(expr, series_rs, a):

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -10,7 +10,7 @@ from sympy.testing.pytest import raises, slow
 from sympy.core.symbol import symbols
 from sympy.functions import (sin, cos, exp, tan, cot, atan, atanh,
     tanh, log, sqrt)
-from sympy.core.numbers import Rational
+from sympy.core.numbers import Rational, pi
 from sympy.core import expand, S
 
 def is_close(a, b):
@@ -637,3 +637,10 @@ def test_rs_series():
     assert rs_series(log(1 + x*a**2), x, 7).as_expr() == -x**6*a**12/6 + \
                     x**5*a**10/5 - x**4*a**8/4 + x**3*a**6/3 - \
                     x**2*a**4/2 + x*a**2
+
+    assert rs_series(atan(1 + x), x, 9).as_expr() == -x**7/112 + x**6/48 - x**5/40 \
+           + x**3/12 - x**2/4 + x/2 + pi/4
+    assert rs_series(atan(1 + x + x**2),x, 9).as_expr() == -15*x**7/112 - x**6/48 + \
+           9*x**5/40 - 5*x**3/12 + x**2/4 + x/2 + pi/4
+    assert rs_series(atan(1 + x * a), x, 9).as_expr() == -a**7*x**7/112 + a**6*x**6/48 \
+           - a**5*x**5/40 + a**3*x**3/12 - a**2*x**2/4 + a*x/2 + pi/4


### PR DESCRIPTION
#### References to other Issues or PRs
issue: #10190

#### Brief description of what is fixed or changed
Now atan series can be calculate directly by using `rs_series`.eg: 
```python
>>> from sympy import QQ, atan, symbols
>>> from sympy.polys.ring_series import rs_series
>>> x=symbols('x')
>>> rs_series(atan(x),x,5).as_expr()
>>> -x**3/3 + x
```
#### Release Note
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
