### PR TITLE
fix(test_dot): correct argument order in an assert statement

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -849,6 +849,7 @@ Justin Blythe <jblythe29@gmail.com>
 Jyn Spring 琴春 <me@vx.st>
 K. Kraus <laqueray@googlemail.com>
 KJaybhaye <krushnajaybhaye01@gmail.com> KJaybhaye <krushnajaybhaye01@gmail.com>
+KJaybhaye <krushnajaybhaye01@gmail.com> Krushna Jaybhaye <80618101+KJaybhaye@users.noreply.github.com>
 Ka Yi <chua.kayi@yahoo.com.sg>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>

--- a/.mailmap
+++ b/.mailmap
@@ -848,6 +848,7 @@ Jurjen N.E. Bos <jnebos@gmail.com> Jurjen N.E. Bos <devnull@localhost>
 Justin Blythe <jblythe29@gmail.com>
 Jyn Spring 琴春 <me@vx.st>
 K. Kraus <laqueray@googlemail.com>
+KJaybhaye <krushnajaybhaye01@gmail.com> KJaybhaye <krushnajaybhaye01@gmail.com>
 Ka Yi <chua.kayi@yahoo.com.sg>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -46,7 +46,7 @@ def test_dot():
     v2 = C.x * i + C.y * j + C.z * k
     assert Dot(v1, v2) == Dot(C.x*C.i + C.z**2*C.j, C.x*C.i + C.y*C.j + C.z*C.k)
     assert Dot(v1, v2).doit() == C.x**2 + C.y*C.z**2
-    assert Dot(v1, v2).doit() == C.x**2 + C.y*C.z**2
+    assert Dot(v2, v1).doit() == C.x**2 + C.y*C.z**2
     assert Dot(v1, v2) == Dot(v2, v1)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Brief description of what is fixed or changed
In 'test_dot' one assert statement was duplicated. Both statements should have the 
arguments order reversed in order to assert commutative property of dot product.

This commit fixes the argument order.   


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
