### PR TITLE
Fix periodic inequalities in solveset by lifting one-period solution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -874,6 +874,7 @@ Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
+Khalid Bagus <khalidbagus@gmail.com> khalidbagus <113655600+khalidbagus@users.noreply.github.com>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>


### PR DESCRIPTION
This PR fixes an issue where periodic inequalities (e.g. sin(x) > 0) were solved only over a single period. Instead of adding a period multiple directly to an interval (which caused a TypeError), the solution now translates the interval endpoints using an ImageSet. This preserves the current one-period solving behavior and “lifts” the solution over ℝ by shifting the base interval appropriately.

For example, the output of `solveset(sin(x) > 0, x, domain=S.Reals)` would be:
```
{(2nπ,2nπ+π)∣n∈Z}
```

Which in LaTeX format:

``` LaTeX
$\displaystyle \left\{\left(2 n \pi, 2 n \pi + \pi\right)\; \middle|\; n \in \mathbb{Z}\right\}$
````

Fixes: #27573
See also: [GitHub issue discussion](https://github.com/sympy/sympy/issues/27573)

---

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed periodic inequalities in solveset by lifting the one-period solution via ImageSet.
<!-- END RELEASE NOTES -->