### PR TITLE
logic: Fix upper_from_neg bug in LRASolver.reset_bounds()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -371,6 +371,7 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
+Atul Bisht <me.atulbisht@gmail.com>
 Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Augusto Borges <borges.augustoar@gmail.com>

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -367,7 +367,7 @@ class LRASolver():
             var.lower_from_neg = False
             var.upper = LRARational(float("inf"), 0)
             var.upper_from_eq= False
-            var.lower_from_neg = False
+            var.upper_from_neg = False
             var.assign = LRARational(0, 0)
 
     def assert_lit(self, enc_constraint):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -366,7 +366,7 @@ class LRASolver():
             var.lower_from_eq = False
             var.lower_from_neg = False
             var.upper = LRARational(float("inf"), 0)
-            var.upper_from_eq= False
+            var.upper_from_eq = False
             var.upper_from_neg = False
             var.assign = LRARational(0, 0)
 


### PR DESCRIPTION
Fixed a bug in the reset_bounds() method where the upper_from_neg flag was not being properly reset to False. This caused issues when the solver was reused after a previous run that had set this flag to True.

The fix ensures that all state variables are properly reset to their default values, maintaining consistent behavior across multiple solver runs.

Enhanced test_reset_bounds() to explicitly verify that all state variables are properly reset, including upper_from_neg.

Fixes #27982

### Changes
- Fixed `reset_bounds()` method to properly reset `upper_from_neg` to `False`
- Enhanced `test_reset_bounds()` to verify all state variables are reset correctly

### Tests
- All tests in `test_lra_theory.py` pass
- Enhanced `test_reset_bounds()` now explicitly checks that `upper_from_neg` is reset to `False`

<!-- BEGIN RELEASE NOTES -->
* logic
  * Fixed a bug in `LRASolver.reset_bounds()` where the `upper_from_neg` flag was not being properly reset.
<!-- END RELEASE NOTES -->