### PR TITLE
Fix is_hermitian to correctly handle block matrices

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -989,6 +989,7 @@ Mary Clark <mary.spriteling@gmail.com> <meclark256@gmail.com>
 Mateusz Paprocki <mattpap@gmail.com> mattpap <devnull@localhost>
 Mathew Chong <mathewchong.dev@gmail.com>
 Mathias Louboutin <mathias.louboutin@gmail.com>
+Mathis Cros <mathis.cros@telecom-paris.fr>
 Matt Bogosian <matt@bogosian.net>
 Matt Curry <mattjcurry@gmail.com>
 Matt Habel <habelinc@gmail.com>

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -1329,7 +1329,7 @@ class MatrixBase(Printable):
     # routines and has a different *args signature.  Make
     # sure the names don't clash by adding `_matrix_` in name.
     def _eval_is_matrix_hermitian(self, simpfunc):
-        herm = lambda i, j: simpfunc(self[i, j] - self[j, i].transpose().conjugate()).is_zero
+        herm = lambda i, j: simpfunc(self[i, j] - self[j, i].adjoint()).is_zero
         return fuzzy_and(herm(i, j) for (i, j), v in self.iter_items())
 
     def _eval_is_zero_matrix(self):

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -1329,8 +1329,7 @@ class MatrixBase(Printable):
     # routines and has a different *args signature.  Make
     # sure the names don't clash by adding `_matrix_` in name.
     def _eval_is_matrix_hermitian(self, simpfunc):
-        from sympy.physics.quantum import Dagger
-        herm = lambda i, j: simpfunc(self[i, j] - Dagger(self[j, i])).is_zero
+        herm = lambda i, j: simpfunc(self[i, j] - self[j, i].transpose().conjugate()).is_zero
         return fuzzy_and(herm(i, j) for (i, j), v in self.iter_items())
 
     def _eval_is_zero_matrix(self):

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -1329,7 +1329,8 @@ class MatrixBase(Printable):
     # routines and has a different *args signature.  Make
     # sure the names don't clash by adding `_matrix_` in name.
     def _eval_is_matrix_hermitian(self, simpfunc):
-        herm = lambda i, j: simpfunc(self[i, j] - self[j, i].conjugate()).is_zero
+        from sympy.physics.quantum import Dagger
+        herm = lambda i, j: simpfunc(self[i, j] - Dagger(self[j, i])).is_zero
         return fuzzy_and(herm(i, j) for (i, j), v in self.iter_items())
 
     def _eval_is_zero_matrix(self):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -21,6 +21,8 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
 from sympy.integrals.integrals import integrate
+from sympy.matrices.expressions.transpose import transpose
+from sympy.physics.quantum.operator import HermitianOperator, Operator, Dagger
 from sympy.polys.polytools import (Poly, PurePoly)
 from sympy.polys.rootoftools import RootOf
 from sympy.printing.str import sstr
@@ -2825,6 +2827,12 @@ def test_hermitian():
     assert a.is_hermitian is None
     a[0, 1] = a[1, 0]*I
     assert a.is_hermitian is False
+    b = HermitianOperator("b")
+    c = Operator("c")
+    assert Matrix([[b]]).is_hermitian is True
+    assert Matrix([[b, c], [Dagger(c), b]]).is_hermitian is True
+    assert Matrix([[b, c], [c, b]]).is_hermitian is False
+    assert Matrix([[b, c], [transpose(c), b]]).is_hermitian is False
 
 def test_doit():
     a = Matrix([[Add(x,x, evaluate=False)]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #27898 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The function is_hermitian didn't work for block matrices like [[A]] where A is an HermitianOperator. Before this change, Matrix[[A]].is_hermitian returned False, whereas Matrix[[A]] is hermitian because A is hermitian. 

This pull request fixes this issue by updating the function _eval_is_matrix_hermitian.  Instead of checking M[i, j] - M[j, i].conjugate(), we now check M[i, j] - Dagger(M[j, i]) to compare the elements of the matrix.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed Matrix.is_hermitian for matrices of quantum operators.
<!-- END RELEASE NOTES -->
