### PR TITLE
Move the function that caches special values of `sqrt` under the `functions` module

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -391,8 +391,8 @@ class tribonacci(DefinedFunction):
                 return cls._tribpoly(n).subs(_sym, sym)
 
     def _eval_rewrite_as_sqrt(self, n, **kwargs):
-        from sympy.functions.elementary.miscellaneous import cbrt, sqrt
-        w = (-1 + S.ImaginaryUnit * sqrt(3)) / 2
+        from sympy.functions.elementary.miscellaneous import cbrt, sqrt, _SQRT3
+        w = (-1 + S.ImaginaryUnit * _SQRT3()) / 2
         a = (1 + cbrt(19 + 3*sqrt(33)) + cbrt(19 - 3*sqrt(33))) / 3
         b = (1 + w*cbrt(19 + 3*sqrt(33)) + w**2*cbrt(19 - 3*sqrt(33))) / 3
         c = (1 + w**2*cbrt(19 + 3*sqrt(33)) + w*cbrt(19 - 3*sqrt(33))) / 3

--- a/sympy/functions/elementary/_trigonometric_special.py
+++ b/sympy/functions/elementary/_trigonometric_special.py
@@ -39,7 +39,7 @@ from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.intfunc import igcdex
 from sympy.core.numbers import Integer
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
 from sympy.core.cache import cacheit
 
 
