### PR TITLE
Handle Sums with lower > upper limit, if ∞ is present

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -687,6 +687,7 @@ Han Wei Ang <ang.h.w@u.nus.edu>
 Hannah Kari <hannah.kari@marquette.edu> hannah-kari <42753364+hannah-kari@users.noreply.github.com>
 Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
 Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Harikrishna Srinivasan <harikrishnasri3@gmail.com>
 Harold Erbin <harold.erbin@gmail.com>
 Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
 Harry Mountain <harrymountain1@icloud.com>

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -279,6 +279,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         zeta function does not converge unless `s > 1` and `q > 0`
         """
         i, a, b = limits
+        if a.is_comparable and b.is_comparable and a > b:
+            return self.eval_zeta_function(f, (i, b + S.One, a - S.One))
         if b is not S.Infinity:
             return
         w, y, z = Wild('w', exclude=[i]), Wild('y', exclude=[i]), Wild('z', exclude=[i])
@@ -1019,6 +1021,8 @@ def eval_sum(f, limits):
         return f*(b - a + 1)
     if a == b:
         return f.subs(i, a)
+    if a.is_comparable and b.is_comparable and a > b:
+        return eval_sum(f, (i, b + S.One, a - S.One))
     if isinstance(f, Piecewise):
         if not any(i in arg.args[1].free_symbols for arg in f.args):
             # Piecewise conditions do not depend on the dummy summation variable,
@@ -1449,8 +1453,16 @@ def eval_sum_residue(f, i_a_b):
            In: Complex Analysis with Applications.
            Undergraduate Texts in Mathematics. Springer, Cham.
            https://doi.org/10.1007/978-3-319-94063-2_5
+
+    .. [#] Michael Karr, "Summation in Finite Terms", Journal of the ACM,
+           Volume 28 Issue 2, April 1981, Pages 305-350
+           https://dl.acm.org/doi/10.1145/322248.322255
     """
     i, a, b = i_a_b
+
+    # If lower limit > upper limit: Karr Summation Convention
+    if a.is_comparable and b.is_comparable and a > b:
+        return eval_sum_residue(f, (i, b + S.One, a - S.One))
 
     def is_even_function(numer, denom):
         """Test if the rational function is an even function"""

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1453,10 +1453,6 @@ def eval_sum_residue(f, i_a_b):
            In: Complex Analysis with Applications.
            Undergraduate Texts in Mathematics. Springer, Cham.
            https://doi.org/10.1007/978-3-319-94063-2_5
-
-    .. [#] Michael Karr, "Summation in Finite Terms", Journal of the ACM,
-           Volume 28 Issue 2, April 1981, Pages 305-350
-           https://dl.acm.org/doi/10.1145/322248.322255
     """
     i, a, b = i_a_b
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -142,8 +142,6 @@ def test_karr_convention():
     n = Symbol('n', integer=True)
     assert Sum(1/(x**2 + 1), (x, oo, 0)).doit(deep=False) == Rational(-1, 2) + pi / (2 * tanh(pi))
     assert Sum(c**x/factorial(x), (x, oo, 0)).doit(deep=False).simplify() == exp(c) - 1 # exponential series
-    assert Sum(1/(x**2 + 1), (x, oo, 0)).doit(deep=False) == -1/2 + pi/(2*tanh(pi))
-    assert Sum(c**x/factorial(x), (x, oo, 0)).simplify().doit(deep=False) == 1 - exp(c) # exponential series
     assert Sum((-1)**x/x, (x, oo,0)).doit() == -log(2) # alternating harmnic series
     assert Sum((1/2)**x,(x, oo, -1)).doit() == S(2) # geometric series
     assert Sum(1/x, (x, oo, 0)).doit() == oo # harmonic series, divergent

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -9,7 +9,7 @@ from sympy.core import (Catalan, EulerGamma)
 from sympy.core.facts import InconsistentAssumptions
 from sympy.core.mod import Mod
 from sympy.core.numbers import (E, I, Rational, nan, oo, pi)
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ne
 from sympy.core.numbers import Float
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
@@ -22,7 +22,7 @@ from sympy.functions.elementary.hyperbolic import (sinh, tanh)
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.functions.elementary.trigonometric import (cos, sin, atan)
 from sympy.functions.special.gamma_functions import (gamma, lowergamma)
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.functions.special.zeta_functions import zeta
@@ -138,6 +138,28 @@ def test_karr_convention():
     s = Sum(e, (i, 0, 11))
     assert s.n(3) == s.doit().n(3)
 
+    # issue #27893
+    n = Symbol('n', integer=True)
+    assert Sum(1/(x**2 + 1), (x, oo, 0)).doit(deep=False) == Rational(-1, 2) + pi / (2 * tanh(pi))
+    assert Sum(c**x/factorial(x), (x, oo, 0)).doit(deep=False).simplify() == exp(c) - 1 # exponential series
+    assert Sum(1/(x**2 + 1), (x, oo, 0)).doit(deep=False) == -1/2 + pi/(2*tanh(pi))
+    assert Sum(c**x/factorial(x), (x, oo, 0)).simplify().doit(deep=False) == 1 - exp(c) # exponential series
+    assert Sum((-1)**x/x, (x, oo,0)).doit() == -log(2) # alternating harmnic series
+    assert Sum((1/2)**x,(x, oo, -1)).doit() == S(2) # geometric series
+    assert Sum(1/x, (x, oo, 0)).doit() == oo # harmonic series, divergent
+    assert Sum((-1)**x/(2*x+1), (x, oo, -1)).doit() == pi/4 # leibniz series
+    assert Sum((((-1)**x) * c**(2*x+1)) / factorial(2*x+1), (x, oo, -1)).doit() == sin(c) # sinusoidal series
+    assert Sum((((-1)**x) * c**(2*x+1)) / (2*x+1), (x, 0, oo)).doit() \
+        == Piecewise((atan(c), Ne(c**2, -1) & (Abs(c**2) <= 1)), \
+                     (Sum((-1)**x*c**(2*x + 1)/(2*x + 1), (x, 0, oo)), True)) # arctangent series
+    assert Sum(binomial(n, x) * c**x, (x, 0, oo)).doit() \
+        == Piecewise(((c + 1)**n, \
+                     ((n <= -1) & (Abs(c) < 1)) \
+                        | ((n > 0) & (Abs(c) <= 1)) \
+                        | ((n <= 0) & (n > -1) & Ne(c, -1) & (Abs(c) <= 1))), \
+                     (Sum(c**x*binomial(n, x), (x, 0, oo)), True)) # binomial series
+    assert Sum(1/x**n, (x, oo, 0)).doit() \
+        == Piecewise((zeta(n), n > 1), (Sum(x**(-n), (x, oo, 0)), True)) # Euler's zeta function
 
 def test_karr_proposition_2a():
     # Test Karr, page 309, proposition 2, part a


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27893

#### Brief description of what is fixed or changed

Check if `a < b` in `eval_sum`, `eval_sum_residue`, `eval_zeta_function` and calls the function with limits as (i, b + 1, a - 1), following Karr Summation Convention

#### Other comments

Added test cases to validate the results when **lower limit > upper limit**

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* concrete
  * Gives **_evaluated_** result when **lower limit > upper limit** in summation, especially in case if either of them is `infinite` (following Karr convention)

<!-- END RELEASE NOTES -->
