### PR TITLE
Add the `FURB` rule of ruff to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ lint.select = [
     "C4",
     "E",
     "F",
+    "FURB",
     "LOG",
     "PIE810",
     "PLE",
@@ -70,6 +71,9 @@ lint.ignore = [
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "E741",  # Ambiguous variable name: `<VARIABLE>`
     "E743",  # Ambiguous function name: `<FUNCTION>`
+    # Rules from the stable "FURB" set that are ignored. See #27897
+    "FURB161",  # Use of `bin({existing}).count('1')`
+    "FURB187",  # Use of assignment of `reversed` on list `{name}`
 ]
 
 # Exclude paths currently excluded in the flake8 configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ lint.ignore = [
     "E741",  # Ambiguous variable name: `<VARIABLE>`
     "E743",  # Ambiguous function name: `<FUNCTION>`
     # Rules from the stable "FURB" set that are ignored. See #27897
+    # Just to be safe, we'll ignore FURB161 until we drop support for Python 3.9
     "FURB161",  # Use of `bin({existing}).count('1')`
     "FURB187",  # Use of assignment of `reversed` on list `{name}`
 ]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27897

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
