### PR TITLE
Fix for Xor operator bug in parse_expr with false evaluation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1698,7 +1698,7 @@ noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
 omahs <73983677+omahs@users.noreply.github.com>
-pasqo <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@ieee.org>
+pasqo <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 platypus <platypus.computerchip@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1698,6 +1698,7 @@ noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
 omahs <73983677+omahs@users.noreply.github.com>
+pasqo <pasquale.cocchini@gmail.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 platypus <platypus.computerchip@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1698,7 +1698,7 @@ noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
 omahs <73983677+omahs@users.noreply.github.com>
-pasqo <pasquale.cocchini@gmail.com>
+pasqo <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@ieee.org>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 platypus <platypus.computerchip@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1153,6 +1153,8 @@ Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.
 Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
 Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>
+Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
+Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@gmail.com>
 Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
@@ -1698,7 +1700,6 @@ noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
 omahs <73983677+omahs@users.noreply.github.com>
-pasqo <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 platypus <platypus.computerchip@gmail.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1111,7 +1111,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         ast.Div: 'Mul',
         ast.BitOr: 'Or',
         ast.BitAnd: 'And',
-        ast.BitXor: 'Not',
+        ast.BitXor: 'Xor',
     }
     functions = (
         'Abs', 'im', 're', 'sign', 'arg', 'conjugate',

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -7,7 +7,7 @@ import types
 from sympy.assumptions import Q
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq, Lt, Le, Gt, Ge, Ne
 from sympy.functions import exp, factorial, factorial2, sin, Min, Max
-from sympy.logic import And
+from sympy.logic import And, Xor
 from sympy.series import Limit
 from sympy.testing.pytest import raises
 
@@ -369,3 +369,7 @@ def test_issue_22822():
     raises(ValueError, lambda: parse_expr('x', {'': 1}))
     data = {'some_parameter': None}
     assert parse_expr('some_parameter is None', data) is True
+
+def test_xor_eval_false():
+    p, q = Symbol("p"), Symbol("q")
+    assert parse_expr("p ^ q", evaluate=False) == Xor(p, q, evaluate=False)


### PR DESCRIPTION
#### References to other Issues or PRs
No references to other Issues or PRs.

#### Brief description of what is fixed or changed
This PR fixes a bug in the `parse_expr` function for which when an expression containing an `Xor` operator "^" is parsed with parameter `evaluation` set to False, the resulting function is `Not` instead of `Xor`.
The bug is not exercised when `parse_expr` is used with evaluation=True.

This can be easily reproduced in a number of ways, for instance:

```python
srepr(parse_expr("p ^ q", evaluate=False)) == "Not(Symbol('p'), Symbol('q'))"
```
which would raise a TypeError exception if later evaluated.

The issue is fixed by replacing `Not` with `Xor` in the parsing code.
A test was added in the parsing submodule.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed a bug encountered in function `parse_expr` when parsing the Xor operator `^` with `evaluation=False`.
<!-- END RELEASE NOTES -->
