### PR TITLE
Possibility to Add a Custom Printer to nsolve

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -587,6 +587,7 @@ Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
 Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>
 Evelyn King <evelyn.cameron.king@gmail.com>
 Evelyn King <evelyn.cameron.king@gmail.com> Cameron King <v-caking@microsoft.com>
+Everus <everuslainus@gmail.com> Everus Lainus <101049736+EverusLainus@users.noreply.github.com>
 Evgenia Karunus <lakesare@gmail.com>
 Fabian Ball <fabian.ball@kit.edu>
 Fabian Froehlich <fabian@schaluck.com> FFroehlich <fabian@schaluck.com>
@@ -1733,4 +1734,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Everus <everuslainus@gmail.com> Everus Lainus <101049736+EverusLainus@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1733,3 +1733,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Everus <everuslainus@gmail.com> Everus Lainus <101049736+EverusLainus@users.noreply.github.com>

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3069,7 +3069,10 @@ def nsolve(*args, dict=False, **kwargs):
         # the function is better behaved when the denominator is present
         # e.g., issue 11768
 
-        f = lambdify(fargs, f, modules, **kwargs)
+        allowed_kwargs = {"printer"} 
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
+
+        f = lambdify(fargs, f, modules, **filtered_kwargs)
         x = sympify(findroot(f, x0, **kwargs))
         if as_dict:
             return [{fargs: x}]
@@ -3088,8 +3091,8 @@ def nsolve(*args, dict=False, **kwargs):
         print('J(x):')
         print(J)
     # create functions
-    f = lambdify(fargs, f.T, modules,**kwargs )
-    J = lambdify(fargs, J, modules, **kwargs)
+    f = lambdify(fargs, f.T, modules,**filtered_kwargs )
+    J = lambdify(fargs, J, modules, **filtered_kwargs)
     # solve the system numerically
     x = findroot(f, x0, J=J, **kwargs)
     if as_dict:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3005,6 +3005,7 @@ def nsolve(*args, dict=False, **kwargs):
 
     """
     allowed_kwargs = {"printer"} 
+    filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
     # there are several other SymPy functions that use method= so
     # guard against that here
     if 'method' in kwargs:
@@ -3071,7 +3072,7 @@ def nsolve(*args, dict=False, **kwargs):
         # e.g., issue 11768
 
         
-        filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
+        
 
         f = lambdify(fargs, f, modules, **filtered_kwargs)
         x = sympify(findroot(f, x0, **kwargs))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3004,8 +3004,8 @@ def nsolve(*args, dict=False, **kwargs):
     0.46792545969349058
 
     """
-    #adding printer based on the issue #27799
-    allowed_kwargs = {"printer"} 
+    # adding printer based on the issue 27799
+    allowed_kwargs = {"printer"}
     filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
     # there are several other SymPy functions that use method= so
     # guard against that here
@@ -3070,7 +3070,7 @@ def nsolve(*args, dict=False, **kwargs):
         # the function is much better behaved if there is no denominator
         # but sending the numerator is left to the user since sometimes
         # the function is better behaved when the denominator is present
-        # e.g., issue 11768           
+        # e.g., issue 11768
 
         f = lambdify(fargs, f, modules, **filtered_kwargs)
         x = sympify(findroot(f, x0, **kwargs))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3069,7 +3069,7 @@ def nsolve(*args, dict=False, **kwargs):
         # the function is better behaved when the denominator is present
         # e.g., issue 11768
 
-        f = lambdify(fargs, f, modules)
+        f = lambdify(fargs, f, modules, **kwargs)
         x = sympify(findroot(f, x0, **kwargs))
         if as_dict:
             return [{fargs: x}]
@@ -3088,8 +3088,8 @@ def nsolve(*args, dict=False, **kwargs):
         print('J(x):')
         print(J)
     # create functions
