### PR TITLE
Fix real predicate for expressions with potential singularities

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -332,7 +332,8 @@ def _(expr, assumptions):
                     ask(Q.even(expr.exp.q), assumptions):
                 return ask(Q.positive(expr.base), assumptions)
             elif ask(Q.integer(expr.exp), assumptions):
-                return True
+                if ask(Q.zero(expr.base),assumptions) is False or ask(Q.positive(expr.exp),assumptions):
+                    return True
             elif ask(Q.positive(expr.base), assumptions):
                 return True
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1968,14 +1968,13 @@ def test_real_basic():
 def test_real_pow():
     assert ask(Q.real(x**2), Q.real(x)) is True
     assert ask(Q.real(sqrt(x)), Q.negative(x)) is False
-    assert ask(Q.real(x**y), Q.real(x) & Q.integer(y)) is True
+    assert ask(Q.real(x**y), Q.real(x) & Q.integer(y)) is None
     assert ask(Q.real(x**y), Q.real(x) & Q.real(y)) is None
     assert ask(Q.real(x**y), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.imaginary(y)) is None  # I**I or (2*I)**I
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.real(y)) is None  # I**1 or I**0
     assert ask(Q.real(x**y), Q.real(x) & Q.imaginary(y)) is None  # could be exp(2*pi*I) or 2**I
     assert ask(Q.real(x**0), Q.imaginary(x)) is True
-    assert ask(Q.real(x**y), Q.real(x) & Q.integer(y)) is True
     assert ask(Q.real(x**y), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.real(x**y), Q.real(x) & Q.rational(y)) is None
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.integer(y)) is None
@@ -1983,7 +1982,7 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.even(y)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.rational(y/z) & Q.even(z) & Q.positive(x)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.rational(y/z) & Q.even(z) & Q.negative(x)) is None
-    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.integer(y/z)) is True
+    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.integer(y/z)) is None
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.positive(x)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.negative(x)) is None
     assert ask(Q.real((-I)**i), Q.imaginary(i)) is True
@@ -1994,6 +1993,11 @@ def test_real_pow():
 
     # https://github.com/sympy/sympy/issues/27485
     assert ask(Q.real(n**p), Q.negative(n) & Q.positive(p)) is None
+    
+    # https://github.com/sympy/sympy/issues/22014
+    a = Symbol('a', real = True)
+    expr = (1/(1-a))
+    assert ask(Q.real(expr)) is None
 
 
 @_both_exp_pow

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1993,7 +1993,7 @@ def test_real_pow():
 
     # https://github.com/sympy/sympy/issues/27485
     assert ask(Q.real(n**p), Q.negative(n) & Q.positive(p)) is None
-    
+
     # https://github.com/sympy/sympy/issues/22014
     a = Symbol('a', real = True)
     expr = (1/(1-a))

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1995,9 +1995,10 @@ def test_real_pow():
     assert ask(Q.real(n**p), Q.negative(n) & Q.positive(p)) is None
 
     # https://github.com/sympy/sympy/issues/22014
-    a = Symbol('a', real = True)
-    expr = (1/(1-a))
-    assert ask(Q.real(expr)) is None
+    expr = (1/(1-x))
+    assert ask(Q.real(expr), Q.real(x)) is None
+    assert ask(Q.real(expr), Q.real(x) & ~Q.zero(1-x)) is True
+    assert ask(Q.real(expr), Q.positive(1-x)) is True
 
 
 @_both_exp_pow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #22014 


#### Brief description of what is fixed or changed
This PR addresses an issue where the ask(Q.real()) function incorrectly returns True for expressions that may have singularities. Specifically, it fixes the case where expressions like 1/(1-x) were being classified as always real, even though they are undefined when x = 1.

Changes:

- Updated the real predicate to consider potential singularities in rational expressions.
- Modified the logic to return None (uncertain) instead of True when an expression might have singularities.
- Added test cases to verify the correct behavior for expressions with potential singularities.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Bug fix: ```ask(Q.real(1/(1-x)), Q.real(x))``` now correctly returns ```None``` instead of ```True```.
<!-- END RELEASE NOTES -->
