### PR TITLE
Fix `evaluate=False` for boolean functions

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -532,7 +532,7 @@ class LatticeOp(AssocOp):
             evaluate = global_parameters.evaluate
 
         if not evaluate:
-            obj = super(LatticeOp, cls).__new__(cls, *args, evaluate=False, **options)
+            obj = super().__new__(cls, *args, evaluate=False, **options)
             obj._argset = frozenset(args)
             return obj
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -525,8 +525,16 @@ class LatticeOp(AssocOp):
 
     is_commutative = True
 
-    def __new__(cls, *args, **options):
+    def __new__(cls, *args, evaluate=None, **options):
         args = (_sympify_(arg) for arg in args)
+
+        if evaluate is None:
+            evaluate = global_parameters.evaluate
+
+        if not evaluate:
+            obj = super(LatticeOp, cls).__new__(cls, *args, evaluate=False, **options)
+            obj._argset = frozenset(args)
+            return obj
 
         try:
             # /!\ args is a generator and _new_args_filter

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -16,7 +16,7 @@ from sympy.core.decorators import sympify_method_args, sympify_return
 from sympy.core.function import Application, Derivative
 from sympy.core.kind import BooleanKind, NumberKind
 from sympy.core.numbers import Number
-from sympy.core.operations import LatticeOp
+from sympy.core.operations import AssocOp, LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
@@ -611,6 +611,10 @@ class And(LatticeOp, BooleanFunction):
             ...
 
     @classmethod
+    def _from_args(cls, args, is_commutative=None):
+        return super(AssocOp, cls).__new__(cls, *args)
+
+    @classmethod
     def _new_args_filter(cls, args):
         args = BooleanFunction.binary_check_and_simplify(*args)
         args = LatticeOp._new_args_filter(args, And)
@@ -776,6 +780,10 @@ class Or(LatticeOp, BooleanFunction):
         @property
         def args(self) -> tuple[Boolean, ...]:
             ...
+
+    @classmethod
+    def _from_args(cls, args, is_commutative=None):
+        return super(AssocOp, cls).__new__(cls, *args)
 
     @classmethod
     def _new_args_filter(cls, args):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1025,7 +1025,7 @@ class Xor(BooleanFunction):
             return super().__new__(cls, *args, evaluate=evaluate, **kwargs)
 
         argset = set()
-        for arg in args:
+        for arg in map(_sympify, args):
             if isinstance(arg, Number) or arg in (True, False):
                 if arg:
                     arg = true

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -17,6 +17,7 @@ from sympy.core.function import Application, Derivative
 from sympy.core.kind import BooleanKind, NumberKind
 from sympy.core.numbers import Number
 from sympy.core.operations import AssocOp, LatticeOp
+from sympy.core.parameters import global_parameters
 from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
@@ -603,7 +604,7 @@ class And(LatticeOp, BooleanFunction):
 
     if TYPE_CHECKING:
 
-        def __new__(cls, *args: Boolean | bool) -> Boolean: # type: ignore
+        def __new__(cls, *args: Boolean | bool, evaluate: bool | None = None) -> Boolean: # type: ignore
             ...
 
         @property
@@ -774,7 +775,7 @@ class Or(LatticeOp, BooleanFunction):
 
     if TYPE_CHECKING:
 
-        def __new__(cls, *args: Boolean | bool) -> Boolean: # type: ignore
+        def __new__(cls, *args: Boolean | bool, evaluate: bool | None = None) -> Boolean: # type: ignore
             ...
 
         @property
