### PR TITLE
Fix Rust printing of sympy.sign

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -194,7 +194,7 @@ Aadit Kamat <aadit.k12@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
 Aaron Gokaslan <aaronGokaslan@gmail.com>
 Aaron Meurer <asmeurer@gmail.com>
-Aaron Miller <acmiller273@gmail.com>
+Aaron Miller <acmiller273@gmail.com> <78561124+aaron-skydio@users.noreply.github.com>
 Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
 Aaryan Dewan <aaryandewan@yahoo.com> Aaryan Dewan <49852384+aaryandewan@users.noreply.github.com>
 Aasim Ali <aasim250205@gmail.com> Aasim Ali <94692076+aasim-maverick@users.noreply.github.com>

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -95,7 +95,7 @@ known_functions = {
     # "": "trunc",
     # "": "fract",
     "Abs": "abs",
-    "sign": "signum",
+    # "": "signum",
     # "": "is_sign_positive",
     # "": "is_sign_negative",
     # "": "mul_add",
@@ -561,6 +561,10 @@ class RustCodePrinter(CodePrinter):
             lhs_code = self._print(lhs)
             rhs_code = self._print(rhs)
             return self._get_statement("%s = %s" % (lhs_code, rhs_code))
+
+    def _print_sign(self, expr):
+        arg = self._print(expr.args[0])
+        return "(if (%s == 0.0) { 0.0 } else { (%s).signum() })" % (arg, arg)
 
     def _cast_to_float(self, expr):
         if not expr.is_number:

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -175,15 +175,15 @@ def test_dereference_printing():
 
 def test_sign():
     expr = sign(x) * y
-    assert rust_code(expr) == "y*x.signum() as f64"
-    assert rust_code(expr, assign_to='r') == "r = y*x.signum() as f64;"
+    assert rust_code(expr) == "y*(if (x == 0.0) { 0.0 } else { (x).signum() }) as f64"
+    assert rust_code(expr, assign_to='r') == "r = y*(if (x == 0.0) { 0.0 } else { (x).signum() }) as f64;"
 
     expr = sign(x + y) + 42
-    assert rust_code(expr) == "(x + y).signum() + 42"
-    assert rust_code(expr, assign_to='r') == "r = (x + y).signum() + 42;"
+    assert rust_code(expr) == "(if (x + y == 0.0) { 0.0 } else { (x + y).signum() }) + 42"
+    assert rust_code(expr, assign_to='r') == "r = (if (x + y == 0.0) { 0.0 } else { (x + y).signum() }) + 42;"
 
     expr = sign(cos(x))
-    assert rust_code(expr) == "x.cos().signum()"
+    assert rust_code(expr) == "(if (x.cos() == 0.0) { 0.0 } else { (x.cos()).signum() })"
 
 
 def test_reserved_words():


### PR DESCRIPTION
This is half issue, half PR - I'm not 100% sure exactly how this should be correctly implemented, and I'm not necessarily going to have time to test this further, but the fix is small enough and the code change demonstrates the issue better than an issue would.

As I understand it, `sympy.sign` is defined to return 0 for 0.  Other code printers also implement it this way, see for example https://github.com/sympy/sympy/pull/14010.  Rust's `signum` returns 1 or -1 for 0 (depending on the sign of the 0, for floats with signed zeroes), which isn't correct.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug with printing of `sympy.sign` in Rust.  Formerly, the printed expression returned +-1 for arguments of 0, which does not match the definition of `sympy.sign`.
<!-- END RELEASE NOTES -->