### PR TITLE
RingSeries: remove redundancy in mul expr in _rs_series.

### DIFF
--- a/sympy/polys/puiseux.py
+++ b/sympy/polys/puiseux.py
@@ -13,7 +13,7 @@ non-negative integers.
 # of polynomial rings.
 #
 # Ideally there would be more of a proper series type that can keep track of
-# not not just the leading terms of a truncated series but also the precision
+# not just the leading terms of a truncated series but also the precision
 # of the series. For now the rings here are just introduced to keep the
 # interface that ring_series was using before.
 

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -672,10 +672,6 @@ def rs_series_from_list(p, c, x, prec, concur=1):
     >>> rs_trunc(pc.compose(x, p), x, 4)
     6*x**3 + 11*x**2 + 8*x + 6
 
-    """
-
-    # TODO: Add this when it is documented in Sphinx
-    """
     See Also
     ========
 
@@ -2029,10 +2025,7 @@ def _rs_series(expr, series_rs, a, prec):
 
     elif expr.is_Mul:
         n = len(args)
-        for arg in args:    # XXX Looks redundant
-            if not arg.is_Number:
-                R1, _ = sring(arg, expand=False, series=True)
-                R = R.compose(R1)
+
         min_pows = list(map(rs_min_pow, args, [R(arg) for arg in args],
             [a]*len(args)))
         sum_pows = sum(min_pows)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

1.  fix typo from puiseux
2. Added a `See Also` section for the compose method in the `rs_series_from_list` Sphinx documentation
3.  Removed redundant code in `_rs_series` function for multiplication expressions
Previously, when processing multiplication expressions (`expr.is_Mul`), the code contained a redundant loop that created and composed rings for non-numeric arguments, as noted by the comment "# XXX Looks redundant". This loop was unnecessary because the same ring composition happens later in the main calculation loop when `_rs_series` is called recursively for each argument

   


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
