### PR TITLE
Simplex method — correctly implement Bland's rule and refactor to be more understandable

### DIFF
--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -115,7 +115,7 @@ class InfeasibleLPError(Exception):
     pass
 
 
-class SimplexTableau:
+class _SimplexTableau:
     Var = namedtuple("Var", ["is_dual", "index"])
 
     def __init__(self, A, B, C, D):
@@ -167,9 +167,9 @@ class SimplexTableau:
         Example
         -------
         >>> from sympy import Matrix, var
-        >>> from sympy.solvers.simplex import SimplexTableau
+        >>> from sympy.solvers.simplex import _SimplexTableau
         >>> a, b, c, d, e, f, g, h, i = var('a:i')
-        >>> T = SimplexTableau([], [], [], [])      # dummy init
+        >>> T = _SimplexTableau([], [], [], [])      # dummy init
         >>> T.M = Matrix([[a, b, c], [d, e, f], [g, h, i]])
         >>> T._pivot(1, 0)
         >>> T.M
@@ -334,7 +334,7 @@ def _simplex(A, B, C, D=None, dual=False):
         _o, d, p = _simplex(-A.T, C.T, B.T, -D)
         return -_o, d, p
 
-    tableau = SimplexTableau(A, B, C, D)
+    tableau = _SimplexTableau(A, B, C, D)
 
     # Phase 1: find a feasible solution
     while True:

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -189,13 +189,13 @@ class _SimplexTableau:
 
         for i, var in enumerate(self.X):
             if not var.is_dual:
-                argmax[var.index] = 0
+                argmax[var.index] = S.Zero
             else:
                 argmin_dual[var.index] = self.M[-1, i]
 
         for i, var in enumerate(self.Y):
             if var.is_dual:
-                argmin_dual[var.index] = 0
+                argmin_dual[var.index] = S.Zero
             else:
                 argmax[var.index] = self.M[i, -1]
 

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -340,12 +340,11 @@ def _simplex(A, B, C, D=None, dual=False):
     while True:
         rhs = tableau.M[:-1, -1]
         lhs = tableau.M[:-1, :-1]
-        if all(rhs[i] >= 0 for i in range(rhs.rows)):
-            break
 
-        for k in range(rhs.rows):
-            if rhs[k] < 0:
-                break
+        # Find first infeasible row
+        k = next((i for i in range(rhs.rows) if rhs[i] < 0), None)
+        if k is None:
+            break  # All RHS entries >= 0 -> feasible solution found
 
         piv_cols = [_ for _ in range(lhs.cols) if lhs[k, _] < 0]
         if not piv_cols:

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -60,6 +60,7 @@ Here is a simple 1-D system: minimize `x` given that ``x >= 1``.
     sympy.solvers.simplex.InfeasibleLPError:
     Inconsistent/False constraint
 """
+from collections import namedtuple
 
 from sympy.core import sympify
 from sympy.core.exprtools import factor_terms
@@ -293,8 +294,9 @@ def _simplex(A, B, C, D=None, dual=False):
 
     # x variables have priority over y variables during Bland's rule
     # since False < True
-    X = [(False, j) for j in range(n)]
-    Y = [(True, i) for i in range(m)]
+    Var = namedtuple("Var", ["is_dual", "index"])
+    X = [Var(False, j) for j in range(n)]
+    Y = [Var(True, i) for i in range(m)]
 
     # Phase 1: find a feasible solution or determine none exist
 
@@ -378,17 +380,17 @@ def _simplex(A, B, C, D=None, dual=False):
     argmax = [None] * n
     argmin_dual = [None] * m
 
-    for i, (v, n) in enumerate(X):
-        if v == False:
-            argmax[n] = 0
+    for i, var in enumerate(X):
+        if var.is_dual == False:
+            argmax[var.index] = 0
         else:
-            argmin_dual[n] = M[-1, i]
+            argmin_dual[var.index] = M[-1, i]
 
-    for i, (v, n) in enumerate(Y):
-        if v == True:
-            argmin_dual[n] = 0
+    for i, var in enumerate(Y):
+        if var.is_dual == True:
+            argmin_dual[var.index] = 0
         else:
-            argmax[n] = M[i, -1]
+            argmax[var.index] = M[i, -1]
 
     if last and not all(i >= 0 for i in argmax + argmin_dual):
         raise InfeasibleLPError(filldedent("""

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -244,7 +244,7 @@ def _simplex(A, B, C, D=None, dual=False):
     constraint that ``y + 2*x >= 4``. This is the "standard form" of
     a minimization.
 
-    In the nonnegative quadrant, this inequality describes a area above
+    In the nonnegative quadrant, this inequality describes an area above
     a triangle with vertices at (0, 4), (0, 0) and (2, 0). The minimum
     of ``f`` occurs at (2, 0). Define A, B, C, D for the standard
     minimization:
@@ -369,7 +369,7 @@ def _simplex(A, B, C, D=None, dual=False):
 
         piv_cols = [_ for _ in range(tableau.n) if cost[_] < 0]
         if not piv_cols:
-            break
+            break  # No improving direction -> current solution is optimal
 
         c = tableau.choose_pivot_column(piv_cols)
 

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -140,12 +140,12 @@ class SimplexTableau:
         self.Y = [self.Var(True, i) for i in range(self.m)]
 
     def choose_pivot_column(self, candidates):
