### PR TITLE
Fix: Add implication ```Q.eq(x, 0)``` => ```Q.zero(x)``` in assumptions system

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -204,6 +204,8 @@ def _(expr, assumptions):
 @ZeroPredicate.register(Expr)
 def _(expr, assumptions):
     ret = expr.is_zero
+    if ask(Q.eq(expr, 0), assumptions):
+            return True
     if ret is None:
         raise MDNotImplementedError
     return ret

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1796,6 +1796,8 @@ def test_zero():
     assert ask(Q.zero(x), Q.odd(x)) is False
     assert ask(Q.zero(x) | Q.zero(y), Q.zero(x*y)) is True
 
+    assert ask(Q.zero(x), Q.eq(x,0)) is True
+
 
 def test_odd_query():
     assert ask(Q.odd(x)) is None


### PR DESCRIPTION
#### Brief description of what is fixed or changed
This PR addresses the logical asymmetry between ```Q.eq(x, 0)``` and ```Q.zero(x)``` within SymPy's assumptions system. Previously, ```Q.zero(x) => Q.eq(x, 0)``` returned ```True```, while the converse ```Q.eq(x, 0) => Q.zero(x)``` returned ```None```.

#### Current Limitations 
1) In some scenarios, this change leads to **maximum recursion depth** exceeded errors. I'm still working on isolating and addressing the root cause of these recursions. This PR is therefore marked as a draft.
2) Its mainly a trivial check, kind of like a fact for the assumption of ```Q.eq(expr,0)```. The reasoning for this is as follows:
- ```Q.zero(x)``` implies that x is real, finite, and equals 0, whereas ```Q.eq(x, 0)``` only implies that x equals 0, without assumptions on realness or finiteness.
-  ```ask(Q.zero(x),Q.eq(x,0) & Q.real(x) & Q.finite(x))``` currently gives ```None``` so even if I add these implications this still wouldn't give it ```True``` as result.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * ```ask(Q.zero(x), Q.eq(x,0))``` now returns ```True``` instead of ```None```.

<!-- END RELEASE NOTES -->
