### PR TITLE
perf: improve performance of ask queries on relational predicates

### DIFF
--- a/blah.py
+++ b/blah.py
@@ -1,0 +1,7 @@
+from sympy.abc import x, y
+from sympy import ask, Q
+from timeit import timeit
+ 
+print(timeit(lambda : ask(Q.eq(x, 1) | Q.eq(y, -1), Q.integer(x) & Q.integer(y)), number=1))
+print(timeit(lambda : ask(Q.eq(x, 1), Q.integer(x) & Q.integer(y)), number=1))
+print(timeit(lambda : ask(Q.eq(x, 1) | Q.eq(y, -1)), number=1))

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -153,7 +153,7 @@ def _preprocess(enc_cnf):
                     new_clause.append(new_enc)
                     continue
                 else:
-                    new_props = (Q.gt(arg1, arg2), Q.lt(arg1, arg2))
+                    new_props = (Q.positive(arg1 - arg2), Q.lt(arg1, arg2))
                     for new_prop in new_props:
                         if new_prop not in new_encoding:
                             new_encoding[new_prop] = cur_enc


### PR DESCRIPTION
Fixes #27826

#### Brief description of what is fixed or changed

Modified a function within lra_satask to include the use Q.positive(x - y), replacing Q.gt(x,y). This approach slightly improves function speed.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
 * Improved speed of an assumption query by replacing Q.gt with Q.positive.
<!-- END RELEASE NOTES -->
