### PR TITLE
Lp bugfix

### DIFF
--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -355,13 +355,13 @@ def _simplex(A, B, C, D=None, dual=False):
 
     for i, (v, n) in enumerate(X):
         if v == False:
-            argmax[n] = 0
+            argmax[n] = S.Zero
         else:
             argmin_dual[n] = M[-1, i]
 
     for i, (v, n) in enumerate(Y):
         if v == True:
-            argmin_dual[n] = 0
+            argmin_dual[n] = S.Zero
         else:
             argmax[n] = M[i, -1]
 

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -255,3 +255,10 @@ def test_28089():
     objective = 5
     constraints = [t >= 0, Eq(s + t, 1), s + 2 * t <= 0]
     raises(InfeasibleLPError, lambda: lpmin(objective, constraints))
+
+
+def test_28104():
+    x, y = symbols('x y')
+    val, var = lpmax(0, [x >= 0, y >= 0])
+    assert var[y] is S.Zero
+    assert var[x] is S.Zero

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -160,17 +160,13 @@ def test_simplex():
     assert lpmin(x, [y >= 1, x >= y + z, x >= 0, z >= 0]
         ) == (1, {x: 1, y: 1, z: 0})
 
-    # detect oscillation
-    # o1
     v = x1, x2, x3, x4 = symbols('x1 x2 x3 x4')
     raises(InfeasibleLPError, lambda: lpmin(
         9*x2 - 8*x3 + 3*x4 + 6,
         [5*x2 - 2*x3 <= 0,
         -x1 - 8*x2 + 9*x3 <= -3,
         10*x1 - x2+ 9*x4 <= -4] + [i >= 0 for i in v]))
-    # o2 - equations fed to lpmin are changed into a matrix
-    # system that doesn't oscillate and has the same solution
-    # as below
+
     M = linear_eq_to_matrix
     f = 5*x2 + x3 + 4*x4 - x1
     L = 5*x2 + 2*x3 + 5*x4 - (x1 + 5)
@@ -252,3 +248,10 @@ def test_linprog():
         ) == (-2, [0, 2])
     assert linprog([1, -1], [[1, 1]], [5], bounds={1:(3, None)}
         ) == (-5, [0, 5])
+
+
+def test_28089():
+    s, t = symbols('s t')
+    objective = 5
+    constraints = [t >= 0, Eq(s + t, 1), s + 2 * t <= 0]
+    raises(InfeasibleLPError, lambda: lpmin(objective, constraints))


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/28089 and https://github.com/sympy/sympy/issues/28104. Previously, these fixes were part of https://github.com/sympy/sympy/pull/28092, but I decided to separate them because there was too much going on in that PR.

#### Other comments

I've removed the oscillation checking which is making one of the existing tests hang. There should be no oscillations since the code uses [Bland's pivoting rule](https://en.wikipedia.org/wiki/Bland%27s_rule) which should guarantee that no cycling occurs. When the example from #28089 hangs its due to cycling (which the existing oscillation checking logic did not catch as it only caught cycles of length 1). 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fix simplex method bug causing infinite loops and impossible solutions on some infeasible LPs.
  * Fix bug where `lpmax`/`lpmin` sometimes returned solutions with native Python `int` 0 instead of `S.Zero`.
<!-- END RELEASE NOTES -->
