### PR TITLE
`_check_smoothness` has been modified to return a vector and `num`

### DIFF
--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -55,9 +55,8 @@ def test_qs_2() -> None:
     sieve_array = _gen_sieve_array(M, factor_base)
     assert sieve_array[0:5] == [8424, 13603, 1835, 5335, 710]
 
-    assert _check_smoothness(9645, factor_base) == (5, False)
-    assert _check_smoothness(210313, factor_base)[0] == 20992
-    assert _check_smoothness(210313, factor_base)[1]
+    assert _check_smoothness(9645, factor_base) == (36028797018963972, 5)
+    assert _check_smoothness(210313, factor_base) == (20992, 1)
 
     partial_relations: dict[int, tuple[int, int]] = {}
     smooth_relation, proper_factor = _trial_division_stage(
@@ -65,10 +64,10 @@ def test_qs_2() -> None:
         ERROR_TERM=25*2**10)
 
     assert partial_relations == {
-        8699: (440, -10009008507),
-        166741: (490, -10008962007),
-        131449: (530, -10008921207),
-        6653: (550, -10008899607)
+        8699: (440, -10009008507, 75557863761098695507973),
+        166741: (490, -10008962007, 524341),
+        131449: (530, -10008921207, 664613997892457936451903530140172325),
+        6653: (550, -10008899607, 19342813113834066795307021)
     }
     assert [smooth_relation[i][0] for i in range(5)] == [
         -250, 1064469, 72819, 231957, 44167]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27636

#### Brief description of what is fixed or changed
In `_check_smoothness`, depending on the value of `num`, it returns either a pair of a vector and `True`, a pair of `num` and `False`, or a pair of `None` and `None`. It would be clearer to simply return the vector and `num` and handle the branching in `_trial_division_stage`. In fact, the current code already performs branching based on the return value, making it redundant.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
