### PR TITLE
Revert passing init_printing settings to the pretty printer

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -80,7 +80,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     def _print_plain(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
         if _can_print(arg):
-            p.text(stringify_func(arg, **settings))
+            p.text(stringify_func(arg))
         else:
             p.text(IPython.lib.pretty.pretty(arg))
 


### PR DESCRIPTION
This is a partial revert of PR #26997.

This caused a regression where settings that are not supported by the pretty printer but that are supported by other printers would lead to an error (there are many such settings in the LaTeX printer). A more correct fix would require some deeper refactoring, so for now we are just reverting this change.

The changes from #26997 updating the minimum IPython version have not been reverted.

That PR did not add any tests for this change and this does not add any tests either, as testing IPython/Jupyter interactive behavior is not straightforward.

Fixes #27992

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
(note: we will need to manually remove the entry from #26997)