### PR TITLE
Fix commutators with SigmaPlus/SigmaMinus with different labels

### DIFF
--- a/sympy/physics/quantum/pauli.py
+++ b/sympy/physics/quantum/pauli.py
@@ -297,7 +297,10 @@ class SigmaMinus(SigmaOpBase):
         return 2 * self
 
     def _eval_commutator_SigmaMinus(self, other, **hints):
-        return SigmaZ(self.name)
+        if self.name != other.name:
+            return S.Zero
+        else:
+            return SigmaZ(self.name)
 
     def _eval_anticommutator_SigmaZ(self, other, **hints):
         return S.Zero
@@ -384,7 +387,10 @@ class SigmaPlus(SigmaOpBase):
             return -2 * self
 
     def _eval_commutator_SigmaMinus(self, other, **hints):
-        return SigmaZ(self.name)
+        if self.name != other.name:
+            return S.Zero
+        else:
+            return SigmaZ(self.name)
 
     def _eval_anticommutator_SigmaZ(self, other, **hints):
         return S.Zero

--- a/sympy/physics/quantum/tests/test_pauli.py
+++ b/sympy/physics/quantum/tests/test_pauli.py
@@ -17,6 +17,7 @@ sx2, sy2, sz2 = SigmaX(2), SigmaY(2), SigmaZ(2)
 
 sm, sp = SigmaMinus(), SigmaPlus()
 sm1, sp1 = SigmaMinus(1), SigmaPlus(1)
+sm2, sp2 = SigmaMinus(2), SigmaPlus(2)
 A, B = Operator("A"), Operator("B")
 
 
@@ -50,6 +51,13 @@ def test_pauli_operators_commutator_with_labels():
     assert Commutator(sy1, sz2).doit() == 0
     assert Commutator(sz1, sx2).doit() == 0
 
+    assert Commutator(sp1, sp1).doit() == 0
+    assert Commutator(sm1, sm1).doit() == 0
+    assert Commutator(sp1, sm1).doit() == sz1
+
+    assert Commutator(sm1, sm2).doit() == 0
+    assert Commutator(sp1, sm2).doit() == 0
+    assert Commutator(sp1, sp2).doit() == 0
 
 def test_pauli_operators_anticommutator():
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Adds some test cases for `SigmaPlus/SigmaMinus` commutators with different labels and fixes commutators with `SigmaMinus`.

#### Other comments

I've not yet found how commutators with `SigmaPlus` are computed.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Fixed commutators with `SigmaMinus` not respecting labels. i.e. `[SigmaMinus(0), SigmaMinus(1)]` incorrectly gave `SigmaZ(0)`
<!-- END RELEASE NOTES -->
