### PR TITLE
TensorProduct: Automatically distribute over sums for correct expansion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1576,6 +1576,7 @@ Vladimir Lagunov <werehuman@gmail.com>
 Vladimir Perić <vlada.peric@gmail.com>
 Vladimir Poluhsin <vovapolu@gmail.com>
 Vladimir Sereda <voffch@gmail.com>
+Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com> <voaides.r@yahoo.com>
 Waldir Pimenta <waldyrious@gmail.com>
 Wang Ran (汪然) <wangr@smail.nju.edu.cn>
 Warren Jacinto <warrenjacinto@gmail.com>

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -136,7 +136,15 @@ class TensorProduct(Expr):
         if isinstance(args[0], (Matrix, ImmutableMatrix, numpy_ndarray,
                                                     scipy_sparse_matrix)):
             return matrix_tensor_product(*args)
-        c_part, new_args = cls.flatten(sympify(args))
+        args = sympify(args)
+        for i, arg in enumerate(args):
+            if arg.is_Add:
+                distributed_terms = []
+                for term in arg.args:
+                    new_args = args[:i] + (term,) + args[i+1:]
+                    distributed_terms.append(TensorProduct(*new_args))
+                return Add(*distributed_terms)
+        c_part, new_args = cls.flatten(args)
         c_part = Mul(*c_part)
         if len(new_args) == 0:
             return c_part

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -815,28 +815,28 @@ def test_big_expr():
     e3 = Wigner3j(1, 2, 3, 4, 5, 6)*TensorProduct(Commutator(Operator('A') + Dagger(Operator('B')), Operator('C') + Operator('D')), Jz - J2)*Dagger(OuterProduct(Dagger(JzBra(1, 1)), JzBra(1, 0)))*TensorProduct(JzKetCoupled(1, 1, (1, 1)) + JzKetCoupled(1, 0, (1, 1)), JzKetCoupled(1, -1, (1, 1)))
     e4 = (ComplexSpace(1)*ComplexSpace(2) + FockSpace()**2)*(L2(Interval(
         0, oo)) + HilbertSpace())
-    assert str(e1) == '(Jz**2)x(Dagger(A) + Dagger(B))*{Dagger(DifferentialOperator(Derivative(f(x), x),f(x)))**3,Dagger(A) + Dagger(B)}*(<1,0| + <1,1|)*(|0,0> + |1,-1>)'
+    assert str(e1) == '((Jz**2)xDagger(A) + (Jz**2)xDagger(B))*{Dagger(DifferentialOperator(Derivative(f(x), x),f(x)))**3,Dagger(A) + Dagger(B)}*(<1,0| + <1,1|)*(|0,0> + |1,-1>)'
     ascii_str = \
 """\
-                 /                                      3        \\                                 \n\
-                 |/                                   +\\         |                                 \n\
-    2  / +    +\\ <|                    /d            \\ |   +    +>                                 \n\
-/J \\ x \\A  + B /*||DifferentialOperator|--(f(x)),f(x)| | ,A  + B |*(<1,0| + <1,1|)*(|0,0> + |1,-1>)\n\
-\\ z/             \\\\                    \\dx           / /         /                                 \
+                        /                                      3        \\                                 \n\
+                        |/                                   +\\         |                                 \n\
+/    2   +       2   +\\ <|                    /d            \\ |   +    +>                                 \n\
+|/J \\ x A  + /J \\ x B |*||DifferentialOperator|--(f(x)),f(x)| | ,A  + B |*(<1,0| + <1,1|)*(|0,0> + |1,-1>)\n\
+\\\\ z/        \\ z/     / \\\\                    \\dx           / /         /                                 \
 """
     ucode_str = \
 """\
-                 ⎧                                      3        ⎫                                 \n\
-                 ⎪⎛                                   †⎞         ⎪                                 \n\
-    2  ⎛ †    †⎞ ⎨⎜                    ⎛d            ⎞ ⎟   †    †⎬                                 \n\
-⎛J ⎞ ⨂ ⎝A  + B ⎠⋅⎪⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ,A  + B ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)\n\
-⎝ z⎠             ⎩⎝                    ⎝dx           ⎠ ⎠         ⎭                                 \
+                        ⎧                                      3        ⎫                                 \n\
+                        ⎪⎛                                   †⎞         ⎪                                 \n\
+⎛    2   †       2   †⎞ ⎨⎜                    ⎛d            ⎞ ⎟   †    †⎬                                 \n\
+⎜⎛J ⎞ ⨂ A  + ⎛J ⎞ ⨂ B ⎟⋅⎪⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ,A  + B ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)\n\
+⎝⎝ z⎠        ⎝ z⎠     ⎠ ⎩⎝                    ⎝dx           ⎠ ⎠         ⎭                                 \
 """
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
-        r'{J_z^{2}}\otimes \left({A^{\dagger} + B^{\dagger}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left(x \right)},f{\left(x \right)}\right)^{\dagger}\right)^{3},A^{\dagger} + B^{\dagger}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
-    sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
+        r'\left({J_z^{2}}\otimes {A^{\dagger}} + {J_z^{2}}\otimes {B^{\dagger}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left(x \right)},f{\left(x \right)}\right)^{\dagger}\right)^{3},A^{\dagger} + B^{\dagger}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+    sT(e1, "Mul(Add(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Dagger(Operator(Symbol('A')))), TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
     ascii_str = \
 """\
@@ -856,26 +856,26 @@ def test_big_expr():
         r'\left[J_z^{2},A + B\right] \left\{E^{-2},D^{\dagger} C^{\dagger}\right\} \left[J^2,J_z\right]'
     sT(e2, "Mul(Commutator(Pow(JzOp(Symbol('J')), Integer(2)),Add(Operator(Symbol('A')), Operator(Symbol('B')))), AntiCommutator(Pow(Operator(Symbol('E')), Integer(-2)),Mul(Dagger(Operator(Symbol('D'))), Dagger(Operator(Symbol('C'))))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
     assert str(e3) == \
-        "Wigner3j(1, 2, 3, 4, 5, 6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x|1,-1,j1=1,j2=1>"
+        "Wigner3j(1, 2, 3, 4, 5, 6)*(-[Dagger(B) + A,C + D]xJ2 + [Dagger(B) + A,C + D]xJz)*|1,0><1,1|*(|1,0,j1=1,j2=1>x|1,-1,j1=1,j2=1> + |1,1,j1=1,j2=1>x|1,-1,j1=1,j2=1>)"
     ascii_str = \
 """\
