### PR TITLE
satisfiable: Fix infinite loop in theory conflict clause handling

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -239,6 +239,10 @@ class SATSolver:
                     else:
                         self._simple_add_learned_clause(res[1])
 
+                        # backtrack until we unassign one of the literals causing the conflict
+                        while not any(-lit in res[1] for lit in self._current_level.var_settings):
+                            self._undo()
+
                     while self._current_level.flipped:
                         self._undo()
                     if len(self.levels) == 1:

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -379,3 +379,18 @@ def test_z3_vs_lra_dpll2():
         lra_dpll2_sat = lra_dpll2_satisfiable(cnf) is not False
 
         assert z3_sat == lra_dpll2_sat
+
+def test_issue_27733():
+    x, y = symbols('x,y')
+    clauses = [[1, -3, -2], [5, 7, -8, -6, -4], [-10, -9, 10, 11, -4], [-12, 13, 14], [-10, 9, -6, 11, -4],
+               [16, -15, 18, -19, -17], [11, -6, 10, -9], [9, 11, -10, -9], [2, -3, -1], [-13, 12], [-15, 3, -17],
+               [-16, -15, 19, -17], [-6, -9, 10, 11, -4], [20, -1, -2], [-23, -22, -21], [10, 11, -10, -9],
+               [9, 11, -4, -10], [24, -6, -4], [-14, 12], [-10, -9, 9, -6, 11], [25, -27, -26], [-15, 19, -18, -17],
+               [5, 8, -7, -6, -4], [-30, -29, 28], [12], [14]]
+
+    encoding = {Q.gt(y, i): i for i in range(1, 31) if i != 11 and i != 12}
+    encoding[Q.gt(x, 0)] = 11
+    encoding[Q.lt(x, 0)] = 12
+
+    cnf = EncodedCNF(clauses, encoding)
+    assert satisfiable(cnf, use_lra_theory=True) is False


### PR DESCRIPTION
Fixes #27733

Previously, when the theory solver detected a conflict, it sometimes repeatedly added the same conflict clause without backtracking, causing an infinite loop. This commit ensures that a conflict clause is added only once, and dpll2 properly backtracks to unassign conflicting literals.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* logic
  * Fixed hanging issue with `satisfiable` queries involving complex expressions where `use_lra_theory` is True.
<!-- END RELEASE NOTES -->
