### PR TITLE
Improve parse_expr() signature visibility in interactive tools

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -6,6 +6,7 @@ from tokenize import (generate_tokens, untokenize, TokenError,
 from keyword import iskeyword
 
 import ast
+import inspect
 import unicodedata
 from io import StringIO
 import builtins
@@ -906,7 +907,30 @@ def eval_expr(code, local_dict: DICT, global_dict: DICT):
         code, global_dict, local_dict)  # take local objects in preference
     return expr
 
+def override_signature(new_sig: str):
+    """
+    Decorator to override the displayed function signature in interactive environments
+    like IPython or Jupyter notebooks.
 
+    Parameters
+    ----------
+    new_sig : str
+        A string representation of the desired function signature. It should be valid
+        as the arguments of a lambda function. Example: "x, y=1, z='foo'".
+
+    Returns
+    -------
+    decorator : Callable
+        A decorator that sets the `__signature__` attribute of the function it wraps.
+        This changes how the function appears in tools like IPython's `?` or `help()`,
+        without affecting the actual behavior or callable interface of the function.
+    """
+    def decorator(func):
+        func.__signature__ = inspect.signature(eval(f"lambda {new_sig}: None"))
+        return func
+    return decorator
+
+@override_signature("s, local_dict=None, transformations='standard', global_dict=None, evaluate=True")
 def parse_expr(s: str, local_dict: DICT | None = None,
                transformations: tuple[TRANS, ...] | str \
                    = standard_transformations,

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -924,6 +924,25 @@ def override_signature(new_sig: str):
         A decorator that sets the `__signature__` attribute of the function it wraps.
         This changes how the function appears in tools like IPython's `?` or `help()`,
         without affecting the actual behavior or callable interface of the function.
+
+     Examples
+    --------
+    >>> @override_signature("x, y=1, z='foo'")
+    ... def my_func(x, y=1, z='foo'):
+    ...     return x + y
+
+    >>> import inspect
+    >>> str(inspect.signature(my_func))
+    '(x, y=1, z=\'foo\')'
+
+    References
+    ==========
+
+    .. [1] https://stackoverflow.com/questions/69845887/simplifying-the-calling-signature-for-repeatedly-used-arguments
+           (Simplifying the calling signature for repeatedly-used arguments)
+
+    .. [2] https://stackoverflow.com/questions/2677185/how-can-i-read-a-functions-signature-including-default-argument-values
+           (How can I read a function’s signature including default argument values?)
     """
     def decorator(func):
         func.__signature__ = inspect.signature(eval(f"lambda {new_sig}: None"))

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -373,3 +373,10 @@ def test_issue_22822():
 def test_xor_eval_false():
     p, q = Symbol("p"), Symbol("q")
     assert parse_expr("p ^ q", evaluate=False) == Xor(p, q, evaluate=False)
+def test_issue_27417():
+    import inspect
+    from sympy.parsing.sympy_parser import parse_expr
+    sig = str(inspect.signature(parse_expr))
+    expected = "(s, local_dict=None, transformations='standard', global_dict=None, evaluate=True)"
+    assert sig == expected
+


### PR DESCRIPTION

#### References to other Issues or PRs
Fixes #27417

#### Brief description of what is fixed or changed
Overrides the displayed function signature of `parse_expr` to simplify the type hints shown in interactive environments like IPython. This improves usability and readability.

Also adds a corresponding regression test to ensure the displayed signature is accurate.

#### Other comments
#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Simplified the displayed function signature of `parse_expr()` in interactive environments
<!-- END RELEASE NOTES -->
