### PR TITLE
Changed the output of `igcdex` for the all-zero case

### DIFF
--- a/sympy/core/intfunc.py
+++ b/sympy/core/intfunc.py
@@ -378,8 +378,6 @@ def igcdex(a, b):
     4
 
     """
-    if (not a) and (not b):
-        return (0, 1, 0)
     g, x, y = gcdext(int(a), int(b))
     return x, y, g
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -280,7 +280,7 @@ def test_igcdex():
     assert igcdex(2, 3) == (-1, 1, 1)
     assert igcdex(10, 12) == (-1, 1, 2)
     assert igcdex(100, 2004) == (-20, 1, 4)
-    assert igcdex(0, 0) == (0, 1, 0)
+    assert igcdex(0, 0) == (0, 0, 0)
     assert igcdex(1, 0) == (1, 0, 1)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27874

#### Brief description of what is fixed or changed
`sympy.core.intfunc.igcdex` returns `(0, 1, 0)` when given `(0, 0)`. However, similar functions in other libraries such as gmpy and flint return `(0, 0, 0)` for the same input. Since there is no compelling reason to return `(0, 1, 0)`, the behavior has been changed to return `(0, 0, 0)` to align with the others.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * The output of `igcdex(0, 0)` has been changed from `(0, 1, 0)` to `(0, 0, 0)`.
<!-- END RELEASE NOTES -->
