### PR TITLE
RingSeries: Hyperbolic Trigonometric Functions (sinh, cosh, tanh) added to rs_series.

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -51,7 +51,8 @@ from mpmath.libmp.libintmath import ifac
 from sympy.core import PoleError, Function, Expr
 from sympy.core.numbers import Rational
 from sympy.core.intfunc import igcd
-from sympy.functions import sin, cos, tan, atan, exp, atanh, tanh, log, ceiling
+from sympy.functions import (sin, cos, tan, atan, exp, atanh, tanh, log, ceiling,
+                             sinh, cosh)
 from sympy.utilities.misc import as_int
 from mpmath.libmp.libintmath import giant_steps
 import math
@@ -1643,6 +1644,34 @@ def rs_sinh(p, x, prec):
     """
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_sinh, p, x, prec)
+    R = p.ring
+    if not p:
+        return R(0)
+    c = _get_constant_term(p, x)
+    if c:
+        if R.domain is EX:
+            c_expr = c.as_expr()
+            t1, t2 = sinh(c_expr), cosh(c_expr)
+        elif isinstance(c, PolyElement):
+            try:
+                c_expr = c.as_expr()
+                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+            except ValueError:
+                R = R.add_gens([sinh(c_expr), cosh(c_expr)])
+                p = p.set_ring(R)
+                x = x.set_ring(R)
+                c = c.set_ring(R)
+                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+        else:
+            try:
+                t1, t2 = R(sinh(c)), R(cosh(c))
+            except ValueError:
+                raise DomainError("The given series cannot be expanded in "
+                                  "this domain.")
+
+        p1 = p - c
+        return rs_sinh(p1, x, prec) * t2 + rs_cosh(p1, x, prec) * t1
+
     t = rs_exp(p, x, prec)
     t1 = rs_series_inversion(t, x, prec)
     return (t - t1)/2
@@ -1670,6 +1699,32 @@ def rs_cosh(p, x, prec):
     """
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_cosh, p, x, prec)
+    R = p.ring
+    c = _get_constant_term(p, x)
+    if c:
+        if R.domain is EX:
+            c_expr = c.as_expr()
+            t1, t2 = sinh(c_expr), cosh(c_expr)
+        elif isinstance(c, PolyElement):
+            try:
+                c_expr = c.as_expr()
+                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+            except ValueError:
+                R = R.add_gens([sinh(c_expr), cosh(c_expr)])
+                p = p.set_ring(R)
+                x = x.set_ring(R)
+                c = c.set_ring(R)
+                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+        else:
+            try:
+                t1, t2 = R(sinh(c)), R(cosh(c))
+            except ValueError:
+                raise DomainError("The given series cannot be expanded in "
+                                  "this domain.")
+
+        p1 = p - c
+        return rs_cosh(p1, x, prec) * t2 + rs_sinh(p1, x, prec) * t1
+
     t = rs_exp(p, x, prec)
     t1 = rs_series_inversion(t, x, prec)
     return (t + t1)/2
@@ -1720,9 +1775,8 @@ def rs_tanh(p, x, prec):
         return rs_puiseux(rs_tanh, p, x, prec)
     R = p.ring
     const = 0
-    if _has_constant_term(p, x):
-        zm = R.zero_monom
-        c = p[zm]
+    c = _get_constant_term(p, x)
+    if c:
         if R.domain is EX:
             c_expr = c.as_expr()
             const = tanh(c_expr)
@@ -1731,8 +1785,11 @@ def rs_tanh(p, x, prec):
                 c_expr = c.as_expr()
                 const = R(tanh(c_expr))
             except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+                R = R.add_gens([tanh(c_expr)])
+                p = p.set_ring(R)
+                x = x.set_ring(R)
+                c = c.set_ring(R)
+                const = R(tanh(c_expr))
         else:
             try:
                 const = R(tanh(c))
@@ -1858,7 +1915,10 @@ _convert_func = {
         'exp': 'rs_exp',
         'tan': 'rs_tan',
         'log': 'rs_log',
-        'atan': 'rs_atan'
+        'atan': 'rs_atan',
+        'sinh': 'rs_sinh',
+        'cosh': 'rs_cosh',
+        'tanh': 'rs_tanh'
         }
 
 def rs_min_pow(expr, series_rs, a):

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -9,7 +9,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
 from sympy.testing.pytest import raises, slow
 from sympy.core.symbol import symbols
-from sympy.functions import (sin, cos, exp, tan, cot, atan, atanh,
+from sympy.functions import (sin, cos, exp, tan, cot, sinh, cosh, atan, atanh,
     tanh, log, sqrt)
 from sympy.core.numbers import Rational, pi
 from sympy.core import expand, S
@@ -652,6 +652,21 @@ def test_rs_series_ConstantInExpr():
     assert rs_series(atan(1 + x * a), x, 9).as_expr() == -a**7*x**7/112 + a**6*x**6/48 \
            - a**5*x**5/40 + a**3*x**3/12 - a**2*x**2/4 + a*x/2 + pi/4
 
+    assert rs_series(tanh(1 + x), x, 5).as_expr() == -5*x**4*tanh(1)**3/3 + x**4* \
+           tanh(1)**5 + 2*x**4*tanh(1)/3 - x**3*tanh(1)**4 - x**3/3 + 4*x**3*tanh(1) \
+           **2/3 - x**2*tanh(1) + x**2*tanh(1)**3 - x*tanh(1)**2 + x + tanh(1)
+    assert rs_series(tanh(1 + x * a), x, 3).as_expr() == -a**2*x**2*tanh(1) + a**2*x** \
+           2*tanh(1)**3 - a*x*tanh(1)**2 + a*x + tanh(1)
+
+    assert rs_series(sinh(1 + x), x, 5).as_expr() == x**4*sinh(1)/24 + x**3*cosh(1)/6 + \
+           x**2*sinh(1)/2 + x*cosh(1) + sinh(1)
+    assert rs_series(sinh(1 + x * a), x, 5).as_expr() == a**4*x**4*sinh(1)/24 + \
+           a**3*x**3*cosh(1)/6 + a**2*x**2*sinh(1)/2 + a*x*cosh(1) + sinh(1)
+
+    assert rs_series(cosh(1 + x), x, 5).as_expr() == x**4*cosh(1)/24 + x**3*sinh(1)/6 + \
+           x**2*cosh(1)/2 + x*sinh(1) + cosh(1)
+    assert rs_series(cosh(1 + x * a), x, 5).as_expr() == a**4*x**4*cosh(1)/24 + \
+           a**3*x**3*sinh(1)/6 + a**2*x**2*cosh(1)/2 + a*x*sinh(1) + cosh(1)
 
 def test_issue():
     # https://github.com/sympy/sympy/issues/10191


### PR DESCRIPTION

### Brief description of what is fixed or changed

Hyperbolic trigonometric functions `(sinh, cosh, tanh)` can now be directly expanded using `rs_series`. This update also addresses handling `constant terms` in function expressions

Example
```python
>>> from sympy import  sinh, symbols
>>> from sympy.polys.ring_series import rs_series
>>> x = symbols('x')
>>> rs_series(sinh(1 + x), x, 5).as_expr()
>>> x**4*sinh(1)/24 + x**3*cosh(1)/6 + x**2*sinh(1)/2 + x*cosh(1) + sinh(1)
```

### Other comments
With this change, only asin, atanh, and asinh remain to be implemented in rs_series.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
