### PR TITLE
fix error when parsing latex without evaluate

### DIFF
--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -20,6 +20,7 @@ from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
+from sympy.core.parameters import evaluate
 from sympy.physics.quantum.state import Bra, Ket
 from sympy.abc import x, y, z, a, b, c, t, k, n
 antlr4 = import_module("antlr4")
@@ -356,3 +357,8 @@ def test_strict_mode():
     for latex_str in FAILING_BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str, strict=True)
+
+def test_parse_without_evaluate():
+    from sympy.parsing.latex import parse_latex
+    with evaluate(False):
+        assert parse_latex(r"a = 42 + 1") == Eq(a, Add(42, 1, evaluate=False))

--- a/sympy/physics/units/systems/si.py
+++ b/sympy/physics/units/systems/si.py
@@ -13,6 +13,7 @@ from sympy.physics.units.quantities import Quantity
 
 from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
+from sympy.core.parameters import evaluate
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.physics.units.definitions.dimension_definitions import (
     acceleration, action, current, impedance, length, mass, time, velocity,
@@ -98,250 +99,251 @@ SI = MKSA.extend(base=(mol, cd, K), units=all_units, name='SI', dimension_system
 
 One = S.One
 
-SI.set_quantity_dimension(radian, One)
+with evaluate(True):
+    SI.set_quantity_dimension(radian, One)
 
-SI.set_quantity_scale_factor(ampere, One)
+    SI.set_quantity_scale_factor(ampere, One)
 
-SI.set_quantity_scale_factor(kelvin, One)
+    SI.set_quantity_scale_factor(kelvin, One)
 
-SI.set_quantity_scale_factor(mole, One)
+    SI.set_quantity_scale_factor(mole, One)
 
-SI.set_quantity_scale_factor(candela, One)
+    SI.set_quantity_scale_factor(candela, One)
 
-# MKSA extension to MKS: derived units
+    # MKSA extension to MKS: derived units
 
-SI.set_quantity_scale_factor(coulomb, One)
+    SI.set_quantity_scale_factor(coulomb, One)
 
-SI.set_quantity_scale_factor(volt, joule/coulomb)
+    SI.set_quantity_scale_factor(volt, joule/coulomb)
 
-SI.set_quantity_scale_factor(ohm, volt/ampere)
+    SI.set_quantity_scale_factor(ohm, volt/ampere)
 
-SI.set_quantity_scale_factor(siemens, ampere/volt)
+    SI.set_quantity_scale_factor(siemens, ampere/volt)
 
-SI.set_quantity_scale_factor(farad, coulomb/volt)
+    SI.set_quantity_scale_factor(farad, coulomb/volt)
 
-SI.set_quantity_scale_factor(henry, volt*second/ampere)
+    SI.set_quantity_scale_factor(henry, volt*second/ampere)
 
-SI.set_quantity_scale_factor(tesla, volt*second/meter**2)
+    SI.set_quantity_scale_factor(tesla, volt*second/meter**2)
 
-SI.set_quantity_scale_factor(weber, joule/ampere)
+    SI.set_quantity_scale_factor(weber, joule/ampere)
 
 
-SI.set_quantity_dimension(lux, luminous_intensity / length ** 2)
-SI.set_quantity_scale_factor(lux, steradian*candela/meter**2)
+    SI.set_quantity_dimension(lux, luminous_intensity / length ** 2)
+    SI.set_quantity_scale_factor(lux, steradian*candela/meter**2)
 
-# katal is the SI unit of catalytic activity
+    # katal is the SI unit of catalytic activity
 
-SI.set_quantity_dimension(katal, amount_of_substance / time)
-SI.set_quantity_scale_factor(katal, mol/second)
+    SI.set_quantity_dimension(katal, amount_of_substance / time)
+    SI.set_quantity_scale_factor(katal, mol/second)
 
-# gray is the SI unit of absorbed dose
+    # gray is the SI unit of absorbed dose
 
-SI.set_quantity_dimension(gray, energy / mass)
-SI.set_quantity_scale_factor(gray, meter**2/second**2)
+    SI.set_quantity_dimension(gray, energy / mass)
+    SI.set_quantity_scale_factor(gray, meter**2/second**2)
 
-# becquerel is the SI unit of radioactivity
+    # becquerel is the SI unit of radioactivity
 
-SI.set_quantity_dimension(becquerel, 1 / time)
-SI.set_quantity_scale_factor(becquerel, 1/second)
+    SI.set_quantity_dimension(becquerel, 1 / time)
+    SI.set_quantity_scale_factor(becquerel, 1/second)
 
-#### CONSTANTS ####
+    #### CONSTANTS ####
 
-# elementary charge
-# REF: NIST SP 959 (June 2019)
+    # elementary charge
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(elementary_charge, charge)
-SI.set_quantity_scale_factor(elementary_charge, 1.602176634e-19*coulomb)
+    SI.set_quantity_dimension(elementary_charge, charge)
+    SI.set_quantity_scale_factor(elementary_charge, 1.602176634e-19*coulomb)
 
-# Electronvolt
-# REF: NIST SP 959 (June 2019)
+    # Electronvolt
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(electronvolt, energy)
-SI.set_quantity_scale_factor(electronvolt, 1.602176634e-19*joule)
+    SI.set_quantity_dimension(electronvolt, energy)
+    SI.set_quantity_scale_factor(electronvolt, 1.602176634e-19*joule)
 
-# Avogadro number
-# REF: NIST SP 959 (June 2019)
+    # Avogadro number
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(avogadro_number, One)
-SI.set_quantity_scale_factor(avogadro_number, 6.02214076e23)
+    SI.set_quantity_dimension(avogadro_number, One)
+    SI.set_quantity_scale_factor(avogadro_number, 6.02214076e23)
 
-# Avogadro constant
+    # Avogadro constant
 
-SI.set_quantity_dimension(avogadro_constant, amount_of_substance ** -1)
-SI.set_quantity_scale_factor(avogadro_constant, avogadro_number / mol)
+    SI.set_quantity_dimension(avogadro_constant, amount_of_substance ** -1)
+    SI.set_quantity_scale_factor(avogadro_constant, avogadro_number / mol)
 
-# Boltzmann constant
-# REF: NIST SP 959 (June 2019)
+    # Boltzmann constant
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(boltzmann_constant, energy / temperature)
-SI.set_quantity_scale_factor(boltzmann_constant, 1.380649e-23*joule/kelvin)
+    SI.set_quantity_dimension(boltzmann_constant, energy / temperature)
+    SI.set_quantity_scale_factor(boltzmann_constant, 1.380649e-23*joule/kelvin)
 
-# Stefan-Boltzmann constant
-# REF: NIST SP 959 (June 2019)
+    # Stefan-Boltzmann constant
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(stefan_boltzmann_constant, energy * time ** -1 * length ** -2 * temperature ** -4)
-SI.set_quantity_scale_factor(stefan_boltzmann_constant, pi**2 * boltzmann_constant**4 / (60 * hbar**3 * speed_of_light ** 2))
+    SI.set_quantity_dimension(stefan_boltzmann_constant, energy * time ** -1 * length ** -2 * temperature ** -4)
+    SI.set_quantity_scale_factor(stefan_boltzmann_constant, pi**2 * boltzmann_constant**4 / (60 * hbar**3 * speed_of_light ** 2))
 
-# Atomic mass
-# REF: NIST SP 959 (June 2019)
+    # Atomic mass
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(atomic_mass_constant, mass)
-SI.set_quantity_scale_factor(atomic_mass_constant, 1.66053906660e-24*gram)
+    SI.set_quantity_dimension(atomic_mass_constant, mass)
+    SI.set_quantity_scale_factor(atomic_mass_constant, 1.66053906660e-24*gram)
 
-# Molar gas constant
-# REF: NIST SP 959 (June 2019)
+    # Molar gas constant
+    # REF: NIST SP 959 (June 2019)
 
-SI.set_quantity_dimension(molar_gas_constant, energy / (temperature * amount_of_substance))
-SI.set_quantity_scale_factor(molar_gas_constant, boltzmann_constant * avogadro_constant)
+    SI.set_quantity_dimension(molar_gas_constant, energy / (temperature * amount_of_substance))
+    SI.set_quantity_scale_factor(molar_gas_constant, boltzmann_constant * avogadro_constant)
 
-# Faraday constant
+    # Faraday constant
 
-SI.set_quantity_dimension(faraday_constant, charge / amount_of_substance)
-SI.set_quantity_scale_factor(faraday_constant, elementary_charge * avogadro_constant)
+    SI.set_quantity_dimension(faraday_constant, charge / amount_of_substance)
+    SI.set_quantity_scale_factor(faraday_constant, elementary_charge * avogadro_constant)
 
-# Josephson constant
+    # Josephson constant
 
-SI.set_quantity_dimension(josephson_constant, frequency / voltage)
-SI.set_quantity_scale_factor(josephson_constant, 0.5 * planck / elementary_charge)
+    SI.set_quantity_dimension(josephson_constant, frequency / voltage)
+    SI.set_quantity_scale_factor(josephson_constant, 0.5 * planck / elementary_charge)
 
-# Von Klitzing constant
+    # Von Klitzing constant
 
-SI.set_quantity_dimension(von_klitzing_constant, voltage / current)
-SI.set_quantity_scale_factor(von_klitzing_constant, hbar / elementary_charge ** 2)
+    SI.set_quantity_dimension(von_klitzing_constant, voltage / current)
+    SI.set_quantity_scale_factor(von_klitzing_constant, hbar / elementary_charge ** 2)
 
-# Acceleration due to gravity (on the Earth surface)
+    # Acceleration due to gravity (on the Earth surface)
 
-SI.set_quantity_dimension(acceleration_due_to_gravity, acceleration)
-SI.set_quantity_scale_factor(acceleration_due_to_gravity, 9.80665*meter/second**2)
+    SI.set_quantity_dimension(acceleration_due_to_gravity, acceleration)
+    SI.set_quantity_scale_factor(acceleration_due_to_gravity, 9.80665*meter/second**2)
 
-# magnetic constant:
+    # magnetic constant:
 
-SI.set_quantity_dimension(magnetic_constant, force / current ** 2)
-SI.set_quantity_scale_factor(magnetic_constant, 4*pi/10**7 * newton/ampere**2)
+    SI.set_quantity_dimension(magnetic_constant, force / current ** 2)
+    SI.set_quantity_scale_factor(magnetic_constant, 4*pi/10**7 * newton/ampere**2)
 
-# electric constant:
+    # electric constant:
 
-SI.set_quantity_dimension(vacuum_permittivity, capacitance / length)
-SI.set_quantity_scale_factor(vacuum_permittivity, 1/(u0 * c**2))
+    SI.set_quantity_dimension(vacuum_permittivity, capacitance / length)
+    SI.set_quantity_scale_factor(vacuum_permittivity, 1/(u0 * c**2))
 
-# vacuum impedance:
+    # vacuum impedance:
 
-SI.set_quantity_dimension(vacuum_impedance, impedance)
-SI.set_quantity_scale_factor(vacuum_impedance, u0 * c)
+    SI.set_quantity_dimension(vacuum_impedance, impedance)
+    SI.set_quantity_scale_factor(vacuum_impedance, u0 * c)
 
-# Electron rest mass
-SI.set_quantity_dimension(electron_rest_mass, mass)
-SI.set_quantity_scale_factor(electron_rest_mass, 9.1093837015e-31*kilogram)
+    # Electron rest mass
+    SI.set_quantity_dimension(electron_rest_mass, mass)
+    SI.set_quantity_scale_factor(electron_rest_mass, 9.1093837015e-31*kilogram)
 
-# Coulomb's constant:
-SI.set_quantity_dimension(coulomb_constant, force * length ** 2 / charge ** 2)
-SI.set_quantity_scale_factor(coulomb_constant, 1/(4*pi*vacuum_permittivity))
+    # Coulomb's constant:
+    SI.set_quantity_dimension(coulomb_constant, force * length ** 2 / charge ** 2)
+    SI.set_quantity_scale_factor(coulomb_constant, 1/(4*pi*vacuum_permittivity))
 
-SI.set_quantity_dimension(psi, pressure)
-SI.set_quantity_scale_factor(psi, pound * gee / inch ** 2)
+    SI.set_quantity_dimension(psi, pressure)
+    SI.set_quantity_scale_factor(psi, pound * gee / inch ** 2)
 
-SI.set_quantity_dimension(mmHg, pressure)
-SI.set_quantity_scale_factor(mmHg, dHg0 * acceleration_due_to_gravity * kilogram / meter**2)
+    SI.set_quantity_dimension(mmHg, pressure)
+    SI.set_quantity_scale_factor(mmHg, dHg0 * acceleration_due_to_gravity * kilogram / meter**2)
 
-SI.set_quantity_dimension(milli_mass_unit, mass)
-SI.set_quantity_scale_factor(milli_mass_unit, atomic_mass_unit/1000)
+    SI.set_quantity_dimension(milli_mass_unit, mass)
+    SI.set_quantity_scale_factor(milli_mass_unit, atomic_mass_unit/1000)
 
-SI.set_quantity_dimension(quart, length ** 3)
-SI.set_quantity_scale_factor(quart, Rational(231, 4) * inch**3)
+    SI.set_quantity_dimension(quart, length ** 3)
+    SI.set_quantity_scale_factor(quart, Rational(231, 4) * inch**3)
 
-# Other convenient units and magnitudes
+    # Other convenient units and magnitudes
 
-SI.set_quantity_dimension(lightyear, length)
-SI.set_quantity_scale_factor(lightyear, speed_of_light*julian_year)
+    SI.set_quantity_dimension(lightyear, length)
+    SI.set_quantity_scale_factor(lightyear, speed_of_light*julian_year)
 
-SI.set_quantity_dimension(astronomical_unit, length)
-SI.set_quantity_scale_factor(astronomical_unit, 149597870691*meter)
+    SI.set_quantity_dimension(astronomical_unit, length)
+    SI.set_quantity_scale_factor(astronomical_unit, 149597870691*meter)
 
-# Fundamental Planck units:
+    # Fundamental Planck units:
 
-SI.set_quantity_dimension(planck_mass, mass)
-SI.set_quantity_scale_factor(planck_mass, sqrt(hbar*speed_of_light/G))
+    SI.set_quantity_dimension(planck_mass, mass)
+    SI.set_quantity_scale_factor(planck_mass, sqrt(hbar*speed_of_light/G))
 
-SI.set_quantity_dimension(planck_time, time)
-SI.set_quantity_scale_factor(planck_time, sqrt(hbar*G/speed_of_light**5))
+    SI.set_quantity_dimension(planck_time, time)
+    SI.set_quantity_scale_factor(planck_time, sqrt(hbar*G/speed_of_light**5))
 
-SI.set_quantity_dimension(planck_temperature, temperature)
-SI.set_quantity_scale_factor(planck_temperature, sqrt(hbar*speed_of_light**5/G/boltzmann**2))
+    SI.set_quantity_dimension(planck_temperature, temperature)
+    SI.set_quantity_scale_factor(planck_temperature, sqrt(hbar*speed_of_light**5/G/boltzmann**2))
 
-SI.set_quantity_dimension(planck_length, length)
-SI.set_quantity_scale_factor(planck_length, sqrt(hbar*G/speed_of_light**3))
+    SI.set_quantity_dimension(planck_length, length)
+    SI.set_quantity_scale_factor(planck_length, sqrt(hbar*G/speed_of_light**3))
 
-SI.set_quantity_dimension(planck_charge, charge)
-SI.set_quantity_scale_factor(planck_charge, sqrt(4*pi*electric_constant*hbar*speed_of_light))
+    SI.set_quantity_dimension(planck_charge, charge)
+    SI.set_quantity_scale_factor(planck_charge, sqrt(4*pi*electric_constant*hbar*speed_of_light))
 
-# Derived Planck units:
+    # Derived Planck units:
 
-SI.set_quantity_dimension(planck_area, length ** 2)
-SI.set_quantity_scale_factor(planck_area, planck_length**2)
+    SI.set_quantity_dimension(planck_area, length ** 2)
+    SI.set_quantity_scale_factor(planck_area, planck_length**2)
 
-SI.set_quantity_dimension(planck_volume, length ** 3)
-SI.set_quantity_scale_factor(planck_volume, planck_length**3)
+    SI.set_quantity_dimension(planck_volume, length ** 3)
+    SI.set_quantity_scale_factor(planck_volume, planck_length**3)
 
-SI.set_quantity_dimension(planck_momentum, mass * velocity)
-SI.set_quantity_scale_factor(planck_momentum, planck_mass * speed_of_light)
+    SI.set_quantity_dimension(planck_momentum, mass * velocity)
+    SI.set_quantity_scale_factor(planck_momentum, planck_mass * speed_of_light)
 
-SI.set_quantity_dimension(planck_energy, energy)
-SI.set_quantity_scale_factor(planck_energy, planck_mass * speed_of_light**2)
+    SI.set_quantity_dimension(planck_energy, energy)
+    SI.set_quantity_scale_factor(planck_energy, planck_mass * speed_of_light**2)
 
-SI.set_quantity_dimension(planck_force, force)
-SI.set_quantity_scale_factor(planck_force, planck_energy / planck_length)
+    SI.set_quantity_dimension(planck_force, force)
+    SI.set_quantity_scale_factor(planck_force, planck_energy / planck_length)
 
-SI.set_quantity_dimension(planck_power, power)
-SI.set_quantity_scale_factor(planck_power, planck_energy / planck_time)
+    SI.set_quantity_dimension(planck_power, power)
+    SI.set_quantity_scale_factor(planck_power, planck_energy / planck_time)
 
-SI.set_quantity_dimension(planck_density, mass / length ** 3)
-SI.set_quantity_scale_factor(planck_density, planck_mass / planck_length**3)
+    SI.set_quantity_dimension(planck_density, mass / length ** 3)
+    SI.set_quantity_scale_factor(planck_density, planck_mass / planck_length**3)
 
-SI.set_quantity_dimension(planck_energy_density, energy / length ** 3)
-SI.set_quantity_scale_factor(planck_energy_density, planck_energy / planck_length**3)
+    SI.set_quantity_dimension(planck_energy_density, energy / length ** 3)
+    SI.set_quantity_scale_factor(planck_energy_density, planck_energy / planck_length**3)
 
-SI.set_quantity_dimension(planck_intensity, mass * time ** (-3))
-SI.set_quantity_scale_factor(planck_intensity, planck_energy_density * speed_of_light)
+    SI.set_quantity_dimension(planck_intensity, mass * time ** (-3))
+    SI.set_quantity_scale_factor(planck_intensity, planck_energy_density * speed_of_light)
 
-SI.set_quantity_dimension(planck_angular_frequency, 1 / time)
-SI.set_quantity_scale_factor(planck_angular_frequency, 1 / planck_time)
+    SI.set_quantity_dimension(planck_angular_frequency, 1 / time)
+    SI.set_quantity_scale_factor(planck_angular_frequency, 1 / planck_time)
 
-SI.set_quantity_dimension(planck_pressure, pressure)
-SI.set_quantity_scale_factor(planck_pressure, planck_force / planck_length**2)
+    SI.set_quantity_dimension(planck_pressure, pressure)
+    SI.set_quantity_scale_factor(planck_pressure, planck_force / planck_length**2)
 
-SI.set_quantity_dimension(planck_current, current)
-SI.set_quantity_scale_factor(planck_current, planck_charge / planck_time)
+    SI.set_quantity_dimension(planck_current, current)
+    SI.set_quantity_scale_factor(planck_current, planck_charge / planck_time)
 
-SI.set_quantity_dimension(planck_voltage, voltage)
-SI.set_quantity_scale_factor(planck_voltage, planck_energy / planck_charge)
+    SI.set_quantity_dimension(planck_voltage, voltage)
+    SI.set_quantity_scale_factor(planck_voltage, planck_energy / planck_charge)
 
-SI.set_quantity_dimension(planck_impedance, impedance)
-SI.set_quantity_scale_factor(planck_impedance, planck_voltage / planck_current)
+    SI.set_quantity_dimension(planck_impedance, impedance)
+    SI.set_quantity_scale_factor(planck_impedance, planck_voltage / planck_current)
 
-SI.set_quantity_dimension(planck_acceleration, acceleration)
-SI.set_quantity_scale_factor(planck_acceleration, speed_of_light / planck_time)
+    SI.set_quantity_dimension(planck_acceleration, acceleration)
+    SI.set_quantity_scale_factor(planck_acceleration, speed_of_light / planck_time)
 
-# Older units for radioactivity
+    # Older units for radioactivity
 
-SI.set_quantity_dimension(curie, 1 / time)
-SI.set_quantity_scale_factor(curie, 37000000000*becquerel)
+    SI.set_quantity_dimension(curie, 1 / time)
+    SI.set_quantity_scale_factor(curie, 37000000000*becquerel)
 
-SI.set_quantity_dimension(rutherford, 1 / time)
-SI.set_quantity_scale_factor(rutherford, 1000000*becquerel)
+    SI.set_quantity_dimension(rutherford, 1 / time)
+    SI.set_quantity_scale_factor(rutherford, 1000000*becquerel)
 
 
-# check that scale factors are the right SI dimensions:
-for _scale_factor, _dimension in zip(
-    SI._quantity_scale_factors.values(),
-    SI._quantity_dimension_map.values()
-):
-    dimex = SI.get_dimensional_expr(_scale_factor)
-    if dimex != 1:
-        # XXX: equivalent_dims is an instance method taking two arguments in
-        # addition to self so this can not work:
-        if not DimensionSystem.equivalent_dims(_dimension, Dimension(dimex)):  # type: ignore
-            raise ValueError("quantity value and dimension mismatch")
-del _scale_factor, _dimension
+    # check that scale factors are the right SI dimensions:
+    for _scale_factor, _dimension in zip(
+        SI._quantity_scale_factors.values(),
+        SI._quantity_dimension_map.values()
+    ):
+        dimex = SI.get_dimensional_expr(_scale_factor)
+        if dimex != 1:
+            # XXX: equivalent_dims is an instance method taking two arguments in
+            # addition to self so this can not work:
+            if not DimensionSystem.equivalent_dims(_dimension, Dimension(dimex)):  # type: ignore
+                raise ValueError("quantity value and dimension mismatch")
+    del _scale_factor, _dimension
 
 __all__ = [
     'mmHg', 'atmosphere', 'inductance', 'newton', 'meter',


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fix: https://github.com/sympy/sympy/issues/27922


#### Brief description of what is fixed or changed

The code to reproduce the error is as follows:

```python3

from sympy import evaluate
from sympy.parsing.latex import parse_latex

with evaluate(False):
    r = parse_latex(r"a = 42 + 1")
```

```
Traceback (most recent call last):
  File "/sympy/my/test.py", line 7, in <module>
    r = parse_latex(r"a = 42 + 1")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sympy/sympy/parsing/latex/__init__.py", line 194, in parse_latex
    _latex = import_module(
             ^^^^^^^^^^^^^^
  File "/sympy/sympy/external/importtools.py", line 145, in import_module
    mod = __import__(module, **import_kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sympy/sympy/parsing/latex/_parse_latex_antlr.py", line 8, in <module>
    from sympy.physics.quantum.state import Bra, Ket
  File "/sympy/sympy/physics/__init__.py", line 5, in <module>
    from . import units
  File "/sympy/sympy/physics/units/__init__.py", line 215, in <module>
    from .systems import (
  File "/sympy/sympy/physics/units/systems/__init__.py", line 4, in <module>
    from sympy.physics.units.systems.si import SI
  File "/sympy/sympy/physics/units/systems/si.py", line 130, in <module>
    SI.set_quantity_dimension(lux, luminous_intensity / length ** 2)
  File "/sympy/sympy/physics/units/dimensions.py", line 53, in set_quantity_dimension
    raise ValueError("expected dimension or 1")
ValueError: expected dimension or 1
```

This is caused by the delayed import：
https://github.com/sympy/sympy/blob/495e45d0681b6c5f39283504a3752a1a7616bca6/sympy/parsing/latex/__init__.py#L194-L196

The expressions in `sympy/physics/units/systems/si.py` will be constructed in the context where evaluate is set to False.
#### Other comments


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fix the error that occurs when parsing LaTeX without evaluating.
<!-- END RELEASE NOTES -->
