### PR TITLE
Added 4 tests for Min/Max refine on 3/5/2025

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -392,6 +392,29 @@ def refine_matrixelement(expr, assumptions):
         if (i - j).could_extract_minus_sign():
             return expr
         return MatrixElement(matrix, j, i)
+    
+#min/max tests for explicitly given infinities
+def test_refine_min_positive_infinity():
+    z = Symbol('z', real=True) 
+    expr = Min(S.Infinity, sqrt(z)) 
+    result = refine(expr)
+    assert result == sqrt(z), f"Expected sqrt(z), got {result}"
+
+def test_refine_max_negative_infinity():
+  z = Symbol('z', real=True)
+  expr = Max(-1*S.infinity, sqrt(z)) 
+  result = refine(expr) 
+  assert result == sqrt(z), f"Expected sqrt(z), got {result}"
+
+def test_refine_min_both_infinities():
+  expr = Min(S.NegativeInfinity, S.Infinity)
+  result = refine(expr)
+  assert result == S.NegativeInfinity, f"Expected -inf, got {result}"
+
+def test_refine_max_both_infinities():
+  expr = Max(S.NegativeInfinity, S.Infinity)
+  result = refine(expr)
+  assert result == S.Infinity, f"Expected +inf, got {result}"
 
 handlers_dict: dict[str, Callable[[Expr, Boolean], Expr]] = {
     'Abs': refine_abs,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -299,7 +299,7 @@ def refine_im(expr, assumptions):
 def refine_arg(expr, assumptions):
     """
     Handler for complex argument
-
+3
     Explanation
     ===========
 
@@ -392,29 +392,6 @@ def refine_matrixelement(expr, assumptions):
         if (i - j).could_extract_minus_sign():
             return expr
         return MatrixElement(matrix, j, i)
-    
-#min/max tests for explicitly given infinities
-def test_refine_min_positive_infinity():
-    z = Symbol('z', real=True) 
-    expr = Min(S.Infinity, sqrt(z)) 
-    result = refine(expr)
-    assert result == sqrt(z), f"Expected sqrt(z), got {result}"
-
-def test_refine_max_negative_infinity():
-  z = Symbol('z', real=True)
-  expr = Max(-1*S.infinity, sqrt(z)) 
-  result = refine(expr) 
-  assert result == sqrt(z), f"Expected sqrt(z), got {result}"
-
-def test_refine_min_both_infinities():
-  expr = Min(S.NegativeInfinity, S.Infinity)
-  result = refine(expr)
-  assert result == S.NegativeInfinity, f"Expected -inf, got {result}"
-
-def test_refine_max_both_infinities():
-  expr = Max(S.NegativeInfinity, S.Infinity)
-  result = refine(expr)
-  assert result == S.Infinity, f"Expected +inf, got {result}"
 
 handlers_dict: dict[str, Callable[[Expr, Boolean], Expr]] = {
     'Abs': refine_abs,

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -12,6 +12,7 @@ from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
+from sympy import Min, Max, oo, ask, Q, refine
 
 
 def test_Abs():
@@ -225,3 +226,42 @@ def test_matrixelement():
     assert refine(x[1, 0], Q.symmetric(x)) == x[0, 1]
     assert refine(x[i, j], Q.symmetric(x)) == x[j, i]
     assert refine(x[j, i], Q.symmetric(x)) == x[j, i]
+
+#min/max tests for explicitly given infinities
+def test_refine_min_max_infinities():
+    z = Symbol('z', real=True) 
+    expr = Min(S.Infinity, sqrt(z)) 
+    result = refine(expr)
+    assert result == sqrt(z), f"Expected sqrt(z), got {result}"
+
+    z = Symbol('z', real=True)
+    expr = Max(-1*S.infinity, sqrt(z)) 
+    result = refine(expr) 
+    assert result == sqrt(z), f"Expected sqrt(z), got {result}"
+
+    expr = Min(S.NegativeInfinity, S.Infinity)
+    result = refine(expr)
+    assert result == S.NegativeInfinity, f"Expected -inf, got {result}"
+
+    expr = Max(S.NegativeInfinity, S.Infinity)
+    result = refine(expr)
+    assert result == S.Infinity, f"Expected +inf, got {result}"
+    
+
+
+
+# def test_refine_max_negative_infinity():
+#   z = Symbol('z', real=True)
+#   expr = Max(-1*S.infinity, sqrt(z)) 
+#   result = refine(expr) 
+#   assert result == sqrt(z), f"Expected sqrt(z), got {result}"
+
+# def test_refine_min_both_infinities():
+#   expr = Min(S.NegativeInfinity, S.Infinity)
+#   result = refine(expr)
+#   assert result == S.NegativeInfinity, f"Expected -inf, got {result}"
+
+# def test_refine_max_both_infinities():
+#   expr = Max(S.NegativeInfinity, S.Infinity)
+#   result = refine(expr)
+#   assert result == S.Infinity, f"Expected +inf, got {result}"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
