### PR TITLE
Restrict the return type of `perfect_power` to `tuple[int, int]` or `False`

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2085,9 +2085,7 @@ class Integer(Rational):
         b_pos = int(abs(self.p))
         p = perfect_power(b_pos)
         if p is not False:
-            # XXX: Convert to int because perfect_power may return fmpz
-            # Ideally that should be fixed in perfect_power though...
-            dict = {int(p[0]): int(p[1])}
+            dict = {p[0]: p[1]}
         else:
             dict = Integer(b_pos).factors(limit=2**15)
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -326,7 +326,7 @@ def _perfect_power(n, next_p=2):
         if g == 1:
             return False
         factors[n] = multi
-        return math.prod(p**(e//g) for p, e in factors.items()), g
+        return int(math.prod(p**(e//g) for p, e in factors.items())), int(g)
 
     # If n is small, only trial factoring is faster
     if n <= 1_000_000:
@@ -336,7 +336,7 @@ def _perfect_power(n, next_p=2):
         g = gcd(*factors.values())
         if g == 1:
             return False
-        return math.prod(p**(e//g) for p, e in factors.items()), g
+        return math.prod(p**(e//g) for p, e in factors.items()), int(g)
 
     # divide by 2
     if next_p < 3:
@@ -353,7 +353,7 @@ def _perfect_power(n, next_p=2):
                 # Otherwise, there is no possibility of perfect power, especially if `g` is prime.
                 m, _exact = iroot(n, g)
                 if _exact:
-                    return 2*m, g
+                    return int(2*m), g
                 elif isprime(g):
                     return False
         next_p = 3
@@ -380,19 +380,19 @@ def _perfect_power(n, next_p=2):
             if t:
                 n = m
                 t *= multi
-                _g = gcd(g, t)
+                _g = int(gcd(g, t))
                 if _g == 1:
                     return False
                 factors[p] = t
                 if n == 1:
-                    return math.prod(p**(e//_g)
-                                        for p, e in factors.items()), _g
+                    return int(math.prod(p**(e//_g)
+                                        for p, e in factors.items())), _g
                 elif g == 0 or _g < g: # If g is updated
                     g = _g
                     m, _exact = iroot(n**multi, g)
                     if _exact:
-                        return m * math.prod(p**(e//g)
-                                            for p, e in factors.items()), g
+                        return int(m * math.prod(p**(e//g)
+                                            for p, e in factors.items())), g
                     elif isprime(g):
                         return False
         next_p = tf_max


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/27949#discussion_r2044357687

#### Brief description of what is fixed or changed
Previously, depending on the environment, it could return `mpz`, but it has now been standardized to `int`. Note that all potential issues occurred within `_perfect_power`, so no modifications to `perfect_power` itself were necessary.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
