### PR TITLE
manualintegrate: Add erf to LIATE rule in integration by parts

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1257,7 +1257,7 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
         return pull_out_u_rl
 
     liate_rules = [pull_out_u(log), pull_out_u(*inverse_trig_functions),
-                   pull_out_algebraic, pull_out_u(sin, cos),
+                   pull_out_u(erf), pull_out_algebraic, pull_out_u(sin, cos),
                    pull_out_u(exp)]
 
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -294,6 +294,8 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
     f, F = exp(-x**2)*exp(x), Rational(1,2)*exp(Rational(1,4))*sqrt(pi)*erf(x - Rational(1,2))
     assert_is_integral_of(f, F)
+    f, F = erf(3*x)*exp(2*x), exp(2*x)*erf(3*x)/2 - exp(Rational(1,9))*erf(3*x - Rational(1,3))/2
+    assert_is_integral_of(f, F)
 
 
 def test_manualintegrate_derivative():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Combined with #27839, solves one of the integrals in #27586. To be extended.

#### Brief description of what is fixed or changed

Placed `erf(x)` in the LIATE hierarchy after inverse trigonometric functions and before algebraic functions. The error function differentiates to an exponential, making it behave similarly to inverse trigonometric functions, which differentiate to algebraic fractions. Since integration by parts works best when `u` simplifies upon differentiation, `erf(x)` should be chosen for `u` before algebraic functions but after inverse trig functions.

#### Other comments
N/A

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Some integrals involving `erf(x)` are now handled by manualintegrate.
<!-- END RELEASE NOTES -->
