### PR TITLE
functions: add _eval_evalf() helper for erfcinv()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -279,6 +279,7 @@ Alexander Dunlap <alexander.dunlap@gmail.com>
 Alexander Eberspächer <alex.eberspaecher@gmail.com>
 Alexander Hirzel <alex@hirzel.us>
 Alexander Pozdneev <pozdneev@users.noreply.github.com>
+Alexander Puck Neuwirth <alexander@neuwirth-informatik.de> Alexander Puck Neuwirth <APN-Pucky@users.noreply.github.com>
 Alexander Zhura <nice.zhura@list.ru>
 Alexandr Gudulin <alexandr.gudulin@gmail.com>
 Alexandr Popov <alexandr.s.popov@gmail.com>

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -21,8 +21,6 @@ from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc
 from sympy.functions.special.hyper import hyper, meijerg
 
-from mpmath.libmp.libmpf import prec_to_dps
-
 # TODO series expansions
 # TODO see the "Note:" in Ei
 
@@ -987,8 +985,7 @@ class erfcinv (DefinedFunction):
         return erfinv(1-z)
 
     def _eval_evalf(self, prec):
-        nprec = prec_to_dps(prec)
-        return self.rewrite(erfinv).evalf(n=nprec)
+        return self.rewrite(erfinv)._eval_evalf(prec)
 
     def _eval_is_zero(self):
         return (self.args[0] - 1).is_zero
@@ -1752,8 +1749,7 @@ class Li(DefinedFunction):
             raise ArgumentIndexError(self, argindex)
 
     def _eval_evalf(self, prec):
-        nprec = prec_to_dps(prec)
-        return self.rewrite(li).evalf(n=nprec)
+        return self.rewrite(li)._eval_evalf(prec)
 
     def _eval_rewrite_as_li(self, z, **kwargs):
         return li(z) - li(2)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -21,6 +21,8 @@ from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc
 from sympy.functions.special.hyper import hyper, meijerg
 
+from mpmath.libmp.libmpf import prec_to_dps
+
 # TODO series expansions
 # TODO see the "Note:" in Ei
 
@@ -985,7 +987,8 @@ class erfcinv (DefinedFunction):
         return erfinv(1-z)
 
     def _eval_evalf(self, prec):
-        return self.rewrite(erfinv).evalf(prec)
+        nprec = prec_to_dps(prec)
+        return self.rewrite(erfinv).evalf(n=nprec)
 
     def _eval_is_zero(self):
         return (self.args[0] - 1).is_zero
@@ -1749,7 +1752,8 @@ class Li(DefinedFunction):
             raise ArgumentIndexError(self, argindex)
 
     def _eval_evalf(self, prec):
-        return self.rewrite(li).evalf(prec)
+        nprec = prec_to_dps(prec)
+        return self.rewrite(li).evalf(n=nprec)
 
     def _eval_rewrite_as_li(self, z, **kwargs):
         return li(z) - li(2)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -984,6 +984,9 @@ class erfcinv (DefinedFunction):
     def _eval_rewrite_as_erfinv(self, z, **kwargs):
         return erfinv(1-z)
 
+    def _eval_evalf(self, prec):
+        return self.rewrite(erfinv).evalf(prec)
+
     def _eval_is_zero(self):
         return (self.args[0] - 1).is_zero
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -353,6 +353,9 @@ def test_erfcinv():
     assert erfcinv(z).rewrite('erfinv') == erfinv(1-z)
     assert erfcinv(z).inverse() == erfc
 
+    # issue sympy/sympy#24684
+    assert abs( erfcinv(Float(0.4)) - 0.59511608144999484) < 1E-13
+
 
 def test_erf2inv():
     assert erf2inv(0, 0) is S.Zero


### PR DESCRIPTION
The problem:
```py
>>> print(sympy.erfcinv(0.4).evalf())  # Should give a numeric result
erfcinv(0.4)
````

The fix:
evalf should rewrite to erfinv, similar to the Li class.

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug where `erfcinv` is not evaluated numerically when using `evalf`
<!-- END RELEASE NOTES -->

Closes: https://github.com/sympy/sympy/issues/24684
See-also: https://github.com/skirpichev/diofant/commit/87ebe6f4d7da0d77fbf9647c8719b66f8ad17b78