### PR TITLE
Replace old-style string formatting to f-strings

### DIFF
--- a/sympy/benchmarks/bench_meijerint.py
+++ b/sympy/benchmarks/bench_meijerint.py
@@ -252,10 +252,10 @@ if __name__ == '__main__':
         sys.stdout.write('.')
         sys.stdout.flush()
         if n % (len(bench) // 10) == 0:
-            sys.stdout.write('%s' % (10*n // len(bench)))
+            sys.stdout.write(f'{10 * n // len(bench)}')
     print()
 
     timings.sort(key=lambda x: -x[0])
 
     for ti, string in timings:
-        print('%.2fs %s' % (ti, string))
+        print(f'{ti:.2f}s {string}')

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -131,4 +131,4 @@ if __name__ == '__main__':
         t = clock()
         b()
         t = clock() - t
-        print("%s%65s: %f" % (b.__name__, b.__doc__, t))
+        print(f"{b.__name__}{b.__doc__:>65}: {t:f}")

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -730,9 +730,7 @@ def _eval_is_le(lhs, rhs): # noqa: F811
 
     """
     if not rhs.is_extended_real:
-            raise TypeError(
-                "Invalid comparison of %s %s" %
-                (type(rhs), rhs))
+        raise TypeError(f"Invalid comparison of {type(rhs)} {rhs}")
     elif rhs.is_comparable:
         if is_le(lhs.max, rhs):
             return True
@@ -770,9 +768,7 @@ def _eval_is_ge(lhs, rhs): # noqa: F811
     """
 
     if not rhs.is_extended_real:
-        raise TypeError(
-            "Invalid comparison of %s %s" %
-            (type(rhs), rhs))
+        raise TypeError(f"Invalid comparison of {type(rhs)} {rhs}")
     elif rhs.is_comparable:
         if is_ge(lhs.min, rhs):
             return True
@@ -783,9 +779,7 @@ def _eval_is_ge(lhs, rhs): # noqa: F811
 @dispatch(Expr, AccumulationBounds)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if not lhs.is_extended_real:
-        raise TypeError(
-            "Invalid comparison of %s %s" %
-            (type(lhs), lhs))
+        raise TypeError(f"Invalid comparison of {type(lhs)} {lhs}")
     elif lhs.is_comparable:
         if is_le(rhs.max, lhs):
             return True

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -76,7 +76,7 @@ def euler_equations(L, funcs=(), vars=()):
     else:
         for f in funcs:
             if not isinstance(f, Function):
-                raise TypeError('Function expected, got: %s' % f)
+                raise TypeError(f'Function expected, got: {f}')
 
     vars = tuple(vars) if iterable(vars) else (vars,)
 
@@ -86,11 +86,11 @@ def euler_equations(L, funcs=(), vars=()):
         vars = tuple(sympify(var) for var in vars)
 
     if not all(isinstance(v, Symbol) for v in vars):
-        raise TypeError('Variables are not symbols, got %s' % vars)
+        raise TypeError(f'Variables are not symbols, got {vars}')
 
     for f in funcs:
         if not vars == f.args:
-            raise ValueError("Variables %s do not match args: %s" % (vars, f))
+            raise ValueError(f"Variables {vars} do not match args: {f}")
 
     order = max([len(d.variables) for d in L.atoms(Derivative)
                         if d.expr in funcs] + [0])

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -398,7 +398,7 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
             continue
         others += [v, derivative.variables.count(v)]
     if len(points) < order+1:
-        raise ValueError("Too few points for order %d" % order)
+        raise ValueError(f"Too few points for order {order}")
     return apply_finite_diff(order, points, [
         Derivative(derivative.expr.subs({wrt: x}), *others) for
         x in points], x0)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -346,14 +346,12 @@ def not_empty_in(finset_intersection, *syms):
         _sets = finset_intersection.args[0]
 
     if not isinstance(finite_set, FiniteSet):
-        raise ValueError('A FiniteSet must be given, not %s: %s' %
-                         (type(finite_set), finite_set))
+        raise ValueError(f"A FiniteSet must be given, not {type(finite_set)}: {finite_set}")
 
     if len(syms) == 1:
         symb = syms[0]
     else:
-        raise NotImplementedError('more than one variables %s not handled' %
-                                  (syms,))
+        raise NotImplementedError(f'more than one variables {syms} not handled')
 
     def elm_domain(expr, intrvl):
         """ Finds the domain of an expression in any given interval """
@@ -456,7 +454,7 @@ def periodicity(f, symbol, check=False):
     >>> periodicity(exp(x), x)
     """
     if symbol.kind is not NumberKind:
-        raise NotImplementedError("Cannot use symbol of kind %s" % symbol.kind)
+        raise NotImplementedError(f"Cannot use symbol of kind {symbol.kind}")
     temp = Dummy('x', real=True)
     f = f.subs(symbol, temp)
     symbol = temp
@@ -467,15 +465,15 @@ def periodicity(f, symbol, check=False):
         if new_f.equals(orig_f):
             return period
         else:
-            raise NotImplementedError(filldedent('''
+            raise NotImplementedError(filldedent(f'''
                 The period of the given function cannot be verified.
-                When `%s` was replaced with `%s + %s` in `%s`, the result
-                was `%s` which was not recognized as being the same as
+                When `{symbol}` was replaced with `{symbol} + {period}` in `{orig_f}`,
+                the result was `{new_f}` which was not recognized as being the same as
                 the original function.
                 So either the period was wrong or the two forms were
                 not recognized as being equal.
-                Set check=False to obtain the value.''' %
-                (symbol, symbol, period, orig_f, new_f)))
+                Set check=False to obtain the value.'''
+            ))
 
     orig_f = f
     period = None
@@ -845,7 +843,7 @@ def maximum(f, symbol, domain=S.Reals):
 
         return function_range(f, symbol, domain).sup
     else:
-        raise ValueError("%s is not a valid symbol." % symbol)
+        raise ValueError(f"{symbol} is not a valid symbol.")
 
 
 def minimum(f, symbol, domain=S.Reals):
@@ -892,4 +890,4 @@ def minimum(f, symbol, domain=S.Reals):
 
         return function_range(f, symbol, domain).inf
     else:
-        raise ValueError("%s is not a valid symbol." % symbol)
+        raise ValueError(f"{symbol} is not a valid symbol.")

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1470,13 +1470,12 @@ class ArrowStringDescription:
 
     def __str__(self):
         if self.curving:
-            curving_str = "@/%s%d%s/" % (self.curving, self.curving_amount,
-                                         self.unit)
+            curving_str = f"@/{self.curving}{self.curving_amount}{self.unit}/"
         else:
             curving_str = ""
 
         if self.looping_start and self.looping_end:
-            looping_str = "@(%s,%s)" % (self.looping_start, self.looping_end)
+            looping_str = f"@({self.looping_start},{self.looping_end})"
         else:
             looping_str = ""
 
@@ -1486,10 +1485,11 @@ class ArrowStringDescription:
         else:
             style_str = ""
 
-        return "\\ar%s%s%s[%s%s]%s%s{%s}" % \
-               (curving_str, looping_str, style_str, self.horizontal_direction,
-                self.vertical_direction, self.label_position,
-                self.label_displacement, self.label)
+        return (
+            f"\\ar{curving_str}{looping_str}{style_str}["
+            f"{self.horizontal_direction}{self.vertical_direction}]"
+            f"{self.label_position}{self.label_displacement}{{{self.label}}}"
+        )
 
 
 class XypicDiagramDrawer:
@@ -2353,7 +2353,7 @@ class XypicDiagramDrawer:
         for morphism in morphisms:
             object_morphisms[morphism.domain].append(morphism)
 
-        result = "\\xymatrix%s{\n" % diagram_format
+        result = f"\\xymatrix{diagram_format}{{\n"
 
         for i in range(grid.height):
             for j in range(grid.width):

--- a/sympy/codegen/algorithms.py
+++ b/sympy/codegen/algorithms.py
@@ -163,7 +163,7 @@ def newtons_method_function(expr, wrt, params=None, func_name="newton", attrs=Tu
     """
     if params is None:
         params = (wrt,)
-    pointer_subs = {p.symbol: Symbol('(*%s)' % p.symbol.name)
+    pointer_subs = {p.symbol: Symbol(f'(*{p.symbol.name})')
                     for p in params if isinstance(p, Pointer)}
     if delta is None:
         delta = Symbol('d_' + wrt.name)
@@ -174,7 +174,7 @@ def newtons_method_function(expr, wrt, params=None, func_name="newton", attrs=Tu
         algo = algo.body
     not_in_params = expr.free_symbols.difference({_symbol_of(p) for p in params})
     if not_in_params:
-        raise ValueError("Missing symbols in params: %s" % ', '.join(map(str, not_in_params)))
+        raise ValueError(f"Missing symbols in params: {', '.join(map(str, not_in_params))}")
     declars = tuple(Variable(p, real) for p in params)
     body = CodeBlock(algo, Return(wrt))
     return FunctionDefinition(real, func_name, declars, body, attrs=attrs)

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -196,7 +196,7 @@ class Token(CodegenAST):
     @classmethod
     def _get_constructor(cls, attr):
         """ Get the constructor function for an attribute by name. """
-        return getattr(cls, '_construct_%s' % attr, lambda x: x)
+        return getattr(cls, f'_construct_{attr}', lambda x: x)
 
     @classmethod
     def _construct(cls, attr, arg):
@@ -216,7 +216,7 @@ class Token(CodegenAST):
             return args[0]
 
         if len(args) > len(cls._fields):
-            raise ValueError("Too many arguments (%d), expected at most %d" % (len(args), len(cls._fields)))
+            raise ValueError(f"Too many arguments ({len(args)}), expected at most {len(cls._fields)}")
 
         attrvals = []
 
@@ -241,7 +241,7 @@ class Token(CodegenAST):
             attrvals.append(cls._construct(attrname, argval))
 
         if kwargs:
-            raise ValueError("Unknown keyword arguments: %s" % ' '.join(kwargs))
+            raise ValueError(f"Unknown keyword arguments: {' '.join(kwargs)}")
 
         # Parent constructor
         basic_args = [
@@ -442,7 +442,7 @@ class AssignmentBase(CodegenAST):
         assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element, Variable,
                 ArrayElement)
         if not isinstance(lhs, assignable):
-            raise TypeError("Cannot assign to lhs of type %s." % type(lhs))
+            raise TypeError(f"Cannot assign to lhs of type {type(lhs)}.")
 
         # Indexed types implement shape, but don't define it until later. This
         # causes issues in assignment validation. For now, matrices are defined
@@ -586,7 +586,7 @@ def aug_assign(lhs, op, rhs):
     AddAugmentedAssignment(x, y)
     """
     if op not in augassign_classes:
-        raise ValueError("Unrecognized operator %s" % op)
+        raise ValueError(f"Unrecognized operator {op}")
     return augassign_classes[op](lhs, rhs)
 
 
@@ -788,8 +788,9 @@ class CodeBlock(CodegenAST):
 
         for i, lhs in enumerate(self.left_hand_sides):
             if lhs in self.left_hand_sides[:i]:
-                raise NotImplementedError("Duplicate assignments to the same "
-                    "variable are not yet supported (%s)" % lhs)
+                raise NotImplementedError(
+                    f"Duplicate assignments to the same variable are not yet supported ({lhs})"
+                )
 
         # Ensure new symbols for subexpressions do not conflict with existing
         existing_symbols = self.atoms(Symbol)
@@ -1157,9 +1158,9 @@ class _SizedIntType(IntBaseType):
 
     def _check(self, value):
         if value < self.min:
-            raise ValueError("Value is too small: %d < %d" % (value, self.min))
+            raise ValueError(f"Value is too small: {value} < {self.min}")
         if value > self.max:
-            raise ValueError("Value is too big: %d > %d" % (value, self.max))
+            raise ValueError(f"Value is too big: {value} > {self.max}")
 
 
 class SignedIntType(_SizedIntType):
@@ -1305,9 +1306,9 @@ class FloatType(FloatBaseType):
 
     def _check(self, value):
         if value < -self.max:
-            raise ValueError("Value is too small: %d < %d" % (value, -self.max))
+            raise ValueError(f"Value is too small: {value} < {-self.max}")
         if value > self.max:
-            raise ValueError("Value is too big: %d > %d" % (value, self.max))
+            raise ValueError(f"Value is too big: {value} > {self.max}")
         if abs(value) < self.tiny:
             raise ValueError("Smallest (absolute) value for data type bigger than new value.")
 
@@ -1399,8 +1400,9 @@ class Attribute(Token):
     def _sympystr(self, printer, *args, **kwargs):
         result = str(self.name)
         if self.parameters:
-            result += '(%s)' % ', '.join((printer._print(
-                arg, *args, **kwargs) for arg in self.parameters))
+            result += (
+                f"({', '.join(printer._print(arg, *args, **kwargs) for arg in self.parameters)})"
+            )
         return result
 
 value_const = Attribute('value_const')
@@ -1547,7 +1549,7 @@ class Variable(Node):
         try:
             rhs = _sympify(rhs)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, rhs))
+            raise TypeError(f"Invalid comparison {self} < {rhs}")
         return op(self, rhs, evaluate=False)
 
     __lt__ = lambda self, other: self._relation(other, Lt)

--- a/sympy/codegen/cutils.py
+++ b/sympy/codegen/cutils.py
@@ -4,5 +4,5 @@ def render_as_source_file(content, Printer=C99CodePrinter, settings=None):
     """ Renders a C source file (with required #include statements) """
     printer = Printer(settings or {})
     code_str = printer.doprint(content)
-    includes = '\n'.join(['#include <%s>' % h for h in printer.headers])
+    includes = '\n'.join([f'#include <{h}>' for h in printer.headers])
     return includes + '\n\n' + code_str

--- a/sympy/codegen/fnodes.py
+++ b/sympy/codegen/fnodes.py
@@ -363,7 +363,7 @@ def array(symbol, dim, intent=None, *, attrs=(), value=None, type=None):
     """
     if isinstance(dim, Attribute):
         if str(dim.name) != 'dimension':
-            raise ValueError("Got an unexpected Attribute argument as dim: %s" % str(dim))
+            raise ValueError(f"Got an unexpected Attribute argument as dim: {str(dim)}")
     else:
         dim = dimension(*dim)
 
@@ -586,8 +586,7 @@ class FFunction(Function):
     def _fcode(self, printer):
         name = self.__class__.__name__
         if printer._settings['standard'] < self._required_standard:
-            raise NotImplementedError("%s requires Fortran %d or newer" %
-                                      (name, self._required_standard))
+            raise NotImplementedError(f"{name} requires Fortran {self._required_standard} or newer")
         return '{}({})'.format(name, ', '.join(map(printer._print, self.args)))
 
 

--- a/sympy/codegen/futils.py
+++ b/sympy/codegen/futils.py
@@ -36,5 +36,5 @@ def render_as_module(definitions, name, declarations=(), printer_settings=None):
                                                 k, v in printer.module_uses.items()])
     module_use_str += '   implicit none\n'
     module_use_str += '   private\n'
-    module_use_str += '   public %s\n' % ', '.join([str(node.name) for node in definitions if getattr(node, 'name', None)])
+    module_use_str += f"   public {', '.join([str(node.name) for node in definitions if getattr(node, 'name', None)])}\n"
     return fstr.replace(printer.doprint(dummy), module_use_str)

--- a/sympy/codegen/pyutils.py
+++ b/sympy/codegen/pyutils.py
@@ -17,8 +17,8 @@ def render_as_module(content, standard='python3'):
     printer = PythonCodePrinter({'standard':standard})
     pystr = printer.doprint(content)
     if printer._settings['fully_qualified_modules']:
-        module_imports_str = '\n'.join('import %s' % k for k in printer.module_imports)
+        module_imports_str = '\n'.join(f"import {k}" for k in printer.module_imports)
     else:
-        module_imports_str = '\n'.join(['from %s import %s' % (k, ', '.join(v)) for
+        module_imports_str = '\n'.join([f"from {k} import {', '.join(v)}" for
                                         k, v in printer.module_imports.items()])
     return module_imports_str + '\n\n' + pystr

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -35,7 +35,8 @@ class Compound:
         return hash((type(self), self.op, self.args))
 
     def __str__(self):
-        return "%s[%s]" % (str(self.op), ', '.join(map(str, self.args)))
+        args = ', '.join(map(str, self.args))
+        return f"{self.op}[{args}]"
 
 class Variable:
     """ A Wild token """
@@ -49,7 +50,7 @@ class Variable:
         return hash((type(self), self.arg))
 
     def __str__(self):
-        return "Variable(%s)" % str(self.arg)
+        return f"Variable({self.arg})"
 
 class CondVariable:
     """ A wild token that matches conditionally.
@@ -70,7 +71,7 @@ class CondVariable:
         return hash((type(self), self.arg, self.valid))
 
     def __str__(self):
-        return "CondVariable(%s)" % str(self.arg)
+        return f"CondVariable({self.arg})"
 
 def unify(x, y, s=None, **fns):
     """ Unify two expressions.

--- a/sympy/utilities/_compilation/availability.py
+++ b/sympy/utilities/_compilation/availability.py
@@ -19,7 +19,7 @@ def has_fortran():
         else:
             if info['exit_status'] != os.EX_OK or 'hello world' not in stdout:
                 if os.environ.get('SYMPY_STRICT_COMPILER_CHECKS', '0') == '1':
-                    raise ValueError("Failed to compile test program:\n%s\n%s\n" % (stdout, stderr))
+                    raise ValueError(f"Failed to compile test program:\n{stdout}\n{stderr}\n")
                 has_fortran.result = False
             else:
                 has_fortran.result = True
@@ -45,7 +45,7 @@ def has_c():
         else:
             if info['exit_status'] != os.EX_OK or 'hello world' not in stdout:
                 if os.environ.get('SYMPY_STRICT_COMPILER_CHECKS', '0') == '1':
-                    raise ValueError("Failed to compile test program:\n%s\n%s\n" % (stdout, stderr))
+                    raise ValueError(f"Failed to compile test program:\n{stdout}\n{stderr}\n")
                 has_c.result = False
             else:
                 has_c.result = True
@@ -70,7 +70,7 @@ def has_cxx():
         else:
             if info['exit_status'] != os.EX_OK or 'hello world' not in stdout:
                 if os.environ.get('SYMPY_STRICT_COMPILER_CHECKS', '0') == '1':
-                    raise ValueError("Failed to compile test program:\n%s\n%s\n" % (stdout, stderr))
+                    raise ValueError(f"Failed to compile test program:\n{stdout}\n{stderr}\n")
                 has_cxx.result = False
             else:
                 has_cxx.result = True

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -90,8 +90,10 @@ class CompilerRunner:
                     break
             else:
                 self.compiler_vendor, self.compiler_name = list(self.compiler_dict.items())[0]
-                warnings.warn("failed to determine what kind of compiler %s is, assuming %s" %
-                              (self.compiler_binary, self.compiler_name))
+                warnings.warn(
+                    f"failed to determine what kind of compiler {self.compiler_binary} "
+                    f"is, assuming {self.compiler_name}"
+                )
         else:
             # Find a compiler
             if preferred_vendor is None:

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -271,7 +271,7 @@ def import_module_from_file(filename, only_if_newer_than=None):
         import importlib.util
         spec = importlib.util.spec_from_file_location(name, filename)
         if spec is None:
-            raise ImportError("Failed to import: '%s'" % filename)
+            raise ImportError(f"Failed to import: '{filename}'")
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
     return mod

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -118,11 +118,11 @@ class CodeWrapper:
 
     @property
     def filename(self):
-        return "%s_%s" % (self._filename, CodeWrapper._module_counter)
+        return f"{self._filename}_{CodeWrapper._module_counter}"
 
     @property
     def module_name(self):
-        return "%s_%s" % (self._module_basename, CodeWrapper._module_counter)
+        return f"{self._module_basename}_{CodeWrapper._module_counter}"
 
     def __init__(self, generator, filepath=None, flags=[], verbose=False):
         """
@@ -183,8 +183,9 @@ class CodeWrapper:
             retoutput = check_output(command, stderr=STDOUT)
         except CalledProcessError as e:
             raise CodeWrapError(
-                "Error while executing command: %s. Command output is:\n%s" % (
-                    " ".join(command), e.output.decode('utf-8')))
+                f"Error while executing command: {' '.join(command)}. "
+                f"Command output is:\n{e.output.decode('utf-8')}"
+            )
         if not self.quiet:
             print(retoutput)
 
@@ -203,7 +204,7 @@ def %(name)s():
         return
 
     def _generate_code(self, routine, helpers):
-        with open('%s.py' % self.module_name, 'w') as f:
+        with open(f"{self.module_name}.py", 'w') as f:
             printed = ", ".join(
                 [str(res.expr) for res in routine.result_variables])
             # convert OutputArguments to return value like f2py
@@ -322,7 +323,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
     def _prepare_files(self, routine, build_dir=os.curdir):
         # NOTE : build_dir is used for testing purposes.
         pyxfilename = self.module_name + '.pyx'
-        codefilename = "%s.%s" % (self.filename, self.generator.code_extension)
+        codefilename = f"{self.filename}.{self.generator.code_extension}"
 
         # pyx
         with open(os.path.join(build_dir, pyxfilename), 'w') as f:
@@ -400,11 +401,11 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
             args_c = ", ".join([self._call_arg(a) for a in routine.arguments])
             rets = ", ".join([self._string_var(r.name) for r in py_rets])
             if routine.results:
-                body = '    return %s(%s)' % (routine.name, args_c)
+                body = f'    return {routine.name}({args_c})'
                 if rets:
                     body = body + ', ' + rets
             else:
-                body = '    %s(%s)\n' % (routine.name, args_c)
+                body = f'    {routine.name}({args_c})\n'
                 body = body + '    return ' + rets
 
             functions.append(self.pyx_func.format(name=name, arg_string=arg_string,
@@ -458,7 +459,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
             mtype = np_types[t]
             return mat_dec.format(mtype=mtype, ndim=ndim, name=self._string_var(arg.name))
         else:
-            return "%s %s" % (t, self._string_var(arg.name))
+            return f"{t} {self._string_var(arg.name)}"
 
     def _declare_arg(self, arg):
         proto = self._prototype_arg(arg)
@@ -1168,7 +1169,7 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
         m = Dummy('m', integer=True)
         i = Idx(Dummy('i', integer=True), m)
         f_dummy = Dummy('f')
-        f = implemented_function('%s_%d' % (f_dummy.name, f_dummy.dummy_index), Lambda(args, expr))
+        f = implemented_function(f"{f_dummy.name}_{f_dummy.dummy_index}", Lambda(args, expr))
         # For each of the args create an indexed version.
         indexed_args = [IndexedBase(Dummy(str(a))) for a in args]
         # Order the arguments (out, args, dim)

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -220,7 +220,7 @@ def public(obj: T) -> T:
         ns = sys.modules[obj.__module__].__dict__
         name = obj.__name__
     else:
-        raise TypeError("expected a function or a class, got %s" % obj)
+        raise TypeError(f"expected a function or a class, got {obj}")
 
     if "__all__" not in ns:
         ns["__all__"] = [name]

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -115,7 +115,7 @@ class PartComponent:
 
     def __repr__(self):
         "for debug/algorithm animation purposes"
-        return 'c:%d u:%d v:%d' % (self.c, self.u, self.v)
+        return f'c:{self.c} u:{self.u} v:{self.v}'
 
     def __eq__(self, other):
         """Define  value oriented equality, which is useful for testers"""

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -97,8 +97,7 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         elif levels > 0:
             levels -= 1
         else:
-            raise ValueError(
-                "expected non-negative number of levels, got %s" % levels)
+            raise ValueError(f"expected non-negative number of levels, got {levels}")
 
     if cls is None:
         def reducible(x):
@@ -125,7 +124,7 @@ def unflatten(iter, n=2):
     the length of ``iter`` is not a multiple of ``n``.
     """
     if n < 1 or len(iter) % n:
-        raise ValueError('iter length is not a multiple of %i' % n)
+        raise ValueError(f'iter length is not a multiple of {n}')
     return list(zip(*(iter[i::n] for i in range(n))))
 
 
@@ -545,7 +544,7 @@ def numbered_symbols(prefix='x', cls=None, start=0, exclude=(), *args, **assumpt
         cls = Symbol
 
     while True:
-        name = '%s%s' % (prefix, start)
+        name = f'{prefix}{start}'
         s = cls(name, *args, **assumptions)
         if s not in exclude:
             yield s
@@ -2931,8 +2930,7 @@ def kbins(l, k, ordered=None):
                         i = j
                 yield rv
     else:
-        raise ValueError(
-            'ordered must be one of 00, 01, 10 or 11, not %s' % ordered)
+        raise ValueError(f'ordered must be one of 00, 01, 10 or 11, not {ordered}')
 
 
 def permute_signs(t):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -146,8 +146,7 @@ def _import(module, reload=False):
         namespace, namespace_default, translations, import_commands = MODULES[
             module]
     except KeyError:
-        raise NameError(
-            "'%s' module cannot be used for lambdification" % module)
+        raise NameError(f"'{module}' module cannot be used for lambdification")
 
     # Clear namespace or exit
     if namespace != namespace_default:
@@ -172,8 +171,7 @@ def _import(module, reload=False):
             except ImportError:
                 pass
 
-        raise ImportError(
-            "Cannot import '%s' with '%s' command" % (module, import_command))
+        raise ImportError(f"Cannot import '{module}' with '{import_command}' command")
 
     # Add translated names to namespace
     for sympyname, translation in translations.items():
@@ -898,14 +896,14 @@ or tuple for the function arguments.
     for mod, keys in (getattr(printer, 'module_imports', None) or {}).items():
         for k in keys:
             if k not in namespace:
-                ln = "from %s import %s" % (mod, k)
+                ln = f"from {mod} import {k}"
                 try:
                     exec(ln, {}, namespace)
                 except ImportError:
                     # Tensorflow 2.0 has issues with importing a specific
                     # function from its submodule.
                     # https://github.com/tensorflow/tensorflow/issues/33022
-                    ln = "%s = %s.%s" % (k, mod, k)
+                    ln = f"{k} = {mod}.{k}"
                     exec(ln, {}, namespace)
                 imp_mod_lines.append(ln)
 
@@ -914,7 +912,7 @@ or tuple for the function arguments.
 
     funclocals = {}
     global _lambdify_generated_counter
-    filename = '<lambdifygenerated-%s>' % _lambdify_generated_counter
+    filename = f'<lambdifygenerated-{_lambdify_generated_counter}>'
     _lambdify_generated_counter += 1
     c = compile(funcstr, filename, 'exec')
     exec(c, namespace, funclocals)
@@ -975,7 +973,7 @@ def _get_namespace(m):
     elif hasattr(m, "__dict__"):
         return m.__dict__
     else:
-        raise TypeError("Argument must be either a string, dict or module but it is: %s" % m)
+        raise TypeError(f"Argument must be either a string, dict or module but it is: {m}")
 
 
 def _recursive_to_string(doprint, arg):
@@ -995,7 +993,7 @@ def _recursive_to_string(doprint, arg):
             if not arg:
                 return "()"
         else:
-            raise NotImplementedError("unhandled type: %s, %s" % (type(arg), arg))
+            raise NotImplementedError(f"unhandled type: {type(arg)}, {arg}")
         return left +', '.join(_recursive_to_string(doprint, e) for e in arg) + right
     elif isinstance(arg, str):
         return arg
@@ -1095,12 +1093,12 @@ def lambdastr(args, expr, printer=None, dummify=None):
         dum_args = [str(Dummy(str(i))) for i in range(len(args))]
 
         indexed_args = ','.join([
-            dum_args[ind[0]] + ''.join(["[%s]" % k for k in ind[1:]])
+            dum_args[ind[0]] + ''.join([f"[{k}]" for k in ind[1:]])
                     for ind in flat_indexes(args)])
 
         lstr = lambdastr(flatten(args), expr, printer=printer, dummify=dummify)
 
-        return 'lambda %s: (%s)(%s)' % (','.join(dum_args), lstr, indexed_args)
+        return f'lambda {",".join(dum_args)}: ({lstr})({indexed_args})'
 
     dummies_dict = {}
     if dummify:
@@ -1118,7 +1116,7 @@ def lambdastr(args, expr, printer=None, dummify=None):
         else:
             expr = sub_expr(expr, dummies_dict)
     expr = _recursive_to_string(lambdarepr, expr)
-    return "lambda %s: (%s)" % (args, expr)
+    return f"lambda {args}: ({expr})"
 
 class _EvaluatorPrinter:
     def __init__(self, printer=None, dummify=False):
@@ -1415,9 +1413,7 @@ def _imp_namespace(expr, namespace=None):
         if imp is not None:
             name = expr.func.__name__
             if name in namespace and namespace[name] != imp:
-                raise ValueError('We found more than one '
-                                 'implementation with name '
-                                 '"%s"' % name)
+                raise ValueError(f'We found more than one implementation with name "{name}"')
             namespace[name] = imp
     # and / or they may take Functions as arguments
     if hasattr(expr, 'args'):

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -165,9 +165,9 @@ def rawlines(s):
     else:
         rv = '\n    '.join(lines)
         if triple[0]:
-            return 'dedent("""\\\n    %s""")' % rv
+            return f'dedent("""\\\n    {rv}""")'
         else:
-            return "dedent('''\\\n    %s''')" % rv
+            return f"dedent('''\\\n    {rv}''')"
 
 ARCH = str(struct.calcsize('P') * 8) + "-bit"
 
@@ -196,14 +196,14 @@ def debug_decorator(func):
         def tree(subtrees):
             def indent(s, variant=1):
                 x = s.split("\n")
-                r = "+-%s\n" % x[0]
+                r = f"+-{x[0]}\n"
                 for a in x[1:]:
                     if a == "":
                         continue
                     if variant == 1:
-                        r += "| %s\n" % a
+                        r += f"| {a}\n"
                     else:
-                        r += "  %s\n" % a
+                        r += f"  {a}\n"
                 return r
             if len(subtrees) == 0:
                 return ""
@@ -223,7 +223,7 @@ def debug_decorator(func):
         r = f(*args, **kw)
 
         _debug_iter -= 1
-        s = "%s%s = %s\n" % (f.__name__, args, r)
+        s = f"{f.__name__}{args} = {r}\n"
         if _debug_tmp != []:
             s += tree(_debug_tmp)
         _debug_tmp = oldtmp
@@ -450,7 +450,7 @@ def translate(s, a, b=None, c=None):
     mr = {}
     if a is None:
         if c is not None:
-            raise ValueError('c should be None when a=None is passed, instead got %s' % c)
+            raise ValueError(f'c should be None when a=None is passed, instead got {c}')
         if b is None:
             return s
         c = b
@@ -553,12 +553,12 @@ def as_int(n, strict=True):
                 raise TypeError
             return operator.index(n)
         except TypeError:
-            raise ValueError('%s is not an integer' % (n,))
+            raise ValueError(f'{n} is not an integer')
     else:
         try:
             result = int(n)
         except TypeError:
-            raise ValueError('%s is not an integer' % (n,))
+            raise ValueError(f'{n} is not an integer')
         if n - result:
-            raise ValueError('%s is not an integer' % (n,))
+            raise ValueError(f'{n} is not an integer')
         return result

--- a/sympy/utilities/source.py
+++ b/sympy/utilities/source.py
@@ -16,8 +16,7 @@ def get_class(lookup_view):
             lookup_view = getattr(
                 __import__(mod_name, {}, {}, ['*']), func_name)
             if not callable(lookup_view):
-                raise AttributeError(
-                    "'%s.%s' is not a callable." % (mod_name, func_name))
+                raise AttributeError(f"'{mod_name}.{func_name}' is not a callable.")
     return lookup_view
 
 

--- a/sympy/vector/kind.py
+++ b/sympy/vector/kind.py
@@ -53,7 +53,7 @@ class VectorKind(Kind):
         return obj
 
     def __repr__(self):
-        return "VectorKind(%s)" % self.element_kind
+        return f"VectorKind({self.element_kind})"
 
 @Mul._kind_dispatcher.register(_NumberKind, VectorKind)
 def num_vec_mul(k1, k2):

--- a/sympy/vector/point.py
+++ b/sympy/vector/point.py
@@ -15,14 +15,11 @@ class Point(Basic):
         name = str(name)
         # Check the args first
         if not isinstance(position, Vector):
-            raise TypeError(
-                "position should be an instance of Vector, not %s" % type(
-                    position))
+            raise TypeError(f"position should be an instance of Vector, not {type(position)}")
         if (not isinstance(parent_point, Point) and
                 parent_point is not None):
             raise TypeError(
-                "parent_point should be an instance of Point, not %s" % type(
-                    parent_point))
+                f"parent_point should be an instance of Point, not {type(parent_point)}")
         # Super class construction
         if parent_point is None:
             obj = super().__new__(cls, Str(name), position)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see gh-28031
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Refactor old-style string formatting to f-strings in 

1. benchmarks
2. calculus
3. codegen
4. unify
5. utilities
6. vector

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
