### PR TITLE
core: deprecate Rational(2, 4, gcd=1)

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,6 +76,17 @@ SymPy deprecation warnings.
 
 ## Version 1.14
 
+(deprecated-rational-gcd)=
+### The gcd parameter to Rational
+
+The ``gcd`` parameter to the ``Rational`` constructor can be used to create an
+unevaluated Rational like ``Rational(2, 4, gcd=1)`` in which the numerator and
+denominator are not reduced. This is now deprecated and unevaluated rationals
+will be removed entirely in a future version of SymPy. This is needed so that
+more efficient implementations of rational numbers can be used internally.
+Instead use something like ``Mul(2, Rational(1, 4), evaluate=False)`` or
+``Symbol('2')/Symbol('4')`` depending on what exactly is wanted.
+
 (deprecated-tensorproduct-simp)=
 ### Deprecated tensor_product_simp from physics.quantum
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -33,6 +33,7 @@ from mpmath.libmp.libmpf import (
     fnan as _mpf_nan, fzero, _normalize as mpf_normalize,
     prec_to_dps, dps_to_prec)
 from sympy.utilities.misc import debug
+from sympy.utilities.exceptions import sympy_deprecation_warning
 from .parameters import global_parameters
 
 _LOG2 = math.log(2)
@@ -1286,16 +1287,6 @@ class Rational(Number):
     >>> r.p/r.q
     0.75
 
-    If an unevaluated Rational is desired, ``gcd=1`` can be passed and
-    this will keep common divisors of the numerator and denominator
-    from being eliminated. It is not possible, however, to leave a
-    negative value in the denominator.
-
-    >>> Rational(2, 4, gcd=1)
-    2/4
-    >>> Rational(2, -4, gcd=1).q
-    4
-
     See Also
     ========
     sympy.core.sympify.sympify, sympy.simplify.simplify.nsimplify
@@ -1344,13 +1335,13 @@ class Rational(Number):
                     except ValueError:
                         pass  # error will raise below
                     else:
-                        return Rational(p.numerator, p.denominator, 1)
+                        return cls._new(p.numerator, p.denominator, 1)
 
                 if not isinstance(p, Rational):
                     raise TypeError('invalid input: %s' % p)
 
             q = 1
-            gcd = 1
+
         Q = 1
 
         if not isinstance(p, SYMPY_INTS):
@@ -1368,7 +1359,20 @@ class Rational(Number):
             Q *= int(q)
         q = Q
 
+        if gcd is not None:
+            sympy_deprecation_warning(
+                "gcd is deprecated in Rational, use nsimplify instead",
+                deprecated_since_version="1.11",
+                active_deprecations_target="deprecated-rational-gcd",
+                stacklevel=4,
+            )
+            return cls._new(p, q, gcd)
+
         # p and q are now ints
+        return cls._new(p, q)
+
+    @classmethod
+    def _new(cls, p, q, gcd=None):
         if q == 0:
             if p == 0:
                 if _errdict["divide"]:
@@ -1376,11 +1380,14 @@ class Rational(Number):
                 else:
                     return S.NaN
             return S.ComplexInfinity
+
         if q < 0:
             q = -q
             p = -p
-        if not gcd:
+
+        if gcd is None:
             gcd = igcd(abs(p), q)
+
         if gcd > 1:
             p //= gcd
             q //= gcd
@@ -1388,6 +1395,7 @@ class Rational(Number):
             return Integer(p)
         if p == 1 and q == 2:
             return S.Half
+
         obj = Expr.__new__(cls)
         obj.p = p
         obj.q = q
@@ -1428,7 +1436,7 @@ class Rational(Number):
     def __add__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational(self.p + self.q*other.p, self.q, 1)
+                return Rational._new(self.p + self.q*other.p, self.q, 1)
             elif isinstance(other, Rational):
                 #TODO: this can probably be optimized more
                 return Rational(self.p*other.q + self.q*other.p, self.q*other.q)
