### PR TITLE
In doc of class Rational, mention .numerator & .denominator properties

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1287,8 +1287,8 @@ class Rational(Number):
     >>> r.p/r.q
     0.75
 
-    For consistency with Python's abstract base class ``Rational`` [1] and 
-    classes ``int``, ``Fraction`` [2], and others, numerator and denominator 
+    For consistency with Python's abstract base class ``Rational`` [1] and
+    classes ``int``, ``Fraction`` [2] and others, numerator and denominator
     are also available as properties ``.numerator`` and ``.denominator``.
     Note that up to SymPy 1.8, these were methods instead of properties.
 
@@ -1297,7 +1297,7 @@ class Rational(Number):
 
     .. [1] http://docs.python.org/3/library/numbers.html#numbers.Rational
     .. [2] http://docs.python.org/3/library/fractions.html#fractions.Fraction
-    
+
     See Also
     ========
     sympy.core.sympify.sympify, sympy.simplify.simplify.nsimplify

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1287,6 +1287,17 @@ class Rational(Number):
     >>> r.p/r.q
     0.75
 
+    For consistency with Python's abstract base class ``Rational`` [1] and 
+    classes ``int``, ``Fraction`` [2], and others, numerator and denominator 
+    are also available as properties ``.numerator`` and ``.denominator``.
+    Note that up to SymPy 1.8, these were methods instead of properties.
+
+    References
+    ==========
+
+    .. [1] http://docs.python.org/3/library/numbers.html#numbers.Rational
+    .. [2] http://docs.python.org/3/library/fractions.html#fractions.Fraction
+    
     See Also
     ========
     sympy.core.sympify.sympify, sympy.simplify.simplify.nsimplify
@@ -2906,8 +2917,8 @@ class NegativeOne(IntegerConstant, metaclass=Singleton):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/%E2%88%921_%28number%29
-
     """
+
     is_number = True
 
     p = -1
@@ -3384,8 +3395,8 @@ class NaN(Number, metaclass=Singleton):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/NaN
-
     """
+
     is_commutative = True
     is_extended_real = None
     is_real = None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #27837

#### Brief description of what is fixed or changed
As discussed in https://github.com/sympy/sympy/issues/27837, I added to the docstring of `class Rational` that numerator & denominator are also available as properties `.numerator` & `.denominator`, conforming to Pythons ABC `numbers.Rational`, and that up to version 1.8, these were methods instead of properties. (That might help to understand compatibility issues with older code.)

(Minor edits: removed empty lines at the end of two docstrings right before the `"""`, and added an empty line after the `"""`, for uniformity with the rest of the document.)

#### Other comments
No change to code, only to docstrings.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
