### PR TITLE
Fix for ruff rule `FURB167`

### DIFF
--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -196,7 +196,7 @@ class NumpyDocString(Mapping):
         return params
 
     _name_rgx = re.compile(r"^\s*(:(?P<role>\w+):`(?P<name>[a-zA-Z0-9_.-]+)`|"
-                           r" (?P<name2>[a-zA-Z0-9_.-]+))\s*", re.X)
+                           r" (?P<name2>[a-zA-Z0-9_.-]+))\s*", re.VERBOSE)
 
     def _parse_see_also(self, content):
         """

--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -199,7 +199,7 @@ class SphinxDocString(NumpyDocString):
                 out += ['.. latexonly::', '']
             items = []
             for line in self['References']:
-                m = re.match(r'.. \[([a-z0-9._-]+)\]', line, re.I)
+                m = re.match(r'.. \[([a-z0-9._-]+)\]', line, re.IGNORECASE)
                 if m:
                     items.append(m.group(1))
             out += ['   ' + ", ".join(["[%s]_" % item for item in items]), '']

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -42,7 +42,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     if what == 'module':
         # Strip top title
         pattern = '^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'
-        title_re = re.compile(pattern, re.I | re.S)
+        title_re = re.compile(pattern, re.IGNORECASE | re.DOTALL)
         lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
         doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
@@ -63,7 +63,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     references = []
     for line in lines:
         line = line.strip()
-        m = re.match('^.. \\[([a-z0-9_.-])\\]', line, re.I)
+        m = re.match('^.. \\[([a-z0-9_.-])\\]', line, re.IGNORECASE)
         if m:
             references.append(m.group(1))
 

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterable
 from sympy.core.function import Derivative
 
-_name_with_digits_p = re.compile(r'^([^\W\d_]+)(\d+)$', re.U)
+_name_with_digits_p = re.compile(r'^([^\W\d_]+)(\d+)$', re.UNICODE)
 
 
 def split_super_sub(text):

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -19,9 +19,9 @@ x, y, z = symbols('x,y,z')
 
 
 class _W(Enum):
-    DEFAULTING_TO_FLOAT = re.compile("Could not infer type of `.+`. Defaulting to float.", re.I)
-    WILL_NOT_DECLARE = re.compile("Non-Symbol/Function `.+` will not be declared.", re.I)
-    WILL_NOT_ASSERT = re.compile("Non-Boolean expression `.+` will not be asserted. Converting to SMTLib verbatim.", re.I)
+    DEFAULTING_TO_FLOAT = re.compile("Could not infer type of `.+`. Defaulting to float.", re.IGNORECASE)
+    WILL_NOT_DECLARE = re.compile("Non-Symbol/Function `.+` will not be declared.", re.IGNORECASE)
+    WILL_NOT_ASSERT = re.compile("Non-Boolean expression `.+` will not be asserted. Converting to SMTLib verbatim.", re.IGNORECASE)
 
 
 @contextlib.contextmanager

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -261,7 +261,7 @@ def warns(warningcls, *, match='', test_stacklevel=True):
     for w in warnrec:
         # Should always be true due to the filters above
         assert issubclass(w.category, warningcls)
-        if not re.compile(match, re.I).match(str(w.message)):
+        if not re.compile(match, re.IGNORECASE).match(str(w.message)):
             raise Failed(f"Failed: WRONG MESSAGE. A warning with of the correct category ({warningcls.__name__}) was issued, but it did not match the given match regex ({match!r})")
 
     if test_stacklevel:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -359,7 +359,7 @@ def _replace(reps):
         return lambda x: x
     D = lambda match: reps[match.group(0)]
     pattern = _re.compile("|".join(
-        [_re.escape(k) for k, v in reps.items()]), _re.M)
+        [_re.escape(k) for k, v in reps.items()]), _re.MULTILINE)
     return lambda string: pattern.sub(D, string)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
