### PR TITLE
maint(release): fix release workflow syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,23 @@ jobs:
         # used by the build script should be pinned...
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
 
+  # -------------------- Check if this is a final release ---------- #
+
+  check-final:
+    name: Check whether the release is final
+    needs: [build, pypi-publish]
+    runs-on: ubuntu-latest
+    outputs:
+      # The env context is not available in jobs.<job id>.if so we set it here
+      is-final: ${{ env.release_version == env.final_release_version }}
+    steps:
+      - run: echo "null"
+
   # -------------------- Make a GitHub release --------------------- #
 
   github-publish:
     name: Publish GitHub release
-    needs: [build, pypi-publish]
+    needs: [check-final]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -163,30 +175,26 @@ jobs:
           name: release_files
           path: dist
 
-      - name: Create GitHub release
+      - name: Create GitHub prerelease
+        if: ${{ needs.check-final.outputs.is-final != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-       run: |
-          if [[ ${{ env.release_version }} == ${{ env.final_release_version }} ]]; then
-            PRERELEASE='--prerelease'
-          fi
-          gh release create ${{ env.release_version }} dist/* \
-              $PRERELEASE                                     \
-              --title "SymPy ${{ env.release_version }}"      \
+        run: >
+          gh release create ${{ env.release_version }} dist/*
+              --prerelease
+              --title "SymPy ${{ env.release_version }}"
+              --notes "See https://github.com/sympy/sympy/wiki/release-notes-for-${{ env.final_release_version }} for release notes"
+
+      - name: Create Final GitHub release
+        if: ${{ needs.check-final.outputs.is-final == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release create ${{ env.release_version }} dist/*
+              --title "SymPy ${{ env.release_version }}"
               --notes "See https://github.com/sympy/sympy/wiki/release-notes-for-${{ env.final_release_version }} for release notes"
 
   # -------------------- Update the docs repository ---------------- #
-
-  # Dummy job to determine whether the release is final
-  check-final:
-    name: Check whether the release is final
-    needs: [build, pypi-publish]
-    runs-on: ubuntu-latest
-    outputs:
-      # The env context is not available in jobs.<job id>.if so we set it here
-      is-final: ${{ env.release_version == env.final_release_version }}
-    steps:
-      - run: echo "null"
 
   update-docs:
     name: Update the docs repository


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

New attempt at gh-26747 after https://github.com/sympy/sympy/pull/27942#issuecomment-2800153295.

#### Brief description of what is fixed or changed

Hopefully fixes the workflow syntax.

#### Other comments

We won't know if this works until merging it.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
