### PR TITLE
PEP 8: Update None comparisons in simplex.py

### DIFF
--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -1003,7 +1003,7 @@ def linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
 
     ## the equalities
     if A_eq is None:
-        if not b_eq is None:
+        if b_eq is not None:
             raise ValueError("A_eq and b_eq must both be given")
     else:
         A_eq, b_eq = [Matrix(i) for i in (A_eq, b_eq)]
@@ -1070,7 +1070,7 @@ def show_linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
 
     ## the equalities
     if A_eq is None:
-        if not b_eq is None:
+        if b_eq is not None:
             raise ValueError("A_eq and b_eq must both be given")
     else:
         A_eq, b_eq = [Matrix(i) for i in (A_eq, b_eq)]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Refactor simplex.py to adhere to PEP 8 for None comparisons.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
