### PR TITLE
fixed geometric distribution error

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -207,6 +207,8 @@ class GeometricDistribution(SingleDiscreteDistribution):
         _value_check((0 < p, p <= 1), "p must be between 0 and 1")
 
     def pdf(self, k):
+        if not k.is_integer or k < 1:
+            return S.Zero  # Return 0 for invalid values
         return (1 - self.p)**(k - 1) * self.p
 
     def _characteristic_function(self, t):


### PR DESCRIPTION
fixed geometric distribution error

#### References to other Issues or PRs
 FIXES #20031



 i have changed the code at self k a bit so that the error is resolved we will get right output 0.
updated code:
def pdf(self, k):
    # Ensure k is an integer and ≥ 1
    if not k.is_integer or k < 1:
        return S.Zero  # Return 0 for invalid values
    return (1 - self.p)**(k - 1) * self.p




<!-- BEGIN RELEASE NOTES -->

* stats
  * Fixed a bug in the Geometric distribution where the probability mass function (PMF) incorrectly returned nonzero values for non-integer and negative inputs. The PMF now correctly restricts the domain to integers greater than or equal to 1.

<!-- END RELEASE NOTES -->



