### PR TITLE
Replace assert with exception in crypto

### DIFF
--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -870,8 +870,10 @@ def encipher_hill(msg, key, symbols=None, pad="Q"):
     decipher_hill
 
     """
-    assert key.is_square
-    assert len(pad) == 1
+    if not key.is_square:
+        raise ValueError("key must be a square matrix")
+    if len(pad) != 1:
+        raise ValueError("pad must be a single character")
     msg, pad, A = _prep(msg, pad, symbols)
     map = {c: i for i, c in enumerate(A)}
     P = [map[c] for c in msg]
@@ -939,7 +941,8 @@ def decipher_hill(msg, key, symbols=None):
     encipher_hill
 
     """
-    assert key.is_square
+    if not key.is_square:
+        raise ValueError("key must be a square matrix")
     msg, _, A = _prep(msg, '', symbols)
     map = {c: i for i, c in enumerate(A)}
     C = [map[c] for c in msg]
@@ -2227,7 +2230,8 @@ def encode_morse(msg, sep='|', mapping=None):
     """
 
     mapping = mapping or char_morse
-    assert sep not in mapping
+    if sep in mapping:
+        raise ValueError(f"Separator {sep!r} is already used in the mapping.")
     word_sep = 2*sep
     mapping[" "] = word_sep
     suffix = msg and msg[-1] in whitespace


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see [gh-5090](https://github.com/sympy/sympy/issues/5090)
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Replace assert with exception in crypto.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
