### PR TITLE
Add Sphinx hyperlinks for missing function references in basic_operations.rst and calculus.rst

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1481,6 +1481,7 @@ Ted Dokos <tdokos@gmail.com> <t.dokos@gmail.com>
 Ted Horst <ted.horst@earthlink.net>
 Tejaswini Sanapathi <sastejaswini2002@gmail.com>
 Temi <ytemiloluwa@gmail.com> ytemiloluwa <ytemiloluwa@gmail.com>
+Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com> Sibi <85477603+t-sibiraj@users.noreply.github.com>
 Theodore Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>

--- a/doc/src/tutorials/intro-tutorial/basic_operations.rst
+++ b/doc/src/tutorials/intro-tutorial/basic_operations.rst
@@ -16,7 +16,8 @@ Substitution
 
 One of the most common things you might want to do with a mathematical
 expression is substitution.  Substitution replaces all instances of something
-in an expression with something else.  It is done using the :func:`~sympy.core.basic.Basic.subs` method.
+in an expression with something else.  It is done using the 
+:func:`~sympy.core.basic.Basic.subs` method.
 For example
 
     >>> expr = cos(x) + 1
@@ -53,9 +54,9 @@ Substitution is usually done for one of two reasons:
    perhaps a simplification that SymPy is otherwise unable to do.  For
    example, say we have `\sin(2x) + \cos(2x)`, and we want to replace
    `\sin(2x)` with `2\sin(x)\cos(x)`.  As we will learn later, the function
-   :func:`~sympy.core.function.expand_trig` does this.  However, this function will also expand
-   `\cos(2x)`, which we may not want.  While there are ways to perform such
-   precise simplification, and we will learn some of them in the
+   :func:`~sympy.core.function.expand_trig` does this.  However, this function 
+   will also expand `\cos(2x)`, which we may not want.  While there are ways to 
+   perform such precise simplification, and we will learn some of them in the
    :ref:`advanced expression manipulation <tutorial-manipulation>` section, an
    easy way is to just replace `\sin(2x)` with `2\sin(x)\cos(x)`.
 
@@ -65,9 +66,10 @@ Substitution is usually done for one of two reasons:
    >>> expr.subs(sin(2*x), 2*sin(x)*cos(x))
    2*sin(x)*cos(x) + cos(2*x)
 
-There are two important things to note about :func:`~sympy.core.basic.Basic.subs`.  First, it returns a
-new expression.  SymPy objects are immutable.  That means that :func:`~sympy.core.basic.Basic.subs` does
-not modify it in-place.  For example
+There are two important things to note about 
+:func:`~sympy.core.basic.Basic.subs`.  First, it returns a new expression.  
+SymPy objects are immutable.  That means that 
+:func:`~sympy.core.basic.Basic.subs` does not modify it in-place.  For example
 
    >>> expr = cos(x)
    >>> expr.subs(x, 0)
@@ -105,8 +107,10 @@ with `y`, to get `y^4 - 4x^3 + 4y^2 - 2x + 3`.
 Converting Strings to SymPy Expressions
 =======================================
 
-The :func:`sympy.core.sympify.sympify` function (that's :func:`sympy.core.sympify.sympify`, not to be confused with
-:func:`~sympy.simplify.simplify.simplify`) can be used to convert strings into SymPy expressions.
+The :func:`sympy.core.sympify.sympify` function (that's 
+:func:`sympy.core.sympify.sympify`, not to be confused with
+:func:`~sympy.simplify.simplify.simplify`) can be used to convert strings into 
+SymPy expressions.
 
 For example
 
@@ -117,10 +121,11 @@ For example
     >>> expr.subs(x, 2)
     19/2
 
-.. warning:: :func:`sympy.core.sympify.sympify` uses ``eval``.  Don't use it on unsanitized input.
+.. warning:: :func:`sympy.core.sympify.sympify` uses ``eval``.  Don't use it on
+     unsanitized input.
 
 :func:`~sympy.core.evalf.EvalfMixin.evalf`
-=========
+==========================================
 
 To evaluate a numerical expression into a floating point number, use
 :func:`~sympy.core.evalf.EvalfMixin.evalf`.
@@ -131,15 +136,19 @@ To evaluate a numerical expression into a floating point number, use
 
 SymPy can evaluate floating point expressions to arbitrary precision.  By
 default, 15 digits of precision are used, but you can pass any number as the
-argument to :func:`~sympy.core.evalf.EvalfMixin.evalf`.  Let's compute the first 100 digits of `\pi`.
+argument to :func:`~sympy.core.evalf.EvalfMixin.evalf`.  Let's compute the 
+first 100 digits of `\pi`.
 
     >>> pi.evalf(100)
     3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
 
 To numerically evaluate an expression with a Symbol at a point, we might use
-:func:`~sympy.core.basic.Basic.subs` followed by :func:`~sympy.core.evalf.EvalfMixin.evalf`, but it is more efficient and numerically
-stable to pass the substitution to :func:`~sympy.core.evalf.EvalfMixin.evalf` using the :func:`~sympy.core.basic.Basic.subs` flag, which
-takes a dictionary of ``Symbol: point`` pairs.
+:func:`~sympy.core.basic.Basic.subs` followed by 
+:func:`~sympy.core.evalf.EvalfMixin.evalf`, but it is more efficient and 
+numerically stable to pass the substitution to 
+:func:`~sympy.core.evalf.EvalfMixin.evalf` using the 
+:func:`~sympy.core.basic.Basic.subs` flag, which takes a dictionary of 
+``Symbol: point`` pairs.
 
     >>> expr = cos(2*x)
     >>> expr.evalf(subs={x: 2.4})
@@ -156,19 +165,21 @@ user's discretion by setting the ``chop`` flag to True.
     0
 
 :func:`~sympy.utilities.lambdify.lambdify`
-============
+==========================================
 
-:func:`~sympy.core.basic.Basic.subs` and :func:`~sympy.core.evalf.EvalfMixin.evalf` are good if you want to do simple evaluation, but if
-you intend to evaluate an expression at many points, there are more efficient
-ways.  For example, if you wanted to evaluate an expression at a thousand
-points, using SymPy would be far slower than it needs to be, especially if you
-only care about machine precision.  Instead, you should use libraries like
-`NumPy <https://numpy.org/>`_ and `SciPy <https://scipy.org/>`_.
+:func:`~sympy.core.basic.Basic.subs` and 
+:func:`~sympy.core.evalf.EvalfMixin.evalf` are good if you want to do simple 
+evaluation, but if you intend to evaluate an expression at many points, there 
+are more efficient ways.  For example, if you wanted to evaluate an expression 
+at a thousand points, using SymPy would be far slower than it needs to be, 
+especially if you only care about machine precision.  Instead, you should use 
+libraries like `NumPy <https://numpy.org/>`_ and `SciPy <https://scipy.org/>`_.
 
 The easiest way to convert a SymPy expression to an expression that can be
