### PR TITLE
feat: remove redundant test_sin_cos_with_infinity

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1547,14 +1547,6 @@ def test_real_imag():
         assert cot(a).as_real_imag(deep=deep) == (cot(a), 0)
 
 
-@XFAIL
-def test_sin_cos_with_infinity():
-    # Test for issue 5196
-    # https://github.com/sympy/sympy/issues/5196
-    assert sin(oo) is S.NaN
-    assert cos(oo) is S.NaN
-
-
 @slow
 def test_sincos_rewrite_sqrt():
     # equivalent to testing rewrite(pow)


### PR DESCRIPTION
Remove redundant test_sin_cos_with_infinity.



#### Brief description of what is fixed or changed
This pull request removes the `test_sin_cos_with_infinity` test case from the test suite. This test case was found to be redundant as it duplicated the functionality already covered by the `test_sin` test.

Specifically, the `test_sin` test already asserts the correct behavior for `sin(oo)` and `cos(oo)`, which should both return `AccumBounds(-1, 1)`. The `test_sin_cos_with_infinity` test, which was checking for `NAN` results, was therefore unnecessary.

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
