### PR TITLE
Physics: Bug fix while converting a expression to a target unit

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1761,3 +1761,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+mukundkumarjha <mukundiiit@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1072,6 +1072,8 @@ MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@u
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
+Mukund Jha <mukundiiitg@gmail.com>
+Mukund Jha <mukundjha@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
 Nabanita Dash <dashnabanita@gmail.com> Naba7 <dashnabanita@gmail.com>
 Nabanita Dash <dashnabanita@gmail.com> Nabanita Dash <31562743+Naba7@users.noreply.github.com>
@@ -1761,4 +1763,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-mukundkumarjha <mukundiiit@gmail.com>

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -108,7 +108,7 @@ def convert_to(expr, target_units, unit_system="SI"):
     elif isinstance(expr, Pow) and isinstance(expr.base, Add):
         return handle_Adds(expr.base) ** expr.exp
 
-    expr = sympify(expr)
+    expr = expr.simplify()
     target_units = sympify(target_units)
 
     if isinstance(expr, Function):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Brief description of what is fixed or changed
sympy/sympy/physics/units/util.py Line 111

I am unsure what is the purpose of expr = sympify(expr)

but if we simplify the source expression before hand, conversion is giving desired output.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Expression simplification

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Simplifying source expression before conversion to target unit.

<!-- END RELEASE NOTES -->