@@ -1443,7 +1451,7 @@ class Rational(Number):
     def __sub__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational(self.p - self.q*other.p, self.q, 1)
+                return Rational._new(self.p - self.q*other.p, self.q, 1)
             elif isinstance(other, Rational):
                 return Rational(self.p*other.q - self.q*other.p, self.q*other.q)
             elif isinstance(other, Float):
@@ -1455,7 +1463,7 @@ class Rational(Number):
     def __rsub__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational(self.q*other.p - self.p, self.q, 1)
+                return Rational._new(self.q*other.p - self.p, self.q, 1)
             elif isinstance(other, Rational):
                 return Rational(self.q*other.p - self.p*other.q, self.q*other.q)
             elif isinstance(other, Float):
@@ -1467,9 +1475,9 @@ class Rational(Number):
     def __mul__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational(self.p*other.p, self.q, igcd(other.p, self.q))
+                return Rational._new(self.p*other.p, self.q, igcd(other.p, self.q))
             elif isinstance(other, Rational):
-                return Rational(self.p*other.p, self.q*other.q, igcd(self.p, other.q)*igcd(self.q, other.p))
+                return Rational._new(self.p*other.p, self.q*other.q, igcd(self.p, other.q)*igcd(self.q, other.p))
             elif isinstance(other, Float):
                 return other*self
             else:
@@ -1484,9 +1492,9 @@ class Rational(Number):
                 if self.p and other.p == S.Zero:
                     return S.ComplexInfinity
                 else:
-                    return Rational(self.p, self.q*other.p, igcd(self.p, other.p))
+                    return Rational._new(self.p, self.q*other.p, igcd(self.p, other.p))
             elif isinstance(other, Rational):
-                return Rational(self.p*other.q, self.q*other.p, igcd(self.p, other.p)*igcd(self.q, other.q))
+                return Rational._new(self.p*other.q, self.q*other.p, igcd(self.p, other.p)*igcd(self.q, other.q))
             elif isinstance(other, Float):
                 return self*(1/other)
             else:
@@ -1496,9 +1504,9 @@ class Rational(Number):
     def __rtruediv__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational(other.p*self.q, self.p, igcd(self.p, other.p))
+                return Rational._new(other.p*self.q, self.p, igcd(self.p, other.p))
             elif isinstance(other, Rational):
-                return Rational(other.p*self.q, other.q*self.p, igcd(self.p, other.p)*igcd(self.q, other.q))
+                return Rational._new(other.p*self.q, other.q*self.p, igcd(self.p, other.p)*igcd(self.q, other.q))
             elif isinstance(other, Float):
                 return other*(1/self)
             else:
@@ -1547,7 +1555,7 @@ class Rational(Number):
                 return S.Zero
             if isinstance(expt, Integer):
                 # (4/3)**2 -> 4**2 / 3**2
-                return Rational(self.p**expt.p, self.q**expt.p, 1)
+                return Rational._new(self.p**expt.p, self.q**expt.p, 1)
             if isinstance(expt, Rational):
                 intpart = expt.p // expt.q
                 if intpart:
@@ -1555,14 +1563,14 @@ class Rational(Number):
                     remfracpart = intpart*expt.q - expt.p
                     ratfracpart = Rational(remfracpart, expt.q)
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q**intpart, 1)
-                    return Integer(self.q)**ratfracpart*Rational(1, self.q**intpart, 1)
+                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational._new(1, self.q**intpart, 1)
+                    return Integer(self.q)**ratfracpart*Rational._new(1, self.q**intpart, 1)
                 else:
                     remfracpart = expt.q - expt.p
                     ratfracpart = Rational(remfracpart, expt.q)
                     if self.p != 1:
-                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational(1, self.q, 1)
-                    return Integer(self.q)**ratfracpart*Rational(1, self.q, 1)
+                        return Integer(self.p)**expt*Integer(self.q)**ratfracpart*Rational._new(1, self.q, 1)
+                    return Integer(self.q)**ratfracpart*Rational._new(1, self.q, 1)
 
         if self.is_extended_negative and expt.is_even:
             return (-self)**expt
