### PR TITLE
Take assumptions into consideration in `Equality._eval_simplify`, add function for determining the domain of a symbol based upon assumptions, use assumptions domain in calculus functions, and change `as_set()` to require a target symbol

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1129,6 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1127,6 +1127,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1129,9 +1129,9 @@ Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
 Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
 Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
 Oscar Gustafsson <oscar.gustafsson@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
 Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
 P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -205,7 +205,7 @@ def assumption_domain(symbol, assumptions=set(), _exclude=frozenset()):
     elif symbol.is_positive is False:
         result = _monotonic_sign(symbol)
         if result is not None:
-            if result in (_eps, -eps):
+            if result in (_eps, -_eps):
                 domain = domain.intersect(Interval(S.NegativeInfinity, S.Zero, S.false, S.true))
             else:
                 domain = domain.intersect(Interval(S.NegativeInfinity, result, S.false, S.false))

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -389,4 +389,4 @@ def test_issue_18747():
 
 
 def test_issue_25942():
-    assert (acos(x) > pi/3).as_set() == Interval.Ropen(-1, S(1)/2)
+    assert (acos(x) > pi/3).as_set(x) == Interval.Ropen(-1, S(1)/2)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -118,7 +118,7 @@ def continuous_domain(f, symbol, domain, _exclude=frozenset()):
             pass    # 0**negative handled by singularities()
         else:
             constraint = solve_univariate_inequality(atom.base >= 0,
-                                                        symbol).as_set(symbol)
+                symbol, _exclude=_exclude).as_set(symbol)
             cont_domain = Intersection(constraint, cont_domain)
 
     for atom in f.atoms(Function):
@@ -126,14 +126,14 @@ def continuous_domain(f, symbol, domain, _exclude=frozenset()):
             for c in constraints[atom.func]:
                 constraint_relational = c.subs(x, atom.args[0])
                 constraint_set = solve_univariate_inequality(
-                    constraint_relational, symbol).as_set(symbol)
+                    constraint_relational, symbol, _exclude=_exclude).as_set(symbol)
                 cont_domain = Intersection(constraint_set, cont_domain)
         elif atom.func in constraints_union:
             constraint_set = S.EmptySet
             for c in constraints_union[atom.func]:
                 constraint_relational = c.subs(x, atom.args[0])
                 constraint_set += solve_univariate_inequality(
-                    constraint_relational, symbol).as_set(symbol)
+                    constraint_relational, symbol, _exclude=_exclude).as_set(symbol)
             cont_domain = Intersection(constraint_set, cont_domain)
         # XXX: the discontinuities below could be factored out in
         # a new "discontinuities()".

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -113,7 +113,7 @@ def _process_limits(*symbols, discrete=None):
             if discrete:
                 raise TypeError(err_msg)
             variable = V.atoms(Symbol).pop()
-            V = (variable, V.as_set())
+            V = (variable, V.as_set(variable))
         elif isinstance(V, Symbol) or getattr(V, '_diff_wrt', False):
             if isinstance(V, Idx):
                 if V.lower is None or V.upper is None:

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -484,7 +484,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         if sequence_term.is_Piecewise:
             for func, cond in sequence_term.args:
                 # see if it represents something going to oo
-                if cond == True or cond.as_set().sup is S.Infinity:
+                if cond == True or cond.as_set(sym).sup is S.Infinity:
                     s = Sum(func, (sym, lower_limit, upper_limit))
                     return s.is_convergent()
             return S.true
@@ -1362,7 +1362,7 @@ def eval_sum_hyper(f, i_a_b):
         res1, cond1 = res1
         res2, cond2 = res2
         cond = And(cond1, cond2)
-        if cond == False or cond.as_set() == S.EmptySet:
+        if cond == False:
             return None
         return Piecewise((res1 + res2, cond), (old_sum, True))
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1604,7 +1604,7 @@ def test_process_limits():
     # these should be (x, union) not union
     # (but then we would get a TypeError because we don't
     # handle non-contiguous sets: see below use of `union`)
