### PR TITLE
Prevent incorrect substitution in Limit.doit() for integers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1576,6 +1576,7 @@ Vladimir Lagunov <werehuman@gmail.com>
 Vladimir Perić <vlada.peric@gmail.com>
 Vladimir Poluhsin <vovapolu@gmail.com>
 Vladimir Sereda <voffch@gmail.com>
+Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com> <voaides.r@yahoo.com>
 Waldir Pimenta <waldyrious@gmail.com>
 Wang Ran (汪然) <wangr@smail.nju.edu.cn>
 Warren Jacinto <warrenjacinto@gmail.com>

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -954,7 +954,6 @@ def test_issue_10978():
     assert LambertW(x).limit(x, 0) == 0
 
 
-@XFAIL # issue 27773
 def test_issue_14313_comment():
     assert limit(floor(n/2), n, oo) is oo
 


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27773.

#### Brief description of what is fixed or changed
Previously, `Limit.doit()` would rewrite limits of the form  

$$
\lim_{x \to \infty} f(x) \quad \text{as} \quad \lim_{x \to 0^+} f(1/x)
$$

without accounting for cases where $x$ is a discrete variable (e.g., an integer).  

This caused incorrect evaluations when the function involved was discontinuous, such as `floor`, `ceiling`, or `mod`.  

Before this fix, evaluating the following limit:

$$
\lim_{n \to \infty} \lfloor \frac{n}{2} \rfloor
$$

resulted in:

$$
\lim_{n \to 0^+} \lfloor \frac{1}{2n} \rfloor = 0
$$

which is incorrect.

To resolve this issue, substitution $x$ to $1/x$ is avoided when the limit variable is an integer and the function being evaluated contains discontinuous operations (`floor`, `ceiling`, `mod`).  

In such cases, the limit is now computed using the Gruntz algorithm directly

#### Other comments
This change allows the removal of a previously XFAILED test, as the issue it covered is now resolved.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