@@ -1867,7 +1875,7 @@ class Integer(Rational):
             elif isinstance(other, Integer):
                 return Integer(self.p + other.p)
             elif isinstance(other, Rational):
-                return Rational(self.p*other.q + other.p, other.q, 1)
+                return Rational._new(self.p*other.q + other.p, other.q, 1)
             return Rational.__add__(self, other)
         else:
             return Add(self, other)
@@ -1877,7 +1885,7 @@ class Integer(Rational):
             if isinstance(other, int):
                 return Integer(other + self.p)
             elif isinstance(other, Rational):
-                return Rational(other.p + self.p*other.q, other.q, 1)
+                return Rational._new(other.p + self.p*other.q, other.q, 1)
             return Rational.__radd__(self, other)
         return Rational.__radd__(self, other)
 
@@ -1888,7 +1896,7 @@ class Integer(Rational):
             elif isinstance(other, Integer):
                 return Integer(self.p - other.p)
             elif isinstance(other, Rational):
-                return Rational(self.p*other.q - other.p, other.q, 1)
+                return Rational._new(self.p*other.q - other.p, other.q, 1)
             return Rational.__sub__(self, other)
         return Rational.__sub__(self, other)
 
@@ -1897,7 +1905,7 @@ class Integer(Rational):
             if isinstance(other, int):
                 return Integer(other - self.p)
             elif isinstance(other, Rational):
-                return Rational(other.p - self.p*other.q, other.q, 1)
+                return Rational._new(other.p - self.p*other.q, other.q, 1)
             return Rational.__rsub__(self, other)
         return Rational.__rsub__(self, other)
 
@@ -1908,7 +1916,7 @@ class Integer(Rational):
             elif isinstance(other, Integer):
                 return Integer(self.p*other.p)
             elif isinstance(other, Rational):
-                return Rational(self.p*other.p, other.q, igcd(self.p, other.q))
+                return Rational._new(self.p*other.p, other.q, igcd(self.p, other.q))
             return Rational.__mul__(self, other)
         return Rational.__mul__(self, other)
 
@@ -1917,7 +1925,7 @@ class Integer(Rational):
             if isinstance(other, int):
                 return Integer(other*self.p)
             elif isinstance(other, Rational):
-                return Rational(other.p*self.p, other.q, igcd(self.p, other.q))
+                return Rational._new(other.p*self.p, other.q, igcd(self.p, other.q))
             return Rational.__rmul__(self, other)
         return Rational.__rmul__(self, other)
 
@@ -2025,7 +2033,7 @@ class Integer(Rational):
             # cases -1, 0, 1 are done in their respective classes
             return S.Infinity + S.ImaginaryUnit*S.Infinity
         if expt is S.NegativeInfinity:
-            return Rational(1, self, 1)**S.Infinity
+            return Rational._new(1, self, 1)**S.Infinity
         if not isinstance(expt, Number):
             # simplify when expt is even
             # (-2)**k --> 2**k
@@ -2043,9 +2051,9 @@ class Integer(Rational):
             # invert base and change sign on exponent
             ne = -expt
             if self.is_negative:
-                return S.NegativeOne**expt*Rational(1, -self, 1)**ne
+                return S.NegativeOne**expt*Rational._new(1, -self.p, 1)**ne
             else:
-                return Rational(1, self.p, 1)**ne
+                return Rational._new(1, self.p, 1)**ne
         # see if base is a perfect root, sqrt(4) --> 2
         x, xexact = integer_nthroot(abs(self.p), expt.q)
         if xexact:
@@ -2062,7 +2070,9 @@ class Integer(Rational):
         b_pos = int(abs(self.p))
         p = perfect_power(b_pos)
         if p is not False:
-            dict = {p[0]: p[1]}
+            # XXX: Convert to int because perfect_power may return fmpz
+            # Ideally that should be fixed in perfect_power though...
+            dict = {int(p[0]): int(p[1])}
         else:
             dict = Integer(b_pos).factors(limit=2**15)
 
@@ -2083,7 +2093,7 @@ class Integer(Rational):
                 # (2**2)**(1/10) -> 2**(1/5)
                 g = igcd(div_m, expt.q)
                 if g != 1:
-                    out_rad *= Pow(prime, Rational(div_m//g, expt.q//g, 1))
+                    out_rad *= Pow(prime, Rational._new(div_m//g, expt.q//g, 1))
                 else:
                     sqr_dict[prime] = div_m
         # identify gcd of remaining powers
@@ -4398,7 +4408,7 @@ def _eval_is_eq(self, other): # noqa: F811
 
 
 def sympify_fractions(f):
-    return Rational(f.numerator, f.denominator, 1)
+    return Rational._new(f.numerator, f.denominator, 1)
 
 _sympy_converter[fractions.Fraction] = sympify_fractions
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1391,6 +1391,21 @@ class Rational(Number):
         if gcd > 1:
             p //= gcd
             q //= gcd
+
+        return cls.from_coprime_ints(p, q)
+
+    @classmethod
+    def from_coprime_ints(cls, p: int, q: int) -> Rational:
+        """Create a Rational from a pair of coprime integers.
+
+        Both ``p`` and ``q`` should be strictly of type ``int``.
+
+        The caller should ensure that ``gcd(p,q) == 1`` and ``q > 0``.
+
+        This may be more efficient than ``Rational(p, q)``. The validity of the
+        arguments may or may not be checked so it should not be relied upon to
+        pass unvalidated or invalid arguments to this function.
+        """
         if q == 1:
             return Integer(p)
         if p == 1 and q == 2:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -31,7 +31,8 @@ from sympy.simplify import simplify
 from sympy.polys.domains.groundtypes import PythonRational
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.iterables import permutations
-from sympy.testing.pytest import XFAIL, raises, _both_exp_pow
+from sympy.testing.pytest import (XFAIL, raises, _both_exp_pow,
+                                  warns_deprecated_sympy)
 from sympy import Add
 
 from mpmath import mpf
@@ -363,8 +364,10 @@ def test_Rational_new():
 
     assert Rational(PythonRational(2, 6)) == Rational(1, 3)
 
-    assert Rational(2, 4, gcd=1).q == 4
-    n = Rational(2, -4, gcd=1)
+    with warns_deprecated_sympy():
+        assert Rational(2, 4, gcd=1).q == 4
+    with warns_deprecated_sympy():
+        n = Rational(2, -4, gcd=1)
     assert n.q == 4
     assert n.p == -2
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -371,6 +371,9 @@ def test_Rational_new():
     assert n.q == 4
     assert n.p == -2
 
+    assert Rational.from_coprime_ints(3, 5) == Rational(3, 5)
+
+
 def test_issue_24543():
     for p in ('1.5', 1.5, 2):
         for q in ('1.5', 1.5, 2):


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-27814
Closes gh-27916

#### Brief description of what is fixed or changed

The gcd parameter to Rational can be used to create an unevaluated Rational. This is a bad idea because any more efficient representation of rational numbers (e.g. flint.fmpq) cannot represent these. Supporting unevaluated rationals prevents using a more efficient implementation for Rational in the normal case.

This PR deprecates using the gcd parameter as in `Rational(4, 2, 1)` or `Rational(4, 2, gcd=1)`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * DEPRECATION: The gcd parameter for Rational is now deprecated. This parameter is used to create "unevaluated rationals" but those are impossible to represent if SymPy uses any more efficient implementation of rational numbers (e.g. from gmpy2 or python-flint). This parameter is deprecated and using it will likely become a hard error much quicker than usual deprecation timelines because keeping this behaviour even with a deprecation warning prevents making Rational much faster.
<!-- END RELEASE NOTES -->