-    union = Or(x < 1, x > 3).as_set()
+    union = Or(x < 1, x > 3).as_set(x)
     raises(ValueError, lambda: _process_limits(
         union, discrete=True))
     raises(ValueError, lambda: _process_limits(

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -449,7 +449,12 @@ class Symbol(AtomicExpr, Boolean): # type: ignore
 
     binary_symbols = free_symbols  # in this case, not always
 
-    def as_set(self):
+    def as_set(self, symbol, _exclude=frozenset()):
+        from sympy.assumptions.wrapper import assumption_domain
+
+        if symbol == self:
+            return assumption_domain(self)
+
         return S.UniversalSet
 
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -252,7 +252,7 @@ class Piecewise(DefinedFunction):
 
             if cond.is_Relational:
                 return None
-            if a in c.as_set().boundary:
+            if a in c.as_set(x).boundary:
                 return None
             # Apply expression if a is an interior point of the domain of e.
             if cond:
@@ -880,7 +880,7 @@ class Piecewise(DefinedFunction):
                             Inequalities in the complex domain are
                             not supported. Try the real domain by
                             setting domain=S.Reals'''))
-            cond_int = U.intersect(cond.as_set())
+            cond_int = U.intersect(cond.as_set(tuple(cond_free)[0]))
             U = U - cond_int
             if cond_int != S.EmptySet:
                 exp_sets.append((expr, cond_int))
@@ -903,7 +903,7 @@ class Piecewise(DefinedFunction):
                 x = free.pop()
                 try:
                     byfree[x] = byfree.setdefault(
-                        x, S.EmptySet).union(c.as_set())
+                        x, S.EmptySet).union(c.as_set(x))
                 except NotImplementedError:
                     if not default:
                         raise NotImplementedError(filldedent('''

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -735,8 +735,6 @@ class And(LatticeOp, BooleanFunction):
         return Intersection(*(arg.operator_domain() for arg in self.args))
 
     def _eval_as_set(self, symbol, _exclude=frozenset()):
-        from sympy.sets.sets import Intersection
-
         set = S.UniversalSet
         for arg in self.args:
             if set == S.EmptySet:
@@ -845,8 +843,6 @@ class Or(LatticeOp, BooleanFunction):
         return Union(*(arg.operator_domain() for arg in self.args))
 
     def _eval_as_set(self, symbol, _exclude=frozenset()):
-        from sympy.sets.sets import Union
-
         maximum_possible_domain = self.operator_domain()
 
         set = S.EmptySet

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -863,30 +863,33 @@ def test_true_false():
 
 
 def test_bool_as_set():
-    assert ITE(y <= 0, False, y >= 1).as_set() == Interval(1, oo)
-    assert And(x <= 2, x >= -2).as_set() == Interval(-2, 2)
-    assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
-    assert Not(x > 2).as_set() == Interval(-oo, 2)
+    assert ITE(y <= 0, False, y >= 1).as_set(y) == Interval(1, oo)
+    assert And(x <= 2, x >= -2).as_set(x) == Interval(-2, 2)
+    assert Or(x >= 2, x <= -2).as_set(x) == Interval(-oo, -2) + Interval(2, oo)
+    assert Not(x > 2).as_set(x) == Interval(-oo, 2)
     # issue 10240
-    assert Not(And(x > 2, x < 3)).as_set() == \
+    assert Not(And(x > 2, x < 3)).as_set(x) == \
            Union(Interval(-oo, 2), Interval(3, oo))
-    assert true.as_set() == S.UniversalSet
-    assert false.as_set() is S.EmptySet
-    assert x.as_set() == S.UniversalSet
-    assert And(Or(x < 1, x > 3), x < 2).as_set() == Interval.open(-oo, 1)
-    assert And(x < 1, sin(x) < 3).as_set() == (x < 1).as_set()
-    raises(NotImplementedError, lambda: (sin(x) < 1).as_set())
+    assert true.as_set(x) == S.UniversalSet
+    assert false.as_set(x) is S.EmptySet
+    assert x.as_set(x) == S.UniversalSet
+    assert And(Or(x < 1, x > 3), x < 2).as_set(x) == Interval.open(-oo, 1)
+    assert And(x < 1, sin(x) < 3).as_set(x) == (x < 1).as_set(x)
+    raises(NotImplementedError, lambda: (sin(x) < 1).as_set(x))
     # watch for object morph in as_set
-    assert Eq(-1, cos(2 * x) ** 2 / sin(2 * x) ** 2).as_set() is S.EmptySet
+    assert Eq(-1, cos(2 * x) ** 2 / sin(2 * x) ** 2).as_set(x) is S.EmptySet
 
 
 @XFAIL
 def test_multivariate_bool_as_set():
+    from sympy.sets import ConditionSet
+
     x, y = symbols('x,y')
 
-    assert And(x >= 0, y >= 0).as_set() == Interval(0, oo) * Interval(0, oo)
-    assert Or(x >= 0, y >= 0).as_set() == S.Reals * S.Reals - \
-           Interval(-oo, 0, True, True) * Interval(-oo, 0, True, True)
+    assert And(x >= 0, y >= 0).as_set(x) == Interval(0, oo)
+    assert And(x >= 0, y >= 0).as_set(y) == Interval(0, oo)
+    assert Or(x >= 0, y >= 0).as_set(x) == ConditionSet(x, y >= 0, Interval(0, oo))
+    assert Or(y >= 0, y >= 0).as_set(y) == ConditionSet(y, x >= 0, Interval(0, oo))
 
 
 def test_all_or_nothing():
@@ -915,14 +918,14 @@ def test_negated_atoms():
 
 
 def test_issue_8777():
-    assert And(x > 2, x < oo).as_set() == Interval(2, oo, left_open=True)
-    assert And(x >= 1, x < oo).as_set() == Interval(1, oo)
-    assert (x < oo).as_set() == Interval(-oo, oo)
-    assert (x > -oo).as_set() == Interval(-oo, oo)
+    assert And(x > 2, x < oo).as_set(x) == Interval(2, oo, left_open=True)
+    assert And(x >= 1, x < oo).as_set(x) == Interval(1, oo)
+    assert (x < oo).as_set(x) == Interval(-oo, oo)
+    assert (x > -oo).as_set(x) == Interval(-oo, oo)
 
 
 def test_issue_8975():
-    assert Or(And(-oo < x, x <= -2), And(2 <= x, x < oo)).as_set() == \
+    assert Or(And(-oo < x, x <= -2), And(2 <= x, x < oo)).as_set(x) == \
            Interval(-oo, -2) + Interval(2, oo)
 
 

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -59,5 +59,8 @@ class Contains(Boolean):
             if i.is_Boolean or i.is_Symbol or
             isinstance(i, (Eq, Ne))])
 