-numerically evaluated is to use the :func:`~sympy.utilities.lambdify.lambdify` function.  :func:`~sympy.utilities.lambdify.lambdify` acts
-like a ``lambda`` function, except it converts the SymPy names to the names of
-the given numerical library, usually NumPy.  For example
+numerically evaluated is to use the :func:`~sympy.utilities.lambdify.lambdify` 
+function.  :func:`~sympy.utilities.lambdify.lambdify` acts like a ``lambda`` 
+function, except it converts the SymPy names to the names of the given 
+numerical library, usually NumPy.  For example
 
     >>> import numpy # doctest:+SKIP
     >>> a = numpy.arange(10) # doctest:+SKIP
@@ -178,7 +189,8 @@ the given numerical library, usually NumPy.  For example
     [ 0.          0.84147098  0.90929743  0.14112001 -0.7568025  -0.95892427
      -0.2794155   0.6569866   0.98935825  0.41211849]
 
-.. warning:: :func:`~sympy.utilities.lambdify.lambdify` uses ``eval``.  Don't use it on unsanitized input.
+.. warning:: :func:`~sympy.utilities.lambdify.lambdify` uses ``eval``.  Don't 
+    use it on unsanitized input.
 
 You can use other libraries than NumPy. For example, to use the standard
 library math module, use ``"math"``.

--- a/doc/src/tutorials/intro-tutorial/basic_operations.rst
+++ b/doc/src/tutorials/intro-tutorial/basic_operations.rst
@@ -16,7 +16,7 @@ Substitution
 
 One of the most common things you might want to do with a mathematical
 expression is substitution.  Substitution replaces all instances of something
-in an expression with something else.  It is done using the ``subs`` method.
+in an expression with something else.  It is done using the :func:`~sympy.core.basic.Basic.subs` method.
 For example
 
     >>> expr = cos(x) + 1
@@ -53,7 +53,7 @@ Substitution is usually done for one of two reasons:
    perhaps a simplification that SymPy is otherwise unable to do.  For
    example, say we have `\sin(2x) + \cos(2x)`, and we want to replace
    `\sin(2x)` with `2\sin(x)\cos(x)`.  As we will learn later, the function
-   ``expand_trig`` does this.  However, this function will also expand
+   :func:`~sympy.core.function.expand_trig` does this.  However, this function will also expand
    `\cos(2x)`, which we may not want.  While there are ways to perform such
    precise simplification, and we will learn some of them in the
    :ref:`advanced expression manipulation <tutorial-manipulation>` section, an
@@ -65,8 +65,8 @@ Substitution is usually done for one of two reasons:
    >>> expr.subs(sin(2*x), 2*sin(x)*cos(x))
    2*sin(x)*cos(x) + cos(2*x)
 
-There are two important things to note about ``subs``.  First, it returns a
-new expression.  SymPy objects are immutable.  That means that ``subs`` does
+There are two important things to note about :func:`~sympy.core.basic.Basic.subs`.  First, it returns a
+new expression.  SymPy objects are immutable.  That means that :func:`~sympy.core.basic.Basic.subs` does
 not modify it in-place.  For example
 
    >>> expr = cos(x)
@@ -86,7 +86,7 @@ In fact, since SymPy expressions are immutable, no function will change them
 in-place.  All functions will return new expressions.
 
 To perform multiple substitutions at once, pass a list of ``(old, new)`` pairs
-to ``subs``.
+to :func:`~sympy.core.basic.Basic.subs`.
 
     >>> expr = x**3 + 4*x*y - z
     >>> expr.subs([(x, 2), (y, 4), (z, 0)])
@@ -105,8 +105,8 @@ with `y`, to get `y^4 - 4x^3 + 4y^2 - 2x + 3`.
 Converting Strings to SymPy Expressions
 =======================================
 
-The ``sympify`` function (that's ``sympify``, not to be confused with
-``simplify``) can be used to convert strings into SymPy expressions.
+The :func:`sympy.core.sympify.sympify` function (that's :func:`sympy.core.sympify.sympify`, not to be confused with
+:func:`~sympy.simplify.simplify.simplify`) can be used to convert strings into SymPy expressions.
 
 For example
 
@@ -117,13 +117,13 @@ For example
     >>> expr.subs(x, 2)
     19/2
 
-.. warning:: ``sympify`` uses ``eval``.  Don't use it on unsanitized input.
+.. warning:: :func:`sympy.core.sympify.sympify` uses ``eval``.  Don't use it on unsanitized input.
 
-``evalf``
+:func:`~sympy.core.evalf.EvalfMixin.evalf`
 =========
 
 To evaluate a numerical expression into a floating point number, use
-``evalf``.
+:func:`~sympy.core.evalf.EvalfMixin.evalf`.
 
     >>> expr = sqrt(8)
     >>> expr.evalf()
@@ -131,14 +131,14 @@ To evaluate a numerical expression into a floating point number, use
 
 SymPy can evaluate floating point expressions to arbitrary precision.  By
 default, 15 digits of precision are used, but you can pass any number as the
-argument to ``evalf``.  Let's compute the first 100 digits of `\pi`.
+argument to :func:`~sympy.core.evalf.EvalfMixin.evalf`.  Let's compute the first 100 digits of `\pi`.
 
     >>> pi.evalf(100)
     3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
 
 To numerically evaluate an expression with a Symbol at a point, we might use
-``subs`` followed by ``evalf``, but it is more efficient and numerically
-stable to pass the substitution to ``evalf`` using the ``subs`` flag, which
+:func:`~sympy.core.basic.Basic.subs` followed by :func:`~sympy.core.evalf.EvalfMixin.evalf`, but it is more efficient and numerically
+stable to pass the substitution to :func:`~sympy.core.evalf.EvalfMixin.evalf` using the :func:`~sympy.core.basic.Basic.subs` flag, which
 takes a dictionary of ``Symbol: point`` pairs.
 
     >>> expr = cos(2*x)
@@ -155,10 +155,10 @@ user's discretion by setting the ``chop`` flag to True.
     >>> (one - 1).evalf(chop=True)
     0
 
-``lambdify``
+:func:`~sympy.utilities.lambdify.lambdify`
 ============
 
