### PR TITLE
Refactor boolean comparisons to follow PEP 8 style

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -471,7 +471,7 @@ def _(mat, assumptions):
             cond = fuzzy_bool(Eq(mat[i, j], conjugate(mat[j, i])))
             if cond is None:
                 ret_val = None
-            if cond == False:
+            if not cond:
                 return False
     if ret_val is None:
         raise MDNotImplementedError
@@ -742,7 +742,7 @@ def _(mat, assumptions):
             cond = fuzzy_bool(Eq(mat[i, j], -conjugate(mat[j, i])))
             if cond is None:
                 ret_val = None
-            if cond == False:
+            if not cond:
                 return False
     if ret_val is None:
         raise MDNotImplementedError

--- a/sympy/assumptions/relation/equality.py
+++ b/sympy/assumptions/relation/equality.py
@@ -60,7 +60,7 @@ class EqualityPredicate(BinaryRelation):
         return Q.ne
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
+        if assumptions:
             # default assumptions for is_eq is None
             assumptions = None
         return is_eq(*args, assumptions)
@@ -104,7 +104,7 @@ class UnequalityPredicate(BinaryRelation):
         return Q.eq
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
+        if assumptions:
             # default assumptions for is_neq is None
             assumptions = None
         return is_neq(*args, assumptions)
@@ -152,7 +152,7 @@ class StrictGreaterThanPredicate(BinaryRelation):
         return Q.le
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
+        if assumptions:
             # default assumptions for is_gt is None
             assumptions = None
         return is_gt(*args, assumptions)
@@ -200,7 +200,7 @@ class GreaterThanPredicate(BinaryRelation):
         return Q.lt
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
+        if assumptions:
             # default assumptions for is_ge is None
             assumptions = None
         return is_ge(*args, assumptions)
@@ -248,7 +248,7 @@ class StrictLessThanPredicate(BinaryRelation):
         return Q.ge
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
+        if assumptions:
             # default assumptions for is_lt is None
             assumptions = None
         return is_lt(*args, assumptions)
@@ -296,7 +296,7 @@ class LessThanPredicate(BinaryRelation):
         return Q.gt
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
+        if assumptions:
             # default assumptions for is_le is None
             assumptions = None
         return is_le(*args, assumptions)

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -248,7 +248,7 @@ class RewritingSystem:
                             return False
                         lhs.extend(new_keys)
                         added += len(new_keys)
-                    elif new_keys == False:
+                    elif not new_keys:
                         # too many rules were added so the process
                         # couldn't complete
                         return self._is_confluent

--- a/sympy/concrete/expr_with_intlimits.py
+++ b/sympy/concrete/expr_with_intlimits.py
@@ -342,9 +342,9 @@ class ExprWithIntLimits(ExprWithLimits):
         for lim in self.limits:
             dif = lim[1] - lim[2]
             eq = Eq(dif, 1)
-            if eq == True:
+            if eq:
                 return True
-            elif eq == False:
+            elif not eq:
                 continue
             else:
                 ret_None = True

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -486,7 +486,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         if sequence_term.is_Piecewise:
             for func, cond in sequence_term.args:
                 # see if it represents something going to oo
-                if cond == True or cond.as_set().sup is S.Infinity:
+                if cond or cond.as_set().sup is S.Infinity:
                     s = Sum(func, (sym, lower_limit, upper_limit))
                     return s.is_convergent()
             return S.true
@@ -762,7 +762,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 term = f.subs(i, a)
                 if term:
                     test = abs(term.evalf(3)) < eps
-                    if test == True:
+                    if test:
                         return s, abs(term)
                     elif not (test == False):
                         # a symbolic Relational class, can't go further
@@ -1354,7 +1354,7 @@ def eval_sum_hyper(f, i_a_b):
                 return
             (res1, cond1), (res2, cond2) = res1, res2
             cond = And(cond1, cond2)
