### PR TITLE
Fix ask prime

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -370,8 +370,7 @@ Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
-Aswin <aswin8681879422@gmail.com>
-Aswin <61832161+Aswin-coder@users.noreply.github.com>
+Aswin <aswin8681879422@gmail.com> Aswin <61832161+Aswin-coder@users.noreply.github.com>
 Atharva Khare <khareatharva@gmail.com>
 Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>

--- a/.mailmap
+++ b/.mailmap
@@ -370,6 +370,7 @@ Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
+Aswin <aswin8681879422@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
 Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>

--- a/.mailmap
+++ b/.mailmap
@@ -371,6 +371,7 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Aswin <aswin8681879422@gmail.com>
+Aswin <61832161+Aswin-coder@users.noreply.github.com>
 Atharva Khare <khareatharva@gmail.com>
 Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -26,8 +26,7 @@ def _PrimePredicate_number(expr, assumptions):
             raise TypeError
     except TypeError:
         return False
-    if exact:
-        return isprime(i)
+    return isprime(i)
     # when not exact, we won't give a True or False
     # since the number represents an approximate value
 

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -19,7 +19,6 @@ from ..predicates.ntheory import (PrimePredicate, CompositePredicate,
 
 def _PrimePredicate_number(expr, assumptions):
     # helper method
-    exact = not expr.atoms(Float)
     try:
         i = int(expr.round())
         if (expr - i).equals(0) is False:
@@ -27,8 +26,6 @@ def _PrimePredicate_number(expr, assumptions):
     except TypeError:
         return False
     return isprime(i)
-    # when not exact, we won't give a True or False
-    # since the number represents an approximate value
 
 @PrimePredicate.register(Expr)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -100,7 +100,7 @@ def test_float_1():
     assert ask(Q.even(z)) is None
     assert ask(Q.odd(z)) is None
     assert ask(Q.finite(z)) is True
-    assert ask(Q.prime(z)) is None
+    assert ask(Q.prime(z)) is True
     assert ask(Q.composite(z)) is None
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False
@@ -2426,7 +2426,6 @@ def test_check_old_assumption():
 
 def test_issue_9636():
     assert ask(Q.integer(1.0)) is None
-    assert ask(Q.prime(3.0)) is None
     assert ask(Q.composite(4.0)) is None
     assert ask(Q.even(2.0)) is None
     assert ask(Q.odd(3.0)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -100,7 +100,7 @@ def test_float_1():
     assert ask(Q.even(z)) is None
     assert ask(Q.odd(z)) is None
     assert ask(Q.finite(z)) is True
-    assert ask(Q.prime(z)) is True
+    assert ask(Q.prime(z)) is False
     assert ask(Q.composite(z)) is None
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False


### PR DESCRIPTION
exact integer like 4.0 are not treating as int

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #27958 



#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixes ask prime function to check float values.
<!-- END RELEASE NOTES -->
