### PR TITLE
printing: Deprecate aesaracode

### DIFF
--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -260,11 +260,6 @@ Most code printers generate Python strings, and therefore do not require the
 given library or language compiler as a dependency. However, a few code
 printers generate Python functions instead of strings:
 
-- **Aesara**: The {mod}`sympy.printing.aesaracode` module contains functions
-  to convert SymPy expressions into a functions using the
-  [Aeseara](https://aesara.readthedocs.io/en/latest) (previously Theano)
-  library. The Aesara code generation functions return Aesara graph objects.
-
 - **llvmlite**: The `sympy.printing.llvmjitcode` module supports generating LLVM Jit
   from a SymPy expression. The functions make use of
   [llvmlite](https://llvmlite.readthedocs.io/en/latest/), a Python wrapper

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -114,6 +114,11 @@ its usage is in their own code.
 The existing implementation will remain, along with its tests for at least
 one year after the 1.14 release.
 
+(deprecated-aesaraprinter)=
+### Deprecated aesaracode from printing
+sympy's aesaracode module is deprecated because aesara itself
+is umaintained and cannot be installed on Python 3.13.
+
 ## Version 1.13
 
 (deprecated-mechanics-body-class)=

--- a/doc/src/explanation/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
+++ b/doc/src/explanation/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
@@ -682,11 +682,6 @@ The tools in the PyDy workflow are :
     offers introspection, rich media, shell syntax, tab completion,
     and history.
 
--  `Aesara <https://aesara.readthedocs.io/en/latest/>`_: Aesara is
-    a numerical computation library for Python. In Aesara,
-    computations are expressed using a NumPy-esque syntax and
-    compiled to run efficiently on either CPU or GPU architectures.
-
 -  `Cython <https://cython.org/>`_: Cython is a superset of the
     Python programming language, designed to give C-like performance
     with code that is mostly written in Python. Cython is a compiled

--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -59,9 +59,8 @@ This is where the meat of code generation is; the translation of SymPy
 actually more like a lightweight version of codegen for Python, and
 Python (:py:func:`sympy.printing.pycode.pycode`), and
 :py:func:`sympy.printing.lambdarepr.lambdarepr`, which supports many libraries
-(like NumPy), and Aesara
-(:py:func:`sympy.printing.aesaracode.aesara_function`). The code printers are
-special cases of the other prints in SymPy (str printer, pretty printer, etc.).
+(like NumPy). The code printers are special cases of the other prints
+in SymPy (str printer, pretty printer, etc.).
 
 An important distinction is that the code printer has to deal with assignments
 (using the :class:`sympy.codegen.ast.Assignment` object). This serves as

--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -13,8 +13,7 @@ Fortunately SymPy offers a number of easy-to-use hooks into other numeric
 systems, allowing you to create mathematical expressions in SymPy and then
 ship them off to the numeric system of your choice.  This page documents many
 of the options available including the ``math`` library, the popular array
-computing package ``numpy``, code generation in ``Fortran`` or ``C``, and the
-use of the array compiler ``Aesara``.
+computing package ``numpy``, code generation in ``Fortran`` or ``C``.
 
 Subs/evalf
 ----------
@@ -117,6 +116,11 @@ The API reference of all the above is listed here: :py:func:`sympy.utilities.aut
 Aesara
 ------
 
+.. deprecated:: 1.14.
+    The ``Aesara Code printing`` is deprecated.See its documentation for
+    more information. See :ref:`deprecated-aesaraprinter` for details.
+
+
 SymPy has a strong connection with
 `Aesara <https://aesara.readthedocs.io/en/latest/>`_, a mathematical array
 compiler.  SymPy expressions can be easily translated to Aesara graphs and then
@@ -143,11 +147,10 @@ So Which Should I Use?
 ----------------------
 
 The options here were listed in order from slowest and least dependencies to
-fastest and most dependencies.  For example, if you have Aesara installed then
-that will often be the best choice.  If you don't have Aesara but do have
-``f2py`` then you should use ``ufuncify``. If you have been comfortable using
-lambdify with the numpy module, but have a GPU, CuPy and JAX can provide substantial
-speedups with little effort.
+fastest and most dependencies. For example, If you have f2py installed,
+then you should use ufuncify, as that will often be the best choice.
+If you have been comfortable using lambdify with the numpy module,
+but have a GPU, CuPy and JAX can provide substantial speedups with little effort.
 
 +-----------------+-------+------------------------------------------+---------------+
 | Tool            | Speed | Qualities                                | Dependencies  |
@@ -163,6 +166,4 @@ speedups with little effort.
 | lambdify-cupy   | 10ns  | Vector functions on GPUs                 | cupy          |
 +-----------------+-------+------------------------------------------+---------------+
 | lambdify-jax    | 10ns  | Vector functions on CPUs, GPUs and TPUs  | jax           |
-+-----------------+-------+------------------------------------------+---------------+
-| Aesara          | 10ns  | Many outputs, CSE, GPUs                  | Aesara        |
 +-----------------+-------+------------------------------------------+---------------+

--- a/sympy/printing/aesaracode.py
+++ b/sympy/printing/aesaracode.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from sympy.external import import_module
 from sympy.printing.printer import Printer
+from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
 import sympy
 from functools import partial
@@ -79,7 +80,12 @@ if aesara:
 
 
 class AesaraPrinter(Printer):
-    """ Code printer which creates Aesara symbolic expression graphs.
+    """
+    .. deprecated:: 1.14.
+        The ``Aesara Code printing`` is deprecated.See its documentation for
+        more information. See :ref:`deprecated-aesaraprinter` for details.
+
+    Code printer which creates Aesara symbolic expression graphs.
 
     Parameters
     ==========
@@ -347,6 +353,14 @@ def aesara_code(expr, cache=None, **kwargs):
         expression graph.
 
     """
+    sympy_deprecation_warning(
+        """
+        The aesara_code function is deprecated.
+        """,
+        deprecated_since_version="1.14",
+        active_deprecations_target='deprecated-aesaraprinter',
+    )
+
     if not aesara:
         raise ImportError("aesara is required for aesara_code")
 
@@ -492,6 +506,14 @@ def aesara_function(inputs, outputs, scalar=False, *,
     dim_handling
 
     """
+    sympy_deprecation_warning(
+        """
+        The aesara_function function is deprecated.
+        """,
+        deprecated_since_version="1.14",
+        active_deprecations_target='deprecated-aesaraprinter',
+    )
+
     if not aesara:
         raise ImportError("Aesara is required for aesara_function")
 

--- a/sympy/printing/tests/test_aesaracode.py
+++ b/sympy/printing/tests/test_aesaracode.py
@@ -10,7 +10,7 @@ cache instead.
 import logging
 
 from sympy.external import import_module
-from sympy.testing.pytest import raises, SKIP
+from sympy.testing.pytest import raises, SKIP, warns_deprecated_sympy
 
 from sympy.utilities.exceptions import ignore_warnings
 
@@ -56,12 +56,14 @@ f_t = sy.Function('f')(t)
 def aesara_code_(expr, **kwargs):
     """ Wrapper for aesara_code that uses a new, empty cache by default. """
     kwargs.setdefault('cache', {})
-    return aesara_code(expr, **kwargs)
+    with warns_deprecated_sympy():
+        return aesara_code(expr, **kwargs)
 
 def aesara_function_(inputs, outputs, **kwargs):
     """ Wrapper for aesara_function that uses a new, empty cache by default. """
     kwargs.setdefault('cache', {})
-    return aesara_function(inputs, outputs, **kwargs)
+    with warns_deprecated_sympy():
+        return aesara_function(inputs, outputs, **kwargs)
 
 
 def fgraph_of(*exprs):
@@ -515,8 +517,9 @@ def test_global_cache():
         global_cache.clear()
 
         for s in [x, X, f_t]:
-            st = aesara_code(s)
-            assert aesara_code(s) is st
+            with warns_deprecated_sympy():
+                st = aesara_code(s)
+                assert aesara_code(s) is st
 
     finally:
         # Restore global cache
@@ -543,7 +546,8 @@ def test_cache_types_distinct():
 
     # Check retrieving
     for s, st in printed.items():
-        assert aesara_code(s, cache=cache) is st
+        with warns_deprecated_sympy():
+            assert aesara_code(s, cache=cache) is st
 
 def test_symbols_are_created_once():
     """
@@ -613,14 +617,17 @@ def test_Relationals():
 
 def test_complexfunctions():
     dtypes = {x:'complex128', y:'complex128'}
-    xt, yt = aesara_code(x, dtypes=dtypes), aesara_code(y, dtypes=dtypes)
+    with warns_deprecated_sympy():
+        xt, yt = aesara_code(x, dtypes=dtypes), aesara_code(y, dtypes=dtypes)
     from sympy.functions.elementary.complexes import conjugate
     from aesara.tensor import as_tensor_variable as atv
     from aesara.tensor import complex as cplx
-    assert theq(aesara_code(y*conjugate(x), dtypes=dtypes), yt*(xt.conj()))
-    assert theq(aesara_code((1+2j)*x), xt*(atv(1.0)+atv(2.0)*cplx(0,1)))
+    with warns_deprecated_sympy():
+        assert theq(aesara_code(y*conjugate(x), dtypes=dtypes), yt*(xt.conj()))
+        assert theq(aesara_code((1+2j)*x), xt*(atv(1.0)+atv(2.0)*cplx(0,1)))
 
 
 def test_constantfunctions():
-    tf = aesara_function([],[1+1j])
+    with warns_deprecated_sympy():
+        tf = aesara_function([],[1+1j])
     assert(tf()==1+1j)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#27784
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The aesaracode.py in sympy.printing module has been deprecated  because aesara itself is umaintained and cannot be installed on Python 3.13.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Breaking change: The aesaracode in sympy.printing has been deprecated.  
<!-- END RELEASE NOTES -->
