### PR TITLE
Revert "Fix benchmarks failure by pinning virtualenv to <20.31" 

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -462,9 +462,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      # NOTE: Pin virtualenv to <20.31 as a workaround until ASV resolves the issue.
-      # See: https://github.com/airspeed-velocity/asv/issues/1484
-      - run: pip install asv virtualenv==20.30 packaging
+      - run: pip install asv virtualenv packaging
       - run: git submodule add https://github.com/sympy/sympy_benchmarks.git
 
         # Need to make sure we can access the branches from the main repo. We


### PR DESCRIPTION
closes #28046
Reverts sympy/sympy#28048
Reverting the virtualenv pin, as the issue causing benchmark failures has been resolved after the release of virtualenv 20.31.2, which reintroduced the --wheel CLI option.
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->