### PR TITLE
Fix for ruff rule `FURB129`

### DIFF
--- a/bin/mailmap_check.py
+++ b/bin/mailmap_check.py
@@ -310,7 +310,7 @@ def sort_lines_mailmap(lines):
 
 def read_lines(path):
     with open(path, 'r', encoding='utf-8') as fin:
-        return [line.strip() for line in fin.readlines()]
+        return [line.strip() for line in fin]
 
 
 def write_lines(path, lines):

--- a/sympy/parsing/autolev/_build_autolev_antlr.py
+++ b/sympy/parsing/autolev/_build_autolev_antlr.py
@@ -66,7 +66,7 @@ def build_parser(output_dir=dir_autolev_antlr):
         new_path = os.path.join(output_dir, os.path.basename(path).lower())
         with open(path, 'r') as f:
             lines = [line.rstrip().replace('AutolevParser import', 'autolevparser import') +'\n'
-                     for line in f.readlines()]
+                     for line in f]
 
         os.unlink(path)
 

--- a/sympy/parsing/latex/_build_latex_antlr.py
+++ b/sympy/parsing/latex/_build_latex_antlr.py
@@ -71,7 +71,7 @@ def build_parser(output_dir=dir_latex_antlr):
 
         new_path = os.path.join(output_dir, os.path.basename(path).lower())
         with open(path, 'r') as f:
-            lines = [line.rstrip() + '\n' for line in f.readlines()]
+            lines = [line.rstrip() + '\n' for line in f]
 
         os.unlink(path)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