-            if cond == False:
+            if not cond:
                 return None
             return Piecewise((res1 - res2, cond), (old_sum, True))
 
@@ -1366,7 +1366,7 @@ def eval_sum_hyper(f, i_a_b):
         res1, cond1 = res1
         res2, cond2 = res2
         cond = And(cond1, cond2)
-        if cond == False or cond.as_set() == S.EmptySet:
+        if not cond or cond.as_set() == S.EmptySet:
             return None
         return Piecewise((res1 + res2, cond), (old_sum, True))
 
@@ -1374,7 +1374,7 @@ def eval_sum_hyper(f, i_a_b):
     res = _eval_sum_hyper(f, i, a)
     if res is not None:
         r, c = res
-        if c == False:
+        if not c:
             if r.is_number:
                 f = f.subs(i, Dummy('i', integer=True, positive=True) + a)
                 if f.is_positive or f.is_zero:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -803,9 +803,9 @@ class Ellipse(GeometrySet):
             return ab[0]
         a, b = ab
         o = b - a < 0
-        if o == True:
+        if o:
             return a
-        elif o == False:
+        elif not o:
             return b
         return self.hradius
 
@@ -850,9 +850,9 @@ class Ellipse(GeometrySet):
             return ab[0]
         a, b = ab
         o = a - b < 0
-        if o == True:
+        if o:
             return a
-        elif o == False:
+        elif not o:
             return b
         return self.vradius
 

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1511,7 +1511,7 @@ def _rewrite_single(f, x, recursive=True):
                 subs = subs_
                 if not isinstance(hint, bool):
                     hint = hint.subs(subs)
-                if hint == False:
+                if not hint:
                     continue
                 if not isinstance(cond, (bool, BooleanAtom)):
                     cond = unpolarify(cond.subs(subs))
@@ -1852,7 +1852,7 @@ def meijerint_definite(f, x, a, b):
             res1, cond1 = res1
             res2, cond2 = res2
             cond = _condsimp(And(cond1, cond2))
-            if cond == False:
+            if not cond:
                 _debug('  But combined condition is always false.')
                 continue
             res = res1 + res2
@@ -2036,10 +2036,10 @@ def _meijerint_definite_4(f, x, only_double=False):
                 C, f = _rewrite_saxena_1(fac*C, po*x**s, f, x)
                 res += C*_int0oo_1(f, x)
                 cond = And(cond, _check_antecedents_1(f, x))
-                if cond == False:
+                if not cond:
                     break
             cond = _my_unpolarify(cond)
-            if cond == False:
+            if not cond:
                 _debug('But cond is always False.')
             else:
                 _debug('Result before branch substitutions is:', res)
@@ -2062,14 +2062,14 @@ def _meijerint_definite_4(f, x, only_double=False):
                     C, f1_, f2_ = r
                     _debug('Saxena subst for yielded:', C, f1_, f2_)
                     cond = And(cond, _check_antecedents(f1_, f2_, x))
-                    if cond == False:
+                    if not cond:
                         break
                     res += C*_int0oo(f1_, f2_, x)
                 else:
                     continue
                 break
             cond = _my_unpolarify(cond)
-            if cond == False:
+            if not cond:
                 _debugf('But cond is always False (full_pb=%s).', full_pb)
             else:
                 _debugf('Result before branch substitutions is: %s', (res, ))
@@ -2155,7 +2155,7 @@ def meijerint_inversion(f, x, t):
     if x not in f.free_symbols:
         _debug('Expression consists of constant and exp shift:', f, shift)
         cond = Eq(im(shift), 0)
-        if cond == False:
+        if not cond:
             _debug('but shift is nonreal, cannot be a Laplace transform')
             return None
         res = f*DiracDelta(t + shift)
@@ -2172,10 +2172,10 @@ def meijerint_inversion(f, x, t):
             C, f = _rewrite_inversion(fac*C, po*x**s, f, x)
             res += C*_int_inversion(f, x, t)
             cond = And(cond, _check_antecedents_inversion(f, x))
