### PR TITLE
Fix Inconsistent behavior in SymPy's ask function for equality and inequality predicates 

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2526,3 +2526,19 @@ def test_issue_25221():
 def test_issue_27440():
     nan = S.NaN
     assert ask(Q.negative(nan)) is None
+    
+def test_issue_27680():
+    assert ask(x >= y, Q.gt(x, y)) is True  
+    assert ask(x <= y, Q.le(x, y)) is True  
+    assert ask(x >= y, Q.ge(x, y)) is True  
+    assert ask(x <= y, Q.lt(x, y)) is True  
+    assert ask(x == 0, Q.zero(x)) is True  
+    assert ask(x == 0, Q.eq(x, 0)) is True  
+    assert ask(Q.eq(x, 0), Q.eq(x, 0)) is True  
+    assert ask(Q.ge(x, y), Q.gt(x, y)) is True  
+    assert ask(Q.le(x, y), Q.lt(x, y)) is True  
+    assert ask(Q.gt(x, y), Q.lt(x, y)) is False
+    assert ask(Q.lt(x, y), Q.gt(x, y)) is False
+    assert ask(Q.ge(x, y), Q.lt(x, y)) is False
+    assert ask(Q.le(x, y), Q.gt(x, y)) is False
+    assert ask(Q.eq(x, y), Q.gt(x, y)) is False


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #27680 

#### Brief description of what is fixed or changed

This resolves bug #27680 inconsistencies in ask() when handling binary relations involving equality and inequalities. Previously, expressions like ask(a == 0, Q.zero(a)) or ask(a == 0, Q.eq(a, 0)) would return False or None, because a == 0 was evaluated too early as a Python bool. Now, ask() detects this and reconstructs the symbolic intent based on common predicates like Q.zero or Q.eq.

Additionally, binary predicate implications and contradictions (e.g. Q.gt(a, b) ⇒ Q.ge(a, b), or Q.gt(a, b) ⊥ Q.lt(a, b)) are handled via _deduce_binrel_from_assumptions. This allows ask() to return logical results for pairs of binary relations that previously returned None.

Examples that now return correctly:

ask(a == 0, Q.zero(a)) → True
ask(Q.ge(a, b), Q.gt(a, b)) → True
ask(Q.gt(a, b), Q.lt(a, b)) → False
ask(Q.eq(a, b), Q.gt(a, b)) → False

