### PR TITLE
CI: Remove aesara from optional dependencies tests

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -171,7 +171,7 @@ jobs:
       # dependencies to install in all Python versions:
       - run: pip install numpy numexpr matplotlib ipython cython          \
                          wurlitzer autowrap lxml lark z3-solver pycosat   \
-                         jax jaxlib libclang scipy aesara                 \
+                         jax jaxlib libclang scipy                        \
                          'antlr4-python3-runtime==4.11.*'                 \
                          symengine                                        \
                          numba llvmlite pymc                              \

--- a/.mailmap
+++ b/.mailmap
@@ -858,7 +858,7 @@ Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@u
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
-Kartikey-M <kartikeymishra2003@gmail.com> Kartikey-M <143963981+Kartikey-M@users.noreply.github.com>
+Kartikey Mishra <kartikeymishra2003@gmail.com> Kartikey Mishra <143963981+Kartikey-M@users.noreply.github.com>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>
 Kaustubh <90597818+kaustubh-765@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -858,7 +858,7 @@ Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@u
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
-Kartikey-M <kartikeymishra2003@gmail.com>
+Kartikey-M <kartikeymishra2003@gmail.com> Kartikey-M <143963981+Kartikey-M@users.noreply.github.com>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>
 Kaustubh <90597818+kaustubh-765@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -858,7 +858,7 @@ Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@u
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
-Kartikey Mishra <kartikeymishra2003@gmail.com> Kartikey Mishra <143963981+Kartikey-M@users.noreply.github.com>
+Kartikey Mishra <kartikeymishra2003@gmail.com> Kartikey-M <143963981+Kartikey-M@users.noreply.github.com>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>
 Kaustubh <90597818+kaustubh-765@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -858,6 +858,7 @@ Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@u
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
+Kartikey-M <kartikeymishra2003@gmail.com>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>
 Kaustubh <90597818+kaustubh-765@users.noreply.github.com>


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27784

#### Brief description of what is fixed or changed
Removed `aesara` from the optional dependencies tests in GitHub Actions workflow in the `runtests.yml` file. This is because `aesara` is unmaintained and relies on `numpy.distutils`, which has been removed in setuptools 76.1.0, causing test failures. 

The failure was:
`AttributeError: module 'setuptools.distutils.ccompiler' has no attribute '_default_compilers'. Did you mean: 'get_default_compiler'?`

This PR:
1. Removes aesara from the list of packages installed during CI testing.
2. Adds my name to the .mailmap file as a new contributor as mentioned [here](https://docs.sympy.org/dev/contributing/new-contributors-guide/workflow-process.html#add-your-name-and-email-address-to-the-mailmap-file).


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