-            if cond == False:
+            if not cond:
                 break
         cond = _my_unpolarify(cond)
-        if cond == False:
+        if not cond:
             _debug('But cond is always False.')
         else:
             _debug('Result before branch substitution:', res)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -112,7 +112,7 @@ class IntegralTransform(Function):
 
     def _collapse_extra(self, extra):
         cond = And(*extra)
-        if cond == False:
+        if not cond:
             raise IntegralTransformError(self.__class__.name, None, '')
         return cond
 
@@ -179,7 +179,7 @@ class IntegralTransform(Function):
                 elif len(x) > 2:
                     # some region parameters and a condition (Mellin, Laplace)
                     extra += [x[1:]]
-            if simplify==True:
+            if simplify:
                 res = Add(*ress).simplify()
             else:
                 res = Add(*ress)
@@ -808,7 +808,7 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
         cond += [And(Or(len(G.ap) != len(G.bq), 0 >= re(G.nu) + 1),
                      Abs(arg(G.argument)) == G.delta*pi)]
         cond = Or(*cond)
-        if cond == False:
+        if not cond:
             raise IntegralTransformError(
                 'Inverse Mellin', F, 'does not converge')
         return (h*fac).subs(x, x_), cond

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -260,10 +260,10 @@ class LRASolver():
             if isinstance(prop, Predicate):
                 prop = prop(empty_var)
             if not isinstance(prop, AppliedPredicate):
-                if prop == True:
+                if prop:
                     conflicts.append([enc])
                     continue
-                if prop == False:
+                if not prop:
                     conflicts.append([-enc])
                     continue
 
@@ -278,10 +278,10 @@ class LRASolver():
                 raise UnhandledInput(f"{prop} contains infinity")
 
             prop = _eval_binrel(prop)  # simplify variable-less quantities to True / False if possible
-            if prop == True:
+            if prop:
                 conflicts.append([enc])
                 continue
-            elif prop == False:
+            elif not prop:
                 conflicts.append([-enc])
                 continue
             elif prop is None:
@@ -301,10 +301,10 @@ class LRASolver():
                 assert prop.function == Q.eq
                 bool = Eq(expr, 0)
 
-            if bool == True:
+            if bool:
                 conflicts.append([enc])
                 continue
-            elif bool == False:
+            elif not bool:
                 conflicts.append([-enc])
                 continue
 
@@ -777,7 +777,7 @@ def _eval_binrel(binrel):
     elif binrel.function == Q.ne:
         res = Ne(binrel.lhs, binrel.rhs)
 
-    if res == True or res == False:
+    if res or not res:
         return res
     else:
         return None

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -166,7 +166,7 @@ def test_random_problems():
             continue
 
         phi = And(*constraints)
-        if phi == False:
+        if not phi:
             continue
         cnf = CNF.from_prop(phi); enc = EncodedCNF()
         enc.from_cnf(cnf)

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -60,7 +60,7 @@ def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
         # is someone wrote a custom iszerofunc, it may return
         # BooleanFalse or BooleanTrue instead of True or False,
         # so use == for comparison instead of `is`
-        if is_zero == False:
+        if not is_zero:
             # we found something that is definitely not zero
             return (i, x, False, newly_determined)
         possible_zeros.append(is_zero)
@@ -83,7 +83,7 @@ def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
         is_zero = iszerofunc(simped)
         if is_zero in (True, False):
             newly_determined.append((i, simped))
-        if is_zero == False:
+        if not is_zero:
             return (i, simped, False, newly_determined)
         possible_zeros[i] = is_zero
 
@@ -166,7 +166,7 @@ def _find_reasonable_pivot_naive(col, iszerofunc=_iszero, simpfunc=None):
     indeterminates = []
     for i, col_val in enumerate(col):
         col_val_is_zero = iszerofunc(col_val)
