### PR TITLE
Issue #26518: Graceful errors function_range handling for unsolvable critical point sets.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1663,7 +1663,7 @@ kangzhiq <709563092@qq.com> <32410422+kangzhiq@users.noreply.github.com>
 kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
-khalidbagus <khalid.bagus.pratama@corp.bri.co.id> khalidbagus <113655600+khalidbagus@users.noreply.github.com>
+khalidbagus <khalid.bagus.pratama@corp.bri.co.id> khalidbagus <113655600+khalidbagus@users.noreply.github.com> khalidbagus <khalidbagus@gmail.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>

--- a/.mailmap
+++ b/.mailmap
@@ -874,7 +874,7 @@ Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
-Khalid Darmadi <khalidbagus@gmail.com> khalidbagus <khalidbagus@gmail.com>
+Khalid Darmadi <khalidbagus@gmail.com> khalidbagus <khalid.bagus.pratama@corp.bri.co.id>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>

--- a/.mailmap
+++ b/.mailmap
@@ -1663,7 +1663,9 @@ kangzhiq <709563092@qq.com> <32410422+kangzhiq@users.noreply.github.com>
 kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
-khalidbagus <khalid.bagus.pratama@corp.bri.co.id> khalidbagus <113655600+khalidbagus@users.noreply.github.com> khalidbagus <khalidbagus@gmail.com>
+khalidbagus <khalid.bagus.pratama@corp.bri.co.id>
+khalidbagus <113655600+khalidbagus@users.noreply.github.com> 
+khalidbagus <khalidbagus@gmail.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1663,8 +1663,7 @@ kangzhiq <709563092@qq.com> <32410422+kangzhiq@users.noreply.github.com>
 kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
-khalidbagus <khalid.bagus.pratama@corp.bri.co.id>
-khalidbagus <113655600+khalidbagus@users.noreply.github.com> 
+khalidbagus <khalid.bagus.pratama@corp.bri.co.id> khalidbagus <113655600+khalidbagus@users.noreply.github.com>
 khalidbagus <khalidbagus@gmail.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -874,6 +874,7 @@ Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
+Khalid Darmadi <khalidbagus@gmail.com> khalidbagus <khalidbagus@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>

--- a/.mailmap
+++ b/.mailmap
@@ -874,7 +874,6 @@ Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
-Khalid Darmadi <khalidbagus@gmail.com> khalidbagus <khalid.bagus.pratama@corp.bri.co.id>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
@@ -1664,6 +1663,7 @@ kangzhiq <709563092@qq.com> <32410422+kangzhiq@users.noreply.github.com>
 kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
+khalidbagus <khalid.bagus.pratama@corp.bri.co.id> khalidbagus <113655600+khalidbagus@users.noreply.github.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -274,7 +274,7 @@ def function_range(f, symbol, domain):
                     raise NotImplementedError(
                         f"Solving for critical points (equation {fprime} = 0) was aborted due to excessive runtime."
                     )
