### PR TITLE
Added new function to conventions.py to assist in fixing underscore i…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -442,6 +442,7 @@ Cameron King <v-caking@microsoft.com>
 Carl Sandrock <carl.sandrock@up.ac.za>
 Carlos Cordoba <ccordoba12@gmail.com>
 Carlos García Montoro <TrilceAC@gmail.com> Carlos García Montoro <cgarcia@ific.uv.es>
+Carter Buell <carterbuell@gmail.com> carterjbuell <carterbuell@gmail.com>
 Carson McManus <carson.mcmanus1@gmail.com> Carson McManus <dyc3@users.noreply.github.com>
 Carsten Knoll <CarstenKnoll@gmx.de>
 Case Van Horsen <casevh@gmail.com>
@@ -1153,8 +1154,6 @@ Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.
 Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
 Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>
-Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
-Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@gmail.com>
 Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1111,7 +1111,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         ast.Div: 'Mul',
         ast.BitOr: 'Or',
         ast.BitAnd: 'And',
-        ast.BitXor: 'Xor',
+        ast.BitXor: 'Not',
     }
     functions = (
         'Abs', 'im', 're', 'sign', 'arg', 'conjugate',

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -7,7 +7,7 @@ import types
 from sympy.assumptions import Q
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq, Lt, Le, Gt, Ge, Ne
 from sympy.functions import exp, factorial, factorial2, sin, Min, Max
-from sympy.logic import And, Xor
+from sympy.logic import And
 from sympy.series import Limit
 from sympy.testing.pytest import raises
 
@@ -369,7 +369,3 @@ def test_issue_22822():
     raises(ValueError, lambda: parse_expr('x', {'': 1}))
     data = {'some_parameter': None}
     assert parse_expr('some_parameter is None', data) is True
-
-def test_xor_eval_false():
-    p, q = Symbol("p"), Symbol("q")
-    assert parse_expr("p ^ q", evaluate=False) == Xor(p, q, evaluate=False)

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 import collections
 from functools import reduce
 
-from sympy import Mul
-
 from sympy.core.basic import Basic
 from sympy.core.containers import (Dict, Tuple)
 from sympy.core.singleton import S
@@ -102,10 +100,6 @@ class _QuantityMapper:
             return Dimension(1)
 
     def get_quantity_scale_factor(self, unit):
-        if isinstance(unit, Mul):
-            return Mul.fromiter(self.get_quantity_scale_factor(arg) for arg in unit.args)
-        if isinstance(unit, Pow):
-            return self.get_quantity_scale_factor(unit.base)**unit.exp
         if unit in self._quantity_scale_factors:
             return self._quantity_scale_factors[unit]
         if unit in self._quantity_scale_factors_global:

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -40,7 +40,7 @@ def test_convert_to():
     Js.set_global_relative_scale_factor(S.One, joule*second)
 
     mksa = UnitSystem((m, kg, s, A), (Js,))
-    assert convert_to(Js, mksa._base_units) == m**2*kg*s**-1
+    assert convert_to(Js, mksa._base_units) == m**2*kg*s**-1/1000
 
 
 def test_extend():

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -3,14 +3,12 @@ from sympy.core.numbers import pi
 from sympy.core.power import Pow
 from sympy.core.symbol import symbols
 from sympy.core.sympify import sympify
-from sympy.physics.units.systems import SI
 from sympy.printing.str import sstr
-from sympy.physics.units.quantities import Quantity
 from sympy.physics.units import (
     G, centimeter, coulomb, day, degree, gram, hbar, hour, inch, joule, kelvin,
     kilogram, kilometer, length, meter, mile, minute, newton, planck,
     planck_length, planck_mass, planck_temperature, planck_time, radians,
-    second, speed_of_light, steradian, time, km, ft, m)
+    second, speed_of_light, steradian, time, km)
 from sympy.physics.units.util import convert_to, check_dimensions
 from sympy.testing.pytest import raises
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -75,19 +73,6 @@ def test_convert_to_quantities():
     # https://github.com/sympy/sympy/issues/26263
     assert convert_to(sqrt(meter**2 + meter**2.0), meter) == sqrt(meter**2 + meter**2.0)
     assert convert_to((meter**2 + meter**2.0)**2, meter) == (meter**2 + meter**2.0)**2
-
-    # https://github.com/sympy/sympy/issues/27812
-    acre_in_ft = Quantity("acre")
-    acre_in_ft.set_global_relative_scale_factor(43560, ft**2)
-    assert convert_to(acre_in_ft, m**2) == 316160658*meter**2/78125
-
-    acre_in_acre = Quantity("acre_in_acre")
-    acre_in_acre.set_global_relative_scale_factor(1, acre_in_ft)
-    assert convert_to(acre_in_acre, m**2) == 316160658*meter**2/78125
-
-    assert SI.get_quantity_scale_factor(kilometer) == 1000
-    assert SI.get_quantity_scale_factor(kilometer*kilogram) == 10**6
-    assert SI.get_quantity_scale_factor(kilometer**2) == 10**6
 
 
 def test_convert_to_tuples_of_quantities():

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -86,3 +86,23 @@ def requires_partial(expr):
         return len(set(expr.variables)) > 1
 
     return sum(not s.is_integer for s in expr.free_symbols) > 1
