### PR TITLE
Fix `solve_univariate_inequality` for periodic solutions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1129,6 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1129,9 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
 Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -113,8 +113,7 @@ def continuous_domain(f, symbol, domain):
         if atom.exp.is_rational and den.is_odd:
             pass    # 0**negative handled by singularities()
         else:
-            constraint = solve_univariate_inequality(atom.base >= 0,
-                                                        symbol).as_set()
+            constraint = solve_univariate_inequality(atom.base >= 0, symbol, relational=False)
             cont_domain = Intersection(constraint, cont_domain)
 
     for atom in f.atoms(Function):
@@ -122,14 +121,14 @@ def continuous_domain(f, symbol, domain):
             for c in constraints[atom.func]:
                 constraint_relational = c.subs(x, atom.args[0])
                 constraint_set = solve_univariate_inequality(
-                    constraint_relational, symbol).as_set()
+                    constraint_relational, symbol, relational=False)
                 cont_domain = Intersection(constraint_set, cont_domain)
         elif atom.func in constraints_union:
             constraint_set = S.EmptySet
             for c in constraints_union[atom.func]:
                 constraint_relational = c.subs(x, atom.args[0])
                 constraint_set += solve_univariate_inequality(
-                    constraint_relational, symbol).as_set()
+                    constraint_relational, symbol, relational=False)
             cont_domain = Intersection(constraint_set, cont_domain)
         # XXX: the discontinuities below could be factored out in
         # a new "discontinuities()".

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -433,6 +433,8 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     Interval(2, oo)
     """
     from sympy.solvers.solvers import denoms
+    from sympy.sets import imageset
+    from sympy.core.function import Lambda
 
     if domain.is_subset(S.Reals) is False:
         raise NotImplementedError(filldedent('''
@@ -665,6 +667,8 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             n = Dummy('n', integer=True)
             x = Dummy('x')
             rv = imageset(Lambda(n, imageset(Lambda(x, x + period * n), rv)), S.Integers)
+        else:
+            rv = original_domain
 
     return rv if not relational else rv.as_relational(_gen)
 

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -380,7 +380,7 @@ def reduce_abs_inequalities(exprs, gen):
         for expr, rel in exprs ])
 
 
-def solve_univariate_inequality2(expr, gen, relational=True, domain=S.Reals, continuous=False):
+def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, continuous=False):
     """Solves a real univariate inequality.
 
     Parameters

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -419,7 +419,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     Examples
     ========
 
-    >>> from sympy import solve_univariate_inequality, Symbol, sin, Interval, S
+    >>> from sympy import solve_univariate_inequality, Symbol, Interval, S
     >>> x = Symbol('x')
 
     >>> solve_univariate_inequality(x**2 >= 4, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This does the same thing as #27720, however it implements it in `solve_univariate_inequality` instead of adding a new function.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27573

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* solvers
  * `solve_univariate_inequality` now returns all solutions for periodic solutions instead of just returning the first interval.

<!-- END RELEASE NOTES -->
