### PR TITLE
Added docstring examples to diophantine() in sympy/solvers/diophantine/diophantine.py.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -898,6 +898,7 @@ Kris Katterjohn <katterjohn@gmail.com>
 Krishnav Bajoria <bajoriakrishnav@gmail.com> Krishnav Bajoria <127018567+krishnavbajoria02@users.noreply.github.com>
 Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
 Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
+Kshipra Wadikar <kwadikar@gmail.com> kshipra361@users.noreply.github.com
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>
 Kshitij Saraogi <KshitijSaraogi@gmail.com>
 Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep <kuldeepborkar.jr@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -899,6 +899,7 @@ Krishnav Bajoria <bajoriakrishnav@gmail.com> Krishnav Bajoria <127018567+krishna
 Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
 Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
 Kshipra Wadikar <kwadikar@gmail.com> kshipra361 <104239388+kshipra361@users.noreply.github.com>
+Kshipra Wadikar <kwadikar@gmail.com> kshipra361 <kwadikar@gmail.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>
 Kshitij Saraogi <KshitijSaraogi@gmail.com>
 Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep <kuldeepborkar.jr@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -898,7 +898,7 @@ Kris Katterjohn <katterjohn@gmail.com>
 Krishnav Bajoria <bajoriakrishnav@gmail.com> Krishnav Bajoria <127018567+krishnavbajoria02@users.noreply.github.com>
 Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
 Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
-Kshipra Wadikar <kwadikar@gmail.com> kshipra361@users.noreply.github.com
+Kshipra Wadikar <kwadikar@gmail.com> kshipra361 <104239388+kshipra361@users.noreply.github.com>
 Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>
 Kshitij Saraogi <KshitijSaraogi@gmail.com>
 Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep <kuldeepborkar.jr@gmail.com>

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1310,6 +1310,13 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     {(0, n1, n2), (t_0, t_1, 2*t_0 + 3*t_1)}
     >>> diophantine(x**2 + 3*x*y + 4*x)
     {(0, n1), (-3*t_0 - 4, t_0)}
+    >>> # Solve a simple linear Diophantine equation: 4x + 6y = 8
+    >>> diophantine(4*x + 6*y - 8)
+    {(3*t_0 - 4, 4 - 2*t_0)}
+
+    >>> # Solve a quadratic Diophantine equation: x^2 + y^2 = 13
+    >>> diophantine(x**2 + y**2 - 13)
+    {(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}
 
     See Also
     ========

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1310,11 +1310,11 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     {(0, n1, n2), (t_0, t_1, 2*t_0 + 3*t_1)}
     >>> diophantine(x**2 + 3*x*y + 4*x)
     {(0, n1), (-3*t_0 - 4, t_0)}
-    >>> # Solve a simple linear Diophantine equation: 4x + 6y = 8
+    
     >>> diophantine(4*x + 6*y - 8)
     {(3*t_0 - 4, 4 - 2*t_0)}
 
-    >>> # Solve a quadratic Diophantine equation: x^2 + y^2 = 13
+    
     >>> diophantine(x**2 + y**2 - 13)
     {(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1311,7 +1311,7 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     >>> diophantine(x**2 + 3*x*y + 4*x)
     {(0, n1), (-3*t_0 - 4, t_0)}
     >>> diophantine(4*x + 6*y - 8)
-    {(3*t_0 - 4, 4 - 2*t_0)}   
+    {(3*t_0 - 4, 4 - 2*t_0)}
     >>> diophantine(x**2 + y**2 - 13)
     {(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1310,11 +1310,8 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     {(0, n1, n2), (t_0, t_1, 2*t_0 + 3*t_1)}
     >>> diophantine(x**2 + 3*x*y + 4*x)
     {(0, n1), (-3*t_0 - 4, t_0)}
-    
     >>> diophantine(4*x + 6*y - 8)
-    {(3*t_0 - 4, 4 - 2*t_0)}
-
-    
+    {(3*t_0 - 4, 4 - 2*t_0)}   
     >>> diophantine(x**2 + y**2 - 13)
     {(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #28044


#### Brief description of what is fixed or changed
Added doctest examples to demonstrate solving a linear Diophantine equation 4*x + 6*y = 8 and a quadratic Diophantine equation x^2 + y^2 = 13. The examples show the expected output and provide clearer understanding of solving these equations using SymPy’s diophantine function.

>>> diophantine(4*x + 6*y - 8)
{(3*t_0 - 4, 4 - 2*t_0)}

>>> diophantine(x**2 + y**2 - 13)
{(-3, -2), (-3, 2), (-2, -3), (-2, 3), (2, -3), (2, 3), (3, -2), (3, 2)}


#### Other comments
These examples were added for educational purposes and are intended to demonstrate the behavior of diophantine with simple linear and quadratic equations.
No changes were made to the underlying code or logic.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added doctest examples for solving linear and quadratic Diophantine equations to showcase SymPy’s functionality.

<!-- END RELEASE NOTES -->
