### PR TITLE
Fix: +,- on Cross objects now return Vector, resolving xfail

### DIFF
--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -14,7 +14,6 @@ from sympy.vector.vector import Cross, Dot, cross
 from sympy.testing.pytest import raises
 from sympy.vector.kind import VectorKind
 from sympy.core.kind import NumberKind
-from sympy.testing.pytest import XFAIL
 
 
 C = CoordSys3D('C')
@@ -30,15 +29,14 @@ def test_cross():
     assert Cross(v1, v2).doit() == C.z**3*C.i + (-C.x*C.z)*C.j + (C.x*C.y - C.x*C.z**2)*C.k
     assert cross(v1, v2) == C.z**3*C.i + (-C.x*C.z)*C.j + (C.x*C.y - C.x*C.z**2)*C.k
     assert Cross(v1, v2) == -Cross(v2, v1)
-    # XXX: Cannot use Cross here. See XFAIL test below:
     assert cross(v1, v2) + cross(v2, v1) == Vector.zero
 
 
-@XFAIL
-def test_cross_xfail():
+def test_cross_opr():
     v1 = C.x * i + C.z * C.z * j
     v2 = C.x * i + C.y * j + C.z * k
     assert Cross(v1, v2) + Cross(v2, v1) == Vector.zero
+    assert Cross(v1, v2) - Cross(v2, v1) == 2*Cross(v1, v2).doit()
 
 
 def test_dot():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -579,6 +579,28 @@ class Cross(Vector):
         obj._expr2 = expr2
         return obj
 
+    def __add__(self, other):
+        self_result = self.doit()
+        if self == self_result:
+            raise NotImplementedError("Cross product not implemented for objects of type "
+                                        f"{type(self._expr1)} and {type(self._expr2)}.")
+        other_result = other.doit()
+        if other == other_result:
+            raise NotImplementedError("Cross product not implemented for objects of type "
+                                        f"{type(other._expr1)} and {type(other._expr2)}.")
+        return self_result + other_result
+
+    def __sub__(self, other):
+        self_result = self.doit()
+        if self == self_result:
+            raise NotImplementedError("Cross product not implemented for objects of type "
+                                        f"{type(self._expr1)} and {type(self._expr2)}.")
+        other_result = other.doit()
+        if other == other_result:
+            raise NotImplementedError("Cross product not implemented for objects of type "
+                                        f"{type(other._expr1)} and {type(other._expr2)}.")
+        return self_result - other_result
+
     def doit(self, **hints):
         return cross(self._expr1, self._expr2)
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Implemented operator overloading to insure '+' and '-" operators on objects of type `Cross` now return a vector.
Previously it raised an error: `AttributeError: 'Cross' object has no attribute '_components'`.
This was addressed in previously `@XFAIL` marked test `test_cross_xfail`.

Now the addition of `Cross` objects returns addition of results of individual cross products, 
calculated using `doit()` function of `Cross` objects.

So `Cross(v1, v2) + Cross(v2, v1)`  is now equivalent to doing `Cross(v1, v2).doit() + Cross(v2, v1).doit()`


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- functions
     - Make `Cross(v1, v2) + Cross(v2, v1)`  perform `Cross(v1, v2).doit() + Cross(v2, v1).doit()`



<!-- END RELEASE NOTES -->
