### PR TITLE
Fix IntegerPredicate Handling for Pow and Mul Expressions

### DIFF
--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -155,10 +155,10 @@ def test_closed_group(expr, assumptions, key):
     return _fuzzy_group(
         (ask(key(a), assumptions) for a in expr.args), quick_exit=True)
 
-def ask_all(queries, assumptions):
+def ask_all(*queries, assumptions):
     return fuzzy_and(
         (ask(query, assumptions) for query in queries))
 
-def ask_any(queries, assumptions):
+def ask_any(*queries, assumptions):
     return fuzzy_or(
         (ask(query, assumptions) for query in queries))

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -5,7 +5,7 @@ This module defines base class for handlers and some core handlers:
 
 from sympy.assumptions import Q, ask, AppliedPredicate
 from sympy.core import Basic, Symbol
-from sympy.core.logic import _fuzzy_group
+from sympy.core.logic import _fuzzy_group, fuzzy_and, fuzzy_or
 from sympy.core.numbers import NaN, Number
 from sympy.logic.boolalg import (And, BooleanTrue, BooleanFalse, conjuncts,
     Equivalent, Implies, Not, Or)
@@ -154,3 +154,11 @@ def test_closed_group(expr, assumptions, key):
     """
     return _fuzzy_group(
         (ask(key(a), assumptions) for a in expr.args), quick_exit=True)
+
+def ask_all(queries, assumptions):
+    return fuzzy_and(
+        (ask(query, assumptions) for query in queries))
+
+def ask_any(queries, assumptions):
+    return fuzzy_or(
+        (ask(query, assumptions) for query in queries))

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -68,10 +68,10 @@ def _(expr, assumptions):
 def _(expr,assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
-    if ask_all([Q.nonzero(expr.base), Q.zero(expr.exp)], assumptions):
+    if ask_all(Q.nonzero(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
-    if ask_all([Q.integer(expr.base), Q.integer(expr.exp)], assumptions):
-        if ask_any([Q.positive(expr.exp), Q.zero(expr.base-1) | Q.zero(expr.base+1)], assumptions):
+    if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
+        if ask_any(Q.positive(expr.exp), Q.zero(expr.base-1) | Q.zero(expr.base+1), assumptions=assumptions):
             return True
         if ask(Q.zero(expr.base), assumptions) is not False and ask(Q.positive(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -53,7 +53,7 @@ def _(expr, assumptions):
         raise MDNotImplementedError
     return ret
 
-@IntegerPredicate.register_many(Add, Pow)
+@IntegerPredicate.register(Add)
 def _(expr, assumptions):
     """
     * Integer + Integer       -> Integer
