### PR TITLE
Add uncertainties.umath as lambdify module

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -181,6 +181,7 @@ jobs:
                          symengine                                        \
                          numba llvmlite pymc                              \
                          gmpy2                                            \
+                         uncertainties                                    \
                          #
 
       # Test external imports

--- a/.mailmap
+++ b/.mailmap
@@ -1442,6 +1442,7 @@ Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpa
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
 Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
+Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <simonblsoerensen@gmail.com>
 SirJohnFranklin <sirjfu@googlemail.com>
 Smit Gajjar <smitgajjar.gs@gmail.com>
 Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit Lunagariya <55887635+Smit-create@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1443,7 +1443,8 @@ Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpa
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
 Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
-Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <simonblsoerensen@gmail.com>
+Simon Sørensen <simonblsoerensen@gmail.com>
+Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <61250140+zarstensen@users.noreply.github.com>
 SirJohnFranklin <sirjfu@googlemail.com>
 Smit Gajjar <smitgajjar.gs@gmail.com>
 Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit Lunagariya <55887635+Smit-create@users.noreply.github.com>

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -311,7 +311,7 @@ for const in _numpy_known_constants:
 
 _unumpy_known_functions = {k: 'uncertainties.unumpy.' + v for k, v in _known_functions_numpy.items()}
 
-class UnumpyPrinter(NumPyPrinter):
+class UnumPyPrinter(NumPyPrinter):
     """
     uncertainties.unumpy printer which handles vectorized piecewise functions,
     logical operators, etc.
@@ -324,10 +324,10 @@ class UnumpyPrinter(NumPyPrinter):
         return f"({super().doprint(expr, assign_to=assign_to)}) * 1"
 
 for func in _unumpy_known_functions:
-    setattr(UnumpyPrinter, f'_print_{func}', _print_known_func)
+    setattr(UnumPyPrinter, f'_print_{func}', _print_known_func)
 
 for const in _numpy_known_constants:
-    setattr(UnumpyPrinter, f'_print_{const}', _print_known_const)
+    setattr(UnumPyPrinter, f'_print_{const}', _print_known_const)
 
 
 _known_functions_scipy_special = {

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -309,6 +309,37 @@ for func in _numpy_known_functions:
 for const in _numpy_known_constants:
     setattr(NumPyPrinter, f'_print_{const}', _print_known_const)
 
+_unumpy_known_functions = {k: 'uncertainties.unumpy.' + v for k, v in _known_functions_numpy.items()}
+
+def _unumpy_print_func(printer):
+    # apply an identity function to the result,
+    # that way numpy automatically converts 0d array to scalar.
+    return lambda expr: f"({printer(expr)} * 1)"
+
+class UnumpyPrinter(NumPyPrinter):
+    """
+    uncertainties.unumpy printer which handles vectorized piecewise functions,
+    logical operators, etc.
+
+    This currently exists primarily to ensure unumpy functions return a scalar variable as output,
+    if the input was also a scalar.
+    """
+
+    def __init__(self, settings=None):
+        super().__init__(settings=settings)
+
+        for kf in self._kf:
+            setattr(self, f'_print_{kf}', _unumpy_print_func(getattr(super(), f'_print_{kf}')))
+
+    def _print_Pow(self, expr, rational=True):
+        return f"({super()._print_Pow(expr, rational=rational)} * 1)"
+
+for func in _unumpy_known_functions:
+    setattr(UnumpyPrinter, f'_print_{func}', _unumpy_print_func(_print_known_func))
+
+for const in _numpy_known_constants:
+    setattr(UnumpyPrinter, f'_print_{const}', _print_known_const)
+
 
 _known_functions_scipy_special = {
     'Ei': 'expi',

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -311,11 +311,6 @@ for const in _numpy_known_constants:
 
 _unumpy_known_functions = {k: 'uncertainties.unumpy.' + v for k, v in _known_functions_numpy.items()}
 
-def _unumpy_print_func(printer):
-    # apply an identity function to the result,
-    # that way numpy automatically converts 0d array to scalar.
-    return lambda expr: f"({printer(expr)} * 1)"
-
 class UnumpyPrinter(NumPyPrinter):
     """
     uncertainties.unumpy printer which handles vectorized piecewise functions,
