### PR TITLE
File read and write operations were updated to use `pathlib.Path`

### DIFF
--- a/bin/ask_update.py
+++ b/bin/ask_update.py
@@ -16,6 +16,7 @@ $ python bin/ask_update.py
 # hook in-tree SymPy into Python path, if possible
 import os
 import sys
+from pathlib import Path
 
 isympy_path = os.path.abspath(__file__)
 isympy_dir = os.path.dirname(isympy_path)
@@ -133,22 +134,17 @@ def generate_code():
 
     return code_string % (all_clauses, matrix_clauses, number_clauses, m)
 
-with open('sympy/assumptions/ask_generated.py', 'w') as f:
-    code = generate_code()
-    f.write(code)
+code = generate_code()
+Path('sympy/assumptions/ask_generated.py').write_text(code)
 
+representation = _generate_assumption_rules()._to_python()
+code_string = dedent('''\
+"""
+Do NOT manually edit this file.
+Instead, run ./bin/ask_update.py.
+"""
 
-with open('sympy/core/assumptions_generated.py', 'w') as f:
-    representation = _generate_assumption_rules()._to_python()
-
-    code_string = dedent('''\
-    """
-    Do NOT manually edit this file.
-    Instead, run ./bin/ask_update.py.
-    """
-
-    %s
-    ''')
-
-    code = code_string % (representation,)
-    f.write(code)
+%s
+''')
+code = code_string % (representation,)
+Path('sympy/core/assumptions_generated.py').write_text(code)

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -23,6 +23,7 @@ import os
 import sys
 import inspect
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from pathlib import Path
 
 try:
     from HTMLParser import HTMLParser
@@ -276,8 +277,7 @@ def find_sphinx(name, mod_path, found={}):
     sphinx_path = os.path.join(sympy_top, 'doc', '_build', 'html', '_modules', *doc_path)
     if not os.path.exists(sphinx_path):
         return False
-    with open(sphinx_path) as f:
-        html_txt = f.read()
+    html_txt = Path(sphinx_path).read_text()
     p = FindInSphinx()
     p.feed(html_txt)
     found[mod_path] = p.is_imported

--- a/doc/ext/convert-svg-to-pdf.py
+++ b/doc/ext/convert-svg-to-pdf.py
@@ -11,6 +11,7 @@ import os
 import platform
 from typing import Any  # NOQA
 from sphinx.application import Sphinx  # NOQA
+from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
@@ -70,13 +71,11 @@ class Converter(ImageConverter):
 
     def convert(self, _from: str, _to: str) -> bool:
         """Converts the image from SVG to PDF using chrome."""
-        with open(_from, 'r') as f:
-            svg = f.read()
+        svg = Path(_from).read_text()
 
         HTML = "<html><head><style>body {margin: 0; }</style><script>function init() {const element = document.querySelector('svg');const positionInfo = element.getBoundingClientRect();const height = positionInfo.height;const width = positionInfo.width;const style = document.createElement('style');style.innerHTML = `@page {margin: 0; size: ${width}px ${height}px}`;document.head.appendChild(style); }window.onload = init;</script></head><body>%s</body></html>" % (svg)
         temp_name = f'{_from}.html'
-        with open(temp_name, 'w') as f:
-            f.write(HTML)
+        Path(temp_name).write_text(HTML)
 
         chromium = self.chromium_command()
         code = self.command_runner(chromium, _to, temp_name)

--- a/doc/generate_logos.py
+++ b/doc/generate_logos.py
@@ -15,6 +15,7 @@ import os.path
 import logging
 import subprocess
 import sys
+from pathlib import Path
 from platform import system
 
 default_source_dir = os.path.join(os.path.dirname(__file__), "src", "logo")
@@ -291,9 +292,8 @@ def load_svg(fn):
     return doc
 
 def save_svg(fn, doc):
-    with open(fn, "wb") as f:
-        xmlstr = doc.toxml("utf-8")
-        f.write(xmlstr)
-        logging.info(" File saved: %s" % fn)
+    xmlstr = doc.toxml("utf-8")
+    Path(fn).write_bytes(xmlstr)
+    logging.info(" File saved: %s" % fn)
 
 main()

