### PR TITLE
Skip evaluation of harmonic(n) for large n to avoid performance issues

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -606,6 +606,7 @@ Fermi Paradox <FermiParadox@users.noreply.github.com>
 Fernando Perez <Fernando.Perez@berkeley.edu>
 Fiach Antaw <fiach.antaw+github@gmail.com>
 Filip Gokstorp <filip@gokstorp.se>
+Firat Bezir <bezir.1@osu.edu> firatbezir <bezir.1@osu.edu>
 Flamy Owl <flamyowl@protonmail.ch>
 Florian Mickler <florian@mickler.org>
 ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -371,6 +371,19 @@ def test_harmonic_calculus():
     assert limit(harmonic(x, z - 1), x, oo) == Limit(harmonic(x, z - 1), x, oo, dir='-')
 
 
+def test_large_harmonic_unevaluated():
+    n_large = 10 ** 6
+    H = harmonic(n_large)
+    assert isinstance(H, harmonic) and H.args[0] == n_large and H.args[1] == S.One, (
+        "For n > 10^5, harmonic(n) should return a symbolic unevaluated expression."
+    )
+    H_numeric = H.evalf(10)
+    assert H_numeric > 0, (
+        "The evaluated numeric value should be positive for harmonic numbers."
+    )
+    print(f"Test passed for harmonic({n_large}).")
+
+
 def test_euler():
     assert euler(0) == 1
     assert euler(1) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #27853

#### Brief description of what is fixed or changed

This PR improves performance of `harmonic(n)` by preventing full symbolic evaluation when `n > 10**5`.

Previously, large harmonic numbers like `harmonic(10**6)` caused slowdowns and huge intermediate values. This was due to internal expansion into Bernoulli or rational terms.

Changes include:

- Returning unevaluated expressions for large `n`
- Normalizing `harmonic(n, 1)` to `harmonic(n)` to avoid recursion and identity mismatch
- `.evalf()` still works to compute numeric approximations on request

Regression test included.

#### Other comments

If this approach is accepted, I'd be happy to help extend it to a more general mechanism for user-configurable evaluation guards for expensive symbolic functions.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Improved performance of `harmonic(n)` by skipping full evaluation for large `n > 10**5`. Prevents timeouts and large intermediate values.
<!-- END RELEASE NOTES -->