-        """Choose pivot column using Bland’s Rule."""
+        """Choose pivot column using Bland's Rule."""
         _, r = min((self.X[i], i) for i in candidates)
         return r
 
     def choose_pivot_row(self, lhs, rhs, candidates, pivot_col):
-        """Choose pivot row using ratio test and Bland’s Rule."""
+        """Choose pivot row using ratio test and Bland's Rule."""
         _, _, r = min(
             ((rhs[i] / lhs[i, pivot_col], self.Y[i], i) for i in candidates)
         )

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -340,11 +340,6 @@ def _simplex(A, B, C, D=None, dual=False):
         for k in range(rhs.rows):
             if rhs[k] < 0:
                 break
-        else:
-            raise InfeasibleLPError(filldedent("""
-                No feasible solution: all RHS entries are non-negative,
-                but pivot selection failed.
-            """))
 
         piv_cols = [_ for _ in range(lhs.cols) if lhs[k, _] < 0]
         if not piv_cols:

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -354,7 +354,7 @@ def _simplex(A, B, C, D=None, dual=False):
 
         c = tableau.choose_pivot_column(piv_cols)
 
-        piv_rows = [_ for _ in range(lhs.rows) if lhs[_, c] > 0 and rhs[_] > 0]
+        piv_rows = [_ for _ in range(lhs.rows) if lhs[_, c] > 0 and rhs[_] >= 0]
         piv_rows.append(k)
 
         r = tableau.choose_pivot_row(lhs, rhs, piv_rows, c)

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -300,9 +300,6 @@ def _simplex(A, B, C, D=None, dual=False):
 
     # Phase 1: find a feasible solution or determine none exist
 
-    ## keep track of last pivot row and column
-    last = None
-
     while True:
         B = M[:-1, -1]
         A = M[:-1, :-1]
@@ -329,26 +326,6 @@ def _simplex(A, B, C, D=None, dual=False):
         piv_rows.append(k)
         r = _choose_pivot_row(A, B, piv_rows, c, Y)
 
-        # check for oscillation
-        if (r, c) == last:
-            # Not sure what to do here; it looks like there will be
-            # oscillations; see o1 test added at this commit to
-            # see a system with no solution and the o2 for one
-            # with a solution. In the case of o2, the solution
-            # from linprog is the same as the one from lpmin, but
-            # the matrices created in the lpmin case are different
-            # than those created without replacements in linprog and
-            # the matrices in the linprog case lead to oscillations.
-            # If the matrices could be re-written in linprog like
-            # lpmin does, this behavior could be avoided and then
-            # perhaps the oscillating case would only occur when
-            # there is no solution. For now, the output is checked
-            # before exit if oscillations were detected and an
-            # error is raised there if the solution was invalid.
-            #
-            # cf section 6 of Ferguson for a non-cycling modification
-            last = True
-            break
         last = r, c
 
         M = _pivot(M, r, c)
@@ -392,11 +369,6 @@ def _simplex(A, B, C, D=None, dual=False):
         else:
             argmax[var.index] = M[i, -1]
 
-    if last and not all(i >= 0 for i in argmax + argmin_dual):
-        raise InfeasibleLPError(filldedent("""
-            Oscillating system led to invalid solution.
-            If you believe there was a valid solution, please
-            report this as a bug."""))
     return -M[-1, -1], argmax, argmin_dual
 
 

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -248,3 +248,10 @@ def test_linprog():
         ) == (-2, [0, 2])
     assert linprog([1, -1], [[1, 1]], [5], bounds={1:(3, None)}
         ) == (-5, [0, 5])
+
+
+def test_28089():
+    s, t = symbols('s t')
+    objective = 5
+    constraints = [t >= 0, Eq(s + t, 1), s + 2 * t <= 0]
+    raises(InfeasibleLPError, lambda: lpmin(objective, constraints))

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -255,3 +255,10 @@ def test_28089():
     objective = 5
     constraints = [t >= 0, Eq(s + t, 1), s + 2 * t <= 0]
     raises(InfeasibleLPError, lambda: lpmin(objective, constraints))
+
+
+def test_28104():
+    x, y = symbols('x y')
+    val, var = lpmax(0, [x >= 0, y >= 0])
+    assert var[y] is S.Zero
+    assert var[x] is S.Zero

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -160,17 +160,13 @@ def test_simplex():
     assert lpmin(x, [y >= 1, x >= y + z, x >= 0, z >= 0]
         ) == (1, {x: 1, y: 1, z: 0})
 
-    # detect oscillation
-    # o1
     v = x1, x2, x3, x4 = symbols('x1 x2 x3 x4')
     raises(InfeasibleLPError, lambda: lpmin(
         9*x2 - 8*x3 + 3*x4 + 6,
         [5*x2 - 2*x3 <= 0,
         -x1 - 8*x2 + 9*x3 <= -3,
         10*x1 - x2+ 9*x4 <= -4] + [i >= 0 for i in v]))
-    # o2 - equations fed to lpmin are changed into a matrix
-    # system that doesn't oscillate and has the same solution
-    # as below
+
     M = linear_eq_to_matrix
     f = 5*x2 + x3 + 4*x4 - x1
     L = 5*x2 + 2*x3 + 5*x4 - (x1 + 5)


### PR DESCRIPTION
Bug fixes moved to https://github.com/sympy/sympy/pull/28105/files as I felt there was too much going on in this PR. I've converted this into a draft as the bug fix PR should get merged first. 

This PR refactors the `_simplex` code into what I believe is a more readable form by introducing the `_SimplexTableau` class, and simplifying some redundant code. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