--- a/release/authors.py
+++ b/release/authors.py
@@ -30,8 +30,7 @@ Thanks to everyone who contributed to this release!
     authors_text += '\n'.join(authors_lines)
 
     # Output to file and to screen
-    with open(outdir / 'authors.txt', 'w') as authorsfile:
-        authorsfile.write(authors_text)
+    Path(outdir / 'authors.txt').write_text(authors_text)
 
     print()
     print(blue("Here are the authors to put at the bottom of the release notes."))

--- a/release/github_release.py
+++ b/release/github_release.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 import glob
 from contextlib import contextmanager
 from getpass import getpass
+from pathlib import Path
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -357,8 +358,7 @@ def save_token_file(token):
     try:
         if not os.path.isdir(token_folder):
             os.mkdir(token_folder, 0o700)
-        with open(token_file_expand, 'w') as f:
-            f.write(token + '\n')
+        Path(token_file_expand).write_text(token + '\n')
         os.chmod(token_file_expand, stat.S_IREAD | stat.S_IWRITE)
     except OSError as e:
         print("> Unable to create folder for token file: ", e)

--- a/release/sha256.py
+++ b/release/sha256.py
@@ -20,8 +20,7 @@ def main(version, outdir):
     out = '\n'.join(["%s\t%s" % (i, os.path.split(j)[1]) for i, j in out])
 
     # Output to file and to screen
-    with open(outdir / 'sha256.txt', 'w') as shafile:
-        shafile.write(out)
+    Path(outdir / 'sha256.txt').write_text(out)
     print(out)
 
 

--- a/setup.py
+++ b/setup.py
@@ -217,8 +217,7 @@ class sdist_sympy(sdist):
             pass
 
         if commit_hash:
-            with open(commit_hash_filepath, 'w') as f:
-                f.write(commit_hash)
+            Path(commit_hash_filepath).write_text(commit_hash)
 
         super().run()
 
@@ -302,9 +301,8 @@ tests = [
 ]
 
 
-with open(os.path.join(dir_setup, 'sympy', 'release.py')) as f:
-    # Defines __version__
-    exec(f.read())
+# Defines __version__
+exec(Path(os.path.join(dir_setup, 'sympy', 'release.py')).read_text())
 
 
 if __name__ == '__main__':

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -6,6 +6,7 @@
 
 import os
 import re
+from pathlib import Path
 
 from sympy.assumptions.ask import Q
 from sympy.core.basic import Basic
@@ -47,8 +48,7 @@ def test_all_classes_are_tested():
             if not file.endswith(".py"):
                 continue
 
-            with open(os.path.join(root, file), encoding='utf-8') as f:
-                text = f.read()
+            text = Path(os.path.join(root, file)).read_text(encoding='utf-8')
 
             submodule = module + '.' + file[:-3]
 

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -1,6 +1,7 @@
 import sympy
 import tempfile
 import os
+from pathlib import Path
 from sympy.core.mod import Mod
 from sympy.core.relational import Eq
 from sympy.core.symbol import symbols
@@ -288,8 +289,7 @@ def test_autowrap_custom_printer():
 
     tmpdir = tempfile.mkdtemp()
     # write a trivial header file to use in the generated code
-    with open(os.path.join(tmpdir, 'shortpi.h'), 'w') as f:
-        f.write('#define S_PI 3.14')
+    Path(os.path.join(tmpdir, 'shortpi.h')).write_text('#define S_PI 3.14')
 
     func = autowrap(expr, backend='cython', tempdir=tmpdir, code_gen=gen)
 

--- a/sympy/external/tests/test_codegen.py
+++ b/sympy/external/tests/test_codegen.py
@@ -28,6 +28,7 @@ import sys
 import os
 import tempfile
 import subprocess
+from pathlib import Path
 
 
 # templates for the main program that will test the generated code.
