### PR TITLE
Remove deprecated Body from explanation

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -659,8 +659,8 @@ the ``parent.z`` axis and ``-child.z`` axis. The previous way to specify this
 joint was:
 
 ```py
->>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
+>>> from sympy.physics.mechanics import PinJoint, RigidBody
+>>> parent, child = RigidBody('parent'), RigidBody('child')
 >>> pin = PinJoint('pin', parent, child, parent_axis=parent.z,
 ...                child_axis=-child.z)   # doctest: +SKIP
 >>> parent.dcm(child)   # doctest: +SKIP
@@ -677,13 +677,13 @@ this exact rotation:
 
 ```py
 >>> from sympy import pi
->>> from sympy.physics.mechanics import Body, PinJoint, ReferenceFrame
->>> parent, child, = Body('parent'), Body('child') # doctest: +SKIP
->>> int_frame = ReferenceFrame('int_frame') # doctest: +SKIP
->>> int_frame.orient_axis(child.frame, child.y, pi) # doctest: +SKIP
+>>> from sympy.physics.mechanics import PinJoint, ReferenceFrame, RigidBody
+>>> parent, child, = RigidBody('parent'), RigidBody('child')
+>>> int_frame = ReferenceFrame('int_frame')
+>>> int_frame.orient_axis(child.frame, child.y, pi)
 >>> pin = PinJoint('pin', parent, child, joint_axis=parent.z,
-...                child_interframe=int_frame) # doctest: +SKIP
->>> parent.dcm(child) # doctest: +SKIP
+...                child_interframe=int_frame)
+>>> parent.frame.dcm(child.frame)
 Matrix([
 [-cos(q_pin(t)), -sin(q_pin(t)),  0],
 [-sin(q_pin(t)),  cos(q_pin(t)),  0],
@@ -697,11 +697,11 @@ that the joint axis expressed in the intermediate frame is aligned with the
 given vector:
 
 ```py
->>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
+>>> from sympy.physics.mechanics import PinJoint, RigidBody
+>>> parent, child = RigidBody('parent'), RigidBody('child')
 >>> pin = PinJoint('pin', parent, child, parent_interframe=parent.z,
-...                child_interframe=-child.z) # doctest: +SKIP
->>> parent.dcm(child) # doctest: +SKIP
+...                child_interframe=-child.z)
+>>> parent.frame.dcm(child.frame)
 Matrix([
 [-cos(q_pin(t)), -sin(q_pin(t)),  0],
 [-sin(q_pin(t)),  cos(q_pin(t)),  0],
@@ -722,8 +722,8 @@ For example, suppose you want a ``PinJoint`` in the parent to be positioned at
 ``-child.frame.x``. The previous way to specify this was:
 
 ```py
->>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
+>>> from sympy.physics.mechanics import PinJoint, RigidBody
+>>> parent, child = RigidBody('parent'), RigidBody('child')
 >>> pin = PinJoint('pin', parent, child, parent_joint_pos=parent.frame.x,
 ...                child_joint_pos=-child.frame.x)   # doctest: +SKIP
 >>> pin.parent_point.pos_from(parent.masscenter)   # doctest: +SKIP
@@ -735,28 +735,28 @@ parent_frame.x
 Now you can do the same with either
 
 ```py
->>> from sympy.physics.mechanics import Body, PinJoint
->>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
+>>> from sympy.physics.mechanics import PinJoint, RigidBody
+>>> parent, child = RigidBody('parent'), RigidBody('child')
 >>> pin = PinJoint('pin', parent, child, parent_point=parent.frame.x,
-...                child_point=-child.frame.x) # doctest: +SKIP
->>> pin.parent_point.pos_from(parent.masscenter) # doctest: +SKIP
+...                child_point=-child.frame.x)
+>>> pin.parent_point.pos_from(parent.masscenter)
 parent_frame.x
->>> pin.child_point.pos_from(child.masscenter) # doctest: +SKIP
+>>> pin.child_point.pos_from(child.masscenter)
 - child_frame.x
 ```
 
 Or
 
 ```py
->>> from sympy.physics.mechanics import Body, PinJoint, Point
->>> parent, child = Body('parent'), Body('child') # doctest: +SKIP
->>> parent_point = parent.masscenter.locatenew('parent_point', parent.frame.x) # doctest: +SKIP
->>> child_point = child.masscenter.locatenew('child_point', -child.frame.x) # doctest: +SKIP
+>>> from sympy.physics.mechanics import PinJoint, Point, RigidBody
+>>> parent, child = RigidBody('parent'), RigidBody('child')
+>>> parent_point = parent.masscenter.locatenew('parent_point', parent.frame.x)
+>>> child_point = child.masscenter.locatenew('child_point', -child.frame.x)
 >>> pin = PinJoint('pin', parent, child, parent_point=parent_point,
-...                child_point=child_point) # doctest: +SKIP
->>> pin.parent_point.pos_from(parent.masscenter) # doctest: +SKIP
+...                child_point=child_point)
+>>> pin.parent_point.pos_from(parent.masscenter)
 parent_frame.x
->>> pin.child_point.pos_from(child.masscenter) # doctest: +SKIP
+>>> pin.child_point.pos_from(child.masscenter)
 - child_frame.x
 ```
 

--- a/sympy/physics/mechanics/joint.py
+++ b/sympy/physics/mechanics/joint.py
@@ -39,9 +39,9 @@ class Joint(ABC):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     coordinates : iterable of dynamicsymbols, optional
         Generalized coordinates of the joint.
@@ -95,9 +95,9 @@ class Joint(ABC):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     coordinates : Matrix
         Matrix of the joint's generalized coordinates.
@@ -576,9 +576,9 @@ class PinJoint(Joint):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     coordinates : dynamicsymbol, optional
         Generalized coordinates of the joint.
@@ -635,9 +635,9 @@ class PinJoint(Joint):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     coordinates : Matrix
         Matrix of the joint's generalized coordinates. The default value is
@@ -841,9 +841,9 @@ class PrismaticJoint(Joint):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     coordinates : dynamicsymbol, optional
         Generalized coordinates of the joint. The default value is
@@ -902,9 +902,9 @@ class PrismaticJoint(Joint):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     coordinates : Matrix
         Matrix of the joint's generalized coordinates.
@@ -1107,9 +1107,9 @@ class CylindricalJoint(Joint):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     rotation_coordinate : dynamicsymbol, optional
         Generalized coordinate corresponding to the rotation angle. The default
@@ -1152,9 +1152,9 @@ class CylindricalJoint(Joint):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     rotation_coordinate : dynamicsymbol
         Generalized coordinate corresponding to the rotation angle.
@@ -1423,9 +1423,9 @@ class PlanarJoint(Joint):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     rotation_coordinate : dynamicsymbol, optional
         Generalized coordinate corresponding to the rotation angle. The default
@@ -1465,9 +1465,9 @@ class PlanarJoint(Joint):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     rotation_coordinate : dynamicsymbol
         Generalized coordinate corresponding to the rotation angle.
@@ -1764,9 +1764,9 @@ class SphericalJoint(Joint):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     coordinates: iterable of dynamicsymbols, optional
         Generalized coordinates of the joint.
@@ -1821,9 +1821,9 @@ class SphericalJoint(Joint):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     coordinates : Matrix
         Matrix of the joint's generalized coordinates.
@@ -2009,9 +2009,9 @@ class WeldJoint(Joint):
 
     name : string
         A unique name for the joint.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The parent body of joint.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The child body of joint.
     parent_point : Point or Vector, optional
         Attachment point where the joint is fixed to the parent body. If a
@@ -2039,9 +2039,9 @@ class WeldJoint(Joint):
 
     name : string
         The joint's name.
-    parent : Particle or RigidBody or Body
+    parent : Particle or RigidBody
         The joint's parent body.
-    child : Particle or RigidBody or Body
+    child : Particle or RigidBody
         The joint's child body.
     coordinates : Matrix
         Matrix of the joint's generalized coordinates. The default value is


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR updates the explanation on the joint definition deprecation to use `RigidBody` instead of `Body`. As the `Body` class is deprecated since version 1.13. [#27943 (comment)](Proposed in https://github.com/sympy/sympy/pull/27943#discussion_r2041162091). Additionally, this PR removes references to the `Body` from the joint docstrings, as this class has been deprecated.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
