### PR TITLE
Fix issues with `simplify` function

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -684,6 +684,7 @@ Han Wei Ang <ang.h.w@u.nus.edu>
 Hannah Kari <hannah.kari@marquette.edu> hannah-kari <42753364+hannah-kari@users.noreply.github.com>
 Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
 Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Harikrishna Srinivasan <harikrishnasri3@gmail.com>
 Harold Erbin <harold.erbin@gmail.com>
 Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
 Harry Mountain <harrymountain1@icloud.com>

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -495,20 +495,19 @@ class Relational(Boolean, EvalfMixin):
                             del nzm[0]
                             newexpr = Add(*[i * j for i, j in nzm])
                             r = r.func(lhsterm, -newexpr)
-
                     else:
                         r = r.func(constant, S.Zero)
                 except ValueError:
                     try:
                         from sympy.polys.polyerrors import PolynomialError
-                        from sympy.polys.polytools import gcd
-                        from sympy.solvers.solvers import solve_undetermined_coeffs
-                        m = list(solve_undetermined_coeffs(dif, free))
-                        constant = m[-1]
-                        del m[-1]
-                        scale = gcd(m)
-                        m = [mtmp / scale for mtmp in m]
-                        nzm = list(filter(lambda f: f[0] != 0, list(zip(m, free))))
+                        from sympy.polys.polytools import gcd, Poly, poly
+                        p = poly(dif, free[0])
+                        c = p.all_coeffs()
+                        constant = c[-1]
+                        c[-1] = 0
+                        scale = gcd(c)
+                        c = [ctmp / scale for ctmp in c]
+                        nzm = list(filter(lambda f: f[0] != 0, list(zip(c, free))))
                         if scale != 0:
                             if constant != 0:
                                 # lhs: expression, rhs: constant


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes the issue in #27769

#### Brief description of what is fixed or changed

Before this PR, the Non-Linear expressions, for example, `Eq(x**2 - y**2, x**2 + y**2)` does not simply to `Eq(y, 0)`, though `solve` method does.
This issue (or problem) is fixed in this PR.

#### Other comments

Added handling of polynomial simplification.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
