### PR TITLE
Add documentation warning to `parse_expr()` about internal `eval()` usage

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1000,6 +1000,7 @@ Matthew Parnell <matt@parnmatt.co.uk>
 Matthew Rocklin <mrocklin@cs.uchicago.edu> <mrocklin@gmail.com>
 Matthew Tadd <matt.tadd@gmail.com>
 Matthew Thomas <mnmt@users.noreply.github.com>
+Matthew Treinish <mtreinish@kortar.org>
 Matthew Wardrop <matthew.wardrop@airbnb.com>
 Matthias Bussonnier <bussonniermatthias@gmail.com>
 Matthias Geier <Matthias.Geier@gmail.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -914,6 +914,10 @@ def parse_expr(s: str, local_dict: Optional[DICT] = None,
                global_dict: Optional[DICT] = None, evaluate=True):
     """Converts the string ``s`` to a SymPy expression, in ``local_dict``.
 
+    .. warning::
+        Note that this function uses ``eval``, and thus shouldn't be used on
+        unsanitized input.
+
     Parameters
     ==========
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

This commit adds a warning the to the parse_expr() function's documentation to include the same warning admonition that the sympify() function contains. Internally parse_expr() also uses eval() and is subject to the same security concerns as sympify, however the documentation did not make this clear. This commit fixes this documentation gap so it's clear that you shouldn't use this function with untrusted input.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
