### PR TITLE
Fix inconsistent normal ordering results in quantum operators Issues 28085

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1430,6 +1430,7 @@ Shravas K Rao <shravas@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
 Shruti Mangipudi <shruti2395@gmail.com>
 Shuai Zhou <shuaivzhou@berkeley.edu>
+Shubh Gupta <gshubh782@gmail.com>
 Shubham Abhang <shubhamabhang77@gmail.com>
 Shubham Agrawal <shubham.ag6845@gmail.com>
 Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
@@ -1658,6 +1659,7 @@ adhoc-king <46354827+adhoc-king@users.noreply.github.com>
 aditisingh2362 <aditisingh2362@gmail.com>
 alejandro <amartinhernan@gmail.com>
 alijosephine <alijosephine@gmail.com>
+aman singh <mesinghaman@gmail.com> Aman Singh <147741923+mesinghaman@users.noreply.github.com>
 amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,8 @@ Andy R. Terrel <aterrel@uchicago.edu>
 Hubert Tsang <intsangity@gmail.com>
 Konrad Meyer <konrad.meyer@gmail.com>
 Henrik Johansson <henjo2006@gmail.com>
+Shubh Gupta <gshubh782@gmail.com>
+aman singh <mesinghaman@gmail.com>
 Priit Laes <plaes@plaes.org>
 Freddie Witherden <freddie@witherden.org>
 Brian E. Granger <ellisonbg@gmail.com>

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -41,7 +41,6 @@ def _distribute_multiplication(product):
     """
     if not isinstance(product, Mul):
         return None
-        
     for i, factor in enumerate(product.args):
         if isinstance(factor, Add):
             # Distribute the multiplication

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -156,9 +156,7 @@ def normal_ordered_form(expr, independent=False, recursive_limit=10,
     if _recursive_depth > recursive_limit:
         warnings.warn("Too many recursions, aborting")
         return expr
-    
     expr = expr.expand()
-    
     if isinstance(expr, Add):
         return _normal_ordered_form_terms(expr,
                                           recursive_limit=recursive_limit,

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -156,7 +156,9 @@ def normal_ordered_form(expr, independent=False, recursive_limit=10,
     if _recursive_depth > recursive_limit:
         warnings.warn("Too many recursions, aborting")
         return expr
-
+    
+    expr = expr.expand()
+    
     if isinstance(expr, Add):
         return _normal_ordered_form_terms(expr,
                                           recursive_limit=recursive_limit,

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -22,7 +22,6 @@ def _expand_powers(factors):
     power expression to a multiplication expression so that that the
     expression can be handled by the normal ordering functions.
     """
-
     new_factors = []
     for factor in factors.args:
         if (isinstance(factor, Pow)
@@ -135,7 +134,6 @@ def _normal_ordered_form_terms(expr, independent=False, recursive_limit=10,
     addition expression and call _normal_ordered_form_factor to perform the
     factor to an normally ordered expression.
     """
-
     new_terms = []
     for term in expr.args:
         if isinstance(term, Mul):
@@ -177,7 +175,6 @@ def normal_ordered_form(expr, independent=False, recursive_limit=10,
     >>> normal_ordered_form(a * Dagger(a))
     1 + Dagger(a)*a
     """
-
     if _recursive_depth > recursive_limit:
         warnings.warn("Too many recursions, aborting")
         return expr
@@ -209,11 +206,9 @@ def _normal_order_factor(product, recursive_limit=10, _recursive_depth=0):
                           _recursive_depth=_recursive_depth)
 
     factors = _expand_powers(product)
-
     n = 0
     new_factors = []
     while n < len(factors) - 1:
-
         if (isinstance(factors[n], BosonOp) and
                 factors[n].is_annihilation):
             # boson
@@ -267,7 +262,6 @@ def _normal_order_terms(expr, recursive_limit=10, _recursive_depth=0):
     expression and call _normal_order_factor to perform the normal ordering
     on the factors.
     """
-
     new_terms = []
     for term in expr.args:
         if isinstance(term, Mul):

--- a/sympy/physics/quantum/tests/test_operatorordering.py
+++ b/sympy/physics/quantum/tests/test_operatorordering.py
@@ -43,7 +43,6 @@ def test_normal_ordered_form():
         1 + Dagger(a) * a + a ** 2
     assert normal_ordered_form(a * (Dagger(a) + a)) == \
         1 + Dagger(a) * a + a ** 2
-        
     assert normal_ordered_form(a ** 2 * Dagger(a) + a * Dagger(a)) == \
         1 + Dagger(a) * a + 2 * a + Dagger(a) * a ** 2
     assert normal_ordered_form(a * (a * Dagger(a) + Dagger(a))) == \

--- a/sympy/physics/quantum/tests/test_operatorordering.py
+++ b/sympy/physics/quantum/tests/test_operatorordering.py
@@ -39,6 +39,27 @@ def test_normal_ordered_form():
     assert normal_ordered_form(c ** 3 * Dagger(c)) == \
         c ** 2 - Dagger(c) * c ** 3
 
+    assert normal_ordered_form(a * Dagger(a) + a * a) == \
+        1 + Dagger(a) * a + a ** 2
+    assert normal_ordered_form(a * (Dagger(a) + a)) == \
+        1 + Dagger(a) * a + a ** 2
+        
+    assert normal_ordered_form(a ** 2 * Dagger(a) + a * Dagger(a)) == \
+        1 + Dagger(a) * a + 2 * a + Dagger(a) * a ** 2
+    assert normal_ordered_form(a * (a * Dagger(a) + Dagger(a))) == \
+        1 + Dagger(a) * a + 2 * a + Dagger(a) * a ** 2
+
+    assert normal_ordered_form(c * Dagger(c) + c * c) == \
+        1 - Dagger(c) * c
+    assert normal_ordered_form(c * (Dagger(c) + c)) == \
+        1 - Dagger(c) * c
+
+    assert normal_ordered_form(Dagger(c) * c) == Dagger(c) * c
+    assert normal_ordered_form(c * Dagger(c)) == 1 - Dagger(c) * c
+    assert normal_ordered_form(c ** 2 * Dagger(c)) == Dagger(c) * c ** 2
+    assert normal_ordered_form(c ** 3 * Dagger(c)) == \
+        c ** 2 - Dagger(c) * c ** 3
+
     assert normal_ordered_form(a * Dagger(b), True) == Dagger(b) * a
     assert normal_ordered_form(Dagger(a) * b, True) == Dagger(a) * b
     assert normal_ordered_form(b * a, True) == a * b


### PR DESCRIPTION
Fix inconsistent normal ordering results in quantum operators

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". Also, please write a comment on that issue linking
back to this pull request once it is open. -->

Fixes #28085

#### Brief description of what is fixed or changed
Fixes inconsistent results in normal_ordered_form when handling equivalent 
expressions with different distributive forms (e.g., a*(b+c) vs a*b + a*c). 
Added expr.expand() to ensure distributive property is applied before normal ordering.

#### Other comments
Added comprehensive test cases for both bosonic and fermionic operators to verify 
consistent results with distributed expressions.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Fixed inconsistent results in normal_ordered_form when handling equivalent expressions with different distributive forms.
<!-- END RELEASE NOTES -->