### PR TITLE
Added missing space after commas in assumptions for PEP 8 compliance.

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -195,8 +195,8 @@ def _(expr, assumptions):
     if base_bounded is False and ask(Q.extended_nonzero(expr.exp), assumptions):
         return False
     if base_bounded and exp_bounded:
-        is_base_zero = ask(Q.zero(expr.base),assumptions)
-        is_exp_negative = ask(Q.negative(expr.exp),assumptions)
+        is_base_zero = ask(Q.zero(expr.base), assumptions)
+        is_exp_negative = ask(Q.negative(expr.exp), assumptions)
         if is_base_zero is True and is_exp_negative is True:
             return False
         if is_base_zero is not False and is_exp_negative is not False:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -65,7 +65,7 @@ def _(expr, assumptions):
     return test_closed_group(expr, assumptions, Q.integer)
 
 @IntegerPredicate.register(Pow)
-def _(expr,assumptions):
+def _(expr, assumptions):
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
     if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
@@ -161,16 +161,16 @@ def _(expr, assumptions):
 
     is_exp_integer = ask(Q.integer(expr.exp), assumptions)
     if is_exp_integer:
-        is_base_rational = ask(Q.rational(expr.base),assumptions)
+        is_base_rational = ask(Q.rational(expr.base), assumptions)
         if is_base_rational:
-            is_base_zero = ask(Q.zero(expr.base),assumptions)
+            is_base_zero = ask(Q.zero(expr.base), assumptions)
             if is_base_zero is False:
                 return True
             if is_base_zero and ask(Q.positive(expr.exp)):
                 return True
-        if ask(Q.algebraic(expr.base),assumptions) is False:
+        if ask(Q.algebraic(expr.base), assumptions) is False:
             return ask(Q.zero(expr.exp), assumptions)
-        if ask(Q.irrational(expr.base),assumptions) and ask(Q.eq(expr.exp,-1)):
+        if ask(Q.irrational(expr.base), assumptions) and ask(Q.eq(expr.exp, -1)):
             return False
         return
     elif ask(Q.rational(expr.exp), assumptions):
@@ -178,7 +178,7 @@ def _(expr, assumptions):
             return False
         if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)):
             return True
-        if ask(Q.eq(expr.base,1)):
+        if ask(Q.eq(expr.base, 1)):
             return True
 
 @RationalPredicate.register_many(asin, atan, cos, sin, tan)
@@ -777,14 +777,14 @@ def _(expr, assumptions):
         return
     exp_rational = ask(Q.rational(expr.exp), assumptions)
     base_algebraic = ask(Q.algebraic(expr.base), assumptions)
-    exp_algebraic = ask(Q.algebraic(expr.exp),assumptions)
+    exp_algebraic = ask(Q.algebraic(expr.exp), assumptions)
     if base_algebraic and exp_algebraic:
         if exp_rational:
             return True
         # Check based on the Gelfond-Schneider theorem:
         # If the base is algebraic and not equal to 0 or 1, and the exponent
         # is irrational,then the result is transcendental.
-        if ask(Q.ne(expr.base,0) & Q.ne(expr.base,1)) and exp_rational is False:
+        if ask(Q.ne(expr.base, 0) & Q.ne(expr.base, 1)) and exp_rational is False:
             return False
 
 @AlgebraicPredicate.register(Rational) # type:ignore


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added missing space after commas in assumptions for PEP 8 compliance.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
