### PR TITLE
Fix: remove hardcoded NUMBER_OF_DIGITS in test_rewriting, use mpmath.…

### DIFF
--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -10,7 +10,6 @@ from sympy.functions.elementary.trigonometric import (cos, sin, sinc)
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.assumptions import assuming, Q
 from sympy.external import import_module
-from sympy.ntheory import digits
 from sympy.printing.codeprinter import ccode
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.cfunctions import log2, exp2, expm1, log1p
@@ -439,7 +438,7 @@ def test_compiled_ccode_with_rewriting():
 
     # Unfortunately, we need to call ``.n()`` on our expressions before we hand them
     # to ``ccode``, and we need to request a large number of significant digits.
-    # In this test, results converged for double precision when the following number
+    # In this test, results converged for double precision when the following numberg
     # of significant digits were chosen:
 
     num_of_digits = max(25, mpmath.mp.dps)

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -1,4 +1,5 @@
 import tempfile
+import mpmath
 from sympy.core.numbers import pi, Rational
 from sympy.core.power import Pow
 from sympy.core.singleton import S
@@ -9,6 +10,7 @@ from sympy.functions.elementary.trigonometric import (cos, sin, sinc)
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.assumptions import assuming, Q
 from sympy.external import import_module
+from sympy.ntheory import digits
 from sympy.printing.codeprinter import ccode
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.cfunctions import log2, exp2, expm1, log1p
@@ -439,7 +441,9 @@ def test_compiled_ccode_with_rewriting():
     # to ``ccode``, and we need to request a large number of significant digits.
     # In this test, results converged for double precision when the following number
     # of significant digits were chosen:
-    NUMBER_OF_DIGITS = 25   # TODO: this should ideally be automatically handled.
+
+    num_of_digits = max(25, mpmath.mp.dps)
+
 
     func_c = '''
 #include <math.h>
@@ -450,8 +454,8 @@ double func_unchanged(double x) {
 double func_rewritten(double x) {
     return %(rewritten)s;
 }
-''' % {"unchanged": ccode(unchanged.n(NUMBER_OF_DIGITS)),
-           "rewritten": ccode(rewritten.n(NUMBER_OF_DIGITS))}
+''' % {"unchanged": ccode(unchanged.n(num_of_digits)),
+           "rewritten": ccode(rewritten.n(num_of_digits))}
 
     func_pyx = '''
 #cython: language_level=3


### PR DESCRIPTION
### Title: Remove Hardcoded `NUMBER_OF_DIGITS` in `test_compiled_ccode_with_rewriting`

#### Description:
I replaced the `NUMBER_OF_DIGITS = 25` with a dynamic approach that checks `mpmath.mp.dps`. 

This came from the existing `# TODO: this should ideally be automatically handled `comment. Now, the test picks either 25 or the current `mp.dps`, whichever is higher, so it no longer depends on a single magic number in all environments.

#### Testing
I ran 
`pytest sympy/codegen/tests/test_rewriting.py -k test_compiled_ccode_with_rewriting -v`


### **Release Notes**
**Subpackage: `codegen`**
<!-- BEGIN RELEASE NOTES -->
- **Dynamic Precision in Code Generation Tests:**  
  The test for `ccode` rewriting now determines the precision dynamically by using the higher value between a fixed minimum (25) and the current `mpmath.mp.dps` setting. This change removes reliance on a hardcoded constant, aligning the test more closely with the actual precision setting and improving robustness across various environments.
  
  *Note:* While this update resolves the immediate issue, it prompts further reflection on how similar cases could eventually be handled even more automatically.
<!-- END RELEASE NOTES -->