@@ -190,8 +190,8 @@ def cos_5() -> Expr:
 def cos_17() -> Expr:
     r"""Computes $\cos \frac{\pi}{17}$ in square roots"""
     return sqrt(
-        (15 + sqrt(17)) / 32 + sqrt(2) * (sqrt(17 - sqrt(17)) +
-        sqrt(sqrt(2) * (-8 * sqrt(17 + sqrt(17)) - (1 - sqrt(17))
+        (15 + sqrt(17)) / 32 + _SQRT2() * (sqrt(17 - sqrt(17)) +
+        sqrt(_SQRT2() * (-8 * sqrt(17 + sqrt(17)) - (1 - sqrt(17))
         * sqrt(17 - sqrt(17))) + 6 * sqrt(17) + 34)) / 32)
 
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -16,7 +16,7 @@ from sympy.core.symbol import Wild, Dummy
 from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import arg, unpolarify, im, re, Abs
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2, _SQRT3
 from sympy.ntheory import multiplicity, perfect_power
 from sympy.ntheory.factor_ import factorint
 
@@ -1264,23 +1264,23 @@ class LambertW(DefinedFunction):
 def _log_atan_table():
     return {
         # first quadrant only
-        sqrt(3): pi / 3,
+        _SQRT3(): pi / 3,
         1: pi / 4,
         sqrt(5 - 2 * sqrt(5)): pi / 5,
-        sqrt(2) * sqrt(5 - sqrt(5)) / (1 + sqrt(5)): pi / 5,
+        _SQRT2() * sqrt(5 - sqrt(5)) / (1 + sqrt(5)): pi / 5,
         sqrt(5 + 2 * sqrt(5)): pi * Rational(2, 5),
-        sqrt(2) * sqrt(sqrt(5) + 5) / (-1 + sqrt(5)): pi * Rational(2, 5),
-        sqrt(3) / 3: pi / 6,
-        sqrt(2) - 1: pi / 8,
-        sqrt(2 - sqrt(2)) / sqrt(sqrt(2) + 2): pi / 8,
-        sqrt(2) + 1: pi * Rational(3, 8),
-        sqrt(sqrt(2) + 2) / sqrt(2 - sqrt(2)): pi * Rational(3, 8),
+        _SQRT2() * sqrt(sqrt(5) + 5) / (-1 + sqrt(5)): pi * Rational(2, 5),
+        _SQRT3() / 3: pi / 6,
+        _SQRT2() - 1: pi / 8,
+        sqrt(2 - _SQRT2()) / sqrt(_SQRT2() + 2): pi / 8,
+        _SQRT2() + 1: pi * Rational(3, 8),
+        sqrt(_SQRT2() + 2) / sqrt(2 - _SQRT2()): pi * Rational(3, 8),
         sqrt(1 - 2 * sqrt(5) / 5): pi / 10,
-        (-sqrt(2) + sqrt(10)) / (2 * sqrt(sqrt(5) + 5)): pi / 10,
+        (-_SQRT2() + sqrt(10)) / (2 * sqrt(sqrt(5) + 5)): pi / 10,
         sqrt(1 + 2 * sqrt(5) / 5): pi * Rational(3, 10),
-        (sqrt(2) + sqrt(10)) / (2 * sqrt(5 - sqrt(5))): pi * Rational(3, 10),
-        2 - sqrt(3): pi / 12,
-        (-1 + sqrt(3)) / (1 + sqrt(3)): pi / 12,
-        2 + sqrt(3): pi * Rational(5, 12),
-        (1 + sqrt(3)) / (-1 + sqrt(3)): pi * Rational(5, 12)
+        (_SQRT2() + sqrt(10)) / (2 * sqrt(5 - sqrt(5))): pi * Rational(3, 10),
+        2 - _SQRT3(): pi / 12,
+        (-1 + _SQRT3()) / (1 + _SQRT3()): pi / 12,
+        2 + _SQRT3(): pi * Rational(5, 12),
+        (1 + _SQRT3()) / (-1 + _SQRT3()): pi * Rational(5, 12)
     }

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -10,7 +10,7 @@ from sympy.functions.combinatorial.numbers import bernoulli, euler, nC
 from sympy.functions.elementary.complexes import Abs, im, re
 from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2, _SQRT3, _INV_SQRT3
 from sympy.functions.elementary.trigonometric import (
     acos, acot, asin, atan, cos, cot, csc, sec, sin, tan,
     _imaginary_unit_as_coefficient)
@@ -25,24 +25,24 @@ def _rewrite_hyperbolics_as_exp(expr):
 @cacheit
 def _acosh_table():
     return {
-        I: log(I*(1 + sqrt(2))),
-        -I: log(-I*(1 + sqrt(2))),
+        I: log(I*(1 + _SQRT2())),
+        -I: log(-I*(1 + _SQRT2())),
         S.Half: pi/3,
         Rational(-1, 2): pi*Rational(2, 3),
-        sqrt(2)/2: pi/4,
-        -sqrt(2)/2: pi*Rational(3, 4),
-        1/sqrt(2): pi/4,
-        -1/sqrt(2): pi*Rational(3, 4),
-        sqrt(3)/2: pi/6,
-        -sqrt(3)/2: pi*Rational(5, 6),
-        (sqrt(3) - 1)/sqrt(2**3): pi*Rational(5, 12),
-        -(sqrt(3) - 1)/sqrt(2**3): pi*Rational(7, 12),
-        sqrt(2 + sqrt(2))/2: pi/8,
-        -sqrt(2 + sqrt(2))/2: pi*Rational(7, 8),
-        sqrt(2 - sqrt(2))/2: pi*Rational(3, 8),
-        -sqrt(2 - sqrt(2))/2: pi*Rational(5, 8),
-        (1 + sqrt(3))/(2*sqrt(2)): pi/12,
-        -(1 + sqrt(3))/(2*sqrt(2)): pi*Rational(11, 12),
+        _SQRT2()/2: pi/4,
+        -_SQRT2()/2: pi*Rational(3, 4),
+        1/_SQRT2(): pi/4,
+        -1/_SQRT2(): pi*Rational(3, 4),
+        _SQRT3()/2: pi/6,
+        -_SQRT3()/2: pi*Rational(5, 6),
+        (_SQRT3() - 1)/sqrt(2**3): pi*Rational(5, 12),
+        -(_SQRT3() - 1)/sqrt(2**3): pi*Rational(7, 12),
+        sqrt(2 + _SQRT2())/2: pi/8,
+        -sqrt(2 + _SQRT2())/2: pi*Rational(7, 8),
+        sqrt(2 - _SQRT2())/2: pi*Rational(3, 8),
+        -sqrt(2 - _SQRT2())/2: pi*Rational(5, 8),
+        (1 + _SQRT3())/(2*_SQRT2()): pi/12,
+        -(1 + _SQRT3())/(2*_SQRT2()): pi*Rational(11, 12),
         (sqrt(5) + 1)/4: pi/5,
         -(sqrt(5) + 1)/4: pi*Rational(4, 5)
     }
@@ -52,17 +52,17 @@ def _acosh_table():
 def _acsch_table():
     return {
             I: -pi / 2,
-            I*(sqrt(2) + sqrt(6)): -pi / 12,
+            I*(_SQRT2() + sqrt(6)): -pi / 12,
             I*(1 + sqrt(5)): -pi / 10,
-            I*2 / sqrt(2 - sqrt(2)): -pi / 8,
+            I*2 / sqrt(2 - _SQRT2()): -pi / 8,
             I*2: -pi / 6,
             I*sqrt(2 + 2/sqrt(5)): -pi / 5,
-            I*sqrt(2): -pi / 4,
+            I*_SQRT2(): -pi / 4,
             I*(sqrt(5)-1): -3*pi / 10,
-            I*2 / sqrt(3): -pi / 3,
-            I*2 / sqrt(2 + sqrt(2)): -3*pi / 8,
+            I*2*_INV_SQRT3(): -pi / 3,
+            I*2 / sqrt(2 + _SQRT2()): -3*pi / 8,
             I*sqrt(2 - 2/sqrt(5)): -2*pi / 5,
-            I*(sqrt(6) - sqrt(2)): -5*pi / 12,
+            I*(sqrt(6) - _SQRT2()): -5*pi / 12,
             S(2): -I*log((1+sqrt(5))/2),
         }
 
@@ -70,30 +70,30 @@ def _acsch_table():
 @cacheit
 def _asech_table():
         return {
-            I: - (pi*I / 2) + log(1 + sqrt(2)),
-            -I: (pi*I / 2) + log(1 + sqrt(2)),
-            (sqrt(6) - sqrt(2)): pi / 12,
-            (sqrt(2) - sqrt(6)): 11*pi / 12,
+            I: - (pi*I / 2) + log(1 + _SQRT2()),
+            -I: (pi*I / 2) + log(1 + _SQRT2()),
+            (sqrt(6) - _SQRT2()): pi / 12,
+            (_SQRT2() - sqrt(6)): 11*pi / 12,
             sqrt(2 - 2/sqrt(5)): pi / 10,
             -sqrt(2 - 2/sqrt(5)): 9*pi / 10,
-            2 / sqrt(2 + sqrt(2)): pi / 8,
-            -2 / sqrt(2 + sqrt(2)): 7*pi / 8,
-            2 / sqrt(3): pi / 6,
-            -2 / sqrt(3): 5*pi / 6,
+            2 / sqrt(2 + _SQRT2()): pi / 8,
+            -2 / sqrt(2 + _SQRT2()): 7*pi / 8,
+            2*_INV_SQRT3(): pi / 6,
+            -2*_INV_SQRT3(): 5*pi / 6,
             (sqrt(5) - 1): pi / 5,
             (1 - sqrt(5)): 4*pi / 5,
-            sqrt(2): pi / 4,
-            -sqrt(2): 3*pi / 4,
+            _SQRT2(): pi / 4,
+            -_SQRT2(): 3*pi / 4,
             sqrt(2 + 2/sqrt(5)): 3*pi / 10,
             -sqrt(2 + 2/sqrt(5)): 7*pi / 10,
             S(2): pi / 3,
             -S(2): 2*pi / 3,
-            sqrt(2*(2 + sqrt(2))): 3*pi / 8,
-            -sqrt(2*(2 + sqrt(2))): 5*pi / 8,
+            sqrt(2*(2 + _SQRT2())): 3*pi / 8,
+            -sqrt(2*(2 + _SQRT2())): 5*pi / 8,
             (1 + sqrt(5)): 2*pi / 5,
             (-1 - sqrt(5)): 3*pi / 5,
-            (sqrt(6) + sqrt(2)): 5*pi / 12,
-            (-sqrt(6) - sqrt(2)): 7*pi / 12,
+            (sqrt(6) + _SQRT2()): 5*pi / 12,
+            (-sqrt(6) - _SQRT2()): 7*pi / 12,
             I*S.Infinity: -pi*I / 2,
             I*S.NegativeInfinity: pi*I / 2,
         }
@@ -1243,9 +1243,9 @@ class asinh(InverseHyperbolicFunction):
             elif arg.is_zero:
                 return S.Zero
             elif arg is S.One:
-                return log(sqrt(2) + 1)
+                return log(_SQRT2() + 1)
             elif arg is S.NegativeOne:
-                return log(sqrt(2) - 1)
+                return log(_SQRT2() - 1)
             elif arg.is_negative:
                 return -cls(-arg)
         else:
@@ -2134,9 +2134,9 @@ class acsch(InverseHyperbolicFunction):
             elif arg.is_zero:
                 return S.ComplexInfinity
             elif arg is S.One:
-                return log(1 + sqrt(2))
+                return log(1 + _SQRT2())
             elif arg is S.NegativeOne:
-                return - log(1 + sqrt(2))
+                return - log(1 + _SQRT2())
 
         if arg.is_number:
             cst_table = _acsch_table()

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,6 +1,7 @@
 from sympy.core import S, sympify, NumberKind
 from sympy.utilities.iterables import sift
 from sympy.core.add import Add
+from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import (Application, Lambda,
@@ -150,6 +151,27 @@ def sqrt(arg, evaluate=None):
     """
     # arg = sympify(arg) is handled by Pow
     return Pow(arg, S.Half, evaluate=evaluate)
+
+
+@cacheit
+def _SQRT2() -> Expr:
+    """ function for internal use that returns cached `sqrt(2)`
+    """
+    return sqrt(2)
+
+
+@cacheit
+def _SQRT3() -> Expr:
+    """ function for internal use that returns cached `sqrt(3)`
+    """
+    return sqrt(3)
+
+
+@cacheit
+def _INV_SQRT3() -> Expr:
+    """ function for internal use that returns cached `1/sqrt(3)`
+    """
+    return 1 / _SQRT3()
 
 
 def cbrt(arg, evaluate=None):

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -15,7 +15,7 @@ from sympy.functions.combinatorial.numbers import bernoulli, euler
 from sympy.functions.elementary.complexes import arg as arg_f, im, re
 from sympy.functions.elementary.exponential import log, exp
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
+from sympy.functions.elementary.miscellaneous import sqrt, Min, Max, _SQRT2, _SQRT3, _INV_SQRT3
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary._trigonometric_special import (
     cos_table, ipartfrac, fermat_coords)
@@ -1759,7 +1759,7 @@ class sec(ReciprocalTrigonometricFunction):
     def _eval_rewrite_as_besselj(self, arg, **kwargs):
         from sympy.functions.special.bessel import besselj
         return Piecewise(
-                (1/(sqrt(pi*arg)/(sqrt(2))*besselj(-S.Half, arg)), Ne(arg, 0)),
+                (1/(sqrt(pi*arg)/_SQRT2()*besselj(-S.Half, arg)), Ne(arg, 0)),
                 (1, True)
             )
 
@@ -2036,27 +2036,27 @@ class InverseTrigonometricFunction(DefinedFunction):
         # Only keys with could_extract_minus_sign() == False
         # are actually needed.
         return {
-            sqrt(3)/2: pi/3,
-            sqrt(2)/2: pi/4,
-            1/sqrt(2): pi/4,
+            _SQRT3()/2: pi/3,
+            _SQRT2()/2: pi/4,
+            1/_SQRT2(): pi/4,
             sqrt((5 - sqrt(5))/8): pi/5,
-            sqrt(2)*sqrt(5 - sqrt(5))/4: pi/5,
+            _SQRT2()*sqrt(5 - sqrt(5))/4: pi/5,
             sqrt((5 + sqrt(5))/8): pi*Rational(2, 5),
-            sqrt(2)*sqrt(5 + sqrt(5))/4: pi*Rational(2, 5),
+            _SQRT2()*sqrt(5 + sqrt(5))/4: pi*Rational(2, 5),
             S.Half: pi/6,
-            sqrt(2 - sqrt(2))/2: pi/8,
-            sqrt(S.Half - sqrt(2)/4): pi/8,
-            sqrt(2 + sqrt(2))/2: pi*Rational(3, 8),
-            sqrt(S.Half + sqrt(2)/4): pi*Rational(3, 8),
+            sqrt(2 - _SQRT2())/2: pi/8,
+            sqrt(S.Half - _SQRT2()/4): pi/8,
+            sqrt(2 + _SQRT2())/2: pi*Rational(3, 8),
+            sqrt(S.Half + _SQRT2()/4): pi*Rational(3, 8),
             (sqrt(5) - 1)/4: pi/10,
             (1 - sqrt(5))/4: -pi/10,
             (sqrt(5) + 1)/4: pi*Rational(3, 10),
-            sqrt(6)/4 - sqrt(2)/4: pi/12,
-            -sqrt(6)/4 + sqrt(2)/4: -pi/12,
-            (sqrt(3) - 1)/sqrt(8): pi/12,
-            (1 - sqrt(3))/sqrt(8): -pi/12,
-            sqrt(6)/4 + sqrt(2)/4: pi*Rational(5, 12),
-            (1 + sqrt(3))/sqrt(8): pi*Rational(5, 12)
+            sqrt(6)/4 - _SQRT2()/4: pi/12,
+            -sqrt(6)/4 + _SQRT2()/4: -pi/12,
+            (_SQRT3() - 1)/sqrt(8): pi/12,
+            (1 - _SQRT3())/sqrt(8): -pi/12,
+            sqrt(6)/4 + _SQRT2()/4: pi*Rational(5, 12),
+            (1 + _SQRT3())/sqrt(8): pi*Rational(5, 12)
         }
 
 
@@ -2066,19 +2066,19 @@ class InverseTrigonometricFunction(DefinedFunction):
         # Only keys with could_extract_minus_sign() == False
         # are actually needed.
         return {
-            sqrt(3)/3: pi/6,
-            1/sqrt(3): pi/6,
-            sqrt(3): pi/3,
-            sqrt(2) - 1: pi/8,
-            1 - sqrt(2): -pi/8,
-            1 + sqrt(2): pi*Rational(3, 8),
+            _SQRT3()/3: pi/6,
+            _INV_SQRT3(): pi/6,
+            _SQRT3(): pi/3,
+            _SQRT2() - 1: pi/8,
+            1 - _SQRT2(): -pi/8,
+            1 + _SQRT2(): pi*Rational(3, 8),
             sqrt(5 - 2*sqrt(5)): pi/5,
             sqrt(5 + 2*sqrt(5)): pi*Rational(2, 5),
             sqrt(1 - 2*sqrt(5)/5): pi/10,
             sqrt(1 + 2*sqrt(5)/5): pi*Rational(3, 10),
-            2 - sqrt(3): pi/12,
-            -2 + sqrt(3): -pi/12,
-            2 + sqrt(3): pi*Rational(5, 12)
+            2 - _SQRT3(): pi/12,
+            -2 + _SQRT3(): -pi/12,
+            2 + _SQRT3(): pi*Rational(5, 12)
         }
 
     @staticmethod
@@ -2087,23 +2087,23 @@ class InverseTrigonometricFunction(DefinedFunction):
         # Keys for which could_extract_minus_sign()
         # will obviously return True are omitted.
         return {
-            2*sqrt(3)/3: pi/3,
-            sqrt(2): pi/4,
+            2*_INV_SQRT3(): pi/3,
+            _SQRT2(): pi/4,
             sqrt(2 + 2*sqrt(5)/5): pi/5,
             1/sqrt(Rational(5, 8) - sqrt(5)/8): pi/5,
             sqrt(2 - 2*sqrt(5)/5): pi*Rational(2, 5),
             1/sqrt(Rational(5, 8) + sqrt(5)/8): pi*Rational(2, 5),
             2: pi/6,
-            sqrt(4 + 2*sqrt(2)): pi/8,
-            2/sqrt(2 - sqrt(2)): pi/8,
-            sqrt(4 - 2*sqrt(2)): pi*Rational(3, 8),
-            2/sqrt(2 + sqrt(2)): pi*Rational(3, 8),
+            sqrt(4 + 2*_SQRT2()): pi/8,
+            2/sqrt(2 - _SQRT2()): pi/8,
+            sqrt(4 - 2*_SQRT2()): pi*Rational(3, 8),
+            2/sqrt(2 + _SQRT2()): pi*Rational(3, 8),
             1 + sqrt(5): pi/10,
             sqrt(5) - 1: pi*Rational(3, 10),
             -(sqrt(5) - 1): pi*Rational(-3, 10),
-            sqrt(6) + sqrt(2): pi/12,
-            sqrt(6) - sqrt(2): pi*Rational(5, 12),
-            -(sqrt(6) - sqrt(2)): pi*Rational(-5, 12)
+            sqrt(6) + _SQRT2(): pi/12,
+            sqrt(6) - _SQRT2(): pi*Rational(5, 12),
+            -(sqrt(6) - _SQRT2()): pi*Rational(-5, 12)
         }
 
 
@@ -2478,7 +2478,7 @@ class acos(InverseTrigonometricFunction):
             return self.func(arg.as_leading_term(x))
         # Handling branch points
         if x0 == 1:
-            return sqrt(2)*sqrt((S.One - arg).as_leading_term(x))
+            return _SQRT2()*sqrt((S.One - arg).as_leading_term(x))
         if x0 in (-S.One, S.ComplexInfinity):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
@@ -3158,7 +3158,7 @@ class asec(InverseTrigonometricFunction):
             return self.func(arg.as_leading_term(x))
         # Handling branch points
         if x0 == 1:
-            return sqrt(2)*sqrt((arg - S.One).as_leading_term(x))
+            return _SQRT2()*sqrt((arg - S.One).as_leading_term(x))
         if x0 in (-S.One, S.Zero):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts (-1, 1)

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -14,7 +14,7 @@ from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 from sympy.functions.elementary.trigonometric import sin, cos, csc, cot
 from sympy.functions.elementary.integers import ceiling
 from sympy.functions.elementary.exponential import exp, log
-from sympy.functions.elementary.miscellaneous import cbrt, sqrt, root
+from sympy.functions.elementary.miscellaneous import cbrt, sqrt, root, _SQRT2, _SQRT3, _INV_SQRT3
 from sympy.functions.elementary.complexes import (Abs, re, im, polar_lift, unpolarify)
 from sympy.functions.special.gamma_functions import gamma, digamma, uppergamma
 from sympy.functions.special.hyper import hyper
@@ -237,7 +237,7 @@ class besselj(BesselBase):
             if not sign.is_negative:
                 # Refer Abramowitz and Stegun 1965, p. 364 for more information on
                 # asymptotic approximation of besselj function.
-                return sqrt(2)*cos(z - pi*(2*nu + 1)/4)/sqrt(pi*z)
+                return _SQRT2()*cos(z - pi*(2*nu + 1)/4)/sqrt(pi*z)
             return self
 
         return super(besselj, self)._eval_as_leading_term(x, logx=logx, cdir=cdir)
@@ -375,7 +375,7 @@ class bessely(BesselBase):
             if not sign.is_negative:
                 # Refer Abramowitz and Stegun 1965, p. 364 for more information on
                 # asymptotic approximation of bessely function.
-                return sqrt(2)*(-sin(pi*nu/2 - z + pi/4) + 3*cos(pi*nu/2 - z + pi/4)/(8*z))*sqrt(1/z)/sqrt(pi)
+                return _SQRT2()*(-sin(pi*nu/2 - z + pi/4) + 3*cos(pi*nu/2 - z + pi/4)/(8*z))*sqrt(1/z)/sqrt(pi)
             return self
 
         return super(bessely, self)._eval_as_leading_term(x, logx=logx, cdir=cdir)
@@ -1540,7 +1540,7 @@ class airyai(AiryBase):
                     n = M[n]
                     pf = (d * z**n)**m / (d**m * z**(m*n))
                     newarg = c * d**m * z**(m*n)
-                    return S.Half * ((pf + S.One)*airyai(newarg) - (pf - S.One)/sqrt(3)*airybi(newarg))
+                    return S.Half * ((pf + S.One)*airyai(newarg) - (pf - S.One)*_INV_SQRT3()*airybi(newarg))
 
 
 class airybi(AiryBase):
@@ -1685,7 +1685,7 @@ class airybi(AiryBase):
         tt = Rational(2, 3)
         a = Pow(z, Rational(3, 2))
         if re(z).is_positive:
-            return sqrt(z)/sqrt(3) * (besseli(-ot, tt*a) + besseli(ot, tt*a))
+            return sqrt(z)*_INV_SQRT3() * (besseli(-ot, tt*a) + besseli(ot, tt*a))
         else:
             b = Pow(a, ot)
             c = Pow(a, -ot)
@@ -1717,7 +1717,7 @@ class airybi(AiryBase):
                     n = M[n]
                     pf = (d * z**n)**m / (d**m * z**(m*n))
                     newarg = c * d**m * z**(m*n)
-                    return S.Half * (sqrt(3)*(S.One - pf)*airyai(newarg) + (S.One + pf)*airybi(newarg))
+                    return S.Half * (_SQRT3()*(S.One - pf)*airyai(newarg) + (S.One + pf)*airybi(newarg))
 
 
 class airyaiprime(AiryBase):
@@ -1874,7 +1874,7 @@ class airyaiprime(AiryBase):
                     n = M[n]
                     pf = (d**m * z**(n*m)) / (d * z**n)**m
                     newarg = c * d**m * z**(n*m)
-                    return S.Half * ((pf + S.One)*airyaiprime(newarg) + (pf - S.One)/sqrt(3)*airybiprime(newarg))
+                    return S.Half * ((pf + S.One)*airyaiprime(newarg) + (pf - S.One)*_INV_SQRT3()*airybiprime(newarg))
 
 
 class airybiprime(AiryBase):
@@ -1996,14 +1996,14 @@ class airybiprime(AiryBase):
         tt = Rational(2, 3)
         a = tt * Pow(-z, Rational(3, 2))
         if re(z).is_negative:
-            return -z/sqrt(3) * (besselj(-tt, a) + besselj(tt, a))
+            return -z*_INV_SQRT3() * (besselj(-tt, a) + besselj(tt, a))
 
     def _eval_rewrite_as_besseli(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = tt * Pow(z, Rational(3, 2))
         if re(z).is_positive:
-            return z/sqrt(3) * (besseli(-tt, a) + besseli(tt, a))
+            return z*_INV_SQRT3() * (besseli(-tt, a) + besseli(tt, a))
         else:
             a = Pow(z, Rational(3, 2))
             b = Pow(a, tt)
@@ -2038,7 +2038,7 @@ class airybiprime(AiryBase):
                     n = M[n]
                     pf = (d**m * z**(n*m)) / (d * z**n)**m
                     newarg = c * d**m * z**(n*m)
-                    return S.Half * (sqrt(3)*(pf - S.One)*airyaiprime(newarg) + (pf + S.One)*airybiprime(newarg))
+                    return S.Half * (_SQRT3()*(pf - S.One)*airyaiprime(newarg) + (pf + S.One)*airybiprime(newarg))
 
 
 class marcumq(DefinedFunction):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import factorial, factorial2, RisingFactorial
 from sympy.functions.elementary.complexes import  polar_lift, re, unpolarify
 from sympy.functions.elementary.integers import ceiling, floor
-from sympy.functions.elementary.miscellaneous import sqrt, root
+from sympy.functions.elementary.miscellaneous import sqrt, root, _SQRT2
 from sympy.functions.elementary.exponential import exp, log, exp_polar
 from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc
@@ -2488,7 +2488,7 @@ class fresnels(FresnelIntegral):
         return pi*z**3/6 * hyper([Rational(3, 4)], [Rational(3, 2), Rational(7, 4)], -pi**2*z**4/16)
 
     def _eval_rewrite_as_meijerg(self, z, **kwargs):
-        return (pi*z**Rational(9, 4) / (sqrt(2)*(z**2)**Rational(3, 4)*(-z)**Rational(3, 4))
+        return (pi*z**Rational(9, 4) / (_SQRT2()*(z**2)**Rational(3, 4)*(-z)**Rational(3, 4))
                 * meijerg([], [1], [Rational(3, 4)], [Rational(1, 4), 0], -pi**2*z**4/16))
 
     def _eval_rewrite_as_Integral(self, z, **kwargs):
@@ -2649,7 +2649,7 @@ class fresnelc(FresnelIntegral):
         return z * hyper([Rational(1, 4)], [S.Half, Rational(5, 4)], -pi**2*z**4/16)
 
     def _eval_rewrite_as_meijerg(self, z, **kwargs):
-        return (pi*z**Rational(3, 4) / (sqrt(2)*root(z**2, 4)*root(-z, 4))
+        return (pi*z**Rational(3, 4) / (_SQRT2()*root(z**2, 4)*root(-z, 4))
                 * meijerg([], [1], [Rational(1, 4)], [Rational(3, 4), 0], -pi**2*z**4/16))
 
     def _eval_rewrite_as_Integral(self, z, **kwargs):

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -14,7 +14,7 @@ from sympy.functions.combinatorial.factorials import binomial, factorial, Rising
 from sympy.functions.elementary.complexes import re
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
 from sympy.functions.elementary.trigonometric import cos, sec
 from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.hyper import hyper
@@ -1102,7 +1102,7 @@ class hermite(OrthogonalPolynomial):
         return self._eval_rewrite_as_Sum(n, x, **kwargs)
 
     def _eval_rewrite_as_hermite_prob(self, n, x, **kwargs):
-        return sqrt(2)**n * hermite_prob(n, x*sqrt(2))
+        return _SQRT2()**n * hermite_prob(n, x*_SQRT2())
 
 
 class hermite_prob(OrthogonalPolynomial):
@@ -1199,7 +1199,7 @@ class hermite_prob(OrthogonalPolynomial):
         return self._eval_rewrite_as_Sum(n, x, **kwargs)
 
     def _eval_rewrite_as_hermite(self, n, x, **kwargs):
-        return sqrt(2)**(-n) * hermite(n, x/sqrt(2))
+        return _SQRT2()**(-n) * hermite(n, x/_SQRT2())
 
 
 #----------------------------------------------------------------------------

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -7,7 +7,7 @@ from sympy.functions import assoc_legendre
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.functions.elementary.exponential import exp
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
 from sympy.functions.elementary.trigonometric import sin, cos, cot
 
 _x = Dummy("x")
@@ -325,10 +325,10 @@ class Znm(DefinedFunction):
     @classmethod
     def eval(cls, n, m, theta, phi):
         if m.is_positive:
-            zz = (Ynm(n, m, theta, phi) + Ynm_c(n, m, theta, phi)) / sqrt(2)
+            zz = (Ynm(n, m, theta, phi) + Ynm_c(n, m, theta, phi)) / _SQRT2()
             return zz
         elif m.is_zero:
             return Ynm(n, m, theta, phi)
         elif m.is_negative:
-            zz = (Ynm(n, m, theta, phi) - Ynm_c(n, m, theta, phi)) / (sqrt(2)*I)
+            zz = (Ynm(n, m, theta, phi) - Ynm_c(n, m, theta, phi)) / (_SQRT2()*I)
             return zz

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -15,7 +15,7 @@ from sympy.functions.elementary.complexes import re, arg, Abs
 from sympy.functions.elementary.exponential import exp, exp_polar
 from sympy.functions.elementary.hyperbolic import cosh, coth, sinh, tanh
 from sympy.functions.elementary.integers import ceiling
-from sympy.functions.elementary.miscellaneous import Max, Min, sqrt
+from sympy.functions.elementary.miscellaneous import Max, Min, sqrt, _SQRT2
 from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.functions.elementary.trigonometric import cos, cot, sin, tan
 from sympy.functions.special.bessel import besselj
@@ -1176,7 +1176,7 @@ class SineTransform(SineCosineTypeTransform):
     _kern = sin
 
     def a(self):
-        return sqrt(2)/sqrt(pi)
+        return _SQRT2()/sqrt(pi)
 
     def b(self):
         return S.One
@@ -1235,7 +1235,7 @@ class InverseSineTransform(SineCosineTypeTransform):
     _kern = sin
 
     def a(self):
-        return sqrt(2)/sqrt(pi)
+        return _SQRT2()/sqrt(pi)
 
     def b(self):
         return S.One
@@ -1295,7 +1295,7 @@ class CosineTransform(SineCosineTypeTransform):
     _kern = cos
 
     def a(self):
-        return sqrt(2)/sqrt(pi)
+        return _SQRT2()/sqrt(pi)
 
     def b(self):
         return S.One
@@ -1354,7 +1354,7 @@ class InverseCosineTransform(SineCosineTypeTransform):
     _kern = cos
 
     def a(self):
-        return sqrt(2)/sqrt(pi)
+        return _SQRT2()/sqrt(pi)
 
     def b(self):
         return S.One

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -25,7 +25,7 @@ from sympy.core.numbers import Number
 from sympy.core.singleton import S as _S
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import _sympify
-from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
+from sympy.functions.elementary.miscellaneous import _SQRT2
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -25,7 +25,7 @@ from sympy.core.numbers import Number
 from sympy.core.singleton import S as _S
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import _sympify
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
@@ -682,22 +682,22 @@ class HadamardGate(HermitianOperator, OneQubitGate):
             return matrix_cache.get_matrix('Hsqrt2', format)
 
     def _eval_commutator_XGate(self, other, **hints):
-        return I*sqrt(2)*YGate(self.targets[0])
+        return I*_SQRT2()*YGate(self.targets[0])
 
     def _eval_commutator_YGate(self, other, **hints):
-        return I*sqrt(2)*(ZGate(self.targets[0]) - XGate(self.targets[0]))
+        return I*_SQRT2()*(ZGate(self.targets[0]) - XGate(self.targets[0]))
 
     def _eval_commutator_ZGate(self, other, **hints):
-        return -I*sqrt(2)*YGate(self.targets[0])
+        return -I*_SQRT2()*YGate(self.targets[0])
 
     def _eval_anticommutator_XGate(self, other, **hints):
-        return sqrt(2)*IdentityGate(self.targets[0])
+        return _SQRT2()*IdentityGate(self.targets[0])
 
     def _eval_anticommutator_YGate(self, other, **hints):
         return _S.Zero
 
     def _eval_anticommutator_ZGate(self, other, **hints):
-        return sqrt(2)*IdentityGate(self.targets[0])
+        return _SQRT2()*IdentityGate(self.targets[0])
 
 
 class XGate(HermitianOperator, OneQubitGate):

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -63,7 +63,7 @@ from sympy.core.sympify import sympify
 from sympy.functions.combinatorial.factorials import (binomial, factorial)
 from sympy.functions.elementary.complexes import re
 from sympy.functions.elementary.exponential import exp
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.functions.special.spherical_harmonics import Ynm
 from sympy.matrices.dense import zeros
@@ -933,7 +933,7 @@ def real_gaunt(l_1, l_2, l_3, mu_1, mu_2, mu_3, prec=None):
     t = lambda x: 1 if x > 0 else 0
     A = lambda mu, m: t(-mu) * (s(m) * kron_del(m, mu) - kron_del(m, -mu))
     B = lambda mu, m: t(mu) * (kron_del(m, mu) + s(m) * kron_del(m, -mu))
-    U = lambda mu, m: kron_del(abs(mu), abs(m)) * (kron_del(mu, 0) * kron_del(m, 0) + (B(mu, m) + I * A(mu, m))/sqrt(2))
+    U = lambda mu, m: kron_del(abs(mu), abs(m)) * (kron_del(mu, 0) * kron_del(m, 0) + (B(mu, m) + I * A(mu, m))/_SQRT2())
 
     ugnt = 0
     for m1 in range(-l_1, l_1+1):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -17,7 +17,7 @@ from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol, symbols
 from sympy.core.sympify import sympify
 from sympy.functions import exp, im, cos, acos, Piecewise
-from sympy.functions.elementary.miscellaneous import root, sqrt
+from sympy.functions.elementary.miscellaneous import root, sqrt, _SQRT2, _SQRT3
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.polys.domains import EX
 from sympy.polys.polyerrors import (PolynomialError, GeneratorsNeeded,
@@ -163,7 +163,7 @@ def roots_cubic(f, trig=False):
     elif q.is_real and q.is_negative:
         u1 = -root(-q/2 + sqrt(q**2/4 + pon3**3), 3)
 
-    coeff = I*sqrt(3)/2
+    coeff = I*_SQRT3()/2
     if u1 is None:
         u1 = S.One
         u2 = Rational(-1, 2) + coeff
@@ -589,7 +589,7 @@ def roots_quintic(f):
 
     # hard-coded results for [factor(i) for i in _vsolve(x**5 - a - I*b, x)]
     x0 = z**(S(1)/5)
-    x1 = sqrt(2)
+    x1 = _SQRT2()
     x2 = sqrt(5)
     x3 = sqrt(5 - x2)
     x4 = I*x2

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -43,10 +43,10 @@ def swinnerton_dyer_poly(n, x=None, polys=False):
         x = Dummy('x')
 
     if n > 3:
-        from sympy.functions.elementary.miscellaneous import sqrt
+        from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
         from .numberfields import minimal_polynomial
         p = 2
-        a = [sqrt(2)]
+        a = [_SQRT2()]
         for i in range(2, n + 1):
             p = nextprime(p)
             a.append(sqrt(p))

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -103,7 +103,7 @@ def get_math_macros():
     """
     from sympy.codegen.cfunctions import log2, Sqrt
     from sympy.functions.elementary.exponential import log
-    from sympy.functions.elementary.miscellaneous import sqrt
+    from sympy.functions.elementary.miscellaneous import sqrt, _SQRT2
 
     return {
         S.Exp1: 'M_E',
@@ -118,9 +118,9 @@ def get_math_macros():
         2/S.Pi: 'M_2_PI',
         2/sqrt(S.Pi): 'M_2_SQRTPI',
         2/Sqrt(S.Pi): 'M_2_SQRTPI',
-        sqrt(2): 'M_SQRT2',
+        _SQRT2(): 'M_SQRT2',
         Sqrt(2): 'M_SQRT2',
-        1/sqrt(2): 'M_SQRT1_2',
+        1/_SQRT2(): 'M_SQRT1_2',
         1/Sqrt(2): 'M_SQRT1_2'
     }
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from sympy.core.add import Add
-from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
 from sympy.core.exprtools import Factors, gcd_terms, factor_terms
 from sympy.core.function import expand_mul

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -16,8 +16,9 @@ from sympy.core.traversal import bottom_up
 from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.hyperbolic import (
     cosh, sinh, tanh, coth, sech, csch, HyperbolicFunction)
+from sympy.functions.elementary.miscellaneous import _SQRT2, _SQRT3, _INV_SQRT3
 from sympy.functions.elementary.trigonometric import (
-    cos, sin, tan, cot, sec, csc, sqrt, TrigonometricFunction)
+    cos, sin, tan, cot, sec, csc, TrigonometricFunction)
 from sympy.ntheory.factor_ import perfect_power
 from sympy.polys.polytools import factor
 from sympy.strategies.tree import greedy
@@ -737,7 +738,7 @@ def TR10i(rv):
             # that have the right ratio
             args = []
             for a in byrad:
-                for b in [_ROOT3()*a, _invROOT3()]:
+                for b in [_SQRT3()*a, _INV_SQRT3()]:
                     if b in byrad:
                         for i in range(len(byrad[a])):
                             if byrad[a][i] is None:
@@ -1715,21 +1716,6 @@ fufuncs = '''
 FU = dict(list(zip(fufuncs, list(map(locals().get, fufuncs)))))
 
 
-@cacheit
-def _ROOT2():
-    return sqrt(2)
-
-
-@cacheit
-def _ROOT3():
-    return sqrt(3)
-
-
-@cacheit
-def _invROOT3():
-    return 1/sqrt(3)
-
-
 def trig_split(a, b, two=False):
     """Return the gcd, s1, s2, a1, a2, bool where
 
@@ -1898,12 +1884,12 @@ def trig_split(a, b, two=False):
         if not cob:
             cob = S.One
         if coa is cob:
-            gcd *= _ROOT2()
+            gcd *= _SQRT2()
             return gcd, n1, n2, c.args[0], pi/4, False
-        elif coa/cob == _ROOT3():
+        elif coa/cob == _SQRT3():
             gcd *= 2*cob
             return gcd, n1, n2, c.args[0], pi/3, False
-        elif coa/cob == _invROOT3():
+        elif coa/cob == _INV_SQRT3():
             gcd *= 2*coa
             return gcd, n1, n2, c.args[0], pi/6, False
 

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -3,6 +3,7 @@ from sympy.core.function import _mexpand, count_ops, expand_mul
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Dummy
 from sympy.functions import root, sign, sqrt
+from sympy.functions.elementary.miscellaneous import _SQRT2
 from sympy.polys import Poly, PolynomialError
 
 
@@ -299,7 +300,7 @@ def _sqrtdenest_rec(expr):
         c_1 = _sqrtdenest_rec(sqrt(c2_1))
         d_1 = _sqrtdenest_rec(sqrt(a1 + c_1))
         num, den = rad_rationalize(b1, d_1)
-        c = _mexpand(d_1/sqrt(2) + num/(den*sqrt(2)))
+        c = _mexpand(d_1/_SQRT2() + num/(den*_SQRT2()))
     else:
         c = _sqrtdenest1(sqrt(c2))
 
@@ -313,7 +314,7 @@ def _sqrtdenest_rec(expr):
     if sqrt_depth(d) > 1:
         raise SqrtdenestStopIteration
     num, den = rad_rationalize(b, d)
-    r = d/sqrt(2) + num/(den*sqrt(2))
+    r = d/_SQRT2() + num/(den*_SQRT2())
     r = radsimp(r)
     return _mexpand(r)
 
@@ -456,7 +457,7 @@ def _sqrt_numeric_denest(a, b, r, d2):
         s1, s2 = sign(s), sign(b)
         if s1 == s2 == -1:
             s1 = s2 = 1
-        res = (s1 * sqrt(a + d) + s2 * sqrt(a - d)) * sqrt(2) / 2
+        res = (s1 * sqrt(a + d) + s2 * sqrt(a - d)) * _SQRT2() / 2
         return res.expand()
 
 
@@ -622,7 +623,7 @@ def _denester(nested, av0, h, max_depth_level):
                     av0[1] = None
                     return None, None
                 sqvad1 = radsimp(1/sqvad)
-                res = _mexpand(sqvad/sqrt(2) + (v[1]*sqrt(R)*sqvad1/sqrt(2)))
+                res = _mexpand(sqvad/_SQRT2() + (v[1]*sqrt(R)*sqvad1/_SQRT2()))
                 return res, f
 
                       #          sign(v[1])*sqrt(_mexpand(v[1]**2*R*vad1/2))), f
@@ -631,7 +632,7 @@ def _denester(nested, av0, h, max_depth_level):
                 if s2 <= 0:
                     return sqrt(nested[-1]), [0]*len(nested)
                 FR, s = root(_mexpand(R), 4), sqrt(s2)
-                return _mexpand(s/(sqrt(2)*FR) + v[0]*FR/(sqrt(2)*s)), f
+                return _mexpand(s/(_SQRT2()*FR) + v[0]*FR/(_SQRT2()*s)), f
 
 
 def _sqrt_ratcomb(cs, args):

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -76,7 +76,7 @@ from sympy.functions.elementary.complexes import (Abs, sign)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import sinh
 from sympy.functions.elementary.integers import floor
-from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
+from sympy.functions.elementary.miscellaneous import sqrt, Max, Min, _SQRT2
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import asin
 from sympy.functions.special.error_functions import (erf, erfc, erfi, erfinv, expint)
@@ -806,7 +806,7 @@ class ChiDistribution(SingleContinuousDistribution):
         k = self.k
 
         part_1 = hyper((k/2,), (S.Half,), -t**2/2)
-        part_2 = I*t*sqrt(2)*gamma((k+1)/2)/gamma(k/2)
+        part_2 = I*t*_SQRT2()*gamma((k+1)/2)/gamma(k/2)
         part_3 = hyper(((k+1)/2,), (Rational(3, 2),), -t**2/2)
         return part_1 + part_2*part_3
 
@@ -814,7 +814,7 @@ class ChiDistribution(SingleContinuousDistribution):
         k = self.k
 
         part_1 = hyper((k / 2,), (S.Half,), t ** 2 / 2)
-        part_2 = t * sqrt(2) * gamma((k + 1) / 2) / gamma(k / 2)
+        part_2 = t * _SQRT2() * gamma((k + 1) / 2) / gamma(k / 2)
         part_3 = hyper(((k + 1) / 2,), (S(3) / 2,), t ** 2 / 2)
         return part_1 + part_2 * part_3
 
@@ -1274,7 +1274,7 @@ class ExGaussianDistribution(SingleContinuousDistribution):
         mean, std, rate = self.mean, self.std, self.rate
         term1 = rate/2
         term2 = exp(rate * (2 * mean + rate * std**2 - 2*x)/2)
-        term3 = erfc((mean + rate*std**2 - x)/(sqrt(2)*std))
+        term3 = erfc((mean + rate*std**2 - x)/(_SQRT2()*std))
         return term1*term2*term3
 
     def _cdf(self, x):
@@ -2804,7 +2804,7 @@ class LogNormalDistribution(SingleContinuousDistribution):
     def _cdf(self, x):
         mean, std = self.mean, self.std
         return Piecewise(
-                (S.Half + S.Half*erf((log(x) - mean)/sqrt(2)/std), x > 0),
+                (S.Half + S.Half*erf((log(x) - mean)/_SQRT2()/std), x > 0),
                 (S.Zero, True)
         )
 
@@ -2967,7 +2967,7 @@ class MaxwellDistribution(SingleContinuousDistribution):
 
     def _cdf(self, x):
         a = self.a
-        return erf(sqrt(2)*x/(2*a)) - sqrt(2)*x*exp(-x**2/(2*a**2))/(sqrt(pi)*a)
+        return erf(_SQRT2()*x/(2*a)) - _SQRT2()*x*exp(-x**2/(2*a**2))/(sqrt(pi)*a)
 
 def Maxwell(name, a):
     r"""
@@ -3217,7 +3217,7 @@ class NormalDistribution(SingleContinuousDistribution):
 
     def _cdf(self, x):
         mean, std = self.mean, self.std
-        return erf(sqrt(2)*(-mean + x)/(2*std))/2 + S.Half
+        return erf(_SQRT2()*(-mean + x)/(2*std))/2 + S.Half
 
     def _characteristic_function(self, t):
         mean, std = self.mean, self.std
@@ -3229,7 +3229,7 @@ class NormalDistribution(SingleContinuousDistribution):
 
     def _quantile(self, p):
         mean, std = self.mean, self.std
-        return mean + std*sqrt(2)*erfinv(2*p - 1)
+        return mean + std*_SQRT2()*erfinv(2*p - 1)
 
 
 def Normal(name, mean, std):
@@ -3811,11 +3811,11 @@ class RayleighDistribution(SingleContinuousDistribution):
 
     def _characteristic_function(self, t):
         sigma = self.sigma
-        return 1 - sigma*t*exp(-sigma**2*t**2/2) * sqrt(pi/2) * (erfi(sigma*t/sqrt(2)) - I)
+        return 1 - sigma*t*exp(-sigma**2*t**2/2) * sqrt(pi/2) * (erfi(sigma*t/_SQRT2()) - I)
 
     def _moment_generating_function(self, t):
         sigma = self.sigma
-        return 1 + sigma*t*exp(sigma**2*t**2/2) * sqrt(pi/2) * (erf(sigma*t/sqrt(2)) + 1)
+        return 1 + sigma*t*exp(sigma**2*t**2/2) * sqrt(pi/2) * (erf(sigma*t/_SQRT2()) + 1)
 
 
 def Rayleigh(name, sigma):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
In `sympy.simplify.fu`, `sqrt(2)`, `sqrt(3)`, and `1/sqrt(3)` are cached, but this cache should be usable in other places as well. Therefore, the caching logic has been moved under the `functions` module so that it can be used by other submodules.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
