### PR TITLE
typ: fix mypy checks after new mypy release

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import MutableSet
-from typing import Any, Callable
 
 from .basic import Basic
 from .sorting import default_sort_key, ordered
@@ -331,7 +330,8 @@ class Dict(Basic):
             return self == Dict(other)
         return super().__eq__(other)
 
-    __hash__ : Callable[[Basic], Any] = Basic.__hash__
+    def __hash__(self):
+        return Basic.__hash__(self)
 
 # this handles dict, defaultdict, OrderedDict
 _sympy_converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -625,9 +625,9 @@ def evalf_add(v: 'Add', prec: int, options: OPT_DICT) -> TMP_RES:
 
     options['maxprec'] = oldmaxprec
     if iszero(re, scaled=True):
-        re = scaled_zero(re)
+        re = scaled_zero(re) # type: ignore
     if iszero(im, scaled=True):
-        im = scaled_zero(im)
+        im = scaled_zero(im) # type: ignore
     return re, im, re_acc, im_acc
 
 
@@ -914,7 +914,7 @@ def evalf_trig(v: Expr, prec: int, options: OPT_DICT) -> TMP_RES:
     if im:
         if 'subs' in options:
             v = v.subs(options['subs'])
-        return evalf(v._eval_evalf(prec), prec, options)
+        return evalf(v._eval_evalf(prec), prec, options) # type: ignore
     if not re:
         if isinstance(v, cos):
             return fone, None, prec, None

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -810,9 +810,9 @@ class Piecewise(DefinedFunction):
     _eval_is_positive = lambda self: self._eval_template_is_attr('is_positive')
     _eval_is_extended_real = lambda self: self._eval_template_is_attr(
             'is_extended_real')
-    _eval_is_extended_positive = lambda self: self._eval_template_is_attr(
+    _eval_is_extended_positive = lambda self: self._eval_template_is_attr( # type: ignore
             'is_extended_positive')
-    _eval_is_extended_negative = lambda self: self._eval_template_is_attr(
+    _eval_is_extended_negative = lambda self: self._eval_template_is_attr( # type: ignore
             'is_extended_negative')
     _eval_is_extended_nonzero = lambda self: self._eval_template_is_attr(
             'is_extended_nonzero')

--- a/sympy/physics/biomechanics/musculotendon.py
+++ b/sympy/physics/biomechanics/musculotendon.py
@@ -1413,7 +1413,7 @@ class MusculotendonDeGroote2016(MusculotendonBase):
 
     """
 
-    curves = CharacteristicCurveCollection(
+    curves = CharacteristicCurveCollection( # type: ignore
         tendon_force_length=TendonForceLengthDeGroote2016,
         tendon_force_length_inverse=TendonForceLengthInverseDeGroote2016,
         fiber_force_length_passive=FiberForceLengthPassiveDeGroote2016,

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -485,7 +485,7 @@ class CodePrinter(StrPrinter):
         return pmeth(obj.args, seq_orders)
 
     # Don't inherit the str-printer method for Heaviside to the code printers
-    _print_Heaviside = None
+    _print_Heaviside = None # type: ignore
 
     def _print_NumberSymbol(self, expr):
         if self._settings.get("inline", False):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, TYPE_CHECKING, overload
+from typing import Any, TYPE_CHECKING, overload
 from functools import reduce
 from collections import defaultdict
 from collections.abc import Mapping, Iterable
@@ -2183,7 +2183,9 @@ class FiniteSet(Set):
             return self._args_set == other
         return super().__eq__(other)
 
-    __hash__ : Callable[[Basic], Any] = Basic.__hash__
+    def __hash__(self):
+        return Basic.__hash__(self)
+
 
 _sympy_converter[set] = lambda x: FiniteSet(*x)
 _sympy_converter[frozenset] = lambda x: FiniteSet(*x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
