### PR TITLE
Improve is_hermitian property for class Mul

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1550,7 +1550,8 @@ class Mul(Expr, AssocOp):
             return fuzzy_and((
                 fuzzy_or((expr1.is_hermitian, expr1.is_antihermitian)),
                 expr1 == expr2
-            ))
+            )) # We check for expr1.is_antihermitian and expr1 == expr2 because
+               # adjoint(A*u*A) = (-A)*adjoint(u)*(-A) = A*adjoint(u)*A
 
         # return True if the product of the list is real
         def is_list_real(l):
@@ -1607,7 +1608,8 @@ class Mul(Expr, AssocOp):
             return fuzzy_and((
                 fuzzy_or((expr1.is_hermitian, expr1.is_antihermitian)),
                 expr1 == expr2
-            ))
+            )) # We check for expr1.is_antihermitian and expr1 == expr2 because
+               # adjoint(A*u*A) = (-A)*adjoint(u)*(-A) = A*adjoint(u)*A
 
         # return True if the product of the list is real
         def is_list_real(l):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1541,9 +1541,15 @@ class Mul(Expr, AssocOp):
             return self._eval_real_imag(False)
 
     def _eval_is_hermitian(self):
+        from sympy.simplify import simplify
+        if simplify(self.func(*self.args) - self._eval_adjoint()).is_zero:
+            return True
         return self._eval_herm_antiherm(True)
 
     def _eval_is_antihermitian(self):
+        from sympy.simplify import simplify
+        if simplify(self.func(*self.args) + self._eval_adjoint()).is_zero:
+            return True
         return self._eval_herm_antiherm(False)
 
     def _eval_herm_antiherm(self, herm):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1541,14 +1541,12 @@ class Mul(Expr, AssocOp):
             return self._eval_real_imag(False)
 
     def _eval_is_hermitian(self):
-        from sympy.simplify import simplify
-        if simplify(self.func(*self.args) - self._eval_adjoint()).is_zero:
+        if (self - self._eval_adjoint()).is_zero:
             return True
         return self._eval_herm_antiherm(True)
 
     def _eval_is_antihermitian(self):
-        from sympy.simplify import simplify
-        if simplify(self.func(*self.args) + self._eval_adjoint()).is_zero:
+        if (self + self._eval_adjoint()).is_zero:
             return True
         return self._eval_herm_antiherm(False)
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1596,8 +1596,6 @@ class Mul(Expr, AssocOp):
 
         return self._eval_herm_antiherm(True)
 
-
-
     def _eval_is_antihermitian(self):
         from sympy import adjoint
 
@@ -1648,8 +1646,8 @@ class Mul(Expr, AssocOp):
             else:
                 middle = nc_part[n//2]
                 is_middle_antihermitian = fuzzy_or((
-                    fuzzy_and((middle.is_hermitian, is_list_imaginary(nc_part))),
-                    fuzzy_and((middle.is_antihermitian, is_list_real(nc_part)))
+                    fuzzy_and((middle.is_hermitian, is_list_imaginary(c_part))),
+                    fuzzy_and((middle.is_antihermitian, is_list_real(c_part)))
                 ))
                 if is_middle_antihermitian:
                     return True

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1540,7 +1540,7 @@ class Mul(Expr, AssocOp):
             return self._eval_real_imag(False)
 
     def _eval_is_hermitian(self):
-        from sympy import adjoint
+        from sympy.functions.elementary.complexes import adjoint
 
         def _is_adjoint_pair(expr1, expr2):
             if isinstance(expr1, adjoint) and expr1.args[0] == expr2:
@@ -1558,7 +1558,7 @@ class Mul(Expr, AssocOp):
             for z in l:
                 if z.is_imaginary is True:
                     n_imaginary += 1
-                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))):
+                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))) != False:
                     return None
             return (n_imaginary % 2 == 0)
 
@@ -1568,7 +1568,7 @@ class Mul(Expr, AssocOp):
             for z in l:
                 if z.is_imaginary is True:
                     n_imaginary += 1
-                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))):
+                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))) != False:
                     return None
             return (n_imaginary % 2 == 1)
         c_part, nc_part = self.args_cnc()
@@ -1597,7 +1597,7 @@ class Mul(Expr, AssocOp):
         return self._eval_herm_antiherm(True)
 
     def _eval_is_antihermitian(self):
-        from sympy import adjoint
+        from sympy.functions.elementary.complexes import adjoint
 
         def _is_adjoint_pair(expr1, expr2):
             if isinstance(expr1, adjoint) and expr1.args[0] == expr2:
@@ -1615,7 +1615,7 @@ class Mul(Expr, AssocOp):
             for z in l:
                 if z.is_imaginary is True:
                     n_imaginary += 1
-                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))):
+                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))) != False:
                     return None
             return (n_imaginary % 2 == 0)
 
@@ -1625,7 +1625,7 @@ class Mul(Expr, AssocOp):
             for z in l:
                 if z.is_imaginary is True:
                     n_imaginary += 1