-``subs`` and ``evalf`` are good if you want to do simple evaluation, but if
+:func:`~sympy.core.basic.Basic.subs` and :func:`~sympy.core.evalf.EvalfMixin.evalf` are good if you want to do simple evaluation, but if
 you intend to evaluate an expression at many points, there are more efficient
 ways.  For example, if you wanted to evaluate an expression at a thousand
 points, using SymPy would be far slower than it needs to be, especially if you
@@ -166,7 +166,7 @@ only care about machine precision.  Instead, you should use libraries like
 `NumPy <https://numpy.org/>`_ and `SciPy <https://scipy.org/>`_.
 
 The easiest way to convert a SymPy expression to an expression that can be
-numerically evaluated is to use the ``lambdify`` function.  ``lambdify`` acts
+numerically evaluated is to use the :func:`~sympy.utilities.lambdify.lambdify` function.  :func:`~sympy.utilities.lambdify.lambdify` acts
 like a ``lambda`` function, except it converts the SymPy names to the names of
 the given numerical library, usually NumPy.  For example
 
@@ -178,7 +178,7 @@ the given numerical library, usually NumPy.  For example
     [ 0.          0.84147098  0.90929743  0.14112001 -0.7568025  -0.95892427
      -0.2794155   0.6569866   0.98935825  0.41211849]
 
-.. warning:: ``lambdify`` uses ``eval``.  Don't use it on unsanitized input.
+.. warning:: :func:`~sympy.utilities.lambdify.lambdify` uses ``eval``.  Don't use it on unsanitized input.
 
 You can use other libraries than NumPy. For example, to use the standard
 library math module, use ``"math"``.

--- a/doc/src/tutorials/intro-tutorial/basic_operations.rst
+++ b/doc/src/tutorials/intro-tutorial/basic_operations.rst
@@ -16,7 +16,7 @@ Substitution
 
 One of the most common things you might want to do with a mathematical
 expression is substitution.  Substitution replaces all instances of something
-in an expression with something else.  It is done using the 
+in an expression with something else.  It is done using the
 :func:`~sympy.core.basic.Basic.subs` method.
 For example
 
@@ -54,8 +54,8 @@ Substitution is usually done for one of two reasons:
    perhaps a simplification that SymPy is otherwise unable to do.  For
    example, say we have `\sin(2x) + \cos(2x)`, and we want to replace
    `\sin(2x)` with `2\sin(x)\cos(x)`.  As we will learn later, the function
-   :func:`~sympy.core.function.expand_trig` does this.  However, this function 
-   will also expand `\cos(2x)`, which we may not want.  While there are ways to 
+   :func:`~sympy.core.function.expand_trig` does this.  However, this function
+   will also expand `\cos(2x)`, which we may not want.  While there are ways to
    perform such precise simplification, and we will learn some of them in the
    :ref:`advanced expression manipulation <tutorial-manipulation>` section, an
    easy way is to just replace `\sin(2x)` with `2\sin(x)\cos(x)`.
@@ -66,9 +66,9 @@ Substitution is usually done for one of two reasons:
    >>> expr.subs(sin(2*x), 2*sin(x)*cos(x))
    2*sin(x)*cos(x) + cos(2*x)
 
-There are two important things to note about 
-:func:`~sympy.core.basic.Basic.subs`.  First, it returns a new expression.  
-SymPy objects are immutable.  That means that 
+There are two important things to note about
+:func:`~sympy.core.basic.Basic.subs`.  First, it returns a new expression.
+SymPy objects are immutable.  That means that
 :func:`~sympy.core.basic.Basic.subs` does not modify it in-place.  For example
 
    >>> expr = cos(x)
@@ -107,9 +107,9 @@ with `y`, to get `y^4 - 4x^3 + 4y^2 - 2x + 3`.
 Converting Strings to SymPy Expressions
 =======================================
 
-The :func:`sympy.core.sympify.sympify` function (that's 
+The :func:`sympy.core.sympify.sympify` function (that's
 :func:`sympy.core.sympify.sympify`, not to be confused with
-:func:`~sympy.simplify.simplify.simplify`) can be used to convert strings into 
+:func:`~sympy.simplify.simplify.simplify`) can be used to convert strings into
 SymPy expressions.
 
 For example
@@ -136,18 +136,18 @@ To evaluate a numerical expression into a floating point number, use
 
 SymPy can evaluate floating point expressions to arbitrary precision.  By
 default, 15 digits of precision are used, but you can pass any number as the
-argument to :func:`~sympy.core.evalf.EvalfMixin.evalf`.  Let's compute the 
+argument to :func:`~sympy.core.evalf.EvalfMixin.evalf`.  Let's compute the
 first 100 digits of `\pi`.
 
     >>> pi.evalf(100)
     3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
 
 To numerically evaluate an expression with a Symbol at a point, we might use
-:func:`~sympy.core.basic.Basic.subs` followed by 
-:func:`~sympy.core.evalf.EvalfMixin.evalf`, but it is more efficient and 
-numerically stable to pass the substitution to 
-:func:`~sympy.core.evalf.EvalfMixin.evalf` using the 
-:func:`~sympy.core.basic.Basic.subs` flag, which takes a dictionary of 
+:func:`~sympy.core.basic.Basic.subs` followed by
+:func:`~sympy.core.evalf.EvalfMixin.evalf`, but it is more efficient and
+numerically stable to pass the substitution to
+:func:`~sympy.core.evalf.EvalfMixin.evalf` using the
+:func:`~sympy.core.basic.Basic.subs` flag, which takes a dictionary of
 ``Symbol: point`` pairs.
 
     >>> expr = cos(2*x)
@@ -167,18 +167,18 @@ user's discretion by setting the ``chop`` flag to True.
 :func:`~sympy.utilities.lambdify.lambdify`
 ==========================================
 
-:func:`~sympy.core.basic.Basic.subs` and 
-:func:`~sympy.core.evalf.EvalfMixin.evalf` are good if you want to do simple 
-evaluation, but if you intend to evaluate an expression at many points, there 
-are more efficient ways.  For example, if you wanted to evaluate an expression 
-at a thousand points, using SymPy would be far slower than it needs to be, 
-especially if you only care about machine precision.  Instead, you should use 
+:func:`~sympy.core.basic.Basic.subs` and
+:func:`~sympy.core.evalf.EvalfMixin.evalf` are good if you want to do simple
+evaluation, but if you intend to evaluate an expression at many points, there
+are more efficient ways.  For example, if you wanted to evaluate an expression
+at a thousand points, using SymPy would be far slower than it needs to be,
+especially if you only care about machine precision.  Instead, you should use
 libraries like `NumPy <https://numpy.org/>`_ and `SciPy <https://scipy.org/>`_.
 
 The easiest way to convert a SymPy expression to an expression that can be