-        if col_val_is_zero == False:
+        if not col_val_is_zero:
             # This pivot candidate is non-zero.
             return i, col_val, False, []
         elif col_val_is_zero is None:

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -516,18 +516,18 @@ class BlockMatrix(MatrixExpr):
         orig_i, orig_j = i, j
         for row_block, numrows in enumerate(self.rowblocksizes):
             cmp = i < numrows
-            if cmp == True:
+            if cmp:
                 break
-            elif cmp == False:
+            elif not cmp:
                 i -= numrows
             elif row_block < self.blockshape[0] - 1:
                 # Can't tell which block and it's not the last one, return unevaluated
                 return MatrixElement(self, orig_i, orig_j)
         for col_block, numcols in enumerate(self.colblocksizes):
             cmp = j < numcols
-            if cmp == True:
+            if cmp:
                 break
-            elif cmp == False:
+            elif not cmp:
                 j -= numcols
             elif col_block < self.blockshape[1] - 1:
                 return MatrixElement(self, orig_i, orig_j)
@@ -870,25 +870,25 @@ def _choose_2x2_inversion_formula(A, B, C, D):
     # Try to find a known invertible matrix.  Note that the Schur complement
     # is currently not being considered for this
     A_inv = ask(Q.invertible(A))
-    if A_inv == True:
+    if A_inv:
         return 'A'
     B_inv = ask(Q.invertible(B))
-    if B_inv == True:
+    if B_inv:
         return 'B'
     C_inv = ask(Q.invertible(C))
-    if C_inv == True:
+    if C_inv:
         return 'C'
     D_inv = ask(Q.invertible(D))
-    if D_inv == True:
+    if D_inv:
         return 'D'
     # Otherwise try to find a matrix that isn't known to be non-invertible
-    if A_inv != False:
+    if A_inv:
         return 'A'
-    if B_inv != False:
+    if B_inv:
         return 'B'
-    if C_inv != False:
+    if C_inv:
         return 'C'
-    if D_inv != False:
+    if D_inv:
         return 'D'
     return None
 

--- a/sympy/matrices/expressions/special.py
+++ b/sympy/matrices/expressions/special.py
@@ -221,7 +221,7 @@ class OneMatrix(MatrixExpr):
 
         if evaluate:
             condition = Eq(m, 1) & Eq(n, 1)
-            if condition == True:
+            if condition:
                 return Identity(1)
 
         obj = super().__new__(cls, m, n)
@@ -271,9 +271,9 @@ class OneMatrix(MatrixExpr):
 
     def _eval_determinant(self):
         condition = self._is_1x1()
-        if condition == True:
+        if condition:
             return S.One
-        elif condition == False:
+        elif not condition:
             return S.Zero
         else:
             from sympy.matrices.expressions.determinant import Determinant
@@ -281,9 +281,9 @@ class OneMatrix(MatrixExpr):
 
     def _eval_inverse(self):
         condition = self._is_1x1()
-        if condition == True:
+        if condition:
             return Identity(1)
-        elif condition == False:
+        elif not condition:
             raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
         else:
             from .inverse import Inverse

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -293,9 +293,9 @@ if cin:
                         value = Symbol(val)
                     elif isinstance(val, bool):
                         if node.type.kind in self._data_types["int"]:
-                            value = Integer(0) if val == False else Integer(1)
+                            value = Integer(0) if not val else Integer(1)
                         elif node.type.kind in self._data_types["float"]:
-                            value = Float(0.0) if val == False else Float(1.0)
+                            value = Float(0.0) if not val else Float(1.0)
                         elif node.type.kind in self._data_types["bool"]:
                             value = sympify(val)
                     elif isinstance(val, (Integer, int, Float, float)):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -795,7 +795,7 @@ def rationalize(tokens: list[TOKEN], local_dict: DICT, global_dict: DICT):
                 passed_float = True
                 tokval = 'Rational'
             result.append((toknum, tokval))
