### PR TITLE
Fix type annotation in docs of ObstacleSetPathway

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1285,7 +1285,7 @@ Roman Inflianskas <infroma@gmail.com>
 Ronan Lamy <ronan.lamy@gmail.com> <Ronan.Lamy@normalesup.org>
 Rudr Tiwari <rudrtiwari@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
-Rushabh Mehta <mehtarushabh2005@gmail.com> RushabhMehta2005 <139112780+RushabhMehta2005@users.noreply.github.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>

--- a/sympy/physics/mechanics/pathway.py
+++ b/sympy/physics/mechanics/pathway.py
@@ -322,7 +322,7 @@ class ObstacleSetPathway(PathwayBase):
     Parameters
     ==========
 
-    attachments : tuple[Point, Point]
+    attachments : tuple[Point, ...]
         The set of ``Point`` objects that define the segmented obstacle-set
         pathway.
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR just fixes a simple type annotation in the doc-string of ObstacleSetPathway in sympy.mechanics

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
