### PR TITLE
Fixed _from_mathematica_to_tokens() function to correctly parse greek…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -950,6 +950,7 @@ Malkhan Singh <malkhansinghrathaur@gmail.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> Praneeth Ratna <63547155+praneethratna@users.noreply.github.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeeth <praneethratna@gmail.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeth <praneethratna@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com>
 Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.noreply.github.com>
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -950,6 +950,7 @@ Malkhan Singh <malkhansinghrathaur@gmail.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> Praneeth Ratna <63547155+praneethratna@users.noreply.github.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeeth <praneethratna@gmail.com>
 Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeth <praneethratna@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.noreply.github.com>
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
@@ -1115,7 +1116,6 @@ Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
-Octomaanav <maanav.vashist@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1115,6 +1115,7 @@ Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+Octomaanav <maanav.vashist@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -587,7 +587,7 @@ class MathematicaParser:
         "#": lambda: ["Slot", "1"],
         "##": lambda: ["SlotSequence", "1"],
     }
-
+    # "\u0370-\u03FF" this range of Unicode code refers to Greek and Coptic characters. This range includes Greek characters, which are often used as variables or constants in mathematical expressions.
     _literal = r"[A-Za-z\u0370-\u03FF][A-Za-z0-9\u0370-\u03FF]*"
     _number = r"(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)"
 

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -594,6 +594,8 @@ class MathematicaParser:
     _enclosure_open = ["(", "[", "[[", "{"]
     _enclosure_close = [")", "]", "]]", "}"]
 
+    _known_constant_symbols = {'\u03c0'} # Pi is a known constant
+
     @classmethod
     def _get_neg(cls, x):
         return f"-{x}" if isinstance(x, str) and re.match(MathematicaParser._number, x) else ["Times", "-1", x]
@@ -658,7 +660,6 @@ class MathematicaParser:
         # Tokenize the input strings with a regular expression:
         token_lists = [tokenizer.findall(i) if isinstance(i, str) and self._is_valid_string(i) else [i] for i in code_splits]
         tokens = [j for i in token_lists for j in i]
-
         # Remove newlines at the beginning
         while tokens and tokens[0] == "\n":
             tokens.pop(0)
@@ -667,11 +668,16 @@ class MathematicaParser:
             tokens.pop(-1)
 
         return tokens
-    
+
     # This function will check is all characters in the string are either
     # ASCII or Greek (Unicode range \u0370 to \u03FF).
-    def _is_valid_string(self,string:str) -> bool:
-        return all(c.isascii() or '\u0370' <= c <= '\u03FF' for c in string)
+    def _is_valid_string(self, string: str) -> bool:
+        if string in self._known_constant_symbols:
+            return True
+        return all(
+            c.isascii() or ('\u0370' <= c <= '\u03FF' and c not in self._known_constant_symbols)
+            for c in string
+        )
 
     def _is_op(self, token: str | list) -> bool:
         if isinstance(token, list):

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -588,7 +588,7 @@ class MathematicaParser:
         "##": lambda: ["SlotSequence", "1"],
     }
 
-    _literal = r"[A-Za-z][A-Za-z0-9]*"
+    _literal = r"[A-Za-z\u0370-\u03FF][A-Za-z0-9\u0370-\u03FF]*"
     _number = r"(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)"
 
     _enclosure_open = ["(", "[", "[[", "{"]
@@ -656,7 +656,7 @@ class MathematicaParser:
             code_splits[i] = code_split
 
         # Tokenize the input strings with a regular expression:
-        token_lists = [tokenizer.findall(i) if isinstance(i, str) and i.isascii() else [i] for i in code_splits]
+        token_lists = [tokenizer.findall(i) if isinstance(i, str) and self._is_valid_string(i) else [i] for i in code_splits]
         tokens = [j for i in token_lists for j in i]
 
         # Remove newlines at the beginning
@@ -667,6 +667,11 @@ class MathematicaParser:
             tokens.pop(-1)
 
         return tokens
+    
+    # This function will check is all characters in the string are either
+    # ASCII or Greek (Unicode range \u0370 to \u03FF).
+    def _is_valid_string(self,string:str) -> bool:
+        return all(c.isascii() or '\u0370' <= c <= '\u03FF' for c in string)
 
     def _is_op(self, token: str | list) -> bool:
         if isinstance(token, list):

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -10,6 +10,7 @@ def test_mathematica():
         '- 6x': '-6*x',
         'Sin[x]^2': 'sin(x)**2',
         '2(x-1)': '2*(x-1)',
+        'Sqrt[2]*σ' : 'sqrt(2)*σ', # test case for issue 27868
         '3y+8': '3*y+8',
         'ArcSin[2x+9(4-x)^2]/x': 'asin(2*x+9*(4-x)**2)/x',
         'x+y': 'x+y',


### PR DESCRIPTION
… letters

## Fix Mathematica parser failing to parse expressions containing Greek letters

#### References to other Issues or PRs
Fixes #27868


#### Brief description of what is fixed or changed
The Mathematica parser previously failed to correctly parse expressions containing Greek letters, such as Sqrt[2]*σ. The issue occurred because the tokenizer did not recognize Greek characters as valid tokens.

The solution was:

1. Modifying the isascii() check to include Greek letters.
2. Updating the tokenizer to correctly identify Greek characters as separate tokens.
3. Ensuring that expressions like Sqrt[2]*σ are correctly parsed as ['Sqrt', '[', '2', ']', '*', 'σ'].


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed the Mathematica parser failing to recognize Greek letters in expressions.
<!-- END RELEASE NOTES -->
