### PR TITLE
Fix for typographical errors

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -21,7 +21,7 @@ Notes
   runner has seen extensive real-world testing and will be removed in the
   future.
 - To regenerate the `.test_durations` file, which is used by pytest-split to
-  determine how to partion the tests into evenly sized groups, run:
+  determine how to partition the tests into evenly sized groups, run:
     `$ bin/test --store-durations`
 
 """
@@ -107,7 +107,7 @@ parser.add_argument(
 parser.add_argument(
     '--store-durations', action='store_true', dest='store_durations',
     default=False, help='Update the `.test_durations` file, which helps '
-    'pytest-split partion tests into even-sized groups.')
+    'pytest-split partition tests into even-sized groups.')
 
 options, args = parser.parse_known_args()
 

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -141,7 +141,7 @@ myst_enable_checkboxes = True
 # myst_update_mathjax = False
 
 # Don't linkify links unless they start with "https://". This is needed
-# because the linkify library treates .py as a TLD.
+# because the linkify library treats .py as a TLD.
 myst_linkify_fuzzy_links = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/src/contributing/new-contributors-guide/workflow-process.md
+++ b/doc/src/contributing/new-contributors-guide/workflow-process.md
@@ -323,7 +323,7 @@ $ ./bin/test /core /utilities
 
 This will run tests for the `core` and `utilities` modules.
 
-Similary, run quality tests with:
+Similarly, run quality tests with:
 
 ```bash
 $ ./bin/test code_quality

--- a/doc/src/contributing/new-contributors-guide/writing-tests.md
+++ b/doc/src/contributing/new-contributors-guide/writing-tests.md
@@ -644,7 +644,7 @@ This will import the module if it is installed and return `None` otherwise.
 
 `sympy.testing.pytest.skip` should be used to skip tests when the module in
 question is not installed (see [](writing-tests-skip) above). This can be done
-at the module level if the entire test file should be skippped, or in each
+at the module level if the entire test file should be skipped, or in each
 individual function.
 
 You should also make sure the test is run in the "Optional Dependencies" CI

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -81,13 +81,13 @@ SymPy deprecation warnings.
 
 The ``tensor_product_simp`` function in the ``sympy.physics.quantum``
 module has been deprecated along with two helper functions,
-``tensor_product_simp_Mul`` and ``tensor_product_simp_Pow``. The 
+``tensor_product_simp_Mul`` and ``tensor_product_simp_Pow``. The
 transformations performed by these functions are now applied
 automatically to all quantum expressions in the new
 ``sympy.physics.quantum.transforms`` module.
 
 If you are using these functions in your code, you can remove them as
-they are now reduntant.
+they are now redundant.
 
 Their current implementations have been replaced by a simple
 pass-through as all quantum expressions will already be in the form
@@ -101,11 +101,11 @@ The ``IdentityOperator`` in the ``sympy.physics.quantum`` module has been
 deprecated. Originally, we thought that it would be helpful to have a
 multiplicative identity for quantum operators and states. However, at this
 time, it is unused in `sympy.physics.quantum` for anything other than tests
-of its own behavior. In addition, users were finding inconsistencies in 
+of its own behavior. In addition, users were finding inconsistencies in
 the behavior of ``IdentityOperator`` compared to what is expected by a
 multiplicative identity.
 
-Moving forward, we recommend that users use the scalar `S.One` as the 
+Moving forward, we recommend that users use the scalar `S.One` as the
 multiplicative identity for all operators and states in the quantum
 module. The code in ``sympy.physics.quantum`` currently does not ever
 return an ``IdentityOperator`` so the only place users will encounter

--- a/doc/src/explanation/modules/physics/biomechanics/biomechanics.rst
+++ b/doc/src/explanation/modules/physics/biomechanics/biomechanics.rst
@@ -372,7 +372,7 @@ ZerothOrderActivation('zeroth')
 
 The argument passed to `name` tries to help ensures that the
 automatically-created :obj:`~sympy.physics.vector.dynamicsymbols` for
-:math:`e(t)` and :math:`a(t)` are unique betweem instances.
+:math:`e(t)` and :math:`a(t)` are unique between instances.
 
 >>> actz.excitation
 e_zeroth(t)
@@ -555,7 +555,7 @@ method allows the equation of the curve to be accessed.
 >>> fl_T2.doit()
 c0*exp(c3*(-c1 + l_T(t)/l_T_slack)) - c2
 
-The class provides an alternate constructor that allows it to be constucted
+The class provides an alternate constructor that allows it to be constructed
 prepopulated with the values for the constants recommended in [DeGroote2016]_.
 This takes a single argument, again corresponding to :math:`\tilde{l}^T`, which
 can against either be a symbol or expression.
@@ -749,7 +749,7 @@ FiberForceLengthPassiveInverseDeGroote2016(fl_M_pas(t), 0.6, 4.0)
 Fiber Active Force-Length
 -------------------------
 
-When a muscle is activated, it contracts to produce a force. This phenomenom is
+When a muscle is activated, it contracts to produce a force. This phenomenon is
 modeled by the contractile element in the parallel fiber component of the
 musculotendon model. The amount of force that the fibers can produce is a
 function of the instantaneous length of the fibers. The characteristic curve
@@ -1088,7 +1088,7 @@ available as a know value due to it being a state variable.
 
 Using :math:`\tilde{l}^T` and the tendon force-length curve
 (:math:`fl^T\left(\tilde{l}^T\right)`), we can write an equation for the
-normalized and absolte tendon force:
+normalized and absolute tendon force:
 
 .. math::
 

--- a/doc/src/explanation/special_topics/finite_diff_derivatives.rst
+++ b/doc/src/explanation/special_topics/finite_diff_derivatives.rst
@@ -246,7 +246,7 @@ of the set of points at `(x_{1},F_{1})` in terms of values at `(x_{2},F_{2})` an
 Also,  we note that output of formats appropriate to Fortran,  C,  etc. may be done in the examples
 given above.
 
-Next we show how to perform these and many other discritizations of derivatives,  but using a
+Next we show how to perform these and many other discretizations of derivatives, but using a
 much more efficient approach originally due to Bengt Fornberg and now incorporated into SymPy.
 
 :ref:`calculus-finite-differences`

--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -278,7 +278,7 @@ that would affect the behaviour of :func:`~.solve`:
     [1]
 
 When using string input SymPy will create the expression and create all of the
-symbolc implicitly so the question arises how can the assumptions be
+symbolic implicitly so the question arises how can the assumptions be
 specified? The answer is that rather than depending on implicit string
 conversion it is better to use the :func:`~.parse_expr` function explicitly
 and then it is possible to provide assumptions for the symbols e.g.:

--- a/doc/src/install.md
+++ b/doc/src/install.md
@@ -49,7 +49,7 @@ also.
 
 ## From Linux Package Managers
 
-Many Linux distrubtions package SymPy, for example on Debian based systems
+Many Linux distributions package SymPy, for example on Debian based systems
 SymPy can be installed with apt:
 
 ```

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -102,7 +102,7 @@ Lark `\mathrm{\LaTeX}` Parser Features
 """"""""""""""""""""""""""""""""""""""
 
 One thing to note is that the Lark backend does not support ill-formed expressions,
-and it does not try to fix any sort of common mistakes that may have occured. For
+and it does not try to fix any sort of common mistakes that may have occurred. For
 example, as mentioned in :ref:`the earlier section <ANTLR parser caveats>`, the
 ANTLR-based parser would simply find ``x`` if we run::
 

--- a/doc/src/modules/physics/biomechanics/api/index.rst
+++ b/doc/src/modules/physics/biomechanics/api/index.rst
@@ -30,7 +30,7 @@ both :mod:`sympy.physics.mechanics` and :mod:`sympy.physics.biomechanics`, and
 use objects from both interchangeably. :mod:`sympy.physics.biomechanics` has
 been designed in such a way that its class hierarchies are related to, and
 interfaces (e.g. attribute names, call signatures, and return types) mimic,
-those of :mod:`sympy.physics.mechanics`. Consequentially, :mod:`sympy.physics.mechanics`
+those of :mod:`sympy.physics.mechanics`. Consequently, :mod:`sympy.physics.mechanics`
 will correctly generate equations of motion for multibody systems that
 incorporate biomechanical components.
 

--- a/doc/src/modules/solvers/diophantine.rst
+++ b/doc/src/modules/solvers/diophantine.rst
@@ -218,7 +218,7 @@ Here A is a 2 X 2 matrix and B is a 2 X 1 matrix such that the transformation
 
     \begin{bmatrix} X\\Y \end{bmatrix} = A \begin{bmatrix} x\\y \end{bmatrix} + B
 
-gives the equation `X^2 -5Y^2 = 920`. Values of `A` and `B` are as belows.
+gives the equation `X^2 -5Y^2 = 920`. Values of `A` and `B` are as below.
 
 >>> A
 Matrix([

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -165,7 +165,7 @@ algorithms implemented for the various heuristics.
 Rational Riccati Solver
 -----------------------
 These functions are intended for internal use to solve a first order Riccati
-differential equation with atleast one rational particular solution.
+differential equation with at least one rational particular solution.
 
 .. autofunction:: sympy.solvers.ode.riccati::riccati_normal
 

--- a/doc/src/modules/vector/vector_integration.rst
+++ b/doc/src/modules/vector/vector_integration.rst
@@ -12,7 +12,7 @@ To integrate a scalar or vector field over a region, we have to first define a r
 
 The :func:`~sympy.vector.integrals.vector_integrate` function is used to integrate scalar or vector field over any type of region. It automatically determines the type of integration (line, surface, or volume) depending on the nature of the object.
 
-We define a coordinate system and make necesssary imports for examples.
+We define a coordinate system and make necessary imports for examples.
 
 >>> from sympy import sin, cos, exp, pi, symbols
 >>> from sympy.vector import CoordSys3D, ParametricRegion, ImplicitRegion, vector_integrate

--- a/doc/src/tutorials/physics/control/control_problems.rst
+++ b/doc/src/tutorials/physics/control/control_problems.rst
@@ -28,7 +28,7 @@ Solution
     Subpart 1
 
     >>> s, k = symbols('s k')
-    >>> gain = k                        # Let unknwon gain be k
+    >>> gain = k                        # Let unknown gain be k
     >>> a = [-3]                        # Zero at -3 in S plane
     >>> b = [-1, -2-I, -2+I]            # Poles at -1, (-2, j) and (-2, -j) in S plane
     >>> tf = TransferFunction.from_zpk(a, b, gain, s)

--- a/doc/src/tutorials/physics/control/index.rst
+++ b/doc/src/tutorials/physics/control/index.rst
@@ -17,7 +17,7 @@ control systems using state variables, inputs, and outputs in matrix form. This
 representation is particularly useful for time-domain analysis and handling complex
 MIMO systems.
 
-This tutorial contains a breif guide on how to solve Control Problems using
+This tutorial contains a brief guide on how to solve Control Problems using
 `TransferFunction` and `StateSpace`.
 
 .. toctree::

--- a/doc/src/tutorials/physics/control/mechanics_problems.rst
+++ b/doc/src/tutorials/physics/control/mechanics_problems.rst
@@ -129,7 +129,7 @@ Example 2
 
 This problem explains how to model a rotaional system to state-space model. The system has input torque `τ_a` and damping effects `B_{r1}` and `B_{r2}`. The system consists of two flywheels connected by a spring, with the angular positions denoted by `θ_1` and `θ_2`.
 
-The energy variables for the rotating system are potential energy stored in springs `1/2 K_r \theta^ 2` and kinetic energy stored in inertial elments `1/2 J \omega ^ 2`.
+The energy variables for the rotating system are potential energy stored in springs `1/2 K_r \theta^ 2` and kinetic energy stored in inertial elements `1/2 J \omega ^ 2`.
 
 The **State Variables:** can be written as:
 

--- a/doc/src/tutorials/physics/mechanics/rollingdisc_example_kane_constraints.rst
+++ b/doc/src/tutorials/physics/mechanics/rollingdisc_example_kane_constraints.rst
@@ -5,7 +5,7 @@ A rolling disc, with Kane's method and constraint forces
 We will now revisit the rolling disc example, except this time we are bringing
 the non-contributing (constraint) forces into evidence. See [Kane1985]_ for a
 more thorough explanation of this. Here, we will turn on the automatic
-simplifcation done when doing vector operations. It makes the outputs nicer for
+simplification done when doing vector operations. It makes the outputs nicer for
 small problems, but can cause larger vector operations to hang. ::
 
   >>> from sympy import symbols, sin, cos, tan

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -150,7 +150,7 @@ def test_failing_number_line_properties():
 
 
 def test_equality():
-    # test symetry and reflexivity
+    # test symmetry and reflexivity
     assert ask(Q.eq(x, x)) is True
     assert ask(Q.eq(y, x), Q.eq(x, y)) is True
     assert ask(Q.eq(y, x), ~Q.eq(z, z) | Q.eq(x, y)) is True

--- a/sympy/codegen/approximations.py
+++ b/sympy/codegen/approximations.py
@@ -5,7 +5,7 @@ from sympy.codegen.rewriting import Optimization
 from sympy.core.function import UndefinedFunction
 
 """
