### PR TITLE
Fix issue #23610: Handle NaN in NonElementaryIntegral conversion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -899,6 +899,7 @@ Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
 Kunal Arora <kunalarora.135@gmail.com>
 Kunal Sheth <kunal@kunalsheth.info>
 Kunal Singh <ksingh19136@gmail.com> kunal singh <ksingh19136@gmail.com>
+Piyush Patle <nikhilgpatle60@gmail.com>
 Kundan Kumar <kundankumar18581@gmail.com>
 Kyle McDaniel <mcdanie5@illinois.edu> <mcdaniel221@gmail.com>
 Lagaras Stelios <stel.lag@hotmail.com> lagamura <stel.lag@hotmail.com>
@@ -1728,5 +1729,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Piyush Patle <piyushpatle228@gmail.com> PiyushPatle26 <nikhilgpatle60@gmail.com>
+
 

--- a/.mailmap
+++ b/.mailmap
@@ -1728,3 +1728,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Piyush Patle <piyushpatle228@gmail.com> PiyushPatle26 <nikhilgpatle60@gmail.com>
+

--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,8 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -899,7 +901,6 @@ Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
 Kunal Arora <kunalarora.135@gmail.com>
 Kunal Sheth <kunal@kunalsheth.info>
 Kunal Singh <ksingh19136@gmail.com> kunal singh <ksingh19136@gmail.com>
-Piyush Patle <nikhilgpatle60@gmail.com>
 Kundan Kumar <kundankumar18581@gmail.com>
 Kyle McDaniel <mcdanie5@illinois.edu> <mcdaniel221@gmail.com>
 Lagaras Stelios <stel.lag@hotmail.com> lagamura <stel.lag@hotmail.com>
@@ -1729,5 +1730,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-
-
+Piyush Patle <nikhilgpatle60@gmail.com>

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1839,7 +1839,12 @@ def risch_integrate(f, x, extension=None, handle_first='log',
         else:
             result = result.subs(DE.backsubs)
             if not i.is_zero:
-                i = NonElementaryIntegral(i.function.subs(DE.backsubs),i.limits)
+                # If i is NaN or contains NaN, do not attempt to build a NonElementaryIntegral.
+                if i is S.NaN or i.has(S.NaN):
+                    i = S.NaN
+                else:
+                    i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
+
             if not separate_integral:
                 result += i
                 return result

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -771,4 +771,3 @@ def test_sympyissue_23610():
     Ia = Integral(fxa, (x, 0, 1))
     dIa_da = simplify(diff(Ia, a))
     _ = integrate(dIa_da, (a,))
-

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -761,3 +761,13 @@ def test_issue_23948():
         *log(-x**2 - 2*x*log(x) - x + exp(x) - log(x)**2 + log(5))**2)
 
     assert risch_integrate(f, x) == F
+
+
+def test_sympyissue_23610():
+    from sympy import Symbol, Integral, diff, simplify, integrate, log
+    a = Symbol("a", real=True)
+    x = Symbol("x", positive=True)
+    fxa = (x**a - 1) / log(x)
+    Ia = Integral(fxa, (x, 0, 1))
+    dIa_da = simplify(diff(Ia, a))
+    result = integrate(dIa_da, (a,))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -770,4 +770,5 @@ def test_sympyissue_23610():
     fxa = (x**a - 1) / log(x)
     Ia = Integral(fxa, (x, 0, 1))
     dIa_da = simplify(diff(Ia, a))
-    result = integrate(dIa_da, (a,))
+    _ = integrate(dIa_da, (a,))
+


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Handle NaN in NonElementaryIntegral Conversion in Risch Integrator


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #23610


Summary
This pull request fixes a crash in the Risch integrator (Issue #23610) that occurred when an intermediate result evaluated to NaN. Previously, the code attempted to convert such a result into a NonElementaryIntegral by accessing its .function attribute, causing an AttributeError. Instead of imposing a domain restriction (e.g. forcing the parameter to be positive), this fix checks for NaN and assigns S.NaN if found, ensuring the integrator remains general.


#### Brief description of what is fixed or changed
- Fix Details
      In sympy/integrals/risch.py (around line 1840), the code:
      if not i.is_zero:
          i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
      is replaced with:
     if not i.is_zero:
          if i is S.NaN or i.has(S.NaN):
             i = S.NaN
          else:
             i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)


#### Other comments
A corresponding test in sympy/integrals/tests/test_risch.py verifies that the crash no longer occurs.

#### Release Notes
Resolves a crash in the Risch integrator by handling NaN values appropriately.
The patch avoids imposing a domain restriction (e.g., requiring a to be positive) to maintain generality in parameter-dependent integration.


<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a crash in the Risch integrator when an intermediate result evaluates to NaN. The integrator now checks for NaN (or expressions containing NaN) before converting to a NonElementaryIntegral, thereby preventing an AttributeError without imposing a domain restriction.

<!-- END RELEASE NOTES -->