-numerically evaluated is to use the :func:`~sympy.utilities.lambdify.lambdify` 
-function.  :func:`~sympy.utilities.lambdify.lambdify` acts like a ``lambda`` 
-function, except it converts the SymPy names to the names of the given 
+numerically evaluated is to use the :func:`~sympy.utilities.lambdify.lambdify`
+function.  :func:`~sympy.utilities.lambdify.lambdify` acts like a ``lambda``
+function, except it converts the SymPy names to the names of the given
 numerical library, usually NumPy.  For example
 
     >>> import numpy # doctest:+SKIP
@@ -189,7 +189,7 @@ numerical library, usually NumPy.  For example
     [ 0.          0.84147098  0.90929743  0.14112001 -0.7568025  -0.95892427
      -0.2794155   0.6569866   0.98935825  0.41211849]
 
-.. warning:: :func:`~sympy.utilities.lambdify.lambdify` uses ``eval``.  Don't 
+.. warning:: :func:`~sympy.utilities.lambdify.lambdify` uses ``eval``.  Don't
     use it on unsanitized input.
 
 You can use other libraries than NumPy. For example, to use the standard

--- a/doc/src/tutorials/intro-tutorial/calculus.rst
+++ b/doc/src/tutorials/intro-tutorial/calculus.rst
@@ -26,10 +26,10 @@ To take derivatives, use the :func:`~sympy.core.function.diff` function.
          ⎝x ⎠
     2⋅x⋅ℯ
 
-:func:`~sympy.core.function.diff` can take multiple derivatives at once.  To take multiple derivatives,
-pass the variable as many times as you wish to differentiate, or pass a number
-after the variable.  For example, both of the following find the third
-derivative of `x^4`.
+:func:`~sympy.core.function.diff` can take multiple derivatives at once.  To 
+take multiple derivatives, pass the variable as many times as you wish to 
+differentiate, or pass a number after the variable.  For example, both of the 
+following find the third derivative of `x^4`.
 
     >>> diff(x**4, x, x, x)
     24⋅x
@@ -52,8 +52,9 @@ derivatives.  For example, each of the following will compute
      3  2 ⎛ 3  3  3       2  2  2                ⎞  x⋅y⋅z
     x ⋅y ⋅⎝x ⋅y ⋅z  + 14⋅x ⋅y ⋅z  + 52⋅x⋅y⋅z + 48⎠⋅ℯ
 
-:func:`~sympy.core.function.diff` can also be called as a method.  The two ways of calling :func:`~sympy.core.function.diff` are
-exactly the same, and are provided only for convenience.
+:func:`~sympy.core.function.diff` can also be called as a method.  The two ways
+ of calling :func:`~sympy.core.function.diff` are exactly the same, and are 
+ provided only for convenience.
 
     >>> expr.diff(x, y, y, z, 4)
      3  2 ⎛ 3  3  3       2  2  2                ⎞  x⋅y⋅z
@@ -71,7 +72,8 @@ same syntax as :func:`~sympy.core.function.diff`.
       4   2
     ∂z  ∂y  ∂x
 
-To evaluate an unevaluated derivative, use the :func:`~sympy.core.basic.Basic.doit` method.
+To evaluate an unevaluated derivative, use the 
+:func:`~sympy.core.basic.Basic.doit` method.
 
     >>> deriv.doit()
      3  2 ⎛ 3  3  3       2  2  2                ⎞  x⋅y⋅z
@@ -98,17 +100,18 @@ Derivatives of unspecified order can be created using tuple ``(x, n)`` where
 Integrals
 =========
 
-To compute an integral, use the :func:`~sympy.integrals.integrals.integrate` function.  There are two kinds
-of integrals, definite and indefinite.  To compute an indefinite integral,
-that is, an antiderivative, or primitive, just pass the variable after the
-expression.
+To compute an integral, use the :func:`~sympy.integrals.integrals.integrate` 
+function.  There are two kinds of integrals, definite and indefinite.  To 
+compute an indefinite integral, that is, an antiderivative, or primitive, just 
+pass the variable after the expression.
 
     >>> integrate(cos(x), x)
     sin(x)
 
 Note that SymPy does not include the constant of integration.  If you want it,
 you can add one yourself, or rephrase your problem as a differential equation
-and use :func:`~sympy.solvers.ode.dsolve` to solve it, which does add the constant (see :ref:`tutorial-dsolve`).
+and use :func:`~sympy.solvers.ode.dsolve` to solve it, which does add the 
+constant (see :ref:`tutorial-dsolve`).
 
 .. sidebar:: Quick Tip
 
@@ -139,8 +142,8 @@ do
     >>> integrate(exp(-x**2 - y**2), (x, -oo, oo), (y, -oo, oo))
     π
 
-If :func:`~sympy.integrals.integrals.integrate` is unable to compute an integral, it returns an unevaluated
-``Integral`` object.
+If :func:`~sympy.integrals.integrals.integrate` is unable to compute an 
+integral, it returns an unevaluated ``Integral`` object.
 
     >>> expr = integrate(x**x, x)
     >>> print(expr)
@@ -152,7 +155,8 @@ If :func:`~sympy.integrals.integrals.integrate` is unable to compute an integral
     ⌡
 
 As with ``Derivative``, you can create an unevaluated integral using
-``Integral``.  To later evaluate this integral, call :func:`~sympy.integrals.integrals.Integral.doit`.
+``Integral``.  To later evaluate this integral, call 
+:func:`~sympy.integrals.integrals.Integral.doit`.
 
     >>> expr = Integral(log(x)**2, x)
     >>> expr
@@ -164,13 +168,15 @@ As with ``Derivative``, you can create an unevaluated integral using
              2
     x⋅log (x) - 2⋅x⋅log(x) + 2⋅x
 
-:func:`~sympy.integrals.integrals.integrate` uses powerful algorithms that are always improving to compute
-both definite and indefinite integrals, including heuristic pattern matching
-type algorithms, a partial implementation of the `Risch algorithm
-<https://en.wikipedia.org/wiki/Risch_algorithm>`_, and an algorithm using
+:func:`~sympy.integrals.integrals.integrate` uses powerful algorithms that are 
+always improving to compute both definite and indefinite integrals, including 
+heuristic pattern matching type algorithms, a partial implementation of the 
+`Risch algorithm <https://en.wikipedia.org/wiki/Risch_algorithm>`_, and an 
+algorithm using 
 `Meijer G-functions <https://en.wikipedia.org/wiki/Meijer_g-function>`_ that is
 useful for computing integrals in terms of special functions, especially
