### PR TITLE
Remove @xfail from tests that are now passing

### DIFF
--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -5,7 +5,7 @@ from sympy.sets.contains import Contains
 from sympy.sets.fancysets import Interval
 from sympy.sets.powerset import PowerSet
 from sympy.sets.sets import FiniteSet
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises
 
 
 def test_powerset_creation():
@@ -53,11 +53,6 @@ def test_powerset__contains__():
                 assert subset_series[i] not in \
                     PowerSet(subset_series[j], evaluate=False)
 
-
-@XFAIL
-def test_failing_powerset__contains__():
-    # XXX These are failing when evaluate=True,
-    # but using unevaluated PowerSet works fine.
     assert FiniteSet(1, 2) not in PowerSet(S.EmptySet).rewrite(FiniteSet)
     assert S.Naturals not in PowerSet(S.EmptySet).rewrite(FiniteSet)
     assert S.Naturals not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -23,7 +23,7 @@ from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
         moment, median)
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, sample_iter, PSpace, is_random, RandomIndexedSymbol, RandomMatrixSymbol)
-from sympy.testing.pytest import raises, skip, XFAIL, warns_deprecated_sympy
+from sympy.testing.pytest import raises, skip, warns_deprecated_sympy
 from sympy.external import import_module
 from sympy.core.numbers import comp
 from sympy.stats.frv_types import BernoulliDistribution
@@ -235,7 +235,6 @@ def test_Sample():
     with warns_deprecated_sympy():
         sample(X, numsamples=2)
 
-@XFAIL
 def test_samplingE():
     scipy = import_module('scipy')
     if not scipy:

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -679,7 +679,6 @@ def test_printing2():
     check(MathMLPresentationPrinter())
 
 
-@XFAIL
 def test_printing3():
     check(PrettyPrinter())
 

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1238,7 +1238,6 @@ def test_N6():
     assert ask(k*x**n > k*y**n, (x > y) & (y > 0) & (k > 0) & (n > 0)) is True
 
 
-@XFAIL
 def test_N7():
     x, y = symbols('x y', real=True)
     assert ask(y > 0, (x > 1) & (y >= x - 1)) is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix: https://github.com/sympy/sympy/issues/6571
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

- This PR removes XFAIL decorators from tests that are now passing consistently.

- - stats/tests/test_rv.py::test_samplingE
- - utilities/tests/test_pickling.py::test_printing3
- - utilities/tests/test_wester.py::test_N7

- Removed sets/tests/test_powerset.py::test_failing_powerset__contains__ and add its content to sets/tests/test_powerset.py::test_powerset__contains__.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Removed XFAIL decorator from test_samplingE in stats/tests/test_rv.py.
 
* utilities
  * Removed XFAIL decorator from test_printing3 in utilities/tests/test_pickling.py.
  * Removed XFAIL decorator from test_N7 in utilities/tests/test_wester.py.
<!-- END RELEASE NOTES -->
