### PR TITLE
Fix for ruff rules `FURB142` and `FURB148`

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2125,11 +2125,8 @@ class Basic(Printable):
         # functions for matching expression node names.
 
         clsname = obj.__class__.__name__
-        postprocessors = set()
-        for i in obj.args:
-            for f in _get_postprocessors(clsname, type(i)):
-                postprocessors.add(f)
-
+        postprocessors = {f for i in obj.args
+                            for f in _get_postprocessors(clsname, type(i))}
         for f in postprocessors:
             obj = f(obj)
 

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1363,7 +1363,7 @@ def _mask_nc(eq, name=None):
     nc_obj = set()
     nc_syms = set()
     pot = preorder_traversal(expr, keys=default_sort_key)
-    for i, a in enumerate(pot):
+    for a in pot:
         if any(a == r[0] for r in rep):
             pot.skip()
         elif not a.is_commutative:

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -94,7 +94,7 @@ class Dyadic(Printable, EvalfMixin):
         """
         newlist = list(self.args)
         other = sympify(other)
-        for i, v in enumerate(newlist):
+        for i in range(len(newlist)):
             newlist[i] = (other * newlist[i][0], newlist[i][1],
                           newlist[i][2])
         return Dyadic(newlist)
@@ -171,7 +171,7 @@ class Dyadic(Printable, EvalfMixin):
         if len(ar) == 0:
             return str(0)
         ol = []  # output list, to be concatenated to a string
-        for i, v in enumerate(ar):
+        for v in ar:
             # if the coef of the dyadic is 1, we skip the 1
             if v[0] == 1:
                 ol.append(' + ' + printer._print(v[1]) + r"\otimes " +
@@ -215,7 +215,7 @@ class Dyadic(Printable, EvalfMixin):
                     return str(0)
                 bar = "\N{CIRCLED TIMES}" if printer._use_unicode else "|"
                 ol = []  # output list, to be concatenated to a string
-                for i, v in enumerate(ar):
+                for v in ar:
                     # if the coef of the dyadic is 1, we skip the 1
                     if v[0] == 1:
                         ol.extend([" + ",
@@ -265,7 +265,7 @@ class Dyadic(Printable, EvalfMixin):
         if len(ar) == 0:
             return printer._print(0)
         ol = []  # output list, to be concatenated to a string
-        for i, v in enumerate(ar):
+        for v in ar:
             # if the coef of the dyadic is 1, we skip the 1
             if v[0] == 1:
                 ol.append(' + (' + printer._print(v[1]) + '|' +

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -174,7 +174,7 @@ class Vector(Printable, EvalfMixin):
 
         newlist = list(self.args)
         other = sympify(other)
-        for i, v in enumerate(newlist):
+        for i in range(len(newlist)):
             newlist[i] = (other * newlist[i][0], newlist[i][1])
         return Vector(newlist)
 
@@ -228,7 +228,7 @@ class Vector(Printable, EvalfMixin):
         if len(ar) == 0:
             return str(0)
         ol = []  # output list, to be concatenated to a string
-        for i, v in enumerate(ar):
+        for v in ar:
             for j in 0, 1, 2:
                 # if the coef of the basis vector is 1, we skip the 1
                 if v[0][j] == 1:
@@ -302,7 +302,7 @@ class Vector(Printable, EvalfMixin):
             for key in keys:
                 ar.append((d[key], key))
         ol = []  # output list, to be concatenated to a string
-        for i, v in enumerate(ar):
+        for v in ar:
             for j in 0, 1, 2:
                 # if the coef of the basis vector is 1, we skip the 1
                 if v[0][j] == 1:
@@ -388,7 +388,7 @@ class Vector(Printable, EvalfMixin):
 
         outlist = []
         ar = other.args  # For brevity
-        for i, v in enumerate(ar):
+        for v in ar:
             tempx = v[1].x
             tempy = v[1].y
             tempz = v[1].z

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -545,7 +545,7 @@ class PermuteDims(_CodegenArrayAbstract):
         permutation_array_blocks_up = []
         image_form = _af_invert(permutation.array_form)
         counter = 0
-        for i, e in enumerate(subranks):
+        for i in range(len(subranks)):
             current = []
             for j in range(cumul[i], cumul[i+1]):
                 if j in contraction_indices_flat:

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -131,7 +131,7 @@ def convert_to_native_paths(lst):
     if the system is case insensitive.
     """
     newlst = []
-    for i, rv in enumerate(lst):
+    for rv in lst:
         rv = os.path.join(*rv.split("/"))
         # on windows the slash after the colon is dropped
         if sys.platform == "win32":


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed
The following Ruff rules have been fixed.
- [FURB142](https://docs.astral.sh/ruff/rules/for-loop-set-mutations/) for-loop-set-mutations
- [FURB148](https://docs.astral.sh/ruff/rules/unnecessary-enumerate/) unnecessary-enumerate

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