-definite integrals.  Here is a sampling of some of the power of :func:`~sympy.integrals.integrals.integrate`.
+definite integrals.  Here is a sampling of some of the power of 
+:func:`~sympy.integrals.integrals.integrate`.
 
     >>> integ = Integral((x**4 + x**2*exp(x) - x**2 - 2*x*exp(x) - 2*x -
     ...     exp(x))*exp(x)/((x - 1)**2*(x + 1)**2*(exp(x) + 1)), x)
@@ -229,9 +235,9 @@ Numeric Integration
 
 Numeric integration is a method employed in mathematical analysis to estimate
 the definite integral of a function across a simplified range. SymPy not only
-facilitates symbolic integration but also provides support for numeric integration.
-It leverages the precision capabilities of the ``mpmath`` library to enhance the
-accuracy of numeric integration calculations.
+facilitates symbolic integration but also provides support for 
+numeric integration. It leverages the precision capabilities of the ``mpmath`` 
+library to enhance the accuracy of numeric integration calculations.
 
     >>> from sympy import Integral, Symbol, sqrt
     >>> x = Symbol('x')
@@ -250,9 +256,10 @@ To compute the integral with a specified precision:
     >>> integral.evalf(50)
     0.70710678118654752440084436210484903928483593768847
 
-Numeric integration becomes a viable approach in situations where symbolic integration
-is impractical or impossible. This method allows for the computation of integrals
-through numerical techniques, even when dealing with infinite intervals or integrands:
+Numeric integration becomes a viable approach in situations where symbolic 
+integration is impractical or impossible. This method allows for the 
+computation of integrals through numerical techniques, even when dealing with 
+infinite intervals or integrands:
 
     >>> Integral(exp(-(x ** 2)), (x, -oo, oo)).evalf()
     1.77245385090552
@@ -263,7 +270,8 @@ through numerical techniques, even when dealing with infinite intervals or integ
 Limits
 ======
 
-SymPy can compute symbolic limits with the :func:`~sympy.core.expr.Expr.limit` function.  The syntax to compute
+SymPy can compute symbolic limits with the :func:`~sympy.core.expr.Expr.limit` 
+function.  The syntax to compute
 
 .. math::
 
@@ -274,10 +282,11 @@ is ``limit(f(x), x, x0)``.
     >>> limit(sin(x)/x, x, 0)
     1
 
-:func:`~sympy.core.expr.Expr.limit` should be used instead of :func:`~sympy.core.basic.Basic.subs` whenever the point of evaluation
-is a singularity.  Even though SymPy has objects to represent `\infty`, using
-them for evaluation is not reliable because they do not keep track of things
-like rate of growth.  Also, things like `\infty - \infty` and
+:func:`~sympy.core.expr.Expr.limit` should be used instead of 
+:func:`~sympy.core.basic.Basic.subs` whenever the point of evaluation is a 
+singularity.  Even though SymPy has objects to represent `\infty`, using them 
+for evaluation is not reliable because they do not keep track of things like 
+rate of growth.  Also, things like `\infty - \infty` and
 `\frac{\infty}{\infty}` return `\mathrm{nan}` (not-a-number).  For example
 
     >>> expr = x**2/exp(x)
@@ -286,8 +295,9 @@ like rate of growth.  Also, things like `\infty - \infty` and
     >>> limit(expr, x, oo)
     0
 
-Like ``Derivative`` and ``Integral``, :func:`~sympy.core.expr.Expr.limit` has an unevaluated
-counterpart, ``Limit``.  To evaluate it, use :func:`~sympy.series.limits.Limit.doit`.
+Like ``Derivative`` and ``Integral``, :func:`~sympy.core.expr.Expr.limit` 
+has an unevaluated counterpart, ``Limit``.  To evaluate it, use 
+:func:`~sympy.series.limits.Limit.doit`.
 
     >>> expr = Limit((cos(x) - 1)/x, x, 0)
     >>> expr
@@ -331,10 +341,10 @@ which case the defaults ``x0=0`` and ``n=6`` will be used.
 
 The `O\left(x^4\right)` term at the end represents the Landau order term at
 `x=0` (not to be confused with big O notation used in computer science, which
-generally represents the Landau order term at `x` where `x \rightarrow \infty`).  It means that all
-x terms with power greater than or equal to `x^4` are omitted.  Order terms
-can be created and manipulated outside of ``series``.  They automatically
-absorb higher order terms.
+generally represents the Landau order term at `x` where `x \rightarrow \infty`)
+.  It means that all x terms with power greater than or equal to `x^4` are 
+omitted.  Order terms can be created and manipulated outside of ``series``.  
+They automatically absorb higher order terms.
 
     >>> x + x**3 + x**6 + O(x**4)
          3    ⎛ 4⎞
@@ -342,7 +352,8 @@ absorb higher order terms.
     >>> x*O(1)
     O(x)
 
-If you do not want the order term, use the :func:`~sympy.core.expr.Expr.removeO` method.
+If you do not want the order term, use the 
+:func:`~sympy.core.expr.Expr.removeO` method.
 
     >>> expr.series(x, 0, 4).removeO()
      2
@@ -378,8 +389,8 @@ the :func:`~sympy.calculus.finite_diff.differentiate_finite` function:
     -f(x - 1/2)⋅g(x - 1/2) + f(x + 1/2)⋅g(x + 1/2)
 
 If you already have a ``Derivative`` instance, you can use the
-:func:`~sympy.core.function.Derivative.as_finite_difference` method to generate approximations of the
-derivative to arbitrary order:
+:func:`~sympy.core.function.Derivative.as_finite_difference` method to generate
+ approximations of the derivative to arbitrary order:
 
     >>> f = Function('f')
     >>> dfdx = f(x).diff(x)
@@ -413,9 +424,10 @@ using fewer points (see the documentation of ``finite_diff_weights``
 for more details).
 
 If using ``finite_diff_weights`` directly looks complicated, and the
-:func:`~sympy.core.function.Derivative.as_finite_difference` method of ``Derivative`` instances
-is not flexible enough, you can use ``apply_finite_diff`` which
-takes ``order``, ``x_list``, ``y_list`` and ``x0`` as parameters:
+:func:`~sympy.core.function.Derivative.as_finite_difference` method of 
+``Derivative`` instances is not flexible enough, you can use 
+``apply_finite_diff`` which takes ``order``, ``x_list``, ``y_list`` and ``x0`` 
+as parameters:
 
     >>> x_list = [-3, 1, 2]
     >>> y_list = symbols('a b c')

