### PR TITLE
`FURB188` has been fixed

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -886,15 +886,12 @@ class Float(Number):
                 # If we're loading an object pickled in Python 2 into
                 # Python 3, we may need to strip a tailing 'L' because
                 # of a shim for int on Python 3, see issue #13470.
-                if num[1].endswith('L'):
-                    num[1] = num[1][:-1]
                 # Strip leading '0x' - gmpy2 only documents such inputs
                 # with base prefix as valid when the 2nd argument (base) is 0.
                 # When mpmath uses Sage as the backend, however, it
                 # ends up including '0x' when preparing the picklable tuple.
                 # See issue #19690.
-                if num[1].startswith('0x'):
-                    num[1] = num[1][2:]
+                num[1] = num[1].removeprefix('0x').removesuffix('L')
                 # Now we can assume that it is in standard form
                 num[1] = MPZ(num[1], 16)
                 _mpf_ = tuple(num)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -753,9 +753,7 @@ class StrPrinter(Printer):
             rv = '-0.' + rv[3:]
         elif rv.startswith('.0'):
             rv = '0.' + rv[2:]
-        if rv.startswith('+'):
-            # e.g., +inf -> inf
-            rv = rv[1:]
+        rv = rv.removeprefix('+') # e.g., +inf -> inf
         return rv
 
     def _print_Relational(self, expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/27892#issuecomment-2779134509

#### Brief description of what is fixed or changed


#### Other comments
Should we add the rule to `pyproject.toml`?

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
