### PR TITLE
Fix `qs` to store vectors as integers

### DIFF
--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -5,8 +5,7 @@ from sympy.core.random import _randint
 from sympy.ntheory import qs, qs_factor
 from sympy.ntheory.qs import SievePolynomial, _generate_factor_base, \
     _initialize_first_polynomial, _initialize_ith_poly, \
-    _gen_sieve_array, _check_smoothness, _trial_division_stage, _gauss_mod_2, \
-    _find_factor
+    _gen_sieve_array, _check_smoothness, _trial_division_stage, _find_factor
 from sympy.testing.pytest import slow
 
 
@@ -57,12 +56,11 @@ def test_qs_2() -> None:
     assert sieve_array[0:5] == [8424, 13603, 1835, 5335, 710]
 
     assert _check_smoothness(9645, factor_base) == (5, False)
-    assert _check_smoothness(210313, factor_base)[0][0:15] == \
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1]
+    assert _check_smoothness(210313, factor_base)[0] == 20992
     assert _check_smoothness(210313, factor_base)[1]
 
     partial_relations: dict[int, tuple[int, int]] = {}
-    smooth_relation, partial_relation = _trial_division_stage(
+    smooth_relation, proper_factor = _trial_division_stage(
         n, M, factor_base, sieve_array, sieve_poly, partial_relations,
         ERROR_TERM=25*2**10)
 
@@ -73,45 +71,23 @@ def test_qs_2() -> None:
         6653: (550, -10008899607)
     }
     assert [smooth_relation[i][0] for i in range(5)] == [
-        -250, -670615476700, -45211565844500, -231723037747200, -1811665537200]
+        -250, 1064469, 72819, 231957, 44167]
     assert [smooth_relation[i][1] for i in range(5)] == [
         -10009139607, 1133094251961, 5302606761, 53804049849, 1950723889]
-    assert smooth_relation[0][2][0:15] == [
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-
-    assert _gauss_mod_2(
-        [[0, 0, 1], [1, 0, 1], [0, 1, 0], [0, 1, 1], [0, 1, 1]]
-    ) == (
-        [[[0, 1, 1], 3], [[0, 1, 1], 4]],
-        [True, True, True, False, False],
-        [[0, 0, 1], [1, 0, 0], [0, 1, 0], [0, 1, 1], [0, 1, 1]]
-    )
+    assert smooth_relation[0][2] == 89213869829863962596973701078031812362502145
+    assert proper_factor == set()
 
 
 def test_qs_3():
     N = 1817
     smooth_relations = [
-        (2455024, 637, [0, 0, 0, 1]),
-        (-27993000, 81536, [0, 1, 0, 1]),
-        (11461840, 12544, [0, 0, 0, 0]),
-        (149, 20384, [0, 1, 0, 1]),
-        (-31138074, 19208, [0, 1, 0, 0])
+        (2455024, 637, 8),
+        (-27993000, 81536, 10),
+        (11461840, 12544, 0),
+        (149, 20384, 10),
+        (-31138074, 19208, 2)
     ]
-    matrix = [s_relation[2] for s_relation in smooth_relations]
-    dependent_row, mark, gauss_matrix = _gauss_mod_2(matrix)
-    assert dependent_row == [[[0, 0, 0, 0], 2], [[0, 1, 0, 0], 3]]
-    assert mark == [True, True, False, False, True]
-    assert gauss_matrix == [
-        [0, 0, 0, 1],
-        [0, 1, 0, 0],
-        [0, 0, 0, 0],
-        [0, 1, 0, 0],
-        [0, 1, 0, 1]
-    ]
-
-    factor = _find_factor(
-        dependent_row, mark, gauss_matrix, 0, smooth_relations, N)
-    assert factor == 23
+    assert next(_find_factor(N, smooth_relations, 4)) == 23
 
 
 def test_qs_4():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27636

#### Brief description of what is fixed or changed
So far, we have been storing vectors of 0s and 1s, but changing this to integers will help reduce memory usage. For example, until now, -490 has been converted into a vector like `[1, 1, 0, 1, 0]`. The 0th element represents the sign, where 1 indicates a negative value. The elements from the 1st position onward correspond to divisibility by prime numbers in the `factor_base` (let's assume 2, 3, 5, and 7 in this case), with a value of 1 if the number is divisible. However, if it is divisible an even number of times, it becomes 0. For example, the 4th element is 0 because 490 is divisible by 7 twice. This vector `[1, 1, 0, 1, 0]` is then treated as a binary number and stored as an integer with a value of 11.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