@@ -1017,10 +1018,14 @@ class Xor(BooleanFunction):
     x
 
     """
-    def __new__(cls, *args, remove_true=True, **kwargs):
+    def __new__(cls, *args, remove_true=True, evaluate=None, **kwargs):
+        if evaluate is None:
+            evaluate = global_parameters.evaluate
+        if not evaluate:
+            return super().__new__(cls, *args, evaluate=evaluate, **kwargs)
+
         argset = set()
-        obj = super().__new__(cls, *args, **kwargs)
-        for arg in obj._args:
+        for arg in args:
             if isinstance(arg, Number) or arg in (True, False):
                 if arg:
                     arg = true
@@ -1060,17 +1065,7 @@ class Xor(BooleanFunction):
         elif True in argset and remove_true:
             argset.remove(True)
             return Not(Xor(*argset))
-        else:
-            obj._args = tuple(ordered(argset))
-            obj._argset = frozenset(argset)
-            return obj
-
-    # XXX: This should be cached on the object rather than using cacheit
-    # Maybe it can be computed in __new__?
-    @property  # type: ignore
-    @cacheit
-    def args(self):
-        return tuple(ordered(self._argset))
+        return super().__new__(cls, *ordered(argset))
 
     def to_nnf(self, simplify=True):
         args = []
@@ -1315,7 +1310,12 @@ class Equivalent(BooleanFunction):
     True
 
     """
-    def __new__(cls, *args, **options):
+    def __new__(cls, *args, evaluate=None, **kwargs):
+        if evaluate is None:
+            evaluate = global_parameters.evaluate
+        if not evaluate:
+            return super().__new__(cls, *args, evaluate=evaluate, **kwargs)
+
         from sympy.core.relational import Relational
         args = [_sympify(arg) for arg in args]
 
@@ -1349,17 +1349,7 @@ class Equivalent(BooleanFunction):
         if False in argset:
             argset.discard(False)
             return And(*[Not(arg) for arg in argset])
-        _args = frozenset(argset)
-        obj = super().__new__(cls, _args)
-        obj._argset = _args
-        return obj
-
-    # XXX: This should be cached on the object rather than using cacheit
-    # Maybe it can be computed in __new__?
-    @property  # type: ignore
-    @cacheit
-    def args(self):
-        return tuple(ordered(self._argset))
+        return super().__new__(cls, *ordered(argset))
 
     def to_nnf(self, simplify=True):
         args = []

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1367,7 +1367,7 @@ def test_issue_26985():
     assert result == d
 
 
-def test_and_or_evaluate_false():
+def test_evaluate_false():
     x, y = symbols('x y')
 
     expr = And(evaluate=False)
@@ -1409,3 +1409,51 @@ def test_and_or_evaluate_false():
     expr = Or(y, x, evaluate=False)
     assert isinstance(expr, Or)
     assert expr.args == (y, x)
+
+    expr = Xor(evaluate=False)
+    assert isinstance(expr, Xor)
+    assert expr.args == ()
+
+    expr = Xor(x, evaluate=False)
+    assert isinstance(expr, Xor)
+    assert expr.args == (x,)
+
+    expr = Xor(x, x, evaluate=False)
+    assert isinstance(expr, Xor)
+    assert expr.args == (x, x)
+
+    expr = Xor(x, y, evaluate=False)
+    assert isinstance(expr, Xor)
+    assert expr.args == (x, y)
+
+    expr = Xor(y, x, evaluate=False)
+    assert isinstance(expr, Xor)
+    assert expr.args == (y, x)
+
+    expr = Xor(x, x, x, evaluate=False)
+    assert isinstance(expr, Xor)
+    assert expr.args == (x, x, x)
+
+    expr = Equivalent(evaluate=False)
+    assert isinstance(expr, Equivalent)
+    assert expr.args == ()
+
+    expr = Equivalent(x, evaluate=False)
+    assert isinstance(expr, Equivalent)
+    assert expr.args == (x,)
+
+    expr = Equivalent(x, x, evaluate=False)
+    assert isinstance(expr, Equivalent)
+    assert expr.args == (x, x)
+
+    expr = Equivalent(x, y, evaluate=False)
+    assert isinstance(expr, Equivalent)
+    assert expr.args == (x, y)
+
+    expr = Equivalent(y, x, evaluate=False)
+    assert isinstance(expr, Equivalent)
+    assert expr.args == (y, x)
+
+    expr = Equivalent(x, x, x, evaluate=False)
+    assert isinstance(expr, Equivalent)
+    assert expr.args == (x, x, x)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1365,3 +1365,31 @@ def test_issue_26985():
 
     assert result_anf == d
     assert result == d
