### PR TITLE
[feat] Ringseries: added rs_cosh_sinh to caluclate the faster cosh, sinh series together.

### DIFF
--- a/doc/src/modules/polys/ringseries.rst
+++ b/doc/src/modules/polys/ringseries.rst
@@ -169,6 +169,7 @@ by ``polys.ring.ring``.
 .. autofunction:: rs_asinh
 .. autofunction:: rs_sinh
 .. autofunction:: rs_cosh
+.. autofunction:: rs_cosh_sinh
 .. autofunction:: rs_tanh
 .. autofunction:: rs_hadamard_exp
 

--- a/sympy/polys/puiseux.py
+++ b/sympy/polys/puiseux.py
@@ -13,7 +13,7 @@ non-negative integers.
 # of polynomial rings.
 #
 # Ideally there would be more of a proper series type that can keep track of
-# not not just the leading terms of a truncated series but also the precision
+# not just the leading terms of a truncated series but also the precision
 # of the series. For now the rings here are just introduced to keep the
 # interface that ring_series was using before.
 

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1532,10 +1532,28 @@ def rs_cos(p, x, prec):
     return rs_series_from_list(p, c, x, prec)
 
 def rs_cos_sin(p, x, prec):
-    r"""
-    Return the tuple ``(rs_cos(p, x, prec)`, `rs_sin(p, x, prec))``.
+    """
+    Cosine and sine of a series
 
-    Is faster than calling rs_cos and rs_sin separately
+    Return the series expansion of the cosine and sine of ``p``, about 0.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_cos_sin
+    >>> R, x, y = ring('x, y', QQ)
+    >>> c, s = rs_cos_sin(x + x*y, x, 4)
+    >>> c
+    -1/2*x**2*y**2 - x**2*y - 1/2*x**2 + 1
+    >>> s
+    -1/6*x**3*y**3 - 1/2*x**3*y**2 - 1/2*x**3*y - 1/6*x**3 + x*y + x
+
+    See Also
+    ========
+
+    rs_cos, rs_sin
     """
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_cos_sin, p, x, prec)
@@ -1779,10 +1797,28 @@ def rs_cosh(p, x, prec):
     return (t + t1)/2
 
 def rs_cosh_sinh(p, x, prec):
-    r"""
-    Return the tuple ``(rs_cosh(p, x, prec)`, `rs_sinh(p, x, prec))``.
+    """
+    Hyperbolic cosine and sine of a series
 
-    Is faster than calling rs_cosh and rs_sinh separately
+    Return the series expansion of the hyperbolic cosine and sine of ``p``, about 0.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_cosh_sinh
+    >>> R, x, y = ring('x, y', QQ)
+    >>> c, s = rs_cosh_sinh(x + x*y, x, 4)
+    >>> c
+    1/2*x**2*y**2 + x**2*y + 1/2*x**2 + 1
+    >>> s
+    1/6*x**3*y**3 + 1/2*x**3*y**2 + 1/2*x**3*y + 1/6*x**3 + x*y + x
+
+    See Also
+    ========
+
+    rs_cosh, rs_sinh
     """
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_cosh_sinh, p, x, prec)

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1789,7 +1789,7 @@ def rs_cosh_sinh(p, x, prec):
     t = rs_exp(p, x, prec)
     t1 = rs_series_inversion(t, x, prec)
     return (t + t1)/2, (t - t1)/2