@@ -63,6 +63,23 @@ def _(expr, assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
     return test_closed_group(expr, assumptions, Q.integer)
+
+@IntegerPredicate.register(Pow)
+def _(expr,assumptions):
+    if expr.is_number:
+        return _IntegerPredicate_number(expr, assumptions)
+    if ask(Q.ne(expr.base,0),assumptions) and ask(Q.zero(expr.exp),assumptions):
+        return True
+    if ask(Q.integer(expr.base),assumptions):
+        if ask(Q.integer(expr.exp),assumptions):
+            if ask(Q.nonnegative(expr.exp),assumptions):
+                return True
+            if ask(Q.eq(expr.base,1),assumptions) or ask(Q.eq(expr.base,-1),assumptions):
+                return True
+            if ask(Q.zero(expr.base),assumptions) is not False:
+                if ask(Q.positive(expr.exp),assumptions):
+                    return True
+            return
 
 @IntegerPredicate.register(Mul)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -68,16 +68,16 @@ def _(expr, assumptions):
 def _(expr,assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
-    if ask(Q.ne(expr.base,0),assumptions) and ask(Q.zero(expr.exp),assumptions):
+    if ask(Q.ne(expr.base,0), assumptions) and ask(Q.zero(expr.exp), assumptions):
         return True
-    if ask(Q.integer(expr.base),assumptions):
-        if ask(Q.integer(expr.exp),assumptions):
-            if ask(Q.nonnegative(expr.exp),assumptions):
+    if ask(Q.integer(expr.base), assumptions):
+        if ask(Q.integer(expr.exp), assumptions):
+            if ask(Q.positive(expr.exp), assumptions):
                 return True
-            if ask(Q.eq(expr.base,1),assumptions) or ask(Q.eq(expr.base,-1),assumptions):
+            if ask(Q.eq(expr.base,1), assumptions) or ask(Q.eq(expr.base,-1), assumptions):
                 return True
-            if ask(Q.zero(expr.base),assumptions) is not False:
-                if ask(Q.positive(expr.exp),assumptions):
+            if ask(Q.zero(expr.base), assumptions) is not False:
+                if ask(Q.positive(expr.exp), assumptions):
                     return True
             return
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -18,7 +18,7 @@ from sympy.matrices.expressions.matexpr import MatrixElement
 
 from sympy.multipledispatch import MDNotImplementedError
 
-from .common import test_closed_group
+from .common import test_closed_group, ask_all, ask_any
 from ..predicates.sets import (IntegerPredicate, RationalPredicate,
     IrrationalPredicate, RealPredicate, ExtendedRealPredicate,
     HermitianPredicate, ComplexPredicate, ImaginaryPredicate,
@@ -68,18 +68,13 @@ def _(expr, assumptions):
 def _(expr,assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
-    if ask(Q.nonzero(expr.base), assumptions) and ask(Q.zero(expr.exp), assumptions):
+    if ask_all([Q.nonzero(expr.base), Q.zero(expr.exp)], assumptions):
         return True
-    if ask(Q.integer(expr.base), assumptions):
-        if ask(Q.integer(expr.exp), assumptions):
-            if ask(Q.positive(expr.exp), assumptions):
-                return True
-            if ask(Q.eq(expr.base,1), assumptions) or ask(Q.eq(expr.base,-1), assumptions):
-                return True
-            if ask(Q.zero(expr.base), assumptions) is not False:
-                if ask(Q.positive(expr.exp), assumptions):
-                    return True
-            return
+    if ask_all([Q.integer(expr.base), Q.integer(expr.exp)], assumptions):
+        if ask_any([Q.positive(expr.exp), Q.eq(expr.base, 1) | Q.eq(expr.base, -1)], assumptions):
+            return True
+        if ask(Q.zero(expr.base), assumptions) is not False and ask(Q.positive(expr.exp), assumptions):
+            return True
 
 @IntegerPredicate.register(Mul)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -73,8 +73,6 @@ def _(expr,assumptions):
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
         if ask_any(Q.positive(expr.exp), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
             return True
-        if ask(Q.positive(expr.exp), assumptions):
-            return True
 
 @IntegerPredicate.register(Mul)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -71,7 +71,7 @@ def _(expr,assumptions):
     if ask_all([Q.nonzero(expr.base), Q.zero(expr.exp)], assumptions):
         return True
     if ask_all([Q.integer(expr.base), Q.integer(expr.exp)], assumptions):
-        if ask_any([Q.positive(expr.exp), Q.eq(expr.base, 1) | Q.eq(expr.base, -1)], assumptions):
+        if ask_any([Q.positive(expr.exp), Q.zero(expr.base-1) | Q.zero(expr.base+1)], assumptions):
             return True
         if ask(Q.zero(expr.base), assumptions) is not False and ask(Q.positive(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -71,7 +71,7 @@ def _(expr,assumptions):
     if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
-        if ask_any(Q.positive(expr.exp), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
+        if ask_any(Q.positive(expr.exp), Q.nonnegative(expr.exp) & Q.ne(expr.base,0), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
             return True
 
 @IntegerPredicate.register(Mul)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -71,7 +71,7 @@ def _(expr,assumptions):
     if ask_all(Q.nonzero(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
-        if ask_any(Q.positive(expr.exp), Q.zero(expr.base-1) | Q.zero(expr.base+1), assumptions=assumptions):
+        if ask_any(Q.positive(expr.exp), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
             return True
         if ask(Q.zero(expr.base), assumptions) is not False and ask(Q.positive(expr.exp), assumptions):
             return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -68,12 +68,12 @@ def _(expr, assumptions):
 def _(expr,assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
-    if ask_all(Q.nonzero(expr.base), Q.zero(expr.exp), assumptions=assumptions):
+    if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
         if ask_any(Q.positive(expr.exp), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
             return True
-        if ask(Q.zero(expr.base), assumptions) is not False and ask(Q.positive(expr.exp), assumptions):
+        if ask(Q.positive(expr.exp), assumptions):
             return True
 
 @IntegerPredicate.register(Mul)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -71,7 +71,7 @@ def _(expr,assumptions):
     if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
-        if ask_any(Q.positive(expr.exp), Q.nonnegative(expr.exp) & Q.ne(expr.base,0), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
+        if ask_any(Q.positive(expr.exp), Q.nonnegative(expr.exp) & ~Q.zero(expr.base), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
             return True
 
 @IntegerPredicate.register(Mul)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -68,7 +68,7 @@ def _(expr, assumptions):
 def _(expr,assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
-    if ask(Q.ne(expr.base,0), assumptions) and ask(Q.zero(expr.exp), assumptions):
+    if ask(Q.nonzero(expr.base), assumptions) and ask(Q.zero(expr.exp), assumptions):
         return True
     if ask(Q.integer(expr.base), assumptions):
         if ask(Q.integer(expr.exp), assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1827,7 +1827,7 @@ def test_odd_query():
     assert ask(Q.odd(3**k), Q.even(k)) is None
 
     assert ask(Q.odd(k**m), Q.even(k) & Q.integer(m) & ~Q.negative(m)) is None
-    assert ask(Q.odd(n**m), Q.odd(n) & Q.integer(m) & ~Q.negative(m)) is None
+    assert ask(Q.odd(n**m), Q.odd(n) & Q.integer(m) & ~Q.negative(m)) is True
 
     assert ask(Q.odd(k**p), Q.even(k) & Q.integer(p) & Q.positive(p)) is False
     assert ask(Q.odd(n**p), Q.odd(n) & Q.integer(p) & Q.positive(p)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1826,7 +1826,7 @@ def test_odd_query():
     assert ask(Q.odd(3**k), Q.even(k)) is None
 
     assert ask(Q.odd(k**m), Q.even(k) & Q.integer(m) & ~Q.negative(m)) is None
-    assert ask(Q.odd(n**m), Q.odd(n) & Q.integer(m) & ~Q.negative(m)) is True
+    assert ask(Q.odd(n**m), Q.odd(n) & Q.integer(m) & ~Q.negative(m)) is None
 
     assert ask(Q.odd(k**p), Q.even(k) & Q.integer(p) & Q.positive(p)) is False
     assert ask(Q.odd(n**p), Q.odd(n) & Q.integer(p) & Q.positive(p)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1658,6 +1658,12 @@ def test_integer():
     assert ask(Q.integer(Abs(x)),Q.complex(x)) is None
     assert ask(Q.integer(Abs(x+I*y)),Q.real(x) & Q.real(y)) is None
 
+    # https://github.com/sympy/sympy/issues/27739
+    assert ask(Q.integer(x/y), Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.integer(1/x), Q.integer(x)) is None
+    assert ask(Q.integer(pi**x), Q.zero(x)) is True
+    assert ask(Q.integer(x**y),Q.integer(x) & Q.integer(y)) is None
+
 
 def test_negative():
     assert ask(Q.negative(x), Q.negative(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1662,7 +1662,7 @@ def test_integer():
     assert ask(Q.integer(x/y), Q.integer(x) & Q.integer(y)) is None
     assert ask(Q.integer(1/x), Q.integer(x)) is None
     assert ask(Q.integer(pi**x), Q.zero(x)) is True
-    assert ask(Q.integer(x**y),Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y)) is None
 
 
 def test_negative():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1661,8 +1661,14 @@ def test_integer():
     # https://github.com/sympy/sympy/issues/27739
     assert ask(Q.integer(x/y), Q.integer(x) & Q.integer(y)) is None
     assert ask(Q.integer(1/x), Q.integer(x)) is None
-    assert ask(Q.integer(pi**x), Q.zero(x)) is True
     assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.integer(sqrt(5))) is False
+    assert ask(Q.integer(x**y), Q.nonzero(x) & Q.zero(y)) is True
+    assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y) & Q.positive(y)) is True
+    assert ask(Q.integer(-1**x), Q.integer(x)) is True
+    assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y) & Q.positive(y)) is True
+    assert ask(Q.integer(x**y), Q.zero(x) & Q.integer(y) & Q.positive(y)) is True
+    assert ask(Q.integer(pi**x), Q.zero(x)) is True
 
 
 def test_negative():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1669,6 +1669,7 @@ def test_integer():
     assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y) & Q.positive(y)) is True
     assert ask(Q.integer(x**y), Q.zero(x) & Q.integer(y) & Q.positive(y)) is True
     assert ask(Q.integer(pi**x), Q.zero(x)) is True
+    assert ask(Q.integer(x**y), Q.imaginary(x) & Q.zero(y)) is True
 
 
 def test_negative():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->Fixes #27739 
Fixes #27740


#### Summary
This PR addresses and fixes two issues related to Q.integer evaluation in SymPy:

Issue 1: ask(Q.integer(x/y), Q.integer(x) & Q.integer(y)) returning True, even when x/y is not guaranteed to be an integer.
Issue 2: ask(Q.integer(1/x), Q.integer(x)) returning True, despite cases where 1/x is not an integer (e.g., x = 2).

#### Fix Details

- Updated @IntegerPredicate.register(Pow) to correctly handle cases where the base or exponent can lead to non-integer results.
- Added checks for zero base and exponent to prevent incorrect assumptions.
- Ensured 1/x properly returns None unless x is explicitly 1 or -1.
- Revised integer division logic to avoid false positives


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Now ```ask(Q.integer(x/y), Q.integer(x) & Q.integer(y))``` gives ```None``` instead of wrongly giving ```True```.
  * Now ```ask(Q.integer(1/x), Q.integer(x))``` gives ```None``` instead of wrongly giving ```True```.

<!-- END RELEASE NOTES -->