@@ -325,17 +320,11 @@ class UnumpyPrinter(NumPyPrinter):
     if the input was also a scalar.
     """
 
-    def __init__(self, settings=None):
-        super().__init__(settings=settings)
-
-        for kf in self._kf:
-            setattr(self, f'_print_{kf}', _unumpy_print_func(getattr(super(), f'_print_{kf}')))
-
-    def _print_Pow(self, expr, rational=True):
-        return f"({super()._print_Pow(expr, rational=rational)} * 1)"
+    def doprint(self, expr, assign_to=None):
+        return f"({super().doprint(expr, assign_to=assign_to)}) * 1"
 
 for func in _unumpy_known_functions:
-    setattr(UnumpyPrinter, f'_print_{func}', _unumpy_print_func(_print_known_func))
+    setattr(UnumpyPrinter, f'_print_{func}', _print_known_func)
 
 for const in _numpy_known_constants:
     setattr(UnumpyPrinter, f'_print_{const}', _print_known_const)

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -315,12 +315,10 @@ class UnumPyPrinter(NumPyPrinter):
     """
     uncertainties.unumpy printer which handles vectorized piecewise functions,
     logical operators, etc.
-
-    This currently exists primarily to ensure unumpy functions return a scalar variable as output,
-    if the input was also a scalar.
     """
 
     def doprint(self, expr, assign_to=None):
+        # performing an arbitrary identity operation on the result, prompts unumpy to convert 0d arrays to scalar values.
         return f"({super().doprint(expr, assign_to=assign_to)}) * 1"
 
 for func in _unumpy_known_functions:

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -309,24 +309,6 @@ for func in _numpy_known_functions:
 for const in _numpy_known_constants:
     setattr(NumPyPrinter, f'_print_{const}', _print_known_const)
 
-_unumpy_known_functions = {k: 'uncertainties.unumpy.' + v for k, v in _known_functions_numpy.items()}
-
-class UnumPyPrinter(NumPyPrinter):
-    """
-    uncertainties.unumpy printer which handles vectorized piecewise functions,
-    logical operators, etc.
-    """
-
-    def doprint(self, expr, assign_to=None):
-        # performing an arbitrary identity operation on the result, prompts unumpy to convert 0d arrays to scalar values.
-        return f"({super().doprint(expr, assign_to=assign_to)}) * 1"
-
-for func in _unumpy_known_functions:
-    setattr(UnumPyPrinter, f'_print_{func}', _print_known_func)
-
-for const in _numpy_known_constants:
-    setattr(UnumPyPrinter, f'_print_{const}', _print_known_const)
-
 
 _known_functions_scipy_special = {
     'Ei': 'expi',

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -32,6 +32,7 @@ CMATH_DEFAULT: dict[str,Any] = {}
 MPMATH_DEFAULT: dict[str, Any] = {}
 UMATH_DEFAULT: dict[str, Any] = {}
 NUMPY_DEFAULT: dict[str, Any] = {"I": 1j}
+UNUMPY_DEFAULT: dict[str, Any] = {"I": 1j}
 SCIPY_DEFAULT: dict[str, Any] = {"I": 1j}
 CUPY_DEFAULT: dict[str, Any] = {"I": 1j}
 JAX_DEFAULT: dict[str, Any] = {"I": 1j}
@@ -49,6 +50,7 @@ CMATH = CMATH_DEFAULT.copy()
 MPMATH = MPMATH_DEFAULT.copy()
 UMATH = UMATH_DEFAULT.copy()
 NUMPY = NUMPY_DEFAULT.copy()
+UNUMPY = UNUMPY_DEFAULT.copy()
 SCIPY = SCIPY_DEFAULT.copy()
 CUPY = CUPY_DEFAULT.copy()
 JAX = JAX_DEFAULT.copy()
@@ -100,7 +102,7 @@ MPMATH_TRANSLATIONS = {
     "betainc_regularized": "betainc",
 }
 
-UMATH_TRANSLATIONS = {
+UMATH_TRANSLATIONS: dict[str, str] = {
     "ceiling": "ceil",
     "E": "e",
     "ln": "log",
@@ -109,6 +111,9 @@ UMATH_TRANSLATIONS = {
 NUMPY_TRANSLATIONS: dict[str, str] = {
     "Heaviside": "heaviside",
 }
+
+UNUMPY_TRANSLATIONS: dict[str, str] = {}
+
 SCIPY_TRANSLATIONS: dict[str, str] = {
     "jn" : "spherical_jn",
     "yn" : "spherical_yn"
@@ -128,6 +133,7 @@ MODULES = {
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "umath": (UMATH, UMATH_DEFAULT, UMATH_TRANSLATIONS, ("from math import*; from uncertainties.umath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
+    "unumpy": (UNUMPY, UNUMPY_DEFAULT, UNUMPY_TRANSLATIONS, ("import uncertainties.unumpy; from uncertainties.unumpy import *; from uncertainties.unumpy.ulinalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "jax": (JAX, JAX_DEFAULT, JAX_TRANSLATIONS, ("import jax",)),
@@ -147,7 +153,7 @@ def _import(module, reload=False):
     Creates a global translation dictionary for module.
 
     The argument module has to be one of the following strings: "math","cmath"
-    "mpmath", "umath", "numpy", "sympy", "tensorflow", "jax".
+    "mpmath", "umath", "numpy", "unumpy", "sympy", "tensorflow", "jax".
     These dictionaries map names of Python functions to their equivalent in
     other modules.
     """
