### PR TITLE
Add check in geodesic_end_vectors

### DIFF
--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -277,7 +277,7 @@ class WrappingSphere(WrappingGeometryBase):
         for point in (point_1, point_2):
             if not self.point_on_surface(point):
                 msg = (
-                    f'Geodesic length cannot be calculated as point {point} '
+                    f'Geodesic end vectors cannot be calculated as point {point} '
                     f'with radius {point.pos_from(self.point).magnitude()} '
                     f'from the sphere\'s center {self.point} does not lie on '
                     f'the surface of {self} with radius {self.radius}.'
@@ -550,7 +550,7 @@ class WrappingCylinder(WrappingGeometryBase):
         for point in (point_1, point_2):
             if not self.point_on_surface(point):
                 msg = (
-                    f'Geodesic length cannot be calculated as point {point} '
+                    f'Geodesic end vectors cannot be calculated as point {point} '
                     f'with radius {point.pos_from(self.point).magnitude()} '
                     f'from the cylinder\'s center {self.point} does not lie on '
                     f'the surface of {self} with radius {self.radius} and axis '

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -274,6 +274,16 @@ class WrappingSphere(WrappingGeometryBase):
             The point at which the geodesic terminates.
 
         """
+        for point in (point_1, point_2):
+            if not self.point_on_surface(point):
+                msg = (
+                    f'Geodesic length cannot be calculated as point {point} '
+                    f'with radius {point.pos_from(self.point).magnitude()} '
+                    f'from the sphere\'s center {self.point} does not lie on '
+                    f'the surface of {self} with radius {self.radius}.'
+                )
+                raise ValueError(msg)
+
         pA, pB = point_1, point_2
         pO = self.point
         pA_vec = pA.pos_from(pO)
@@ -537,6 +547,17 @@ class WrappingCylinder(WrappingGeometryBase):
             The point at which the geodesic terminates.
 
         """
+        for point in (point_1, point_2):
+            if not self.point_on_surface(point):
+                msg = (
+                    f'Geodesic length cannot be calculated as point {point} '
+                    f'with radius {point.pos_from(self.point).magnitude()} '
+                    f'from the cylinder\'s center {self.point} does not lie on '
+                    f'the surface of {self} with radius {self.radius} and axis '
+                    f'{self.axis}.'
+                )
+                raise ValueError(msg)
+
         point_1_from_origin_point = point_1.pos_from(self.point)
         point_2_from_origin_point = point_2.pos_from(self.point)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None

#### Brief description of what is fixed or changed
This PR adds a check to `geodesic_end_vectors()` method in both WrappingSphere and WrappingCylinder class to confirm before computing the geodesic vectors that the points actually lie on the geometry.

#### Other comments
This is need as WrappingPathway calls the `geodesic_end_vectors()` method without assessing the points.
Code blob [here](https://github.com/sympy/sympy/blob/064958283f4e077bb77c9bdd79cb5c3285575d51/sympy/physics/mechanics/pathway.py#L655C9-L657C72).
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
