### PR TITLE
Changed `./bin/test`, `./bin/doctest` to `python bin/test`, `python bin/doctest`

### DIFF
--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -364,7 +364,7 @@ library code should be imported with `import_module()`.
 
 - **pytest**: [Pytest](https://docs.pytest.org/en/latest/) is not a required dependency
   for the SymPy test suite. SymPy has its own test runner, which can be
-  accessed via the `bin/test` script in the SymPy source directory or the
+  accessed by running `python bin/test` script in the SymPy source directory or the
   {func}`~.test` function.
 
   However, if you prefer to use pytest, you can use it to run the tests

--- a/doc/src/contributing/docstring.rst
+++ b/doc/src/contributing/docstring.rst
@@ -224,8 +224,8 @@ tested. They should demonstrate the API of the function to the user (i.e., what
 the input parameters look like, what the output looks like, and what it does).
 If you only want to test something, add a test to the relevant ``test_*.py file``.
 
-You can use the ``./bin/coverage_doctest.py`` script to test the doctest
-coverage of a file or module. Run the doctests with ``./bin/doctest``.
+You can use the ``bin/coverage_doctest.py`` script to test the doctest
+coverage of a file or module. Run the doctests with ``python bin/doctest``.
 
 You should only skip the testing of an example if it is impossible to test it.
 If necessary, testing of an example can be skipped by adding a special comment.
@@ -274,7 +274,7 @@ sympy`` or ``from sympy import *``. To define symbols, use ``from sympy.abc
 import x``, unless the name is not in ``sympy.abc`` (for instance, if it has
 assumptions), in which case use ``symbols`` like ``x, y = symbols('x y')``.
 
-In general, you should run ``./bin/doctest`` to make sure your examples run
+In general, you should run ``python bin/doctest`` to make sure your examples run
 correctly, and fix them if they do not.
 
 4. Parameters Section

--- a/doc/src/contributing/new-contributors-guide/workflow-process.md
+++ b/doc/src/contributing/new-contributors-guide/workflow-process.md
@@ -21,7 +21,7 @@ pull request, or even before committing a change.
   checks](workflow-process-code-quality) pass.**
 
   ```bash
-  ./bin/test quality
+  python bin/test quality
   flake8 sympy/
   ```
 
@@ -37,7 +37,7 @@ pull request, or even before committing a change.
 
 - [ ] **Make sure all tests pass.** [You may want to run a relevant subset of
   the test suite locally](workflow-process-run-tests) before committing (e.g.,
-  `./bin/test solvers`). When you open a pull request, all tests will be run
+  `python bin/test solvers`). When you open a pull request, all tests will be run
   on CI. The CI must be all green before a PR can be merged.
 
 - [ ] **[Write good commit messages](workflow-process-commit-messages).**
@@ -165,7 +165,7 @@ are some code quality checks that will run automatically on the CI once you
 create a pull request, but you can also run them locally with
 
 ```
-./bin/test quality
+python bin/test quality
 flake8 sympy/
 ```
 
@@ -304,13 +304,13 @@ directly as well if you prefer.
 Run all tests by using the command:
 
 ```bash
-$ ./bin/test
+$ python bin/test
 ```
 
 To run tests for a specific file, use:
 
 ```bash
-$ ./bin/test test_basic
+$ python bin/test test_basic
 ```
 
 Where `test_basic` is from file `sympy/core/basic.py`.
@@ -318,7 +318,7 @@ Where `test_basic` is from file `sympy/core/basic.py`.
 To run tests for modules, use:
 
 ```bash
-$ ./bin/test /core /utilities
+$ python bin/test /core /utilities
 ```
 
 This will run tests for the `core` and `utilities` modules.
@@ -326,7 +326,7 @@ This will run tests for the `core` and `utilities` modules.
 Similarly, run quality tests with:
 
 ```bash
-$ ./bin/test code_quality
+$ python bin/test code_quality
 ```
 
 ## Commit the changes

--- a/doc/src/contributing/new-contributors-guide/writing-tests.md
+++ b/doc/src/contributing/new-contributors-guide/writing-tests.md
@@ -64,13 +64,13 @@ you can create a new test function.
 The basic way to run the tests is to use
 
 ```
-./bin/test
+python bin/test
 ```
 
 to run the tests, and
 
 ```
-./bin/doctest
+python bin/doctest
 ```
 
 to run the doctests. Note that the full test suite can take some time to run,