-    def as_set(self):
+    def as_set(self, symbol, _exclude=frozenset()):
+        if symbol != self.args[0]:
+            raise ValueError("symbol does not match first operand")
+
         return self.args[1]

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -53,7 +53,7 @@ def _(f, x):
             if p_cond is true:
                 intrvl = domain_set
             else:
-                intrvl = p_cond.as_set()
+                intrvl = p_cond.as_set(var)
                 intrvl = Intersection(domain_set, intrvl)
 
             if p_expr.is_Number:

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -42,9 +42,9 @@ def test_binary_symbols():
 def test_as_set():
     x = Symbol('x')
     y = Symbol('y')
-    assert Contains(x, FiniteSet(y)).as_set() == FiniteSet(y)
-    assert Contains(x, S.Integers).as_set() == S.Integers
-    assert Contains(x, S.Reals).as_set() == S.Reals
+    assert Contains(x, FiniteSet(y)).as_set(x) == FiniteSet(y)
+    assert Contains(x, S.Integers).as_set(x) == S.Integers
+    assert Contains(x, S.Reals).as_set(x) == S.Reals
 
 
 def test_type_error():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -972,7 +972,7 @@ def test_Union_as_relational():
         Or(And(Le(0, x), Le(x, 1)), Eq(x, 2))
     assert (Interval(0, 1, True, True) + FiniteSet(1)).as_relational(x) == \
         And(Lt(0, x), Le(x, 1))