-    
+
 
 def _tanh(p, x, prec):
     r"""

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1562,27 +1562,17 @@ def rs_cos_sin(p, x, prec):
         return R(0), R(0)
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            t1, t2 = sin(c_expr), cos(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
-            except ValueError:
-                R = R.add_gens([sin(c_expr), cos(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
-        else:
-            try:
-                t1, t2 = R(sin(c)), R(cos(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
-        p1 = p - c
+            t1, t2 = R(sin(c_expr)), R(cos(c_expr))
+        except ValueError:
+            R = R.add_gens([sin(c_expr), cos(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            t1, t2 = R(sin(c_expr)), R(cos(c_expr))
 
+        p1 = p - c
         p_cos, p_sin = rs_cos_sin(p1, x, prec)
         return p_cos*t2 - p_sin*t1, p_cos*t1 + p_sin*t2
 
@@ -1869,25 +1859,16 @@ def rs_cosh_sinh(p, x, prec):
         return R(0), R(0)
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            t1, t2 = sinh(c_expr), cosh(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
-            except ValueError:
-                R = R.add_gens([sinh(c_expr), cosh(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
-        else:
-            try:
-                t1, t2 = R(sinh(c)), R(cosh(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                                  "this domain.")
+            t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+        except ValueError:
+            R = R.add_gens([sinh(c_expr), cosh(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+
         p1 = p - c
         p_cosh, p_sinh = rs_cosh_sinh(p1, x, prec)
         return p_cosh * t2 + p_sinh * t1, p_sinh * t2 + p_cosh * t1

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1805,6 +1805,8 @@ def rs_cosh(p, x, prec):
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_cosh, p, x, prec)
     R = p.ring
+    if not p:
+        return R(0)
     c = _get_constant_term(p, x)
     if c:
         if R.domain is EX:

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1564,26 +1564,27 @@ def rs_cos_sin(p, x, prec):
     if c:
         if R.domain is EX:
             c_expr = c.as_expr()
-            t1, t2 = cos(c_expr), sin(c_expr)
+            t1, t2 = sin(c_expr), cos(c_expr)
         elif isinstance(c, PolyElement):
             try:
                 c_expr = c.as_expr()
-                t1, t2 = R(cos(c_expr)), R(sin(c_expr))
+                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
             except ValueError:
-                R = R.add_gens([cos(c_expr), sin(c_expr)])
+                R = R.add_gens([sin(c_expr), cos(c_expr)])
                 p = p.set_ring(R)
                 x = x.set_ring(R)
                 c = c.set_ring(R)
-                t1, t2 = R(cos(c_expr)), R(sin(c_expr))
+                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
         else:
             try:
-                t1, t2 = R(cos(c)), R(sin(c))
+                t1, t2 = R(sin(c)), R(cos(c))
             except ValueError:
                 raise DomainError("The given series cannot be expanded in "
                     "this domain.")
         p1 = p - c
+
         p_cos, p_sin = rs_cos_sin(p1, x, prec)
-        return p_cos*t1 - p_sin*t2, p_cos*t2 + p_sin*t1
+        return p_cos*t2 - p_sin*t1, p_cos*t1 + p_sin*t2
 
     if len(p) > 20 and R.ngens == 1:
         t = rs_tan(p/2, x, prec)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -370,12 +370,24 @@ def test_cos():
 
 def test_cos_sin():
     R, x, y = ring('x, y', QQ)
-    cos, sin = rs_cos_sin(x, x, 9)
-    assert cos == rs_cos(x, x, 9)
-    assert sin == rs_sin(x, x, 9)
-    cos, sin = rs_cos_sin(x + x*y, x, 5)
-    assert cos == rs_cos(x + x*y, x, 5)
-    assert sin == rs_sin(x + x*y, x, 5)
+    c, s = rs_cos_sin(x, x, 9)
+    assert c == rs_cos(x, x, 9)
+    assert s == rs_sin(x, x, 9)
+    c, s = rs_cos_sin(x + x*y, x, 5)
+    assert c == rs_cos(x + x*y, x, 5)
+    assert s == rs_sin(x + x*y, x, 5)
+
+    # constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[sin(a), cos(a), a])
+    c, s = rs_cos_sin(x + a, x, 5)
+    assert c == rs_cos(x + a, x, 5)
+    assert s == rs_sin(x + a, x, 5)
+
+    R, x, y = ring('x, y', EX)
+    c, s = rs_cos_sin(x + a, x, 5)
+    assert c == rs_cos(x + a, x, 5)
+    assert s == rs_sin(x + a, x, 5)
 
 def test_atanh():
     R, x, y = ring('x, y', QQ)
@@ -427,6 +439,23 @@ def test_sinh():
         x**6*y**7/24 + x**5*y**7/2 + x**5*y**5/120 + x**4*y**5/2 + \
         x**3*y**3/6 + x**2*y**3 + x*y
 
+    # constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[sinh(a), cosh(a), a])
+    assert rs_sinh(x + a, x, 5) == 1/24*x**4*(sinh(a)) + 1/6*x**3*(cosh(a)) + 1/\
+        2*x**2*(sinh(a)) + x*(cosh(a)) + (sinh(a))
+    assert rs_sinh(x + x**2*y + a, x, 5) == 1/2*(sinh(a))*x**4*y**2 + 1/2*(cosh(a))\
+        *x**4*y + 1/24*(sinh(a))*x**4 + (sinh(a))*x**3*y + 1/6*(cosh(a))*x**3 + \
+        (cosh(a))*x**2*y + 1/2*(sinh(a))*x**2 + (cosh(a))*x + (sinh(a))
+
+    R, x, y = ring('x, y', EX)
+    assert rs_sinh(x + a, x, 5) == EX(sinh(a)/24)*x**4 + EX(cosh(a)/6)*x**3 + \
+        EX(sinh(a)/2)*x**2 + EX(cosh(a))*x + EX(sinh(a))
+    assert rs_sinh(x + x**2*y + a, x, 5) == EX(sinh(a)/2)*x**4*y**2 + EX(cosh(a)/\
+        2)*x**4*y + EX(sinh(a)/24)*x**4 + EX(sinh(a))*x**3*y + EX(cosh(a)/6)*x**3 \
+        + EX(cosh(a))*x**2*y + EX(sinh(a)/2)*x**2 + EX(cosh(a))*x + EX(sinh(a))
+
+
 def test_cosh():
     R, x, y = ring('x, y', QQ)
     assert rs_cosh(x, x, 9) == 1 + x**2/2 + x**4/24 + x**6/720 + x**8/40320
@@ -435,14 +464,40 @@ def test_cosh():
         x**7*y**8/120 + x**6*y**8/4 + x**6*y**6/720 + x**5*y**6/6 + \
         x**4*y**6/2 + x**4*y**4/24 + x**3*y**4 + x**2*y**2/2 + 1
 
+    # constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[sinh(a), cosh(a), a])
+    assert rs_cosh(x + a, x, 5) == 1/24*(cosh(a))*x**4 + 1/6*(sinh(a))*x**3 + \
+        1/2*(cosh(a))*x**2 + (sinh(a))*x + (cosh(a))
+    assert rs_cosh(x + x**2*y + a, x, 5) == 1/2*(cosh(a))*x**4*y**2 + 1/2*(sinh(a))\
+        *x**4*y + 1/24*(cosh(a))*x**4 + (cosh(a))*x**3*y + 1/6*(sinh(a))*x**3 + \
+        (sinh(a))*x**2*y + 1/2*(cosh(a))*x**2 + (sinh(a))*x + (cosh(a))
+    R, x, y = ring('x, y', EX)
+    assert rs_cosh(x + a, x, 5) == EX(cosh(a)/24)*x**4 + EX(sinh(a)/6)*x**3 + \
+        EX(cosh(a)/2)*x**2 + EX(sinh(a))*x + EX(cosh(a))
+    assert rs_cosh(x + x**2*y + a, x, 5) == EX(cosh(a)/2)*x**4*y**2 + EX(sinh(a)/\
+        2)*x**4*y + EX(cosh(a)/24)*x**4 + EX(cosh(a))*x**3*y + EX(sinh(a)/6)*x**3 \
+        + EX(sinh(a))*x**2*y + EX(cosh(a)/2)*x**2 + EX(sinh(a))*x + EX(cosh(a))
+
 def test_cosh_sinh():
     R, x, y = ring('x, y', QQ)
-    cosh, sinh = rs_cosh_sinh(x, x, 9)
-    assert cosh == rs_cosh(x, x, 9)
-    assert sinh == rs_sinh(x, x, 9)
-    cosh, sinh = rs_cosh_sinh(x + x*y, x, 5)
-    assert cosh == rs_cosh(x + x*y, x, 5)
-    assert sinh == rs_sinh(x + x*y, x, 5)
+    ch, sh = rs_cosh_sinh(x, x, 9)
+    assert ch == rs_cosh(x, x, 9)
+    assert sh == rs_sinh(x, x, 9)
+    ch, sh = rs_cosh_sinh(x + x*y, x, 5)
+    assert ch == rs_cosh(x + x*y, x, 5)
+    assert sh == rs_sinh(x + x*y, x, 5)
+
+    # constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[sinh(a), cosh(a), a])
+    ch, sh = rs_cosh_sinh(x + a, x, 5)
+    assert ch == rs_cosh(x + a, x, 5)
+    assert sh == rs_sinh(x + a, x, 5)
+    R, x, y = ring('x, y', EX)
+    ch, sh = rs_cosh_sinh(x + a, x, 5)
+    assert ch == rs_cosh(x + a, x, 5)
+    assert sh == rs_sinh(x + a, x, 5)
 
 def test_tanh():
     R, x, y = ring('x, y', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -378,6 +378,10 @@ def test_cos_sin():
     assert s == rs_sin(x + x*y, x, 5)
 
     # constant term in series
+    c, s = rs_cos_sin(1 + x + x**2, x, 5)
+    assert c == rs_cos(1 + x + x**2, x, 5)
+    assert s == rs_sin(1 + x + x**2, x, 5)
+
     a = symbols('a')
     R, x, y = ring('x, y', QQ[sin(a), cos(a), a])
     c, s = rs_cos_sin(x + a, x, 5)
@@ -489,6 +493,10 @@ def test_cosh_sinh():
     assert sh == rs_sinh(x + x*y, x, 5)
 
     # constant term in series
+    c, s = rs_cosh_sinh(1 + x + x**2, x, 5)
+    assert c == rs_cosh(1 + x + x**2, x, 5)
+    assert s == rs_sinh(1 + x + x**2, x, 5)
+
     a = symbols('a')
     R, x, y = ring('x, y', QQ[sinh(a), cosh(a), a])
     ch, sh = rs_cosh_sinh(x + a, x, 5)
@@ -597,13 +605,19 @@ def test_puiseux():
     assert r == x**QQ(9,5) + x**QQ(26,15) + x**QQ(22,15) + x**QQ(6,5)/3 + x + \
         x**QQ(2,3) + x**QQ(2,5)
 
+    r = rs_cosh(p, x, 2)
+    assert r == x**QQ(28,15)/6 + x**QQ(5,3) + x**QQ(8,5)/24 + x**QQ(7,5) + \
+        x**QQ(4,3)/2 + x**QQ(16,15) + x**QQ(4,5)/2 + 1
+
     r = rs_sinh(p, x, 2)
     assert r == x**QQ(9,5)/2 + x**QQ(26,15)/2 + x**QQ(22,15)/2 + \
         x**QQ(6,5)/6 + x + x**QQ(2,3) + x**QQ(2,5)
 
-    r = rs_cosh(p, x, 2)
-    assert r == x**QQ(28,15)/6 + x**QQ(5,3) + x**QQ(8,5)/24 + x**QQ(7,5) + \
+    r = rs_cosh_sinh(p, x, 2)
+    assert r[0] == x**QQ(28,15)/6 + x**QQ(5,3) + x**QQ(8,5)/24 + x**QQ(7,5) + \
         x**QQ(4,3)/2 + x**QQ(16,15) + x**QQ(4,5)/2 + 1
+    assert r[1] == x**QQ(9,5)/2 + x**QQ(26,15)/2 + x**QQ(22,15)/2 + \
+        x**QQ(6,5)/6 + x + x**QQ(2,3) + x**QQ(2,5)
 
     r = rs_tanh(p, x, 2)
     assert r == -x**QQ(9,5) - x**QQ(26,15) - x**QQ(22,15) - x**QQ(6,5)/3 + \

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -1,6 +1,5 @@
 from sympy.polys.domains import ZZ, QQ, EX, RR
 from sympy.polys.rings import ring
-from sympy.polys.polyerrors import DomainError
 from sympy.polys.puiseux import puiseux_ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -1,5 +1,6 @@
 from sympy.polys.domains import ZZ, QQ, EX, RR
 from sympy.polys.rings import ring
+from sympy.polys.polyerrors import DomainError
 from sympy.polys.puiseux import puiseux_ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,
@@ -420,8 +421,8 @@ def test_asinh():
     R, x, y = ring('x, y', QQ)
     assert rs_asinh(x, x, 9) == -5/112*x**7 + 3/40*x**5 - 1/6*x**3 + x
     assert rs_asinh(x*y + x**2*y**3, x, 9) == 3/4*x**8*y**11 - 5/16*x**8*y**9 + \
-           3/4*x**7*y**9 - 5/112*x**7*y**7 - 1/6*x**6*y**9 + 3/8*x**6*y**7 - 1/2*x \
-           **5*y**7 + 3/40*x**5*y**5 - 1/2*x**4*y**5 - 1/6*x**3*y**3 + x**2*y**3 + x*y
+        3/4*x**7*y**9 - 5/112*x**7*y**7 - 1/6*x**6*y**9 + 3/8*x**6*y**7 - 1/2*x \
+        **5*y**7 + 3/40*x**5*y**5 - 1/2*x**4*y**5 - 1/6*x**3*y**3 + x**2*y**3 + x*y
 
     # Constant term in series
     a = symbols('a')

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -442,7 +442,7 @@ def test_cosh_sinh():
     assert sinh == rs_sinh(x, x, 9)
     cosh, sinh = rs_cosh_sinh(x + x*y, x, 5)
     assert cosh == rs_cosh(x + x*y, x, 5)
-    assert sinh == rs_sin(x + x*y, x, 5)
+    assert sinh == rs_sinh(x + x*y, x, 5)
 
 def test_tanh():
     R, x, y = ring('x, y', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -5,8 +5,8 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,
     rs_series_from_list, rs_exp, rs_log, rs_newton, rs_series_inversion,
     rs_compose_add, rs_asin, rs_atan, rs_atanh, rs_asinh, rs_tan, rs_cot, rs_sin,
-    rs_cos, rs_cos_sin, rs_sinh, rs_cosh, rs_tanh, _tan1, rs_fun, rs_nth_root,
-    rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
+    rs_cos, rs_cos_sin, rs_sinh, rs_cosh, rs_cosh_sinh, rs_tanh, _tan1, rs_fun,
+    rs_nth_root, rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
 from sympy.testing.pytest import raises, slow
 from sympy.core.symbol import symbols
 from sympy.functions import (sin, cos, exp, tan, cot, sinh, cosh, atan, atanh,
@@ -434,6 +434,15 @@ def test_cosh():
         x**8*y**10/48 + x**8*y**8/40320 + x**7*y**10/6 + \
         x**7*y**8/120 + x**6*y**8/4 + x**6*y**6/720 + x**5*y**6/6 + \
         x**4*y**6/2 + x**4*y**4/24 + x**3*y**4 + x**2*y**2/2 + 1
+
+def test_cosh_sinh():
+    R, x, y = ring('x, y', QQ)
+    cosh, sinh = rs_cosh_sinh(x, x, 9)
+    assert cosh == rs_cosh(x, x, 9)
+    assert sinh == rs_sinh(x, x, 9)
+    cosh, sinh = rs_cosh_sinh(x + x*y, x, 5)
+    assert cosh == rs_cosh(x + x*y, x, 5)
+    assert sinh == rs_sin(x + x*y, x, 5)
 
 def test_tanh():
     R, x, y = ring('x, y', QQ)


### PR DESCRIPTION
### Summary of changes

1. Fixed a typo in the puiseux documentation.
2. TODO of `rs_series_from_list`.
3. Added `rs_cosh_sinh` function to compute the `cosh` and `sinh` series simultaneously. This improves performance by avoiding redundant computation of the exponential and its inverse.
4. Integrated `rs_cosh_sinh` into the `rs_cosh` and `rs_sinh` implementations within the constant expression code.
5. Updated rs_sin and rs_cos to utilize the shared `rs_cos_sin` function for efficiency.


### Release Note
<!-- BEGIN RELEASE NOTES -->
- polys
   - Added `rs_cosh_sinh` to calculate faster `cosh`,  `sinh` series together.
<!-- END RELEASE NOTES -->
