### PR TITLE
Fix RecursionError when solving ODEs with Float coefficients

### DIFF
--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -885,7 +885,7 @@ class Factorable(SingleODESolver):
         for i in factors:
             if i.has(f(x)):
                 self.eqs.append(i)
-        return len(self.eqs)>0 and len(factors)>1
+        return len(self.eqs) > 1
 
     def _get_general_solution(self, *, simplify_flag: bool = True):
         func = self.ode_problem.func.func

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -34,7 +34,7 @@ Functions that are for internal use:
 """
 from sympy.core.function import (Derivative, diff)
 from sympy.core.mul import Mul
-from sympy.core.numbers import (E, I, Rational, pi)
+from sympy.core.numbers import (E, Float, I, Rational, pi)
 from sympy.core.relational import (Eq, Ne)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
@@ -1051,11 +1051,6 @@ def _get_examples_ode_sol_factorable():
     'fact_19': {
         'eq': Derivative(f(x), x)**2 - x**3,
         'sol': [Eq(f(x), C1 - 2*x**Rational(5,2)/5), Eq(f(x), C1 + 2*x**Rational(5,2)/5)],
-    },
-
-    'fact_20': {
-        'eq': x*f(x).diff(x, 2) - x*f(x),
-        'sol': [Eq(f(x), C1*exp(-x) + C2*exp(x))],
     },
     }
     }
@@ -2106,6 +2101,11 @@ def _get_examples_ode_sol_2nd_linear_bessel():
         'eq': x**2*f(x).diff(x, 2) + x*f(x).diff(x) + (a**2*x**2/c**2 - b**2)*f(x),
         'sol': [Eq(f(x), C1*besselj(sqrt(b**2), x*sqrt(a**2/c**2)) + C2*bessely(sqrt(b**2), x*sqrt(a**2/c**2)))],
     },
+
+    '2nd_lin_bessel_13': {
+    'eq': x*f(x).diff(x, 2) - x*f(x),
+    'sol': [Eq(f(x), sqrt(x)*(C1*besselj(Rational(1, 2), I*x) + C2*bessely(Rational(1, 2), I*x)))],
+    },
     }
     }
 
@@ -2900,3 +2900,13 @@ def _get_all_examples():
     _get_examples_ode_sol_linear_coefficients
 
     return all_examples
+
+
+def test_issue_27683():
+    # https://github.com/sympy/sympy/issues/27683
+    v = Function('v')(x)
+    EQ1 = Eq(diff(v, x, x) * 4000.0, 1)
+    EQ2 = Eq(diff(v, x, x) * Float(4000), Float(1))
+    expected_result = Eq(v, C1 + C2*x + 0.000125*x**2)
+    assert dsolve(EQ1, v) == expected_result
+    assert dsolve(EQ2, v) == expected_result


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes https://github.com/sympy/sympy/issues/27683
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

- Fix :-  RecursionError when solving ODEs with Float coefficients.

#### Other comments
Previously it was recursion error. now it correctly finds result.
Example : 
```
>>> import sympy as sp
>>> x = sp.Symbol('x')
>>> u = sp.Function('u')(x)
>>> EQ = sp.Eq(sp.diff(u,x,x) * sp.Float(4000), sp.Float(1))
>>> sp.dsolve(EQ, u)
Eq(u(x), C1 + C2*x + 0.000125*x**2)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
   * Fixed RecursionError in ODE solver when using Float coefficients.
<!-- END RELEASE NOTES -->
