### PR TITLE
Refactor old-style string formatting to f-strings in assumptions

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -490,7 +490,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     # check the satisfiability of given assumptions
     if local_facts.clauses and satisfiable(enc_cnf) is False:
-        raise ValueError("inconsistent assumptions %s" % assumptions)
+        raise ValueError(f"inconsistent assumptions {assumptions}")
 
     # quick computation for single fact
     res = _ask_single_fact(key, local_facts)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -71,7 +71,7 @@ class AssumptionsContext(set):
 
     def _sympystr(self, printer):
         if not self:
-            return "%s()" % self.__class__.__name__
+            return f"{self.__class__.__name__}()"
         return "{}({})".format(self.__class__.__name__, printer._print_set(self))
 
 global_assumptions = AssumptionsContext()
@@ -110,7 +110,7 @@ class AppliedPredicate(Boolean):
 
     def __new__(cls, predicate, *args):
         if not isinstance(predicate, Predicate):
-            raise TypeError("%s is not a Predicate." % predicate)
+            raise TypeError(f"{predicate} is not a Predicate.")
         args = map(_sympify, args)
         return super().__new__(cls, predicate, *args)
 
@@ -176,7 +176,7 @@ class PredicateMeta(type):
         # If handler is not defined, assign empty dispatcher.
         if "handler" not in dct:
             name = f"Ask{clsname.capitalize()}Handler"
-            handler = Dispatcher(name, doc="Handler for key %s" % name)
+            handler = Dispatcher(name, doc=f"Handler for key {name}")
             dct["handler"] = handler
 
         dct["_orig_doc"] = dct.get("__doc__", "")
@@ -192,20 +192,20 @@ class PredicateMeta(type):
             doc += "    =======\n\n"
 
             # Append the handler's doc without breaking sphinx documentation.
-            docs = ["    Multiply dispatched method: %s" % handler.name]
+            docs = [f"    Multiply dispatched method: {handler.name}"]
             if handler.doc:
                 for line in handler.doc.splitlines():
                     if not line:
                         continue
-                    docs.append("    %s" % line)
+                    docs.append(f"    {line}")
             other = []
             for sig in handler.ordering[::-1]:
                 func = handler.funcs[sig]
                 if func.__doc__:
-                    s = '    Inputs: <%s>' % str_signature(sig)
+                    s = f"    Inputs: <{str_signature(sig)}>"
                     lines = []
                     for line in func.__doc__.splitlines():
-                        lines.append("    %s" % line)
+                        lines.append(f"    {line}")
                     s += "\n".join(lines)
                     docs.append(s)
                 else:
@@ -213,7 +213,7 @@ class PredicateMeta(type):
             if other:
                 othersig = "    Other signatures:"
                 for line in other:
-                    othersig += "\n        * %s" % line
+                    othersig += f"\n        * {line}"
                 docs.append(othersig)
 
             doc += '\n\n'.join(docs)
@@ -319,7 +319,7 @@ class Predicate(Boolean, metaclass=PredicateMeta):
         Register the signature to the handler.
         """
         if cls.handler is None:
-            raise TypeError("%s cannot be dispatched." % type(cls))
+            raise TypeError(f"{type(cls)} cannot be dispatched.")
         return cls.handler.register(*types, **kwargs)
 
     @classmethod

--- a/sympy/assumptions/relation/binrel.py
+++ b/sympy/assumptions/relation/binrel.py
@@ -79,7 +79,7 @@ class BinaryRelation(Predicate):
 
     def __call__(self, *args):
         if not len(args) == 2:
-            raise ValueError("Binary relation takes two arguments, but got %s." % len(args))
+            raise ValueError(f"Binary relation takes two arguments, but got {len(args)}.")
         return AppliedBinaryRelation(self, *args)
 
     @property
@@ -208,5 +208,5 @@ class AppliedBinaryRelation(AppliedPredicate):
     def __bool__(self):
         ret = ask(self)
         if ret is None:
-            raise TypeError("Cannot determine truth value of %s" % self)
+            raise TypeError(f"Cannot determine truth value of {self}")
         return ret


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see gh-28031
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Refactor old-style string formatting to f-strings in assumptions

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