@@ -182,9 +183,8 @@ def run_test(label, routines, numerical_tests, language, commands, friendly=True
         raise NotImplementedError(
             "FIXME: filename extension unknown for language: %s" % language)
 
-    with open(f_name, "w") as f:
-        f.write(
-            main_template[language] % {'statements': "".join(test_strings)})
+    Path(f_name).write_text(
+        main_template[language] % {'statements': "".join(test_strings)})
 
     # 4) Compile and link
     compiled = try_run(commands)

--- a/sympy/logic/utilities/dimacs.py
+++ b/sympy/logic/utilities/dimacs.py
@@ -7,6 +7,7 @@ www.cs.ubc.ca/~hoos/SATLIB/Benchmarks/SAT/satformat.ps
 from sympy.core import Symbol
 from sympy.logic.boolalg import And, Or
 import re
+from pathlib import Path
 
 
 def load(s):
@@ -64,7 +65,5 @@ def load(s):
 
 def load_file(location):
     """Loads a boolean expression from a file."""
-    with open(location) as f:
-        s = f.read()
-
+    s = Path(location).read_text()
     return load(s)

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import re
+from pathlib import Path
 
 from sympy.external import import_module
 from sympy.parsing.latex.lark.transformer import TransformToSymPyExpr
@@ -43,11 +44,9 @@ class LarkLaTeXParser:
         grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
 
         if grammar_file is None:
-            with open(os.path.join(grammar_dir_path, "latex.lark"), encoding="utf-8") as f:
-                latex_grammar = f.read()
+            latex_grammar = Path(os.path.join(grammar_dir_path, "latex.lark")).read_text(encoding="utf-8")
         else:
-            with open(grammar_file, encoding="utf-8") as f:
-                latex_grammar = f.read()
+            latex_grammar = Path(grammar_file).read_text(encoding="utf-8")
 
         self.parser = _lark.Lark(
             latex_grammar,

--- a/sympy/parsing/tests/test_custom_latex.py
+++ b/sympy/parsing/tests/test_custom_latex.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from pathlib import Path
 
 import sympy
 from sympy.testing.pytest import raises
@@ -23,9 +24,7 @@ modification2 = r"""
 """
 
 def init_custom_parser(modification, transformer=None):
-    with open(grammar_file, encoding="utf-8") as f:
-        latex_grammar = f.read()
-
+    latex_grammar = Path(grammar_file).read_text(encoding="utf-8")
     latex_grammar += modification
 
     with tempfile.NamedTemporaryFile() as f:

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -2,6 +2,7 @@ import os
 from os.path import join
 import shutil
 import tempfile
+from pathlib import Path
 
 try:
     from subprocess import STDOUT, CalledProcessError, check_output
@@ -298,8 +299,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     debug("Latex code:")
     debug(latex_main)
     with tempfile.TemporaryDirectory() as workdir:
-        with open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
-            fh.write(latex_main)
+        Path(join(workdir, 'texput.tex')).write_text(latex_main, encoding='utf-8')
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)
@@ -376,8 +376,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         if viewer == "file":
             shutil.move(join(workdir, src), filename)
         elif viewer == "BytesIO":
-            with open(join(workdir, src), 'rb') as fh:
-                outputbuffer.write(fh.read())
+            s = Path(join(workdir, src)).read_bytes()
+            outputbuffer.write(s)
         elif callable(viewer):
             viewer(join(workdir, src), fmt=output)
         else:

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -297,8 +297,7 @@ calls the deprecated code (the current stacklevel is showing code from
         targets = []
         for w in warnrec:
             targets.append(w.message.active_deprecations_target)
-        with open(active_deprecations_file, encoding="utf-8") as f:
-            text = f.read()
+        text = pathlib.Path(active_deprecations_file).read_text(encoding="utf-8")
         for target in targets:
             if f'({target})=' not in text:
                 raise Failed(f"The active deprecations target {target!r} does not appear to be a valid target in the active-deprecations.md file ({active_deprecations_file}).")

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -34,6 +34,7 @@ import tempfile
 import warnings
 from contextlib import contextmanager
 from inspect import unwrap
+from pathlib import Path
 
 from sympy.core.cache import clear_cache
 from sympy.external import import_module
@@ -1577,8 +1578,7 @@ class SymPyDocTests:
                   '    exit("wrong number of args")\n')
 
             for viewer in disable_viewers:
-                with open(os.path.join(tempdir, viewer), 'w') as fh:
-                    fh.write(vw)
+                Path(os.path.join(tempdir, viewer)).write_text(vw)
 
                 # make the file executable
                 os.chmod(os.path.join(tempdir, viewer),

--- a/sympy/testing/runtests_pytest.py
+++ b/sympy/testing/runtests_pytest.py
@@ -162,15 +162,14 @@ def update_args_with_paths(
 
     def find_tests_matching_keywords(keywords, filepath):
         matches = []
-        with open(filepath, encoding='utf-8') as tests_file:
-            source = tests_file.read()
-            for line in source.splitlines():
-                if line.lstrip().startswith('def '):
-                    for kw in keywords:
-                        if line.lower().find(kw.lower()) != -1:
-                            test_name = line.split(' ')[1].split('(')[0]
-                            full_test_path = filepath + '::' + test_name
-                            matches.append(full_test_path)
+        source = pathlib.Path(filepath).read_text(encoding='utf-8')
+        for line in source.splitlines():
+            if line.lstrip().startswith('def '):
+                for kw in keywords:
+                    if line.lower().find(kw.lower()) != -1:
+                        test_name = line.split(' ')[1].split('(')[0]
+                        full_test_path = filepath + '::' + test_name
+                        matches.append(full_test_path)
         return matches
 
     valid_testpaths_default = []

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import warnings
+from pathlib import Path
 from sysconfig import get_config_var, get_config_vars, get_path
 
 from .runners import (
@@ -568,8 +569,7 @@ def _write_sources_to_build_dir(sources, build_dir):
         sha256_in_mem = sha256_of_string(src.encode('utf-8')).hexdigest()
         if os.path.exists(dest):
             if os.path.exists(dest + '.sha256'):
-                with open(dest + '.sha256') as fh:
-                    sha256_on_disk = fh.read()
+                sha256_on_disk = Path(dest + '.sha256').read_text()
             else:
                 sha256_on_disk = sha256_of_file(dest).hexdigest()
 

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -84,6 +84,7 @@ import sys
 import os
 import shutil
 import tempfile
+from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
 from string import Template
 from warnings import warn
@@ -335,10 +336,9 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
         else:
             np_import = ''
 
-        with open(os.path.join(build_dir, 'setup.py'), 'w') as f:
-            includes = str(self._include_dirs).replace("'np.get_include()'",
-                                                       'np.get_include()')
-            f.write(self.setup_template.format(
+        includes = str(self._include_dirs).replace("'np.get_include()'",
+                                                    'np.get_include()')
+        code = self.setup_template.format(
                 ext_args=", ".join(ext_args),
                 np_import=np_import,
                 include_dirs=includes,
@@ -346,8 +346,8 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
                 libraries=self._libraries,
                 extra_compile_args=self._extra_compile_args,
                 extra_link_args=self._extra_link_args,
-                cythonize_options=self._cythonize_options
-            ))
+                cythonize_options=self._cythonize_options)
+        Path(os.path.join(build_dir, 'setup.py')).write_text(code)
 
     @classmethod
     def _get_wrapped_function(cls, mod, name):

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import shutil
 from io import StringIO
+from pathlib import Path
 
 from sympy.core import symbols, Eq
 from sympy.utilities.autowrap import (autowrap, binary_function,
@@ -113,8 +114,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
     setup_file_path = os.path.join(temp_dir, 'setup.py')
 
     code_gen._prepare_files(routine, build_dir=temp_dir)
-    with open(setup_file_path) as f:
-        setup_text = f.read()
+    setup_text = Path(setup_file_path).read_text()
     assert setup_text == expected
 
     code_gen = CythonCodeWrapper(CCodeGen(),
@@ -143,8 +143,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
 """ % {'num': CodeWrapper._module_counter}
 
     code_gen._prepare_files(routine, build_dir=temp_dir)
-    with open(setup_file_path) as f:
-        setup_text = f.read()
+    setup_text = Path(setup_file_path).read_text()
     assert setup_text == expected
 
     expected = """\
@@ -167,8 +166,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
 
     code_gen._need_numpy = True
     code_gen._prepare_files(routine, build_dir=temp_dir)
-    with open(setup_file_path) as f:
-        setup_text = f.read()
+    setup_text = Path(setup_file_path).read_text()
     assert setup_text == expected
 
     TmpFileManager.cleanup()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed
Fixes were made to `FURB101` and `FURB103` in Ruff.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
