### PR TITLE
[DRAFT] Add missing sphinx hyperlinks for functions and classes in the intro tutorial pages

### DIFF
--- a/doc/src/tutorials/intro-tutorial/gotchas.rst
+++ b/doc/src/tutorials/intro-tutorial/gotchas.rst
@@ -36,17 +36,17 @@ Oops! What happened here?  We tried to use the variable ``x``, but it tells us
 that ``x`` is not defined.  In Python, variables have no meaning until they
 are defined.  SymPy is no different.  Unlike many symbolic manipulation
 systems you may have used, in SymPy, variables are not defined automatically.
-To define variables, we must use ``symbols``.
+To define variables, we must use :func:`~sympy.core.symbol.symbols`.
 
     >>> x = symbols('x')
     >>> x + 1
     x + 1
 
-``symbols`` takes a string of variable names separated by spaces or commas,
-and creates Symbols out of them.  We can then assign these to variable names.
-Later, we will investigate some convenient ways we can work around this issue.
-For now, let us just define the most common variable names, ``x``, ``y``, and
-``z``, for use through the rest of this section
+:func:`~sympy.core.symbol.symbols` takes a string of variable names separated
+by spaces or commas, and creates Symbols out of them.  We can then assign these
+to variable names. Later, we will investigate some convenient ways we can work
+around this issue. For now, let us just define the most common variable names,
+``x``, ``y``, and ``z``, for use through the rest of this section
 
     >>> x, y, z = symbols('x y z')
 
@@ -118,7 +118,8 @@ do not change automatically.  For example
 
 .. sidebar:: Quick Tip
 
-   To change the value of a Symbol in an expression, use ``subs``
+   To change the value of a Symbol in an expression, use
+   :func:`~sympy.core.basic.Basic.subs`
 
      >>> x = symbols('x')
      >>> expr = x + 1
@@ -130,7 +131,8 @@ In this example, if we want to know what ``expr`` is with the new value of
 x + 1``.  This can be complicated if several lines created ``expr``.  One
 advantage of using a symbolic computation system like SymPy is that we can
 build a symbolic representation for ``expr``, and then substitute ``x`` with
-values.  The correct way to do this in SymPy is to use ``subs``, which will be
+values.  The correct way to do this in SymPy is to use
+:func:`~sympy.core.basic.Basic.subs`, which will be
 discussed in more detail later.
 
     >>> x = symbols('x')
@@ -160,8 +162,9 @@ us see what happens when we use ``==``.
 Instead of treating ``x + 1 == 4`` symbolically, we just got ``False``.  In
 SymPy, ``==`` represents exact structural equality testing.  This means that
 ``a == b`` means that we are *asking* if `a = b`.  We always get a ``bool`` as
-the result of ``==``.  There is a separate object, called ``Eq``, which can be
-used to create symbolic equalities
+the result of ``==``.  There is a separate object, called
+:func:`~sympy.core.relational.Eq`, which can be used to create symbolic
+equalities
 
     >>> Eq(x + 1, 4)
     Eq(x + 1, 4)
@@ -186,15 +189,16 @@ It turns out that when using SymPy as a library, having ``==`` test for exact
 structural equality is far more useful than having it represent symbolic
 equality, or having it test for mathematical equality.  However, as a new
 user, you will probably care more about the latter two.  We have already seen
-an alternative to representing equalities symbolically, ``Eq``.  To test if
-two things are equal, it is best to recall the basic fact that if `a = b`,
-then `a - b = 0`.  Thus, the best way to check if `a = b` is to take `a - b`
-and simplify it, and see if it goes to 0.  We will learn :ref:`later
-<tutorial-simplify>` that the function to do this is called ``simplify``. This
-method is not infallible---in fact, it can be `theoretically proven
-<https://en.wikipedia.org/wiki/Richardson%27s_theorem>`_ that it is impossible
-to determine if two symbolic expressions are identically equal in
-general---but for most common expressions, it works quite well.
+an alternative to representing equalities symbolically,
+:func:`~sympy.core.relational.Eq`.  To test if two things are equal, it is best
+to recall the basic fact that if `a = b`, then `a - b = 0`.  Thus, the best way
+to check if `a = b` is to take `a - b` and simplify it, and see if it goes to 0
+.  We will learn :ref:`later <tutorial-simplify>` that the function to do this 
+is called :func:`~sympy.simplify.simplify.simplify`. This method is not 
+infallible---in fact, it can be 
+`theoretically proven <https://en.wikipedia.org/wiki/Richardson%27s_theorem>`_ 
+that it is impossible to determine if two symbolic expressions are identically 
+equal in general---but for most common expressions, it works quite well.
 
     >>> a = (x + 1)**2
     >>> b = x**2 + 2*x + 1