-This module collects classes useful for approimate rewriting of expressions.
+This module collects classes useful for approximate rewriting of expressions.
 This can be beneficial when generating numeric code for which performance is
 of greater importance than precision (e.g. for preconditioners used in iterative
 methods).

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -21,7 +21,7 @@ if USE_SYMENGINE:
         SymEngine's ``sympify`` does not accept keyword arguments and is
         therefore not compatible with SymPy's ``sympify`` with ``strict=True``
         (which ensures that only the types for which an explicit conversion has
-        been defined are converted). This wrapper adds an addiotional parameter
+        been defined are converted). This wrapper adds an additional parameter
         ``strict`` (with default ``False``) that will raise a ``SympifyError``
         if ``strict=True`` and the argument passed to the parameter ``a`` is a
         string.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1079,7 +1079,7 @@ class Derivative(Expr):
         2*f(x)
 
     Such derivatives will show up when the chain rule is used to
-    evalulate a derivative:
+    evaluate a derivative:
 
         >>> f(g(x)).diff(x)
         Derivative(f(g(x)), g(x))*Derivative(g(x), x)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -4200,7 +4200,7 @@ def equal_valued(x, y):
     Explanation
     ===========
 
-    In future SymPy verions Float and Rational might compare unequal and floats
+    In future SymPy versions Float and Rational might compare unequal and floats
     with different precisions might compare unequal. In that context a function
     is needed that can check if a number is equal to 1 or 0 etc. The idea is
     that instead of testing ``if x == 1:`` if we want to accept floats like
@@ -4360,7 +4360,7 @@ def all_close(expr1, expr2, rtol=1e-5, atol=1e-8):
         assert expr1.is_Add or expr2.is_Add
         cd1 = expr1.as_coefficients_dict()
         cd2 = expr2.as_coefficients_dict()
-        # this test will asure that the key of 1 is in
+        # this test will assure that the key of 1 is in
         # each dict and that they have equal values
         if not _close_num(cd1[1], cd2[1]):
             return False

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -348,7 +348,7 @@ class Symbol(AtomicExpr, Boolean): # type: ignore
         #
         assumptions_orig = assumptions.copy()
 
-        # The only assumption that is assumed by default is comutative=True:
+        # The only assumption that is assumed by default is commutative=True:
         assumptions.setdefault('commutative', True)
 
         assumptions_kb = StdFactKB(assumptions)

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -201,7 +201,7 @@ def test_call():
     assert sin(x).rcall(1) == sin(x)
     assert (1 + sin(x)).rcall(1) == 1 + sin(x)
 
-    # Effect in the pressence of callables
+    # Effect in the presence of callables
     l = Lambda(x, 2*x)
     assert (l + x).rcall(y) == 2*y + x
     assert (x**l).rcall(2) == x**4

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2638,7 +2638,7 @@ def encipher_elgamal(i, key, seed=None):
     ``i`` is a plaintext message expressed as an integer.
     ``key`` is public key (p, r, e). In order to encrypt
     a message, a random number ``a`` in ``range(2, p)``
-    is generated and the encryped message is returned as
+    is generated and the encrypted message is returned as
     `c_{1}` and `c_{2}` where:
 
     `c_{1} \equiv r^{a} \pmod p`

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -882,7 +882,7 @@ class Point(Basic):
         """
         Coordinates of the point in given coordinate system. If coordinate system
         is not passed, it returns the coordinates in the coordinate system in which
-        the poin was defined.
+        the point was defined.
         """
         if sys is None:
             return self._coords

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3507,7 +3507,7 @@ class atan2(InverseTrigonometricFunction):
     >>> atan2(1, -1)
     3*pi/4
 
