### PR TITLE
TODO: Implement rank method for DDM and SDM Classes

### DIFF
--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -689,6 +689,27 @@ class DFM:
             # what happens here.
             raise NotImplementedError("DFM.inv() is not implemented for %s" % K)
 
+    @doctest_depends_on(ground_types='flint')
+    def rank(self):
+        """
+        Returns the rank of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> M = Matrix([[1, 2], [2, 4]])
+        >>> dfm = M.to_DM().to_dfm()
+        >>> dfm.rank()
+
+        See Also
+        ========
+
+        sympy.polys.matrices.domainmatrix.DomainMatrix.rank
+            Higher level interface to compute the rank of a matrix.
+        """
+        return self.rep.rank()
+
     def lu(self):
         """Return the LU decomposition of the matrix."""
         L, U, swaps = self.to_ddm().lu()

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -701,6 +701,13 @@ class DFM:
         >>> M = Matrix([[1, 2], [2, 4]])
         >>> dfm = M.to_DM().to_dfm()
         >>> dfm.rank()
+        1
+
+        See Also
+        ========
+
+        sympy.polys.matrices.ddm.DDM.rank
+        sympy.polys.matrices.sdm.SDM.rank
         """
         return self.rep.rank()
 

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -701,12 +701,6 @@ class DFM:
         >>> M = Matrix([[1, 2], [2, 4]])
         >>> dfm = M.to_DM().to_dfm()
         >>> dfm.rank()
-
-        See Also
-        ========
-
-        sympy.polys.matrices.domainmatrix.DomainMatrix.rank
-            Higher level interface to compute the rank of a matrix.
         """
         return self.rep.rank()
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -972,7 +972,7 @@ class DDM(list):
             rref, pivots = self.rref()
             return len(pivots)
         else:
-            # For non-field domains like ZZ, use fraction-free LU decomposition
+            # For non-field domains like ZZ, use fraction-free LU decomposition (fflu)
             _, _, rank = self._fflu()
             return rank
 

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -973,18 +973,7 @@ class DDM(list):
             return len(pivots)
         else:
             # For non-field domains like ZZ, use fraction-free LU decomposition
-            rows, cols = self.shape
-            # Use _fflu to get the decomposition as a single matrix
-            LU, perm = self._fflu()
-            # Count the number of non-zero pivots
-            rank = 0
-            i = j = 0
-            while i < rows and j < cols:
-                if LU[i][j] != self.domain.zero:
-                    rank += 1
-                    i += 1
-                j += 1
-
+            _, _, rank = self._fflu()
             return rank
 
     def lu(a):
@@ -1006,6 +995,7 @@ class DDM(list):
         Returns:
             LU : decomposition as a single matrix.
             perm (list): Permutation indices for row swaps.
+            rank (int): Rank of the matrix.
         """
         rows, cols = self.shape
         K = self.domain
@@ -1047,7 +1037,7 @@ class DDM(list):
                 LU[i][j] = multiplier
             rank += 1
 
-        return LU, perm
+        return LU, perm, rank
 
     def fflu(self):
         """
@@ -1063,7 +1053,7 @@ class DDM(list):
         K = self.domain
 
         # Phase 1: Perform row operations and get permutation
-        U, perm = self._fflu()
+        U, perm, rank = self._fflu()
 
         # Phase 2: Construct P, L, D matrices
         # Create P from permutation

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -950,11 +950,42 @@ class DDM(list):
     def rank(self):
         """
         Returns the rank of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy import QQ, ZZ
+        >>> from sympy.polys.matrices.ddm import DDM
+        >>> A = DDM([[QQ(1), QQ(2)], [QQ(2), QQ(4)]], (2, 2), QQ)
+        >>> A.rank()
+        1
+        >>> B = DDM([[ZZ(1), ZZ(2)], [ZZ(2), ZZ(4)]], (2, 2), ZZ)
+        >>> B.rank()
+        1
+
+        See Also
+        ========
+        sympy.polys.matrices.sdm.SDM.rank
+        sympy.polys.matrices._dfm.DFM.rank
         """
-        if not self.domain.is_Field:
-            return self.convert_to(QQ).rank()
-        rref, pivots = self.rref()
-        return len(pivots)
+        if self.domain.is_Field:
+            rref, pivots = self.rref()
+            return len(pivots)
+        else:
+            # For non-field domains like ZZ, use fraction-free LU decomposition
+            rows, cols = self.shape
+            # Use _fflu to get the decomposition as a single matrix
+            LU, perm = self._fflu()
+            # Count the number of non-zero pivots
+            rank = 0
+            i = j = 0
+            while i < rows and j < cols:
+                if LU[i][j] != self.domain.zero:
+                    rank += 1
+                    i += 1
+                j += 1
+
+            return rank
 
     def lu(a):
         """L, U decomposition of a"""

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -947,6 +947,15 @@ class DDM(list):
         ddm_iinv(ainv, a, K)
         return ainv
 
