### PR TITLE
Fix typo in domainsintro.rst

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1129,6 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/doc/src/modules/polys/domainsintro.rst
+++ b/doc/src/modules/polys/domainsintro.rst
@@ -116,7 +116,7 @@ different ways e.g.::
   >>> e.expand()
   x**2 + x
 
-These two expression although equivalent have different tree representations::
+These two expressions, although equivalent, have different tree representations::
 
   >>> print(srepr(e))
   Mul(Symbol('x'), Add(Symbol('x'), Integer(1)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Fixed a typo in domainsintro.rst.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixed a typo in domainsintro.rst.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