--- a/doc/src/tutorials/intro-tutorial/calculus.rst
+++ b/doc/src/tutorials/intro-tutorial/calculus.rst
@@ -26,10 +26,9 @@ To take derivatives, use the :func:`~sympy.core.function.diff` function.
          ⎝x ⎠
     2⋅x⋅ℯ
 
-:func:`~sympy.core.function.diff` can take multiple derivatives at once.  To 
-take multiple derivatives, pass the variable as many times as you wish to 
-differentiate, or pass a number after the variable.  For example, both of the 
-following find the third derivative of `x^4`.
+:func:`~sympy.core.function.diff` can take multiple derivatives at once.  To
+ take multiple derivatives, pass the variable as many times as you wish to
+ following find the third derivative of `x^4`.
 
     >>> diff(x**4, x, x, x)
     24⋅x
@@ -53,7 +52,7 @@ derivatives.  For example, each of the following will compute
     x ⋅y ⋅⎝x ⋅y ⋅z  + 14⋅x ⋅y ⋅z  + 52⋅x⋅y⋅z + 48⎠⋅ℯ
 
 :func:`~sympy.core.function.diff` can also be called as a method.  The two ways
- of calling :func:`~sympy.core.function.diff` are exactly the same, and are 
+ of calling :func:`~sympy.core.function.diff` are exactly the same, and are
  provided only for convenience.
 
     >>> expr.diff(x, y, y, z, 4)
@@ -72,7 +71,7 @@ same syntax as :func:`~sympy.core.function.diff`.
       4   2
     ∂z  ∂y  ∂x
 
-To evaluate an unevaluated derivative, use the 
+To evaluate an unevaluated derivative, use the
 :func:`~sympy.core.basic.Basic.doit` method.
 
     >>> deriv.doit()
@@ -100,9 +99,9 @@ Derivatives of unspecified order can be created using tuple ``(x, n)`` where
 Integrals
 =========
 
-To compute an integral, use the :func:`~sympy.integrals.integrals.integrate` 
-function.  There are two kinds of integrals, definite and indefinite.  To 
-compute an indefinite integral, that is, an antiderivative, or primitive, just 
+To compute an integral, use the :func:`~sympy.integrals.integrals.integrate`
+function.  There are two kinds of integrals, definite and indefinite.  To
+compute an indefinite integral, that is, an antiderivative, or primitive, just
 pass the variable after the expression.
 
     >>> integrate(cos(x), x)
@@ -110,7 +109,7 @@ pass the variable after the expression.
 
 Note that SymPy does not include the constant of integration.  If you want it,
 you can add one yourself, or rephrase your problem as a differential equation
-and use :func:`~sympy.solvers.ode.dsolve` to solve it, which does add the 
+and use :func:`~sympy.solvers.ode.dsolve` to solve it, which does add the
 constant (see :ref:`tutorial-dsolve`).
 
 .. sidebar:: Quick Tip
@@ -142,7 +141,7 @@ do
     >>> integrate(exp(-x**2 - y**2), (x, -oo, oo), (y, -oo, oo))
     π
 
-If :func:`~sympy.integrals.integrals.integrate` is unable to compute an 
+If :func:`~sympy.integrals.integrals.integrate` is unable to compute an
 integral, it returns an unevaluated ``Integral`` object.
 
     >>> expr = integrate(x**x, x)
@@ -155,7 +154,7 @@ integral, it returns an unevaluated ``Integral`` object.
     ⌡
 
 As with ``Derivative``, you can create an unevaluated integral using
-``Integral``.  To later evaluate this integral, call 
+``Integral``.  To later evaluate this integral, call
 :func:`~sympy.integrals.integrals.Integral.doit`.
 
     >>> expr = Integral(log(x)**2, x)
@@ -168,14 +167,14 @@ As with ``Derivative``, you can create an unevaluated integral using
              2
     x⋅log (x) - 2⋅x⋅log(x) + 2⋅x
 
-:func:`~sympy.integrals.integrals.integrate` uses powerful algorithms that are 
-always improving to compute both definite and indefinite integrals, including 
-heuristic pattern matching type algorithms, a partial implementation of the 
-`Risch algorithm <https://en.wikipedia.org/wiki/Risch_algorithm>`_, and an 
-algorithm using 
+:func:`~sympy.integrals.integrals.integrate` uses powerful algorithms that are
+always improving to compute both definite and indefinite integrals, including
+heuristic pattern matching type algorithms, a partial implementation of the
+`Risch algorithm <https://en.wikipedia.org/wiki/Risch_algorithm>`_, and an
+algorithm using
 `Meijer G-functions <https://en.wikipedia.org/wiki/Meijer_g-function>`_ that is
 useful for computing integrals in terms of special functions, especially
