### PR TITLE
Removed duplicate `dif` computation, added XFAIL tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -685,6 +685,7 @@ Han Wei Ang <ang.h.w@u.nus.edu>
 Hannah Kari <hannah.kari@marquette.edu> hannah-kari <42753364+hannah-kari@users.noreply.github.com>
 Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
 Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Harikrishna Srinivasan <harikrishnasri3@gmail.com>
 Harold Erbin <harold.erbin@gmail.com>
 Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
 Harry Mountain <harrymountain1@icloud.com>

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -441,12 +441,13 @@ class Relational(Boolean, EvalfMixin):
             r = r.canonical
             # If there is only one symbol in the expression,
             # try to write it on a simplified form
-            free = list(filter(lambda x: x.is_real is not False, r.free_symbols))
+            if len(r.free_symbols):
+                dif = r.lhs - r.rhs
+            free = list(filter(lambda x: x.is_real is not False, dif.free_symbols))
             if len(free) == 1:
                 try:
                     from sympy.solvers.solveset import linear_coeffs
                     x = free.pop()
-                    dif = r.lhs - r.rhs
                     m, b = linear_coeffs(dif, x)
                     if m.is_zero is False:
                         if m.is_negative:
@@ -476,7 +477,6 @@ class Relational(Boolean, EvalfMixin):
                     from sympy.solvers.solveset import linear_coeffs
                     from sympy.polys.polytools import gcd
                     free = list(ordered(free))
-                    dif = r.lhs - r.rhs
                     m = linear_coeffs(dif, *free)
                     constant = m[-1]
                     del m[-1]

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -147,24 +147,8 @@ def test_issue_27754():
     # Simplify for Multivariable Non-linear polynomials
     assert simplify(Eq(y - sqrt(x), y + sqrt(x))) == Eq(x, 0)
     assert simplify(Eq(x**2 + y**2, x**2 - y**2)) == Eq(y**2, 0)
-
-    assert simplify(Eq(x**6 + sqrt(x), x**6 - sqrt(x))) == Eq(x, 0)
-    assert simplify(Eq(sqrt(x + y) + sqrt(y), sqrt(x + y) - sqrt(y))) == Eq(y, 0)
-
-    assert simplify(Eq(sqrt(sqrt(x + y)), sqrt(sqrt(x - y)))) == Eq(y, 0)
-    assert simplify(Eq(sqrt(x + sqrt(y)), sqrt(x - sqrt(y)))) == Eq(y, 0)
-
-    # Cases with no solution
-    assert simplify(Eq(sqrt(x) + 1, -sqrt(x) - 1)) is S.false
-    assert simplify(Eq(x**2 + 2, x**2 + 4)) is S.false
-
-    # Trivial cases
+    # 3 - variables
     assert simplify(Eq(sqrt(x + y + z), sqrt(x + y - z))) == Eq(z, 0)
-    assert simplify(Eq(sqrt(x + 1)**2, x + 1)) is S.true
-    assert simplify(Gt(x**2, (x + 1)**2)) == Eq(Lt(x, Rational(-1, 2)))
-
-    # Case with mixed polynomials and radicals on both sides
-    assert simplify(Eq(x**2 + sqrt(x + y), x**2 - sqrt(x + y))) == Eq(x + y, 0)
 
 def test_issue_3557():
     f_1 = x*a + y*b + z*c - 1

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -146,7 +146,7 @@ def test_simplify_expr():
 def test_issue_27754():
     # Simplify for Multivariable Non-linear polynomials
     assert simplify(Eq(y - sqrt(x), y + sqrt(x))) == Eq(x, 0)
-    assert simplify(Eq(x**2 + y**2, x**2 - y**2)) == Eq(y, 0)
+    assert simplify(Eq(x**2 + y**2, x**2 - y**2)) == Eq(y**2, 0)
 
     assert simplify(Eq(x**6 + sqrt(x), x**6 - sqrt(x))) == Eq(x, 0)
     assert simplify(Eq(sqrt(x + y) + sqrt(y), sqrt(x + y) - sqrt(y))) == Eq(y, 0)
@@ -161,7 +161,7 @@ def test_issue_27754():
     # Trivial cases
     assert simplify(Eq(sqrt(x + y + z), sqrt(x + y - z))) == Eq(z, 0)
     assert simplify(Eq(sqrt(x + 1)**2, x + 1)) is S.true
-    assert simplify(Gt(x**2, (x + 1)**2)) is S.false
+    assert simplify(Gt(x**2, (x + 1)**2)) == Eq(Lt(x, Rational(-1, 2)))
 
     # Case with mixed polynomials and radicals on both sides
     assert simplify(Eq(x**2 + sqrt(x + y), x**2 - sqrt(x + y))) == Eq(x + y, 0)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -142,6 +142,29 @@ def test_simplify_expr():
 
     assert simplify(hyper([], [], x)) == exp(x)
 
+@XFAIL
+def test_issue_27754():
+    # Simplify for Multivariable Non-linear polynomials
+    assert simplify(Eq(y - sqrt(x), y + sqrt(x))) == Eq(x, 0)
+    assert simplify(Eq(x**2 + y**2, x**2 - y**2)) == Eq(y, 0)
+
+    assert simplify(Eq(x**6 + sqrt(x), x**6 - sqrt(x))) == Eq(x, 0)
+    assert simplify(Eq(sqrt(x + y) + sqrt(y), sqrt(x + y) - sqrt(y))) == Eq(y, 0)
+
+    assert simplify(Eq(sqrt(sqrt(x + y)), sqrt(sqrt(x - y)))) == Eq(y, 0)
+    assert simplify(Eq(sqrt(x + sqrt(y)), sqrt(x - sqrt(y)))) == Eq(y, 0)
+
+    # Cases with no solution
+    assert simplify(Eq(sqrt(x) + 1, -sqrt(x) - 1)) is S.false
+    assert simplify(Eq(x**2 + 2, x**2 + 4)) is S.false
+
+    # Trivial cases
+    assert simplify(Eq(sqrt(x + y + z), sqrt(x + y - z))) == Eq(z, 0)
+    assert simplify(Eq(sqrt(x + 1)**2, x + 1)) is S.true
+    assert simplify(Gt(x**2, (x + 1)**2)) is S.false
+
+    # Case with mixed polynomials and radicals on both sides
+    assert simplify(Eq(x**2 + sqrt(x + y), x**2 - sqrt(x + y))) == Eq(x + y, 0)
 
 def test_issue_3557():
     f_1 = x*a + y*b + z*c - 1


### PR DESCRIPTION
Removed duplicate `dif` computation, added XFAIL tests

#### References to other Issues or PRs

Test cases added for Issue #27754

#### Brief description of what is fixed or changed

Removed redundant computation of `dif` of r.lhs - r.rhs more than once.

Added a few test cases for `simplify`, with _expected to FAIL_ decorator that Issue #27754 says.

#### Other comments

From the conversation had in issue #27754 the test cases are added.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
