### PR TITLE
Refactor: Replace old-style string formatting with f-strings in ntheory

### DIFF
--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -69,8 +69,7 @@ def continued_fraction(a) -> list:
                         # (a + b*sqrt(c))/d
                         c = c.base
                         return continued_fraction_periodic(a, d, c, b)
-    raise ValueError(
-        'expecting a rational or quadratic irrational, not %s' % e)
+    raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
 def continued_fraction_periodic(p, q, d=0, s=1) -> list:
@@ -135,7 +134,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
     p, q, d, s = list(map(as_int, [p, q, d, s]))
 
     if d < 0:
-        raise ValueError("expected non-negative for `d` but got %s" % d)
+        raise ValueError(f"expected non-negative for `d` but got {d}")
 
     if q == 0:
         raise ValueError("The denominator cannot be 0.")

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -65,8 +65,7 @@ def digits(n, b=10, digits=None):
         ndig = len(y) - 1
         if digits is not None:
             if ndig > digits:
-                raise ValueError(
-                    "For %s, at least %s digits are needed." % (n, ndig))
+                raise ValueError(f"For {n}, at least {ndig} digits are needed.")
             elif ndig < digits:
                 y[1:1] = [0]*(digits - ndig)
         return y

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -217,10 +217,10 @@ def multiplicity(p, n):
                 isinstance(n.args[0], Integer) and
                 n.args[0] >= 0):
             return multiplicity_in_factorial(p, n.args[0])
-        raise ValueError('expecting ints or fractions, got %s and %s' % (p, n))
+        raise ValueError(f"expecting ints or fractions, got {p} and {n}")
 
     if n == 0:
-        raise ValueError('no such integer exists: multiplicity of %s is not-defined' %(n))
+        raise ValueError(f"no such integer exists: multiplicity of {n} is not-defined")
     return remove(n, p)[1]
 
 
@@ -269,10 +269,10 @@ def multiplicity_in_factorial(p, n):
     p, n = as_int(p), as_int(n)
 
     if p <= 0:
-        raise ValueError('expecting positive integer got %s' % p )
+        raise ValueError(f"expecting positive integer got {p}")
 
     if n < 0:
-        raise ValueError('expecting non-negative integer got %s' % n )
+        raise ValueError(f"expecting non-negative integer got {n}")
 
     # keep only the largest of a given multiplicity since those
     # of a given multiplicity will be goverened by the behavior
@@ -1470,8 +1470,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     if verbose:
         sn = str(n)
         if len(sn) > 50:
-            print('Factoring %s' % sn[:5] + \
-                  '..(%i other digits)..' % (len(sn) - 10) + sn[-5:])
+            print(f"Factoring {sn[:5]}..({len(sn) - 10} other digits)..{sn[-5:]}")
         else:
             print('Factoring', n)
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -322,7 +322,7 @@ class Sieve:
         test = _as_int_ceiling(n)
         n = as_int(n)
         if n < 2:
-            raise ValueError("n should be >= 2 but got: %s" % n)
+            raise ValueError(f"n should be >= 2 but got: {n}")
         if n > self._list[-1]:
             self.extend(n)
         b = bisect(self._list, n)

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -591,9 +591,9 @@ def is_mersenne_prime(n):
         return False
     result = _lucas_lehmer_primality_test(p)
     if result:
-        raise ValueError(filldedent('''
-            This Mersenne Prime, 2^%s - 1, should
-            be added to SymPy's known values.''' % p))
+        raise ValueError(filldedent(f'''
+            This Mersenne Prime, 2^{p} - 1, should
+            be added to SymPy's known values.'''))
     return result
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see gh-28031
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Refactor: Replace old-style string formatting with f-strings in ntheory

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
