### PR TITLE
Fix IntegerPredicate for Abs to handle non-integer inputs correctly

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -94,7 +94,8 @@ def _(expr, assumptions):
 
 @IntegerPredicate.register(Abs)
 def _(expr, assumptions):
-    return ask(Q.integer(expr.args[0]), assumptions)
+    if ask(Q.integer(expr.args[0]), assumptions):
+        return True
 
 @IntegerPredicate.register_many(Determinant, MatrixElement, Trace)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1642,6 +1642,9 @@ def test_integer():
     assert ask(Q.integer(x/3), Q.odd(x)) is None
     assert ask(Q.integer(x/3), Q.even(x)) is None
 
+    # https://github.com/sympy/sympy/issues/7286
+    assert ask(Q.integer(Abs(x)), ~Q.integer(x)) is None
+
 
 def test_negative():
     assert ask(Q.negative(x), Q.negative(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1643,7 +1643,11 @@ def test_integer():
     assert ask(Q.integer(x/3), Q.even(x)) is None
 
     # https://github.com/sympy/sympy/issues/7286
+    assert ask(Q.integer(Abs(x)),Q.integer(x)) is True
+    assert ask(Q.integer(Abs(-x)),Q.integer(x)) is True
     assert ask(Q.integer(Abs(x)), ~Q.integer(x)) is None
+    assert ask(Q.integer(Abs(x)),Q.complex(x)) is None
+    assert ask(Q.integer(Abs(x+I*y)),Q.real(x) & Q.real(y)) is None
 
 
 def test_negative():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially fixes #7286


#### Brief description of what is fixed or changed
This PR fixes a bug in the IntegerPredicate for the Abs function where it incorrectly handled non-integer inputs. The fix ensures that the predicate returns the correct result when dealing with absolute values of non-integer expressions.

Changes:
-  Updated IntegerPredicate.register(Abs) to return None when the argument is not known to be an integer, instead of incorrectly returning  False.
- Added a test case in test_query.py to verify the correct behavior of Abs with non-integer input.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Bug fix: ```ask(Q.integer(Abs(x)), ~Q.integer(x))``` now correctly returns ```None``` instead of ```False```.
<!-- END RELEASE NOTES -->
