### PR TITLE
Replace assert with exception and type annotations  in ode/single.py

### DIFF
--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -77,11 +77,7 @@ class SingleODEProblem:
     _eq_preprocessed: Expr
     _eq_high_order_free = None
 
-    def __init__(self, eq, func, sym, prep=True, **kwargs):
-        assert isinstance(eq, Expr)
-        assert isinstance(func, AppliedUndef)
-        assert isinstance(sym, Symbol)
-        assert isinstance(prep, bool)
+    def __init__(self, eq: Expr, func: AppliedUndef, sym: Symbol, prep: bool = True, **kwargs):
         self.eq = eq
         self.func = func
         self.sym = sym
@@ -1956,7 +1952,8 @@ class NthOrderReducible(SingleODESolver):
         are considered, and only in them should ``func`` appear.
         """
         # ODE only handles functions of 1 variable so this affirms that state
-        assert len(func.args) == 1
+        if len(func.args) != 1:
+            raise ValueError("Function must have exactly one argument")
         vc = [d.variable_count[0] for d in eq.atoms(Derivative)
             if d.expr == func and len(d.variable_count) == 1]
         ords = [c for v, c in vc if v == x]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see gh-5090
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Replace assert with exception and type annotations in ode/single.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