-    where only the `\operatorname{atan2}` function reurns what we expect.
+    where only the `\operatorname{atan2}` function returns what we expect.
     We can differentiate the function with respect to both arguments:
 
     >>> from sympy import diff

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -651,7 +651,7 @@ def test_type_of_triangle():
     assert p2.is_scalene() == True
     assert p2.is_equilateral() == False
 
-    # Equilateral triagle
+    # Equilateral triangle
     p3 = Polygon(Point(0, 0), Point(6, 0), Point(3, sqrt(27)))
     assert p3.is_isosceles() == True
     assert p3.is_scalene() == False

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -298,7 +298,7 @@ def _laplace_transform_integration(f, t, s_, *, simplify):
 @DEBUG_WRAP
 def _laplace_deep_collect(f, t):
     """
-    This is an internal helper function that traverses through the epression
+    This is an internal helper function that traverses through the expression
     tree of `f(t)` and collects arguments. The purpose of it is that
     anything like `f(w*t-1*t-c)` will be written as `f((w-1)*t-c)` such that
     it can match `f(a*t+b)`.
@@ -975,7 +975,7 @@ def _laplace_expand(f, t, s):
     """
     This function tries to expand its argument with successively stronger
     methods: first it will expand on the top level, then it will expand any
-    multiplications in depth, then it will try all avilable expansion methods,
+    multiplications in depth, then it will try all available expansion methods,
     and finally it will try to expand trigonometric functions.
 
     If it can expand, it will then compute the Laplace transform of the

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -796,7 +796,7 @@ def gcdex_diophantine(a, b, c):
     """
     # Extended Euclidean Algorithm (Diophantine Version) pg. 13
     # TODO: This should go in densetools.py.
-    # XXX: Bettter name?
+    # XXX: Better name?
 
     s, g = a.half_gcdex(b)
     s *= c.exquo(g)  # Inexact division means c is not in (a, b)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -436,8 +436,8 @@ def _rewrite_sin(m_n, s, a, b):
     # (This is a separate function because it is moderately complicated,
     #  and I want to doctest it.)
     # We want to use pi/sin(pi*x) = gamma(x)*gamma(1-x).
-    # But there is one comlication: the gamma functions determine the
-    # inegration contour in the definition of the G-function. Usually
+    # But there is one complication: the gamma functions determine the
+    # integration contour in the definition of the G-function. Usually
     # it would not matter if this is slightly shifted, unless this way
     # we create an undefined function!
     # So we try to write this in such a way that the gammas are

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -59,7 +59,7 @@ Here's an example of how that would work:
 
     Note that since EncodedCNF is inherently non-deterministic,
     the int each predicate is encoded as is not consistent. As a
-    result, the code bellow likely does not reflect the assignment
+    result, the code below likely does not reflect the assignment
     given above.
 
     >>> lra.assert_lit(-1) #doctest: +SKIP
@@ -169,7 +169,7 @@ class LRASolver():
         if self.run_checks:
             assert A[:, n-m:] == -eye(m)
 
-        self.enc_to_boundary = enc_to_boundary  # mapping of int to Boundry objects
+        self.enc_to_boundary = enc_to_boundary  # mapping of int to Boundary objects
         self.boundary_to_enc = {value: key for key, value in enc_to_boundary.items()}
         self.A = A
         self.slack = slack_variables
@@ -230,7 +230,7 @@ class LRASolver():
         """
         # This function has three main jobs:
         # - raise errors if the input formula is not handled
-        # - preprocesses the formula into a matirx and single variable constraints
+        # - preprocesses the formula into a matrix and single variable constraints
         # - create one-literal conflict clauses from predicates that are always True
         #   or always False such as Q.gt(3, 2)
         #
@@ -647,7 +647,7 @@ class LRASolver():
     def _pivot(M, i, j):
         """
         Performs a pivot operation about entry i, j of M by performing
-        a series of row operations on a copy of M and returing the result.
+        a series of row operations on a copy of M and returning the result.
         The original M is left unmodified.
 
         Conceptually, M represents a system of equations and pivoting
@@ -840,7 +840,7 @@ class Boundary:
             return self.var.var >= self.bound
 
     def __repr__(self):
-        return repr("Boundry(" + repr(self.get_inequality()) + ")")
+        return repr("Boundary(" + repr(self.get_inequality()) + ")")
 
     def __eq__(self, other):
         other = (other.var, other.bound, other.strict, other.upper, other.equality)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1,5 +1,5 @@
 """
-A module contining deprecated matrix mixin classes.
+A module containing deprecated matrix mixin classes.
 
 The classes in this module are deprecated and will be removed in a future
 release. They are kept here for backwards compatibility in case downstream

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -213,7 +213,7 @@ def rot_givens(i, j, theta, dim=3):
     j : int between ``0`` and ``dim - 1``
         Represents second axis
     dim : int bigger than 1
-        Number of dimentions. Defaults to 3.
+        Number of dimensions. Defaults to 3.
 
     Examples
     ========

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -296,7 +296,7 @@ def remove_ids(mul):
     """ Remove Identities from a MatMul
 
     This is a modified version of sympy.strategies.rm_id.
-    This is necesssary because MatMul may contain both MatrixExprs and Exprs
+    This is necessary because MatMul may contain both MatrixExprs and Exprs
     as args.
 
     See Also

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -4274,7 +4274,7 @@ class MatrixBase(Printable):
         [sin(theta(t)),  cos(theta(t)), 0],
         [            0,              0, 1]])
 
-        We can retrive the angular velocity:
+        We can retrieve the angular velocity:
 
         >>> Omega = R.T * R.diff()
         >>> Omega = trigsimp(Omega)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1110,7 +1110,7 @@ rho_msg = "Pollard's rho with retries %i, max_steps %i and seed %i"
 pm1_msg = "Pollard's p-1 with smoothness bound %i and seed %i"
 ecm_msg = "Elliptic Curve with B1 bound %i, B2 bound %i, num_curves %i"
 factor_msg = '\t%i ** %i'
-fermat_msg = 'Close factors satisying Fermat condition found.'
+fermat_msg = 'Close factors satisfying Fermat condition found.'
 complete_msg = 'Factorization is complete.'
 
 

--- a/sympy/ntheory/qs.py
+++ b/sympy/ntheory/qs.py
@@ -8,7 +8,7 @@ from sympy.ntheory.residue_ntheory import _sqrt_mod_prime_power
 
 class SievePolynomial:
     def __init__(self, a, b, N):
-        """This class denotes the seive polynomial.
+        """This class denotes the sieve polynomial.
         Provide methods to compute `(a*x + b)**2 - N` and
         `a*x + b` when given `x`.
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1435,7 +1435,7 @@ def _discrete_log_pollard_rho(n, a, b, order=None, retries=10, rseed=None):
 
 def _discrete_log_is_smooth(n: int, factorbase: list):
     """Try to factor n with respect to a given factorbase.
