### PR TITLE
Fix: `discrete_log` function raising an error when given a nonprime order as a parameter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -263,6 +263,7 @@ Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 Alec Kalinin <alec.kalinin@gmail.com>
 Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com> AlexGarciaPrada <114813960+AlexGarciaPrada@users.noreply.github.com>
+Aleksa Prtenjača <aleksa.prtenjaca03@gmail.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
 Alex Argunov <sajkoooo@gmail.com>
 Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -263,7 +263,7 @@ Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
 Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
 Alec Kalinin <alec.kalinin@gmail.com>
 Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com> AlexGarciaPrada <114813960+AlexGarciaPrada@users.noreply.github.com>
-Aleksa Prtenjača <aleksa.prtenjaca03@gmail.com>
+Aleksa Prtenjača <aleksa.prtenjaca03@gmail.com> Aleksa Prtenjača <48697336+Prki42@users.noreply.github.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
 Alex Argunov <sajkoooo@gmail.com>
 Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1616,7 +1616,7 @@ def _discrete_log_with_prime_order(n, a, b, order):
         Vanstone, S. A. (1997).
 
     """
-    from math import log
+    from math import log, sqrt
 
     # Shanks and Pollard rho are O(sqrt(order)) while index calculus is O(exp(2*sqrt(log(n)log(log(n)))))
     # we compare the expected running times to determine the algorithm which is expected to be faster

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1668,7 +1668,7 @@ def discrete_log(n, a, b, order=None, prime_order=None):
         return 0
 
     if prime_order is not None and not isinstance(prime_order, bool):
-        raise ValueError("prime_order should be a boolean")
+        raise TypeError("prime_order should be a boolean")
 
     if order is not None:
         order = as_int(order)

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -12,7 +12,7 @@ from sympy.ntheory.residue_ntheory import _primitive_root_prime_iter, \
     _primitive_root_prime_power_iter, _primitive_root_prime_power2_iter, \
     _nthroot_mod_prime_power, _discrete_log_trial_mul, _discrete_log_shanks_steps, \
     _discrete_log_pollard_rho, _discrete_log_index_calculus, _discrete_log_pohlig_hellman, \
-    _binomial_mod_prime_power, binomial_mod
+    _discrete_log_with_prime_order, _binomial_mod_prime_power, binomial_mod
 from sympy.polys.domains import ZZ
 from sympy.testing.pytest import raises
 from sympy.core.random import randint, choice
@@ -265,6 +265,10 @@ def test_residue():
     assert _discrete_log_pohlig_hellman(78723213, 11**31, 11) == 31
     assert _discrete_log_pohlig_hellman(32942478, 11**98, 11) == 98
     assert _discrete_log_pohlig_hellman(14789363, 11**444, 11) == 444
+    assert _discrete_log_with_prime_order(131, 63, 107, 13) == 11
+    assert _discrete_log_with_prime_order(928858687, 680878378, 414021216, 5351) == 1456
+    assert _discrete_log_with_prime_order(1800089287, 565636273, 1234453013, 3) == 2
+    assert _discrete_log_with_prime_order(309619555093087, 140898220853159, 57600725599583, 7371894168883) == 152868906156
     assert discrete_log(1, 0, 2) == 0
     raises(ValueError, lambda: discrete_log(-4, 1, 3))
     raises(ValueError, lambda: discrete_log(10, 3, 2))
@@ -279,6 +283,10 @@ def test_residue():
     args = 5779, 3528, 6215
     assert discrete_log(*args) == 687
     assert discrete_log(*Tuple(*args)) == 687
+    assert discrete_log(2326570877, 1286723896, 268435456, 83091817, False) == 39680941
+    assert discrete_log(7247914829, 1680923475, 6396875911, 997, True) == 624
+    raises(ValueError, lambda: discrete_log(11, 7, 2, 0))
+    raises(TypeError, lambda: discrete_log(11, 7, 2, 6, 16))
     assert quadratic_congruence(400, 85, 125, 1600) == [295, 615, 935, 1255, 1575]
     assert quadratic_congruence(3, 6, 5, 25) == [3, 20]
     assert quadratic_congruence(120, 80, 175, 500) == []


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
/
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed
When `discrete_log` is called with the `order` parameter set as a nonprime number, `order_factors` dictionary is not created and the function breaks when trying to call `_discrete_log_pohlig_hellman()` at the end (if the `order` is greater than 1000).

**Example**: `discrete_log(31063, 5774, 729, 5177)` raises `UnboundLocalError: cannot access local variable 'order_factors' where it is not associated with a value`

**Changes**
- `discrete_log()` now does basic checks for `order` and `prime_order` parameters (since it is a public-facing function). 
- inside `discrete_log()`, `group_order` variable is now used to denote the group order (totient(`n`)) and `order` is used for the order of the base `b`.
- `discrete_log()` only calculates the `order_factors` when needed.
- Introduced `_discrete_log_with_prime_order()` for refactoring purposes.
- Added tests.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* ntheory
  * `discrete_log` function no longer errors when given a large nonprime order as a parameter

<!-- END RELEASE NOTES -->