@@ -79,13 +79,13 @@ the module you modified. You can do this by passing the name of the submodules
 or tests files to the test command. For example,
 
 ```
-./bin/test solvers
+python bin/test solvers
 ```
 
 will run only the tests for the solvers.
 
 If you want, you can also use `pytest` to run the tests instead of the
-`./bin/test` tool, for example
+`bin/test` tool, for example
 
 ```
 pytest -m 'not slow' sympy/solvers
@@ -113,7 +113,7 @@ The bit in between `_________________` is the name of the test. You can
 reproduce the test locally by copying and pasting this:
 
 ```
-./bin/test sympy/printing/pretty/tests/test_pretty.py -k test_upretty_sub_super
+python bin/test sympy/printing/pretty/tests/test_pretty.py -k test_upretty_sub_super
 ```
 
 or
@@ -145,7 +145,7 @@ locally. Some common causes of this are:
 
 - A test may fail sporadically. Try rerunning the test multiple times. The
   beginning of the test log on CI prints the random seed, which can be passed
-  to `./bin/test --seed`, and the `PYTHONHASHSEED` environment variable, which
+  to `bin/test --seed`, and the `PYTHONHASHSEED` environment variable, which
   may be helpful for reproducing such failures.
 
 It is also sometimes possible that a failure on CI may be unrelated to your
@@ -516,7 +516,7 @@ that it always passes. Random tests can be reproduced by using the random seed
 printed at the top of the tests. For example
 
 ```
-$./bin/test
+$python bin/test
 ========================================================================== test process starts ==========================================================================
 executable:         /Users/aaronmeurer/anaconda3/bin/python  (3.9.13-final-0) [CPython]
 architecture:       64-bit
@@ -530,7 +530,7 @@ hash randomization: on (PYTHONHASHSEED=3923913114)
 Here the random seed is `7357232`. It can be reproduced with
 
 ```
-./bin/test --seed 7357232
+python bin/test --seed 7357232
 ```
 
 In general you may need to use the same Python version and architecture as
@@ -629,7 +629,7 @@ instead of `@slow`. The slow tests will be run automatically in a separate CI
 job, but are skipped by default. You can manually run the slow tests with
 
 ```
-./bin/test --slow
+python bin/test --slow
 ```
 
 (writing-tests-external-dependencies)=
@@ -673,7 +673,7 @@ format examples in docstrings.
 To run the doctests, use the
 
 ```
-./bin/doctest
+python bin/doctest
 ```
 
 command. This command can also take arguments to test a specific file or
@@ -966,7 +966,7 @@ The code quality checks are all straightforward to fix. You can run the checks
 locally using
 
 ```
-./bin/test quality
+python bin/test quality
 ```
 
 and
@@ -980,13 +980,13 @@ latest version of flake8 and its dependencies `pycodestyle` and `pyflakes`
 installed. Sometimes newer versions of these packages will add new checks and
 if you have an older version installed you won't see the checks for them.
 
-The `./bin/test quality` check tests for very basic code quality things. The
+The `python bin/test quality` check tests for very basic code quality things. The
 most common of these that will cause the test to fail is trailing whitespace.
 Trailing whitespace is when a line of code has spaces at the end of it. These
 spaces do nothing, and they only cause the code diff to be polluted. The best
 way to handle trailing whitespace is to configure your text editor to
 automatically strip trailing whitespace when you save. You can also use the
-`./bin/strip_whitepace` command in the SymPy repo.
+`python bin/strip_whitepace` command in the SymPy repo.
 
 The `flake8` command will check the code for basic code errors like undefined
 variables. These are restricted by the configuration in `setup.cfg` to only
@@ -1119,14 +1119,14 @@ To generate a test coverage report, first install
 install coverage`). Then run
 
 ```
-./bin/coverage_report.py
+python bin/coverage_report.py
 ```
 
 This will run the test suite and analyze which lines of the codebase are
 covered by at least one test. Note that this will take longer than running the
-tests normally with `./bin/test` because the coverage tooling makes Python run
+tests normally with `python bin/test` because the coverage tooling makes Python run
 a little bit slower. You can also run a subset of the tests, e.g.,
-`./bin/coverage_report.py sympy/solvers`.
+`python bin/coverage_report.py sympy/solvers`.
 
 Once the tests are done, the coverage report will be in `covhtml`, which you
 can view by opening `covhtml/index.html`. Each file will show which lines were


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses #28020 

#### Brief description of what is fixed or changed
As was stated in the issue, I fixed all the `./bin/test`, `./bin/doctest`, etc. to `python bin/test`, `python bin/doctest`, etc. where applicable.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
