### PR TITLE
maint(ci): fix benchmarks on 1.14 branch

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -490,10 +490,10 @@ jobs:
         run: asv run --config asv.conf.actions.json
 
         # Output benchmark results
-      - run: asv compare upstream/master HEAD --config asv.conf.actions.json --factor 1.5 | tee pr_vs_master.txt
-      - run: asv compare upstream/master HEAD --config asv.conf.actions.json --factor 1.5 --only-changed | tee pr_vs_master_changed.txt
-      - run: asv compare upstream/1.14 upstream/master --config asv.conf.actions.json --factor 1.5 | tee master_vs_release.txt
-      - run: asv compare upstream/1.14 upstream/master --config asv.conf.actions.json --factor 1.5 --only-changed | tee master_vs_release_changed.txt
+      - run: asv compare upstream/1.14 HEAD --config asv.conf.actions.json --factor 1.5 | tee pr_vs_1.14.txt
+      - run: asv compare upstream/1.14 HEAD --config asv.conf.actions.json --factor 1.5 --only-changed | tee pr_vs_1.14_changed.txt
+      - run: asv compare upstream/1.13 upstream/1.14 --config asv.conf.actions.json --factor 1.5 | tee 1.14_vs_1.13.txt
+      - run: asv compare upstream/1.13 upstream/1.14 --config asv.conf.actions.json --factor 1.5 --only-changed | tee 1.14_vs_1.13_changed.txt
 
         # we save all outputs as artifacts that can be downloaded from the
         # GitHub Actions summary page.

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -503,7 +503,7 @@ jobs:
         with:
           name: benchmarks
           path: |
-            pr_vs_master.txt
-            pr_vs_master_changed.txt
-            master_vs_release.txt
-            master_vs_release_changed.txt
+            pr_vs_1.14.txt
+            pr_vs_1.14_changed.txt
+            1.14_vs_1.13.txt
+            1.14_vs_1.13_changed.txt


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See gh-27939

#### Brief description of what is fixed or changed

Fix the benchmarks CI job to compare 1.14 against 1.13

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
