### PR TITLE
Made solve_triangulated support extension=True for algebraic roots

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -605,6 +605,7 @@ Filip Gokstorp <filip@gokstorp.se>
 Flamy Owl <flamyowl@protonmail.ch>
 Florian Mickler <florian@mickler.org>
 ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>
+ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com> <1378855363@qq.com>
 Francesco Bonazzi <franz.bonazzi@gmail.com> <francesco.bonazzi@mpikg.mpg.de>
 Francesco Bonazzi <franz.bonazzi@gmail.com> <none@universe.org>
 Freddie Witherden <freddie@witherden.org>

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -15,6 +15,7 @@ from sympy.core.sorting import default_sort_key
 from sympy.logic.boolalg import Boolean
 from sympy.polys import Poly, groebner, roots
 from sympy.polys.domains import ZZ
+from sympy.polys.polyoptions import build_options
 from sympy.polys.polytools import parallel_poly_from_expr, sqf_part
 from sympy.polys.polyerrors import (
     ComputationFailed,
@@ -394,6 +395,13 @@ def solve_triangulated(polys, *gens, **args):
     >>> solve_triangulated(F, x, y, z)
     [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
 
+    Using extension for algebraic solutions.
+
+    >>> solve_triangulated(F, x, y, z, extension=True) #doctest: +NORMALIZE_WHITESPACE
+    [(0, 0, 1), (0, 1, 0), (1, 0, 0),
+     (CRootOf(x**2 + 2*x - 1, 0), CRootOf(x**2 + 2*x - 1, 0), CRootOf(x**2 + 2*x - 1, 0)),
+     (CRootOf(x**2 + 2*x - 1, 1), CRootOf(x**2 + 2*x - 1, 1), CRootOf(x**2 + 2*x - 1, 1))]
+
     References
     ==========
 
@@ -402,20 +410,34 @@ def solve_triangulated(polys, *gens, **args):
     Algebraic Algorithms and Error-Correcting Codes, LNCS 356 247--257, 1989
 
     """
+    opt = build_options(gens, args)
+
     G = groebner(polys, gens, polys=True)
     G = list(reversed(G))
 
-    domain = args.get('domain')
+    extension = opt.get('extension', False)
+    if extension:
+        def _solve_univariate(f):
+            return [r for r, _ in f.all_roots(multiple=False, radicals=False)]
+    else:
+        domain = opt.get('domain')
 
-    if domain is not None:
-        for i, g in enumerate(G):
-            G[i] = g.set_domain(domain)
+        if domain is not None:
+            for i, g in enumerate(G):
+                G[i] = g.set_domain(domain)
+
+        def _solve_univariate(f):
+            return list(f.ground_roots().keys())
 
     f, G = G[0].ltrim(-1), G[1:]
     dom = f.get_domain()
 
-    zeros = f.ground_roots()
-    solutions = {((zero,), dom) for zero in zeros}
+    zeros = _solve_univariate(f)
+
+    if extension:
+        solutions = {((zero,), dom.algebraic_field(zero)) for zero in zeros}
+    else:
+        solutions = {((zero,), dom) for zero in zeros}
 
     var_seq = reversed(gens[:-1])
     vars_seq = postfixes(gens[1:])
@@ -430,16 +452,18 @@ def solve_triangulated(polys, *gens, **args):
                 _vars = (var,) + vars
 
                 if g.has_only_gens(*_vars) and g.degree(var) != 0:
+                    if extension:
+                        g = g.set_domain(g.domain.unify(dom))
                     h = g.ltrim(var).eval(dict(mapping))
 
                     if g.degree(var) == h.degree():
                         H.append(h)
 
             p = min(H, key=lambda h: h.degree())
-            zeros = p.ground_roots()
+            zeros = _solve_univariate(p)
 
             for zero in zeros:
-                if not zero.is_Rational:
+                if not (zero in dom):
                     dom_zero = dom.algebraic_field(zero)
                 else:
                     dom_zero = dom

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -8,6 +8,7 @@ from sympy.polys.domains.rationalfield import QQ
 from sympy.polys.polyerrors import UnsolvableFactorError
 from sympy.polys.polyoptions import Options
 from sympy.polys.polytools import Poly
+from sympy.polys.rootoftools import CRootOf
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import flatten
 from sympy.abc import a, b, c, x, y, z
@@ -169,6 +170,10 @@ def test_solve_triangulated():
     dom = QQ.algebraic_field(sqrt(2))
 
     assert solve_triangulated([f_1, f_2, f_3], x, y, z, domain=dom) == \
+        [(0, 0, 1), (0, 1, 0), (1, 0, 0), (a, a, a), (b, b, b)]
+
+    a, b = CRootOf(z**2 + 2*z - 1, 0), CRootOf(z**2 + 2*z - 1, 1)
+    assert solve_triangulated([f_1, f_2, f_3], x, y, z, extension=True) == \
         [(0, 0, 1), (0, 1, 0), (1, 0, 0), (a, a, a), (b, b, b)]
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR addresses #27624 regarding polynomial system solutions. However, it does not directly resolve the mentioned issue, as the current implementation invokes `solve_poly_system` instead of `solve_triangulated` in the `solve` function.

#### Brief description of what is fixed or changed

This PR adds an `extension=True` parameter to `solve_triangulated`, enabling complete algebraic root finding for multivariate polynomial systems. Unlike the previous implementation that required manual domain specification, this automatically handles field extensions. For example,
```py
>>> from sympy import solve_triangulated
>>> from sympy.abc import x, y, z
>>> F = [x**2 + y + z - 1, x + y**2 + z - 1, x + y + z**2 - 1]
>>> solve_triangulated(F, x, y, z, extension=True)  #doctest: +NORMALIZE_WHITESPACE
[(0, 0, 1), (0, 1, 0), (1, 0, 0),
 (CRootOf(x**2 + 2*x - 1, 0), CRootOf(x**2 + 2*x - 1, 0), CRootOf(x**2 + 2*x - 1, 0)),
 (CRootOf(x**2 + 2*x - 1, 1), CRootOf(x**2 + 2*x - 1, 1), CRootOf(x**2 + 2*x - 1, 1))]
```

The implementation replaces `ground_roots` with `all_roots` while dynamically unifying domains (when `extension=True`), ensuring polynomials evaluated in algebraic extension fields throughout the solving process.

Also, the docstring and tests are updated.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added `extension=True` option to `solve_triangulated` for computing solutions in algebraic fields using `CRootOf`.
<!-- END RELEASE NOTES -->
