### PR TITLE
manualintegrate: Add powsimp_rule for simplifying exponent expressions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1336,6 +1336,8 @@ Saket Kumar Singh <saketkumar1202@gmail.com>
 Saketh <alurusaisaketh@gmail.com>
 Sakirul Alam <binarysakir@gmail.com>
 Saksham Alok <sakshamalok13@gmail.com> Saksham-13 <sakshamalok13@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg> SalahDin Rezk <salah2112004@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg> salastro <salah2112004@gmail.com>
 Salil Vishnu Kapur <salilvishnukapur@gmail.com>
 Salmista-94 <alejandrogroso@hotmail.com> alejandrogroso@hotmail.com <Salmista-94>
 Saloni Jain <tosalonijain@gmail.com>

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -63,6 +63,7 @@ from sympy.ntheory.factor_ import primefactors
 from sympy.polys.polytools import degree, lcm_list, gcd_list, Poly
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
+from sympy.simplify.powsimp import powsimp
 from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
@@ -969,6 +970,29 @@ def exp_rule(integral):
     integrand, symbol = integral
     if isinstance(integrand.args[0], Symbol):
         return ExpRule(integrand, symbol, E, integrand.args[0])
+
+
+def powsimp_rule(integral):
+    """
+    Strategy that simplifies the exponent of a power.
+    exp(a*x**2) * exp(b*x) -> exp((a*x**2 + b*x))
+    For example, this is useful for the ErfRule.
+    """
+    integrand, symbol = integral
+    a = Wild('a', exclude=[symbol])
+    b = Wild('b', exclude=[symbol])
+    k = Wild('k', exclude=[symbol])
+
+    match = integrand.match(k**(a*symbol**2) * k**(b*symbol))
+
+    if not match:
+        return
+
+    simplified = powsimp(integrand, combine='exp')
+
+    if simplified != integrand:
+        steps = integral_steps(simplified, symbol)
+        return RewriteRule(integrand, symbol, simplified, steps)
 
 
 def orthogonal_poly_rule(integral):
@@ -2074,7 +2098,7 @@ def integral_steps(integrand, symbol, **options):
             Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_linear_rule),
-                        null_safe(sqrt_quadratic_rule)),
+                        null_safe(sqrt_quadratic_rule), null_safe(powsimp_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2098,7 +2098,7 @@ def integral_steps(integrand, symbol, **options):
             Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_linear_rule),
-                        null_safe(sqrt_quadratic_rule), null_safe(powsimp_rule)),
+                        null_safe(sqrt_quadratic_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,
@@ -2112,6 +2112,9 @@ def integral_steps(integrand, symbol, **options):
             null_safe(alternatives(
                 rewrites_rule,
                 substitution_rule,
+                condition(
+                    integral_is_subclass(Mul, Pow),
+                    powsimp_rule),
                 condition(
                     integral_is_subclass(Mul, Pow),
                     partial_fractions_rule),

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -292,6 +292,8 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
     f, F = sqrt(4 + 9*sin(x)**2), 2*elliptic_e(x, Rational(-9, 4))
     assert_is_integral_of(f, F)
+    f, F = exp(-x**2)*exp(x), Rational(1,2)*exp(Rational(1,4))*sqrt(pi)*erf(x - Rational(1,2))
+    assert_is_integral_of(f, F)
 
 
 def test_manualintegrate_derivative():


### PR DESCRIPTION
## Added powsimp_rule to simplify exponent expressions in integration

### Summary
Added a new integration rule, `powsimp_rule`, which simplifies exponent expressions by combining exponential terms where applicable. This is useful for cases like the ErfRule, where terms of the form `exp(a*x**2) * exp(b*x)` can be rewritten as `exp((a*x**2 + b*x))`.

### Changes
- Introduced `powsimp_rule` using `sympy.simplify.powsimp`.
- Integrated `powsimp_rule` into the manual integration strategy.
- Updated `test_manual.py` to include a test case validating the rule.

This enhancement improves integration handling by allowing more cases to be rewritten into a simpler form before applying further rules.

### Example
```python
In [1]: integrate(exp(-x**2)*exp(x))

Out [2]:
    1/4
√π⋅ℯ   ⋅erf(x - 1/2)
──────────────────
         2
```

### References to other Issues or PRs
Related to #27586. To be extended.

### Brief description of what is fixed or changed
This PR improves symbolic integration by adding a strategy that simplifies exponent expressions before applying further integration rules. This leads to more efficient computations and ensures better handling of cases involving exponentiated terms.

### Other comments
This is meant to be coupled with adding `erf(x)` to the liate integration by parts rule to solve special integrals of the form `erf(az)*exp(bz)`. I will open a pull request with the latter.

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added `powsimp_rule` to simplify exponent expressions in manual integration.
<!-- END RELEASE NOTES -->