### PR TITLE
maint(release): pin mpmath < 1.4 for sympy 1.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Check out with full git history for authors check:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
   test-install:
     needs: [build]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -233,7 +233,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          # flint==0.6.0 needs 3.12
+          python-version: '3.12'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint==${{ matrix.flint-version }}

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -223,6 +223,11 @@ jobs:
   python-flint:
     needs: [doctests-latest, tests-latest]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        flint-version: ['0.6.0', '0.7.1']
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -231,7 +236,7 @@ jobs:
           python-version: '3.13'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pip install python-flint
+      - run: pip install python-flint==${{ matrix.flint-version }}
       - run: pip install .
       - run: pytest -n auto
 

--- a/setup.py
+++ b/setup.py
@@ -321,7 +321,7 @@ if __name__ == '__main__':
           },
           # Set upper bound when making the release branch.
           install_requires=[
-              'mpmath >= 1.1.0',
+              'mpmath >= 1.1.0, < 1.4',
           ],
           py_modules=['isympy'],
           packages=['sympy'] + modules + tests,

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -93,7 +93,7 @@ __all__ = [
 # Tested python-flint version. Future versions might work but we will only use
 # them if explicitly requested by SYMPY_GROUND_TYPES=flint.
 #
-_PYTHON_FLINT_VERSION_NEEDED = ["0.6", "0.7", "0.8", "0.9"]
+_PYTHON_FLINT_VERSION_NEEDED = ["0.6", "0.7", "0.8", "0.9", "0.10"]
 
 
 def _flint_version_okay(flint_version):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Release issue gh-27939

#### Brief description of what is fixed or changed

Pin mpmath<1.4 in the 1.14 release. This was also done for 1.13 but the pin is only on the release branch rather than the master branch so it needs to be redone.

This prevents sympy from being broken on older Python versions by any new mpmath release in future.

mpmath releases can be seen here:
https://pypi.org/project/mpmath/#history

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
