### PR TITLE
maint(release): bump version to 1.15.0.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,18 @@ name: release
 on:
   push:
     branches:
-      - '1.14'
+      - '1.15'
     tags:
-      - 'sympy-1.14.*'
+      - 'sympy-1.15.*'
   pull_request:
     branches:
-      - '1.14'
+      - '1.15'
 env:
-  release_branch: '1.14'
-  release_version: '1.14.0-dev'
-  final_release_version: '1.14.0'
-  previous_version: '1.13.0'
-  dev_version: '1.14-dev'
+  release_branch: '1.15'
+  release_version: '1.15.0-dev'
+  final_release_version: '1.15.0'
+  previous_version: '1.14.0'
+  dev_version: '1.15-dev'
 
 jobs:
 
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build release files
         run: release/ci_release_script.sh ${{ env.release_version }} ${{ env.previous_version }}

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -74,6 +74,10 @@ will need to either add a `warnings` filter as above or use pytest to filter
 SymPy deprecation warnings.
 ```
 
+## Version 1.15
+
+There are no deprecations yet for SymPy 1.15.
+
 ## Version 1.14
 
 (deprecated-tensorproduct-simp)=

--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "1.14.dev"
+__version__ = "1.15.0.dev"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/issues/27939

#### Brief description of what is fixed or changed

Bump `sympy.__version__` to 1.15.0.dev on the master branch.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
