### PR TITLE
Fix inconsistent normal ordering results for equivalent expressions Issue #28085

### DIFF
--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -156,7 +156,9 @@ def normal_ordered_form(expr, independent=False, recursive_limit=10,
     if _recursive_depth > recursive_limit:
         warnings.warn("Too many recursions, aborting")
         return expr
-
+    
+    expr = expr.expand()
+    
     if isinstance(expr, Add):
         return _normal_ordered_form_terms(expr,
                                           recursive_limit=recursive_limit,

--- a/sympy/physics/quantum/tests/test_operatorordering.py
+++ b/sympy/physics/quantum/tests/test_operatorordering.py
@@ -32,7 +32,21 @@ def test_normal_ordered_form():
         2 * a + Dagger(a) * a ** 2
     assert normal_ordered_form(a ** 3 * Dagger(a)) == \
         3 * a ** 2 + Dagger(a) * a ** 3
-
+    
+    assert normal_ordered_form(a * Dagger(a) + a * a) == \
+        1 + Dagger(a) * a + a ** 2
+    assert normal_ordered_form(a * (Dagger(a) + a)) == \
+        1 + Dagger(a) * a + a ** 2
+        
+    assert normal_ordered_form(a ** 2 * Dagger(a) + a * Dagger(a)) == \
+        1 + Dagger(a) * a + 2 * a + Dagger(a) * a ** 2
+    assert normal_ordered_form(a * (a * Dagger(a) + Dagger(a))) == \
+        1 + Dagger(a) * a + 2 * a + Dagger(a) * a ** 2
+    assert normal_ordered_form(c * Dagger(c) + c * c) == \
+        1 - Dagger(c) * c
+    assert normal_ordered_form(c * (Dagger(c) + c)) == \
+        1 - Dagger(c) * c
+    
     assert normal_ordered_form(Dagger(c) * c) == Dagger(c) * c
     assert normal_ordered_form(c * Dagger(c)) == 1 - Dagger(c) * c
     assert normal_ordered_form(c ** 2 * Dagger(c)) == Dagger(c) * c ** 2

--- a/sympy/physics/quantum/tests/test_operatorordering.py
+++ b/sympy/physics/quantum/tests/test_operatorordering.py
@@ -32,12 +32,12 @@ def test_normal_ordered_form():
         2 * a + Dagger(a) * a ** 2
     assert normal_ordered_form(a ** 3 * Dagger(a)) == \
         3 * a ** 2 + Dagger(a) * a ** 3
-    
+
     assert normal_ordered_form(a * Dagger(a) + a * a) == \
         1 + Dagger(a) * a + a ** 2
     assert normal_ordered_form(a * (Dagger(a) + a)) == \
         1 + Dagger(a) * a + a ** 2
-        
+
     assert normal_ordered_form(a ** 2 * Dagger(a) + a * Dagger(a)) == \
         1 + Dagger(a) * a + 2 * a + Dagger(a) * a ** 2
     assert normal_ordered_form(a * (a * Dagger(a) + Dagger(a))) == \
@@ -46,7 +46,7 @@ def test_normal_ordered_form():
         1 - Dagger(c) * c
     assert normal_ordered_form(c * (Dagger(c) + c)) == \
         1 - Dagger(c) * c
-    
+
     assert normal_ordered_form(Dagger(c) * c) == Dagger(c) * c
     assert normal_ordered_form(c * Dagger(c)) == 1 - Dagger(c) * c
     assert normal_ordered_form(c ** 2 * Dagger(c)) == Dagger(c) * c ** 2


### PR DESCRIPTION
Title: Fix inconsistent normal ordering results for equivalent expressions

This PR addresses the inconsistent results when normal ordering equivalent
expressions written in different forms (e.g., `a*(b+c)` vs `a*b + a*c`).

Key changes:
- Added expr.expand() in normal_ordered_form to ensure distributive property 
  is applied before normal ordering
- Added comprehensive test cases for both bosonic and fermionic operators 
  to verify consistent results with distributed expressions

Before:
```python
a*(Dagger(a) + a) != a*Dagger(a) + a*a