### PR TITLE
Fix for ruff rule `FURB152`

### DIFF
--- a/sympy/plotting/pygletplot/plot_rotation.py
+++ b/sympy/plotting/pygletplot/plot_rotation.py
@@ -4,7 +4,7 @@ except ImportError:
     pass
 
 import pyglet.gl as pgl
-from math import sqrt as _sqrt, acos as _acos
+from math import sqrt as _sqrt, acos as _acos, pi
 
 
 def cross(a, b):
@@ -43,7 +43,7 @@ def get_sphere_mapping(x, y, width, height):
         sz = 0
         return norm((sx, sy, sz))
 
-rad2deg = 180.0 / 3.141592
+rad2deg = 180.0 / pi
 
 
 def get_spherical_rotatation(p1, p2, width, height, theta_multiplier):

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import math
 from typing import Any
 
 from sympy.external import import_module
@@ -225,7 +226,7 @@ class AesaraPrinter(Printer):
                         for i in (expr.start, expr.stop, expr.step)])
 
     def _print_Pi(self, expr, **kwargs):
-        return 3.141592653589793
+        return math.pi
 
     def _print_Piecewise(self, expr, **kwargs):
         import numpy as np

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -7,6 +7,7 @@
 
 """
 from __future__ import annotations
+import math
 from typing import Any
 
 from sympy.external import import_module
@@ -229,7 +230,7 @@ class TheanoPrinter(Printer):
                         for i in (expr.start, expr.stop, expr.step)])
 
     def _print_Pi(self, expr, **kwargs):
-        return 3.141592653589793
+        return math.pi
 
     def _print_Exp1(self, expr, **kwargs):
         return ts.exp(1)


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed


#### Other comments
No modifications have been made to the test code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