-          [ +          ]  /   2     \\                                                                 \n\
-/1  3  5\\*[B  + A,C + D]x |- J  + J |*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x |1,-1,j1=1,j2=1>\n\
-|       |                 \\        z/                                                                 \n\
-\\2  4  6/                                                                                             \
+          /  [ +          ]   2   [ +          ]    \\                                                                                   \n\
+/1  3  5\\*|- [B  + A,C + D]x J  + [B  + A,C + D]x J |*|1,0><1,1|*(|1,0,j1=1,j2=1>x |1,-1,j1=1,j2=1> + |1,1,j1=1,j2=1>x |1,-1,j1=1,j2=1>)\n\
+|       | \\                                        z/                                                                                   \n\
+\\2  4  6/                                                                                                                               \
 """
     ucode_str = \
 """\
-          ⎡ †          ⎤  ⎛   2     ⎞                                                                 \n\
-⎛1  3  5⎞⋅⎣B  + A,C + D⎦⨂ ⎜- J  + J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,j₁=1,j₂=1⟩ + ❘1,1,j₁=1,j₂=1⟩)⨂ ❘1,-1,j₁=1,j₂=1⟩\n\
-⎜       ⎟                 ⎝        z⎠                                                                 \n\
-⎝2  4  6⎠                                                                                             \
+          ⎛  ⎡ †          ⎤   2   ⎡ †          ⎤    ⎞                                                                                   \n\
+⎛1  3  5⎞⋅⎜- ⎣B  + A,C + D⎦⨂ J  + ⎣B  + A,C + D⎦⨂ J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,j₁=1,j₂=1⟩⨂ ❘1,-1,j₁=1,j₂=1⟩ + ❘1,1,j₁=1,j₂=1⟩⨂ ❘1,-1,j₁=1,j₂=1⟩)\n\
+⎜       ⎟ ⎝                                        z⎠                                                                                   \n\
+⎝2  4  6⎠                                                                                                                               \
 """
     assert pretty(e3) == ascii_str
     assert upretty(e3) == ucode_str
     assert latex(e3) == \
-        r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dagger} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle } + {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\right)\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}'
-    sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))))")
+        r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) \left(- {\left[B^{\dagger} + A,C + D\right]}\otimes {J^2} + {\left[B^{\dagger} + A,C + D\right]}\otimes {J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle }}\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }} + {{\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}\right)'
+    sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), Add(Mul(Integer(-1), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), J2Op(Symbol('J')))), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), Add(TensorProduct(JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))), TensorProduct(JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))))))")
     assert str(e4) == '(C(1)*C(2)+F**2)*(L2(Interval(0, oo))+H)'
     ascii_str = \
 """\


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27703.


#### Brief description of what is fixed or changed
- Modified `TensorProduct` to automatically distribute over sums, ensuring correct expansion.
- Updated the `__new__` method to detect `Add` instances and expand `TensorProduct` accordingly.
- Updated tests in order to reflect this change. 

This prevents behaviors such as encountered in the issue:  
```python
from sympy.physics.quantum import Ket, TensorProduct, Operator, Dagger

psi1 = Ket("1")
psi2 = Ket("2")
sum_state = psi1 - 2*psi2

print(TensorProduct(Dagger(psi1), Dagger(psi1))*TensorProduct(sum_state, psi2)) #Exception
```  
With the error being:  
```
TypeError                                 Traceback (most recent call last)
Cell In[3], line 11
      9 print(Dagger(psi1)*sum_state) # Ok
     10 print(TensorProduct(Dagger(psi1), Dagger(psi1))*TensorProduct(psi2, psi2)) # Also ok
---> 11 print(TensorProduct(Dagger(psi1), Dagger(psi1))*TensorProduct(sum_state, psi2)) #Exception

...

File .../sympy/physics/quantum/transforms.py:166, in <listcomp>(.0)
    164 if len(a.args) == len(b.args):
    165     if a.kind == BraKind and b.kind == KetKind:
--> 166         return tuple([InnerProduct(i, j) for (i, j) in zip(a.args, b.args)])
    167     else:
    168         return (TensorProduct(*(i*j for (i, j) in zip(a.args, b.args))), )

File .../sympy/physics/quantum/innerproduct.py:79, in InnerProduct.__new__(cls, bra, ket)
     77 from sympy.physics.quantum.state import KetBase, BraBase
     78 if not isinstance(ket, KetBase):
---> 79     raise TypeError('KetBase subclass expected, got: %r' % ket)
     80 if not isinstance(bra, BraBase):
     81     raise TypeError('BraBase subclass expected, got: %r' % ket)

TypeError: KetBase subclass expected, got: |1> - 2*|2>
```  
This now leads to a correct result:
```
<1|x<1|*(|1>x|2> - 2*|2>x|2>)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
