### PR TITLE
Optimize GramSchmidt with DomainMatrix QR decomposition 

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -831,13 +831,15 @@ def GramSchmidt(vlist, orthonormal=False):
     """
     from sympy.polys.matrices import DomainMatrix
     from sympy.sets.sets import FiniteSet
+    from sympy import simplify, radsimp, cancel
     if isinstance(vlist, FiniteSet):
         vlist = list(vlist)
     if not vlist:
         return []
     if len(vlist) == 1:
         if orthonormal:
-            return [vlist[0] / vlist[0].norm()]
+            norm = vlist[0].norm()
+            return [simplify(vlist[0] / norm) if norm != 0 else vlist[0]]
         return [vlist[0]]
     is_row_vector = vlist[0].shape[0] == 1
     if is_row_vector:
@@ -846,9 +848,12 @@ def GramSchmidt(vlist, orthonormal=False):
     A = A.to_field()
     Q, _ = A.qr()
     Q_matrix = Q.to_Matrix()
-    orthogonal_vectors = [Q_matrix.col(i) for i in range(Q_matrix.cols)]
+    orthogonal_vectors = [simplify(Q_matrix.col(i)) for i in range(Q_matrix.cols)]
     if orthonormal:
-        orthogonal_vectors = [v / v.norm() for v in orthogonal_vectors]
+        orthogonal_vectors = [
+            Matrix([radsimp(cancel(element / v.norm())) for element in v]) if v.norm() != 0 else v
+            for v in orthogonal_vectors
+        ]
     if is_row_vector:
         orthogonal_vectors = [v.transpose() for v in orthogonal_vectors]
     return orthogonal_vectors


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/27250

#### Brief description of what is fixed or changed

This PR addresses the issue of expression blowup in the GramSchmidt process by using the `DomainMatrix.qr` method, that was added in PR https://github.com/sympy/sympy/pull/27352 . The DomainMatrix implementation of QR decomposition is more efficient and avoids the symbolic expression blowup that occurs with the current approach. By using `DomainMatrix.qr`, this PR improves performance and stability for orthogonalizing vectors especially in symbolic computations.

#### Other comments

The GramSchmidt function uses the domainmatrix qr method but adds additional steps to handle row vectors, normalize vectors (if orthonormal=True), and manage edge cases such as empty lists and single vectors. The difference between the two output is that the qr method returns results in matrix form while GramSchmidt returns a list of vectors, optionally normalized and ensures compatibility with row vectors. These extra steps make GramSchmidt more user friendly but differentiate its output from the raw qr decomposition result.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices

   * Optimize GramSchmidt with QR decomposition
<!-- END RELEASE NOTES -->