+
+    def split_leading_trailing_underscore(text):
+    """
+    Removes leading and trailing underscores and returns a tuple as:
+    (number of leading underscores, text without leading and trailing underscores, number of trailing underscores)
+    """
+    leading = 0
+    pos = 0
+    while pos < len(text) and text[pos] == "_":
+        leading += 1
+        pos += 1
+
+    trailing = 0
+    pos = len(text) - 1
+    while pos >= leading and text[pos] == "_":
+        trailing += 1
+        pos -= 1
+
+    trimmed_text = text[leading:len(text)-trailing]
+    return (leading, trimmed_text, trailing)

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -87,7 +87,7 @@ def requires_partial(expr):
 
     return sum(not s.is_integer for s in expr.free_symbols) > 1
 
-    def split_leading_trailing_underscore(text):
+def split_leading_trailing_underscore(text):
     """
     Removes leading and trailing underscores and returns a tuple as:
     (number of leading underscores, text without leading and trailing underscores, number of trailing underscores)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -3318,5 +3318,5 @@ def multiline_latex(lhs, rhs, terms_per_line=1, environment="align*", use_dots=F
     result += end_term
     return result
 
-    def _print_Dummy(self, expr):
-        return '\\_' + self._print_Symbol(expr)
+def _print_Dummy(self, expr):
+    return '\\_' + self._print_Symbol(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -20,7 +20,7 @@ from sympy.logic.boolalg import true, BooleanTrue, BooleanFalse
 # sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
 from sympy.printing.printer import Printer, print_function
-from sympy.printing.conventions import split_super_sub, requires_partial
+from sympy.printing.conventions import split_super_sub, requires_partial, split_leading_trailing_underscore
 from sympy.printing.precedence import precedence, PRECEDENCE
 
 from mpmath.libmp.libmpf import prec_to_dps, to_str as mlib_to_str
@@ -1627,7 +1627,8 @@ class LatexPrinter(Printer):
         if name is not None:
             return name
 
-        return self._deal_with_super_sub(expr.name, style=style)
+        leading, name, trailing = split_leading_trailing_underscore(expr.name)
+        return leading*r'\_' + self._deal_with_super_sub(expr.name, style=style)
 
     _print_RandomSymbol = _print_Symbol
 
@@ -3316,3 +3317,6 @@ def multiline_latex(lhs, rhs, terms_per_line=1, environment="align*", use_dots=F
         term_count += 1
     result += end_term
     return result
+
+    def _print_Dummy(self, expr):
+        return '\\_' + self._print_Symbol(expr)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2851,6 +2851,11 @@ class PrettyPrinter(Printer):
     def _print_Str(self, s):
         return self._print(s.name)
 
+    def _print_Dummy(self, expr):
+        printed = self._print('_')
+        printed = prettyForm(*printed.right(self._print_Symbol(expr)))
+        return printed
+
 
 @print_function(PrettyPrinter)
 def pretty(expr, **settings):
@@ -2936,7 +2941,3 @@ def pager_print(expr, **settings):
         settings['num_columns'] = 500000  # disable line wrap
     pager(pretty(expr, **settings).encode(getpreferredencoding()))
 
-    def _print_Dummy(self, expr):
-        printed = self._print('_')
-        printed = prettyForm(*printed.right(self._print_Symbol(expr)))
-        return printed

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2935,3 +2935,8 @@ def pager_print(expr, **settings):
     if 'num_columns' not in settings:
         settings['num_columns'] = 500000  # disable line wrap
     pager(pretty(expr, **settings).encode(getpreferredencoding()))
+
+    def _print_Dummy(self, expr):
+        printed = self._print('_')
+        printed = prettyForm(*printed.right(self._print_Symbol(expr)))
+        return printed

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2940,4 +2940,3 @@ def pager_print(expr, **settings):
     if 'num_columns' not in settings:
         settings['num_columns'] = 500000  # disable line wrap
     pager(pretty(expr, **settings).encode(getpreferredencoding()))
-    

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2940,4 +2940,3 @@ def pager_print(expr, **settings):
     if 'num_columns' not in settings:
         settings['num_columns'] = 500000  # disable line wrap
     pager(pretty(expr, **settings).encode(getpreferredencoding()))
-

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2940,3 +2940,4 @@ def pager_print(expr, **settings):
     if 'num_columns' not in settings:
         settings['num_columns'] = 500000  # disable line wrap
     pager(pretty(expr, **settings).encode(getpreferredencoding()))
+    

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2940,3 +2940,4 @@ def pager_print(expr, **settings):
     if 'num_columns' not in settings:
         settings['num_columns'] = 500000  # disable line wrap
     pager(pretty(expr, **settings).encode(getpreferredencoding()))
+

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -20,7 +20,7 @@ def U(name):
         unicode_warnings += 'No \'%s\' in unicodedata\n' % name
         return None
 
-from sympy.printing.conventions import split_super_sub
+from sympy.printing.conventions import split_super_sub, split_leading_trailing_underscore
 from sympy.core.alphabets import greeks
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
@@ -556,7 +556,8 @@ def pretty_symbol(symb_name, bold_name=False):
     if not _use_unicode:
         return symb_name
 
-    name, sups, subs = split_super_sub(symb_name)
+    leading, name, trailing = split_leading_trailing_underscore(symb_name)
+    name, sups, subs = split_super_sub(name)
 
     def translate(s, bold_name) :
         if bold_name:
@@ -605,7 +606,7 @@ def pretty_symbol(symb_name, bold_name=False):
         sups_result = ' '.join(pretty_sups)
         subs_result = ' '.join(pretty_subs)
 
-    return ''.join([name, sups_result, subs_result])
+    return leading*'_' + ''.join([name, sups_result, subs_result]) + trailing*'_'
 
 
 def annotated(letter):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2378,8 +2378,8 @@ __________ __________      \n\
 def test_pretty_Lambda():
     # S.IdentityFunction is a special case
     expr = Lambda(y, y)
-    assert pretty(expr) == "x -> x"
-    assert upretty(expr) == "x ↦ x"
+    assert pretty(expr) == "_x -> _x"
+    assert upretty(expr) == u"_x ↦ _x"
 
     expr = Lambda(x, x+1)
     assert pretty(expr) == "x -> x + 1"

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -9,7 +9,7 @@ from sympy.integrals.integrals import Integral
 from sympy.functions.special.bessel import besselj
 from sympy.functions.special.polynomials import legendre
 from sympy.functions.combinatorial.numbers import bell
-from sympy.printing.conventions import split_super_sub, requires_partial
+from sympy.printing.conventions import split_super_sub, requires_partial, split_leading_trailing_underscore
 from sympy.testing.pytest import XFAIL
 
 def test_super_sub():
@@ -114,3 +114,7 @@ def test_requires_partial_unspecified_variables():
     f = symbols('f', cls=Function)
     assert requires_partial(Derivative(f, x)) is False
     assert requires_partial(Derivative(f, x, y)) is True
+
+def test_split_leading_trailing_underscore():
+    assert split_leading_trailing_underscore('___123__') == (3, '123', 2)
+    assert split_leading_trailing_underscore('a_x^2____') == (0, 'a_x^2', 4)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,7 +17,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, Wild, symbols)
 from sympy.functions.combinatorial.factorials import (FallingFactorial, RisingFactorial, binomial, factorial, factorial2, subfactorial)
 from sympy.functions.combinatorial.numbers import (bernoulli, bell, catalan, euler, genocchi,
-                                                   lucas, fibonacci, tribonacci, divisor_sigma, udivisor_sigma,
+                                                   lucas, fibonacci, tribonacci, divisor_sigma, Dummy, udivisor_sigma,
                                                    mobius, primenu, primeomega,
                                                    totient, reduced_totient)
 from sympy.functions.elementary.complexes import (Abs, arg, conjugate, im, polar_lift, re)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -3162,3 +3162,8 @@ def test_latex_disable_split_super_sub():
     assert latex(Symbol('u^a_b')) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=False) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=True) == 'u\\^a\\_b'
+
+def test_dummy_underscores():
+    a = Dummy('a')
+    assert latex(a) == "\\_a"
+    assert latex(a + x) == "\\_a + x"

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -258,7 +258,7 @@ class BasisDependentMul(BasisDependent, Mul):
             if isinstance(arg, cls._zero_func):
                 count += 1
                 zeroflag = True
-            elif arg == S.Zero or arg == 0.0:
+            elif arg == S.Zero:
                 zeroflag = True
             elif isinstance(arg, (cls._base_func, cls._mul_func)):
                 count += 1

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -127,7 +127,6 @@ def test_vector():
 
     assert isinstance(v1, VectorAdd)
     assert v1 - v1 == Vector.zero
-    assert v1*0.0 == Vector.zero
     assert v1 + Vector.zero == v1
     assert v1.dot(i) == a
     assert v1.dot(j) == b


### PR DESCRIPTION
Fixes #14718
Fixed leading and trailing underscores and printing Dummy in LaTeX and pretty

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed leading and trailing underscores and printing Dummy in LaTeX and pretty by creating new function and changing some existing functions to work with the new function. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added function to split leading and trailing underscores
<!-- END RELEASE NOTES -->
