### PR TITLE
Ensure trigsimp uses custom measure function in simplify.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1714,6 +1714,7 @@ vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
+vitrun <vitrun@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -710,7 +710,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         expr = besselsimp(expr)
 
     if expr.has(TrigonometricFunction, HyperbolicFunction):
-        expr = trigsimp(expr, deep=True)
+        expr = trigsimp(expr, deep=True, measure=measure)
 
     if expr.has(log):
         expr = shorter(expand_log(expr, deep=True), logcombine(expr))

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -518,3 +518,12 @@ def test_trigsimp_inverse():
             assert angle_inverted != angle  # assures simplification happened
             assert sin(angle_inverted) == trigsimp(sin(angle))
             assert cos(angle_inverted) == trigsimp(cos(angle))
+
+
+def test_issue_25906():
+    # https://github.com/sympy/sympy/issues/25906
+    expr = sin(x)**2 + cos(x)**2
+    custom_measure = lambda expr: expr.count_ops()
+    default_simplified = simplify(expr)
+    custom_simplified = simplify(expr, measure=custom_measure)
+    assert custom_simplified.equals(default_simplified)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -554,10 +554,10 @@ def trigsimp(expr, inverse=False, **opts):
 
     trigsimpfunc = {
         'fu': (lambda x: fu(x, **opts)),
-        'matching': (lambda x: futrig(x)),
+        'matching': (lambda x: futrig(x, **opts)),
         'groebner': (lambda x: groebnersimp(x, **opts)),
         'combined': (lambda x: futrig(groebnersimp(x,
-                               polynomial=True, hints=[2, tan]))),
+                               polynomial=True, hints=[2, tan]), **opts)),
         'old': lambda x: trigsimp_old(x, **opts),
                    }[method]
 
@@ -1155,11 +1155,11 @@ def futrig(e, *, hyper=True, **kwargs):
         return e
 
     old = e
-    e = bottom_up(e, _futrig)
+    e = bottom_up(e, lambda x: _futrig(x, kwargs.get('measure')))
 
     if hyper and e.has(HyperbolicFunction):
         e, f = hyper_as_trig(e)
-        e = f(bottom_up(e, _futrig))
+        e = f(bottom_up(e, lambda x: _futrig(x, kwargs.get('measure'))))
 
     if e != old and e.is_Mul and e.args[0].is_Rational:
         # redistribute leading coeff on 2-arg Add
@@ -1167,7 +1167,7 @@ def futrig(e, *, hyper=True, **kwargs):
     return e
 
 
-def _futrig(e):
+def _futrig(e, measure=None):
     """Helper for futrig."""
     from sympy.simplify.fu import (
         TR1, TR2, TR3, TR2i, TR10, L, TR10i,
@@ -1182,7 +1182,7 @@ def _futrig(e):
     else:
         coeff = None
 
-    Lops = lambda x: (L(x), x.count_ops(), _nodes(x), len(x.args), x.is_Add)
+    Lops = lambda x: (L(x), measure(x) if measure is not None else x.count_ops(), _nodes(x), len(x.args), x.is_Add)
     trigs = lambda x: x.has(TrigonometricFunction)
 
     tree = [identity,

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1182,7 +1182,8 @@ def _futrig(e, measure=None):
     else:
         coeff = None
 
-    Lops = lambda x: (L(x), measure(x) if measure is not None else x.count_ops(), _nodes(x), len(x.args), x.is_Add)
+    measure = measure if measure is not None else lambda x: x.count_ops()
+    Lops = lambda x: (L(x), measure(x), _nodes(x), len(x.args), x.is_Add)
     trigs = lambda x: x.has(TrigonometricFunction)
 
     tree = [identity,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
FIX:#25906
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
trigsimp now accepts and propagates the measure argument.
Add test case for measure propagation in trigsimp  
#### Other comments
This PR is based on gh-25917 by @vitrun. I have revived their work and included commit 37da2a9. Additionally, I have made the necessary changes mentioned in their PR and added test cases.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
   * simplify now utilizes the custom complexity measure function more comprehensively. 
<!-- END RELEASE NOTES -->
