### PR TITLE
Fix ask(Q.finite(x**-1), Q.real(x)) to handle potential division by zero

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -195,7 +195,11 @@ def _(expr, assumptions):
     if base_bounded is False and ask(Q.extended_nonzero(expr.exp), assumptions):
         return False
     if base_bounded and exp_bounded:
-        if ask(Q.zero(expr.base),assumptions) is not False and ask(Q.negative(expr.exp),assumptions) is not False:
+        is_base_zero = ask(Q.zero(expr.base),assumptions)
+        is_exp_negative = ask(Q.negative(expr.exp),assumptions)
+        if is_base_zero is False and is_exp_negative is False:
+            return False
+        if is_base_zero is not False and is_exp_negative is not False:
             return None
         return True
     if (abs(expr.base) <= 1) == True and ask(Q.extended_positive(expr.exp), assumptions):

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -195,6 +195,8 @@ def _(expr, assumptions):
     if base_bounded is False and ask(Q.extended_nonzero(expr.exp), assumptions):
         return False
     if base_bounded and exp_bounded:
+        if ask(Q.zero(expr.base),assumptions) is not False and ask(Q.negative(expr.exp),assumptions) is not False:
+            return None
         return True
     if (abs(expr.base) <= 1) == True and ask(Q.extended_positive(expr.exp), assumptions):
         return True

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -197,7 +197,7 @@ def _(expr, assumptions):
     if base_bounded and exp_bounded:
         is_base_zero = ask(Q.zero(expr.base),assumptions)
         is_exp_negative = ask(Q.negative(expr.exp),assumptions)
-        if is_base_zero is False and is_exp_negative is False:
+        if is_base_zero is True and is_exp_negative is True:
             return False
         if is_base_zero is not False and is_exp_negative is not False:
             return None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1082,6 +1082,15 @@ def test_bounded():
     assert ask(Q.finite(2**x), ~Q.finite(x)) is False
     assert ask(Q.finite(x**2), ~Q.finite(x)) is False
 
+    # https://github.com/sympy/sympy/issues/27707
+    assert ask(Q.finite(x**y),Q.real(x) & Q.real(y)) is None
+    assert ask(Q.finite(x**y),Q.real(x) & Q.negative(y)) is None
+    assert ask(Q.finite(x**y),Q.zero(x) & Q.negative(y)) is None
+    assert ask(Q.finite(x**y),Q.real(x) & Q.positive(y)) is True
+    assert ask(Q.finite(x**y),Q.nonzero(x) & Q.real(y)) is True
+    assert ask(Q.finite(x**y),Q.nonzero(x) & Q.negative(y)) is True
+    assert ask(Q.finite(x**y),Q.zero(x) & Q.positive(y)) is True
+
     # sign function
     assert ask(Q.finite(sign(x))) is True
     assert ask(Q.finite(sign(x)), ~Q.finite(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1083,13 +1083,13 @@ def test_bounded():
     assert ask(Q.finite(x**2), ~Q.finite(x)) is False
 
     # https://github.com/sympy/sympy/issues/27707
-    assert ask(Q.finite(x**y),Q.real(x) & Q.real(y)) is None
-    assert ask(Q.finite(x**y),Q.real(x) & Q.negative(y)) is None
-    assert ask(Q.finite(x**y),Q.zero(x) & Q.negative(y)) is False
-    assert ask(Q.finite(x**y),Q.real(x) & Q.positive(y)) is True
-    assert ask(Q.finite(x**y),Q.nonzero(x) & Q.real(y)) is True
-    assert ask(Q.finite(x**y),Q.nonzero(x) & Q.negative(y)) is True
-    assert ask(Q.finite(x**y),Q.zero(x) & Q.positive(y)) is True
+    assert ask(Q.finite(x**y), Q.real(x) & Q.real(y)) is None
+    assert ask(Q.finite(x**y), Q.real(x) & Q.negative(y)) is None
+    assert ask(Q.finite(x**y), Q.zero(x) & Q.negative(y)) is False
+    assert ask(Q.finite(x**y), Q.real(x) & Q.positive(y)) is True
+    assert ask(Q.finite(x**y), Q.nonzero(x) & Q.real(y)) is True
+    assert ask(Q.finite(x**y), Q.nonzero(x) & Q.negative(y)) is True
+    assert ask(Q.finite(x**y), Q.zero(x) & Q.positive(y)) is True
 
     # sign function
     assert ask(Q.finite(sign(x))) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1085,7 +1085,7 @@ def test_bounded():
     # https://github.com/sympy/sympy/issues/27707
     assert ask(Q.finite(x**y),Q.real(x) & Q.real(y)) is None
     assert ask(Q.finite(x**y),Q.real(x) & Q.negative(y)) is None
-    assert ask(Q.finite(x**y),Q.zero(x) & Q.negative(y)) is None
+    assert ask(Q.finite(x**y),Q.zero(x) & Q.negative(y)) is False
     assert ask(Q.finite(x**y),Q.real(x) & Q.positive(y)) is True
     assert ask(Q.finite(x**y),Q.nonzero(x) & Q.real(y)) is True
     assert ask(Q.finite(x**y),Q.nonzero(x) & Q.negative(y)) is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->Fixes #27707


#### Brief description of what is fixed or changed
This PR addresses the issue where ```ask(Q.finite(x**-1), Q.real(x))``` incorrectly returns ```True```, ignoring the potential for division by zero when x could be zero.

Changes made:

- Modified the ```Pow``` handler for FinitePredicate to check if the base of an exponent could be zero and the exponent could be negative.
- Added a condition to return ```None``` when there's a possibility of division by zero.
- Added tests to verify the correct behavior for expressions like ```x**-1``` when x is real (and could be zero).



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Bug fix: Now ```ask(Q.finite(x**-1), Q.real(x))``` correctly returns ```None``` instead of ```True```.
<!-- END RELEASE NOTES -->
