### PR TITLE
add more instructions for './bin/test qualify' on Windows

### DIFF
--- a/doc/src/contributing/new-contributors-guide/workflow-process.md
+++ b/doc/src/contributing/new-contributors-guide/workflow-process.md
@@ -24,7 +24,7 @@ pull request, or even before committing a change.
   ./bin/test quality
   flake8 sympy/
   ```
-
+  If you are developing on Windows and `./bin/test quality` doesn't generate any output. Use `python -u bin/test quality` instead as you may need mannually flush the buffer output with `-u`.   
 - [ ] **[Add tests](workflow-process-add-tests).** All new functionality
   should be tested. Bug fixes should add regression tests. Tests are written
   in pytest `assert f(x) == y` style and are included in corresponding `tests`


### PR DESCRIPTION
**Changelog:**  
- **Fixed:** Clarified Windows usage for `./bin/test quality` to address output buffering issues.  

---

**Checklist:**  
- [ ] Documentation updated where relevant (e.g., README, testing guide).  
- [ ] Changes reviewed for clarity and accuracy.  
- [ ] Tested on Windows to confirm output appears with `-u` flag.  


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