-    f = lambdify(fargs, f.T, modules)
-    J = lambdify(fargs, J, modules)
+    f = lambdify(fargs, f.T, modules,**kwargs )
+    J = lambdify(fargs, J, modules, **kwargs)
     # solve the system numerically
     x = findroot(f, x0, J=J, **kwargs)
     if as_dict:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3004,6 +3004,7 @@ def nsolve(*args, dict=False, **kwargs):
     0.46792545969349058
 
     """
+    allowed_kwargs = {"printer"} 
     # there are several other SymPy functions that use method= so
     # guard against that here
     if 'method' in kwargs:
@@ -3069,7 +3070,7 @@ def nsolve(*args, dict=False, **kwargs):
         # the function is better behaved when the denominator is present
         # e.g., issue 11768
 
-        allowed_kwargs = {"printer"} 
+        
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
 
         f = lambdify(fargs, f, modules, **filtered_kwargs)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3004,6 +3004,7 @@ def nsolve(*args, dict=False, **kwargs):
     0.46792545969349058
 
     """
+    #adding printer based on the issue #27799
     allowed_kwargs = {"printer"} 
     filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
     # there are several other SymPy functions that use method= so
@@ -3069,10 +3070,7 @@ def nsolve(*args, dict=False, **kwargs):
         # the function is much better behaved if there is no denominator
         # but sending the numerator is left to the user since sometimes
         # the function is better behaved when the denominator is present
-        # e.g., issue 11768
-
-        
-        
+        # e.g., issue 11768           
 
         f = lambdify(fargs, f, modules, **filtered_kwargs)
         x = sympify(findroot(f, x0, **kwargs))
@@ -3093,7 +3091,7 @@ def nsolve(*args, dict=False, **kwargs):
         print('J(x):')
         print(J)
     # create functions
-    f = lambdify(fargs, f.T, modules,**filtered_kwargs )
+    f = lambdify(fargs, f.T, modules, **filtered_kwargs)
     J = lambdify(fargs, J, modules, **filtered_kwargs)
     # solve the system numerically
     x = findroot(f, x0, J=J, **kwargs)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3004,9 +3004,8 @@ def nsolve(*args, dict=False, **kwargs):
     0.46792545969349058
 
     """
-    # adding printer based on the issue 27799
-    allowed_kwargs = {"printer"}
-    filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_kwargs}
+    # adding user_lambdify based on the issue 27799
+    user_lambdify = kwargs.pop("lambdify", lambdify)
     # there are several other SymPy functions that use method= so
     # guard against that here
     if 'method' in kwargs:
@@ -3072,7 +3071,7 @@ def nsolve(*args, dict=False, **kwargs):
         # the function is better behaved when the denominator is present
         # e.g., issue 11768
 
-        f = lambdify(fargs, f, modules, **filtered_kwargs)
+        f = user_lambdify(fargs, f, modules)
         x = sympify(findroot(f, x0, **kwargs))
         if as_dict:
             return [{fargs: x}]
@@ -3091,8 +3090,8 @@ def nsolve(*args, dict=False, **kwargs):
         print('J(x):')
         print(J)
     # create functions
-    f = lambdify(fargs, f.T, modules, **filtered_kwargs)
-    J = lambdify(fargs, J, modules, **filtered_kwargs)
+    f = user_lambdify(fargs, f.T, modules)
+    J = user_lambdify(fargs, J, modules)
     # solve the system numerically
     x = findroot(f, x0, J=J, **kwargs)
     if as_dict:


### PR DESCRIPTION
issue #27799

**Possibility to Add a Custom Printer to nsolve**

I have added a way to pass a printer as an argument to nsolve to allow for custom printing functionality. This change addresses the error mentioned in the issue #27799

```
File "/usr/lib/python3.13/site-packages/sympy/printing/codeprinter.py", line 582, in _print_not_supported
raise PrintMethodNotImplementedError("Unsupported by %s: %s" % (str(type(self)), str(type(expr))) +
"\nSet the printer option 'strict' to False in order to generate partially printed code.")
sympy.printing.codeprinter.PrintMethodNotImplementedError: Unsupported by <class 'sympy.printing.pycode.MpmathPrinter'>: <class 'sympy.core.function.Derivative'>
Set the printer option 'strict' to False in order to generate partially printed code.
```

The solution allows users to specify a custom printer when calling nsolve, that let's users to set printer option to 'strict'.

**Example usage:**

```
from sympy.printing.pycode import MpmathPrinter
from sympy import sin, nsolve
from sympy.abc import x

printer = MpmathPrinter(settings={'fully_qualified_modules': False, 'strict': False})
print(nsolve(sin(x), x, 2, printer=printer))
```

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

.
