### PR TITLE
Refactor boolean comparisons to follow PEP 8 style

### DIFF
--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -293,9 +293,9 @@ if cin:
                         value = Symbol(val)
                     elif isinstance(val, bool):
                         if node.type.kind in self._data_types["int"]:
-                            value = Integer(0) if val == False else Integer(1)
+                            value = Integer(0) if not val else Integer(1)
                         elif node.type.kind in self._data_types["float"]:
-                            value = Float(0.0) if val == False else Float(1.0)
+                            value = Float(0.0) if not val else Float(1.0)
                         elif node.type.kind in self._data_types["bool"]:
                             value = sympify(val)
                     elif isinstance(val, (Integer, int, Float, float)):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -795,7 +795,7 @@ def rationalize(tokens: list[TOKEN], local_dict: DICT, global_dict: DICT):
                 passed_float = True
                 tokval = 'Rational'
             result.append((toknum, tokval))
-        elif passed_float == True and toknum == NUMBER:
+        elif passed_float and toknum == NUMBER:
             passed_float = False
             result.append((STRING, tokval))
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Refactor boolean comparisons to follow PEP 8 style

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
