### PR TITLE
[DRAFT] Deprecate and replace internal usage of gcd in Rational

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -75,6 +75,27 @@ SymPy deprecation warnings.
 ```
 
 ## Version 1.14
+(rational-gcd-deprecation)=
+### `gcd` argument in `Rational()`
+
+The `gcd` keyword argument in `sympy.core.numbers.Rational` is deprecated.
+
+This internal-only argument was previously used to bypass simplification of
+the numerator and denominator. However, it introduced inconsistencies in
+behavior especially for equality comparisons and was never intended for
+public use.
+
+Instead, users should construct unreduced Rationals via: Rational(2)/Rational(4)
+or use string parsing example sympify("2/4")
+This change is necessary for future improvements such as switching to
+gmpy2.mpq or flint.fmpq, which don’t support unevaluated rationals.
+
+There is no public replacement for constructing unreduced `Rational` objects.
+
+If you are working on SymPy internals and need to avoid redundant GCD
+calculations, use the new private constructor instead.
+
+Users should **not attempt to bypass simplification** in normal usage.
 
 (deprecated-tensorproduct-simp)=
 ### Deprecated tensor_product_simp from physics.quantum

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -8,7 +8,7 @@ from sympy.core.expr import unchanged
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import (mpf_norm, seterr,
-    Integer, I, pi, comp, Rational, E, nan,
+    Integer, I, pi, comp, Rational, E, nan, _Rational,
     oo, AlgebraicNumber, Number, Float, zoo, equal_valued,
     int_valued, all_close)
 from sympy.core.intfunc import (igcd, igcdex, igcd2, igcd_lehmer,
@@ -33,6 +33,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.iterables import permutations
 from sympy.testing.pytest import XFAIL, raises, _both_exp_pow
 from sympy import Add
+from sympy.testing.pytest import warns_deprecated_sympy
 
 from mpmath import mpf
 import mpmath
@@ -363,8 +364,8 @@ def test_Rational_new():
 
     assert Rational(PythonRational(2, 6)) == Rational(1, 3)
 
-    assert Rational(2, 4, gcd=1).q == 4
-    n = Rational(2, -4, gcd=1)
+    assert _Rational(2, 4, gcd=1).q == 4
+    n = _Rational(2, -4, _gcd=1)
     assert n.q == 4
     assert n.p == -2
 
@@ -2327,3 +2328,14 @@ def test_all_close():
     assert not all_close(x + exp(2.*x)*y, 1.*x + 2*exp(2*x)*y)
     assert not all_close(x + exp(2.*x)*y, 1.*x + exp(3*x)*y)
     assert not all_close(x + 2.*y, 1.*x + 3*y)
+
+
+def test_rational_gcd_deprecation():
+    #https://github.com/sympy/sympy/issues/27814
+    with warns_deprecated_sympy():
+        r = Rational(2, 4, gcd=1)
+        assert r.p == 2 and r.q == 4
+
+# TODO: Once `gcd` is removed from Rational constructor, this test should pass and can be uncommented.
+# def test_rational_equality_post_deprecation():
+#     assert Rational(2, 2) == Rational(2, 2, gcd=1)  # Will fail until `gcd` is removed


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27814

#### Brief description of what is fixed or changed

- Added a sympy_deprecation_warning() for gcd usage with proper messaging.
- Added a private constructor _Rational(p, q, _gcd) for internal usage.
- Replaced all internal calls to Rational(p, q, gcd) with _Rational() to avoid triggering deprecation warnings.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core.numbers
  * BREAKING CHANGE: The `gcd` argument to `Rational()` is deprecated. It was used to prevent automatic reduction of numerator and denominator, but caused inconsistent behavior (e.g., in equality comparisons). See :ref:`rational-gcd-deprecation` for details.
  * Internal uses of `Rational(p, q, gcd)` have been replaced with _Rational(p, q, _gcd)`.
<!-- END RELEASE NOTES -->