@@ -204,8 +208,8 @@ general---but for most common expressions, it works quite well.
     >>> simplify(a - c)
     4*x
 
-There is also a method called ``equals`` that tests if two expressions are
-equal by evaluating them numerically at random points.
+There is also a method called :func:`~sympy.core.expr.Expr.equals` that tests
+if two expressions are equal by evaluating them numerically at random points.
 
     >>> a = cos(x)**2 - sin(x)**2
     >>> b = cos(2*x)

--- a/doc/src/tutorials/intro-tutorial/intro.rst
+++ b/doc/src/tutorials/intro-tutorial/intro.rst
@@ -55,10 +55,10 @@ computation systems (which by the way, are also often called computer algebra
 systems, or just CASs) such as SymPy are capable of computing symbolic
 expressions with variables.
 
-As we will see later, in SymPy, variables are defined using ``symbols``.
-Unlike many symbolic manipulation systems, variables in SymPy must be defined
-before they are used (the reason for this will be discussed in the :ref:`next
-section <tutorial-gotchas-symbols>`).
+As we will see later, in SymPy, variables are defined using
+:func:`~sympy.core.symbol.symbols`. Unlike many symbolic manipulation systems, 
+variables in SymPy must be defined before they are used (the reason for this 
+will be discussed in the :ref:`next section <tutorial-gotchas-symbols>`).
 
 Let us define a symbolic expression, representing the mathematical expression
 `x + 2y`.

--- a/doc/src/tutorials/intro-tutorial/manipulation.rst
+++ b/doc/src/tutorials/intro-tutorial/manipulation.rst
@@ -15,7 +15,7 @@ Understanding Expression Trees
 Before we can do this, we need to understand how expressions are represented
 in SymPy.  A mathematical expression is represented as a tree.  Let us take
 the expression `x^2 + xy`, i.e., ``x**2 + x*y``.  We can see what this
-expression looks like internally by using ``srepr``
+expression looks like internally by using :func:`~sympy.printing.repr.srepr`
 
     >>> from sympy import *
     >>> x, y, z = symbols('x y z')
