### PR TITLE
Replacing with `enumerate` or `for` loops

### DIFF
--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -296,10 +296,8 @@ class Partition(FiniteSet):
             raise ValueError('mismatch in rgs and element lengths')
         max_elem = max(rgs) + 1
         partition = [[] for i in range(max_elem)]
-        j = 0
-        for i in rgs:
+        for j, i in enumerate(rgs):
             partition[i].append(elements[j])
-            j += 1
         if not all(p for p in partition):
             raise ValueError('some blocks of the partition were empty.')
         return Partition(*partition)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -195,12 +195,11 @@ def test_coset_rank():
     gens = [Permutation(p) for p in gens_cube]
     G = PermutationGroup(gens)
     i = 0
-    for h in G.generate(af=True):
+    for i, h in enumerate(G.generate(af=True)):
         rk = G.coset_rank(h)
         assert rk == i
         h1 = G.coset_unrank(rk, af=True)
         assert h == h1
-        i += 1
     assert G.coset_unrank(48) is None
     assert G.coset_unrank(G.coset_rank(gens[0])) == gens[0]
 

--- a/sympy/holonomic/recurrence.py
+++ b/sympy/holonomic/recurrence.py
@@ -324,10 +324,8 @@ class HolonomicSequence:
             return str_sol
         else:
             cond_str = ''
-            seq_str = 0
-            for i in self.u0:
+            for seq_str, i in enumerate(self.u0):
                 cond_str += ', u(%s) = %s' % (sstr(seq_str), sstr(i))
-                seq_str += 1
 
             sol = str_sol + cond_str
             return sol

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -157,15 +157,13 @@ def _polynomial_integrate(polynomials, facets, hp_params):
     integral_value = S.Zero
     for deg in polynomials:
         poly_contribute = S.Zero
-        facet_count = 0
-        for hp in hp_params:
+        for facet_count, hp in enumerate(hp_params):
             value_over_boundary = integration_reduction(facets,
                                                         facet_count,
                                                         hp[0], hp[1],
                                                         polynomials[deg],
                                                         dims, deg)
             poly_contribute += value_over_boundary * (hp[1] / norm(hp[0]))