-definite integrals.  Here is a sampling of some of the power of 
+definite integrals.  Here is a sampling of some of the power of
 :func:`~sympy.integrals.integrals.integrate`.
 
     >>> integ = Integral((x**4 + x**2*exp(x) - x**2 - 2*x*exp(x) - 2*x -
@@ -235,8 +234,8 @@ Numeric Integration
 
 Numeric integration is a method employed in mathematical analysis to estimate
 the definite integral of a function across a simplified range. SymPy not only
-facilitates symbolic integration but also provides support for 
-numeric integration. It leverages the precision capabilities of the ``mpmath`` 
+facilitates symbolic integration but also provides support for
+numeric integration. It leverages the precision capabilities of the ``mpmath``
 library to enhance the accuracy of numeric integration calculations.
 
     >>> from sympy import Integral, Symbol, sqrt
@@ -256,9 +255,9 @@ To compute the integral with a specified precision:
     >>> integral.evalf(50)
     0.70710678118654752440084436210484903928483593768847
 
-Numeric integration becomes a viable approach in situations where symbolic 
-integration is impractical or impossible. This method allows for the 
-computation of integrals through numerical techniques, even when dealing with 
+Numeric integration becomes a viable approach in situations where symbolic
+integration is impractical or impossible. This method allows for the
+computation of integrals through numerical techniques, even when dealing with
 infinite intervals or integrands:
 
     >>> Integral(exp(-(x ** 2)), (x, -oo, oo)).evalf()
@@ -270,7 +269,7 @@ infinite intervals or integrands:
 Limits
 ======
 
-SymPy can compute symbolic limits with the :func:`~sympy.core.expr.Expr.limit` 
+SymPy can compute symbolic limits with the :func:`~sympy.core.expr.Expr.limit`
 function.  The syntax to compute
 
 .. math::
@@ -282,10 +281,10 @@ is ``limit(f(x), x, x0)``.
     >>> limit(sin(x)/x, x, 0)
     1
 
-:func:`~sympy.core.expr.Expr.limit` should be used instead of 
-:func:`~sympy.core.basic.Basic.subs` whenever the point of evaluation is a 
-singularity.  Even though SymPy has objects to represent `\infty`, using them 
-for evaluation is not reliable because they do not keep track of things like 
+:func:`~sympy.core.expr.Expr.limit` should be used instead of
+:func:`~sympy.core.basic.Basic.subs` whenever the point of evaluation is a
+singularity.  Even though SymPy has objects to represent `\infty`, using them
+for evaluation is not reliable because they do not keep track of things like
 rate of growth.  Also, things like `\infty - \infty` and
 `\frac{\infty}{\infty}` return `\mathrm{nan}` (not-a-number).  For example
 
@@ -295,8 +294,8 @@ rate of growth.  Also, things like `\infty - \infty` and
     >>> limit(expr, x, oo)
     0
 
-Like ``Derivative`` and ``Integral``, :func:`~sympy.core.expr.Expr.limit` 
-has an unevaluated counterpart, ``Limit``.  To evaluate it, use 
+Like ``Derivative`` and ``Integral``, :func:`~sympy.core.expr.Expr.limit`
+has an unevaluated counterpart, ``Limit``.  To evaluate it, use
 :func:`~sympy.series.limits.Limit.doit`.
 
     >>> expr = Limit((cos(x) - 1)/x, x, 0)
@@ -342,8 +341,8 @@ which case the defaults ``x0=0`` and ``n=6`` will be used.
 The `O\left(x^4\right)` term at the end represents the Landau order term at
 `x=0` (not to be confused with big O notation used in computer science, which
 generally represents the Landau order term at `x` where `x \rightarrow \infty`)
-.  It means that all x terms with power greater than or equal to `x^4` are 
-omitted.  Order terms can be created and manipulated outside of ``series``.  
+.  It means that all x terms with power greater than or equal to `x^4` are
+omitted.  Order terms can be created and manipulated outside of ``series``.
 They automatically absorb higher order terms.
 
     >>> x + x**3 + x**6 + O(x**4)
@@ -352,7 +351,7 @@ They automatically absorb higher order terms.
     >>> x*O(1)
     O(x)
 
-If you do not want the order term, use the 
+If you do not want the order term, use the
 :func:`~sympy.core.expr.Expr.removeO` method.
 
     >>> expr.series(x, 0, 4).removeO()
@@ -424,9 +423,9 @@ using fewer points (see the documentation of ``finite_diff_weights``
 for more details).
 
 If using ``finite_diff_weights`` directly looks complicated, and the
-:func:`~sympy.core.function.Derivative.as_finite_difference` method of 
-``Derivative`` instances is not flexible enough, you can use 
-``apply_finite_diff`` which takes ``order``, ``x_list``, ``y_list`` and ``x0`` 
+:func:`~sympy.core.function.Derivative.as_finite_difference` method of
+``Derivative`` instances is not flexible enough, you can use
+``apply_finite_diff`` which takes ``order``, ``x_list``, ``y_list`` and ``x0``
 as parameters:
 
     >>> x_list = [-3, 1, 2]

--- a/doc/src/tutorials/intro-tutorial/calculus.rst
+++ b/doc/src/tutorials/intro-tutorial/calculus.rst
@@ -389,7 +389,7 @@ the :func:`~sympy.calculus.finite_diff.differentiate_finite` function:
 
 If you already have a ``Derivative`` instance, you can use the
 :func:`~sympy.core.function.Derivative.as_finite_difference` method to generate
- approximations of the derivative to arbitrary order:
+approximations of the derivative to arbitrary order:
 
     >>> f = Function('f')
     >>> dfdx = f(x).diff(x)

--- a/doc/src/tutorials/intro-tutorial/calculus.rst
+++ b/doc/src/tutorials/intro-tutorial/calculus.rst
@@ -17,7 +17,7 @@ with the math of any part of this section, you may safely skip it.
 Derivatives
 ===========
 
-To take derivatives, use the ``diff`` function.
+To take derivatives, use the :func:`~sympy.core.function.diff` function.
 
     >>> diff(cos(x), x)
     -sin(x)
@@ -26,7 +26,7 @@ To take derivatives, use the ``diff`` function.
          ⎝x ⎠
     2⋅x⋅ℯ
 
-``diff`` can take multiple derivatives at once.  To take multiple derivatives,
+:func:`~sympy.core.function.diff` can take multiple derivatives at once.  To take multiple derivatives,
 pass the variable as many times as you wish to differentiate, or pass a number
 after the variable.  For example, both of the following find the third
 derivative of `x^4`.
@@ -52,7 +52,7 @@ derivatives.  For example, each of the following will compute
      3  2 ⎛ 3  3  3       2  2  2                ⎞  x⋅y⋅z
     x ⋅y ⋅⎝x ⋅y ⋅z  + 14⋅x ⋅y ⋅z  + 52⋅x⋅y⋅z + 48⎠⋅ℯ
 
-``diff`` can also be called as a method.  The two ways of calling ``diff`` are
+:func:`~sympy.core.function.diff` can also be called as a method.  The two ways of calling :func:`~sympy.core.function.diff` are
 exactly the same, and are provided only for convenience.
 
     >>> expr.diff(x, y, y, z, 4)
@@ -61,7 +61,7 @@ exactly the same, and are provided only for convenience.
 
 
 To create an unevaluated derivative, use the ``Derivative`` class.  It has the
-same syntax as ``diff``.
+same syntax as :func:`~sympy.core.function.diff`.
 
     >>> deriv = Derivative(expr, x, y, y, z, 4)
     >>> deriv
@@ -71,7 +71,7 @@ same syntax as ``diff``.
       4   2
     ∂z  ∂y  ∂x
 
-To evaluate an unevaluated derivative, use the ``doit`` method.
+To evaluate an unevaluated derivative, use the :func:`~sympy.core.basic.Basic.doit` method.
 
     >>> deriv.doit()
      3  2 ⎛ 3  3  3       2  2  2                ⎞  x⋅y⋅z
@@ -98,7 +98,7 @@ Derivatives of unspecified order can be created using tuple ``(x, n)`` where
 Integrals
 =========
 
-To compute an integral, use the ``integrate`` function.  There are two kinds
+To compute an integral, use the :func:`~sympy.integrals.integrals.integrate` function.  There are two kinds
 of integrals, definite and indefinite.  To compute an indefinite integral,
 that is, an antiderivative, or primitive, just pass the variable after the
 expression.
@@ -108,7 +108,7 @@ expression.
 
 Note that SymPy does not include the constant of integration.  If you want it,
 you can add one yourself, or rephrase your problem as a differential equation
-and use ``dsolve`` to solve it, which does add the constant (see :ref:`tutorial-dsolve`).
+and use :func:`~sympy.solvers.ode.dsolve` to solve it, which does add the constant (see :ref:`tutorial-dsolve`).
 
 .. sidebar:: Quick Tip
 
@@ -139,7 +139,7 @@ do
     >>> integrate(exp(-x**2 - y**2), (x, -oo, oo), (y, -oo, oo))
     π
 
-If ``integrate`` is unable to compute an integral, it returns an unevaluated
+If :func:`~sympy.integrals.integrals.integrate` is unable to compute an integral, it returns an unevaluated
 ``Integral`` object.
 
     >>> expr = integrate(x**x, x)
@@ -152,7 +152,7 @@ If ``integrate`` is unable to compute an integral, it returns an unevaluated
     ⌡
 
 As with ``Derivative``, you can create an unevaluated integral using
-``Integral``.  To later evaluate this integral, call ``doit``.
+``Integral``.  To later evaluate this integral, call :func:`~sympy.integrals.integrals.Integral.doit`.
 
     >>> expr = Integral(log(x)**2, x)
     >>> expr
@@ -164,13 +164,13 @@ As with ``Derivative``, you can create an unevaluated integral using
              2
     x⋅log (x) - 2⋅x⋅log(x) + 2⋅x
 
-``integrate`` uses powerful algorithms that are always improving to compute
+:func:`~sympy.integrals.integrals.integrate` uses powerful algorithms that are always improving to compute
 both definite and indefinite integrals, including heuristic pattern matching
 type algorithms, a partial implementation of the `Risch algorithm
 <https://en.wikipedia.org/wiki/Risch_algorithm>`_, and an algorithm using
 `Meijer G-functions <https://en.wikipedia.org/wiki/Meijer_g-function>`_ that is
 useful for computing integrals in terms of special functions, especially
-definite integrals.  Here is a sampling of some of the power of ``integrate``.
+definite integrals.  Here is a sampling of some of the power of :func:`~sympy.integrals.integrals.integrate`.
 
     >>> integ = Integral((x**4 + x**2*exp(x) - x**2 - 2*x*exp(x) - 2*x -
     ...     exp(x))*exp(x)/((x - 1)**2*(x + 1)**2*(exp(x) + 1)), x)
@@ -263,7 +263,7 @@ through numerical techniques, even when dealing with infinite intervals or integ
 Limits
 ======
 
-SymPy can compute symbolic limits with the ``limit`` function.  The syntax to compute
+SymPy can compute symbolic limits with the :func:`~sympy.core.expr.Expr.limit` function.  The syntax to compute
 
 .. math::
 
@@ -274,7 +274,7 @@ is ``limit(f(x), x, x0)``.
     >>> limit(sin(x)/x, x, 0)
     1
 
-``limit`` should be used instead of ``subs`` whenever the point of evaluation
+:func:`~sympy.core.expr.Expr.limit` should be used instead of :func:`~sympy.core.basic.Basic.subs` whenever the point of evaluation
 is a singularity.  Even though SymPy has objects to represent `\infty`, using
 them for evaluation is not reliable because they do not keep track of things
 like rate of growth.  Also, things like `\infty - \infty` and
@@ -286,8 +286,8 @@ like rate of growth.  Also, things like `\infty - \infty` and
     >>> limit(expr, x, oo)
     0
 
-Like ``Derivative`` and ``Integral``, ``limit`` has an unevaluated
-counterpart, ``Limit``.  To evaluate it, use ``doit``.
+Like ``Derivative`` and ``Integral``, :func:`~sympy.core.expr.Expr.limit` has an unevaluated
+counterpart, ``Limit``.  To evaluate it, use :func:`~sympy.series.limits.Limit.doit`.
 
     >>> expr = Limit((cos(x) - 1)/x, x, 0)
     >>> expr
@@ -298,7 +298,7 @@ counterpart, ``Limit``.  To evaluate it, use ``doit``.
     0
 
 To evaluate a limit at one side only, pass ``'+'`` or ``'-'`` as a fourth
-argument to ``limit``.  For example, to compute
+argument to :func:`~sympy.core.expr.Expr.limit`.  For example, to compute
 
 .. math::
 
@@ -342,7 +342,7 @@ absorb higher order terms.
     >>> x*O(1)
     O(x)
 
-If you do not want the order term, use the ``removeO`` method.
+If you do not want the order term, use the :func:`~sympy.core.expr.Expr.removeO` method.
 
     >>> expr.series(x, 0, 4).removeO()
      2
@@ -371,14 +371,14 @@ values for yet. One approach would be to use a finite difference
 approach.
 
 The simplest way the differentiate using finite differences is to use
-the ``differentiate_finite`` function:
+the :func:`~sympy.calculus.finite_diff.differentiate_finite` function:
 
     >>> f, g = symbols('f g', cls=Function)
     >>> differentiate_finite(f(x)*g(x))
     -f(x - 1/2)⋅g(x - 1/2) + f(x + 1/2)⋅g(x + 1/2)
 
 If you already have a ``Derivative`` instance, you can use the
-``as_finite_difference`` method to generate approximations of the
+:func:`~sympy.core.function.Derivative.as_finite_difference` method to generate approximations of the
 derivative to arbitrary order:
 
     >>> f = Function('f')
@@ -413,7 +413,7 @@ using fewer points (see the documentation of ``finite_diff_weights``
 for more details).
 
 If using ``finite_diff_weights`` directly looks complicated, and the
-``as_finite_difference`` method of ``Derivative`` instances
+:func:`~sympy.core.function.Derivative.as_finite_difference` method of ``Derivative`` instances
 is not flexible enough, you can use ``apply_finite_diff`` which
 takes ``order``, ``x_list``, ``y_list`` and ``x0`` as parameters:
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27621 


#### Brief description of what is fixed or changed
Added missing Sphinx hyperlinks for the following functions
`subs` ,`expand_trig` ,`sympify` ,`simplify` ,`evalf` ,`lambdify` ,`diff` ,`doit` ,`Limit.doit` ,`integrate` ,`dsolve` ,`limit` ,`removeO` ,`differentiate_finite` and `as_finite_difference`
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
