### PR TITLE
Define is_annihilation on Pauli operators

### DIFF
--- a/sympy/physics/quantum/pauli.py
+++ b/sympy/physics/quantum/pauli.py
@@ -278,6 +278,8 @@ class SigmaMinus(SigmaOpBase):
     [1, 0]])
     """
 
+    is_annihilation = True
+
     def __new__(cls, *args, **hints):
         return SigmaOpBase.__new__(cls, *args)
 
@@ -361,6 +363,8 @@ class SigmaPlus(SigmaOpBase):
     [0, 1],
     [0, 0]])
     """
+
+    is_annihilation = False
 
     def __new__(cls, *args, **hints):
         return SigmaOpBase.__new__(cls, *args)

--- a/sympy/physics/quantum/tests/test_pauli.py
+++ b/sympy/physics/quantum/tests/test_pauli.py
@@ -157,3 +157,8 @@ def test_represent():
     assert represent(sz) == Matrix([[1, 0], [0, -1]])
     assert represent(sm) == Matrix([[0, 0], [1, 0]])
     assert represent(sp) == Matrix([[0, 1], [0, 0]])
+
+
+def test_is_annihilation():
+    assert sm.is_annihilation is True
+    assert sp.is_annihilation is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Pauli operators $\sigma_+$ and $\sigma_-$ play the same role for spins as do creation and annihilation operators for bosons and fermions. However, unlike `physics.quantum.BosonOp` and `physics.quantum.FermionOp`, `physics.quantum.pauli.SigmaPlus` and `physics.quantum.pauli.SigmaMinus` do not have the `is_annihilation` attribute defined. This PR changes this to improve the API uniformity.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Defined `is_annihilation` attribute on `pauli.SigmaPlus` and `pauli.SigmaMinus`.
<!-- END RELEASE NOTES -->