@@ -76,11 +76,11 @@ we could have also done
     >>> x = Symbol('x')
 
 Either way, we get a Symbol with the name "x" [#symbols-fn]_.  For the number in the
-expression, 2, we got ``Integer(2)``.  ``Integer`` is the SymPy class for
+expression, 2, we got ``Integer(2)``. :class:`~sympy.core.numbers.Integer` is the SymPy class for
 integers.  It is similar to the Python built-in type ``int``, except that
-``Integer`` plays nicely with other SymPy types.
+:class:`~sympy.core.numbers.Integer` plays nicely with other SymPy types.
 
-When we write ``x**2``, this creates a ``Pow`` object.  ``Pow`` is short for
+When we write ``x**2``, this creates a :class:`sympy.core.power.Pow` object.  :class:`sympy.core.power.Pow` is short for
 "power".
 
     >>> srepr(x**2)
@@ -91,11 +91,11 @@ We could have created the same object by calling ``Pow(x, 2)``
     >>> Pow(x, 2)
     x**2
 
-Note that in the ``srepr`` output, we see ``Integer(2)``, the SymPy version of
+Note that in the `~sympy.printing.repr.srepr` output, we see ``Integer(2)``, the SymPy version of
 integers, even though technically, we input ``2``, a Python int.  In general,
 whenever you combine a SymPy object with a non-SymPy object via some function
 or operation, the non-SymPy object will be converted into a SymPy object.  The
-function that does this is ``sympify`` [#sympify-fn]_.
+function that does this is :func:`sympy.core.sympify.sympify` [#sympify-fn]_.
 
     >>> type(2)
     <... 'int'>
@@ -104,7 +104,7 @@ function that does this is ``sympify`` [#sympify-fn]_.
 
 We have seen that ``x**2`` is represented as ``Pow(x, 2)``.  What about
 ``x*y``?  As we might expect, this is the multiplication of ``x`` and ``y``.
-The SymPy class for multiplication is ``Mul``.
+The SymPy class for multiplication is :class:`~sympy.core.mul.Mul`.
 
     >>> srepr(x*y)
     "Mul(Symbol('x'), Symbol('y'))"
@@ -270,7 +270,7 @@ numbers are always combined into a single term in a multiplication, so that
 when we divide by 2, it is represented as multiplying by 1/2.
 
 Finally, one last note.  You may have noticed that the order we entered our
-expression and the order that it came out from ``srepr`` or in the graph were
+expression and the order that it came out from `~sympy.printing.repr.srepr` or in the graph were
 different.  You may have also noticed this phenomenon earlier in the
 tutorial.  For example
 
@@ -278,7 +278,7 @@ tutorial.  For example
      x + 1
 
 This because in SymPy, the arguments of the commutative operations ``Add`` and
-``Mul`` are stored in an arbitrary (but consistent!) order, which is
+:class:`~sympy.core.mul.Mul` are stored in an arbitrary (but consistent!) order, which is
 independent of the order inputted (if you're worried about noncommutative
 multiplication, don't be.  In SymPy, you can create noncommutative Symbols
 using ``Symbol('A', commutative=False)``, and the order of multiplication for
@@ -309,7 +309,7 @@ important attributes, ``func``, and ``args``.
 func
 ----
 
-``func`` is the head of the object. For example, ``(x*y).func`` is ``Mul``.
+``func`` is the head of the object. For example, ``(x*y).func`` is :class:`~sympy.core.mul.Mul`.
 Usually it is the same as the class of the object (though there are exceptions
 to this rule).
 
@@ -321,13 +321,13 @@ as the one used to create it.  For example
     <class 'sympy.core.mul.Mul'>
 
 We created ``Add(x, x)``, so we might expect ``expr.func`` to be ``Add``, but
-instead we got ``Mul``.  Why is that?  Let's take a closer look at ``expr``.
+instead we got :class:`~sympy.core.mul.Mul`.  Why is that?  Let's take a closer look at ``expr``.
 
     >>> expr
     2*x
 
 ``Add(x, x)``, i.e., ``x + x``, was automatically converted into ``Mul(2,
-x)``, i.e., ``2*x``, which is a ``Mul``.   SymPy classes make heavy use of the
+x)``, i.e., ``2*x``, which is a :class:`~sympy.core.mul.Mul`.   SymPy classes make heavy use of the
 ``__new__`` class constructor, which, unlike ``__init__``, allows a different
 class to be returned from the constructor.
 
@@ -342,7 +342,7 @@ Second, some classes are special-cased, usually for efficiency reasons
     <class 'sympy.core.numbers.NegativeOne'>
 
 For the most part, these issues will not bother us.  The special classes
-``Zero``, ``One``, ``NegativeOne``, and so on are subclasses of ``Integer``,
+``Zero``, ``One``, ``NegativeOne``, and so on are subclasses of :class:`~sympy.core.numbers.Integer`,
 so as long as you use ``isinstance``, it will not be an issue.
 
 args
@@ -367,7 +367,7 @@ that we can completely reconstruct ``expr`` from its ``func`` and its
     True
 
 Note that although we entered ``3*y**2*x``, the ``args`` are ``(3, x, y**2)``.
-In a ``Mul``, the Rational coefficient will come first in the ``args``, but
+In a :class:`~sympy.core.mul.Mul`, the Rational coefficient will come first in the ``args``, but
 other than that, the order of everything else follows no special pattern.  To
 be sure, though, there is an order.
 
@@ -375,11 +375,11 @@ be sure, though, there is an order.
     >>> expr.args
     (3, x, y**2)
 
-Mul's ``args`` are sorted, so that the same ``Mul`` will have the same
+Mul's ``args`` are sorted, so that the same :class:`~sympy.core.mul.Mul` will have the same
 ``args``.  But the sorting is based on some criteria designed to make the
 sorting unique and efficient that has no mathematical significance.
 
-The ``srepr`` form of our ``expr`` is ``Mul(3, x, Pow(y, 2))``.  What if we
+The `~sympy.printing.repr.srepr` form of our ``expr`` is ``Mul(3, x, Pow(y, 2))``.  What if we
 want to get at the ``args`` of ``Pow(y, 2)``.  Notice that the ``y**2`` is in
 the third slot of ``expr.args``, i.e., ``expr.args[2]``.
 
@@ -484,7 +484,7 @@ For example:
 
 If you don't remember the class corresponding to the expression you
 want to build (operator overloading usually assumes ``evaluate=True``),
-just use ``sympify`` and pass a string:
+just use :func:`sympy.core.sympify.sympify` and pass a string:
 
     >>> from sympy import sympify
     >>> sympify("x + x", evaluate=False)
@@ -567,7 +567,7 @@ just use ``.doit()``:
   ``symbols('x y z')`` returns a tuple of three ``Symbol``\ s.  ``Symbol('x y
   z')`` returns a single ``Symbol`` called ``x y z``.
 .. [#sympify-fn] Technically, it is an internal function called ``_sympify``,
-  which differs from ``sympify`` in that it does not convert strings.  ``x +
+  which differs from :func:`sympy.core.sympify.sympify` in that it does not convert strings.  ``x +
   '2'`` is not allowed.
 .. [#singleton-fn] Classes like ``One`` and ``Zero`` are singletonized, meaning
   that only one object is ever created, no matter how many times the class is


### PR DESCRIPTION
### THIS IS A DRAFT WILL BE PUSHING CHANGES SOON

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