+
+
+def test_and_or_evaluate_false():
+    x, y = symbols('x y')
+
+    expr = And(x, x, evaluate=False)
+    assert isinstance(expr, And)
+    assert expr.args == (x, x)
+
+    expr = And(x, y, evaluate=False)
+    assert isinstance(expr, And)
+    assert expr.args == (x, y)
+
+    expr = And(y, x, evaluate=False)
+    assert isinstance(expr, And)
+    assert expr.args == (y, x)
+
+    expr = Or(x, x, evaluate=False)
+    assert isinstance(expr, Or)
+    assert expr.args == (x, x)
+
+    expr = Or(x, y, evaluate=False)
+    assert isinstance(expr, Or)
+    assert expr.args == (x, y)
+
+    expr = Or(y, x, evaluate=False)
+    assert isinstance(expr, Or)
+    assert expr.args == (y, x)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1370,6 +1370,14 @@ def test_issue_26985():
 def test_and_or_evaluate_false():
     x, y = symbols('x y')
 
+    expr = And(evaluate=False)
+    assert isinstance(expr, And)
+    assert expr.args == ()
+
+    expr = And(x, evaluate=False)
+    assert isinstance(expr, And)
+    assert expr.args == (x,)
+
     expr = And(x, x, evaluate=False)
     assert isinstance(expr, And)
     assert expr.args == (x, x)
@@ -1381,6 +1389,14 @@ def test_and_or_evaluate_false():
     expr = And(y, x, evaluate=False)
     assert isinstance(expr, And)
     assert expr.args == (y, x)
+
+    expr = Or(evaluate=False)
+    assert isinstance(expr, Or)
+    assert expr.args == ()
+
+    expr = Or(x, evaluate=False)
+    assert isinstance(expr, Or)
+    assert expr.args == (x,)
 
     expr = Or(x, x, evaluate=False)
     assert isinstance(expr, Or)

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -332,7 +332,7 @@ def test_fcode_Xlogical():
     assert fcode(Xor(x, Not(y), evaluate=False), source_format="free") == \
         "x .neqv. .not. y"
     assert fcode(Xor(Not(x), y, evaluate=False), source_format="free") == \
-        "y .neqv. .not. x"
+        ".not. x .neqv. y"
     assert fcode(Xor(Not(x), Not(y), evaluate=False),
         source_format="free") == ".not. x .neqv. .not. y"
     assert fcode(Not(Xor(x, y, evaluate=False), evaluate=False),
@@ -377,39 +377,39 @@ def test_fcode_Xlogical():
     assert fcode(Equivalent(Xor(y, z, evaluate=False), x),
         source_format="free") == "x .eqv. (y .neqv. z)"
     assert fcode(Equivalent(Xor(z, x, evaluate=False), y),
-        source_format="free") == "y .eqv. (x .neqv. z)"
+        source_format="free") == "y .eqv. (z .neqv. x)"
     assert fcode(Equivalent(Xor(x, y, evaluate=False), z),
         source_format="free") == "z .eqv. (x .neqv. y)"
     assert fcode(Xor(Equivalent(y, z), x, evaluate=False),
-        source_format="free") == "x .neqv. (y .eqv. z)"
+        source_format="free") == "(y .eqv. z) .neqv. x"
     assert fcode(Xor(Equivalent(z, x), y, evaluate=False),
-        source_format="free") == "y .neqv. (x .eqv. z)"
+        source_format="free") == "(x .eqv. z) .neqv. y"
     assert fcode(Xor(Equivalent(x, y), z, evaluate=False),
-        source_format="free") == "z .neqv. (x .eqv. y)"
+        source_format="free") == "(x .eqv. y) .neqv. z"
     # mixed And/Xor
     assert fcode(Xor(And(y, z), x, evaluate=False), source_format="free") == \
