### PR TITLE
lint: remove unneeded global statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ lint.select = [
     "PIE810",
     "PLE",
     "PLR1736",
+    "PLW0602", # Global statement used but no assignment
     "SIM101",
     "SLOT",
     "TRY002",

--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -77,7 +77,6 @@ def DEBUG_WRAP(func):
 
 def _debug(text):
     from sympy import SYMPY_DEBUG
-    global _LT_level
 
     if SYMPY_DEBUG:
         print('-LT- %s%s' % ('  '*_LT_level, text), file=sys.stderr)

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -568,6 +568,7 @@ def _inflate_fox_h(g, a):
     bs = [(n + 1)/p for n in range(p)]
     return D, meijerg(g.an, g.aother, g.bm, list(g.bother) + bs, z)
 
+
 _dummies: dict[tuple[str, str], Dummy]  = {}
 
 
@@ -588,7 +589,6 @@ def _dummy_(name, token, **kwargs):
     Return a dummy associated to name and token. Same effect as declaring
     it globally.
     """
-    global _dummies
     if not (name, token) in _dummies:
         _dummies[(name, token)] = Dummy(name, **kwargs)
     return _dummies[(name, token)]

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -180,7 +180,7 @@ class LLVMJitCode:
 
     def _create_function_base(self):
         """Create function with name and type signature"""
-        global link_names, current_link_suffix
+        global current_link_suffix
         default_link_name = 'jit_func'
         current_link_suffix += 1
         self.link_name = default_link_name + str(current_link_suffix)
@@ -263,7 +263,6 @@ class LLVMJitCode:
         return vals
 
     def _compile_function(self, strmod):
-        global exe_engines
         llmod = llvm.parse_assembly(strmod)
 
         pmb = llvm.create_pass_manager_builder()

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from sympy.core.add import Add
+from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
 from sympy.core.exprtools import Factors, gcd_terms, factor_terms
 from sympy.core.function import expand_mul
@@ -653,10 +654,6 @@ def TR10i(rv):
     2*sqrt(2)*x*sin(x + pi/6)
 
     """
-    global _ROOT2, _ROOT3, _invROOT3
-    if _ROOT2 is None:
-        _roots()
-
     def f(rv):
         if not rv.is_Add:
             return rv
@@ -740,7 +737,7 @@ def TR10i(rv):
             # that have the right ratio
             args = []
             for a in byrad:
-                for b in [_ROOT3*a, _invROOT3]:
+                for b in [_ROOT3()*a, _invROOT3()]:
                     if b in byrad:
                         for i in range(len(byrad[a])):
                             if byrad[a][i] is None:
@@ -1718,11 +1715,19 @@ fufuncs = '''
 FU = dict(list(zip(fufuncs, list(map(locals().get, fufuncs)))))
 
 
-def _roots():
-    global _ROOT2, _ROOT3, _invROOT3
-    _ROOT2, _ROOT3 = sqrt(2), sqrt(3)
-    _invROOT3 = 1/_ROOT3
-_ROOT2 = None
+@cacheit
+def _ROOT2():
+    return sqrt(2)
+
+
+@cacheit
+def _ROOT3():
+    return sqrt(3)
+
+
+@cacheit
+def _invROOT3():
+    return 1/sqrt(3)
 
 
 def trig_split(a, b, two=False):
@@ -1775,10 +1780,6 @@ def trig_split(a, b, two=False):
     >>> trig_split(cos(x)*cos(y), sin(x)*sin(y))
     >>> trig_split(-sqrt(6)*cos(x), sqrt(2)*sin(x)*sin(y), two=True)
     """
-    global _ROOT2, _ROOT3, _invROOT3
-    if _ROOT2 is None:
-        _roots()
-
     a, b = [Factors(i) for i in (a, b)]
     ua, ub = a.normal(b)
     gcd = a.gcd(b).as_expr()
@@ -1897,12 +1898,12 @@ def trig_split(a, b, two=False):
         if not cob:
             cob = S.One
         if coa is cob:
-            gcd *= _ROOT2
+            gcd *= _ROOT2()
             return gcd, n1, n2, c.args[0], pi/4, False
-        elif coa/cob == _ROOT3:
+        elif coa/cob == _ROOT3():
             gcd *= 2*cob
             return gcd, n1, n2, c.args[0], pi/3, False
-        elif coa/cob == _invROOT3:
+        elif coa/cob == _invROOT3():
             gcd *= 2*coa
             return gcd, n1, n2, c.args[0], pi/6, False
 

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -123,7 +123,6 @@ if __name__ == "__main__":
     sorted_messages = []
 
     def msg(msg, *args):
-        global options, sorted_messages
         if options.by_process:
             print(msg % args)
         else:
@@ -143,7 +142,6 @@ if __name__ == "__main__":
         question was already imported.
 
         Keeps the semantics of __import__ unchanged."""
-        global options, symbol_definers
         caller_frame = inspect.getframeinfo(sys._getframe(1))
         importer_filename = caller_frame.filename
         importer_module = globals['__name__']

--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -52,7 +52,6 @@ def _print_timestack(stack, level=1):
 
 def timethis(name):
     def decorator(func):
-        global _do_timings
         if name not in _do_timings:
             return func
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-27855.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
