### PR TITLE
Add rewriting and simplification rules to inequalities so that they may be rewritten as Equality or Unequality

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1129,6 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1129,9 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
 Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -639,6 +639,18 @@ class Equality(Relational):
     def _eval_relation(cls, lhs, rhs):
         return _sympify(lhs == rhs)
 
+    def _eval_rewrite(self, rule, args, **hints):
+        if rule == GreaterThan:
+            if is_ge(self.lhs, self.rhs):
+                return GreaterThan(self.rhs, self.lhs)
+            elif is_ge(self.rhs, self.lhs):
+                return GreaterThan(self.lhs, self.rhs)
+        elif rule == LessThan:
+            if is_ge(self.lhs, self.rhs):
+                return LessThan(self.lhs, self.rhs)
+            elif is_ge(self.rhs, self.lhs):
+                return LessThan(self.rhs, self.lhs)
+
     def _eval_rewrite_as_Add(self, L, R, evaluate=True, **kwargs):
         """
         return Eq(L, R) as L - R. To control the evaluation of
@@ -812,6 +824,18 @@ class Unequality(Relational):
                 return {self.rhs}
         return set()
 
+    def _eval_rewrite(self, rule, args, **hints):
+        if rule == StrictGreaterThan:
+            if is_ge(self.lhs, self.rhs):
+                return StrictGreaterThan(self.rhs, self.lhs)
+            elif is_ge(self.rhs, self.lhs):
+                return StrictGreaterThan(self.lhs, self.rhs)
+        elif rule == StrictLessThan:
+            if is_ge(self.lhs, self.rhs):
+                return StrictLessThan(self.lhs, self.rhs)
+            elif is_ge(self.rhs, self.lhs):
+                return StrictLessThan(self.rhs, self.lhs)
+
     def _eval_simplify(self, **kwargs):
         # simplify as an equality
         eq = Equality(*self.args)._eval_simplify(**kwargs)
@@ -868,6 +892,21 @@ class _Inequality(Relational):
             return cls(lhs, rhs, evaluate=False)
         else:
             return _sympify(val)
+
+    def _eval_simplify(self, **kwargs):
+        e = super()._eval_simplify(**kwargs)
+        if not isinstance(e, _Inequality):
+            return e
+
+        equality_form = e.rewrite(Equality)
+        if equality_form != e:
+            return equality_form
+
+        unequality_form = e.rewrite(Unequality)
+        if unequality_form != e:
+            return unequality_form
+
+        return e
 
 
 class _Greater(_Inequality):
@@ -1144,6 +1183,11 @@ class GreaterThan(_Greater):
     def strict(self):
         return Gt(*self.args)
 
+    def _eval_rewrite(self, rule, args, **hints):
+        if rule == Equality:
+            if is_ge(self.rhs, self.lhs):
+                return Equality(self.lhs, self.rhs)
+
 Ge = GreaterThan
 
 
@@ -1160,6 +1204,11 @@ class LessThan(_Less):
     @property
     def strict(self):
         return Lt(*self.args)
+
+    def _eval_rewrite(self, rule, args, **hints):
+        if rule == Equality:
+            if is_ge(self.lhs, self.rhs):
+                return Equality(self.lhs, self.rhs)
 
 Le = LessThan
 
@@ -1178,6 +1227,10 @@ class StrictGreaterThan(_Greater):
     def weak(self):
         return Ge(*self.args)
 
+    def _eval_rewrite(self, rule, args, **hints):
+        if rule == Unequality:
+            if is_ge(self.lhs, self.rhs):
+                return Unequality(self.lhs, self.rhs)
 
 Gt = StrictGreaterThan
 
@@ -1195,6 +1248,11 @@ class StrictLessThan(_Less):
     @property
     def weak(self):
         return Le(*self.args)
+
+    def _eval_rewrite(self, rule, args, **hints):
+        if rule == Unequality:
+            if is_ge(self.rhs, self.lhs):
+                return Unequality(self.lhs, self.rhs)
 
 Lt = StrictLessThan
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -900,11 +900,11 @@ class _Inequality(Relational):
 
         equality_form = e.rewrite(Equality)
         if equality_form != e:
-            return equality_form
+            return equality_form.simplify(**kwargs)
 
         unequality_form = e.rewrite(Unequality)
         if unequality_form != e:
-            return unequality_form
+            return unequality_form.simplify(**kwargs)
 
         return e
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Inequalities can now be rewritten as an `Equality` or `Unequality` when possible.

For example:

```
>>> X = Symbol("X", real=True, negative=False)
>>> Y = Symbol("Y", real=True, negative=False)
>>> Ge(-Y, X).rewrite(Equality)
Eq(X, -Y)
>>> Ge(-Y, X).simplify()
```

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Supersedes part of #27757, with the rest in #27842.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Inequalities may now be rewritten in terms of `Equality` and `Unequality`.

<!-- END RELEASE NOTES -->