+    def rank(self):
+        """
+        Returns the rank of the matrix.
+        """
+        if not self.domain.is_Field:
+            return self.convert_to(QQ).rank()
+        rref, pivots = self.rref()
+        return len(pivots)
+
     def lu(a):
         """L, U decomposition of a"""
         m, n = a.shape

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1265,7 +1265,7 @@ class DomainMatrix:
         ...    [x, x**2],
         ...    [x**3, x**4]], (2, 2), ZZ[x])
         >>> A.rank()
-        2
+        1
 
         Notes
         =====

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1251,7 +1251,7 @@ class DomainMatrix:
         Examples
         ========
 
-        >>> from sympy import ZZ, QQ, Symbol
+        >>> from sympy import ZZ, Symbol
         >>> from sympy.polys.matrices import DomainMatrix
         >>> A = DomainMatrix([
         ...    [ZZ(1), ZZ(2), ZZ(3)],

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1050,9 +1050,7 @@ class SDM(dict):
             rref, pivots = self.rref()
             return len(pivots)
         else:
-            # For non-field domains like ZZ, convert to DDM and use fflu
-            ddm = self.to_ddm()
-            return ddm.rank()
+            return self.to_dfm_or_ddm().rank()
 
     def det(A):
         """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1027,11 +1027,32 @@ class SDM(dict):
     def rank(self):
         """
         Returns the rank of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy import QQ, ZZ
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> A = SDM({0: {0: QQ(1), 1: QQ(2)}, 1: {0: QQ(2), 1: QQ(4)}}, (2, 2), QQ)
+        >>> A.rank()
+        1
+        >>> B = SDM({0: {0: ZZ(1), 1: ZZ(2)}, 1: {0: ZZ(2), 1: ZZ(4)}}, (2, 2), ZZ)
+        >>> B.rank()
+        1
+
+        See Also
+        ========
+
+        rref
+        fflu
         """
-        if not self.domain.is_Field:
-            return self.convert_to(QQ).rank()
-        rref, pivots = self.rref()
-        return len(pivots)
+        if self.domain.is_Field:
+            rref, pivots = self.rref()
+            return len(pivots)
+        else:
+            # For non-field domains like ZZ, convert to DDM and use fflu
+            ddm = self.to_ddm()
+            return ddm.rank()
 
     def det(A):
         """

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1024,6 +1024,15 @@ class SDM(dict):
         """
         return A.to_dfm_or_ddm().inv().to_sdm()
 
+    def rank(self):
+        """
+        Returns the rank of the matrix.
+        """
+        if not self.domain.is_Field:
+            return self.convert_to(QQ).rank()
+        rref, pivots = self.rref()
+        return len(pivots)
+
     def det(A):
         """
         Returns determinant of A

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -1050,7 +1050,8 @@ class SDM(dict):
             rref, pivots = self.rref()
             return len(pivots)
         else:
-            return self.to_dfm_or_ddm().rank()
+            rref_sdm, _, pivots = sdm_rref_den(self, self.domain)
+            return len(pivots)
 
     def det(A):
         """

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -817,6 +817,27 @@ def test_XXM_inv_ZZ(DM):
 
 
 @pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_rank_ZZ(DM):
+    assert DM([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).rank() == 3
+    assert DM([[1, 2, 3], [4, 5, 6], [7, 8, 9]]).rank() == 2
+    assert DM([[0, 0], [0, 0]]).rank() == 0
+    assert DM([[1, 0, 2], [0, 1, 3]]).rank() == 2
+    assert DM([[1, 0], [0, 1], [2, 3]]).rank() == 2
+    assert DM([[1, 2], [2, 4], [3, 6]]).rank() == 1
+
+
+@pytest.mark.parametrize('DM', DMQ_all)
+def test_XXM_rank_QQ(DM):
+    assert DM([[(1, 2), (1, 3)], [(1, 4), (1, 5)]]).rank() == 2
+    assert DM([[(1, 2), (1, 3)], [(2, 4), (2, 6)]]).rank() == 1
+    assert DM([[(1, 1), (2, 1), (3, 1)],
+               [(4, 1), (5, 1), (6, 1)],
+               [(7, 1), (8, 1), (9, 1)]]).rank() == 2
+    assert DM([[(1, 2), (2, 3), (3, 4)],
+               [(1, 5), (1, 6), (1, 7)]]).rank() == 2
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
 def test_XXM_charpoly_ZZ(DM):
     dM1 = DM([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
     assert dM1.charpoly() == [1, -16, -12, 3]


### PR DESCRIPTION
#### Brief description of what is fixed or changed

This pull request implements the `rank()` method for the Dense Domain Matrix (DDM) and Sparse Domain Matrix (SDM) classes in `ddm.py` and `sdm.py`, addressing the **TODO** in `_dfm.py` . This implementation ensures accurate rank calculations for integer matrices (ZZ) by converting them to the rational field (QQ) when necessary, allowing the use of the rref() method. Updated test cases in `test_xxm.py` cover various scenarios, including full rank and rank-deficient matrices, ensuring comprehensive testing. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