-    assert Or(x < 0, x > 0).as_set().as_relational(x) == \
+    assert Or(x < 0, x > 0).as_set(x).as_relational(x) == \
         And((x > -oo), (x < oo), Ne(x, 0))
     assert (Interval.Ropen(1, 3) + Interval.Lopen(3, 5)
         ).as_relational(x) == And(Ne(x,3),(x>=1),(x<=5))
@@ -1742,8 +1742,8 @@ def test_issue_14336():
     #https://github.com/sympy/sympy/issues/14336
     U = S.Complexes
     x = Symbol("x")
-    U -= U.intersect(Ne(x, 1).as_set())
-    U -= U.intersect(S.true.as_set())
+    U -= U.intersect(Ne(x, 1).as_set(x))
+    U -= U.intersect(S.true.as_set(x))
 
 def test_issue_9855():
     #https://github.com/sympy/sympy/issues/9855

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -1,6 +1,7 @@
 """Tools for solving inequalities and systems of inequalities. """
 import itertools
 
+from sympy.assumptions.wrapper import assumption_domain
 from sympy.calculus.util import (continuous_domain, periodicity,
     function_range)
 from sympy.core import sympify
@@ -438,6 +439,8 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
 
     """
     from sympy.solvers.solvers import denoms
+
+    domain = domain.intersect(assumption_domain(gen, _exclude=_exclude | {expr}))
 
     if domain.is_subset(S.Reals) is False:
         raise NotImplementedError(filldedent('''

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -380,7 +380,7 @@ def reduce_abs_inequalities(exprs, gen):
         for expr, rel in exprs ])
 
 
-def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, continuous=False):
+def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, continuous=False, _exclude=frozenset()):
     """Solves a real univariate inequality.
 
     Parameters
@@ -490,7 +490,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             elif const is S.false:
                 rv = S.EmptySet
         elif period is not None:
-            frange = function_range(e, gen, domain)
+            frange = function_range(e, gen, domain, _exclude=_exclude | {expr})
 
             rel = expr.rel_op
             if rel in ('<', '<='):
@@ -561,7 +561,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             for d in denoms(expr, gen):
                 singularities.extend(solvify(d, gen, domain))
             if not continuous:
-                domain = continuous_domain(expanded_e, gen, domain)
+                domain = continuous_domain(expanded_e, gen, domain, _exclude=_exclude | {expr})
 
             include_x = '=' in expr.rel_op and expr.rel_op != '!='
 

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -646,7 +646,7 @@ def _rel_as_nonpos(constr, syms):
                 x = freei.pop()
                 if x in unbound:
                     continue  # will handle later
-                ivl = Le(i, 0, evaluate=False).as_set()
+                ivl = Le(i, 0, evaluate=False).as_set(x)
                 if x not in univariate:
                     univariate[x] = ivl
                 else:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1293,7 +1293,11 @@ def _solveset(f, symbol, domain, _check=False):
         expr_set_pairs = f.as_expr_set_pairs(domain)
         for (expr, in_set) in expr_set_pairs:
             if in_set.is_Relational:
-                in_set = in_set.as_set()
+                free = in_set.free_symbols
+                if len(free) > 1:
+                    raise NotImplementedError("multivariate piecewise conditions are not supported in solveset yet")
+
+                in_set = in_set.as_set(free.pop())
             solns = solver(expr, symbol, in_set)
             result += solns
     elif isinstance(f, Eq):