-    Upon success a list of exponents with repect to the factorbase is returned.
+    Upon success a list of exponents with respect to the factorbase is returned.
     Otherwise None."""
     factors = [0]*len(factorbase)
     for i, p in enumerate(factorbase):
@@ -1482,7 +1482,7 @@ def _discrete_log_index_calculus(n, a, b, order, rseed=None):
     # We have added an extra term to the asymptotic value which
     # is closer to the theoretical optimum for n up to 2^70.
     B = int(exp(0.5 * sqrt( log(n) * log(log(n)) )*( 1 + 1/log(log(n)) )))
-    max = 5 * B * B  # expected number of trys to find a relation
+    max = 5 * B * B  # expected number of tries to find a relation
     factorbase = list(primerange(B)) # compute the factorbase
     lf = len(factorbase) # length of the factorbase
     ordermo = order-1
@@ -1535,7 +1535,7 @@ def _discrete_log_index_calculus(n, a, b, order, rseed=None):
                     relationa[j] = (relationa[j] - rbi*relations[i][j]) % order
             if relationa[i] > 0:  # the index of the first nonzero entry
                 break  # we do not need to reduce further at this point
-        else:  # all unkowns are gone
+        else:  # all unknowns are gone
             #print(f"Success after {k} relations out of {lf}")
             x = (order -relationa[lf]) % order
             if pow(b,x,n) == a:
@@ -1671,7 +1671,7 @@ def discrete_log(n, a, b, order=None, prime_order=None):
         return _discrete_log_trial_mul(n, a, b, order)
     elif prime_order:
         # Shanks and Pollard rho are O(sqrt(order)) while index calculus is O(exp(2*sqrt(log(n)log(log(n)))))
-        # we compare the expected running times to determine the algorithmus which is expected to be faster
+        # we compare the expected running times to determine the algorithm which is expected to be faster
         if 4*sqrt(log(n)*log(log(n))) < log(order) - 10:  # the number 10 was determined experimental
             return _discrete_log_index_calculus(n, a, b, order)
         elif order < 1000000000000:

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -293,7 +293,7 @@ def processVariables(self, ctx):
             self.var_list.append(name + strfunc(i))
 
     elif "{" in ctx.getText():
-        # Process variables of the type: Variales x{3}, y{2}
+        # Process variables of the type: Variables x{3}, y{2}
 
         if "'" in ctx.getText():
             dash_count = ctx.getText().count("'")

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -123,7 +123,7 @@ if cin:
             It takes the filename as an attribute and creates a Clang AST
             Translation Unit parsing the file.
             Then the transformation function is called on the translation unit,
-            whose reults are collected into a list which is returned by the
+            whose results are collected into a list which is returned by the
             function.
 
             Parameters
@@ -159,7 +159,7 @@ if cin:
             It takes the source code as an attribute, stores it in a temporary
             file and creates a Clang AST Translation Unit parsing the file.
             Then the transformation function is called on the translation unit,
-            whose reults are collected into a list which is returned by the
+            whose results are collected into a list which is returned by the
             function.
 
             Parameters
@@ -588,7 +588,7 @@ if cin:
                 the result from the wrapped expression
 
             None : NoneType
-                No childs are found for the node
+                No children are found for the node
 
             Raises
             ======
@@ -658,7 +658,7 @@ if cin:
             return Return(next(node.get_children()).spelling)
 
         def transform_compound_stmt(self, node):
-            """Transformation function for compond statemets
+            """Transformation function for compound statements
 
             Returns
             =======

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -449,7 +449,7 @@ class MathematicaParser:
 
         s = m.string                # whole string
         anc = m.end() + 1           # pointing the first letter of arguments
-        square, curly = [], []      # stack for brakets
+        square, curly = [], []      # stack for brackets
         args = []
 
         # current cursor

--- a/sympy/physics/biomechanics/activation.py
+++ b/sympy/physics/biomechanics/activation.py
@@ -280,7 +280,7 @@ class ZerothOrderActivation(ActivationBase):
     exictation to activation. As a result, no additional state equations are
     introduced to your system. They also remove a potential source of delay
     between the input and dynamics of your system as no (ordinary) differential
-    equations are involed.
+    equations are involved.
 
     """
 

--- a/sympy/physics/biomechanics/musculotendon.py
+++ b/sympy/physics/biomechanics/musculotendon.py
@@ -265,7 +265,7 @@ class MusculotendonBase(ForceActuator, _NamedMixin):
         # actual force has been calculated by
         # `self._<MUSCULOTENDON FORMULATION>_musculotendon_dynamics`.
         # Note that `self._force` assumes forces are expansile, musculotendon
-        # forces are contractile hence the minus sign preceeding `self._F_T`
+        # forces are contractile hence the minus sign preceding `self._F_T`
         # (the tendon force).
         self._force = -self._F_T
 

--- a/sympy/physics/continuum_mechanics/arch.py
+++ b/sympy/physics/continuum_mechanics/arch.py
@@ -99,7 +99,7 @@ class Arch:
             self._crown_y = solution[c]
 
         else:
-            raise KeyError("please provide crown_x to contruct arch")
+            raise KeyError("please provide crown_x to construct arch")
 
         return parabola_eqn
 
@@ -337,7 +337,7 @@ class Arch:
                 The x coordinate of the position of the hinge
                 - if not provided, defaults to old value
 
-            crown_y: Flaot
+            crown_y: Float
                 The y coordinate of the position of the hinge
                 - if not provided defaults to None
         """

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -2092,7 +2092,7 @@ class Beam:
 
         Warning
         =======
-        The values for a = 0 and a = l, with l the lenght of the beam, in
+        The values for a = 0 and a = l, with l the length of the beam, in
         the plot can be incorrect.
 
         Examples
@@ -2170,7 +2170,7 @@ class Beam:
         Warning
         =======
         This method creates equations that can give incorrect results when
-        substituting a = 0 or a = l, with l the lenght of the beam.
+        substituting a = 0 or a = l, with l the length of the beam.
 
         Examples
         ========

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -900,8 +900,8 @@ class TransferFunction(SISOLinearTimeInvariant):
 
     def _eval_rewrite_as_StateSpace(self, *args):
         """
-        Returns the equivalent space space model of the transfer function model.
-        The state space model will be returned in the controllable cannonical form.
+        Returns the equivalent space model of the transfer function model.
+        The state space model will be returned in the controllable canonical form.
 
         Unlike the space state to transfer function model conversion, the transfer function
         to state space model conversion is not unique. There can be multiple state space
@@ -4270,11 +4270,11 @@ class StateSpace(LinearTimeInvariant):
             if A.rows != B.rows:
                 raise ShapeError("Matrices A and B must have the same number of rows.")
 
-            # Check Ouput and Feedthrough matrices have same rows
+            # Check Output and Feedthrough matrices have same rows
             if C.rows != D.rows:
                 raise ShapeError("Matrices C and D must have the same number of rows.")
 
-            # Check State and Ouput matrices have same columns
+            # Check State and Output matrices have same columns
             if A.cols != C.cols:
                 raise ShapeError("Matrices A and C must have the same number of columns.")
 

--- a/sympy/physics/mechanics/actuator.py
+++ b/sympy/physics/mechanics/actuator.py
@@ -651,7 +651,7 @@ class TorqueActuator(ActuatorBase):
 
     @classmethod
     def at_pin_joint(cls, torque, pin_joint):
-        """Alternate construtor to instantiate from a ``PinJoint`` instance.
+        """Alternate constructor to instantiate from a ``PinJoint`` instance.
 
         Examples
         ========

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -109,7 +109,7 @@ class Linearizer:
         self._qd_dup = Matrix([var if var not in dup_vars else Dummy() for var
                                in self._qd])
 
-        # Derive dimesion terms
+        # Derive dimension terms
         l = len(self.f_c)
         m = len(self.f_v)
         n = len(self.q)

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -268,7 +268,7 @@ class ObstacleSetPathway(PathwayBase):
     ===========
 
     An obstacle-set pathway forms a series of straight-line segment between
-    pairs of consecutive points in a set of points. It is similiar to multiple
+    pairs of consecutive points in a set of points. It is similar to multiple
     linear pathways joined end-to-end. It will not interact with any other
     objects in the system, i.e. an ``ObstacleSetPathway`` will intersect other
     objects to ensure that the path between its pairs of points (its

--- a/sympy/physics/mechanics/tests/test_actuator.py
+++ b/sympy/physics/mechanics/tests/test_actuator.py
@@ -674,7 +674,7 @@ class NonSympifyable:
 
 class TestDuffingSpring:
     @pytest.fixture(autouse=True)
-    # Set up common vairables that will be used in multiple tests
+    # Set up common variables that will be used in multiple tests
     def _duffing_spring_fixture(self):
         self.linear_stiffness = Symbol('beta')
         self.nonlinear_stiffness = Symbol('alpha')
@@ -743,7 +743,7 @@ class TestDuffingSpring:
         ]
     )
 
