### PR TITLE
Fixed a bug where `Mod` returns an incorrect result

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -104,8 +104,11 @@ class Mod(DefinedFunction):
             else:
                 return
             ls = -2*q
+            r = p - q
             for _ in range(4):
-                if fuzzy_and([comp1(ls, p), comp2(p, ls + q)]):
+                if not comp1(ls, p):
+                    return
+                if comp2(r, ls):
                     return p - ls
                 ls += q
 

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -5,6 +5,7 @@ from .kind import NumberKind
 from .logic import fuzzy_and, fuzzy_not
 from .mul import Mul
 from .numbers import equal_valued
+from .relational import is_le, is_lt, is_ge, is_gt
 from .singleton import S
 
 
@@ -96,21 +97,17 @@ class Mod(DefinedFunction):
 
             # by difference
             # -2|q| < p < 2|q|
-            d = abs(p)
-            for _ in range(2):
-                d -= abs(q)
-                if d.is_negative:
-                    if q.is_positive:
-                        if p.is_positive:
-                            return d + q
-                        elif p.is_negative:
-                            return -d
-                    elif q.is_negative:
-                        if p.is_positive:
-                            return d
-                        elif p.is_negative:
-                            return -d + q
-                    break
+            if q.is_positive:
+                comp1, comp2 = is_le, is_lt
+            elif q.is_negative:
+                comp1, comp2 = is_ge, is_gt
+            else:
+                return
+            ls = -2*q
+            for _ in range(4):
+                if fuzzy_and([comp1(ls, p), comp2(p, ls + q)]):
+                    return p - ls
+                ls += q
 
         rv = number_eval(p, q)
         if rv is not None:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1908,6 +1908,12 @@ def test_Mod():
     assert Mod(-p - 5, -p - 3) == -2
     assert Mod(p + 1, p - 1).func is Mod
 
+    # issue 27749
+    n = symbols('n', integer=True, positive=True)
+    assert unchanged(Mod, 1, n)
+    n = symbols('n', prime=True)
+    assert Mod(1, n) == 1
+
     # handling sums
     assert (x + 3) % 1 == Mod(x, 1)
     assert (x + 3.0) % 1 == Mod(1.*x, 1)

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -2,6 +2,7 @@ from sympy.core.decorators import call_highest_priority
 from sympy.core.expr import Expr
 from sympy.core.mod import Mod
 from sympy.core.numbers import Integer
+from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.integers import floor
 
@@ -14,7 +15,7 @@ class Higher(Integer):
     '''
 
     _op_priority = 20.0
-    result = 1
+    result = S.One
 
     def __new__(cls):
         obj = Expr.__new__(cls)
@@ -86,7 +87,7 @@ class Lower(Higher):
     '''
 
     _op_priority = 5.0
-    result = -1
+    result = S.NegativeOne
 
     def __new__(cls):
         obj = Expr.__new__(cls)
@@ -133,8 +134,7 @@ def test_div():
 def test_mod():
     assert h%l == h%x == 1
     assert l%h == x%h == 2
-    # An issue arises within `Mod.eval` when performing comparisons
-    # assert x%l == Mod(x, -1)
+    assert x%l == Mod(x, -1)
     assert l%x == Mod(-1, x)
 
 

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -133,7 +133,8 @@ def test_div():
 def test_mod():
     assert h%l == h%x == 1
     assert l%h == x%h == 2
-    assert x%l == Mod(x, -1)
+    # An issue arises within `Mod.eval` when performing comparisons
+    # assert x%l == Mod(x, -1)
     assert l%x == Mod(-1, x)
 
 

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -15,7 +15,7 @@ class Higher(Integer):
     '''
 
     _op_priority = 20.0
-    result = S.One
+    result: Expr = S.One
 
     def __new__(cls):
         obj = Expr.__new__(cls)
@@ -87,7 +87,7 @@ class Lower(Higher):
     '''
 
     _op_priority = 5.0
-    result = S.NegativeOne
+    result: Expr = S.NegativeOne
 
     def __new__(cls):
         obj = Expr.__new__(cls)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27749
#27769

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug where `Mod(1, n)` evaluates to `1 - n` when n is a positive integer.
<!-- END RELEASE NOTES -->