-            facet_count += 1
         poly_contribute /= (dim_length + deg)
         integral_value += poly_contribute
 

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -202,16 +202,12 @@ class WeylGroup(Atom):
         Weyl group of G2.  It takes a Weyl element and if repeated simple reflections
         in it, it deletes them.
         """
-        counter = 0
         copy = list(reflections)
-        for elt in copy:
+        for counter, elt in enumerate(copy):
             if counter < len(copy)-1:
                 if copy[counter + 1] == elt:
                     del copy[counter]
                     del copy[counter]
-            counter += 1
-
-
         return copy
 
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -743,13 +743,11 @@ class Wavefunction(Function):
     #avoid errors from calling is_Float in the constructor
     def __new__(cls, *args, **options):
         new_args = [None for i in args]
-        ct = 0
-        for arg in args:
+        for ct, arg in enumerate(args):
             if isinstance(arg, tuple):
                 new_args[ct] = Tuple(*arg)
             else:
                 new_args[ct] = arg
-            ct += 1
 
         return super().__new__(cls, *new_args, **options)
 

--- a/sympy/plotting/series.py
+++ b/sympy/plotting/series.py
@@ -1167,10 +1167,8 @@ class Line2DBaseSeries(BaseSeries):
                         (points[k][:idx], [prev, e, post], points[k][idx+1:]))
 
                     # add points to the other coordinates
-                    c = 0
-                    for j in j_indeces:
+                    for c, j in enumerate(j_indeces):
                         values = funcs[c](np.array([prev, post]))
-                        c += 1
                         points[j] = np.concatenate(
                             (points[j][:idx], [values[0], np.nan, values[1]], points[j][idx+1:]))
         return points

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1090,9 +1090,9 @@ def dmp_zz_wang(f, u, K, mod=None, seed=None):
         else:
             mod += eez_mod_step
 
-    s_norm, s_arg, i = None, 0, 0
+    s_norm, s_arg = None, 0
 
-    for s, _, _, _, _ in configs:
+    for i, (s, _, _, _, _) in enumerate(configs):
         _s_norm = dup_max_norm(s, K)
 
         if s_norm is not None:
@@ -1101,8 +1101,6 @@ def dmp_zz_wang(f, u, K, mod=None, seed=None):
                 s_arg = i
         else:
             s_norm = _s_norm
-
-        i += 1
 
     _, cs, E, H, A = configs[s_arg]
     orig_f = f

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -821,7 +821,7 @@ def modified_subresultants_bezout(p, q, x):
     # and form subresultant polys
     for j in range(2 if degF > degG else 1, degF + 1):
         M = B[0:j, :]
-        k, coeff_L = j - 1, []
+        coeff_L = []
         for k in range(j - 1, degF):
             coeff_L.append(M[:, 0:j].det())
             if k < degF - 1:

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -319,20 +319,12 @@ def sylvester(f, g, x, method = 1):
     # Sylvester's matrix of 1840 (default; a.k.a. sylvester1)
     if method <= 1:
         M = zeros(m + n)
-        k = 0
         for i in range(n):
-            j = k
-            for coeff in fp:
+            for j, coeff in enumerate(fp, i):
                 M[i, j] = coeff
-                j = j + 1
-            k = k + 1
-        k = 0
         for i in range(n, m + n):
-            j = k
-            for coeff in gp:
+            for j, coeff in enumerate(gp, i - n):
                 M[i, j] = coeff
-                j = j + 1
-            k = k + 1
         return M
 
     # Sylvester's matrix of 1853 (a.k.a sylvester2)
@@ -350,17 +342,11 @@ def sylvester(f, g, x, method = 1):
         mx = max(m, n)
         dim = 2*mx
         M = zeros( dim )
-        k = 0
         for i in range( mx ):
-            j = k
-            for coeff in fp:
+            for j, coeff in enumerate(fp, i):
                 M[2*i, j] = coeff
-                j = j + 1
-            j = k
-            for coeff in gp:
+            for j, coeff in enumerate(gp, i):
                 M[2*i + 1, j] = coeff
-                j = j + 1
-            k = k + 1
         return M
 
 def process_matrix_output(poly_seq, x):
@@ -436,9 +422,7 @@ def subresultants_sylv(f, g, x):
 
     # pick appropriate submatrices of S
     # and form subresultant polys
-    j = m - 1
-
-    while j > 0:
+    for j in range(m - 1, 0, -1):
         Sp = S[:, :]  # copy of S
         # delete last j rows of coeffs of g
         for ind in range(m + n - j, m + n):
@@ -448,15 +432,13 @@ def subresultants_sylv(f, g, x):
             Sp.row_del(m - j)
 
         # evaluate determinants and form coefficients list
-        coeff_L, k, l = [], Sp.rows, 0
-        while l <= j:
+        coeff_L, k = [], Sp.rows
+        for l in range(j + 1):
             coeff_L.append(Sp[:, 0:k].det())
             Sp.col_swap(k - 1, k + l)
-            l += 1
 
         # form poly and append to SP_L
         SR_L.append(Poly(coeff_L, x).as_expr())
-        j -= 1
 
     # j = 0
     SR_L.append(S.det())
@@ -509,22 +491,18 @@ def modified_subresultants_sylv(f, g, x):
 
     # pick appropriate submatrices of S
     # and form modified subresultant polys
-    j = m - 1
-
-    while j > 0:
+    for j in range(m - 1, 0, -1):
         # delete last 2*j rows of pairs of coeffs of f, g
         Sp = S[0:2*n - 2*j, :]  # copy of first 2*n - 2*j rows of S
 
         # evaluate determinants and form coefficients list
-        coeff_L, k, l = [], Sp.rows, 0
-        while l <= j:
+        coeff_L, k = [], Sp.rows
+        for l in range(j + 1):
             coeff_L.append(Sp[:, 0:k].det())
             Sp.col_swap(k - 1, k + l)
-            l += 1
 
         # form poly and append to SP_L
         SR_L.append(Poly(coeff_L, x).as_expr())
-        j -= 1
 
     # j = 0
     SR_L.append(S.det())
@@ -841,24 +819,18 @@ def modified_subresultants_bezout(p, q, x):
 
     # pick appropriate submatrices of B
     # and form subresultant polys
-    if degF > degG:
-        j = 2
-    if degF == degG:
-        j = 1
-    while j <= degF:
+    for j in range(2 if degF > degG else 1, degF + 1):
         M = B[0:j, :]
         k, coeff_L = j - 1, []
-        while k <= degF - 1:
+        for k in range(j - 1, degF):
             coeff_L.append(M[:, 0:j].det())
             if k < degF - 1:
                 M.col_swap(j - 1, k + 1)
-            k = k + 1
 
         ## Theorem 2.1 in the paper by Toca & Vega 2004 is _not needed_
         ## in this case since
         ## the bezout matrix is equivalent to sylvester2
         SR_L.append(( Poly(coeff_L, x)).as_expr())
-        j = j + 1
 
     return process_matrix_output(SR_L, x)
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -206,8 +206,7 @@ class AbstractPythonCodePrinter(CodePrinter):
 
     def _print_Piecewise(self, expr):
         result = []
-        i = 0
-        for arg in expr.args:
+        for i, arg in enumerate(expr.args):
             e = arg.expr
             c = arg.cond
             if i == 0:
@@ -218,7 +217,6 @@ class AbstractPythonCodePrinter(CodePrinter):
             result.append(' if ')
             result.append(self._print(c))
             result.append(' else ')
-            i += 1
         result = result[:-1]
         if result[-1] == 'True':
             result = result[:-2]

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -158,10 +158,9 @@ class Ordinal(Basic):
 
     def __str__(self):
         net_str = ""
-        plus_count = 0
         if self == ord0:
             return 'ord0'
-        for i in self.terms:
+        for plus_count, i in enumerate(self.terms):
             if plus_count:
                 net_str += " + "
 
@@ -176,8 +175,6 @@ class Ordinal(Basic):
 
             if not i.mult == 1 and not i.exp == ord0:
                 net_str += '*%s'%i.mult
-
-            plus_count += 1
         return(net_str)
 
     __repr__ = __str__

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1014,13 +1014,11 @@ class GeneralSumOfSquares(DiophantineEquationType):
         signs = [-1 if x.is_nonpositive else 1 for x in var]
         negs = signs.count(-1) != 0
 
-        took = 0
-        for t in sum_of_squares(k, n, zeros=True):
+        for took, t in enumerate(sum_of_squares(k, n, zeros=True), 1):
             if negs:
                 result.add([signs[i]*j for i, j in enumerate(t)])
             else:
                 result.add(t)
-            took += 1
             if took == limit:
                 break
         return result
@@ -1182,13 +1180,11 @@ class GeneralSumOfEvenPowers(DiophantineEquationType):
         sign = [-1 if x.is_nonpositive else 1 for x in var]
         negs = sign.count(-1) != 0
 
-        took = 0
-        for t in power_representation(n, p, k):
+        for took, t in enumerate(power_representation(n, p, k), 1):
             if negs:
                 result.add([sign[i]*j for i, j in enumerate(t)])
             else:
                 result.add(t)
-            took += 1
             if took == limit:
                 break
         return result

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -133,10 +133,8 @@ def test_iterator():
     assert array[1] == ImmutableDenseNDimArray([2, 3])
 
     array = array.reshape(4)
-    j = 0
-    for i in array:
+    for j, i in enumerate(array):
         assert i == j
-        j += 1
 
 
 def test_sparse():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -112,10 +112,8 @@ def test_iterator():
     assert array[1] == MutableDenseNDimArray([2, 3])
 
     array = array.reshape(4)
-    j = 0
-    for i in array:
+    for j, i in enumerate(array):
         assert i == j
-        j += 1
 
 
 def test_getitem():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1075,16 +1075,12 @@ def lambdastr(args, expr, printer=None, dummify=None):
         return iterable(l, exclude=(str, DeferredVector, NotIterable))
 
     def flat_indexes(iterable):
-        n = 0
-
-        for el in iterable:
+        for n, el in enumerate(iterable):
             if isiter(el):
                 for ndeep in flat_indexes(el):
                     yield (n,) + ndeep
             else:
                 yield (n,)
-
-            n += 1
 
     if dummify is None:
         dummify = any(isinstance(a, Basic) and
@@ -1342,16 +1338,12 @@ class _TensorflowEvaluatorPrinter(_EvaluatorPrinter):
         """
 
         def flat_indexes(elems):
-            n = 0
-
-            for el in elems:
+            for n, el in enumerate(elems):
                 if iterable(el):
                     for ndeep in flat_indexes(el):
                         yield (n,) + ndeep
                 else:
                     yield (n,)
-
-                n += 1
 
         indexed = ', '.join('{}[{}]'.format(rvalue, ']['.join(map(str, ind)))
                                 for ind in flat_indexes(lvalues))
@@ -1583,10 +1575,7 @@ def _too_large_for_docstring(expr, limit):
 
     if limit is None:
         return False
-
-    i = 0
-    for _ in postorder_traversal(expr):
-        i += 1
+    for i, _ in enumerate(postorder_traversal(expr), 1):
         if i > limit:
             return True
     return False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Rather than writing:

```python
counter = 0
for i in iterable:
    ...
    counter += 1
```

or

```python
i = 0
while i < j:
    ...
    i += 1
```

it is more readable to write:

```python
for counter, i in enumerate(iterable):
    ...
```

or

```python
for i in range(j):
    ...
```


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
