### PR TITLE
Raise an error for matrices with symbolic shape to prevent infinite loops.

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -964,6 +964,12 @@ def solve(f, *symbols, **flags):
 
         # if we have a Matrix, we need to iterate over its elements again
         if f[i].is_Matrix:
+            try:
+                f[i] = f[i].as_explicit()
+            except ValueError:
+                raise ValueError(
+                    "solve cannot handle matrices with symbolic shape."
+                )
             bare_f = False
             f.extend(list(f[i]))
             f[i] = S.Zero

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -22,7 +22,7 @@ from sympy.functions.special.error_functions import (erf, erfc, erfcinv, erfinv)
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import (And, Or)
 from sympy.matrices.dense import Matrix
-from sympy.matrices import SparseMatrix
+from sympy.matrices import MatrixSymbol, SparseMatrix
 from sympy.polys.polytools import Poly, groebner
 from sympy.printing.str import sstr
 from sympy.simplify.radsimp import denom
@@ -708,7 +708,8 @@ def test_issue_3725():
     assert solve(e, f(x).diff(x)) in [[(2 - x)/f(x)], [-((x - 2)/f(x))]]
 
 
-def test_issue_3870():
+def test_solve_Matrix():
+    # https://github.com/sympy/sympy/issues/3870
     a, b, c, d = symbols('a b c d')
     A = Matrix(2, 2, [a, b, c, d])
     B = Matrix(2, 2, [0, 2, -3, 0])
@@ -725,6 +726,16 @@ def test_issue_3870():
     assert solve([Eq(A*B, B*A)], [a, b, c, d]) == {a: d, b: Rational(-2, 3)*c}
     assert solve([Eq(A*C, C*A)], [a, b, c, d]) == {a: d - c, b: Rational(2, 3)*c}
     assert solve([Eq(A*B, B*A), Eq(A*C, C*A)], [a, b, c, d]) == {a: d, b: 0, c: 0}
+
+    # https://github.com/sympy/sympy/issues/27854
+    m, n = symbols("m n")
+    A = MatrixSymbol("A", m, n)
+    x = MatrixSymbol("x", n, 1)
+    b = MatrixSymbol('b', m, 1)
+    r = A * x - b
+    f = r.T * r
+    grad_f = f.diff(x)
+    raises(ValueError, lambda: solve(grad_f, x))
 
 
 def test_solve_linear():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#27854
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously, if a matrix had a symbolic shape, it would cause an infinite loop. Now, the code correctly raise error

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve` will now reject matrices with symbolic shape. Previously it would go into an infinite loop.
<!-- END RELEASE NOTES -->
