### PR TITLE
Add Caching to Speed Up Harmonic Number Computation

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -6,9 +6,10 @@ sequences of rational numbers such as Bernoulli and Fibonacci numbers.
 Factorials, binomial coefficients and related functions are located in
 the separate 'factorials' module.
 """
+from __future__ import annotations
 from math import prod
 from collections import defaultdict
-from typing import Tuple as tTuple
+from typing import Callable, Tuple as tTuple
 
 from sympy.core import S, Symbol, Add, Dummy
 from sympy.core.cache import cacheit
@@ -890,6 +891,9 @@ class harmonic(DefinedFunction):
 
     """
 
+    # This prevents redundant recalculations and speeds up harmonic number computations.
+    harmonic_cache: dict[Integer, Callable[[int], Rational]] = {}
+
     @classmethod
     def eval(cls, n, m=None):
         from sympy.functions.special.zeta_functions import zeta
@@ -914,7 +918,14 @@ class harmonic(DefinedFunction):
             if n.is_negative and (m.is_integer is False or m.is_nonpositive is False):
                 return S.ComplexInfinity if m is S.One else S.NaN
             if n.is_nonnegative:
-                return Add(*(k**(-m) for k in range(1, int(n)+1)))
+                if m.is_Integer:
+                    if m not in cls.harmonic_cache:
+                        @recurrence_memo([0])
+                        def f(n, prev):
+                            return prev[-1] + S.One / n**m
+                        cls.harmonic_cache[m] = f
+                    return cls.harmonic_cache[m](int(n))
+                return Add(*(k**(-m) for k in range(1, int(n) + 1)))
 
     def _eval_rewrite_as_polygamma(self, n, m=S.One, **kwargs):
         from sympy.functions.special.gamma_functions import gamma, polygamma


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes : #27259
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR replaces the explicit summation in harmonic number computation with a memoized recurrence approach. By caching previously computed values, it avoids redundant calculations and improves performance, especially for larger inputs.

#### Other comments
Before Change : Total time: 7.1152989864349365 seconds to go to order=100
After change :  Total time: 1.7343776226043701 seconds to go to order=100

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added caching to speed up harmonic number computation.
<!-- END RELEASE NOTES -->
