### PR TITLE
Fixing PolyRing.index to disallow unwanted generator identifiers 

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -423,25 +423,18 @@ class PolyRing(DefaultPrinting, IPolys):
                 i = -1  # indicate impossible choice
         elif isinstance(gen, int):
             i = gen
-
-            if 0 <= i and i < self.ngens:
+            if 0 <= i < self.ngens:
                 pass
-            elif -self.ngens <= i and i <= -1:
-                i = self.ngens + i
             else:
-                raise ValueError("invalid generator index: %s" % gen)
+                raise ValueError(
+                    "generator index must be a non-negative integer less than %s, got %s" % (self.ngens, gen))
         elif self.is_element(gen):
             try:
                 i = self.gens.index(gen)
             except ValueError:
                 raise ValueError("invalid generator: %s" % gen)
-        elif isinstance(gen, str):
-            try:
-                i = self.symbols.index(gen)
-            except ValueError:
-                raise ValueError("invalid generator: %s" % gen)
         else:
-            raise ValueError("expected a polynomial generator, an integer, a string or None, got %s" % gen)
+            raise ValueError("expected a polynomial generator, a non-negative integer, or None, got %s" % gen)
 
         return i
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -427,7 +427,7 @@ class PolyRing(DefaultPrinting, IPolys):
             if 0 <= i and i < self.ngens:
                 pass
             elif -self.ngens <= i and i <= -1:
-                i = -i - 1
+                i = self.ngens + i
             else:
                 raise ValueError("invalid generator index: %s" % gen)
         elif self.is_element(gen):

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -86,10 +86,6 @@ def test_PolyRing_index():
     assert R.index(1) == 1
     assert R.index(2) == 2
 
-    assert R.index(-1) == 2
-    assert R.index(-2) == 1
-    assert R.index(-3) == 0
-
     assert R.index(x) == 0
     assert R.index(y) == 1
     assert R.index(z) == 2
@@ -99,10 +95,13 @@ def test_PolyRing_index():
     assert R_empty.index(None) == -1
 
     raises(ValueError, lambda: R.index(3))
-    raises(ValueError, lambda: R.index(-4))
+    raises(ValueError, lambda: R.index(-1))
+    raises(ValueError, lambda: R.index(-2))
+    raises(ValueError, lambda: R.index(-3))
     w = Symbol('w')
     raises(ValueError, lambda: R.index(w))
     raises(ValueError, lambda: R.index("u"))
+    raises(ValueError, lambda: R.index("x"))
 
 
 def test_PolyRing_drop():

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -78,6 +78,33 @@ def test_PolyRing_ring_new():
     R, = ring("", QQ)
     assert R.ring_new([((), 7)]) == R(7)
 
+
+def test_PolyRing_index():
+    R, x, y, z = ring("x,y,z", ZZ)
+
+    assert R.index(0) == 0
+    assert R.index(1) == 1
+    assert R.index(2) == 2
+
+    assert R.index(-1) == 2
+    assert R.index(-2) == 1
+    assert R.index(-3) == 0
+
+    assert R.index(x) == 0
+    assert R.index(y) == 1
+    assert R.index(z) == 2
+
+    assert R.index(None) == 0
+    R_empty = PolyRing([], ZZ)
+    assert R_empty.index(None) == -1
+
+    raises(ValueError, lambda: R.index(3))
+    raises(ValueError, lambda: R.index(-4))
+    w = Symbol('w')
+    raises(ValueError, lambda: R.index(w))
+    raises(ValueError, lambda: R.index("u"))
+
+
 def test_PolyRing_drop():
     R, x,y,z = ring("x,y,z", ZZ)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27794  
Fixes #27819

#### Brief description of what is fixed or changed
`PolyRing.index` has been refactored to raise errors when unwanted `gen` identifiers are passed to it.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Made `PolyRing.index` raise error for unwanted `gen` identifier types.
<!-- END RELEASE NOTES -->