-                
+                                
                 # Check if the result is unsolvable or non-iterable
                 if (isinstance(critical_points, ConditionSet) or (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or not iterable(critical_points)):
                     raise NotImplementedError(

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -268,7 +268,7 @@ def function_range(f, symbol, domain):
 
                 prev_handler = signal.signal(signal.SIGALRM, _timeout_handler)
                 signal.alarm(10)
-                try:                
+                try:
                     critical_points = solveset(f.diff(symbol), symbol, interval)
                 except _SolvesetTimeoutError:
                     raise NotImplementedError(

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -263,8 +263,7 @@ def function_range(f, symbol, domain):
                 # then try again with derivative simplification.
                 if (isinstance(critical_points, ConditionSet) or
                     (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or
-                    (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) 
-                                                            for sub in critical_points.args)) or
+                    (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or
                     not iterable(critical_points)):
                     critical_points = solveset(f.diff(symbol), symbol, interval, simplify_derivative=True)
                     if (isinstance(critical_points, ConditionSet) or

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -259,8 +259,7 @@ def function_range(f, symbol, domain):
 
                 critical_points = solveset(f.diff(symbol), symbol, interval)
                 # Check if the result is unsolvable or non-iterable
-                if (isinstance(critical_points, ConditionSet) or (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or 
-                    (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or not iterable(critical_points)):
+                if (isinstance(critical_points, ConditionSet) or (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or not iterable(critical_points)):
                     raise NotImplementedError(
                         f"Unable to find explicit critical points for the derivative of given function:\n\n  {f.diff(symbol)} = 0\n\n"
                         "This may be due to the unsimplified form of the derivative (e.g. involving radicals or transcendental functions)."

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -289,7 +289,6 @@ def function_range(f, symbol, domain):
                         f"  {f.diff(symbol)} = 0\n"
                         "This may be due to an unsimplifiable or transcendental equation."
                     )
-                
                 # Check if the result is unsolvable or non-iterable
                 if (isinstance(critical_points, ConditionSet) or (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or not iterable(critical_points)):
                     raise NotImplementedError(
@@ -301,8 +300,7 @@ def function_range(f, symbol, domain):
                         f"Found an infinite number of critical points for the derivative:\n\n  {f.diff(symbol)} = 0\n\n"
                         "This indicates a periodic function; consider restricting the domain."
                     )
-                
-            
+
             if not iterable(critical_points):
                 raise NotImplementedError(
                         'Unable to find critical points for {}'.format(f))

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -257,29 +257,24 @@ def function_range(f, symbol, domain):
                 else:
                     vals += FiniteSet(f.subs(symbol, limit_point))
 
-                # Evaluate critical points in the interval using solveset with no derivative simplification.
-                critical_points = solveset(f.diff(symbol), symbol, interval, simplify_derivative=False)
-                # If the result is unsolvable (e.g. a ConditionSet, or a Complement/Union containing one),
-                # then try again with derivative simplification.
+                critical_points = solveset(f.diff(symbol), symbol, interval)
+                # Check if the result is unsolvable or non-iterable
                 if (isinstance(critical_points, ConditionSet) or
-                    (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or
-                    (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or
+                    (isinstance(critical_points, Complement) and 
+                    any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or
+                    (isinstance(critical_points, Union) and 
+                    any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or
                     not iterable(critical_points)):
-                    critical_points = solveset(f.diff(symbol), symbol, interval, simplify_derivative=True)
-                    if (isinstance(critical_points, ConditionSet) or
-                        (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or
-                            (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or
-                                not iterable(critical_points)):
-                        raise NotImplementedError(
-                            f"Unable to find explicit critical points for the derivative:\n\n  {f.diff(symbol)} = 0\n\n"
-                            "This may be due to the transcendental or radical nature of the function. "
-                            "Consider using a numerical method (e.g. nsolve) or analyze monotonicity manually."
-                        )
+                    raise NotImplementedError(
+                        f"Unable to find explicit critical points for the derivative of given function:\n\n  {f.diff(symbol)} = 0\n\n"
+                        "This may be due to the unsimplified form of the derivative (e.g. involving radicals or transcendental functions)."
+                    )
                 if isinstance(critical_points, ImageSet):
                     raise NotImplementedError(
                         f"Found an infinite number of critical points for the derivative:\n\n  {f.diff(symbol)} = 0\n\n"
                         "This indicates a periodic function; consider restricting the domain."
                     )
+
 
 
             if not iterable(critical_points):

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -257,7 +257,6 @@ def function_range(f, symbol, domain):
                     vals += critical_values
                 else:
                     vals += FiniteSet(f.subs(symbol, limit_point))
-                
                 # Set up iteration limit and safe solveset wrapper
                 MAX_ITER = 1000
                 iter_count = 0

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -266,15 +266,15 @@ def function_range(f, symbol, domain):
                 else:
                     vals += FiniteSet(f.subs(symbol, limit_point))
 
+                # For the purpose of finding critical points, we need to find the derivative of the function
+                # the value of f.diff(symbol) is stored for the purpose of the usage of _SolvetTimeoutError
+                fprime = f.diff(symbol)
                 prev_handler = signal.signal(signal.SIGALRM, _timeout_handler)
                 signal.alarm(10)
                 try:
-                    critical_points = solveset(f.diff(symbol), symbol, interval)
+                    critical_points = solveset(fprime, symbol, interval)
                 except _SolvesetTimeoutError:
-                    raise NotImplementedError(
-                        f"Solving for critical points (equation {fprime} = 0) was aborted due to excessive runtime."
-                    )
-                                
+                    raise NotImplementedError(f"Solving for critical points (equation {fprime} = 0) was aborted due to excessive runtime.")
                 # Check if the result is unsolvable or non-iterable
                 if (isinstance(critical_points, ConditionSet) or (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or not iterable(critical_points)):
                     raise NotImplementedError(

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -216,7 +216,7 @@ def function_range(f, symbol, domain):
 
     # This is a helper function for the solveset function to raise a timeout error
     def _timeout_handler(signum, frame):
-        raise _SolveSetTimeoutError()
+        raise _SolvesetTimeoutError()
 
     if domain is S.EmptySet:
         return S.EmptySet

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -259,12 +259,8 @@ def function_range(f, symbol, domain):
 
                 critical_points = solveset(f.diff(symbol), symbol, interval)
                 # Check if the result is unsolvable or non-iterable
-                if (isinstance(critical_points, ConditionSet) or
-                    (isinstance(critical_points, Complement) and 
-                    any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or
-                    (isinstance(critical_points, Union) and 
-                    any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or
-                    not iterable(critical_points)):
+                if (isinstance(critical_points, ConditionSet) or (isinstance(critical_points, Complement) and any(isinstance(sub, ConditionSet) for sub in critical_points.args)) or 
+                    (isinstance(critical_points, Union) and any(isinstance(sub, ConditionSet) or not iterable(sub) for sub in critical_points.args)) or not iterable(critical_points)):
                     raise NotImplementedError(
                         f"Unable to find explicit critical points for the derivative of given function:\n\n  {f.diff(symbol)} = 0\n\n"
                         "This may be due to the unsimplified form of the derivative (e.g. involving radicals or transcendental functions)."

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2334,7 +2334,7 @@ def _transolve(f, symbol, domain):
     return result
 
 
-def solveset(f, symbol=None, domain=S.Complexes):
+def solveset(f, symbol=None, domain=S.Complexes, simplify_derivative=False):
     r"""Solves a given inequality or equation with set as output
 
     Parameters
@@ -2437,6 +2437,12 @@ def solveset(f, symbol=None, domain=S.Complexes):
     """
     f = sympify(f)
     symbol = sympify(symbol)
+    if simplify_derivative:
+        try:
+            # Simplify derivative expressions for easier solving
+            f = simplify(f)
+        except Exception:
+            pass  # If simplification fails or is not needed, continue with original f
 
     if f is S.true:
         return domain

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2334,7 +2334,7 @@ def _transolve(f, symbol, domain):
     return result
 
 
-def solveset(f, symbol=None, domain=S.Complexes, simplify_derivative=False):
+def solveset(f, symbol=None, domain=S.Complexes):
     r"""Solves a given inequality or equation with set as output
 
     Parameters
@@ -2437,12 +2437,6 @@ def solveset(f, symbol=None, domain=S.Complexes, simplify_derivative=False):
     """
     f = sympify(f)
     symbol = sympify(symbol)
-    if simplify_derivative:
-        try:
-            # Simplify derivative expressions for easier solving
-            f = simplify(f)
-        except Exception:
-            pass  # If simplification fails or is not needed, continue with original f
 
     if f is S.true:
         return domain


### PR DESCRIPTION
### Graceful errors function_range handling for unsolvable critical point sets.

This PR addresses issues in determining the range of functions when the derivative cannot be solved symbolically. In particular, it:

- Improves `function_range` so that if the critical-point equation (f′(x) = 0) remains unsolvable (i.e. yields a non-iterable ConditionSet or similar), it raises a detailed `NotImplementedError`. The error message now includes the derivative expression and suggests numerical methods or monotonicity analysis as alternatives.

This change fixes the issues observed with functions like `Abs((log(x))**(1/3))` and the more complex `log(1+x)/(x**(1/3)*(2+x))`.  
  
Fixes: #26518  
See also: [GitHub issue discussion](https://github.com/sympy/sympy/issues/26518)


#### Brief description of what is fixed or changed
- **function_range:**  
  Improved error handling so that if critical points remain unsolvable (even after simplification), a detailed `NotImplementedError` is raised. The error message now includes the unsolvable derivative expression and recommends alternative approaches.

#### Other comments
These changes help prevent low-level TypeErrors (such as those arising from attempting to iterate a ConditionSet) and give users clear guidance when analytic methods fail.

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Improved `function_range` to detect unsolvable critical point sets and raise a detailed error message with suggestions for numerical or monotonicity analysis.
<!-- END RELEASE NOTES -->
