### PR TITLE
bug fix: added finite condition to anyarg expression

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -877,7 +877,7 @@ Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
-Keyron Linarez <keyronlinarez@gmail.com> KeyronLinarez <keyronlinarez@gmail.com>
+Keyron Linarez <keyronlinarez@gmail.com> KeyronLinarez <112719213+KeyronLinarez@users.noreply.github.com>
 Khagesh Patel <khageshpatel93@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>

--- a/.mailmap
+++ b/.mailmap
@@ -871,6 +871,7 @@ Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
+Keyron Linarez <keyronlinarez@gmail.com> KeyronLinarez <keyronlinarez@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>

--- a/.mailmap
+++ b/.mailmap
@@ -877,6 +877,7 @@ Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
+Keyron Linarez <keyronlinarez@gmail.com> KeyronLinarez <112719213+KeyronLinarez@users.noreply.github.com>
 Keyron Linarez <keyronlinarez@gmail.com> KeyronLinarez <keyronlinarez@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>

--- a/blah.py
+++ b/blah.py
@@ -31,9 +31,13 @@ x,y = symbols('x y')
 print("Tests")
 print(ask(Q.finite(x*y), Q.infinite(x)))
 print(ask(Q.finite(x*y), ~Q.finite(x)))
+# should return true
+print(satask(Q.zero(x*y),   ((Q.zero(x)) & Q.finite(y)))  )
+print(satask(Q.zero(x*y),   (((Q.zero(x) | Q.zero(y)) & Q.finite(x)) & Q.finite(y)))    )
 
-print(satask(Q.zero(x*y), ((Q.zero(x) & Q.finite(x)) & Q.finite(y))))
-print(satask(Q.zero(x*y), (((Q.zero(x) | Q.zero(y)) & Q.finite(x)) & Q.finite(y))))
+# bruh
+print(satask((Q.zero(x) | Q.zero(y)), Q.nonzero(x*y)))
+
 # print(satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)))
 # print(satask(Q.zero(x) | Q.zero(y), Q.finite(x*y)))
 # print(satask(Q.zero(x) | Q.zero(y), Q.positive(x*y)))

--- a/blah.py
+++ b/blah.py
@@ -32,6 +32,8 @@ print("Tests")
 print(ask(Q.finite(x*y), Q.infinite(x)))
 print(ask(Q.finite(x*y), ~Q.finite(x)))
 
+print(satask(Q.zero(x*y), ((Q.zero(x) & Q.finite(x)) & Q.finite(y))))
+print(satask(Q.zero(x*y), (((Q.zero(x) | Q.zero(y)) & Q.finite(x)) & Q.finite(y))))
 # print(satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)))
 # print(satask(Q.zero(x) | Q.zero(y), Q.finite(x*y)))
 # print(satask(Q.zero(x) | Q.zero(y), Q.positive(x*y)))

--- a/blah.py
+++ b/blah.py
@@ -35,8 +35,10 @@ print(ask(Q.finite(x*y), ~Q.finite(x)))
 print(satask(Q.zero(x*y),   ((Q.zero(x)) & Q.finite(y)))  )
 print(satask(Q.zero(x*y),   (((Q.zero(x) | Q.zero(y)) & Q.finite(x)) & Q.finite(y)))    )
 
-# bruh
+# all false
+print(satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)))
 print(satask((Q.zero(x) | Q.zero(y)), Q.nonzero(x*y)))
+print(satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)))
 
 # print(satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)))
 # print(satask(Q.zero(x) | Q.zero(y), Q.finite(x*y)))

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -234,6 +234,7 @@ def _(expr):
 @class_fact_registry.multiregister(Mul)
 def _(expr):
     return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
+            Equivalent(Q.finite(expr), allargs(x, Q.finite(x), expr)),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -230,10 +230,10 @@ def _(expr):
 
 
 ### Mul ###
-
 @class_fact_registry.multiregister(Mul)
 def _(expr):
     return [Q.complex(expr) >> Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr)),
+            Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -233,7 +233,7 @@ def _(expr):
 
 @class_fact_registry.multiregister(Mul)
 def _(expr):
-    return [Q.complex(expr)  >> Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr)),
+    return [Q.complex(expr) >> Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr)),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -233,7 +233,6 @@ def _(expr):
 
 @class_fact_registry.multiregister(Mul)
 def _(expr):
-    #      not an iff and only if -- everything has to be finite
     return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -233,8 +233,7 @@ def _(expr):
 
 @class_fact_registry.multiregister(Mul)
 def _(expr):
-    return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
-            allargs(x, Q.finite(expr) | Q.infinite(expr), expr) >> (Q.finite(expr) >> allargs(x, Q.finite(x), expr)),
+    return [Q.complex(expr)  >> Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr)),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -233,7 +233,8 @@ def _(expr):
 
 @class_fact_registry.multiregister(Mul)
 def _(expr):
-    return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr)),
+    #      not an iff and only if -- everything has to be finite
+    return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -234,7 +234,8 @@ def _(expr):
 @class_fact_registry.multiregister(Mul)
 def _(expr):
     return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
