### PR TITLE
Fix: Allow multiplication of basis vectors by float zero (0.0) 

### DIFF
--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -258,7 +258,7 @@ class BasisDependentMul(BasisDependent, Mul):
             if isinstance(arg, cls._zero_func):
                 count += 1
                 zeroflag = True
-            elif arg == S.Zero:
+            elif arg == S.Zero or arg == 0.0:
                 zeroflag = True
             elif isinstance(arg, (cls._base_func, cls._mul_func)):
                 count += 1

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -127,6 +127,7 @@ def test_vector():
 
     assert isinstance(v1, VectorAdd)
     assert v1 - v1 == Vector.zero
+    assert v1*0.0 == Vector.zero
     assert v1 + Vector.zero == v1
     assert v1.dot(i) == a
     assert v1.dot(j) == b


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27963


#### Brief description of what is fixed or changed
Previously, multiplying a basis vector (e.g., N.i) by ```0.0``` would raise an ```AttributeError``` due to improper zero detection in the vector module. This commit updates the zero-check logic in ```BasisDependent._new()``` to recognize both ```S.Zero``` and ```0.0``` as zero scalars, restoring expected behavior.




#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
