### PR TITLE
Document different operator types in physics.quantum

### DIFF
--- a/doc/src/modules/physics/quantum/boson.rst
+++ b/doc/src/modules/physics/quantum/boson.rst
@@ -1,0 +1,6 @@
+=====
+Boson
+=====
+
+.. automodule:: sympy.physics.quantum.boson
+   :members:

--- a/doc/src/modules/physics/quantum/fermion.rst
+++ b/doc/src/modules/physics/quantum/fermion.rst
@@ -1,0 +1,6 @@
+=======
+Fermion
+=======
+
+.. automodule:: sympy.physics.quantum.fermion
+   :members:

--- a/doc/src/modules/physics/quantum/index.rst
+++ b/doc/src/modules/physics/quantum/index.rst
@@ -26,10 +26,13 @@ States and Operators
 .. toctree::
    :titlesonly:
 
+   boson.rst
    cartesian.rst
+   fermion.rst
    hilbert.rst
    operator.rst
    operatorset.rst
+   pauli.rst
    qapply.rst
    represent.rst
    spin.rst

--- a/doc/src/modules/physics/quantum/pauli.rst
+++ b/doc/src/modules/physics/quantum/pauli.rst
@@ -1,0 +1,6 @@
+=====
+Pauli
+=====
+
+.. automodule:: sympy.physics.quantum.pauli
+   :members:

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1,8 +1,11 @@
 """
 Second quantization operators and states for bosons.
 
-This follow the formulation of Fetter and Welecka, "Quantum Theory
-of Many-Particle Systems."
+This follow the formulation of Fetter and Welecka, "Quantum Theory of
+Many-Particle Systems."
+
+This module is a predecessor of the sympy.physics.quantum package, and it will
+be superseded by it in the future versions.
 """
 from collections import defaultdict
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
closes #27553

#### Brief description of what is fixed or changed
- Added stubs for pauli, boson, fermion modules from physics.quantum
- Documented that the plan is to supersede secondquant (based on https://github.com/sympy/sympy/pull/27530#issuecomment-2635495993)

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Documented previously omitted modules `pauli`, `boson`, `fermion`
<!-- END RELEASE NOTES -->