-    # Check if DuffingSpring correctly inializes its attributes
+    # Check if DuffingSpring correctly initializes its attributes
     # It tests various combinations of linear & nonlinear stiffness, equilibriun length, and the resulting force expression
     def test_valid_constructor(
         self,

--- a/sympy/physics/mechanics/tests/test_lagrange2.py
+++ b/sympy/physics/mechanics/tests/test_lagrange2.py
@@ -4,10 +4,10 @@ from sympy.physics.mechanics import ReferenceFrame, Point, Particle
 from sympy.physics.mechanics import LagrangesMethod, Lagrangian
 
 ### This test asserts that a system with more than one external forces
-### is acurately formed with Lagrange method (see issue #8626)
+### is accurately formed with Lagrange method (see issue #8626)
 
 def test_lagrange_2forces():
-    ### Equations for two damped springs in serie with two forces
+    ### Equations for two damped springs in series with two forces
 
     ### generalized coordinates
     q1, q2 = dynamicsymbols('q1, q2')

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -138,7 +138,7 @@ def matrix_dagger(e):
     raise TypeError('Expected sympy/numpy/scipy.sparse matrix, got: %r' % e)
 
 
-# TODO: Move this into sympy.matricies.
+# TODO: Move this into sympy.matrices.
 def _sympy_tensor_product(*matrices):
     """Compute the kronecker product of a sequence of SymPy Matrices.
     """

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -1,4 +1,4 @@
-"""Quantum mechanical angular momemtum."""
+"""Quantum mechanical angular momentum."""
 
 from sympy.concrete.summations import Sum
 from sympy.core.add import Add

--- a/sympy/physics/quantum/tests/test_matrixutils.py
+++ b/sympy/physics/quantum/tests/test_matrixutils.py
@@ -48,7 +48,7 @@ def test_matrix_tensor_product():
         l3[i] = i
     vec = Matrix([1, 2, 3])
 
-    #test for Matrix known 4x4 matricies
+    #test for Matrix known 4x4 matrices
     numpyl1 = np.array(l1.tolist())
     numpyl2 = np.array(l2.tolist())
     numpy_product = np.kron(numpyl1, numpyl2)

--- a/sympy/physics/quantum/tests/test_sho1d.py
+++ b/sympy/physics/quantum/tests/test_sho1d.py
@@ -163,7 +163,7 @@ def test_sho_coherant_state():
     cstate = exp(-Abs(alpha)**2/S(2))*Sum(((alpha**p)/sqrt(factorial(p)))*SHOKet(p), (p,0,oo))
     # Projection onto the number eigenstate
     assert qapply(SHOBra(q)*cstate, sum_doit=True) == exp(-Abs(alpha)**2/S(2))*alpha**q/sqrt(factorial(q))
-    # Ensure that the coherent state is an eigenstate of anihilation operator
+    # Ensure that the coherent state is an eigenstate of annihilation operator
     assert simplify(qapply(SHOBra(q)*a*cstate, sum_doit=True)) == simplify(qapply(SHOBra(q)*alpha*cstate, sum_doit=True))
 
 def test_issue_26495():

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -238,11 +238,11 @@ def test_wavefunction():
     assert type(k.variables[0]) == Symbol
 
 def test_orthogonal_states():
-    braket = OrthogonalBra(x) * OrthogonalKet(x)
-    assert braket.doit() == 1
+    bracket = OrthogonalBra(x) * OrthogonalKet(x)
+    assert bracket.doit() == 1
 
-    braket = OrthogonalBra(x) * OrthogonalKet(x+1)
-    assert braket.doit() == 0
+    bracket = OrthogonalBra(x) * OrthogonalKet(x+1)
+    assert bracket.doit() == 0
 
-    braket = OrthogonalBra(x) * OrthogonalKet(y)
-    assert braket.doit() == braket
+    bracket = OrthogonalBra(x) * OrthogonalKet(y)
+    assert bracket.doit() == bracket

--- a/sympy/physics/quantum/transforms.py
+++ b/sympy/physics/quantum/transforms.py
@@ -179,7 +179,7 @@ def _transform_op_op(a, b):
 
 
 def _postprocess_state_mul(expr):
-    """Trasform a ``Mul`` of quantum expressions into canonical form.
+    """Transform a ``Mul`` of quantum expressions into canonical form.
 
     This function is registered ``_constructor_postprocessor_mapping`` as a
     transformer for ``Mul``. This means that every time a quantum expression

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -117,7 +117,7 @@ class Dimension(Expr):
 
     For example, in classical mechanics we know that time is different from
     temperature and dimensions make this difference (but they do not provide
-    any measure of these quantites.
+    any measure of these quantities.
 
         >>> from sympy.physics.units import Dimension
         >>> length = Dimension('length')

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -883,7 +883,7 @@ def real_gaunt(l_1, l_2, l_3, mu_1, mu_2, mu_3, prec=None):
     requirement that the sum of the `l_i` be even to yield a non-zero value.
     It also obeys the following symmetry rules:
 
-    - zero for `l_1`, `l_2`, `l_3` not fulfiling the condition
+    - zero for `l_1`, `l_2`, `l_3` not fulfilling the condition
       `l_1 \in \{l_{\text{max}}, l_{\text{max}}-2, \ldots, l_{\text{min}}\}`,
       where `l_{\text{max}} = l_2+l_3`,
 

--- a/sympy/plotting/series.py
+++ b/sympy/plotting/series.py
@@ -209,7 +209,7 @@ class BaseSeries:
         # line and surface series can show data with a colormap, hence a
         # colorbar is essential to understand the data. However, sometime it
         # is useful to hide it on series-by-series base. The following keyword
-        # controls wheter the series should show a colorbar or not.
+        # controls whether the series should show a colorbar or not.
         self.colorbar = kwargs.get("colorbar", True)
         # Some series might use a colormap as default coloring. Setting this
         # attribute to False will inform the backends to use solid color.
@@ -266,7 +266,7 @@ class BaseSeries:
         # this attribute will eventually contain a dictionary with the
         # discretized ranges
         self._discretized_domain = None
-        # wheter the series contains any interactive range, which is a range
+        # whether the series contains any interactive range, which is a range
         # where the minimum and maximum values can be changed with an
         # interactive widget
         self._interactive_ranges = False
@@ -301,7 +301,7 @@ class BaseSeries:
                 "expression.")
 
     def _check_fs(self):
-        """ Checks if there are enogh parameters and free symbols.
+        """ Checks if there are enough parameters and free symbols.
         """
         exprs, ranges = self.expr, self.ranges
         params, label = self.params, self.label
@@ -344,7 +344,7 @@ class BaseSeries:
             remaining_fs = fs.difference(params.keys())
             if len(remaining_fs) > 0:
                 raise ValueError(
-                    "Unkown symbols found in plotting range: %s. " % (r,) +
+                    "Unknown symbols found in plotting range: %s. " % (r,) +
                     "Are the following parameters? %s" % remaining_fs)
 
     def _create_lambda_func(self):
@@ -491,7 +491,7 @@ class BaseSeries:
 
     def _aggregate_args(self):
         """Create a list of arguments to be passed to the lambda function,
-        sorted accoring to self._signature.
+        sorted according to self._signature.
         """
         args = []
         for s in self._signature:
@@ -636,7 +636,7 @@ class BaseSeries:
 
         # if the expressions is a lambda function and no label has been
         # provided, then its better to do the following in order to avoid
-        # suprises on the backend
+        # surprises on the backend
         if any(callable(e) for e in exprs):
             if self._label == str(self.expr):
                 self.label = ""
@@ -769,7 +769,7 @@ class BaseSeries:
             # surface_color). For example:
             # p = plot(sin(x), line_color=lambda x, y: -y)
             # This creates a ColoredLineOver1DRangeSeries with line_color=None
-            # and color_func=lambda x, y: -y, which efffectively is a
+            # and color_func=lambda x, y: -y, which effectively is a
             # parametric series. Later we could change it to a string value:
             # p[0].line_color = "red"
             # However, this sets ine_color="red" and color_func=None, but the
@@ -959,7 +959,7 @@ def _detect_poles_symbolic_helper(expr, symb, start, end):
     Returns
     =======
     pole : list
-        List of symbolic poles, possibily empty.
+        List of symbolic poles, possibly empty.
     """
     poles = []
     interval = Interval(nsimplify(start), nsimplify(end))
@@ -1123,7 +1123,7 @@ class Line2DBaseSeries(BaseSeries):
 
     def _insert_exclusions(self, points):
         """Add NaN to each of the exclusion point. Practically, this adds a
-        NaN to the exlusion point, plus two other nearby points evaluated with
+        NaN to the exclusion point, plus two other nearby points evaluated with
         the numerical functions associated to this data series.
         These nearby points are important when the number of discretization
         points is low, or the scale is logarithm.
@@ -1141,7 +1141,7 @@ class Line2DBaseSeries(BaseSeries):
         k = n - 1
         if n == 2:
             k = 0
-        # indeces of the other coordinates
+        # indices of the other coordinates
         j_indeces = sorted(set(range(n)).difference([k]))
         # TODO: for now, I assume that numpy functions are going to succeed
         funcs = [f[0] for f in self._functions]
@@ -1513,7 +1513,7 @@ class ParametricLineBaseSeries(Line2DBaseSeries):
             self._latex_label = latex(self.expr)
         # if the expressions is a lambda function and use_cm=False and no label
         # has been provided, then its better to do the following in order to
-        # avoid suprises on the backend
+        # avoid surprises on the backend
         if any(callable(e) for e in self.expr) and (not self.use_cm):
             if self._label == str(self.expr):
                 self._label = ""
@@ -1825,7 +1825,7 @@ class SurfaceBaseSeries(BaseSeries):
         self._latex_label = latex(exprs) if label is None else label
         # if the expressions is a lambda function and no label
         # has been provided, then its better to do the following to avoid
-        # suprises on the backend
+        # surprises on the backend
         is_lambda = (callable(exprs) if not hasattr(exprs, "__iter__")
             else any(callable(e) for e in exprs))
         if is_lambda and (self._label == str(exprs)):
@@ -2163,7 +2163,7 @@ class GenericDataSeries(BaseSeries):
        ax.plot([0, 1, 2], [0, 1, -1], "*")
        fig
 
-    Which is far better in terms of readibility. Also, it gives access to the
+    Which is far better in terms of readability. Also, it gives access to the
     full plotting library capabilities, without the need to reinvent the wheel.
     """
     is_generic = True
@@ -2478,7 +2478,7 @@ class ImplicitSeries(BaseSeries):
             The rewritten expression
 
         equality : Boolean
-            Wheter the original expression was an Equality or not.
+            Whether the original expression was an Equality or not.
         """
         equality = False
         if isinstance(expr, Equality):

--- a/sympy/plotting/tests/test_series.py
+++ b/sympy/plotting/tests/test_series.py
@@ -1507,7 +1507,7 @@ def test_complex_params_number_eval():
     #       sum(blablabla for for n in range(1, m+1))
     # But range requires integer numbers, whereas per above example, the series
     # casts parameters to complex. Verify that the series is able to detect
-    # upper bounds in summations and cast it to int in order to get successfull
+    # upper bounds in summations and cast it to int in order to get successful
     # evaluation
     x, T, n, m = symbols("x, T, n, m")
     fs = S(1) / 2 - (1 / pi) * Sum(sin(2 * n * pi * x / T) / n, (n, 1, m))
@@ -1524,7 +1524,7 @@ def test_complex_params_number_eval():
 
 def test_complex_range_line_plot_1():
     # verify that univariate functions are evaluated with a complex
-    # data range (with zero imaginary part). There shouln't be any
+    # data range (with zero imaginary part). There shouldn't be any
     # NaN value in the output.
     if not np:
         skip("numpy not installed.")
@@ -1552,7 +1552,7 @@ def test_complex_range_line_plot_1():
 @XFAIL
 def test_complex_range_line_plot_2():
     # verify that univariate functions are evaluated with a complex
-    # data range (with non-zero imaginary part). There shouln't be any
+    # data range (with non-zero imaginary part). There shouldn't be any
     # NaN value in the output.
     if not np:
         skip("numpy not installed.")

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -112,7 +112,7 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
 
     @property
     def tp(self):
-        # XXX: Domain treats tp as an alis of dtype. Here we need to two
+        # XXX: Domain treats tp as an alias of dtype. Here we need to two
         # separate things: dtype is a callable to make/convert instances.
         # We use tp with isinstance to check if an object is an instance
         # of the domain already.

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -288,7 +288,7 @@ class DFM:
         return DDM.from_dok(dok, shape, domain).to_dfm()
 
     def iter_values(self):
-        """Iterater over the non-zero values of the matrix."""
+        """Iterate over the non-zero values of the matrix."""
         m, n = self.shape
         rep = self.rep
         for i in range(m):
@@ -702,7 +702,7 @@ class DFM:
     # XXX: The lu_solve function should be renamed to solve. Whether or not it
     # uses an LU decomposition is an implementation detail. A method called
     # lu_solve would make sense for a situation in which an LU decomposition is
-    # reused several times to solve iwth different rhs but that would imply a
+    # reused several times to solve with different rhs but that would imply a
     # different call signature.
     #
     # The underlying python-flint method has an algorithm= argument so we could

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -424,7 +424,7 @@ class DDM(list):
 
     def iter_values(self):
         """
-        Iterater over the non-zero values of the matrix.
+        Iterate over the non-zero values of the matrix.
 
         Examples
         ========

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -2187,7 +2187,7 @@ class DomainMatrix:
               for dense matrices or for matrices with simple denominators.
 
             - ``A.rref(method='CD')`` clears the denominators before using
-              fraction-free Gauss-Jordan elimination in the assoicated ring.
+              fraction-free Gauss-Jordan elimination in the associated ring.
               This is most efficient for dense matrices with very simple
               denominators.
 
@@ -2272,7 +2272,7 @@ class DomainMatrix:
               simple denominators.
 
             - ``A.rref(method='CD')`` clears denominators before using
-              fraction-free Gauss-Jordan elimination in the assoicated ring.
+              fraction-free Gauss-Jordan elimination in the associated ring.
               The result will be converted back to the original domain unless
               ``keep_domain=False`` is passed in which case the result will be
               over the ring used for elimination. This is most efficient for

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1529,7 +1529,7 @@ def sdm_matmul_exraw(A, B, K, m, o):
     #
     # Like sdm_matmul above except that:
     #
-    # - Handles cases like 0*oo -> nan (sdm_matmul skips multipication by zero)
+    # - Handles cases like 0*oo -> nan (sdm_matmul skips multiplication by zero)
     # - Uses K.sum (Add(*items)) for efficient addition of Expr
     #
     zero = K.zero

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -4,7 +4,7 @@
 # These three types are supposed to be interchangeable, so we should use the
 # same tests for all of them for the most part.
 #
-# The tests here cover the basic part of the inerface that the three types
+# The tests here cover the basic part of the interface that the three types
 # should expose and that DomainMatrix should mostly rely on.
 #
 # More in-depth tests of the heavier algorithms like rref etc should go in

--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -2141,7 +2141,7 @@ def func_field_modgcd(f, g):
     This is done by calculating the GCD in
     `\mathbb{Z}_p(x_1, \ldots, x_{n-1})[z]/(\check m_{\alpha}(z))[x_0]` for
     suitable primes `p` and then reconstructing the coefficients with the
-    Chinese Remainder Theorem and Rational Reconstuction. The GCD over
+    Chinese Remainder Theorem and Rational Reconstruction. The GCD over
     `\mathbb{Z}_p(x_1, \ldots, x_{n-1})[z]/(\check m_{\alpha}(z))[x_0]` is
     computed with a recursive subroutine, which evaluates the polynomials at
     `x_{n-1} = a` for suitable evaluation points `a \in \mathbb Z_p` and

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1776,7 +1776,7 @@ def rs_hadamard_exp(p1, inverse=False):
     Return ``sum f_i/i!*x**i`` from ``sum f_i*x**i``,
     where ``x`` is the first variable.
 
-    If ``invers=True`` return ``sum f_i*i!*x**i``
+    If ``inverse=True`` return ``sum f_i*i!*x**i``
 
     Examples
     ========

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2708,7 +2708,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> g = 2*x + 2
         >>> f.prem(g) # first generator is chosen by default if it is not given
         -4*y + 4
-        >>> f.rem(g) # shows the differnce between prem and rem
+        >>> f.rem(g) # shows the difference between prem and rem
         x**2 + x*y
         >>> f.prem(g, y) # generator is given
         0
@@ -2928,7 +2928,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         >>> h = 2*x + 2
         >>> f.pexquo(g)
         2*x
-        >>> f.exquo(g) # shows the differnce between pexquo and exquo
+        >>> f.exquo(g) # shows the difference between pexquo and exquo
         Traceback (most recent call last):
         ...
         ExactQuotientFailed: 2*x + 2*y does not divide x**2 + x*y

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1062,7 +1062,7 @@ CRootOf = ComplexRootOf
 
 @dispatch(ComplexRootOf, ComplexRootOf)
 def _eval_is_eq(lhs, rhs): # noqa:F811
-    # if we use is_eq to check here, we get infinite recurion
+    # if we use is_eq to check here, we get infinite recursion
     return lhs == rhs
 
 

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -622,7 +622,7 @@ def dmp_sqf_list(f, u, K, all=False):
     Explanation
     ===========
 
-    Uses Yun's algorithm for univariate polynomials from [Yun76]_ recrusively.
+    Uses Yun's algorithm for univariate polynomials from [Yun76]_ recursively.
     The multivariate polynomial is treated as a univariate polynomial in its
     leading variable. Then Yun's algorithm computes the square-free
     factorization of the primitive and the content is factored recursively.

--- a/sympy/polys/tests/test_dispersion.py
+++ b/sympy/polys/tests/test_dispersion.py
@@ -55,7 +55,7 @@ def test_dispersion():
     assert sorted(dispersionset(gp, fp)) == [1, 4]
 
     # There are some difficulties if we compute over Z[a]
-    # and alpha happenes to lie in Z[a] instead of simply Z.
+    # and alpha happens to lie in Z[a] instead of simply Z.
     # Hence we can not decide if alpha is indeed integral
     # in general.
 

--- a/sympy/polys/tests/test_modulargcd.py
+++ b/sympy/polys/tests/test_modulargcd.py
@@ -314,7 +314,7 @@ def test_modgcd_algebraic_field():
     assert func_field_modgcd(f, g) == (A.one, f, g)
 
 
-# when func_field_modgcd suppors function fields, this test can be changed
+# when func_field_modgcd supports function fields, this test can be changed
 def test_modgcd_func_field():
     D, t = ring("t", ZZ)
     R, x, z = ring("x, z", D)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -468,7 +468,7 @@ class CodePrinter(StrPrinter):
         obj, *wrt_order_pairs = expr.args
         for func_arg in obj.args:
             if not func_arg.is_Symbol:
-                raise ValueError("%s._print_Derivative(...) only supports functions with symobls as arguments." %
+                raise ValueError("%s._print_Derivative(...) only supports functions with symbols as arguments." %
                                  self.__class__.__name__)
         meth_name = '_print_Derivative_%s' % obj.func.__name__
         pmeth = getattr(self, meth_name, None)

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -165,7 +165,7 @@ class AbstractPythonCodePrinter(CodePrinter):
 
     def _expand_reduce_binary_op(self, op, args):
         """
-        This method expands a reductin on binary operations.
+        This method expands a reduction on binary operations.
 
         Notice: this is NOT the same as ``functools.reduce``.
 

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -71,13 +71,13 @@ def tree(node, assumptions=True):
     Parameters
     ==========
 
-    asssumptions : bool, optional
+    assumptions : bool, optional
         The flag to decide whether to print out all the assumption data
         (such as ``is_integer`, ``is_real``) associated with the
         expression or not.
 
         Enabling the flag makes the result verbose, and the printed
-        result may not be determinisitic because of the randomness used
+        result may not be deterministic because of the randomness used
         in backtracing the assumptions.
 
     See Also
@@ -100,13 +100,13 @@ def print_tree(node, assumptions=True):
     Parameters
     ==========
 
-    asssumptions : bool, optional
+    assumptions : bool, optional
         The flag to decide whether to print out all the assumption data
         (such as ``is_integer`, ``is_real``) associated with the
         expression or not.
 
         Enabling the flag makes the result verbose, and the printed
-        result may not be determinisitic because of the randomness used
+        result may not be deterministic because of the randomness used
         in backtracing the assumptions.
 
     Examples

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -395,7 +395,7 @@ def test_fps__logarithmic_singularity():
 
 @XFAIL
 def test_fps__logarithmic_singularity_fail():
-    f = asech(x)  # Algorithms for computing limits probably needs improvemnts
+    f = asech(x)  # Algorithms for computing limits probably needs improvements
     assert fps(f, x) == log(2) - log(x) - x**2/4 - 3*x**4/64 + O(x**6)
 
 

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -181,7 +181,7 @@ def _sqrt_match(p):
                         rv.append(x)
                 b = Mul._from_args(bv)
                 r = Mul._from_args(rv)
-            # collect terms comtaining r
+            # collect terms containing r
             a1 = []
             b1 = [b]
             for x in v:

--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -155,7 +155,7 @@ def _lambert(eq, x):
 
     # There are infinitely many branches for LambertW
     # but only branches for k = -1 and 0 might be real. The k = 0
-    # branch is real and the k = -1 branch is real if the LambertW argumen
+    # branch is real and the k = -1 branch is real if the LambertW argument
     # in in range [-1/e, 0]. Since `solve` does not return infinite
     # solutions we will only include the -1 branch if it tests as real.
     # Otherwise, inclusion of any LambertW in the solution indicates to

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -3839,7 +3839,7 @@ def power_representation(n, p, k, zeros=False):
                 '''Todd G. Will, "When Is n^2 a Sum of k Squares?", [online].
                 Available: https://www.maa.org/sites/default/files/Will-MMz-201037918.pdf'''
                 return
-            # quick tests since feasibility includes the possiblity of 0
+            # quick tests since feasibility includes the possibility of 0
             if k == 4 and (n in (1, 3, 5, 9, 11, 17, 29, 41) or remove(n, 4)[0] in (2, 6, 14)):
                 # A000534
                 return

--- a/sympy/solvers/ode/hypergeometric.py
+++ b/sympy/solvers/ode/hypergeometric.py
@@ -144,10 +144,10 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func):
     beta = Wild("beta")
     gamma = Wild("gamma")
     delta = Wild("delta")
-    # I0 of the standerd 2F1 equation.
+    # I0 of the standard 2F1 equation.
     I0 = ((a-b+1)*(a-b-1)*x**2 + 2*((1-a-b)*c + 2*a*b)*x + c*(c-2))/(4*x**2*(x-1)**2)
     if sing_point != [0, 1]:
-        # If singular point is [0, 1] then we have standerd equation.
+        # If singular point is [0, 1] then we have standard equation.
         eqs = []
         sing_eqs = [-beta/alpha, -delta/gamma, (delta-beta)/(alpha-gamma)]
         # making equations for the finding the mobius transformation
@@ -179,14 +179,14 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func):
     I = factor(I)
     dict_I = {x**2:0, x:0, 1:0}
     I0_num, I0_dem = I0.as_numer_denom()
-    # collecting coeff of (x**2, x), of the standerd equation.
+    # collecting coeff of (x**2, x), of the standard equation.
     # substituting (a-b) = s, (a+b) = r
     dict_I0 = {x**2:s**2 - 1, x:(2*(1-r)*c + (r+s)*(r-s)), 1:c*(c-2)}
     # collecting coeff of (x**2, x) from I0 of the given equation.
     dict_I.update(collect(expand(cancel(I*I0_dem)), [x**2, x], evaluate=False))
     eqs = []
     # We are comparing the coeff of powers of different x, for finding the values of
-    # parameters of standerd equation.
+    # parameters of standard equation.
     for key in [x**2, x, 1]:
         eqs.append(Eq(dict_I[key], dict_I0[key]))
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -2749,12 +2749,12 @@ class SecondLinearBessel(SingleODESolver):
             if coeff1 is None:
                 return False
             # c3 maybe of very complex form so I am simply checking (a - b) form
-            # if yes later I will match with the standerd form of bessel in a and b
+            # if yes later I will match with the standard form of bessel in a and b
             # a, b are wild variable defined above.
             _coeff2 = expand(r[c3]).match(a - b)
             if _coeff2 is None:
                 return False
-            # matching with standerd form for c3
+            # matching with standard form for c3
             coeff2 = factor(_coeff2[a]).match(c4**2*(x)**(2*a4))
             if coeff2 is None:
                 return False

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -15,7 +15,7 @@ indicate otherwise.
 
 Errors that might be raised are UnboundedLPError when there is no
 finite solution for the system or InfeasibleLPError when the
-constraints represent impossible conditions (i.e. a non-existant
+constraints represent impossible conditions (i.e. a non-existent
  simplex).
 
 Here is a simple 1-D system: minimize `x` given that ``x >= 1``.
@@ -76,7 +76,7 @@ from sympy.utilities.misc import filldedent
 
 class UnboundedLPError(Exception):
     """
-    A linear programing problem is said to be unbounded if its objective
+    A linear programming problem is said to be unbounded if its objective
     function can assume arbitrarily large values.
 
     Example
@@ -95,9 +95,9 @@ class UnboundedLPError(Exception):
 
 class InfeasibleLPError(Exception):
     """
-    A linear programing problem is considered infeasible if its
+    A linear programming problem is considered infeasible if its
     constraint set is empty. That is, if the set of all vectors
-    satisfying the contraints is empty, then the problem is infeasible.
+    satisfying the constraints is empty, then the problem is infeasible.
 
     Example
     =======
@@ -234,7 +234,7 @@ def _simplex(A, B, C, D=None, dual=False):
     >>> [i <= j for i, j in zip(a*y,b)]
     [2*y <= 1, y <= 1]
 
-    In this 1-dimensional dual system, the more restrictive contraint is
+    In this 1-dimensional dual system, the more restrictive constraint is
     the first which limits ``y`` between 0 and 1/2 and the maximum of
     ``F`` is attained at the nonzero value, hence is ``4*(1/2) + 1 = 3``.
 
@@ -827,7 +827,7 @@ def lpmin(f, constr):
     (1/3, {x: 1/3, y: 5/9})
 
     Negative values for variables are permitted unless explicitly
-    exluding, so minimizing ``x`` for ``x <= 3`` is an
+    excluding, so minimizing ``x`` for ``x <= 3`` is an
     unbounded problem while the following has a bounded solution:
 
     >>> lpmin(x, [x >= 0, x <= 3])
@@ -865,7 +865,7 @@ def lpmax(f, constr):
     (4/5, {x: 4/5, y: 2/5})
 
     Negative values for variables are permitted unless explicitly
-    exluding:
+    excluding:
 
     >>> lpmax(x, [x <= -1])
     (-1, {x: -1})
@@ -886,7 +886,7 @@ def lpmax(f, constr):
 
 
 def _handle_bounds(bounds):
-    # introduce auxilliary variables as needed for univariate
+    # introduce auxiliary variables as needed for univariate
     # inequalities
 
     def _make_list(length: int, index_value_pairs):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -797,7 +797,7 @@ def solve(f, *symbols, **flags):
             Allows ``solve`` to return a solution for a pattern in terms of
             other functions that contain that pattern; this is only
             needed if the pattern is inside of some invertible function
-            like cos, exp, ect.
+            like cos, exp, etc.
         particular=True (default is False)
             Instructs ``solve`` to try to find a particular solution to
             a linear system with as many zeros as possible; this is very
@@ -1791,7 +1791,7 @@ def _solve_system(exprs, symbols, **flags):
                 if not isinstance(subsol, list):
                     subsol = [subsol]
                 subsols.append(subsol)
-            # Full solution is cartesion product of subsystems
+            # Full solution is cartesian product of subsystems
             sols = []
             for soldicts in product(*subsols):
                 sols.append(dict(item for sd in soldicts

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -195,7 +195,7 @@ def _invert(f_x, y, x, domain=S.Complexes):
     # "Fancier" solution sets like those obtained by inversion of trigonometric
     # functions already include general validity conditions (i.e. conditions on
     # the domain of the respective inverse functions), so we should avoid adding
-    # blanket intesections with S.Reals. But subsets of R (or C) must still be
+    # blanket intersections with S.Reals. But subsets of R (or C) must still be
     # accounted for.
     if domain is S.Reals:
         return x1, s

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -637,7 +637,7 @@ def test_solve_transcendental():
     # issue 15325
     assert solve(y**(1/x) - z, x) == [log(y)/log(z)]
 
-    # issue 25685 (basic trig identies should give simple solutions)
+    # issue 25685 (basic trig identities should give simple solutions)
     for yi in [cos(2*x),sin(2*x),cos(x - pi/3)]:
         sol = solve([cos(x) - S(3)/5, yi - y])
         assert (sol[0][y] + sol[1][y]).is_Rational, (yi,sol)

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -104,7 +104,7 @@ std = standard_deviation
 
 def entropy(expr, condition=None, **kwargs):
     """
-    Calculuates entropy of a probability distribution.
+    Calculates entropy of a probability distribution.
 
     Parameters
     ==========
@@ -390,7 +390,7 @@ def factorial_moment(X, n, condition=None, **kwargs):
 
 def median(X, evaluate=True, **kwargs):
     r"""
-    Calculuates the median of the probability distribution.
+    Calculates the median of the probability distribution.
 
     Explanation
     ===========

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1333,7 +1333,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         This means that state 2 is the only absorbing state
         (since A is a 1x1 matrix). B is a 4x1 matrix since
-        the 4 remaining transient states all merge into reccurent
+        the 4 remaining transient states all merge into recurrent
         state 2. And C is the 4x4 matrix that shows how the
         transient states 0, 1, 3, 4 all interact.
 

--- a/sympy/strategies/rl.py
+++ b/sympy/strategies/rl.py
@@ -20,7 +20,7 @@ def rm_id(isid, new=new):
     >>> remove_zeros = rm_id(lambda x: x==0)
     >>> remove_zeros(Basic(S(1), S(0), S(2)))
     Basic(1, 2)
-    >>> remove_zeros(Basic(S(0), S(0))) # If only identites then we keep one
+    >>> remove_zeros(Basic(S(0), S(0))) # If only identities then we keep one
     Basic(0)
 
     See Also:

--- a/sympy/testing/runtests_pytest.py
+++ b/sympy/testing/runtests_pytest.py
@@ -8,7 +8,7 @@ SymPy historically had its own testing framework that aimed to:
 - have no magic, just import the test file and execute the test functions; and
 - be portable.
 
-To reduce the maintence burden of developing an independent testing framework
+To reduce the maintenance burden of developing an independent testing framework
 and to leverage the benefits of existing Python testing infrastructure, SymPy
 now uses pytest (and various of its plugins) to run the test suite.
 
@@ -252,7 +252,7 @@ def test(*paths, subprocess=True, rerun=0, **kwargs):
 
     Note that a `pytest.ExitCode`, which is an `enum`, is returned. This is
     different to the legacy SymPy test runner which would return a `bool`. If
-    all tests sucessfully pass the `pytest.ExitCode.OK` with value `0` is
+    all tests successfully pass the `pytest.ExitCode.OK` with value `0` is
     returned, whereas the legacy SymPy test runner would return `True`. In any
     other scenario, a non-zero `enum` value is returned, whereas the legacy
     SymPy test runner would return `False`. Users need to, therefore, be careful

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -65,7 +65,7 @@ def make_dirs(path):
 
 def missing_or_other_newer(path, other_path, cwd=None):
     """
-    Investigate if path is non-existant or older than provided reference
+    Investigate if path is non-existent or older than provided reference
     path.
 
     Parameters
@@ -87,7 +87,7 @@ def missing_or_other_newer(path, other_path, cwd=None):
     if not os.path.exists(path):
         return True
     if os.path.getmtime(other_path) - 1e-6 >= os.path.getmtime(path):
-        # 1e-6 is needed beacuse http://stackoverflow.com/questions/17086426/
+        # 1e-6 is needed because http://stackoverflow.com/questions/17086426/
         return True
     return False
 
@@ -126,7 +126,7 @@ def copy(src, dst, only_update=False, copystat=True, cwd=None,
         if not os.path.isabs(dst):
             dst = os.path.join(cwd, dst)
 
-    if not os.path.exists(src):  # Make sure source file extists
+    if not os.path.exists(src):  # Make sure source file exists
         raise FileNotFoundError("Source: `{}` does not exist".format(src))
 
     # We accept both (re)naming destination file _or_

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1331,7 +1331,7 @@ class _TensorflowEvaluatorPrinter(_EvaluatorPrinter):
     def _print_unpacking(self, lvalues, rvalue):
         """Generate argument unpacking code.
 
-        This method is used when the input value is not interable,
+        This method is used when the input value is not iterable,
         but can be indexed (see issue #14655).
         """
 

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -180,7 +180,7 @@ def _(obj, parameters=('t', 's')):
     bounds = []
 
     for i in range(len(obj.variables) - 1):
-        # Each parameter is replaced by its tangent to simplify intergation
+        # Each parameter is replaced by its tangent to simplify integration
         parameter = _symbol(parameters[i], real=True)
         definition = [trigsimp(elem.subs(parameter, tan(parameter/2))) for elem in definition]
         bounds.append((parameter, 0, 2*pi),)

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -124,7 +124,7 @@ class Vector(BasisDependent):
 
         ``True``, ``False`` or ``None``. A return value of ``True`` indicates
         that the two vectors are identically equal. A return value of ``False``
-        indictes that they are not. In some cases it is not possible to
+        indicates that they are not. In some cases it is not possible to
         determine if the two vectors are identically equal and ``None`` is
         returned.
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
The typo "Recommenation" should be corrected to "Recommendation," but I wasn't sure if it was okay to make this correction.

https://github.com/sympy/sympy/blob/ba9d0f610617b919c657187aad12bef73866ba3c/sympy/utilities/mathml/data/mmlctop.xsl#L6-L8

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