-            Equivalent(Q.finite(expr), allargs(x, Q.finite(x), expr)),
+            allargs(x, Q.finite(expr) | Q.infinite(expr), expr) >> (Q.finite(expr) >> allargs(x, Q.finite(x), expr)),
+            allargs(x, Q.finite(x), expr) >> Q.finite(expr),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -235,7 +235,6 @@ def _(expr):
 def _(expr):
     return [Equivalent(Q.zero(expr), anyarg(x, Q.zero(x), expr) & allargs(x, Q.finite(x), expr)),
             allargs(x, Q.finite(expr) | Q.infinite(expr), expr) >> (Q.finite(expr) >> allargs(x, Q.finite(x), expr)),
-            allargs(x, Q.finite(x), expr) >> Q.finite(expr),
             allargs(x, Q.positive(x), expr) >> Q.positive(expr),
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -69,8 +69,7 @@ def test_zero():
     # relevant facts, because going from Q.nonzero(x*y) -> ~Q.zero(x*y) and
     # Q.zero(x*y) -> Equivalent(Q.zero(x*y), Q.zero(x) | Q.zero(y)) takes two
     # steps.
-    assert satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y) & Q.finite(x) & Q.finite(y)) is False
-
+    assert satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)) is False
     assert satask(Q.zero(x), Q.zero(x**2)) is True
 
 

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -5,7 +5,6 @@ from sympy.core.relational import (Eq, Gt)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.complexes import Abs
-from sympy.logic.boolalg import Implies
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.satask import (satask, extract_predargs,

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -40,7 +40,7 @@ def test_satask():
     assert satask(Q.real(x), Q.zero(x)) is True
     assert satask(Q.zero(x), Q.zero(x*y)) is None
     assert satask(Q.zero(x*y), Q.zero(x) & Q.finite(x) & Q.finite(y))
-    
+
     # https://github.com/sympy/sympy/issues/27662
     assert satask(Q.finite(x*y), ~Q.finite(x) & Q.zero(y)) is None
     assert satask(~Q.finite(x) & Q.zero(y)) is None
@@ -49,7 +49,6 @@ def test_satask():
     assert satask(Q.zero(x*y), Q.zero(x) | Q.zero(y)) is None
     assert satask(Implies(Q.zero(x), Q.zero(x*y))) is None
     assert satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)) is None
-
 
 
 def test_zero():
@@ -61,7 +60,7 @@ def test_zero():
     """
     assert satask(Q.zero(x) | Q.zero(y), Q.zero(x*y)) is True
     assert satask(Q.zero(x*y), (Q.zero(x) | Q.zero(y)) & (Q.finite(x) & Q.finite(y))) is True
-    assert satask(Implies(Q.zero(x), Q.zero(x*y))) is None
+    assert satask(Q.zero(x*y), Q.zero(x)) is None
 
     # https://github.com/sympy/sympy/issues/27662
     assert (satask(Q.zero(x*y), (Q.finite(x)) & (Q.finite(y)) & Q.zero(x))) is True

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -47,7 +47,7 @@ def test_satask():
     assert satask(~Q.finite(x) & Q.zero(y) & Q.finite(x*y)) is None
     assert satask(~Q.finite(x) & Q.zero(y) & ~Q.finite(x*y)) is None
     assert satask(Q.zero(x*y), Q.zero(x) | Q.zero(y)) is None
-    assert satask(Implies(Q.zero(x), Q.zero(x*y))) is None
+    assert satask(Q.zero(x*y), Q.zero(x)) is None
     assert satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)) is None
 
 
@@ -59,17 +59,18 @@ def test_zero():
 
     """
     assert satask(Q.zero(x) | Q.zero(y), Q.zero(x*y)) is True
-    assert satask(Q.zero(x*y), (Q.zero(x) | Q.zero(y)) & (Q.finite(x) & Q.finite(y))) is True
+    assert satask(Q.zero(x*y), (Q.zero(x) | Q.zero(y)) & Q.finite(x) & Q.finite(y)) is True
     assert satask(Q.zero(x*y), Q.zero(x)) is None
 
     # https://github.com/sympy/sympy/issues/27662
-    assert (satask(Q.zero(x*y), (Q.finite(x)) & (Q.finite(y)) & Q.zero(x))) is True
+    assert (satask(Q.zero(x*y), Q.finite(x) & Q.finite(y) & Q.zero(x))) is True
 
     # This one in particular requires computing the fixed-point of the
     # relevant facts, because going from Q.nonzero(x*y) -> ~Q.zero(x*y) and
     # Q.zero(x*y) -> Equivalent(Q.zero(x*y), Q.zero(x) | Q.zero(y)) takes two
     # steps.
     assert satask(Q.zero(x) | Q.zero(y), Q.nonzero(x*y)) is False
+
     assert satask(Q.zero(x), Q.zero(x**2)) is True
 
 


### PR DESCRIPTION
Fixes #27662

#### Brief description of what is fixed or changed
Modified a function within sathandlers to include an extra assumption that every symbol in an expression is finite. Previously, only the Q.zero was being used.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Made `ask(Q.zero(x*y*z), Q.zero(x*z))` return `None` instead of  wrongly returning `True`
<!-- END RELEASE NOTES -->