-        elif passed_float == True and toknum == NUMBER:
+        elif passed_float and toknum == NUMBER:
             passed_float = False
             result.append((STRING, tokval))
         else:

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -391,7 +391,7 @@ def roots_binomial(f):
     neg = base.is_negative
     even = n % 2 == 0
     if neg:
-        if even == True and (base + 1).is_positive:
+        if even and (base + 1).is_positive:
             big = True
         else:
             big = False

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -366,9 +366,9 @@ class ImageSet(Set):
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
             is_empty = fuzzy_or(s.is_empty for s in sets)
-            if is_empty == True:
+            if is_empty:
                 return S.EmptySet
-            elif is_empty == False:
+            elif not is_empty:
                 return FiniteSet(flambda.expr)
 
         return Basic.__new__(cls, flambda, *sets)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -968,9 +968,9 @@ def reduce_inequalities(inequalities, symbols=[]):
             i = i.func(i.lhs.as_expr() - i.rhs.as_expr(), 0)
         elif i not in (True, False):
             i = Eq(i, 0)
-        if i == True:
+        if i:
             continue
-        elif i == False:
+        elif not i:
             return S.false
         if i.lhs.is_number:
             raise NotImplementedError(

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -379,13 +379,13 @@ def _simplex(A, B, C, D=None, dual=False):
     argmin_dual = [None] * m
 
     for i, (v, n) in enumerate(X):
-        if v == False:
+        if not v:
             argmax[n] = 0
         else:
             argmin_dual[n] = M[-1, i]
 
     for i, (v, n) in enumerate(Y):
-        if v == True:
+        if v:
             argmin_dual[n] = 0
         else:
             argmax[n] = M[i, -1]
@@ -566,9 +566,9 @@ def _primal_dual(M, factor=True):
     def ineq(L, r, op):
         rv = []
         for r in (op(i, j) for i, j in zip(L, r)):
-            if r == True:
+            if r:
                 continue
-            elif r == False:
+            elif not r:
                 return [False]
             if factor:
                 f = factor_terms(r)
@@ -627,9 +627,9 @@ def _rel_as_nonpos(constr, syms):
 
     # separate out univariates
     for i in constr:
-        if i == True:
+        if i:
             continue  # ignore
-        if i == False:
+        if not i:
             return  # no solution
         if i.has(S.Infinity, S.NegativeInfinity):
             raise ValueError("only finite bounds are permitted")
@@ -664,7 +664,7 @@ def _rel_as_nonpos(constr, syms):
         i = univariate.get(x, True)
         if not i:
             return None  # no solution possible
-        if i == True:
+        if i:
             unbound.append(x)
             continue
         a, b = i.inf, i.sup

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1440,9 +1440,9 @@ def _solve(f, *symbols, **flags):
                 except TypeError:
                     # incompatible type with condition(s)
                     continue
-                if v == False:
+                if not v:
                     continue
-                if v == True:
+                if v:
                     result.add(candidate)
                 else:
                     result.add(Piecewise(

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -231,9 +231,9 @@ class DiscretePSpace(PSpace):
             condition = Eq(condition.args[0], condition.args[1])
         try:
             _domain = self.where(condition).set
-            if condition == False or _domain is S.EmptySet:
+            if not condition or _domain is S.EmptySet:
                 return S.Zero
-            if condition == True or _domain == self.domain.set:
+            if condition or _domain == self.domain.set:
                 return S.One
             prob = self.eval_prob(_domain)
         except NotImplementedError:

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -100,7 +100,7 @@ class Probability(Expr):
             raise ValueError("%s is not a relational or combination of relationals"
                     % (given_condition))
 
-        if given_condition == False or condition is S.false:
+        if not given_condition or condition is S.false:
             return S.Zero
         if not isinstance(condition, (Relational, Boolean)):
             raise ValueError("%s is not a relational or combination of relationals"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Refactor boolean comparisons to follow PEP 8 style

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
