### PR TITLE
fix(test): disable doctests that give warnings

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -160,15 +160,15 @@ motion.
 >>> from sympy.physics.mechanics import (
 ...   Body, JointsMethod, PinJoint, PrismaticJoint)
 >>> g, l = symbols("g l")
->>> wall = Body("wall")
->>> cart = Body("cart")
->>> pendulum = Body("Pendulum")
->>> slider = PrismaticJoint("s", wall, cart, joint_axis=wall.x)
+>>> wall = Body("wall") # doctest: +SKIP
+>>> cart = Body("cart") # doctest: +SKIP
+>>> pendulum = Body("Pendulum") # doctest: +SKIP
+>>> slider = PrismaticJoint("s", wall, cart, joint_axis=wall.x) # doctest: +SKIP
 >>> pin = PinJoint("j", cart, pendulum, joint_axis=cart.z,
-...                child_point=l * pendulum.y)
->>> pendulum.masscenter.set_vel(pendulum.frame, 0)
->>> cart.apply_force(-g * cart.mass * wall.y)
->>> pendulum.apply_force(-g * pendulum.mass * wall.y)
+...                child_point=l * pendulum.y) # doctest: +SKIP
+>>> pendulum.masscenter.set_vel(pendulum.frame, 0) # doctest: +SKIP
+>>> cart.apply_force(-g * cart.mass * wall.y) # doctest: +SKIP
+>>> pendulum.apply_force(-g * pendulum.mass * wall.y) # doctest: +SKIP
 >>> method = JointsMethod(wall, slider, pin)  # doctest: +SKIP
 >>> method.form_eoms()  # doctest: +SKIP
 Matrix([
@@ -485,7 +485,7 @@ integers modulo ``n`` and can be used like:
 >>> from sympy import GF
 >>> K = GF(5)
 >>> a = K(7)
->>> a
+>>> a # doctest: +SKIP
 2 mod 5
 ```
 
@@ -593,7 +593,7 @@ If you are using these functions, change from
 
 ```py
 >>> from sympy import carmichael
->>> carmichael.is_carmichael(561)
+>>> carmichael.is_carmichael(561) # doctest: +SKIP
 True
 ```
 
@@ -655,7 +655,7 @@ joint was:
 
 ```py
 >>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child')
+>>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
 >>> pin = PinJoint('pin', parent, child, parent_axis=parent.z,
 ...                child_axis=-child.z)   # doctest: +SKIP
 >>> parent.dcm(child)   # doctest: +SKIP
@@ -673,12 +673,12 @@ this exact rotation:
 ```py
 >>> from sympy import pi
 >>> from sympy.physics.mechanics import Body, PinJoint, ReferenceFrame
->>> parent, child, = Body('parent'), Body('child')
->>> int_frame = ReferenceFrame('int_frame')
->>> int_frame.orient_axis(child.frame, child.y, pi)
+>>> parent, child, = Body('parent'), Body('child') # doctest: +SKIP
+>>> int_frame = ReferenceFrame('int_frame') # doctest: +SKIP
+>>> int_frame.orient_axis(child.frame, child.y, pi) # doctest: +SKIP
 >>> pin = PinJoint('pin', parent, child, joint_axis=parent.z,
-...                child_interframe=int_frame)
->>> parent.dcm(child)
+...                child_interframe=int_frame) # doctest: +SKIP
+>>> parent.dcm(child) # doctest: +SKIP
 Matrix([
 [-cos(q_pin(t)), -sin(q_pin(t)),  0],
 [-sin(q_pin(t)),  cos(q_pin(t)),  0],
@@ -693,10 +693,10 @@ given vector:
 
 ```py
 >>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child')
+>>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
 >>> pin = PinJoint('pin', parent, child, parent_interframe=parent.z,
-...                child_interframe=-child.z)
->>> parent.dcm(child)
+...                child_interframe=-child.z) # doctest: +SKIP
+>>> parent.dcm(child) # doctest: +SKIP
 Matrix([
 [-cos(q_pin(t)), -sin(q_pin(t)),  0],
 [-sin(q_pin(t)),  cos(q_pin(t)),  0],
@@ -718,7 +718,7 @@ For example, suppose you want a ``PinJoint`` in the parent to be positioned at
 
 ```py
 >>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child')
+>>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
 >>> pin = PinJoint('pin', parent, child, parent_joint_pos=parent.frame.x,
 ...                child_joint_pos=-child.frame.x)   # doctest: +SKIP
 >>> pin.parent_point.pos_from(parent.masscenter)   # doctest: +SKIP
@@ -731,12 +731,12 @@ Now you can do the same with either
 
 ```py
 >>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child')
+>>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
 >>> pin = PinJoint('pin', parent, child, parent_point=parent.frame.x,
-...                child_point=-child.frame.x)
->>> pin.parent_point.pos_from(parent.masscenter)
+...                child_point=-child.frame.x) # doctest: +SKIP
+>>> pin.parent_point.pos_from(parent.masscenter) # doctest: +SKIP
 parent_frame.x
->>> pin.child_point.pos_from(child.masscenter)
+>>> pin.child_point.pos_from(child.masscenter) # doctest: +SKIP
 - child_frame.x
 ```
 
@@ -744,14 +744,14 @@ Or
 
 ```py
 >>> from sympy.physics.mechanics import Body, PinJoint, Point
->>> parent, child = Body('parent'), Body('child')
->>> parent_point = parent.masscenter.locatenew('parent_point', parent.frame.x)
->>> child_point = child.masscenter.locatenew('child_point', -child.frame.x)
+>>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
+>>> parent_point = parent.masscenter.locatenew('parent_point', parent.frame.x) # doctest: +SKIP
+>>> child_point = child.masscenter.locatenew('child_point', -child.frame.x) # doctest: +SKIP
 >>> pin = PinJoint('pin', parent, child, parent_point=parent_point,
-...                child_point=child_point)
->>> pin.parent_point.pos_from(parent.masscenter)
+...                child_point=child_point) # doctest: +SKIP
+>>> pin.parent_point.pos_from(parent.masscenter) # doctest: +SKIP
 parent_frame.x
->>> pin.child_point.pos_from(child.masscenter)
+>>> pin.child_point.pos_from(child.masscenter) # doctest: +SKIP
 - child_frame.x
 ```
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -272,7 +272,7 @@ class IdentityOperator(Operator):
     ========
 
     >>> from sympy.physics.quantum import IdentityOperator
-    >>> IdentityOperator()
+    >>> IdentityOperator() # doctest: +SKIP
     I
     """
     is_hermitian = True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/26319

#### Brief description of what is fixed or changed

Disable doctests that print warnings.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
