### PR TITLE
Enhance PositivePredicate for real base and even exponent in power expressions

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -319,8 +319,6 @@ def _(expr, assumptions):
         if ask(Q.real(expr.exp), assumptions):
             return True
     if ask(Q.negative(expr.base), assumptions):
-        if ask(Q.even(expr.exp), assumptions):
-            return True
         if ask(Q.odd(expr.exp), assumptions):
             return False
 

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -315,9 +315,9 @@ def _(expr, assumptions):
     if ask(Q.even(expr.exp), assumptions):
         if ask(Q.real(expr.base), assumptions):
             _zero = ask(Q.zero(expr.base), assumptions)
-            if is_base_zero is None:
+            if _zero is None:
                 return None
-            if is_base_zero:
+            if _zero:
                 if ask(Q.positive(expr.exp), assumptions):
                     return False
                 return

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -312,6 +312,9 @@ def _(expr, assumptions):
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
+    if ask(Q.even(expr.exp),assumptions):
+        if ask(Q.real(expr.base), assumptions):
+            return True
     if ask(Q.positive(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -313,7 +313,14 @@ def _(expr, assumptions):
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
     if ask(Q.even(expr.exp),assumptions):
-        if ask(Q.real(expr.base), assumptions):
+        if ask(Q.real(expr.base), assumptions): 
+            is_base_zero = ask(Q.zero(expr.base),assumptions)
+            if is_base_zero is None:
+                return None
+            if is_base_zero:
+                if (ask(Q.positive(expr.exp),assumptions)):
+                    return False
+                return
             return True
     if ask(Q.positive(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -312,13 +312,13 @@ def _(expr, assumptions):
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
-    if ask(Q.even(expr.exp),assumptions):
+    if ask(Q.even(expr.exp), assumptions):
         if ask(Q.real(expr.base), assumptions):
-            is_base_zero = ask(Q.zero(expr.base),assumptions)
+            _zero = ask(Q.zero(expr.base), assumptions)
             if is_base_zero is None:
                 return None
             if is_base_zero:
-                if (ask(Q.positive(expr.exp),assumptions)):
+                if ask(Q.positive(expr.exp), assumptions):
                     return False
                 return
             return True

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -312,16 +312,15 @@ def _(expr, assumptions):
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
-    if ask(Q.even(expr.exp), assumptions):
-        if ask(Q.real(expr.base), assumptions):
-            _zero = ask(Q.zero(expr.base), assumptions)
-            if _zero is None:
-                return None
-            if _zero:
-                if ask(Q.positive(expr.exp), assumptions):
-                    return False
-                return
-            return True
+    if ask(Q.even(expr.exp), assumptions) and ask(Q.real(expr.base), assumptions):
+        _zero = ask(Q.zero(expr.base), assumptions)
+        if _zero is None:
+            return None
+        if _zero:
+            if ask(Q.positive(expr.exp), assumptions):
+                return False
+            return
+        return True
     if ask(Q.positive(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -313,14 +313,11 @@ def _(expr, assumptions):
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
     if ask(Q.even(expr.exp), assumptions) and ask(Q.real(expr.base), assumptions):
-        _zero = ask(Q.zero(expr.base), assumptions)
-        if _zero is None:
-            return None
-        if _zero:
-            if ask(Q.positive(expr.exp), assumptions):
-                return False
-            return
-        return True
+        zero_base = ask(Q.zero(expr.base), assumptions)
+        if zero_base:
+            positive_exp = ask(Q.positive(expr.exp), assumptions)
+            return False if positive_exp else None
+        return True if zero_base is False else None
     if ask(Q.positive(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -313,7 +313,7 @@ def _(expr, assumptions):
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
     if ask(Q.even(expr.exp),assumptions):
-        if ask(Q.real(expr.base), assumptions): 
+        if ask(Q.real(expr.base), assumptions):
             is_base_zero = ask(Q.zero(expr.base),assumptions)
             if is_base_zero is None:
                 return None

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -314,10 +314,10 @@ def _(expr, assumptions):
         return _PositivePredicate_number(expr, assumptions)
     if ask(Q.even(expr.exp), assumptions) and ask(Q.real(expr.base), assumptions):
         zero_base = ask(Q.zero(expr.base), assumptions)
-        if zero_base:
-            positive_exp = ask(Q.positive(expr.exp), assumptions)
-            return False if positive_exp else None
-        return True if zero_base is False else None
+        if zero_base and ask(Q.positive(expr.exp), assumptions):
+            return False
+        elif zero_base is False:
+            return True
     if ask(Q.positive(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -312,6 +312,9 @@ def _(expr, assumptions):
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
+    if ask(Q.integer(expr.exp/2)):
+        if ask(Q.real(expr.exp), assumptions):
+            return True
     if ask(Q.positive(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1907,6 +1907,8 @@ def test_positive():
     assert ask(Q.positive(exp(x*pi*I)), Q.even(x)) is True
     assert ask(Q.positive(exp(x*pi*I)), Q.odd(x)) is False
     assert ask(Q.positive(exp(x*pi*I)), Q.real(x)) is None
+    assert ask(Q.positive(x**2),Q.real(x)) is True
+    assert ask(Q.positive(x**y),Q.even(y) & Q.real(x)) is True
 
     # logarithm
     assert ask(Q.positive(log(x)), Q.imaginary(x)) is False
@@ -2282,7 +2284,7 @@ def test_issue_3906():
 
 
 def test_issue_5833():
-    assert ask(Q.positive(log(x)**2), Q.positive(x)) is None
+    assert ask(Q.positive(log(x)**2), Q.positive(x)) is True
     assert ask(~Q.negative(log(x)**2), Q.positive(x)) is True
 
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1899,6 +1899,7 @@ def test_positive():
 
     #exponential
     assert ask(Q.positive(exp(x)), Q.real(x)) is True
+    assert ask(Q.positive(x**y), Q.nonzero(x) & Q.even(y)) is True
     assert ask(~Q.negative(exp(x)), Q.real(x)) is True
     assert ask(Q.positive(x + exp(x)), Q.real(x)) is None
     assert ask(Q.positive(exp(x)), Q.imaginary(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1906,9 +1906,13 @@ def test_positive():
     assert ask(Q.negative(exp(pi*I, evaluate=False)), Q.imaginary(x)) is True
     assert ask(Q.positive(exp(x*pi*I)), Q.even(x)) is True
     assert ask(Q.positive(exp(x*pi*I)), Q.odd(x)) is False
+    assert ask(Q.positive(x**y), Q.zero(x) & Q.positive(y)) is False
     assert ask(Q.positive(exp(x*pi*I)), Q.real(x)) is None
     assert ask(Q.positive(x**2), Q.real(x)) is None
     assert ask(Q.positive(x**y), Q.even(y) & Q.real(x)) is None
+    assert ask(Q.positive(x**y),Q.zero(x)) is None
+    assert ask(Q.positive(x**y), Q.zero(x) & Q.negative(y)) is None
+    assert ask(Q.positive(x**y), Q.zero(x) & Q.even(y)) is None
 
     # logarithm
     assert ask(Q.positive(log(x)), Q.imaginary(x)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1907,8 +1907,8 @@ def test_positive():
     assert ask(Q.positive(exp(x*pi*I)), Q.even(x)) is True
     assert ask(Q.positive(exp(x*pi*I)), Q.odd(x)) is False
     assert ask(Q.positive(exp(x*pi*I)), Q.real(x)) is None
-    assert ask(Q.positive(x**2),Q.real(x)) is None
-    assert ask(Q.positive(x**y),Q.even(y) & Q.real(x)) is None
+    assert ask(Q.positive(x**2), Q.real(x)) is None
+    assert ask(Q.positive(x**y), Q.even(y) & Q.real(x)) is None
 
     # logarithm
     assert ask(Q.positive(log(x)), Q.imaginary(x)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1907,8 +1907,8 @@ def test_positive():
     assert ask(Q.positive(exp(x*pi*I)), Q.even(x)) is True
     assert ask(Q.positive(exp(x*pi*I)), Q.odd(x)) is False
     assert ask(Q.positive(exp(x*pi*I)), Q.real(x)) is None
-    assert ask(Q.positive(x**2),Q.real(x)) is True
-    assert ask(Q.positive(x**y),Q.even(y) & Q.real(x)) is True
+    assert ask(Q.positive(x**2),Q.real(x)) is None
+    assert ask(Q.positive(x**y),Q.even(y) & Q.real(x)) is None
 
     # logarithm
     assert ask(Q.positive(log(x)), Q.imaginary(x)) is False
@@ -2284,7 +2284,7 @@ def test_issue_3906():
 
 
 def test_issue_5833():
-    assert ask(Q.positive(log(x)**2), Q.positive(x)) is True
+    assert ask(Q.positive(log(x)**2), Q.positive(x)) is None
     assert ask(~Q.negative(log(x)**2), Q.positive(x)) is True
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes part of #27568


#### Brief description of what is fixed or changed
This PR addresses part of the issue described in #27568, where simple piecewise integral results do not simplify nicely under certain assumptions.
What has been solved:

- Added a condition in the PositivePredicate for Pow to recognize expressions of the form b^n as positive when b is real and n is even.
- This allows the system to correctly identify a = b^2 as positive when b is real and b is non-zero.

What is still left:

- The integral result still doesn't automatically simplify even after recognizing a is positive.
- The meijerg algorithm produces conditions involving arg(expr) that need to be simplified for real expressions.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * ```ask(Q.positive(a**b), Q.nonzero(a) & Q.even(b))``` now returns ```True``` instead of ```None```.
<!-- END RELEASE NOTES -->
