### PR TITLE
Fix `Max/Min` for `lambdify` with `torch`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1755,6 +1755,7 @@ znxftw <vishnu2101@gmail.com>
 zsc347 <zsc347@gmail.com>
 zzc <1378113190@qq.com> zzc <58017008+zzc0430@users.noreply.github.com>
 zzj <29055749+zjzh@users.noreply.github.com>
+Élie Goudout <eliegoudout@hotmail.com> eliegoudout <114467748+eliegoudout@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>

--- a/sympy/printing/pytorch.py
+++ b/sympy/printing/pytorch.py
@@ -61,8 +61,8 @@ class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
         sympy.And: "torch.logical_and",
         sympy.Or: "torch.logical_or",
         sympy.Not: "torch.logical_not",
-        sympy.Max: "torch.max",
-        sympy.Min: "torch.min",
+        sympy.Max: "torch.maximum",
+        sympy.Min: "torch.minimum",
 
         # Matrices
         sympy.MatAdd: "torch.add",

--- a/sympy/printing/tests/test_torch.py
+++ b/sympy/printing/tests/test_torch.py
@@ -11,7 +11,7 @@ from sympy.tensor.array.expressions.array_expressions import (
 from sympy.utilities.lambdify import lambdify
 from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
 from sympy.functions import \
-    Abs, ceiling, exp, floor, sign, sin, asin, cos, \
+    Abs, Min, Max, ceiling, exp, floor, sign, sin, asin, cos, \
     acos, tan, atan, atan2, cosh, acosh, sinh, asinh, tanh, atanh, \
     re, im, arg, erf, loggamma, sqrt
 from sympy.testing.pytest import skip
@@ -215,6 +215,22 @@ def test_torch_relational():
     expr = Lt(x, y)
     assert torch_code(expr) == "torch.lt(x, y)"
     _compare_torch_relational((x, y), expr)
+
+
+def test_torch_max_min():
+    if torch is None:
+        skip("PyTorch not installed")
+
+    x, y = symbols('x y')
+    expr = Max(x, y) + Min(x, y)
+    assert torch_code(expr) == "torch.maximum(x, y) + torch.minimum(x, y)"
+
+    func = lambdify([x, y], expr, "torch")
+    x_test, y_test = torch.rand((2, 3, 4))
+
+    result = func(x_test, y_test)
+    expected = x_test + y_test
+    assert torch.allclose(result, expected)
 
 
 def test_torch_matrix():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -329,9 +329,10 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
         *modules* can be one of the following types:
 
-        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"numpy"``, ``"numexpr"``,
-          ``"scipy"``, ``"sympy"``, or ``"tensorflow"`` or ``"jax"``. This uses the
-          corresponding printer and namespace mapping for that module.
+        - The strings ``"math"``, ``"cmath"``, ``"mpmath"``, ``"numpy"``,
+          ``"numexpr"``, ``"scipy"``, ``"sympy"``, ``"tensorflow"``,
+          ``"torch"`` or ``"jax"``. This uses the corresponding printer
+          and namespace mapping for that module.
         - A module (e.g., ``math``). This uses the global namespace of the
           module. If the module is one of the above known modules, it will
           also use the corresponding printer and namespace mapping


### PR DESCRIPTION
Fixes #28076.

_Edit: forgot the release note section._

----
<!-- BEGIN RELEASE NOTES -->
* utilities
    * A bug in lambdify for the torch backend was fixed. Previously incorrect code was generated for the Max and Min functions.
<!-- END RELEASE NOTES -->