### PR TITLE
Convert Floats to Rationals in ratint to Prevent Rounding Errors

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -1,7 +1,7 @@
 """This module implements tools for integrating rational functions. """
 
 from sympy.core.function import Lambda
-from sympy.core.numbers import I
+from sympy.core.numbers import Float, I, Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import log
@@ -52,7 +52,11 @@ def ratint(f, x, **flags):
     else:
         p, q = f.as_numer_denom()
 
+    p = p.xreplace({c: Rational(c) for c in p.atoms(Float)})
+    q = q.xreplace({c: Rational(c) for c in q.atoms(Float)})
+
     p, q = Poly(p, x, composite=False, field=True), Poly(q, x, composite=False, field=True)
+
 
     coeff, p, q = p.cancel(q)
     poly, p = p.div(q)
@@ -118,6 +122,7 @@ def ratint(f, x, **flags):
                         q, Lambda(t, t*log(h.as_expr())), quadratic=True)
 
         result += eps
+    result = result.xreplace({c: c.evalf(22) for c in result.atoms(Rational)})
 
     return coeff*result
 

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -6,7 +6,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import atan
 from sympy.integrals.integrals import integrate
 from sympy.polys.polytools import Poly
-from sympy.simplify.simplify import simplify
+from sympy.simplify.simplify import simplify,nsimplify
 
 from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan
 
@@ -111,6 +111,19 @@ def test_ratint():
     # even if the symbol is already a Dummy
     d = Dummy()
     assert ratint(1/(d**2 + 1), d, symbol=d) == atan(d)
+
+    #issue 27675
+    f = 2.06 * (x + 0.20) / (x + 0.34) ** 2
+    expected_result = nsimplify(
+        """
+        1.03 * log(0.68*x + x**2.0 + 0.1156000000000000221823)
+        - 61233967.47800592524007 * atan(
+            212323049.5076488392513*x + 72189836.83260060534544
+        )
+        """
+    )
+    assert nsimplify(ratint(f, x)) == expected_result
+    assert abs(integrate(f, (x,0,1)) - 2.19223589366895) < 1e-10
 
 
 def test_ratint_logpart():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix:#27675
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Ensured `ratint` properly converts floats to rationals and back to floats, preventing rounding errors and maintaining expected output precision.


#### Other comments
Output 
```
>>> import sympy as sp
>>> x = sp.symbols('x')
>>> f = 2.06*(x+0.20)/(x+0.34)**2
>>> sp.integrate(f, (x,0,1))
2.192235893668954105351
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
