### PR TITLE
Removed an unnecessary check in `runtests.py`

### DIFF
--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -224,10 +224,6 @@ def run_in_subprocess_with_hash_randomization(
     use a predetermined seed for tests, we must start Python in a separate
     subprocess.
 
-    Hash randomization was added in the minor Python versions 2.6.8, 2.7.3,
-    3.1.5, and 3.2.3, and is enabled by default in all Python versions after
-    and including 3.3.0.
-
     Examples
     ========
 
@@ -245,14 +241,6 @@ def run_in_subprocess_with_hash_randomization(
     cwd = get_sympy_dir()
     # Note, we must return False everywhere, not None, as subprocess.call will
     # sometimes return None.
-
-    # First check if the Python version supports hash randomization
-    # If it does not have this support, it won't recognize the -R flag
-    p = subprocess.Popen([command, "-RV"], stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT, cwd=cwd)
-    p.communicate()
-    if p.returncode != 0:
-        return False
 
     hash_seed = os.getenv("PYTHONHASHSEED")
     if not hash_seed:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
There was code checking if the Python version being used supports hash randomization, and the documentation in the code mentions that it's supported in all Python versions 3.3.0 onwards. Since our minimal Python version supported is 3.9, this test is now unnecessary.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
