### PR TITLE
fix-domainMatrix-subtraction

### DIFF
--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -56,6 +56,9 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         def __abs__(f):
             return f.__class__(abs(f.ex))
 
+        def __pos__(f):
+            return f
+
         def __neg__(f):
             return f.__class__(-f.ex)
 

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -477,6 +477,8 @@ def test_DomainMatrix_add():
 
 
 def test_DomainMatrix_sub():
+    from sympy import Abs, EX, I
+
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     B = DomainMatrix([[ZZ(0), ZZ(0)], [ZZ(0), ZZ(0)]], (2, 2), ZZ)
     assert A - A == A.sub(A) == B
@@ -511,6 +513,22 @@ def test_DomainMatrix_sub():
     assert Asd == -Ads
     assert Asd.rep == -Ads.rep
 
+    # https://github.com/sympy/sympy/issues/28097
+    X = DomainMatrix({0: {0: EX(-3), 1: EX(1), 2: EX(2)}, 1: {0: EX(1), 1: EX(-1)},
+                      2: {0: EX(1), 2: EX(-2)}}, (3, 3), EX)
+    Y = DomainMatrix({0: {0: EX(-2 - (27 + 3*sqrt(111)*I)**(1/3)/3 - 4/(27 + 3*sqrt(111)*I)**(1/3))},
+                      1: {1: EX(-2 - (27 + 3*sqrt(111)*I)**(1/3)/3 - 4/(27 + 3*sqrt(111)*I)**(1/3))},
+                      2: {2: EX(-2 - (27 + 3*sqrt(111)*I)**(1/3)/3 - 4/(27 + 3*sqrt(111)*I)**(1/3))}}, (3, 3), EX)
+    P = (9 + sqrt(111)*I)**0.333333333333333
+    Q = 2.77344509740254 / P
+    R = 0.480749856769136 * P
+    expected = DomainMatrix({
+        0: {0: EX(-1.0 + Q + R), 1: EX(1), 2: EX(2)},
+        1: {0: EX(1), 1: EX(1.0 + Q + R)},
+        2: {0: EX(1), 2: EX(Q + R)},
+    }, (3, 3), EX)
+    diff = X.sub(Y).to_Matrix() - expected.to_Matrix()
+    assert all(Abs(e.evalf()) < 1e-12 for e in diff)
 
 def test_DomainMatrix_neg():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
closes: #28097
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
 This Pr fixes a bug in domainMatrix-subtraction by implementing __pos__ 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed  a bug in DomainMatrix subtraction by implementing __pos__  
<!-- END RELEASE NOTES -->
