### PR TITLE
Fix for ruff rule `FURB110`

### DIFF
--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -479,7 +479,7 @@ class Collector(DefaultPrinting):
                 word = word*perm_to_free[g]
 
             word = self.collected_word(word)
-            pc_relators[relation] = word if word else ()
+            pc_relators[relation] = word or ()
             self.pc_presentation = pc_relators
 
             collected_gens.append(gen)
@@ -500,7 +500,7 @@ class Collector(DefaultPrinting):
                         word = word*perm_to_free[g]
 
                     word = self.collected_word(word)
-                    pc_relators[relation] = word if word else ()
+                    pc_relators[relation] = word or ()
                     self.pc_presentation = pc_relators
 
         return pc_relators

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -302,7 +302,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
         # Transform sequence (division by factorial)
         w, f = [], S.One
         for i, k in enumerate(v):
-            f *= i if i else 1
+            f *= i or 1
             w.append(k/f)
         # Perform some convolutions of the sequence with itself
         t = [1] + [0]*(len(w) - 1)
@@ -370,7 +370,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
         # Transform sequence / step 1 (division by factorial)
         z, f = [], S.One
         for i, k in enumerate(v):
-            f *= i if i else 1
+            f *= i or 1
             z.append(k/f)
         # Transform sequence / step 2 by computing f'(x)/f(x)
         # because log(f(x)) = integrate( f'(x)/f(x) )

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1786,7 +1786,7 @@ def intcurve_series(vector_field, param, start_point, n=6, coord_sys=None, coeff
         """Return the series for one of the coordinates."""
         return [param**i*iter_vfield(coord_function, i).rcall(start_point)/factorial(i)
                 for i in range(n)]
-    coord_sys = coord_sys if coord_sys else start_point._coord_sys
+    coord_sys = coord_sys or start_point._coord_sys
     coord_functions = coord_sys.coord_functions()
     taylor_terms = [taylor_terms_per_coord(f) for f in coord_functions]
     if coeffs:
@@ -1873,7 +1873,7 @@ def intcurve_diffequ(vector_field, param, start_point, coord_sys=None):
     """
     if contravariant_order(vector_field) != 1 or covariant_order(vector_field):
         raise ValueError('The supplied field was not a vector field.')
-    coord_sys = coord_sys if coord_sys else start_point._coord_sys
+    coord_sys = coord_sys or start_point._coord_sys
     gammas = [Function('f_%d' % i)(param) for i in range(
         start_point._coord_sys.dim)]
     arbitrary_p = Point(coord_sys, gammas)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1311,7 +1311,7 @@ class asinh(InverseHyperbolicFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts (-I*oo, -I) U (I, I*oo)
         if (1 + x0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if re(ndir).is_positive:
                 if im(x0).is_negative:
                     return -self.func(x0) - I*pi
@@ -1336,7 +1336,7 @@ class asinh(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-I*oo, -I) U (I, I*oo)
         if (1 + arg0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if re(ndir).is_positive:
                 if im(arg0).is_negative:
                     return -res - I*pi
@@ -1499,7 +1499,7 @@ class acosh(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-oo, 1)
         if (x0 - 1).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if (x0 + 1).is_negative:
                     return self.func(x0) - 2*I*pi
@@ -1522,7 +1522,7 @@ class acosh(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-oo, 1)
         if (arg0 - 1).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if (arg0 + 1).is_negative:
                     return res - 2*I*pi
@@ -1668,7 +1668,7 @@ class atanh(InverseHyperbolicFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts (-oo, -1] U [1, oo)
         if (1 - x0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if x0.is_negative:
                     return self.func(x0) - I*pi
@@ -1693,7 +1693,7 @@ class atanh(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-oo, -1] U [1, oo)
         if (1 - arg0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if arg0.is_negative:
                     return res - I*pi
@@ -1820,7 +1820,7 @@ class acoth(InverseHyperbolicFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts [-1, 1]
         if x0.is_real and (1 - x0**2).is_positive:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if x0.is_positive:
                     return self.func(x0) + I*pi
@@ -1845,7 +1845,7 @@ class acoth(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts [-1, 1]
         if arg0.is_real and (1 - arg0**2).is_positive:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if arg0.is_positive:
                     return res + I*pi
@@ -1991,7 +1991,7 @@ class asech(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-oo, 0] U (1, oo)
         if x0.is_negative or (1 - x0).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_positive:
                 if x0.is_positive or (x0 + 1).is_negative:
                     return -self.func(x0)
@@ -2036,7 +2036,7 @@ class asech(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-oo, 0] U (1, oo)
         if arg0.is_negative or (1 - arg0).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_positive:
                 if arg0.is_positive or (arg0 + 1).is_negative:
                     return -res
@@ -2192,7 +2192,7 @@ class acsch(InverseHyperbolicFunction):
             return (1/arg).as_leading_term(x)
         # Handling points lying on branch cuts (-I, I)
         if x0.is_imaginary and (1 + x0**2).is_positive:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if re(ndir).is_positive:
                 if im(x0).is_positive:
                     return -self.func(x0) - I*pi
@@ -2240,7 +2240,7 @@ class acsch(InverseHyperbolicFunction):
 
         # Handling points lying on branch cuts (-I, I)
         if arg0.is_imaginary and (1 + arg0**2).is_positive:
-            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            ndir = self.args[0].dir(x, cdir or 1)
             if re(ndir).is_positive:
                 if im(arg0).is_positive:
                     return -res - I*pi

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2254,7 +2254,7 @@ class asin(InverseTrigonometricFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir).expand()
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
         if (1 - x0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if x0.is_negative:
                     return -pi - self.func(x0)
@@ -2298,7 +2298,7 @@ class asin(InverseTrigonometricFunction):
             return res
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
         if (1 - arg0**2).is_negative:
-            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            ndir = self.args[0].dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if arg0.is_negative:
                     return -pi - res
@@ -2483,7 +2483,7 @@ class acos(InverseTrigonometricFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
         if (1 - x0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if x0.is_negative:
                     return 2*pi - self.func(x0)
@@ -2534,7 +2534,7 @@ class acos(InverseTrigonometricFunction):
             return res
         # Handling points lying on branch cuts (-oo, -1) U (1, oo)
         if (1 - arg0**2).is_negative:
-            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            ndir = self.args[0].dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if arg0.is_negative:
                     return 2*pi - res
@@ -2724,7 +2724,7 @@ class atan(InverseTrigonometricFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir).expand()
         # Handling points lying on branch cuts (-I*oo, -I) U (I, I*oo)
         if (1 + x0**2).is_negative:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if re(ndir).is_negative:
                 if im(x0).is_positive:
                     return self.func(x0) - pi
@@ -2743,7 +2743,7 @@ class atan(InverseTrigonometricFunction):
             return self.rewrite(log)._eval_nseries(x, n, logx=logx, cdir=cdir)
 
         res = super()._eval_nseries(x, n=n, logx=logx)
-        ndir = self.args[0].dir(x, cdir if cdir else 1)
+        ndir = self.args[0].dir(x, cdir or 1)
         if arg0 is S.ComplexInfinity:
             if re(ndir) > 0:
                 return res - pi
@@ -2939,7 +2939,7 @@ class acot(InverseTrigonometricFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir).expand()
         # Handling points lying on branch cuts [-I, I]
         if x0.is_imaginary and (1 + x0**2).is_positive:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if re(ndir).is_positive:
                 if im(x0).is_positive:
                     return self.func(x0) + pi
@@ -2960,7 +2960,7 @@ class acot(InverseTrigonometricFunction):
         res = super()._eval_nseries(x, n=n, logx=logx)
         if arg0 is S.ComplexInfinity:
             return res
-        ndir = self.args[0].dir(x, cdir if cdir else 1)
+        ndir = self.args[0].dir(x, cdir or 1)
         if arg0.is_zero:
             if re(ndir) < 0:
                 return res - pi
@@ -3163,7 +3163,7 @@ class asec(InverseTrigonometricFunction):
             return self.rewrite(log)._eval_as_leading_term(x, logx=logx, cdir=cdir)
         # Handling points lying on branch cuts (-1, 1)
         if x0.is_real and (1 - x0**2).is_positive:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if x0.is_positive:
                     return -self.func(x0)
@@ -3203,7 +3203,7 @@ class asec(InverseTrigonometricFunction):
             return res
         # Handling points lying on branch cuts (-1, 1)
         if arg0.is_real and (1 - arg0**2).is_positive:
-            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            ndir = self.args[0].dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if arg0.is_positive:
                     return -res
@@ -3373,7 +3373,7 @@ class acsc(InverseTrigonometricFunction):
             return (1/arg).as_leading_term(x)
         # Handling points lying on branch cuts (-1, 1)
         if x0.is_real and (1 - x0**2).is_positive:
-            ndir = arg.dir(x, cdir if cdir else 1)
+            ndir = arg.dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if x0.is_positive:
                     return pi - self.func(x0)
@@ -3413,7 +3413,7 @@ class acsc(InverseTrigonometricFunction):
             return res
         # Handling points lying on branch cuts (-1, 1)
         if arg0.is_real and (1 - arg0**2).is_positive:
-            ndir = self.args[0].dir(x, cdir if cdir else 1)
+            ndir = self.args[0].dir(x, cdir or 1)
             if im(ndir).is_negative:
                 if arg0.is_positive:
                     return pi - res

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -348,7 +348,7 @@ class Plane(GeometryEntity):
         6*x + 6*y + 6*z - 42
 
         """
-        x, y, z = [i if i else Symbol(j, real=True) for i, j in zip((x, y, z), 'xyz')]
+        x, y, z = [i or Symbol(j, real=True) for i, j in zip((x, y, z), 'xyz')]
         a = Point3D(x, y, z)
         b = self.p1.direction_ratio(a)
         c = self.normal_vector

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -210,7 +210,7 @@ class Beam:
         self._joined_beam = False
 
     def __str__(self):
-        shape_description = self._cross_section if self._cross_section else self._second_moment
+        shape_description = self._cross_section or self._second_moment
         str_sol = 'Beam({}, {}, {})'.format(sstr(self._length), sstr(self._elastic_modulus), sstr(shape_description))
         return str_sol
 

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -140,7 +140,7 @@ class LagrangesMethod(_Methods):
         self._f_d = Matrix()            # Forcing part of the dynamic equations
         self.lam_coeffs = Matrix()      # The coeffecients of the multipliers
 
-        forcelist = forcelist if forcelist else []
+        forcelist = forcelist or []
         if not iterable(forcelist):
             raise TypeError('Force pairs must be supplied in an iterable.')
         self._forcelist = forcelist

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -865,7 +865,7 @@ class System(_Methods):
         # KanesMethod does not accept empty iterables
         loads = self.loads + tuple(
             load for act in self.actuators for load in act.to_loads())
-        loads = loads if loads else None
+        loads = loads or None
         if issubclass(eom_method, KanesMethod):
             disallowed_kwargs = {
                 "frame", "q_ind", "u_ind", "kd_eqs", "q_dependent",

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2734,7 +2734,7 @@ class PrettyPrinter(Printer):
 
     def _print_DiagramGrid(self, grid):
         from sympy.matrices import Matrix
-        matrix = Matrix([[grid[i, j] if grid[i, j] else Symbol(" ")
+        matrix = Matrix([[grid[i, j] or Symbol(" ")
                           for j in range(grid.width)]
                          for i in range(grid.height)])
         return self._print_matrix_contents(matrix)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1090,7 +1090,7 @@ def _solve_as_poly(f, symbol, domain=S.Complexes):
 def _solve_radical(f, unradf, symbol, solveset_solver):
     """ Helper function to solve equations with radicals """
     res = unradf
-    eq, cov = res if res else (f, [])
+    eq, cov = res or (f, [])
     if not cov:
         result = solveset_solver(eq, symbol) - \
             Union(*[solveset_solver(g, symbol) for g in denoms(f, symbol)])
@@ -3595,7 +3595,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                                 # soln is in domain=S.Reals
                                 intersections[sym] = soln.args[0]
                             soln_new += soln.args[1]
-                        soln = soln_new if soln_new else soln
+                        soln = soln_new or soln
                         if index > 0 and solver == solveset_real:
                             # one symbol's real soln, another symbol may have
                             # corresponding complex soln.

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -650,7 +650,7 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
     # two cases 1) helpers is an iterable of 3-tuples and 2) helpers is a
     # 3-tuple
     if iterable(helpers) and len(helpers) != 0 and iterable(helpers[0]):
-        helpers = helpers if helpers else ()
+        helpers = helpers or ()
     else:
         helpers = [helpers] if helpers else ()
     args = list(args) if iterable(args, exclude=set) else args
@@ -663,7 +663,7 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
         'CYTHON': CythonCodeWrapper,
         'DUMMY': DummyWrapper
     }[backend.upper()]
-    code_wrapper = CodeWrapperClass(code_gen, tempdir, flags if flags else (),
+    code_wrapper = CodeWrapperClass(code_gen, tempdir, flags or (),
                                     verbose, **kwargs)
 
     helps = []
@@ -1137,8 +1137,8 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     else:
         language = _infer_language(backend)
 
-    helpers = helpers if helpers else ()
-    flags = flags if flags else ()
+    helpers = helpers or ()
+    flags = flags or ()
 
     if backend.upper() == 'NUMPY':
         # maxargs is set by numpy compile-time constant NPY_MAXARGS


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
