### PR TITLE
feat: Add NonIntegerPredicate handler

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -76,7 +76,7 @@ class AssumptionKeys:
 
     @memoize_property
     def noninteger(self):
-        from .predicates.sets import NonIntegerPredicate
+        from .handlers.sets import NonIntegerPredicate
         return NonIntegerPredicate()
 
     @memoize_property

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -19,7 +19,7 @@ from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.multipledispatch import MDNotImplementedError
 
 from .common import test_closed_group, ask_all, ask_any
-from ..predicates.sets import (IntegerPredicate, RationalPredicate,
+from ..predicates.sets import (IntegerPredicate, NonIntegerPredicate, RationalPredicate,
     IrrationalPredicate, RealPredicate, ExtendedRealPredicate,
     HermitianPredicate, ComplexPredicate, ImaginaryPredicate,
     AntihermitianPredicate, AlgebraicPredicate)
@@ -110,6 +110,13 @@ def _(expr, assumptions):
 @IntegerPredicate.register_many(Determinant, MatrixElement, Trace)
 def _(expr, assumptions):
     return ask(Q.integer_elements(expr.args[0]), assumptions)
+
+
+# NonIntegerPredicate
+
+@NonIntegerPredicate.register(Expr)
+def _(expr, assumptions):
+    return ask(~Q.integer(expr), assumptions) and ask(Q.extended_real(expr), assumptions)
 
 
 # RationalPredicate

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1672,6 +1672,46 @@ def test_integer():
     assert ask(Q.integer(x**y), Q.imaginary(x) & Q.zero(y)) is True
 
 
+def test_non_integer():
+    assert ask(Q.noninteger(x)) is None
+    assert ask(Q.noninteger(x), Q.noninteger(x)) is True
+    assert ask(Q.noninteger(x), ~Q.integer(x) & Q.extended_real(x)) is True
+    assert ask(Q.noninteger(x), ~Q.extended_real(x)) is False
+    assert ask(Q.noninteger(x), ~Q.positive(x)) is None
+    assert ask(Q.noninteger(x), Q.even(x) | Q.odd(x)) is False
+
+    assert ask(Q.noninteger(2*x), Q.integer(x)) is False
+    assert ask(Q.noninteger(2*x), Q.even(x)) is False
+    assert ask(Q.noninteger(2*x), Q.prime(x)) is False
+    assert ask(Q.noninteger(2*x), Q.rational(x)) is None
+    assert ask(Q.noninteger(2*x), Q.real(x)) is None
+    assert ask(Q.noninteger(sqrt(2)*x), Q.integer(x)) is True
+    assert ask(Q.noninteger(sqrt(2)*x), Q.irrational(x)) is None
+
+    assert ask(Q.noninteger(x/2), Q.odd(x)) is True
+    assert ask(Q.noninteger(x/2), Q.even(x)) is False
+    assert ask(Q.noninteger(x/3), Q.odd(x)) is None
+    assert ask(Q.noninteger(x/3), Q.even(x)) is None
+
+    assert ask(Q.noninteger(Abs(x)), Q.integer(x)) is False
+    assert ask(Q.noninteger(Abs(-x)), Q.integer(x)) is False
+    assert ask(Q.noninteger(Abs(x)), ~Q.integer(x)) is None
+    assert ask(Q.noninteger(Abs(x)), Q.complex(x)) is None
+    assert ask(Q.noninteger(Abs(x+I*y)), Q.real(x) & Q.real(y)) is None
+
+    assert ask(Q.noninteger(x/y), Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.noninteger(1/x), Q.integer(x)) is None
+    assert ask(Q.noninteger(x**y), Q.integer(x) & Q.integer(y)) is None
+    assert ask(Q.noninteger(sqrt(5))) is True
+    assert ask(Q.noninteger(x**y), Q.nonzero(x) & Q.zero(y)) is False
+    assert ask(Q.noninteger(x**y), Q.integer(x) & Q.integer(y) & Q.positive(y)) is False
+    assert ask(Q.noninteger(-1**x), Q.integer(x)) is False
+    assert ask(Q.noninteger(x**y), Q.integer(x) & Q.integer(y) & Q.positive(y)) is False
+    assert ask(Q.noninteger(x**y), Q.zero(x) & Q.integer(y) & Q.positive(y)) is False
+    assert ask(Q.noninteger(pi**x), Q.zero(x)) is False
+    assert ask(Q.noninteger(x**y), Q.imaginary(x) & Q.zero(y)) is False
+
+
 def test_negative():
     assert ask(Q.negative(x), Q.negative(x)) is True
     assert ask(Q.negative(x), Q.positive(x)) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27748 


#### Brief description of what is fixed or changed
This PR introduces a new ```NonIntegerPredicate``` handler to SymPy's assumptions system, addressing the issue where ```ask(Q.noninteger(x), Q.integer(x))``` incorrectly returned ```None```. The new handler ensures that expressions involving ```Q.noninteger``` are interpreted accurately in various assumption contexts.

What was done:

- Moved ```NonIntegerPredicate``` from a basic predicate to a proper handler-based implementation under ```handlers.sets```.
- Registered logical inference rules for ```Q.noninteger(expr)``` under various assumptions using Expr types.
- Added extensive test coverage in ```test_non_integer``` to verify behavior under multiple assumptions and expression structures.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Added support for handling queries of type ```Q.noninteger()```.

<!-- END RELEASE NOTES -->
