### PR TITLE
make parse_latex method with the Lark backend can parse consecutive equalities/inequalities

### DIFF
--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -199,7 +199,9 @@ group_curly_parentheses: L_BRACE _expression R_BRACE
 _relation: eq | ne | lt | lte | gt | gte
 
 eq: _expression EQUAL _expression
+    | _relation EQUAL _expression
 ne: _expression NOT_EQUAL _expression
+    |  _relation NOT_EQUAL _expression
 lt: _expression LT _expression
 lte: _expression LTE _expression
 gt: _expression GT _expression

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -687,6 +687,13 @@ EVALUATED_MATRIX_EXPRESSION_PAIRS = [
      (Matrix([[-2*I, 6], [4, 8]])))
 ]
 
+CONTINUOUS_RELATION_EXPRESSION_PAIRS = [
+    (r"a = b = c", Eq(Eq(a, b), c)),
+    (r"a = b = c = d", Eq(Eq(Eq(a, b), c), d) ),
+    (r"a \ne b \ne c", Ne(Ne(a, b), c)),
+    (r"a \ne b \ne x + y", Ne(Ne(a, b), x + y, evaluate=False)),
+    (r"a \ne b = c", Eq(Ne(a, b), c)),
+]
 
 def test_symbol_expressions():
     expected_failures = {6, 7}
@@ -870,3 +877,8 @@ def test_matrix_expressions():
 
     for latex_str, sympy_expr in EVALUATED_MATRIX_EXPRESSION_PAIRS:
         assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+def test_continuous_relation_expression_pairs():
+    for i, (latex_str, sympy_expr) in enumerate(CONTINUOUS_RELATION_EXPRESSION_PAIRS):
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str


### PR DESCRIPTION
#### References to other Issues or PRs

ref: https://github.com/sympy/sympy/issues/27172

#### Brief description of what is fixed or changed
case:
```python3
from sympy.parsing.latex import parse_latex

r = parse_latex(r"a = b = c", backend="antlr")
print(r)  # Eq(Eq(a, b), c)
r = parse_latex(r"a = b = c", backend="lark")
print(r)  # Error
```
#### Other comments


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* parsing
  * make parse_latex method with the Lark backend can parse consecutive equalities/inequalities
<!-- END RELEASE NOTES -->
