### PR TITLE
Refactor of qapply to use type dispatchers and `_constructor_postprocessor_mapping`

### DIFF
--- a/sympy/physics/quantum/__init__.py
+++ b/sympy/physics/quantum/__init__.py
@@ -1,6 +1,8 @@
 # Names exposed by 'from sympy.physics.quantum import *'
 
 __all__ = [
+   # 'SlidingTransform', 'DipatchingSlidingTransform'
+
     'AntiCommutator',
 
     'qapply',
@@ -31,6 +33,10 @@ __all__ = [
 
     '_postprocess_state_mul', '_postprocess_state_pow'
 ]
+
+# from .slidingtransform import (
+#     SlidingTransform, DipatchingSlidingTransform
+# )
 
 from .anticommutator import AntiCommutator
 

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -10,7 +10,6 @@ from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.operator import HermitianOperator
-from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.matrixutils import numpy_ndarray, scipy_sparse_matrix, to_numpy
 from sympy.physics.quantum.trace import Tr
 
@@ -191,6 +190,7 @@ class Density(HermitianOperator):
         return Mul(*c_part1)*Mul(*c_part2) * op
 
     def _represent(self, **options):
+        from sympy.physics.quantum.represent import represent
         return represent(self.doit(), **options)
 
     def _print_operator_name_latex(self, printer, *args):
@@ -238,6 +238,7 @@ def entropy(density):
 
     """
     if isinstance(density, Density):
+        from sympy.physics.quantum.represent import represent
         density = represent(density)  # represent in Matrix
 
     if isinstance(density, scipy_sparse_matrix):
@@ -299,6 +300,7 @@ def fidelity(state1, state2):
     .. [1] https://en.wikipedia.org/wiki/Fidelity_of_quantum_states
 
     """
+    from sympy.physics.quantum.represent import represent
     state1 = represent(state1) if isinstance(state1, Density) else state1
     state2 = represent(state2) if isinstance(state2, Density) else state2
 

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -1,24 +1,40 @@
 """Logic for applying operators to states.
 
-Todo:
-* Sometimes the final result needs to be expanded, we should do this by hand.
+TODO:
+
+- Finish slidingtransform
+- Finish slidingtransform tests
+- Add extra type handlers to get rid of warnings in qapply
+- Optimize performance
+- Finish tests for qapply
+- Fix all other tests
+
 """
 
 from sympy.concrete import Sum
 from sympy.core.add import Add
+from sympy.core.expr import Expr
 from sympy.core.kind import NumberKind
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify, _sympify
+from sympy.functions.elementary.complexes import Abs
+from sympy.integrals import Integral
+from sympy.multipledispatch import Dispatcher
+
+from sympy.utilities.misc import debug
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.dagger import Dagger
+from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.operator import OuterProduct, Operator
 from sympy.physics.quantum.state import State, KetBase, BraBase, Wavefunction
 from sympy.physics.quantum.tensorproduct import TensorProduct
+from sympy.physics.quantum.slidingtransform import SlidingTransform
+
 
 __all__ = [
     'qapply'
@@ -26,207 +42,240 @@ __all__ = [
 
 
 #-----------------------------------------------------------------------------
-# Main code
+# Utilities
 #-----------------------------------------------------------------------------
 
 
-def ip_doit_func(e):
+def _ip_doit_func(e):
     """Transform the inner products in an expression by calling ``.doit()``."""
     return e.replace(InnerProduct, lambda *args: InnerProduct(*args).doit())
 
 
-def sum_doit_func(e):
+def _sum_doit_func(e):
     """Transform the sums in an expression by calling ``.doit()``."""
-    return e.replace(Sum, lambda *args: Sum(*args).doit())
+    result = e.replace(Sum, lambda *args: Sum(*args).doit())
+    result = result.replace(Integral, lambda *args: Integral(*args).doit())
+    return result
 
+
+def _handle_doit_unary(f):
+
+    def apply_doit(expr, **options):
+        sum_doit = options.get('sum_doit', False)
+        ip_doit = options.get('ip_doit', True)
+        result = f(expr, **options)
+        result = _ip_doit_func(result) if ip_doit else result
+        result = _sum_doit_func(result) if sum_doit else result
+        return result
+
+    return apply_doit
+
+
+def _flatten_mul(f):
+    
+    def g(*args, **options):
+        seq = f(*args, **options)
+        if seq is None:
+            return
+        result = []
+        for item in seq:
+            if isinstance(item, Mul):
+                result.extend(item.args)
+            else:
+                result.append(item)
+        return tuple(result)
+
+    return g
+
+
+#-----------------------------------------------------------------------------
+# Main code
+#-----------------------------------------------------------------------------
+
+# Level 0: int, float, complex
+# Level 1: Expr
+# Level 2: Mul, Add, Pow, Abs
+# Level 3: Sum, Integral
+# Level 3: Bra, Ket, Operator, Dagger
+# Level 4: InnerProduct, OuterProduct
+# Level 5: TensorProduct, Density
+
+#-----------------------------------------------------------------------------
+# _qapply_unary
+#-----------------------------------------------------------------------------
+
+_qapply_unary = Dispatcher('_qapply_unary')
+
+
+@_qapply_unary.register(Expr)
+def _qapply_unary_expr(expr, **options):
+    return None
+
+
+@_qapply_unary.register((int, float, complex))
+def _qapply_unary_number(expr, **options):
+    return sympify(expr)
+
+
+@_qapply_unary.register(Abs)
+def _qapply_unary_abs(expr, **options):
+    debug('Abs: ', expr, **options)
+    return Abs(qapply(expr.args[0], **options))
+
+
+@_qapply_unary.register(Add)
+def _qapply_unary_state(expr, **options):
+    result = 0
+    for arg in expr.args:
+        result += qapply(arg, **options)
+    return result
+
+
+@_qapply_unary.register(Pow)
+def _qapply_unary_pow(expr, **options):
+    # For a Pow, call qapply on its base.
+    base, exp = expr.as_base_exp()
+    return qapply(base, **options)**exp
+
+
+@_qapply_unary.register(Mul)
+@_handle_doit_unary
+def _qapply_unary_mul(expr, **options):
+    """We have a Mul where there might be actual operators to apply."""
+    dagger = options.get('dagger', False)
+    result = qapply_Mul(expr, **options)
+    if dagger:
+        result = Dagger(qapply_Mul(Dagger(result), **options))
+    return result
+
+
+@_qapply_unary.register(Sum)
+@_handle_doit_unary
+def _qapply_unary_sum(expr, **options):
+    """For a Sum, call qapply on its function."""
+    result = Sum(qapply(expr.function, **options), *expr.limits)
+    return result
+
+
+@_qapply_unary.register(Integral)
+@_handle_doit_unary
+def _qapply_unary_integral(expr, **options):
+    """For a Sum, call qapply on its function."""
+    result = Integral(qapply(expr.function, **options), *expr.limits)
+    return result
+
+
+@_qapply_unary.register(Dagger)
+def _qapply_unary_dagger(expr, **options):
+    return Dagger(qapply(expr, **options))
+
+
+@_qapply_unary.register(Density)
+def _qapply_unary_density(expr, **options):
+    # For a Density operator call qapply on its state
+    new_args = [(qapply(state, **options), prob) for (state,
+                     prob) in expr.args]
+    return Density(*new_args)
+
+
+@_qapply_unary.register(TensorProduct)
+def _qapply_unary_tp(expr, **options):
+    new_args = [qapply(t, **options) for t in expr.args]
+    return TensorProduct(*new_args)
+
+
+#-----------------------------------------------------------------------------
+# qapply
+#-----------------------------------------------------------------------------
 
 def qapply(e, **options):
-    """Apply operators to states in a quantum expression.
-
-    Parameters
-    ==========
-
-    e : Expr
-        The expression containing operators and states. This expression tree
-        will be walked to find operators acting on states symbolically.
-    options : dict
-        A dict of key/value pairs that determine how the operator actions
-        are carried out.
-
-        The following options are valid:
-
-        * ``dagger``: try to apply Dagger operators to the left
-          (default: False).
-        * ``ip_doit``: call ``.doit()`` in inner products when they are
-          encountered (default: True).
-        * ``sum_doit``: call ``.doit()`` on sums when they are encountered
-          (default: False). This is helpful for collapsing sums over Kronecker
-          delta's that are created when calling ``qapply``.
-
-    Returns
-    =======
-
-    e : Expr
-        The original expression, but with the operators applied to states.
-
-    Examples
-    ========
-
-        >>> from sympy.physics.quantum import qapply, Ket, Bra
-        >>> b = Bra('b')
-        >>> k = Ket('k')
-        >>> A = k * b
-        >>> A
-        |k><b|
-        >>> qapply(A * b.dual / (b * b.dual))
-        |k>
-        >>> qapply(k.dual * A / (k.dual * k))
-        <b|
-    """
-    from sympy.physics.quantum.density import Density
-
-    dagger = options.get('dagger', False)
-    sum_doit = options.get('sum_doit', False)
+    debug('qapply: ', e)
     ip_doit = options.get('ip_doit', True)
 
     e = _sympify(e)
 
     # Using the kind API here helps us to narrow what types of expressions
-    # we call ``ip_doit_func`` on.
+    # we call ``_ip_doit_func`` on. Here, we are covering the case where there
+    # is an inner product in a scalar input.
     if e.kind == NumberKind:
-        return ip_doit_func(e) if ip_doit else e
+        return _ip_doit_func(e) if ip_doit else e
 
-    # This may be a bit aggressive but ensures that everything gets expanded
-    # to its simplest form before trying to apply operators. This includes
-    # things like (A+B+C)*|a> and A*(|a>+|b>) and all Commutators and
-    # TensorProducts. The only problem with this is that if we can't apply
-    # all the Operators, we have just expanded everything.
-    # TODO: don't expand the scalars in front of each Mul.
-    e = e.expand(commutator=True, tensorproduct=True)
+    result = _qapply_unary(e, **options)
 
-    # If we just have a raw ket, return it.
-    if isinstance(e, KetBase):
-        return e
+    return e if (result is None) else result
 
-    # We have an Add(a, b, c, ...) and compute
-    # Add(qapply(a), qapply(b), ...)
-    elif isinstance(e, Add):
-        result = 0
-        for arg in e.args:
-            result += qapply(arg, **options)
-        return result.expand()
 
-    # For a Density operator call qapply on its state
-    elif isinstance(e, Density):
-        new_args = [(qapply(state, **options), prob) for (state,
-                     prob) in e.args]
-        return Density(*new_args)
+#-----------------------------------------------------------------------------
+# qapply_Mul
+#-----------------------------------------------------------------------------
 
-    # For a raw TensorProduct, call qapply on its args.
-    elif isinstance(e, TensorProduct):
-        return TensorProduct(*[qapply(t, **options) for t in e.args])
 
-    # For a Sum, call qapply on its function.
-    elif isinstance(e, Sum):
-        result = Sum(qapply(e.function, **options), *e.limits)
-        result = sum_doit_func(result) if sum_doit else result
-        return result
+qapply_Mul = SlidingTransform(
+    unary=Dispatcher('_qapply_mul_unary'),
+    binary=Dispatcher('_qapply_mul_binary'),
+    reverse=True
+)
 
-    # For a Pow, call qapply on its base.
-    elif isinstance(e, Pow):
-        return qapply(e.base, **options)**e.exp
+# Unary transformations for qapply_Mul
 
-    # We have a Mul where there might be actual operators to apply to kets.
-    elif isinstance(e, Mul):
-        c_part, nc_part = e.args_cnc()
-        c_mul = Mul(*c_part)
-        nc_mul = Mul(*nc_part)
-        if not nc_part: # If we only have a commuting part, just return it.
-            result = c_mul
-        elif isinstance(nc_mul, Mul):
-            result = c_mul*qapply_Mul(nc_mul, **options)
-        else:
-            result = c_mul*qapply(nc_mul, **options)
-        if result == e and dagger:
-            result = Dagger(qapply_Mul(Dagger(e), **options))
-        result = ip_doit_func(result) if ip_doit else result
-        result = sum_doit_func(result) if sum_doit else result
-        return result
 
-    # In all other cases (State, Operator, Pow, Commutator, InnerProduct,
-    # OuterProduct) we won't ever have operators to apply to kets.
+@qapply_Mul.unary.register((int, float, complex))
+def _qapply_mul_unary_number(expr, **options):
+    return (sympify(expr),)
+
+
+@qapply_Mul.unary.register(Expr)
+def qapply_mul_unary_expr(expr, **options):
+    return None
+
+
+@qapply_Mul.unary.register(Pow)
+@_flatten_mul
+def _qapply_mul_unary_pow(expr, **options):
+    base, exp = expr.as_base_exp()
+    if exp.is_Integer and exp > 0:
+        return tuple(expr.base for i in range(int(expr.exp)))
     else:
-        return e
+        return (qapply(expr, **options),)
 
 
-def qapply_Mul(e, **options):
+@qapply_Mul.unary.register(OuterProduct)
+def _qapply_mul_unary_op(expr, **options):
+    return (expr.ket, expr.bra)
 
-    args = list(e.args)
-    extra = S.One
-    result = None
 
-    # If we only have 0 or 1 args, we have nothing to do and return.
-    if len(args) <= 1 or not isinstance(e, Mul):
-        return e
-    rhs = args.pop()
-    lhs = args.pop()
+@qapply_Mul.unary.register((Commutator, AntiCommutator))
+@_flatten_mul
+def _qapply_mul_unary_comm(expr, **options):
+    return (expr.doit(),)
 
-    # Make sure we have two non-commutative objects before proceeding.
-    if (not isinstance(rhs, Wavefunction) and sympify(rhs).is_commutative) or \
-            (not isinstance(lhs, Wavefunction) and sympify(lhs).is_commutative):
-        return e
 
-    # For a Pow with an integer exponent, apply one of them and reduce the
-    # exponent by one.
-    if isinstance(lhs, Pow) and lhs.exp.is_Integer:
-        args.append(lhs.base**(lhs.exp - 1))
-        lhs = lhs.base
+@qapply_Mul.unary.register(TensorProduct)
+@_flatten_mul
+def _qapply_mul_unary_tp(expr, **options):
+    new_args = [qapply(t, **options) for t in expr.args]
+    return (TensorProduct(*new_args),)
 
-    # Pull OuterProduct apart
-    if isinstance(lhs, OuterProduct):
-        args.append(lhs.ket)
-        lhs = lhs.bra
 
-    if isinstance(rhs, OuterProduct):
-        extra = rhs.bra # Append to the right of the result
-        rhs = rhs.ket
+@qapply_Mul.unary.register(Density)
+def _qapply_mul_unary_density(expr, **options):
+    # For a Density operator call qapply on its state
+    new_args = [(qapply(state, **options), prob) for (state,
+                     prob) in expr.args]
+    return (Density(*new_args),)
 
-    # Call .doit() on Commutator/AntiCommutator.
-    if isinstance(lhs, (Commutator, AntiCommutator)):
-        comm = lhs.doit()
-        if isinstance(comm, Add):
-            return qapply(
-                e.func(*(args + [comm.args[0], rhs])) +
-                e.func(*(args + [comm.args[1], rhs])),
-                **options
-            )*extra
-        else:
-            return qapply(e.func(*args)*comm*rhs, **options)*extra
 
-    # Apply tensor products of operators to states
-    if isinstance(lhs, TensorProduct) and all(isinstance(arg, (Operator, State, Mul, Pow)) or arg == 1 for arg in lhs.args) and \
-            isinstance(rhs, TensorProduct) and all(isinstance(arg, (Operator, State, Mul, Pow)) or arg == 1 for arg in rhs.args) and \
-            len(lhs.args) == len(rhs.args):
-        result = TensorProduct(*[qapply(lhs.args[n]*rhs.args[n], **options) for n in range(len(lhs.args))]).expand(tensorproduct=True)
-        return qapply_Mul(e.func(*args), **options)*result*extra
+# Binary transformations for qapply_Mul
 
-    # For Sums, move the Sum to the right.
-    if isinstance(rhs, Sum):
-        if isinstance(lhs, Sum):
-            if set(lhs.variables).intersection(set(rhs.variables)):
-                raise ValueError('Duplicated dummy indices in separate sums in qapply.')
-            limits = lhs.limits + rhs.limits
-            result = Sum(qapply(lhs.function*rhs.function, **options), *limits)
-            return qapply_Mul(e.func(*args)*result, **options)
-        else:
-            result = Sum(qapply(lhs*rhs.function, **options), *rhs.limits)
-            return qapply_Mul(e.func(*args)*result, **options)
 
-    if isinstance(lhs, Sum):
-        result = Sum(qapply(lhs.function*rhs, **options), *lhs.limits)
-        return qapply_Mul(e.func(*args)*result, **options)
+@qapply_Mul.binary.register(Expr, Expr)
+def _qapply_mul_binary_expr_expr(lhs, rhs, **options):
+    return None
 
-    # Now try to actually apply the operator and build an inner product.
+
+@qapply_Mul.binary.register(Operator, KetBase)
+@_flatten_mul
+def _qapply_mul_binary_op_ket(lhs, rhs, **options):
     _apply = getattr(lhs, '_apply_operator', None)
     if _apply is not None:
         try:
@@ -244,20 +293,74 @@ def qapply_Mul(e, **options):
             except NotImplementedError:
                 result = None
 
-    if result is None:
-        if isinstance(lhs, BraBase) and isinstance(rhs, KetBase):
-            result = InnerProduct(lhs, rhs)
+    return None if result is None else (result,)
 
-    # TODO: I may need to expand before returning the final result.
-    if isinstance(result, (int, complex, float)):
-        return _sympify(result)
-    elif result is None:
-        if len(args) == 0:
-            # We had two args to begin with so args=[].
-            return e
-        else:
-            return qapply_Mul(e.func(*(args + [lhs])), **options)*rhs*extra
-    elif isinstance(result, InnerProduct):
-        return result*qapply_Mul(e.func(*args), **options)*extra
-    else:  # result is a scalar times a Mul, Add or TensorProduct
-        return qapply(e.func(*args)*result, **options)*extra
+
+@qapply_Mul.binary.register(BraBase, Operator)
+def _qapply_mul_binary_bra_op(lhs, rhs, **options):
+    """Register this to remind us that we only do this when dagger=True."""
+    return None
+
+
+@qapply_Mul.binary.register(Add, Expr)
+def _qapply_mul_binary_add_expr(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = Add(*(qapply(item*rhs, **options) for item in lhs.args))
+        return (result,)
+
+
+@qapply_Mul.binary.register(Expr, Add)
+def _qapply_mul_binary_expr_add(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = Add(*(qapply(lhs*item, **options) for item in rhs.args))
+        return (result,)
+
+
+@qapply_Mul.binary.register((Sum, Integral), Expr)
+def _qapply_mul_binary_sum_expr(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = lhs.func(qapply(lhs.function*rhs, **options), *lhs.limits)
+        return (result,)
+
+
+@qapply_Mul.binary.register(Expr, (Sum, Integral))
+def _qapply_mul_binary_expr_sum(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = rhs.func(qapply(lhs*rhs.function, **options), *rhs.limits)
+        return (result,)
+
+
+@qapply_Mul.binary.register(Sum, Sum)
+def _qapply_mul_binary_sum_sum(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        if set(lhs.variables).intersection(set(rhs.variables)):
+            raise ValueError(
+                'Duplicated dummy indices in separate sums in qapply.'
+            )
+        limits = lhs.limits + rhs.limits
+        result = Sum(
+            qapply(lhs.function*rhs.function, **options),
+            *limits
+        )
+        return (result,)
+
+
+@qapply_Mul.binary.register(Integral, Integral)
+def _qapply_mul_binary_integral_integral(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        if set(lhs.variables).intersection(set(rhs.variables)):
+            raise ValueError(
+                'Duplicated dummy indices in separate sums in qapply.'
+            )
+        limits = lhs.limits + rhs.limits
+        result = Integral(
+            qapply(lhs.function*rhs.function, **options),
+            *limits
+        )
+        return (result,)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -21,7 +21,6 @@ from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.matrixutils import flatten_scalar
 from sympy.physics.quantum.state import KetBase, BraBase, StateBase
 from sympy.physics.quantum.operator import Operator, OuterProduct
-from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.operatorset import operators_to_state, state_to_operators
 
 
@@ -327,7 +326,7 @@ def rep_expectation(expr, **options):
     <px_2|*X*|px_1>
 
     """
-
+    from sympy.physics.quantum.qapply import qapply
     if "index" not in options:
         options["index"] = 1
 

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -1,0 +1,110 @@
+"""A sliding window tranform to process Mul-like expressions."""
+
+from sympy.core.expr import Expr
+from sympy.core.mul import Mul
+from sympy.multipledispatch.dispatcher import Dispatcher
+
+
+class SlidingTransform(object):
+ 
+    def __init__(self, unary=None, binary=None, reverse=False):
+        self._unary = unary
+        self._binary = binary
+        self._reverse = reverse
+
+    @property
+    def reverse(self):
+        return self._reverse
+
+    def __call__(self, expr):
+        if not isinstance(expr, Mul):
+            raise TypeError('The SlidingTransform only works on Mul instances.')
+
+        input = list(expr.args)
+        output = []
+
+        if self._unary is not None:
+            while len(input) > 0:
+                next = input.pop(0)
+                transformed = self._unary(next)
+                if transformed is None:
+                    output.append(next)
+                else:
+                    output.extend(transformed)
+            input = output
+            output = []
+
+
+        if self._binary is not None:
+            if not self.reverse:
+                # Continue as long as we have at least 2 elements
+                while len(input) > 1:
+                    # Get first two elements
+                    lhs = input.pop(0)
+                    rhs = input[0]  # Look at second element without popping yet
+
+                    transformed = self._binary(lhs, rhs)
+
+                    if transformed is None:
+                        # If transform returns None, append first element
+                        output.append(lhs)
+                    else:
+                        # This item was transformed, pop and discard
+                        input.pop(0)
+                        # The last item goes back to be transformed again
+                        input.insert(0, transformed[-1])
+                        # All other items go directly into the result
+                        output.extend(transformed[:-1])
+
+                # Append any remaining element
+                if input:
+                    output.append(input[0])
+
+            else:
+                while len(input) > 1:
+                    # Get first two elements
+                    rhs = input.pop(-1)
+                    lhs = input[-1]
+
+                    transformed = self._binary(lhs, rhs)
+
+                    if transformed is None:
+                        output.insert(0, rhs)
+                    else:
+                        input.pop(-1)
+                        input.append(transformed[0])
+                        output[0:0] = transformed[1:]
+
+                if input:
+                    output.insert(0, input[-1])
+
+            input = output
+            output = []
+
+        return Mul._from_args(input, is_commutative=False)
+
+
+class DipatchingSlidingTransform(SlidingTransform):
+
+    def __init__(self, unary=False, binary=True):
+        if unary:
+            unary = Dispatcher('_sliding_transform_unary')
+            unary.register((Expr), lambda x: None)
+        else:
+            unary = None
+
+        if binary:
+            binary = Dispatcher('_sliding_transform_binary')
+            binary.register((Expr, Expr), lambda x, y: None)
+        else:
+            binary = None
+
+        super().__init__(unary, binary)
+
+    @property
+    def unary(self):
+        return self._unary
+
+    @property
+    def binary(self):
+        return self._binary

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -1,8 +1,27 @@
 """A sliding window tranform to process Mul-like expressions."""
 
+from itertools import tee
+
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.multipledispatch.dispatcher import Dispatcher
+
+from sympy.utilities.misc import debug
+
+__all__ = [
+    'SlidingTransform',
+    'DipatchingSlidingTransform'
+]
+
+
+def _split_on_condition(seq, condition):
+    l1, l2 = tee((condition(item), item) for item in seq)
+    return tuple(i for p, i in l1 if p), tuple(i for p, i in l2 if not p)
+
+
+def _split_cnc(seq):
+    c, nc = _split_on_condition(seq, lambda x: x.is_commutative)
+    return c, nc
 
 
 class SlidingTransform(object):
@@ -16,25 +35,37 @@ class SlidingTransform(object):
     def reverse(self):
         return self._reverse
 
-    def __call__(self, expr):
+    @property
+    def unary(self):
+        return self._unary
+
+    @property
+    def binary(self):
+        return self._binary
+
+    def __call__(self, expr, **options):
         if not isinstance(expr, Mul):
             raise TypeError('The SlidingTransform only works on Mul instances.')
 
         input = list(expr.args)
         output = []
-
+        # if self.reverse:
+        #     debug('ST1: ', input, output)
         if self._unary is not None:
             while len(input) > 0:
                 next = input.pop(0)
-                transformed = self._unary(next)
+                transformed = self._unary(next, **options)
                 if transformed is None:
                     output.append(next)
                 else:
                     output.extend(transformed)
             input = output
             output = []
+            # debug('qapply_Mul unary: ', input)
 
-
+        # if self.reverse:
+        #     debug('ST2: ', input, output)
+        c_parts = []
         if self._binary is not None:
             if not self.reverse:
                 # Continue as long as we have at least 2 elements
@@ -43,68 +74,63 @@ class SlidingTransform(object):
                     lhs = input.pop(0)
                     rhs = input[0]  # Look at second element without popping yet
 
-                    transformed = self._binary(lhs, rhs)
+                    transformed = self._binary(lhs, rhs, **options)
 
                     if transformed is None:
                         # If transform returns None, append first element
                         output.append(lhs)
                     else:
+                        c_t, nc_t = _split_cnc(transformed)
+                        c_parts.extend(c_t)
                         # This item was transformed, pop and discard
                         input.pop(0)
-                        # The last item goes back to be transformed again
-                        input.insert(0, transformed[-1])
-                        # All other items go directly into the result
-                        output.extend(transformed[:-1])
+                        if nc_t:
+                            # The last item goes back to be transformed again
+                            input.insert(0, nc_t[-1])
+                            # All other items go directly into the result
+                            output.extend(nc_t[:-1])
 
                 # Append any remaining element
                 if input:
                     output.append(input[0])
 
-            else:
+            else: # reverse = True case
                 while len(input) > 1:
                     # Get first two elements
                     rhs = input.pop(-1)
                     lhs = input[-1]
+
+                    # Make sure that lhs and rhs are commutative
+                    if rhs.is_commutative:
+                        c_parts.append(rhs)
+                        continue
+                    if lhs.is_commutative:
+                        c_parts.append(lhs)
+                        input.pop(-1)
+                        input.append(rhs)
+                        continue
 
                     transformed = self._binary(lhs, rhs)
 
                     if transformed is None:
                         output.insert(0, rhs)
                     else:
+                        c_t, nc_t = _split_cnc(transformed)
+                        c_parts.extend(c_t)
                         input.pop(-1)
-                        input.append(transformed[0])
-                        output[0:0] = transformed[1:]
+                        if nc_t:
+                            input.append(nc_t[0])
+                            output[0:0] = nc_t[1:]
 
                 if input:
                     output.insert(0, input[-1])
+            # if self.reverse:
+            #     debug('ST3: ', c_parts, input, output)
 
             input = output
             output = []
 
-        return Mul._from_args(input, is_commutative=False)
-
-
-class DipatchingSlidingTransform(SlidingTransform):
-
-    def __init__(self, unary=False, binary=True):
-        if unary:
-            unary = Dispatcher('_sliding_transform_unary')
-            unary.register((Expr), lambda x: None)
+        if self.reverse:
+            return Mul(*c_parts)*Mul(*input)
         else:
-            unary = None
-
-        if binary:
-            binary = Dispatcher('_sliding_transform_binary')
-            binary.register((Expr, Expr), lambda x, y: None)
-        else:
-            binary = None
-
-        super().__init__(unary, binary)
-
-    @property
-    def unary(self):
-        return self._unary
-
-    @property
-    def binary(self):
-        return self._binary
+            return Mul(*c_parts)*Mul._from_args(input, is_commutative=False)

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -1,32 +1,144 @@
+from sympy.concrete.summations import Sum
+from sympy.core import oo
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer, Rational)
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols
+from sympy.simplify import simplify
+from sympy.core.symbol import symbols, Symbol
+from sympy.core.sympify import sympify
+from sympy.integrals import Integral
+from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.special.delta_functions import DiracDelta
+from sympy.functions.special.tensor_functions import KroneckerDelta
+
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
+from sympy.physics.quantum.cartesian import X, XKet, XBra
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.gate import H, XGate, IdentityGate
-from sympy.physics.quantum.operator import Operator, IdentityOperator
+from sympy.physics.quantum.operator import (
+    Operator, IdentityOperator, OuterProduct
+)
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
 from sympy.physics.quantum.tensorproduct import TensorProduct
-from sympy.physics.quantum.state import Ket
+from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.qubit import Qubit, QubitBra
 from sympy.physics.quantum.boson import BosonOp, BosonFockKet, BosonFockBra
 from sympy.testing.pytest import warns_deprecated_sympy
 
 
+#-----------------------------------------------------------------------------
+# Variables and utilities
+#-----------------------------------------------------------------------------
+
+
 j, jp, m, mp = symbols("j j' m m'")
+p, q, r, st = symbols('p q r s', integer=True, nonnegative=True)
+x, y, z = symbols('x y z', real=True)
+omega = Symbol('omega', real=True)
+alpha = Symbol('alpha', complex=True)
 
 z = JzKet(1, 0)
 po = JzKet(1, 1)
 mo = JzKet(1, -1)
 
+a = BosonOp('a')
+
+class SimpleBra(Bra):
+    pass
+
+class SimpleKet(Ket):
+    def _eval_innerproduct_SimpleBra(self, bra, **hints):
+        return alpha*exp(I*omega)
+
+TP = TensorProduct
+
+sqa = lambda x: simplify(qapply(x))
+
 A = Operator('A')
+
+
+#-----------------------------------------------------------------------------
+# Tests for the main unary dispatcher for qapply
+#-----------------------------------------------------------------------------
+
+
+def test_unary_number():
+    assert qapply(0) == S.Zero
+    assert qapply(1.0) == sympify(1.0)
+
+
+def test_unary_abs():
+    assert qapply(Abs(alpha)) == Abs(alpha)
+
+
+def test_unary_add():
+    assert qapply(a*BosonFockKet(p) + Dagger(a)*BosonFockKet(q)) == \
+        sqrt(p)*BosonFockKet(p-1) + sqrt(q+1)*BosonFockKet(q+1)
+
+
+def test_unary_pow():
+    assert qapply((SimpleBra()*SimpleKet())**2) == alpha**2*exp(2*I*omega)
+    assert qapply(sqrt(SimpleBra()*SimpleKet())) == sqrt(alpha*exp(I*omega))
+
+
+def test_unary_sum():
+    assert qapply(Sum(a*BosonFockKet(p), (p,0,2))) == Sum(sqrt(p)*BosonFockKet(p-1), (p,0,2))
+    assert qapply(Sum(a*BosonFockKet(p), (p,0,2)), sum_doit=True) == \
+        sqrt(1)*BosonFockKet(0) + sqrt(2)*BosonFockKet(1)
+    assert qapply(Jz*po + Jz*mo) == hbar*po - hbar*mo
+
+
+def test_unary_integral():
+    assert qapply(Integral(XBra(x)*XKet(y), (x,-oo,oo))).doit() == S.One
+
+
+def test_unary_dagger():
+    assert qapply(Dagger(a*BosonFockKet(p)), dagger=True) == \
+        sqrt(p)*BosonFockBra(p-1)
+
+
+def test_unary_tensorproduct():
+    assert qapply(TP(a*BosonFockKet(p), a*BosonFockKet(q))) == \
+        TP(sqrt(p)*BosonFockKet(p-1), sqrt(q)*BosonFockKet(q-1))
+
+
+def test_unary_density():
+    d = Density([a*BosonFockKet(p), 0.5], [a*BosonFockKet(q), 0.5])
+    assert qapply(d) == \
+        Density([sqrt(p)*BosonFockKet(p-1), 0.5], [sqrt(q)*BosonFockKet(q-1), 0.5])
+    d = Density([Jz*mo, 0.5], [Jz*po, 0.5])
+    assert qapply(d) == Density([-hbar*mo, 0.5], [hbar*po, 0.5])
+
+
+#-----------------------------------------------------------------------------
+# Tests for the main unary dispatcher for qapply_Mul
+#-----------------------------------------------------------------------------
+
+
+def test_mul_unary_pow():
+    assert qapply(a**2*BosonFockKet(p)) == sqrt(p)*sqrt(p-1)*BosonFockKet(p-2)
+    assert qapply(BosonFockBra(q)*a**2*BosonFockKet(p)) == \
+        KroneckerDelta(q, p-2)*sqrt(p)*sqrt(p-1)
+    # Here we are testing the path for a Mul that has a Pow with a non-integer
+    # power
+    assert qapply(alpha*sqrt(
+        BosonFockBra(p)*a*BosonFockKet(p+1)*BosonFockBra(p+1)*Dagger(a)*BosonFockKet(p)
+    )) == \
+        simplify(alpha*sqrt(p+1))
+
+
+def test_mul_unary_op():
+    assert qapply(
+        OuterProduct(BosonFockKet(p), BosonFockBra(q))*a*BosonFockKet(q+1)
+    ) == \
+        sqrt(q+1)*BosonFockKet(p)
 
 
 class Foo(Operator):
@@ -34,12 +146,69 @@ class Foo(Operator):
         return ket
 
 
+def test_mul_unary_commutator():
+    assert qapply(Commutator(Jx, Jy)*Jz*po) == I*hbar**3*po
+    assert qapply(Commutator(J2, Jz)*Jz*po) == 0
+    assert qapply(Commutator(Jz, Foo('F'))*po) == 0
+    assert qapply(Commutator(Foo('F'), Jz)*po) == 0
+
+
+def test_mul_unary_anticommutator():
+    assert qapply(AntiCommutator(Jz, Foo('F'))*po) == 2*hbar*po
+    assert qapply(AntiCommutator(Foo('F'), Jz)*po) == 2*hbar*po
+
+
+#-----------------------------------------------------------------------------
+# Tests for the main binary dispatcher for qapply_Mul
+#-----------------------------------------------------------------------------
+
+
+def test_mul_binary_op_ket():
+    assert qapply(a*BosonFockKet(q)) == sqrt(q)*BosonFockKet(q-1)
+    assert qapply(A*BosonFockKet(q)) == A*BosonFockKet(q)
+    assert qapply(Jplus*Jplus*mo) == 2*hbar**2*po
+
+
+def test_mul_binary_bra_op():
+    assert qapply(BosonFockBra(q)*a, dagger=True) == \
+        sqrt(q+1)*BosonFockBra(q+1)
+
+
+def test_mul_binary_add():
+    assert sqa((Jplus + Jminus)*z/sqrt(2)) == \
+        hbar*(po + mo)
+    assert sqa(Jz*(po + mo)) == hbar*(po - mo)
+
+
+def test_mul_binary_sum():
+    e = qapply(Jz*Sum(JzKet(j, m), (m, -1, 1)))
+    assert e == Sum(hbar*m*JzKet(j, m), (m, -1, 1))
+    assert e.doit() == hbar*(JzKet(j,1) - JzKet(j,-1))
+    assert qapply(Sum(BosonFockBra(p),(p,0,3))*Sum(BosonFockKet(q),(q,0,3))) == \
+        Sum(KroneckerDelta(p, q), (p,0,3), (q,0,3))
+
+
+def test_mul_binary_integral():
+        e = qapply(XBra(x)*Integral(X*XKet(y), (y,-oo,oo)))
+        assert e == Integral(y*DiracDelta(y-x), (y,-oo,oo))
+        assert e.doit() == x
+
+        e = qapply(Integral(XBra(y)*X,(y,-oo,oo))*XKet(x))
+        assert e == Integral(x*DiracDelta(x-y), (y,-oo,oo))
+        assert e.doit() == x
+
+        e = qapply(Integral(XBra(x), (x,-oo,oo))*Integral(XKet(y), (y,-oo,oo)))
+        assert e == Integral(DiracDelta(y-x), (x,-oo,oo), (y,-oo,oo))
+
+
+#-----------------------------------------------------------------------------
+# Additional tests
+#-----------------------------------------------------------------------------
+
+
 def test_basic():
     assert qapply(Jz*po) == hbar*po
-    assert qapply(Jx*z) == hbar*po/sqrt(2) + hbar*mo/sqrt(2)
-    assert qapply((Jplus + Jminus)*z/sqrt(2)) == hbar*po + hbar*mo
-    assert qapply(Jz*(po + mo)) == hbar*po - hbar*mo
-    assert qapply(Jz*po + Jz*mo) == hbar*po - hbar*mo
+    assert sqa(Jx*z) == sqrt(2)*hbar*(po + mo)/sympify(2)
     assert qapply(Jminus*Jminus*po) == 2*hbar**2*mo
     assert qapply(Jplus**2*mo) == 2*hbar**2*po
     assert qapply(Jplus**2*Jminus**2*po) == 4*hbar**4*po
@@ -48,36 +217,19 @@ def test_basic():
 def test_extra():
     extra = z.dual*A*z
     assert qapply(Jz*po*extra) == hbar*po*extra
-    assert qapply(Jx*z*extra) == (hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra
-    assert qapply(
-        (Jplus + Jminus)*z/sqrt(2)*extra) == hbar*po*extra + hbar*mo*extra
-    assert qapply(Jz*(po + mo)*extra) == hbar*po*extra - hbar*mo*extra
-    assert qapply(Jz*po*extra + Jz*mo*extra) == hbar*po*extra - hbar*mo*extra
-    assert qapply(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
-    assert qapply(Jplus**2*mo*extra) == 2*hbar**2*po*extra
-    assert qapply(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
+    assert sqa(Jx*z*extra) == simplify((hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra)
+    assert sqa(
+        (Jplus + Jminus)*z/sqrt(2)*extra) == hbar*(po + mo)*extra
+    assert sqa(Jz*(po + mo)*extra) == hbar*(po - mo)*extra
+    assert sqa(Jz*po*extra + Jz*mo*extra) == hbar*(po - mo)*extra
+    assert sqa(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
+    assert sqa(Jplus**2*mo*extra) == 2*hbar**2*po*extra
+    assert sqa(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
 
 
 def test_innerproduct():
     assert qapply(po.dual*Jz*po, ip_doit=False) == hbar*(po.dual*po)
     assert qapply(po.dual*Jz*po) == hbar
-
-
-def test_zero():
-    assert qapply(0) == 0
-    assert qapply(Integer(0)) == 0
-
-
-def test_commutator():
-    assert qapply(Commutator(Jx, Jy)*Jz*po) == I*hbar**3*po
-    assert qapply(Commutator(J2, Jz)*Jz*po) == 0
-    assert qapply(Commutator(Jz, Foo('F'))*po) == 0
-    assert qapply(Commutator(Foo('F'), Jz)*po) == 0
-
-
-def test_anticommutator():
-    assert qapply(AntiCommutator(Jz, Foo('F'))*po) == 2*hbar*po
-    assert qapply(AntiCommutator(Foo('F'), Jz)*po) == 2*hbar*po
 
 
 def test_outerproduct():
@@ -117,11 +269,6 @@ def test_issue_6073():
     B = Operator('B')
     assert qapply(A) == A
     assert qapply(A.dual*B) == A.dual*B
-
-
-def test_density():
-    d = Density([Jz*mo, 0.5], [Jz*po, 0.5])
-    assert qapply(d) == Density([-hbar*mo, 0.5], [hbar*po, 0.5])
 
 
 def test_issue3044():

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -2,9 +2,7 @@ from sympy.core.mul import Mul
 from sympy.core.symbol import symbols
 from sympy.testing.pytest import raises
 
-from sympy.physics.quantum.slidingtransform import (
-    SlidingTransform, DipatchingSlidingTransform
-)
+from sympy.physics.quantum.slidingtransform import SlidingTransform
 
 a, b, c, d, e, f = symbols('a b c d e f', commutative=False)
 

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -1,0 +1,67 @@
+from sympy.core.mul import Mul
+from sympy.core.symbol import symbols
+from sympy.testing.pytest import raises
+
+from sympy.physics.quantum.slidingtransform import (
+    SlidingTransform, DipatchingSlidingTransform
+)
+
+a, b, c, d, e, f = symbols('a b c d e f', commutative=False)
+
+
+def doubler(x):
+    return (x, x)
+
+def drone(x):
+    return (a,)
+
+
+def test_unary():
+    st = SlidingTransform(unary=doubler)
+    assert st(a*b*c) == Mul._from_args((a, a, b, b, c, c))
+
+    st = SlidingTransform(unary=drone)
+    assert st(a*b*c) == Mul._from_args((a, a, a))
+
+    st = SlidingTransform(unary=lambda x: None)
+    assert st(a*b*c) == Mul._from_args((a, b, c))
+
+
+def mapping(lhs, rhs):
+    if lhs == a and rhs == b:
+        return (c,)
+    elif lhs == b and rhs == c:
+        return (d,)
+    elif lhs == a and rhs == c:
+        return None
+    elif lhs == c and rhs == d:
+        return (e, f)
+    
+
+def test_binary():
+    st = SlidingTransform(binary=mapping)
+
+    assert st(a*b) == Mul._from_args((c,))
+    assert st(b*c) == Mul._from_args((d,))
+    assert st(a*c) == Mul._from_args((a,c))
+    assert st(c*d) == Mul._from_args((e,f))
+
+    assert st(a*b*c) == Mul._from_args((c, c))
+    assert st(b*c*d) == Mul._from_args((d, d))
+    assert st(c*d*e) == Mul._from_args((e, f, e))
+
+    assert st(a*b*d) == Mul._from_args((e, f))
+
+
+def test_reverse():
+    st = SlidingTransform(binary=mapping, reverse=True)
+
+    assert st(a*b) == Mul._from_args((c,))
+    assert st(b*c) == Mul._from_args((d,))
+    assert st(a*c) == Mul._from_args((a,c))
+    assert st(c*d) == Mul._from_args((e,f))
+
+    assert st(a*b*c) == Mul._from_args((a, d))
+    assert st(d*b*c) == Mul._from_args((d, d))
+    assert st(a*c*b*a*b) == Mul._from_args((a, e, f))
+


### PR DESCRIPTION
#### References to other Issues or PRs

Related to #28022
Replacement for #24349
Fixes #27526, #27213

#### Brief description of what is fixed or changed

This PR introduces a new SlidingTransform class to refactor and improve the implementation of qapply in the quantum module, with a strong focus on type-based dispatching

* Added new SlidingTransform class that provides a generic sliding window transform for processing Mul-like expressions
* Implemented comprehensive type-based dispatch system using multipledispatch
* Split transformations into unary and binary operations with clear separation of concerns
* Improved handling of commutative vs non-commutative terms
* Added support for additional operations like Integrals and better Sum handling
* More consistent handling of various quantum expressions like tensor project and inner products

The SlidingTransform class implements a sequential transformation for products of quantum expressions. At its core, the algorithm processes terms through two distinct phases. In the first phase, it applies individual (unary) transformations to each term in sequence, allowing for term-by-term modifications. The second phase then examines pairs of adjacent terms, applying binary transformations that can combine or modify pairs of terms. Throughout both phases, the algorithm carefully maintains the distinction between commutative and non-commutative terms. The algorithm can operate in either forward or reverse direction, with special handling for term ordering in each case. When processing pairs, if a transformation produces new terms, these can be fed back into the algorithm for further processing, ensuring complete transformation of complex expressions. This algorithm simplifies the various cases that need to be handled and makes it easy to add new type-based dispatchers for unary and binary transformations.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