-        "x .neqv. y .and. z"
+        "y .and. z .neqv. x"
     assert fcode(Xor(And(z, x), y, evaluate=False), source_format="free") == \
-        "y .neqv. x .and. z"
+        "x .and. z .neqv. y"
     assert fcode(Xor(And(x, y), z, evaluate=False), source_format="free") == \
-        "z .neqv. x .and. y"
+        "x .and. y .neqv. z"
     assert fcode(And(Xor(y, z, evaluate=False), x), source_format="free") == \
         "x .and. (y .neqv. z)"
     assert fcode(And(Xor(z, x, evaluate=False), y), source_format="free") == \
-        "y .and. (x .neqv. z)"
+        "y .and. (z .neqv. x)"
     assert fcode(And(Xor(x, y, evaluate=False), z), source_format="free") == \
         "z .and. (x .neqv. y)"
     # mixed Or/Xor
     assert fcode(Xor(Or(y, z), x, evaluate=False), source_format="free") == \
-        "x .neqv. y .or. z"
+        "y .or. z .neqv. x"
     assert fcode(Xor(Or(z, x), y, evaluate=False), source_format="free") == \
-        "y .neqv. x .or. z"
+        "x .or. z .neqv. y"
     assert fcode(Xor(Or(x, y), z, evaluate=False), source_format="free") == \
-        "z .neqv. x .or. y"
+        "x .or. y .neqv. z"
     assert fcode(Or(Xor(y, z, evaluate=False), x), source_format="free") == \
         "x .or. (y .neqv. z)"
     assert fcode(Or(Xor(z, x, evaluate=False), y), source_format="free") == \
-        "y .or. (x .neqv. z)"
+        "y .or. (z .neqv. x)"
     assert fcode(Or(Xor(x, y, evaluate=False), z), source_format="free") == \
         "z .or. (x .neqv. y)"
     # trinary Xor
@@ -418,9 +418,9 @@ def test_fcode_Xlogical():
     assert fcode(Xor(x, y, Not(z), evaluate=False), source_format="free") == \
         "x .neqv. y .neqv. .not. z"
     assert fcode(Xor(x, Not(y), z, evaluate=False), source_format="free") == \
-        "x .neqv. z .neqv. .not. y"
+        "x .neqv. .not. y .neqv. z"
     assert fcode(Xor(Not(x), y, z, evaluate=False), source_format="free") == \
-        "y .neqv. z .neqv. .not. x"
+        ".not. x .neqv. y .neqv. z"
 
 
 def test_fcode_Relational():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1044,7 +1044,7 @@ def test_Equivalent():
     assert str(Equivalent(y, x)) == "Equivalent(x, y)"
 
 def test_Xor():
-    assert str(Xor(y, x, evaluate=False)) == "x ^ y"
+    assert str(Xor(y, x, evaluate=False)) == "y ^ x"
 
 def test_Complement():
     assert str(Complement(S.Reals, S.Naturals)) == 'Complement(Reals, Naturals)'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/28055

#### Brief description of what is fixed or changed

This fixes general issues with `LatticeOp` as well, so any subclass of `LatticeOp` that does not override `__new__` may get some benefit.

`And` and `Or` need to override `_from_args` because the one shipped with `LatticeOp` forces evaluating for 0 and 1 argument cases.

For the issues with `Xor` and `Equivalent`, `_argset` forces set-evaluation, so that should be removed as well.

https://github.com/sympy/sympy/blob/115b33704c6ee5b4947d3576596576fa46b1a119/sympy/logic/boolalg.py#L1349-L1354


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- logic
  - Fixed an issue that `evaluate=False` is not working for `And`, `Or`, `Xor`, `Equivalent`.
<!-- END RELEASE NOTES -->
