### PR TITLE
Enhance Pow handler to correctly handle zero base cases in Q.real evaluation

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -328,6 +328,10 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
+            if ask(Q.zero(expr.base),assumptions) is not False:
+                if ask(Q.positive(expr.exp),assumptions):
+                    return True
+                return
             if expr.exp.is_Rational and \
                     ask(Q.even(expr.exp.q), assumptions):
                 return ask(Q.positive(expr.base), assumptions)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -328,8 +328,8 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
-            if ask(Q.zero(expr.base),assumptions) is not False:
-                if ask(Q.positive(expr.exp),assumptions):
+            if ask(Q.zero(expr.base), assumptions) is not False:
+                if ask(Q.positive(expr.exp), assumptions):
                     return True
                 return
             if expr.exp.is_Rational and \

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1968,14 +1968,13 @@ def test_real_basic():
 def test_real_pow():
     assert ask(Q.real(x**2), Q.real(x)) is True
     assert ask(Q.real(sqrt(x)), Q.negative(x)) is False
-    assert ask(Q.real(x**y), Q.real(x) & Q.integer(y)) is True
+    assert ask(Q.real(x**y), Q.real(x) & Q.integer(y)) is None
     assert ask(Q.real(x**y), Q.real(x) & Q.real(y)) is None
     assert ask(Q.real(x**y), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.imaginary(y)) is None  # I**I or (2*I)**I
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.real(y)) is None  # I**1 or I**0
     assert ask(Q.real(x**y), Q.real(x) & Q.imaginary(y)) is None  # could be exp(2*pi*I) or 2**I
     assert ask(Q.real(x**0), Q.imaginary(x)) is True
-    assert ask(Q.real(x**y), Q.real(x) & Q.integer(y)) is True
     assert ask(Q.real(x**y), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.real(x**y), Q.real(x) & Q.rational(y)) is None
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.integer(y)) is None
@@ -1983,7 +1982,7 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.even(y)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.rational(y/z) & Q.even(z) & Q.positive(x)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.rational(y/z) & Q.even(z) & Q.negative(x)) is None
-    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.integer(y/z)) is True
+    assert ask(Q.real(x**(y/z)), Q.real(x) & Q.integer(y/z)) is None
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.positive(x)) is True
     assert ask(Q.real(x**(y/z)), Q.real(x) & Q.real(y/z) & Q.negative(x)) is None
     assert ask(Q.real((-I)**i), Q.imaginary(i)) is True
@@ -1994,6 +1993,9 @@ def test_real_pow():
 
     # https://github.com/sympy/sympy/issues/27485
     assert ask(Q.real(n**p), Q.negative(n) & Q.positive(p)) is None
+
+    # https://github.com/sympy/sympy/issues/16530
+    assert ask(Q.real(1/Abs(x))) is None
 
 
 @_both_exp_pow

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1996,6 +1996,8 @@ def test_real_pow():
 
     # https://github.com/sympy/sympy/issues/16530
     assert ask(Q.real(1/Abs(x))) is None
+    assert(ask(Q.real(x**y),Q.zero(x) & Q.real(y))) is None
+    assert(ask(Q.real(x**y),Q.zero(x) & Q.positive(y))) is True
 
 
 @_both_exp_pow

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1996,8 +1996,8 @@ def test_real_pow():
 
     # https://github.com/sympy/sympy/issues/16530
     assert ask(Q.real(1/Abs(x))) is None
-    assert(ask(Q.real(x**y),Q.zero(x) & Q.real(y))) is None
-    assert(ask(Q.real(x**y),Q.zero(x) & Q.positive(y))) is True
+    assert ask(Q.real(x**y), Q.zero(x) & Q.real(y)) is None
+    assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
 
 @_both_exp_pow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

The same sort of bug as #16530, but in the new assumptions instead of the old assumptions.
Fixes #22014.


#### Brief description of what is fixed or changed
This PR addresses an issue in the Pow handler where zero base cases were not properly considered during Q.real evaluation. Previously, expressions like Q.real(1/Abs(x)) would incorrectly return True, not accounting for the possibility of x being zero.
The changes include:
- Adding a check for zero base cases in the ```Pow``` handler
- Returning ```None``` for indeterminate cases (when base is zero and exponent is not positive)
- Ensuring correct behavior for  ```ask(Q.real(1/Abs(x))) is None```.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Bug Fix: Now ```ask(Q.real(1/Abs(x)))```  correctly returns ```None``` instead of incorrectly returning ```True```.

<!-- END RELEASE NOTES -->