@@ -2447,7 +2451,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
     if not isinstance(f, (Expr, Relational, Number)):
         raise ValueError("%s is not a valid SymPy expression" % f)
 
-    if not isinstance(symbol, (Expr, Relational)) and  symbol is not None:
+    if not isinstance(symbol, (Expr, Relational)) and symbol is not None:
         raise ValueError("%s is not a valid SymPy symbol" % (symbol,))
 
     if not isinstance(domain, Set):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -635,7 +635,7 @@ class MarkovProcess(StochasticProcess):
                     return s if greater else 1 - s
 
             rv = rv[0]
-            states = condition.as_set()
+            states = condition.as_set(condition.lhs) # XXX: is the variate symbol always condition.lhs?
             prob, gstate = {}, None
             for gc in gcs:
                 if gc.has(min_key_rv):
@@ -643,7 +643,7 @@ class MarkovProcess(StochasticProcess):
                         p, gp = (gc.rhs, gc.lhs) if isinstance(gc.lhs, Probability) \
                                     else (gc.lhs, gc.rhs)
                         gr = gp.args[0]
-                        gset = Intersection(gr.as_set(), state_index)
+                        gset = Intersection(gr.as_set(gr.lhs), state_index) # XXX: is the variate symbol always gr.lhs?
                         gstate = list(gset)[0]
                         prob[gset] = p
                     else:
@@ -700,7 +700,7 @@ class MarkovProcess(StochasticProcess):
             ris = []
             for ri in state2cond:
                 ris.append(ri)
-                cset = Intersection(state2cond[ri].as_set(), state_index)
+                cset = Intersection(state2cond[ri].as_set(ri), state_index)
                 if len(cset) == 0:
                     return S.Zero
                 state2cond[ri] = cset.as_relational(ri)
@@ -2047,11 +2047,11 @@ class CountingProcess(ContinuousTimeStochasticProcess):
             if isinstance(curr, Eq):
                 working_set = Intersection(working_set, Interval.Lopen(curr.args[1], oo))
             else:
-                working_set = Intersection(working_set, curr.as_set())
+                working_set = Intersection(working_set, curr.as_set(curr.lhs)) # XXX: is the variate symbol always curr.lhs?
             if isinstance(nex, Eq):
                 working_set = Intersection(working_set, Interval(-oo, nex.args[1]))
             else:
-                working_set = Intersection(working_set, nex.as_set())
+                working_set = Intersection(working_set, nex.as_set(nex.lhs)) # XXX: is the variate symbol always nex.lhs?
             if working_set == EmptySet:
                 rv = Eq(curr.args[0].pspace.process(diff_key), 0)
                 result.append(_SubstituteRV._probability(rv))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Unfortunately, there isn't really a way to separate these changes because they all depend on each other. This fixes #27757 by determining the minimum and maximum of the sides of the inequality. However `calculus.util.minimum` and `calculus.util.maximum` do not take assumptions into consideration. To solve this, `assumptions.wrapper.assumption_domain` has been introduced that returns the domain of a symbol based upon assumptions (both the old and new system are taken into consideration). This function is also added to `calculus.util.continuous_domain` and `calculus.util.function_range`. `Symbol.as_set` now wraps around `assumptions.wrapper.assumption_domain`. The `as_set` API has been changed to require the target symbol as mentioned in #27836.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27755 (the comment is addressed by #27756). Fixes #27836. Supersedes #27757.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * **BREAKING CHANGE:** `as_set` now requires a target symbol.
  * `Symbol.as_set` now takes assumptions into consideration.
  * Simplification of equalities with assumptions has been improved.

* calculus
  * `continuous_domain`, `function_range`, `minimum`, and `maximum` now take assumptions on the target variable into consideration.

<!-- END RELEASE NOTES -->