@@ -338,8 +344,8 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
         *modules* can be one of the following types:
 
-        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"umath"``, ``"numpy"``, ``"numexpr"``,
-          ``"scipy"``, ``"sympy"``, or ``"tensorflow"`` or ``"jax"``. This uses the
+        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"umath"``, ``"numpy"``, ``"unumpy"``,
+          ``"numexpr"``, ``"scipy"``, ``"sympy"``, or ``"tensorflow"`` or ``"jax"``. This uses the
           corresponding printer and namespace mapping for that module.
         - A module (e.g., ``math``). This uses the global namespace of the
           module. If the module is one of the above known modules, it will
@@ -830,6 +836,8 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         elif _module_present('scipy', namespaces):
             from sympy.printing.numpy import SciPyPrinter as Printer # type: ignore
         elif _module_present('numpy', namespaces):
+            from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
+        elif _module_present('unumpy', namespaces):
             from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
         elif _module_present('cupy', namespaces):
             from sympy.printing.numpy import CuPyPrinter as Printer # type: ignore

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -131,7 +131,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "cmath": (CMATH, CMATH_DEFAULT, CMATH_TRANSLATIONS, ("import cmath; from cmath import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
-    "umath": (UMATH, UMATH_DEFAULT, UMATH_TRANSLATIONS, ("from math import*; from uncertainties.umath import *",)),
+    "umath": (UMATH, UMATH_DEFAULT, UMATH_TRANSLATIONS, ("from math import pi, e, tau, inf, nan; from uncertainties.umath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "unumpy": (UNUMPY, UNUMPY_DEFAULT, UNUMPY_TRANSLATIONS, ("import uncertainties.unumpy; from uncertainties.unumpy import *; from uncertainties.unumpy.ulinalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -838,7 +838,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         elif _module_present('numpy', namespaces):
             from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
         elif _module_present('unumpy', namespaces):
-            from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
+            from sympy.printing.numpy import UnumpyPrinter as Printer # type: ignore
         elif _module_present('cupy', namespaces):
             from sympy.printing.numpy import CuPyPrinter as Printer # type: ignore
         elif _module_present('jax', namespaces):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -30,6 +30,7 @@ __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 MATH_DEFAULT: dict[str, Any] = {}
 CMATH_DEFAULT: dict[str,Any] = {}
 MPMATH_DEFAULT: dict[str, Any] = {}
+UMATH_DEFAULT: dict[str, Any] = {}
 NUMPY_DEFAULT: dict[str, Any] = {"I": 1j}
 SCIPY_DEFAULT: dict[str, Any] = {"I": 1j}
 CUPY_DEFAULT: dict[str, Any] = {"I": 1j}
@@ -46,6 +47,7 @@ NUMEXPR_DEFAULT: dict[str, Any] = {}
 MATH = MATH_DEFAULT.copy()
 CMATH = CMATH_DEFAULT.copy()
 MPMATH = MPMATH_DEFAULT.copy()
+UMATH = UMATH_DEFAULT.copy()
 NUMPY = NUMPY_DEFAULT.copy()
 SCIPY = SCIPY_DEFAULT.copy()
 CUPY = CUPY_DEFAULT.copy()
@@ -98,6 +100,12 @@ MPMATH_TRANSLATIONS = {
     "betainc_regularized": "betainc",
 }
 
+UMATH_TRANSLATIONS = {
+    "ceiling": "ceil",
+    "E": "e",
+    "ln": "log",
+}
+
 NUMPY_TRANSLATIONS: dict[str, str] = {
     "Heaviside": "heaviside",
 }
@@ -118,6 +126,7 @@ MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "cmath": (CMATH, CMATH_DEFAULT, CMATH_TRANSLATIONS, ("import cmath; from cmath import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
+    "umath": (UMATH, UMATH_DEFAULT, UMATH_TRANSLATIONS, ("from math import*; from uncertainties.umath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import scipy; import numpy; from scipy.special import *",)),
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
@@ -138,7 +147,7 @@ def _import(module, reload=False):
     Creates a global translation dictionary for module.
 
     The argument module has to be one of the following strings: "math","cmath"
-    "mpmath", "numpy", "sympy", "tensorflow", "jax".
+    "mpmath", "umath", "numpy", "sympy", "tensorflow", "jax".
     These dictionaries map names of Python functions to their equivalent in
     other modules.
     """
@@ -329,7 +338,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
         *modules* can be one of the following types:
 
-        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"numpy"``, ``"numexpr"``,
+        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"umath"``, ``"numpy"``, ``"numexpr"``,
           ``"scipy"``, ``"sympy"``, or ``"tensorflow"`` or ``"jax"``. This uses the
           corresponding printer and namespace mapping for that module.
         - A module (e.g., ``math``). This uses the global namespace of the

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -838,7 +838,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         elif _module_present('numpy', namespaces):
             from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
         elif _module_present('unumpy', namespaces):
-            from sympy.printing.numpy import UnumpyPrinter as Printer # type: ignore
+            from sympy.printing.numpy import UnumPyPrinter as Printer # type: ignore
         elif _module_present('cupy', namespaces):
             from sympy.printing.numpy import CuPyPrinter as Printer # type: ignore
         elif _module_present('jax', namespaces):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -344,7 +344,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
         *modules* can be one of the following types:
 
-        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"umpmath"``,
+        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"umath"``,
           ``"numpy"``, ``"unumpy"``, ``"numexpr"``, ``"scipy"``, ``"sympy"``,
           ``"tensorflow"``, ``"torch"`` or ``"jax"``. This uses the corresponding printer
           and namespace mapping for that module.

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -839,7 +839,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         elif _module_present('numpy', namespaces):
             from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
         elif _module_present('unumpy', namespaces):
-            from sympy.printing.numpy import UnumPyPrinter as Printer # type: ignore
+            from sympy.printing.numpy import NumPyPrinter as Printer # type: ignore
         elif _module_present('cupy', namespaces):
             from sympy.printing.numpy import CuPyPrinter as Printer # type: ignore
         elif _module_present('jax', namespaces):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -750,24 +750,41 @@ def test_umath_functions():
         skip("numpy not installed.")
 
     x = symbols("x")
-
     f = lambdify((x,), log(x, 2), "umath")
-
     res = f(uncertainties.ufloat(8, 0.25))
 
     numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [3, 0.045084220027780106])
 
     f = lambdify((x,), sin(x)**2 + cos(x)**2, "umath")
-
     res = f(uncertainties.ufloat(1, 1))
 
     numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [1, 0])
 
     f = lambdify((x,), sin(x * pi), "umath")
-
     res = f(uncertainties.ufloat(2, 1.0))
 
     numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [0, float(pi)], atol=1e-15)
+
+def test_unumpy_vectorized():
+    if not uncertainties:
+        skip("uncertainties not installed.")
+    if not numpy:
+        skip("numpy not installed.")
+
+    x, y = symbols("x y")
+    f = lambdify((x, y), Matrix([x + y, x**2, sqrt(y)]), "unumpy")
+    res = f(uncertainties.ufloat(5, 0.1), uncertainties.ufloat(1, 0.5))
+
+    assert len(res) == 3
+    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ 6, 0.5099019513492785 ])
+    numpy.testing.assert_allclose([ res[1][0].nominal_value, res[1][0].std_dev ], [25, 1])
+    numpy.testing.assert_allclose([ res[2][0].item().nominal_value, res[2][0].item().std_dev ], [1, 0.25])
+
+    f = lambdify((x, y), Matrix([[sin(x), cos(x)]]) * Matrix([1, 2]), "unumpy")
+    res = f(uncertainties.ufloat(pi, 0.2), uncertainties.ufloat(pi/2, 0.2))
+
+    assert len(res) == 1
+    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ -2, 0.2 ])
 
 def test_python_div_zero_issue_11306():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -73,6 +73,7 @@ tensorflow = import_module('tensorflow')
 cupy = import_module('cupy')
 jax = import_module('jax')
 numba = import_module('numba')
+uncertainties = import_module('uncertainties')
 
 if tensorflow:
     # Hide Tensorflow warnings
@@ -727,6 +728,48 @@ def test_scipy_sparse_matrix():
     B = f(1, 2)
     assert isinstance(B, scipy.sparse.coo_matrix)
 
+
+
+def test_umath_basic_math():
+    if not uncertainties:
+        skip("uncertainties not installed.")
+
+    x, y, z = symbols("x y z")
+    f = lambdify((x, y, z), x**2 + y * z, "umath")
+
+    res = f(uncertainties.ufloat(2.0, 0.1), uncertainties.ufloat(3.0, 0.2), uncertainties.ufloat(4.0, 0.3))
+
+    assert res.nominal_value == 16
+    assert res.std_dev == 1.268857754044952
+
+def test_umath_functions():
+    if not uncertainties:
+        skip("uncertainties not installed.")
+
+    x = symbols("x")
+
+    f = lambdify((x,), log(x, 2), "umath")
+
+    res = f(uncertainties.ufloat(8, 0.25))
+
+    assert res.nominal_value == 3.0
+    assert res.std_dev == 0.045084220027780106
+
+    f = lambdify((x,), sin(x)**2 + cos(x)**2, "umath")
+
+    res = f(uncertainties.ufloat(1, 1))
+
+    prec = 1e-15
+
+    assert abs(res.nominal_value - 1.0) <= prec
+    assert abs(res.std_dev) <= prec
+
+    f = lambdify((x,), sin(x * pi), "umath")
+
+    res = f(uncertainties.ufloat(2, 1.0))
+
+    assert abs(res.nominal_value) <= prec
+    assert abs(res.std_dev - pi) <= prec
 
 def test_python_div_zero_issue_11306():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -776,15 +776,13 @@ def test_unumpy_vectorized():
     res = f(uncertainties.ufloat(5, 0.1), uncertainties.ufloat(1, 0.5))
 
     assert len(res) == 3
-    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ 6, 0.5099019513492785 ])
-    numpy.testing.assert_allclose([ res[1][0].nominal_value, res[1][0].std_dev ], [25, 1])
-    numpy.testing.assert_allclose([ res[2][0].item().nominal_value, res[2][0].item().std_dev ], [1, 0.25])
+    numpy.testing.assert_allclose(uncertainties.unumpy.nominal_values(res), [ [6], [25], [1] ])
+    numpy.testing.assert_allclose(uncertainties.unumpy.std_devs(res), [ [0.5099019513492785], [1], [0.25] ])
 
-    f = lambdify((x, y), Matrix([[sin(x), cos(x)]]) * Matrix([1, 2]), "unumpy")
+    f = lambdify((x, y), Matrix([sin(x), cos(x)]).dot(Matrix([1, 2])), "unumpy")
     res = f(uncertainties.ufloat(pi, 0.2), uncertainties.ufloat(pi/2, 0.2))
 
-    assert len(res) == 1
-    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ -2, 0.2 ])
+    numpy.testing.assert_allclose([ res.nominal_value, res.std_dev ], [ -2, 0.2 ])
 
 def test_python_div_zero_issue_11306():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -733,18 +733,21 @@ def test_scipy_sparse_matrix():
 def test_umath_basic_math():
     if not uncertainties:
         skip("uncertainties not installed.")
+    if not numpy:
+        skip("numpy not installed.")
 
     x, y, z = symbols("x y z")
     f = lambdify((x, y, z), x**2 + y * z, "umath")
 
     res = f(uncertainties.ufloat(2.0, 0.1), uncertainties.ufloat(3.0, 0.2), uncertainties.ufloat(4.0, 0.3))
 
-    assert res.nominal_value == 16
-    assert res.std_dev == 1.268857754044952
+    numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [16, 1.268857754044952])
 
 def test_umath_functions():
     if not uncertainties:
         skip("uncertainties not installed.")
+    if not numpy:
+        skip("numpy not installed.")
 
     x = symbols("x")
 
@@ -752,24 +755,19 @@ def test_umath_functions():
 
     res = f(uncertainties.ufloat(8, 0.25))
 
-    assert res.nominal_value == 3.0
-    assert res.std_dev == 0.045084220027780106
+    numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [3, 0.045084220027780106])
 
     f = lambdify((x,), sin(x)**2 + cos(x)**2, "umath")
 
     res = f(uncertainties.ufloat(1, 1))
 
-    prec = 1e-15
-
-    assert abs(res.nominal_value - 1.0) <= prec
-    assert abs(res.std_dev) <= prec
+    numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [1, 0])
 
     f = lambdify((x,), sin(x * pi), "umath")
 
     res = f(uncertainties.ufloat(2, 1.0))
 
-    assert abs(res.nominal_value) <= prec
-    assert abs(res.std_dev - pi) <= prec
+    numpy.testing.assert_allclose([res.nominal_value, res.std_dev], [0, float(pi)], atol=1e-15)
 
 def test_python_div_zero_issue_11306():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -773,18 +773,16 @@ def test_unumpy_vectorized():
 
     x, y = symbols("x y")
     f = lambdify((x, y), Matrix([x + y, x**2, sqrt(y)]), "unumpy")
-    res = f(uncertainties.ufloat(5, 0.1), uncertainties.ufloat(1, 0.5))
+    res = f(uncertainties.ufloat(5, 0.1), uncertainties.ufloat(1, 0.5)) * 1
 
     assert len(res) == 3
-    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ 6, 0.5099019513492785 ])
-    numpy.testing.assert_allclose([ res[1][0].nominal_value, res[1][0].std_dev ], [25, 1])
-    numpy.testing.assert_allclose([ res[2][0].item().nominal_value, res[2][0].item().std_dev ], [1, 0.25])
+    numpy.testing.assert_allclose(uncertainties.unumpy.nominal_values(res), [ [6], [25], [1] ])
+    numpy.testing.assert_allclose(uncertainties.unumpy.std_devs(res), [ [0.5099019513492785], [1], [0.25] ])
 
-    f = lambdify((x, y), Matrix([[sin(x), cos(x)]]) * Matrix([1, 2]), "unumpy")
-    res = f(uncertainties.ufloat(pi, 0.2), uncertainties.ufloat(pi/2, 0.2))
+    f = lambdify((x, y), Matrix([sin(x), cos(x)]).dot(Matrix([1, 2])), "unumpy")
+    res = f(uncertainties.ufloat(pi, 0.2), uncertainties.ufloat(pi/2, 0.2)) * 1
 
-    assert len(res) == 1
-    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ -2, 0.2 ])
+    numpy.testing.assert_allclose([ res.nominal_value, res.std_dev ], [ -2, 0.2 ])
 
 def test_python_div_zero_issue_11306():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -776,13 +776,15 @@ def test_unumpy_vectorized():
     res = f(uncertainties.ufloat(5, 0.1), uncertainties.ufloat(1, 0.5))
 
     assert len(res) == 3
-    numpy.testing.assert_allclose(uncertainties.unumpy.nominal_values(res), [ [6], [25], [1] ])
-    numpy.testing.assert_allclose(uncertainties.unumpy.std_devs(res), [ [0.5099019513492785], [1], [0.25] ])
+    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ 6, 0.5099019513492785 ])
+    numpy.testing.assert_allclose([ res[1][0].nominal_value, res[1][0].std_dev ], [25, 1])
+    numpy.testing.assert_allclose([ res[2][0].item().nominal_value, res[2][0].item().std_dev ], [1, 0.25])
 
-    f = lambdify((x, y), Matrix([sin(x), cos(x)]).dot(Matrix([1, 2])), "unumpy")
+    f = lambdify((x, y), Matrix([[sin(x), cos(x)]]) * Matrix([1, 2]), "unumpy")
     res = f(uncertainties.ufloat(pi, 0.2), uncertainties.ufloat(pi/2, 0.2))
 
-    numpy.testing.assert_allclose([ res.nominal_value, res.std_dev ], [ -2, 0.2 ])
+    assert len(res) == 1
+    numpy.testing.assert_allclose([ res[0][0].nominal_value, res[0][0].std_dev ], [ -2, 0.2 ])
 
 def test_python_div_zero_issue_11306():
     if not numpy:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28030

#### Brief description of what is fixed or changed

Adds `umath` as a possible module for `lambdify`.
When this string is passed, the standard math package (used primarily for constants such as pi, e, ...), and the uncertainties.umath package is used as the backends for lambdifying an expression.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* utilities
  * added `umath` and `unumpy` as possible modules value to `lambdify`, which uses a combination of the standard python math package and the `uncertainties.umath/unumpy` package as a backend, when chosen.

<!-- END RELEASE NOTES -->
