### PR TITLE
Add option to disable name splitting when printing MathML

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -507,6 +507,7 @@ Danny Hermes <daniel.j.hermes@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>
 Dave Witte Morris <Dave.Morris@uleth.ca>
 Davi Laerte <davilae011@gmail.com>
+David Brooks <dave@bcs.co.nz>
 David Daly <david.daly12@kzoo.edu>
 David Hagen <david@drhagen.com>
 David Joyner <wdjoyner@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -507,7 +507,8 @@ Danny Hermes <daniel.j.hermes@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>
 Dave Witte Morris <Dave.Morris@uleth.ca>
 Davi Laerte <davilae011@gmail.com>
-David Brooks <dave@bcs.co.nz>
+David Brooks <dave@bcs.co.nz> David Brooks <d.brooks@auckland.ac.nz>
+David Brooks <dave@bcs.co.nz> David Brooks <dbrnz@users.noreply.github.com>
 David Daly <david.daly12@kzoo.edu>
 David Hagen <david@drhagen.com>
 David Joyner <wdjoyner@gmail.com>

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -38,6 +38,7 @@ class MathMLPrinterBase(Printer):
         "root_notation": True,
         "symbol_names": {},
         "mul_symbol_mathml_numbers": '&#xB7;',
+        "disable_split_super_sub": False,
     }
 
     def __init__(self, settings=None):
@@ -72,6 +73,9 @@ class MathMLPrinterBase(Printer):
         xmlbstr = unistr.encode('ascii', 'xmlcharrefreplace')
         res = xmlbstr.decode()
         return res
+
+    def _split_super_sub(self, name):
+        return (name, [], []) if self._settings["disable_split_super_sub"] else split_super_sub(name)
 
 
 class MathMLContentPrinter(MathMLPrinterBase):
@@ -373,7 +377,7 @@ class MathMLContentPrinter(MathMLPrinterBase):
             else:
                 return s
 
-        name, supers, subs = split_super_sub(sym.name)
+        name, supers, subs = self._split_super_sub(sym.name)
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]
@@ -997,7 +1001,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             else:
                 return s
 
-        name, supers, subs = split_super_sub(sym.name)
+        name, supers, subs = self._split_super_sub(sym.name)
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -75,7 +75,10 @@ class MathMLPrinterBase(Printer):
         return res
 
     def _split_super_sub(self, name):
-        return (name, [], []) if self._settings["disable_split_super_sub"] else split_super_sub(name)
+        if self._settings["disable_split_super_sub"]:
+            return (name, [], [])
+        else:
+            return split_super_sub(name)
 
 
 class MathMLContentPrinter(MathMLPrinterBase):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -3156,3 +3156,7 @@ def test_Array():
 def test_latex_with_unevaluated():
     with evaluate(False):
         assert latex(a * a) == r"a a"
+
+
+def test_latex_disable_split_super_sub():
+    assert latex(Symbol('u^a_b'), disable_split_super_sub=True) == 'u\\^a\\_b'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -3159,4 +3159,6 @@ def test_latex_with_unevaluated():
 
 
 def test_latex_disable_split_super_sub():
+    assert latex(Symbol('u^a_b')) == 'u^{a}_{b}'
+    assert latex(Symbol('u^a_b'), disable_split_super_sub=False) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=True) == 'u\\^a\\_b'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2032,9 +2032,17 @@ def test_float_roundtrip():
 
 
 def test_content_mathml_disable_split_super_sub():
+    mp = MathMLContentPrinter()
+    assert mp.doprint(Symbol('u_b')) == '<ci><mml:msub><mml:mi>u</mml:mi><mml:mi>b</mml:mi></mml:msub></ci>'
+    mp = MathMLContentPrinter({'disable_split_super_sub': False})
+    assert mp.doprint(Symbol('u_b')) == '<ci><mml:msub><mml:mi>u</mml:mi><mml:mi>b</mml:mi></mml:msub></ci>'
     mp = MathMLContentPrinter({'disable_split_super_sub': True})
     assert mp.doprint(Symbol('u_b')) == '<ci>u_b</ci>'
 
 def test_presentation_mathml_disable_split_super_sub():
+    mpp = MathMLPresentationPrinter()
+    assert mpp.doprint(Symbol('u_b')) == '<msub><mi>u</mi><mi>b</mi></msub>'
+    mpp = MathMLPresentationPrinter({'disable_split_super_sub': False})
+    assert mpp.doprint(Symbol('u_b')) == '<msub><mi>u</mi><mi>b</mi></msub>'
     mpp = MathMLPresentationPrinter({'disable_split_super_sub': True})
     assert mpp.doprint(Symbol('u_b')) == '<mi>u_b</mi>'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2029,3 +2029,12 @@ def test_float_roundtrip():
     x = sympify(0.8975979010256552)
     y = float(mp.doprint(x).strip('</cn>'))
     assert x == y
+
+
+def test_content_mathml_disable_split_super_sub():
+    mp = MathMLContentPrinter({'disable_split_super_sub': True})
+    assert mp.doprint(Symbol('u_b')) == '<ci>u_b</ci>'
+
+def test_presentation_mathml_disable_split_super_sub():
+    mpp = MathMLPresentationPrinter({'disable_split_super_sub': True})
+    assert mpp.doprint(Symbol('u_b')) == '<mi>u_b</mi>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The `disable_split_super_sub` setting for `print_mathml` will prevent symbol names being split into name, superscript, and subscript parts.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Add `disable_split_super_sub` option to `print_mathml` to stop symbol names being split into name, superscript, and subscript parts.
<!-- END RELEASE NOTES -->
