### PR TITLE
Add tangent function to eval_trig()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -262,6 +262,7 @@ Alan Bromborsky <abrombo@verizon.net> <abrombo@verizon.net>
 Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 Alec Kalinin <alec.kalinin@gmail.com>
+Alejandro García Prada <alexgarciaprada2004@gmail.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
 Alex Argunov <sajkoooo@gmail.com>
 Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>
@@ -1727,4 +1728,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Alejandro García Prada <alexgarciaprada2004@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -262,7 +262,7 @@ Alan Bromborsky <abrombo@verizon.net> <abrombo@verizon.net>
 Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 Alec Kalinin <alec.kalinin@gmail.com>
-Alejandro García Prada <alexgarciaprada2004@gmail.com> AlexGarciaPrada <114813960+AlexGarciaPrada@users.noreply.github.com>
+Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com> AlexGarciaPrada <114813960+AlexGarciaPrada@users.noreply.github.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
 Alex Argunov <sajkoooo@gmail.com>
 Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -262,6 +262,7 @@ Alan Bromborsky <abrombo@verizon.net> <abrombo@verizon.net>
 Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 Alec Kalinin <alec.kalinin@gmail.com>
+Alejandro García Prada <alexgarciaprada2004@gmail.com> AlexGarciaPrada <114813960+AlexGarciaPrada@users.noreply.github.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
 Alex Argunov <sajkoooo@gmail.com>
 Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>
@@ -1727,4 +1728,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Alejandro García Prada <alexgarciaprada2004@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1727,3 +1727,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Alejandro García Prada <alexgarciaprada2004@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -262,7 +262,7 @@ Alan Bromborsky <abrombo@verizon.net> <abrombo@verizon.net>
 Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 Alec Kalinin <alec.kalinin@gmail.com>
-Alejandro García Prada <alexgarciaprada2004@gmail.com>
+Alejandro García Prada <alexgarciaprada2004@gmail.com> <alexgarciaprada2004@gmail.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
 Alex Argunov <sajkoooo@gmail.com>
 Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1406,7 +1406,7 @@ def _create_evalf_table():
     from sympy.functions.elementary.exponential import exp, log
     from sympy.functions.elementary.integers import ceiling, floor
     from sympy.functions.elementary.piecewise import Piecewise
-    from sympy.functions.elementary.trigonometric import atan, cos, sin
+    from sympy.functions.elementary.trigonometric import atan, cos, sin, tan
     from sympy.integrals.integrals import Integral
     evalf_table = {
         Symbol: evalf_symbol,
@@ -1428,6 +1428,7 @@ def _create_evalf_table():
 
         cos: evalf_trig,
         sin: evalf_trig,
+        tan: evalf_trig,
 
         Add: evalf_add,
         Mul: evalf_mul,

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -13,10 +13,10 @@ from mpmath import (
     make_mpc, make_mpf, mp, mpc, mpf, nsum, quadts, quadosc, workprec)
 from mpmath import inf as mpmath_inf
 from mpmath.libmp import (from_int, from_man_exp, from_rational, fhalf,
-        fnan, finf, fninf, fnone, fone, fzero, mpf_abs, mpf_add,
-        mpf_atan, mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt,
-        mpf_mul, mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin,
-        mpf_sqrt, normalize, round_nearest, to_int, to_str)
+                          fnan, finf, fninf, fnone, fone, fzero, mpf_abs, mpf_add,
+                          mpf_atan, mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt,
+                          mpf_mul, mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin,
+                          mpf_sqrt, normalize, round_nearest, to_int, to_str, mpf_tan)
 from mpmath.libmp import bitcount as mpmath_bitcount
 from mpmath.libmp.backend import MPZ
 from mpmath.libmp.libmpc import _infs_nan
@@ -895,15 +895,16 @@ def evalf_exp(expr: 'exp', prec: int, options: OPT_DICT) -> TMP_RES:
 
 def evalf_trig(v: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
     """
-    This function handles sin and cos of complex arguments.
+    This function handles sin , cos and tan of complex arguments.
 
-    TODO: should also handle tan of complex arguments.
     """
-    from sympy.functions.elementary.trigonometric import cos, sin
+    from sympy.functions.elementary.trigonometric import cos, sin, tan
     if isinstance(v, cos):
         func = mpf_cos
     elif isinstance(v, sin):
         func = mpf_sin
+    elif isinstance(v,tan):
+        func = mpf_tan
     else:
         raise NotImplementedError
     arg = v.args[0]
@@ -919,6 +920,8 @@ def evalf_trig(v: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
         if isinstance(v, cos):
             return fone, None, prec, None
         elif isinstance(v, sin):
+            return None, None, None, None
+        elif isinstance(v,tan):
             return None, None, None, None
         else:
             raise NotImplementedError
@@ -943,7 +946,7 @@ def evalf_trig(v: 'Expr', prec: int, options: OPT_DICT) -> TMP_RES:
         accuracy = (xprec - xsize) - gap
         if accuracy < prec:
             if options.get('verbose'):
-                print("SIN/COS", accuracy, "wanted", prec, "gap", gap)
+                print("SIN/COS/TAN", accuracy, "wanted", prec, "gap", gap)
                 print(to_str(y, 10))
             if xprec > options.get('maxprec', DEFAULT_MAXPREC):
                 return y, None, accuracy, None

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -167,8 +167,10 @@ def test_evalf_logs():
 def test_evalf_trig():
     assert NS('sin(1)', 15) == '0.841470984807897'
     assert NS('cos(1)', 15) == '0.540302305868140'
+    assert NS('tan(1)', 15) == '1.55740772465490'
     assert NS('sin(10**-6)', 15) == '9.99999999999833e-7'
     assert NS('cos(10**-6)', 15) == '0.999999999999500'
+    assert NS('tan(10**-6)', 15) == '1.00000000000033e-6'
     assert NS('sin(E*10**100)', 15) == '0.409160531722613'
     # Some input near roots
     assert NS(sin(exp(pi*sqrt(163))*pi), 15) == '-2.35596641936785e-12'

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -172,6 +172,8 @@ def test_evalf_trig():
     assert NS('cos(10**-6)', 15) == '0.999999999999500'
     assert NS('tan(10**-6)', 15) == '1.00000000000033e-6'
     assert NS('sin(E*10**100)', 15) == '0.409160531722613'
+    assert NS('tan(I)',15) =='0.761594155955765*I'
+    assert NS('tan(1000*I)',15)== '1.00000000000000*I'
     # Some input near roots
     assert NS(sin(exp(pi*sqrt(163))*pi), 15) == '-2.35596641936785e-12'
     assert NS(sin(pi*10**100 + Rational(7, 10**5), evaluate=False), 15, maxn=120) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I added the tangent function for complex numbers that was required in the TODO

#### Other comments
I made a TODO that was in the eval_trig(). I assume that in certain high-precision cases this is useful because sympy already does it before this changes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Added handling for tan functions of complex numbers in evalf
<!-- END RELEASE NOTES -->
