### PR TITLE
Fix for ruff rules `FURB154` and `FURB156`

### DIFF
--- a/.ci/parse_durations_log.py
+++ b/.ci/parse_durations_log.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 import os
+import string
 import json
 import time
 
@@ -18,7 +19,7 @@ def read_log():
             except ValueError:
                 return
             else:
-                if dur[0] not in '0123456789':
+                if dur[0] not in string.digits:
                     return
             if kind != 'call':
                 continue

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -14,6 +14,7 @@ and the Diffie-Hellman key exchange.
 
 from string import whitespace, ascii_uppercase as uppercase, printable
 from functools import reduce
+import string
 import warnings
 
 from itertools import cycle
@@ -84,7 +85,7 @@ def AZ(s=None):
     return rv
 
 bifid5 = AZ().replace('J', '')
-bifid6 = AZ() + '0123456789'
+bifid6 = AZ() + string.digits
 bifid10 = printable
 
 

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -10,8 +10,7 @@ from itertools import count
 
 def _pre():
     maxn = 10**5
-    global _factor
-    global _totient
+    global _factor, _totient
     _factor = [0]*maxn
     _totient = [1]*maxn
     lim = int(maxn**0.5) + 5

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -40,8 +40,7 @@ _use_unicode = False
 
 def pretty_use_unicode(flag=None):
     """Set whether pretty-printer should use unicode by default"""
-    global _use_unicode
-    global unicode_warnings
+    global _use_unicode, unicode_warnings
     if flag is None:
         return _use_unicode
 

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -188,8 +188,7 @@ def debug_decorator(func):
         return func
 
     def maketree(f, *args, **kw):
-        global _debug_tmp
-        global _debug_iter
+        global _debug_tmp, _debug_iter
         oldtmp = _debug_tmp
         _debug_tmp = []
         _debug_iter += 1

--- a/sympy/utilities/tests/test_enumerative.py
+++ b/sympy/utilities/tests/test_enumerative.py
@@ -1,3 +1,4 @@
+import string
 from itertools import zip_longest
 
 from sympy.utilities.enumerative import (
@@ -85,7 +86,7 @@ def compare_multiset_w_baseline(multiplicities):
     baseline implementation, and compare the results.
 
     """
-    letters = "abcdefghijklmnopqrstuvwxyz"
+    letters = string.ascii_lowercase
     bl_partitions = multiset_partitions_baseline(multiplicities, letters)
 
     # The partitions returned by the different algorithms may have


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed
The following fixes were made based on the ruff check.
- FURB154
- FURB156

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
