### PR TITLE
RingSeries: Refactor `rs_` function and add missing tests for _atan, _atanh, and test_puiseux.

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -970,10 +970,7 @@ def rs_nth_root(p, n, x, prec):
     if _has_constant_term(p - 1, x):
         zm = R.zero_monom
         c = p[zm]
-        if R.domain is EX:
-            c_expr = c.as_expr()
-            const = EX(c_expr**QQ(1, n))
-        elif isinstance(c, PolyElement):
+        if isinstance(c, PolyElement):
             try:
                 c_expr = c.as_expr()
                 const = R(c_expr**(QQ(1, n)))
@@ -1025,25 +1022,15 @@ def rs_log(p, x, prec):
         const = 0
         if c == 1:
             pass
-        else:
+        try:
             c_expr = c.as_expr()
-            if R.domain is EX:
-                const = log(c_expr)
-            elif isinstance(c, (PolyElement, PuiseuxPoly)):
-                try:
-                    const = R(log(c_expr))
-                except ValueError:
-                    R = R.add_gens([log(c_expr)])
-                    p = p.set_ring(R)
-                    x = x.set_ring(R)
-                    c = c.set_ring(R)
-                    const = R(log(c_expr))
-            else:
-                try:
-                    const = R(log(c))
-                except ValueError:
-                    raise DomainError("The given series cannot be expanded in "
-                        "this domain.")
+            const = R(log(c_expr))
+        except ValueError:
+            R = R.add_gens([log(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            const = R(log(c_expr))
 
         dlog = p.diff(x)
         dlog = rs_mul(dlog, _series_inversion1(p, x, prec), x, prec - 1)
@@ -1119,25 +1106,16 @@ def rs_exp(p, x, prec):
     R = p.ring
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            const = exp(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                const = R(exp(c_expr))
-            except ValueError:
-                R = R.add_gens([exp(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                const = R(exp(c_expr))
-        else:
-            try:
-                const = R(exp(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            const = R(exp(c_expr))
+        except ValueError:
+            R = R.add_gens([exp(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            const = R(exp(c_expr))
+
         p1 = p - c
 
     # Makes use of SymPy functions to evaluate the values of the cos/sin
@@ -1200,25 +1178,15 @@ def rs_atan(p, x, prec):
     const = 0
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            const = atan(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                const = R(atan(c_expr))
-            except ValueError:
-                R = R.add_gens([atan(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                const = R(atan(c_expr))
-        else:
-            try:
-                const = R(atan(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            const = R(atan(c_expr))
+        except ValueError:
+            R = R.add_gens([atan(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            const = R(atan(c_expr))
 
     # Instead of using a closed form formula, we differentiate atan(p) to get
     # `1/(1+p**2) * dp`, whose series expansion is much easier to calculate.
@@ -1254,7 +1222,7 @@ def rs_asin(p, x, prec):
         return rs_puiseux(rs_asin, p, x, prec)
     if _has_constant_term(p, x):
         raise NotImplementedError("Polynomial must not have constant term in "
-                                  "series variables")
+                                    "series variables")
     R = p.ring
     if x in R.gens:
         # get a good value
@@ -1323,25 +1291,16 @@ def rs_tan(p, x, prec):
     const = 0
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            const = tan(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                const = R(tan(c_expr))
-            except ValueError:
-                R = R.add_gens([tan(c_expr, )])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                const = R(tan(c_expr))
-        else:
-            try:
-                const = R(tan(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            const = R(tan(c_expr))
+        except ValueError:
+            R = R.add_gens([tan(c_expr, )])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            const = R(tan(c_expr))
+
         p1 = p - c
 
     # Makes use of SymPy functions to evaluate the values of the cos/sin
@@ -1421,25 +1380,16 @@ def rs_sin(p, x, prec):
         return R(0)
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            t1, t2 = sin(c_expr), cos(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
-            except ValueError:
-                R = R.add_gens([sin(c_expr), cos(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
-        else:
-            try:
-                t1, t2 = R(sin(c)), R(cos(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            t1, t2 = R(sin(c_expr)), R(cos(c_expr))
+        except ValueError:
+            R = R.add_gens([sin(c_expr), cos(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            t1, t2 = R(sin(c_expr)), R(cos(c_expr))
+
         p1 = p - c
 
     # Makes use of SymPy cos, sin functions to evaluate the values of the
@@ -1490,29 +1440,19 @@ def rs_cos(p, x, prec):
     R = p.ring
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            t1, t2 = sin(c_expr), cos(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
-            except ValueError:
-                R = R.add_gens([sin(c_expr), cos(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                t1, t2 = R(sin(c_expr)), R(cos(c_expr))
-        else:
-            try:
-                t1, t2 = R(sin(c)), R(cos(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
-        p1 = p - c
+            t1, t2 = R(sin(c_expr)), R(cos(c_expr))
+        except ValueError:
+            R = R.add_gens([sin(c_expr), cos(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            t1, t2 = R(sin(c_expr)), R(cos(c_expr))
 
-    # Makes use of SymPy cos, sin functions to evaluate the values of the
-    # cos/sin of the constant term.
+        p1 = p - c
+        # Makes use of SymPy cos, sin functions to evaluate the values of the
+        # cos/sin of the constant term.
         p_cos, p_sin = rs_cos_sin(p1, x, prec)
         return p_cos*t2 - p_sin*t1
 
@@ -1633,25 +1573,14 @@ def rs_atanh(p, x, prec):
         return rs_puiseux(rs_atanh, p, x, prec)
     R = p.ring
     const = 0
-    if _has_constant_term(p, x):
-        zm = R.zero_monom
-        c = p[zm]
-        if R.domain is EX:
+    c = _get_constant_term(p, x)
+    if c:
+        try:
             c_expr = c.as_expr()
-            const = atanh(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                const = R(atanh(c_expr))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
-        else:
-            try:
-                const = R(atanh(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            const = R(atanh(c_expr))
+        except ValueError:
+            raise DomainError("The given series cannot be expanded in "
+                "this domain.")
 
     # Instead of using a closed form formula, we differentiate atanh(p) to get
     # `1/(1-p**2) * dp`, whose series expansion is much easier to calculate.
@@ -1689,22 +1618,12 @@ def rs_asinh(p, x, prec):
     const = 0
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            const = asinh(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                const = R(asinh(c_expr))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
-        else:
-            try:
-                const = R(asinh(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            const = R(asinh(c_expr))
+        except ValueError:
+            raise DomainError("The given series cannot be expanded in "
+                "this domain.")
 
     # Instead of using a closed form formula, we differentiate asinh(p) to get
     # `1/sqrt(1+p**2) * dp`, whose series expansion is much easier to calculate.
@@ -1744,25 +1663,15 @@ def rs_sinh(p, x, prec):
         return R(0)
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            t1, t2 = sinh(c_expr), cosh(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
-            except ValueError:
-                R = R.add_gens([sinh(c_expr), cosh(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
-        else:
-            try:
-                t1, t2 = R(sinh(c)), R(cosh(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                                  "this domain.")
+            t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+        except ValueError:
+            R = R.add_gens([sinh(c_expr), cosh(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
 
         p1 = p - c
         p_cosh, p_sinh = rs_cosh_sinh(p1, x, prec)
@@ -1800,25 +1709,15 @@ def rs_cosh(p, x, prec):
         return R(0)
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            t1, t2 = sinh(c_expr), cosh(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
-            except ValueError:
-                R = R.add_gens([sinh(c_expr), cosh(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
-        else:
-            try:
-                t1, t2 = R(sinh(c)), R(cosh(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                                  "this domain.")
+            t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
+        except ValueError:
+            R = R.add_gens([sinh(c_expr), cosh(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            t1, t2 = R(sinh(c_expr)), R(cosh(c_expr))
 
         p1 = p - c
         p_cosh, p_sinh = rs_cosh_sinh(p1, x, prec)
@@ -1926,25 +1825,16 @@ def rs_tanh(p, x, prec):
     const = 0
     c = _get_constant_term(p, x)
     if c:
-        if R.domain is EX:
+        try:
             c_expr = c.as_expr()
-            const = tanh(c_expr)
-        elif isinstance(c, PolyElement):
-            try:
-                c_expr = c.as_expr()
-                const = R(tanh(c_expr))
-            except ValueError:
-                R = R.add_gens([tanh(c_expr)])
-                p = p.set_ring(R)
-                x = x.set_ring(R)
-                c = c.set_ring(R)
-                const = R(tanh(c_expr))
-        else:
-            try:
-                const = R(tanh(c))
-            except ValueError:
-                raise DomainError("The given series cannot be expanded in "
-                    "this domain.")
+            const = R(tanh(c_expr))
+        except ValueError:
+            R = R.add_gens([tanh(c_expr)])
+            p = p.set_ring(R)
+            x = x.set_ring(R)
+            c = c.set_ring(R)
+            const = R(tanh(c_expr))
+
         p1 = p - c
         t1 = rs_tanh(p1, x, prec)
         t = rs_series_inversion(1 + const*t1, x, prec)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -282,7 +282,7 @@ def test_atan():
         *x**3*y + EX((3*a**2 - 1)/(3*a**6 + 9*a**4 + 9*a**2 + 3))*x**3 + \
         EX(1/(a**2 + 1))*x**2*y - EX(a/(a**4 + 2*a**2 + 1))*x**2 + EX(1/(a**2 \
         + 1))*x + EX(atan(a))
-        
+
     # Test for _atan faster for small and univariate series
     R, x = ring('x', QQ)
     p = x**2 + 2*x
@@ -441,7 +441,7 @@ def test_atanh():
     p = x + x**2 + 5
     assert rs_atanh(p, x, 10).compose(x, 10) == EX(Rational(-733442653682135, 5079158784) \
         + atanh(5))
-    
+
     # Test for _atanh faster for small and univariate series
     R,x  = ring('x', QQ)
     p = x**2 + 2*x

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -4,9 +4,10 @@ from sympy.polys.puiseux import puiseux_ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,
     rs_series_from_list, rs_exp, rs_log, rs_newton, rs_series_inversion,
-    rs_compose_add, rs_asin, rs_atan, _atanh, rs_atanh, rs_asinh, rs_tan, rs_cot,
-    rs_sin, rs_cos, rs_cos_sin, rs_sinh, rs_cosh, rs_cosh_sinh, rs_tanh, _tan1,
-    rs_fun, rs_nth_root, rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
+    rs_compose_add, rs_asin, _atan, rs_atan, _atanh, rs_atanh, rs_asinh, rs_tan,
+    rs_cot, rs_sin, rs_cos, rs_cos_sin, rs_sinh, rs_cosh, rs_cosh_sinh, rs_tanh,
+    _tan1, rs_fun, rs_nth_root, rs_LambertW, rs_series_reversion, rs_is_puiseux,
+    rs_series)
 from sympy.testing.pytest import raises, slow
 from sympy.core.symbol import symbols
 from sympy.functions import (sin, cos, exp, tan, cot, sinh, cosh, atan, atanh,
@@ -17,6 +18,7 @@ from sympy.core import expand, S
 def is_close(a, b):
     tol = 10**(-10)
     assert abs(a - b) < tol
+
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -31,11 +33,13 @@ def test_ring_series1():
     assert rs_integrate(p, x) == x**3*y**2/3 + x**2/2 + x
     assert rs_integrate(p, y) == x**2*y**3/3 + x*y + y
 
+
 def test_trunc():
     R, x, y, t = ring('x, y, t', QQ)
     p = (y + t*x)**4
     p1 = rs_trunc(p, x, 3)
     assert p1 == y**4 + 4*y**3*t*x + 6*y**2*t**2*x**2
+
 
 def test_mul_trunc():
     R, x, y, t = ring('x, y, t', QQ)
@@ -54,6 +58,7 @@ def test_mul_trunc():
     p2 = 3 + x**2
     assert rs_mul(p1, p2, x, 4) == 2*x**3 + 11*x**2 + 6*x + 6
 
+
 def test_square_trunc():
     R, x, y, t = ring('x, y, t', QQ)
     p = (1 + t*x + t*y)*2
@@ -62,6 +67,7 @@ def test_square_trunc():
     assert p1 == p2
     p = 1 + x + x**2 + x**3
     assert rs_square(p, x, 4) == 4*x**3 + 3*x**2 + 2*x + 1
+
 
 def test_pow_trunc():
     R, x, y, z = ring('x, y, z', QQ)
@@ -81,6 +87,7 @@ def test_pow_trunc():
     assert rs_pow(p, 3, y, 3) == x**3 + 3*x**2*y + 3*x*y**2
     assert rs_pow(1 + x, Rational(2, 3), x, 4) == 4*x**3/81 - x**2/9 + x*Rational(2, 3) + 1
 
+
 def test_has_constant_term():
     R, x, y, z = ring('x, y, z', QQ)
     p = y + x*z
@@ -90,6 +97,7 @@ def test_has_constant_term():
     p = 1 + x + x**4
     assert _has_constant_term(p, x)
     p = x + y + x*z
+
 
 def test_inversion():
     R, x = ring('x', QQ)
@@ -122,6 +130,7 @@ def test_series_reversion():
     p = rs_sin(x, x, 10)
     assert rs_series_reversion(p, x, 8, y) == 5*y**7/112 + 3*y**5/40 + \
         y**3/6 + y
+
 
 def test_series_from_list():
     R, x = ring('x', QQ)
@@ -210,17 +219,20 @@ def test_exp():
         EX(exp(a)/6)*x**3 + EX(exp(a))*x**2*y + EX(exp(a)/2)*x**2 + \
         EX(exp(a))*x + EX(exp(a))
 
+
 def test_newton():
     R, x = ring('x', QQ)
     p = x**2 - 2
     r = rs_newton(p, x, 4)
     assert r == 8*x**4 + 4*x**2 + 2
 
+
 def test_compose_add():
     R, x = ring('x', QQ)
     p1 = x**3 - 1
     p2 = x**2 - 2
     assert rs_compose_add(p1, p2) == x**6 - 6*x**4 - 2*x**3 + 12*x**2 - 12*x - 7
+
 
 def test_fun():
     R, x, y = ring('x, y', QQ)
@@ -270,6 +282,16 @@ def test_atan():
         *x**3*y + EX((3*a**2 - 1)/(3*a**6 + 9*a**4 + 9*a**2 + 3))*x**3 + \
         EX(1/(a**2 + 1))*x**2*y - EX(a/(a**4 + 2*a**2 + 1))*x**2 + EX(1/(a**2 \
         + 1))*x + EX(atan(a))
+        
+    # Test for _atan faster for small and univariate series
+    R, x = ring('x', QQ)
+    p = x**2 + 2*x
+    assert _atan(p, x, 5) == rs_atan(p, x, 5)
+
+    R, x = ring('x', EX)
+    p = x**2 + 2*x
+    assert _atan(p, x, 9) == rs_atan(p, x, 9)
+
 
 def test_asin():
     R, x, y = ring('x, y', QQ)
@@ -277,6 +299,7 @@ def test_asin():
         x**3/6 + x*y + x
     assert rs_asin(x*y + x**2*y**3, x, 6) == x**5*y**7/2 + 3*x**5*y**5/40 + \
         x**4*y**5/2 + x**3*y**3/6 + x**2*y**3 + x*y
+
 
 def test_tan():
     R, x, y = ring('x, y', QQ)
@@ -343,6 +366,7 @@ def test_sin():
         EX(cos(a)/6)*x**3 + EX(cos(a))*x**2*y - EX(sin(a)/2)*x**2 + \
         EX(cos(a))*x + EX(sin(a))
 
+
 def test_cos():
     R, x, y = ring('x, y', QQ)
     assert rs_cos(x, x, 9) == 1 - x**2/2 + x**4/24 - x**6/720 + x**8/40320
@@ -367,6 +391,7 @@ def test_cos():
         EX(sin(a)/2)*x**4*y + EX(cos(a)/24)*x**4 - EX(cos(a))*x**3*y + \
         EX(sin(a)/6)*x**3 - EX(sin(a))*x**2*y - EX(cos(a)/2)*x**2 - \
         EX(sin(a))*x + EX(cos(a))
+
 
 def test_cos_sin():
     R, x, y = ring('x, y', QQ)
@@ -393,14 +418,6 @@ def test_cos_sin():
     assert c == rs_cos(x + a, x, 5)
     assert s == rs_sin(x + a, x, 5)
 
-def test_fast_atanh():
-    R,x  = ring('x', QQ)
-    p = x**2 + 2*x
-    assert _atanh(p, x, 5) == rs_atanh(p, x, 5)
-
-    R,x = ring('x', EX)
-    p = x**2 + 2*x
-    assert _atanh(p, x, 9) == rs_atanh(p, x, 9)
 
 def test_atanh():
     R, x, y = ring('x, y', QQ)
@@ -424,6 +441,16 @@ def test_atanh():
     p = x + x**2 + 5
     assert rs_atanh(p, x, 10).compose(x, 10) == EX(Rational(-733442653682135, 5079158784) \
         + atanh(5))
+    
+    # Test for _atanh faster for small and univariate series
+    R,x  = ring('x', QQ)
+    p = x**2 + 2*x
+    assert _atanh(p, x, 5) == rs_atanh(p, x, 5)
+
+    R,x = ring('x', EX)
+    p = x**2 + 2*x
+    assert _atanh(p, x, 9) == rs_atanh(p, x, 9)
+
 
 def test_asinh():
     R, x, y = ring('x, y', QQ)
@@ -443,6 +470,7 @@ def test_asinh():
     p = x + x ** 2 + 5
     assert rs_asinh(p, x, 10).compose(x, 10) == EX(asinh(5) + 4643789843094995*sqrt(26)/\
         205564141692)
+
 
 def test_sinh():
     R, x, y = ring('x, y', QQ)
@@ -492,6 +520,7 @@ def test_cosh():
         2)*x**4*y + EX(cosh(a)/24)*x**4 + EX(cosh(a))*x**3*y + EX(sinh(a)/6)*x**3 \
         + EX(sinh(a))*x**2*y + EX(cosh(a)/2)*x**2 + EX(sinh(a))*x + EX(cosh(a))
 
+
 def test_cosh_sinh():
     R, x, y = ring('x, y', QQ)
     ch, sh = rs_cosh_sinh(x, x, 9)
@@ -516,6 +545,7 @@ def test_cosh_sinh():
     assert ch == rs_cosh(x + a, x, 5)
     assert sh == rs_sinh(x + a, x, 5)
 
+
 def test_tanh():
     R, x, y = ring('x, y', QQ)
     assert rs_tanh(x, x, 9) == x - QQ(1,3)*x**3 + QQ(2,15)*x**5 - QQ(17,315)*x**7
@@ -534,6 +564,7 @@ def test_tanh():
     p = rs_tanh(x + x**2*y + a, x, 4)
     assert (p.compose(x, 10)).compose(y, 5) == EX(-1000*tanh(a)**4 + \
         10100*tanh(a)**3 + 2470*tanh(a)**2/3 - 10099*tanh(a) + QQ(530, 3))
+
 
 def test_RR():
     rs_funcs = [rs_sin, rs_cos, rs_tan, rs_cot, rs_atan, rs_tanh]
@@ -768,27 +799,28 @@ def test_rs_series_ConstantInExpr():
             x**5*a**10/5 - x**4*a**8/4 + x**3*a**6/3 - x**2*a**4/2 + x*a**2
 
     assert rs_series(atan(1 + x), x, 9).as_expr() == -x**7/112 + x**6/48 - x**5/40 \
-           + x**3/12 - x**2/4 + x/2 + pi/4
+            + x**3/12 - x**2/4 + x/2 + pi/4
     assert rs_series(atan(1 + x + x**2),x, 9).as_expr() == -15*x**7/112 - x**6/48 + \
-           9*x**5/40 - 5*x**3/12 + x**2/4 + x/2 + pi/4
+            9*x**5/40 - 5*x**3/12 + x**2/4 + x/2 + pi/4
     assert rs_series(atan(1 + x * a), x, 9).as_expr() == -a**7*x**7/112 + a**6*x**6/48 \
-           - a**5*x**5/40 + a**3*x**3/12 - a**2*x**2/4 + a*x/2 + pi/4
+            - a**5*x**5/40 + a**3*x**3/12 - a**2*x**2/4 + a*x/2 + pi/4
 
     assert rs_series(tanh(1 + x), x, 5).as_expr() == -5*x**4*tanh(1)**3/3 + x**4* \
-           tanh(1)**5 + 2*x**4*tanh(1)/3 - x**3*tanh(1)**4 - x**3/3 + 4*x**3*tanh(1) \
+            tanh(1)**5 + 2*x**4*tanh(1)/3 - x**3*tanh(1)**4 - x**3/3 + 4*x**3*tanh(1) \
            **2/3 - x**2*tanh(1) + x**2*tanh(1)**3 - x*tanh(1)**2 + x + tanh(1)
     assert rs_series(tanh(1 + x * a), x, 3).as_expr() == -a**2*x**2*tanh(1) + a**2*x** \
-           2*tanh(1)**3 - a*x*tanh(1)**2 + a*x + tanh(1)
+            2*tanh(1)**3 - a*x*tanh(1)**2 + a*x + tanh(1)
 
     assert rs_series(sinh(1 + x), x, 5).as_expr() == x**4*sinh(1)/24 + x**3*cosh(1)/6 + \
-           x**2*sinh(1)/2 + x*cosh(1) + sinh(1)
+            x**2*sinh(1)/2 + x*cosh(1) + sinh(1)
     assert rs_series(sinh(1 + x * a), x, 5).as_expr() == a**4*x**4*sinh(1)/24 + \
-           a**3*x**3*cosh(1)/6 + a**2*x**2*sinh(1)/2 + a*x*cosh(1) + sinh(1)
+            a**3*x**3*cosh(1)/6 + a**2*x**2*sinh(1)/2 + a*x*cosh(1) + sinh(1)
 
     assert rs_series(cosh(1 + x), x, 5).as_expr() == x**4*cosh(1)/24 + x**3*sinh(1)/6 + \
-           x**2*cosh(1)/2 + x*sinh(1) + cosh(1)
+            x**2*cosh(1)/2 + x*sinh(1) + cosh(1)
     assert rs_series(cosh(1 + x * a), x, 5).as_expr() == a**4*x**4*cosh(1)/24 + \
-           a**3*x**3*sinh(1)/6 + a**2*x**2*cosh(1)/2 + a*x*sinh(1) + cosh(1)
+            a**3*x**3*sinh(1)/6 + a**2*x**2*cosh(1)/2 + a*x*sinh(1) + cosh(1)
+
 
 def test_issue():
     # https://github.com/sympy/sympy/issues/10191

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -586,6 +586,18 @@ def test_puiseux():
     assert r ==  x**QQ(9,5)*y**9/9 + x**QQ(9,5)*y**4 - x**QQ(7,5)*y**7/7 - \
         x**QQ(7,5)*y**2 + x*y**5/5 + x - x**QQ(3,5)*y**3/3 + x**QQ(1,5)*y
 
+    r = rs_tan(p, x, 2)
+    assert r == x**QQ(2,5) + x**QQ(2,3) + x + QQ(1,3)*x**QQ(6,5) + x**QQ(22,15)\
+        + x**QQ(26,15) + x**QQ(9,5)
+
+    r = rs_sin(p, x, 2)
+    assert r == x**QQ(2,5) + x**QQ(2,3) + x - QQ(1,6)*x**QQ(6,5) - QQ(1,2)*x**\
+        QQ(22,15) - QQ(1,2)*x**QQ(26,15) - QQ(1,2)*x**QQ(9,5)
+
+    r = rs_cos(p, x, 2)
+    assert r == 1 - QQ(1,2)*x**QQ(4,5) - x**QQ(16,15) - QQ(1,2)*x**QQ(4,3) - \
+        x**QQ(7,5) + QQ(1,24)*x**QQ(8,5) - x**QQ(5,3) + QQ(1,6)*x**QQ(28,15)
+
     r = rs_asin(p, x, 2)
     assert r == x**QQ(9,5)/2 + x**QQ(26,15)/2 + x**QQ(22,15)/2 + \
         x**QQ(6,5)/6 + x + x**QQ(2,3) + x**QQ(2,5)
@@ -604,6 +616,10 @@ def test_puiseux():
     r = rs_atanh(p, x, 2)
     assert r == x**QQ(9,5) + x**QQ(26,15) + x**QQ(22,15) + x**QQ(6,5)/3 + x + \
         x**QQ(2,3) + x**QQ(2,5)
+
+    r = rs_asinh(p, x, 2)
+    assert r == x**QQ(2,5) + x**QQ(2,3) + x - QQ(1,6)*x**QQ(6,5) - QQ(1,2)*x**\
+        QQ(22,15) - QQ(1,2)*x**QQ(26,15) - QQ(1,2)*x**QQ(9,5)
 
     r = rs_cosh(p, x, 2)
     assert r == x**QQ(28,15)/6 + x**QQ(5,3) + x**QQ(8,5)/24 + x**QQ(7,5) + \

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -4,9 +4,9 @@ from sympy.polys.puiseux import puiseux_ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_hadamard_exp,
     rs_series_from_list, rs_exp, rs_log, rs_newton, rs_series_inversion,
-    rs_compose_add, rs_asin, rs_atan, rs_atanh, rs_asinh, rs_tan, rs_cot, rs_sin,
-    rs_cos, rs_cos_sin, rs_sinh, rs_cosh, rs_cosh_sinh, rs_tanh, _tan1, rs_fun,
-    rs_nth_root, rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
+    rs_compose_add, rs_asin, rs_atan, _atanh, rs_atanh, rs_asinh, rs_tan, rs_cot,
+    rs_sin, rs_cos, rs_cos_sin, rs_sinh, rs_cosh, rs_cosh_sinh, rs_tanh, _tan1,
+    rs_fun, rs_nth_root, rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
 from sympy.testing.pytest import raises, slow
 from sympy.core.symbol import symbols
 from sympy.functions import (sin, cos, exp, tan, cot, sinh, cosh, atan, atanh,
@@ -392,6 +392,15 @@ def test_cos_sin():
     c, s = rs_cos_sin(x + a, x, 5)
     assert c == rs_cos(x + a, x, 5)
     assert s == rs_sin(x + a, x, 5)
+
+def test_fast_atanh():
+    R,x  = ring('x', QQ)
+    p = x**2 + 2*x
+    assert _atanh(p, x, 5) == rs_atanh(p, x, 5)
+
+    R,x = ring('x', EX)
+    p = x**2 + 2*x
+    assert _atanh(p, x, 9) == rs_atanh(p, x, 9)
 
 def test_atanh():
     R, x, y = ring('x, y', QQ)


### PR DESCRIPTION
### Brief description of what is fixed or changed

- Refactored the `rs_ `function in ring_series.py by removing redundant constant checks and eliminating an unnecessary `else` block, resulting in cleaner and more efficient code.
- Added unit tests for previously untested functions `_atan` and `_atanh`.
- Included a missing test case for an `rs_` function in `test_puiseux` to enhance overall test coverage.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->