### PR TITLE
fix(euler): Use mpmath for complex Float evaluation

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1127,6 +1127,16 @@ class euler(DefinedFunction):
                 return Integer(res)
         # Euler polynomials
         elif n.is_Number:
+            from sympy.core.evalf import pure_complex
+            n = int(n)
+            reim = pure_complex(x, or_real=True)
+            if reim and all(a.is_Float or a.is_Integer for a in reim) \
+                    and any(a.is_Float for a in reim):
+                from mpmath import mp
+                prec = min([a._prec for a in reim if a.is_Float])
+                with workprec(prec):
+                    res = mp.eulerpoly(n, x)
+                return Expr._from_mpmath(res, prec)
             return euler_poly(n, x)
 
     def _eval_rewrite_as_Sum(self, n, x=None, **kwargs):

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -426,6 +426,9 @@ def test_euler_polynomials():
     A = Float('-0.46237208575048694923364757452876131e8')  # from Maple
     B = euler(19, S.Pi).evalf(32)
     assert abs((A - B)/A) < 1e-31
+    z = Float(0.1) + Float(0.2)*I
+    expected = Float(-3126.54721663773 ) + Float(565.736261497056) * I
+    assert abs(euler(13, z) - expected) < 1e-10
 
 
 def test_euler_polynomial_rewrite():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
FIX:#24156
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously, euler(n, x) returned a symbolic expression for complex Float inputs.
After commit [6cdecdc1](https://github.com/sympy/sympy/commit/6cdecdc1f454afb854c0b546034a012433dafba7), it started returning results like:
```
>>> z = Float(0.1) + Float(0.2)*I
>>> euler(13, z)
-5461/2 - 1287*(0.1 + 0.2*I)**8/2 + 143*(0.1 + 0.2*I)**10/2 - 13*(0.1 + 0.2*I)**12/2 + (0.1 + 0.2*I)**13 + 7293*(0.1 + 0.2*I)**6/2 - 22165*(0.1 + 0.2*I)**4/2 + 26949*(0.1 + 0.2*I)**2/2
```
After my fix, I restored the removed numerical evaluation, making the function return a fully simplified numerical result again:
```
>>> z = Float(0.1) + Float(0.2)*I
>>> euler(13, z)
-3126.54721663773 + 565.736261497056*I

```

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
