### PR TITLE
Harmonic perf guard

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1739,3 +1739,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Firat Bezir <bezir.1@osu.edu> firatbezir <bezir.1@osu.edu>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1313,4 +1313,3 @@ Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 Dean Price <dean1357price1357@gmail.com>
 Hugo Kerstens <hugo@kerstens.me>
-Firat Bezir <frt.bzr@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1313,3 +1313,4 @@ Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 Dean Price <dean1357price1357@gmail.com>
 Hugo Kerstens <hugo@kerstens.me>
+Firat Bezir <frt.bzr@gmail.com>

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -896,7 +896,6 @@ class harmonic(DefinedFunction):
     harmonic_cache: dict[Integer, Callable[[int], Rational]] = {}
 
     @classmethod
-    @classmethod
     def eval(cls, n, m=None):
         from sympy.functions.special.zeta_functions import zeta
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -18,7 +18,7 @@ from sympy.core.expr import Expr
 from sympy.core.function import ArgumentIndexError, DefinedFunction, expand_mul
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
-from sympy.core.numbers import E, I, pi, oo, Rational, Integer
+from sympy.core.numbers import E, I, pi, oo, Rational, Integer, Float
 from sympy.core.relational import Eq, is_le, is_gt, is_lt
 from sympy.external.gmpy import SYMPY_INTS, remove, lcm, legendre, jacobi, kronecker
 from sympy.functions.combinatorial.factorials import (binomial,
@@ -32,6 +32,7 @@ from sympy.ntheory.partitions_ import _partition, _partition_rec
 from sympy.ntheory.primetest import isprime, is_square
 from sympy.polys.appellseqs import bernoulli_poly, euler_poly, genocchi_poly
 from sympy.polys.polytools import cancel
+from sympy.printing.tests.test_llvmjit import eval_cse
 from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import multiset, multiset_derangements, iterable
@@ -895,37 +896,51 @@ class harmonic(DefinedFunction):
     harmonic_cache: dict[Integer, Callable[[int], Rational]] = {}
 
     @classmethod
+    @classmethod
     def eval(cls, n, m=None):
         from sympy.functions.special.zeta_functions import zeta
-        if m is S.One:
-            return cls(n)
+
         if m is None:
             m = S.One
-        if n.is_zero:
-            return S.Zero
-        elif m.is_zero:
-            return n
-        elif n is S.Infinity:
+
+        # Handle symbolic infinity case early to avoid unnecessary processing
+        if n is S.Infinity:
             if m.is_negative:
                 return S.NaN
             elif is_le(m, S.One):
                 return S.Infinity
             elif is_gt(m, S.One):
                 return zeta(m)
+
+        # Return unevaluated expression for harmonic(n, 1) to prevent recursion and allow identity: harmonic(n, 1) == harmonic(n)
+        if m == S.One and not isinstance(n, (Float, Rational)):
+            return cls.__new__(cls, n, evaluate=False)
+
+        # Guard: prevent performance issues for very large integer n by returning unevaluated
+        if n.is_Integer and n.is_positive and int(n) > 10 ** 5:
+            return cls.__new__(cls, n, m, evaluate=False)
+
+        if n.is_zero:
+            return S.Zero
+        elif m.is_zero:
+            return n
         elif m.is_Integer and m.is_nonpositive:
-            return (bernoulli(1-m, n+1) - bernoulli(1-m)) / (1-m)
+            return (bernoulli(1 - m, n + 1) - bernoulli(1 - m)) / (1 - m)
+
         elif n.is_Integer:
             if n.is_negative and (m.is_integer is False or m.is_nonpositive is False):
-                return S.ComplexInfinity if m is S.One else S.NaN
+                return S.ComplexInfinity if m == S.One else S.NaN
+
             if n.is_nonnegative:
                 if m.is_Integer:
                     if m not in cls.harmonic_cache:
                         @recurrence_memo([0])
                         def f(n, prev):
-                            return prev[-1] + S.One / n**m
+                            return prev[-1] + S.One / n ** m
+
                         cls.harmonic_cache[m] = f
                     return cls.harmonic_cache[m](int(n))
-                return Add(*(k**(-m) for k in range(1, int(n) + 1)))
+                return Add(*(k ** (-m) for k in range(1, int(n) + 1)))
 
     def _eval_rewrite_as_polygamma(self, n, m=S.One, **kwargs):
         from sympy.functions.special.gamma_functions import gamma, polygamma

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -32,7 +32,6 @@ from sympy.ntheory.partitions_ import _partition, _partition_rec
 from sympy.ntheory.primetest import isprime, is_square
 from sympy.polys.appellseqs import bernoulli_poly, euler_poly, genocchi_poly
 from sympy.polys.polytools import cancel
-from sympy.printing.tests.test_llvmjit import eval_cse
 from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import multiset, multiset_derangements, iterable

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -371,6 +371,26 @@ def test_harmonic_calculus():
     assert limit(harmonic(x, z - 1), x, oo) == Limit(harmonic(x, z - 1), x, oo, dir='-')
 
 
+def test_large_harmonic_unevaluated():
+    # For n greater than 10^5, our guard should prevent full evaluation.
+    # Instead, harmonic(n) should return a symbolic (unevaluated) expression.
+    n_large = 10 ** 6
+    H = harmonic(n_large)
+
+    # Check that H is still a symbolic unevaluated expression
+    assert isinstance(H, harmonic) and H.args[0] == n_large and H.args[1] == S.One, (
+        "For n > 10^5, harmonic(n) should return a symbolic unevaluated expression."
+    )
+
+    # Evaluate explicitly using .evalf()
+    H_numeric = H.evalf(10)
+    assert H_numeric > 0, (
+        "The evaluated numeric value should be positive for harmonic numbers."
+    )
+
+    print(f"Test passed for harmonic({n_large}).")
+
+
 def test_euler():
     assert euler(0) == 1
     assert euler(1) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #27853

#### Brief description of what is fixed or changed

This PR improves the performance of the `harmonic(n)` function for large `n` by preventing full symbolic evaluation when `n > 10**5`.

Previously, attempting to compute large harmonic numbers like `harmonic(10**6)` caused a massive slowdown, excessive memory use, and could even trigger `ValueError` due to integer string conversion during printing. This was due to internal expansion into huge rational numbers involving Bernoulli numbers.

Changes introduced:

- For `harmonic(n)` where `n > 10**5` and both `n` and `m` are integers, the expression is now returned unevaluated by default to avoid heavy computation.
- Symbolic identity `harmonic(n, 1) == harmonic(n)` is now preserved explicitly, and such expressions also return unevaluated unless `.evalf()` is called.
- This resolves both evaluation and printing issues for large harmonic numbers.

All existing behaviors are preserved for small and moderate-sized `n`. Users can still explicitly evaluate using `.evalf()` as expected.

#### Other comments

This change was implemented in the `eval` method of the `harmonic` class. Guard conditions for large `n` and normalization of `harmonic(n, 1)` to `harmonic(n)` were added in line with suggestions from the original issue and follow-up comments by maintainers.

A regression test is included to ensure large `harmonic(n)` expressions return unevaluated, and that `.evalf()` works when explicitly called.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* functions
  * Improved performance of `harmonic(n)` by skipping full evaluation for large `n > 10**5`. This prevents timeouts and printing errors due to huge intermediate rational numbers.

<!-- END RELEASE NOTES -->