-                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))):
+                elif fuzzy_not(fuzzy_or((z.is_imaginary, z.is_real))) != False:
                     return None
             return (n_imaginary % 2 == 1)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1591,6 +1591,9 @@ def test_Mul_hermitian_antihermitian():
     assert Mul(xnc*xnc.adjoint(), I*ync*ync.adjoint(), xnc*xnc.adjoint(), evaluate=False).is_antihermitian is True
     assert Mul(1+I, xnc, xnc.adjoint()).is_hermitian is None
     assert Mul(1+I, xnc, xnc.adjoint()).is_antihermitian is None
+    # assert Mul(2*xnc*xnc.adjoint(), Mul(xnc, xnc.adjoint(), evaluate=False), evaluate=False).is_hermitian is True    # doesn't succeed
+    assert (b*xnc*xnc.adjoint()).is_hermitian is None
+
 
 
 def test_Add_is_comparable():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1586,10 +1586,11 @@ def test_Mul_hermitian_antihermitian():
     assert Mul(I, I*xnc*xnc.adjoint(), I*ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is True
     assert Mul(I, I*xnc*xnc.adjoint(), ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is None
     assert Mul(13, I*xnc*xnc.adjoint(), I*ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is None
-
-
-
-
+    assert Mul(I, I*xnc*xnc.adjoint(), ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_antihermitian is True
+    assert Mul(13, I*xnc*xnc.adjoint(), I*ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_antihermitian is True
+    assert Mul(xnc*xnc.adjoint(), I*ync*ync.adjoint(), xnc*xnc.adjoint(), evaluate=False).is_antihermitian is True
+    assert Mul(1+I, xnc, xnc.adjoint()).is_hermitian is None
+    assert Mul(1+I, xnc, xnc.adjoint()).is_antihermitian is None
 
 
 def test_Add_is_comparable():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1573,8 +1573,9 @@ def test_Mul_hermitian_antihermitian():
     assert e6.is_antihermitian is None
 
     xnc = symbols("xnc", commutative=False)
-    assert (xnc*xnc.adjoint()).is_hermitian
-    assert (xnc.adjoint()*10*xnc).is_hermitian
+    assert (xnc*xnc.adjoint()).is_hermitian is True
+    assert (xnc.adjoint()*10*xnc).is_hermitian is True
+    assert (xnc.adjoint()*(I+10)*xnc).is_hermitian is None
 
 
 def test_Add_is_comparable():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1572,6 +1572,10 @@ def test_Mul_hermitian_antihermitian():
     assert e5.is_antihermitian is None
     assert e6.is_antihermitian is None
 
+    xnc = symbols("xnc", commutative=False)
+    assert (xnc*xnc.adjoint()).is_hermitian
+    assert (xnc.adjoint()*10*xnc).is_hermitian
+
 
 def test_Add_is_comparable():
     assert (x + y).is_comparable is False

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1572,10 +1572,24 @@ def test_Mul_hermitian_antihermitian():
     assert e5.is_antihermitian is None
     assert e6.is_antihermitian is None
 
-    xnc = symbols("xnc", commutative=False)
+    xnc, ync = symbols("xnc ync", commutative=False)
     assert (xnc*xnc.adjoint()).is_hermitian is True
     assert (xnc.adjoint()*10*xnc).is_hermitian is True
     assert (xnc.adjoint()*(I+10)*xnc).is_hermitian is None
+    assert (I*xnc.adjoint()*xnc).is_antihermitian is True
+    assert (xnc*ync*ync.adjoint()*xnc.adjoint()).is_hermitian is True
+    # assert Mul(xnc, I, 13, ync.adjoint(), I, ync, I, xnc.adjoint(), I, evaluate=False).is_hermitian is True # Issue 24480 mentions this test
+    assert (-4*I*xnc.adjoint()*ync*ync.adjoint()*xnc).is_antihermitian is True
+    assert (xnc*xnc).is_hermitian is None
+    assert Mul(I*xnc*xnc.adjoint(), ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is True
+    assert Mul(xnc*xnc.adjoint(), ync*ync.adjoint(), xnc*xnc.adjoint(), evaluate=False).is_hermitian is True
+    assert Mul(I, I*xnc*xnc.adjoint(), I*ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is True
+    assert Mul(I, I*xnc*xnc.adjoint(), ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is None
+    assert Mul(13, I*xnc*xnc.adjoint(), I*ync*ync.adjoint(), I*xnc*xnc.adjoint(), evaluate=False).is_hermitian is None
+
+
+
+
 
 
 def test_Add_is_comparable():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #27989 

#### Brief description of what is fixed or changed
This PR improves the `is_hermitian` property for the Mul class by adding a test based on the definition of a Hermitian object. It checks if A.adjoint() == A.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Added a test in the property _eval_is_hermitian for the Mul class that check the definition of a Hermitian object. For example, now, `A*Dagger(A).is_hermitian is True` because `Dagger(A*Dagger(A)) == A*Dagger(A)`
<!-- END RELEASE NOTES -->
