### PR TITLE
Enable complex number support in `eval_zeta_function`

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -17,6 +17,7 @@ from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Wild, Symbol, symbols
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.combinatorial.numbers import bernoulli, harmonic
+from sympy.functions.elementary.complexes import re
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import cot, csc
@@ -24,7 +25,7 @@ from sympy.functions.special.hyper import hyper
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.functions.special.zeta_functions import zeta
 from sympy.integrals.integrals import Integral
-from sympy.logic.boolalg import And
+from sympy.logic.boolalg import And, Not
 from sympy.polys.partfrac import apart
 from sympy.polys.polyerrors import PolynomialError, PolificationFailed
 from sympy.polys.polytools import parallel_poly_from_expr, Poly, factor
@@ -32,6 +33,7 @@ from sympy.polys.rationaltools import together
 from sympy.series.limitseq import limit_seq
 from sympy.series.order import O
 from sympy.series.residues import residue
+from sympy.sets.contains import Contains
 from sympy.sets.sets import FiniteSet, Interval
 from sympy.utilities.iterables import sift
 import itertools
@@ -277,13 +279,16 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         zeta function does not converge unless `s > 1` and `q > 0`
         """
         i, a, b = limits
+        if b is not S.Infinity:
+            return
         w, y, z = Wild('w', exclude=[i]), Wild('y', exclude=[i]), Wild('z', exclude=[i])
-        result = f.match((w * i + y) ** (-z))
-        if result is not None and b is S.Infinity:
+        if result := f.match((w * i + y) ** (-z)):
             coeff = 1 / result[w] ** result[z]
             s = result[z]
             q = result[y] / result[w] + a
-            return Piecewise((coeff * zeta(s, q), And(q > 0, s > 1)), (self, True))
+            return Piecewise((coeff * zeta(s, q),
+                              And(Not(Contains(-q, S.Naturals0)), re(s) > S.One)),
+                             (self, True))
 
     def _eval_derivative(self, x):
         """

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -16,7 +16,7 @@ from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import (rf, binomial, factorial)
 from sympy.functions.combinatorial.numbers import harmonic
-from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.complexes import Abs, re
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (sinh, tanh)
 from sympy.functions.elementary.integers import floor
@@ -32,6 +32,7 @@ from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
 from sympy.matrices import (Matrix, SparseMatrix,
     ImmutableDenseMatrix, ImmutableSparseMatrix, diag)
+from sympy.sets.contains import Contains
 from sympy.sets.fancysets import Range
 from sympy.sets.sets import Interval
 from sympy.simplify.combsimp import combsimp
@@ -636,18 +637,21 @@ def test_Sum_doit():
                     (0, True)), (n, 1, nmax))
 
     q, s = symbols('q, s')
-    assert summation(1/n**(2*s), (n, 1, oo)) == Piecewise((zeta(2*s), 2*s > 1),
+    assert summation(1/n**(2*s), (n, 1, oo)) == Piecewise((zeta(2*s), 2*re(s) > 1),
         (Sum(n**(-2*s), (n, 1, oo)), True))
-    assert summation(1/(n+1)**s, (n, 0, oo)) == Piecewise((zeta(s), s > 1),
+    assert summation(1/(n+1)**s, (n, 0, oo)) == Piecewise((zeta(s), re(s) > 1),
         (Sum((n + 1)**(-s), (n, 0, oo)), True))
     assert summation(1/(n+q)**s, (n, 0, oo)) == Piecewise(
-        (zeta(s, q), And(q > 0, s > 1)),
+        (zeta(s, q), And(~Contains(-q, S.Naturals0), re(s) > 1)),
         (Sum((n + q)**(-s), (n, 0, oo)), True))
     assert summation(1/(n+q)**s, (n, q, oo)) == Piecewise(
-        (zeta(s, 2*q), And(2*q > 0, s > 1)),
+        (zeta(s, 2*q), And(~Contains(-2*q, S.Naturals0), re(s) > 1)),
         (Sum((n + q)**(-s), (n, q, oo)), True))
     assert summation(1/n**2, (n, 1, oo)) == zeta(2)
     assert summation(1/n**s, (n, 0, oo)) == Sum(n**(-s), (n, 0, oo))
+    assert summation(1/(n+1)**(2+I), (n, 0, oo)) == zeta(2+I)
+    t = symbols('t', real=True, positive=True)
+    assert summation(1/(n+I)**(t+1), (n, 0, oo)) == zeta(t+1, I)
 
 
 def test_Product_doit():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
In `eval_zeta_function`, conversion from `Sum` to `zeta` is performed whenever possible. Currently, the conditions `s > 1` and `q > 0` are set for `s` and `q`, but these conditions do not handle cases where `s` or `q` are complex numbers correctly. According to Wikipedia, the [Hurwitz zeta function](https://en.wikipedia.org/wiki/Hurwitz_zeta_function) is defined under the conditions `Re(s) > 1` and `q != 0, -1, -2, ...`. Therefore, we have modified the conditions accordingly.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
