### PR TITLE
Reduce references to mpmath internal code

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -20,7 +20,6 @@ from sympy.core.logic import fuzzy_not, fuzzy_or
 from sympy.utilities.misc import as_int
 
 
-
 if TYPE_CHECKING:
     from typing import Iterable, Sequence
     from sympy.integrals.integrals import SymbolLimits

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -20,6 +20,7 @@ from sympy.core.logic import fuzzy_not, fuzzy_or
 from sympy.utilities.misc import as_int
 
 
+
 if TYPE_CHECKING:
     from typing import Iterable, Sequence
     from sympy.integrals.integrals import SymbolLimits

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -7,17 +7,15 @@ from typing import Callable, TYPE_CHECKING, Any, overload, Type
 
 import math
 
-from mpmath import (
-    make_mpc, make_mpf, mp, mpc, mpf, nsum, quadts, quadosc, workprec)
-from mpmath import inf as mpmath_inf
-
 from sympy.external.mpmath import (
+    inf as mpmath_inf, make_mpf, make_mpc, mp, mpc, mpf,
     MPZ, from_int, from_man_exp, from_rational, fhalf, fnan, finf, fninf,
     fnone, fone, fzero, mpf_abs, mpf_add, mpf_atan, mpf_atan2, mpf_cmp,
     mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt, mpf_mul, mpf_neg, mpf_pi,
     mpf_pow, mpf_pow_int, mpf_shift, mpf_sin, mpf_sqrt, normalize,
     round_nearest, to_int, to_str, mpf_tan, mpc_abs, mpc_pow, mpc_pow_mpf,
-    mpc_pow_int, mpc_sqrt, mpc_exp, dps_to_prec, prec_to_dps
+    mpc_pow_int, mpc_sqrt, mpc_exp, dps_to_prec, prec_to_dps,
+    local_workprec,
 )
 
 from .sympify import sympify
@@ -1091,7 +1089,7 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
     oldmaxprec = options.get('maxprec', DEFAULT_MAXPREC)
     options['maxprec'] = min(oldmaxprec, 2*prec)
 
-    with workprec(prec + 5):
+    with local_workprec(prec + 5) as ctx:
         xlow = as_mpmath(xlow, prec + 15, options)
         xhigh = as_mpmath(xhigh, prec + 15, options)
 
@@ -1133,11 +1131,11 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
                 raise ValueError("An integrand of the form sin(A*x+B)*f(x) "
                   "or cos(A*x+B)*f(x) is required for oscillatory quadrature")
             period = as_mpmath(2*S.Pi/m[A], prec + 15, options)
-            result = quadosc(f, [xlow, xhigh], period=period)
+            result = ctx.quadosc(f, [xlow, xhigh], period=period)
             # XXX: quadosc does not do error detection yet
             quadrature_error = MINUS_INF
         else:
-            result, quadrature_err = quadts(f, [xlow, xhigh], error=1)
+            result, quadrature_err = ctx.quadts(f, [xlow, xhigh], error=1)
             quadrature_error = fastlog(quadrature_err._mpf_)
 
     options['maxprec'] = oldmaxprec
@@ -1304,8 +1302,8 @@ def hypsum(expr: Expr, n: Symbol, start: int, prec: int) -> mpf:
                     _term[0] //= MPZ(func2(k - 1))
                 return make_mpf(from_man_exp(_term[0], -prec2))
 
-            with workprec(prec):
-                v = nsum(summand, [0, mpmath_inf], method='richardson')
+            with local_workprec(prec) as ctx:
+                v = ctx.nsum(summand, [0, mpmath_inf], method='richardson')
             vf = Float(v, ndig)
             if vold is not None and vold == vf:
                 break

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from sympy.integrals.integrals import Integral
     from sympy.concrete.summations import Sum
     from sympy.concrete.products import Product
+    from sympy.external.mpmath import MPContext
     from sympy.functions.elementary.exponential import exp, log
     from sympy.functions.elementary.complexes import Abs, re, im
     from sympy.functions.elementary.integers import ceiling, floor
@@ -1057,7 +1058,9 @@ def evalf_alg_num(a: 'AlgebraicNumber', prec: int, options: OPT_DICT) -> TMP_RES
 #----------------------------------------------------------------------------#
 
 
-def as_mpmath(x: Any, prec: int, options: OPT_DICT) -> mpc | mpf:
+def as_mpmath(
+    x: Any, prec: int, options: OPT_DICT, ctx: MPContext | None = None
+) -> mpc | mpf:
     from .numbers import Infinity, NegativeInfinity, Zero
     x = sympify(x)
     if isinstance(x, Zero) or x == 0.0:
@@ -1068,7 +1071,7 @@ def as_mpmath(x: Any, prec: int, options: OPT_DICT) -> mpc | mpf:
         return mpf('-inf')
     # XXX
     result = evalf(x, prec, options)
-    return quad_to_mpmath(result)
+    return quad_to_mpmath(result, ctx)
 
 
 def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
@@ -1090,8 +1093,8 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
     options['maxprec'] = min(oldmaxprec, 2*prec)
 
     with local_workprec(prec + 5) as ctx:
-        xlow = as_mpmath(xlow, prec + 15, options)
-        xhigh = as_mpmath(xhigh, prec + 15, options)
+        xlow = as_mpmath(xlow, prec + 15, options, ctx)
+        xhigh = as_mpmath(xhigh, prec + 15, options, ctx)
 
         # Integration is like summation, and we can phone home from
         # the integrand function to update accuracy summation style
@@ -1130,7 +1133,7 @@ def do_integral(expr: 'Integral', prec: int, options: OPT_DICT) -> TMP_RES:
             if not m:
                 raise ValueError("An integrand of the form sin(A*x+B)*f(x) "
                   "or cos(A*x+B)*f(x) is required for oscillatory quadrature")
-            period = as_mpmath(2*S.Pi/m[A], prec + 15, options)
+            period = as_mpmath(2*S.Pi/m[A], prec + 15, options, ctx)
             result = ctx.quadosc(f, [xlow, xhigh], period=period)
             # XXX: quadosc does not do error detection yet
             quadrature_error = MINUS_INF

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -434,7 +434,7 @@ class Expr(Basic, EvalfMixin):
         return super().__format__(format_spec)
 
     @staticmethod
-    def _from_mpmath(x, prec):
+    def _from_mpmath(x, prec) -> Expr:
         if hasattr(x, "_mpf_"):
             return Float._new(x._mpf_, prec)
         elif hasattr(x, "_mpc_"):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -61,7 +61,8 @@ from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
 from sympy.utilities.misc import as_int, filldedent, func_name
 
 import mpmath
-from sympy.external.mpmath import prec_to_dps
+from sympy.external.mpmath import (prec_to_dps, mpf, mpc, mp, workprec, diff as
+                                   mpmath_diff)
 
 import inspect
 from collections import Counter
@@ -570,7 +571,6 @@ class Function(Application, Expr):
         try:
             args = [arg._to_mpmath(prec + 5) for arg in args]
             def bad(m):
-                from mpmath import mpf, mpc
                 # the precision of an mpf value is the last element
                 # if that is 1 (and m[1] is not 1 which would indicate a
                 # power of 2), then the eval failed; so check that none of
@@ -592,7 +592,12 @@ class Function(Application, Expr):
         except ValueError:
             return
 
-        with mpmath.workprec(prec):
+        # XXX: This should really use local_workprec rather than
+        # mpmath.workprec to avoid messing with mpmath's global precision. That
+        # would be incompatible with any class that uses _eval_mpmath though
+        # since those would have to use the global precision.
+
+        with workprec(prec):
             v = func(*args)
 
         return Expr._from_mpmath(v, prec)
@@ -1653,13 +1658,17 @@ class Derivative(Expr):
             raise NotImplementedError('partials and higher order derivatives')
         z = list(self.free_symbols)[0]
 
+        # XXX: This should not depend on the precision that is set in mp.
+        # The precision should be a parameter.
+
         def eval(x):
-            f0 = self.expr.subs(z, Expr._from_mpmath(x, prec=mpmath.mp.prec))
-            f0 = f0.evalf(prec_to_dps(mpmath.mp.prec))
-            return f0._to_mpmath(mpmath.mp.prec)
-        return Expr._from_mpmath(mpmath.diff(eval,
-                                             z0._to_mpmath(mpmath.mp.prec)),
-                                 mpmath.mp.prec)
+            f0 = self.expr.subs(z, Expr._from_mpmath(x, prec=mp.prec))
+            f0 = f0.evalf(prec_to_dps(mp.prec))
+            return f0._to_mpmath(mp.prec)
+
+        fp = mpmath_diff(eval, z0._to_mpmath(mp.prec))
+
+        return Expr._from_mpmath(fp, mp.prec)
 
     @property
     def expr(self):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -29,7 +29,6 @@ from sympy.printing.latex import latex
 from sympy.printing.repr import srepr
 from sympy.simplify import simplify
 from sympy.polys.domains.groundtypes import PythonRational
-from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.iterables import permutations
 from sympy.testing.pytest import (raises, _both_exp_pow,
                                   warns_deprecated_sympy)
@@ -37,7 +36,7 @@ from sympy import Add
 
 from mpmath import mpf
 import mpmath
-from sympy.external.mpmath import finf, fninf
+from sympy.external.mpmath import finf, fninf, conserve_mpmath_dps
 from sympy.core import numbers
 t = Symbol('t', real=False)
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -23,11 +23,11 @@ from sympy.core.sympify import (sympify, _sympify, SympifyError, kernS,
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.testing.pytest import raises, XFAIL, skip
-from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
 from sympy.external.gmpy import gmpy as _gmpy, flint as _flint
+from sympy.external.mpmath import conserve_mpmath_dps
 from sympy.sets import FiniteSet, EmptySet
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -198,6 +198,8 @@ GROUND_TYPES: str
 
 if TYPE_CHECKING:
 
+    HAS_GMPY = 0
+
     class MPZ:
         """
         Dummy class for type checking purposes. This will be either int,

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -144,34 +144,4 @@ __all__ = [
     "to_int",
     "to_rational",
     "to_str",
-    "_giant_steps_mpmath",
 ]
-
-
-def _giant_steps_mpmath(start, target, n=2):
-    """
-    Return a list of integers ~=
-
-    [start, n*start, ..., target/n^2, target/n, target]
-
-    but conservatively rounded so that the quotient between two
-    successive elements is actually slightly less than n.
-
-    With n = 2, this describes suitable precision steps for a
-    quadratically convergent algorithm such as Newton's method;
-    with n = 3 steps for cubic convergence (Halley's method), etc.
-
-        >>> from sympy.polys.ring_series import _giant_steps_mpmath
-        >>> _giant_steps_mpmath(50,1000)
-        [66, 128, 253, 502, 1000]
-        >>> _giant_steps_mpmath(50,1000,4)
-        [65, 252, 1000]
-
-    """
-    # This function is copied from mpmath to avoid depending on mpmath
-    # internals. This implementation could possibly be improved for the
-    # particular purpose here though.
-    L = [target]
-    while L[-1] > start*n:
-        L = L + [L[-1]//n + 2]
-    return L[::-1]

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -6,6 +6,29 @@
 # More functions could be added here if needed but these are the ones that were
 # used in the sympy codebase when this module was added.
 #
+from functools import update_wrapper as _update_wrapper
+
+from mpmath import (
+    MPContext,
+    bernfrac,
+    diff,
+    eulernum,
+    fac,
+    findroot,
+    inf,
+    make_mpf,
+    make_mpc,
+    mp,
+    mpc,
+    mpf,
+    mpi,
+    ninf,
+    sqrt,
+    workprec,
+)
+
+NoConvergence = mp.NoConvergence
+
 from mpmath.libmp import (
     MPZ,
     MPZ_ONE,
@@ -74,15 +97,25 @@ from mpmath.libmp import (
     to_rational,
     to_str,
 )
+
 from mpmath.libmp.libintmath import giant_steps
+from mpmath.matrices.matrices import _matrix
+from mpmath.ctx_mp_python import mpnumeric
 
 __all__ = [
+    "MPContext",
     "MPZ",
     "MPZ_ONE",
     "ComplexResult",
+    "NoConvergence",
+    "bernfrac",
     "catalan_fixed",
+    "diff",
     "dps_to_prec",
     "euler_fixed",
+    "eulernum",
+    "fac",
+    "findroot",
     "fhalf",
     "finf",
     "fnan",
@@ -98,8 +131,16 @@ __all__ = [
     "giant_steps",
     "ifac",
     "ifib",
+    "inf",
     "int_types",
     "isqrt",
+    "make_mpf",
+    "make_mpc",
+    "mp",
+    "mpc",
+    "mpf",
+    "mpi",
+    "mpnumeric",
     "mpc_abs",
     "mpc_exp",
     "mpc_pow",
@@ -134,14 +175,111 @@ __all__ = [
     "mpf_sqrt",
     "mpf_sub",
     "mpf_tan",
+    "ninf",
     "normalize",
     "phi_fixed",
     "prec_to_dps",
     "repr_dps",
     "round_nearest",
     "sqrtrem",
+    "sqrt",
     "to_float",
     "to_int",
     "to_rational",
     "to_str",
+    "workprec",
+    "_matrix",
 ]
+
+
+def conserve_mpmath_dps(func):
+    """Decorator to rest mpmath's global precision after a function call.
+
+    It is not recommended to use this in new code which should instead use
+    the :class:`local_workdps` or :class:`local_workprec` context managers.
+    """
+    import mpmath
+
+    def func_wrapper(*args, **kwargs):
+        dps = mpmath.mp.dps
+        try:
+            return func(*args, **kwargs)
+        finally:
+            mpmath.mp.dps = dps
+
+    func_wrapper = _update_wrapper(func_wrapper, func)
+    return func_wrapper
+
+
+class local_workprec:
+    """Context manager to borrow an mpmath MPContext with given precision.
+
+    >>> from sympy.external.mpmath import local_workprec
+    >>> with local_workprec(10) as ctx:
+    ...     print(ctx.sin(1))
+    0.84
+
+    The context must not be used outside the ``with`` block, as it will be
+    returned to the context pool for reuse. Even just converting an mpmath
+    object to a string or sympifying it will use its context so these
+    operations should also be done within the ``with`` block.
+
+    Unlike mpmath's ``workdps``, this context manager does not change the
+    global precision, it only provides a local context with the requested
+    precision for the duration of the ``with`` block. Context methods like
+    ``ctx.sin`` must be used instead of global functions like ``mpmath.sin``.
+    Likewise ``ctx.fadd(a, b)`` should be used rather than ``a + b``.
+
+    See Also
+    ========
+
+    local_workdps
+    """
+    _contexts: list[MPContext] = []
+    _ctx: MPContext
+
+    def __init__(self, prec):
+        self.prec = prec
+        try:
+            self._ctx = self._contexts.pop()
+        except IndexError:
+            self._ctx = MPContext()
+        self._ctx.prec = prec
+
+    def __enter__(self) -> MPContext:
+        """Return the MPContext with the requested precision."""
+        return self._ctx
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Return the MPContext to the pool."""
+        self._contexts.append(self._ctx)
+
+
+class local_workdps:
+    """Context manager to borrow an mpmath MPContext with given dps.
+
+    See :class:`local_workprec` for usage.
+
+    See Also
+    ========
+
+    local_workprec
+    """
+    _contexts: list[MPContext] = []
+    _ctx: MPContext
+
+    def __init__(self, dps):
+        self.dps = dps
+        try:
+            self._ctx = self._contexts.pop()
+        except IndexError:
+            self._ctx = MPContext()
+        self._ctx.dps = dps
+
+    def __enter__(self) -> MPContext:
+        """Return the MPContext with the requested dps."""
+        return self._ctx
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Return the MPContext to the pool."""
+        self._contexts.append(self._ctx)

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -144,4 +144,34 @@ __all__ = [
     "to_int",
     "to_rational",
     "to_str",
+    "_giant_steps_mpmath",
 ]
+
+
+def _giant_steps_mpmath(start, target, n=2):
+    """
+    Return a list of integers ~=
+
+    [start, n*start, ..., target/n^2, target/n, target]
+
+    but conservatively rounded so that the quotient between two
+    successive elements is actually slightly less than n.
+
+    With n = 2, this describes suitable precision steps for a
+    quadratically convergent algorithm such as Newton's method;
+    with n = 3 steps for cubic convergence (Halley's method), etc.
+
+        >>> from sympy.polys.ring_series import _giant_steps_mpmath
+        >>> _giant_steps_mpmath(50,1000)
+        [66, 128, 253, 502, 1000]
+        >>> _giant_steps_mpmath(50,1000,4)
+        [65, 252, 1000]
+
+    """
+    # This function is copied from mpmath to avoid depending on mpmath
+    # internals. This implementation could possibly be improved for the
+    # particular purpose here though.
+    L = [target]
+    while L[-1] > start*n:
+        L = L + [L[-1]//n + 2]
+    return L[::-1]

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -10,14 +10,15 @@ from functools import update_wrapper as _update_wrapper
 
 from mpmath import (
     MPContext,
+    MPIntervalContext,
     bernfrac,
     diff,
     eulernum,
     fac,
     findroot,
     inf,
-    make_mpf,
     make_mpc,
+    make_mpf,
     mp,
     mpc,
     mpf,
@@ -29,6 +30,7 @@ from mpmath import (
 
 NoConvergence = mp.NoConvergence
 
+from mpmath.ctx_mp_python import mpnumeric
 from mpmath.libmp import (
     MPZ,
     MPZ_ONE,
@@ -97,13 +99,12 @@ from mpmath.libmp import (
     to_rational,
     to_str,
 )
-
 from mpmath.libmp.libintmath import giant_steps
 from mpmath.matrices.matrices import _matrix
-from mpmath.ctx_mp_python import mpnumeric
 
 __all__ = [
     "MPContext",
+    "MPIntervalContext",
     "MPZ",
     "MPZ_ONE",
     "ComplexResult",
@@ -211,6 +212,15 @@ def conserve_mpmath_dps(func):
     return func_wrapper
 
 
+def _new_mpcontext() -> MPContext:
+    # Note sure how much is really needed here...
+    ctx = MPContext()
+    iv = MPIntervalContext()
+    ctx._iv = iv
+    ctx.mpi = iv._mpi
+    return ctx
+
+
 class local_workprec:
     """Context manager to borrow an mpmath MPContext with given precision.
 
@@ -235,6 +245,7 @@ class local_workprec:
 
     local_workdps
     """
+
     _contexts: list[MPContext] = []
     _ctx: MPContext
 
@@ -243,7 +254,7 @@ class local_workprec:
         try:
             self._ctx = self._contexts.pop()
         except IndexError:
-            self._ctx = MPContext()
+            self._ctx = _new_mpcontext()
         self._ctx.prec = prec
 
     def __enter__(self) -> MPContext:
@@ -265,6 +276,7 @@ class local_workdps:
 
     local_workprec
     """
+
     _contexts: list[MPContext] = []
     _ctx: MPContext
 
@@ -273,7 +285,7 @@ class local_workdps:
         try:
             self._ctx = self._contexts.pop()
         except IndexError:
-            self._ctx = MPContext()
+            self._ctx = _new_mpcontext()
         self._ctx.dps = dps
 
     def __enter__(self) -> MPContext:

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -8,6 +8,7 @@
 #
 from functools import update_wrapper as _update_wrapper
 
+
 from mpmath import (
     MPContext,
     MPIntervalContext,

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -24,7 +24,7 @@ import sympy
 
 import mpmath
 from sympy.abc import x, y, z
-from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.external.mpmath import conserve_mpmath_dps
 from sympy.utilities.exceptions import ignore_warnings
 from sympy.testing.pytest import raises
 

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -256,6 +256,9 @@ class betainc(DefinedFunction):
         a, b, x1, x2 = [a._to_mpmath(prec) for a in self.args]
         with local_workprec(prec) as ctx:
             res = ctx.betainc(a, b, x1, x2, 0)
+            # Workaround for bug in mpmath < 1.4
+            if isinstance(res, int):
+                res = ctx.mpf(res)
         return Expr._from_mpmath(res, prec)
 
     def _eval_is_real(self):
@@ -358,6 +361,9 @@ class betainc_regularized(DefinedFunction):
         a, b, x1, x2 = [a._to_mpmath(prec) for a in self.args]
         with local_workprec(prec) as ctx:
             res = ctx.betainc(a, b, x1, x2, 1)
+            # Workaround for bug in mpmath < 1.4
+            if isinstance(res, int):
+                res = ctx.mpf(res)
         return Expr._from_mpmath(res, prec)
 
     def fdiff(self, argindex):

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -849,15 +849,18 @@ class polygamma(DefinedFunction):
             return
         s = self.args[0]._to_mpmath(prec+12)
         z = self.args[1]._to_mpmath(prec+12)
-        with local_workprec(prec+12) as ctx:
-            if ctx.isint(z) and z <= 0:
+        with local_workprec(prec+12) as mp:
+            if mp.isint(z) and z <= 0:
                 return S.ComplexInfinity
-            if ctx.isint(s) and s >= 0:
-                res = ctx.polygamma(s, z)
+            if mp.isint(s) and s >= 0:
+                res = mp.polygamma(s, z)
             else:
-                zt = ctx.zeta(s+1, z)
-                dzt = ctx.zeta(s+1, z, 1)
-                res = (dzt + (ctx.euler + ctx.digamma(-s)) * zt) * ctx.rgamma(-s)
+                zt = mp.zeta(mp.fadd(s,1), z)
+                dzt = mp.zeta(mp.fadd(s,1), z, 1)
+                res = mp.fmul(
+                    mp.fadd(dzt, mp.fmul(mp.fadd(mp.euler, mp.digamma(mp.fneg(s))), zt)),
+                    mp.rgamma(mp.fneg(s))
+                )
         return Expr._from_mpmath(res, prec)
 
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -6,6 +6,7 @@ from sympy.core.function import DefinedFunction, ArgumentIndexError, PoleError
 from sympy.core.logic import fuzzy_and, fuzzy_not
 from sympy.core.numbers import Rational, pi, oo, I
 from sympy.core.power import Pow
+from sympy.external.mpmath import prec_to_dps, local_workprec
 from sympy.functions.special.zeta_functions import zeta
 from sympy.functions.special.error_functions import erf, erfc, Ei
 from sympy.functions.elementary.complexes import re, unpolarify
@@ -17,8 +18,6 @@ from sympy.functions.combinatorial.numbers import bernoulli, harmonic
 from sympy.functions.combinatorial.factorials import factorial, rf, RisingFactorial
 from sympy.utilities.misc import as_int
 
-from mpmath import mp, workprec
-from sympy.external.mpmath import prec_to_dps
 
 def intlike(n):
     try:
@@ -342,8 +341,8 @@ class lowergamma(DefinedFunction):
         if all(x.is_number for x in self.args):
             a = self.args[0]._to_mpmath(prec)
             z = self.args[1]._to_mpmath(prec)
-            with workprec(prec):
-                res = mp.gammainc(a, 0, z)
+            with local_workprec(prec) as ctx:
+                res = ctx.gammainc(a, 0, z)
             return Expr._from_mpmath(res, prec)
         else:
             return self
@@ -476,8 +475,8 @@ class uppergamma(DefinedFunction):
         if all(x.is_number for x in self.args):
             a = self.args[0]._to_mpmath(prec)
             z = self.args[1]._to_mpmath(prec)
-            with workprec(prec):
-                res = mp.gammainc(a, z, mp.inf)
+            with local_workprec(prec) as ctx:
+                res = ctx.gammainc(a, z, ctx.inf)
             return Expr._from_mpmath(res, prec)
         return self
 
@@ -850,15 +849,15 @@ class polygamma(DefinedFunction):
             return
         s = self.args[0]._to_mpmath(prec+12)
         z = self.args[1]._to_mpmath(prec+12)
-        if mp.isint(z) and z <= 0:
-            return S.ComplexInfinity
-        with workprec(prec+12):
-            if mp.isint(s) and s >= 0:
-                res = mp.polygamma(s, z)
+        with local_workprec(prec+12) as ctx:
+            if ctx.isint(z) and z <= 0:
+                return S.ComplexInfinity
+            if ctx.isint(s) and s >= 0:
+                res = ctx.polygamma(s, z)
             else:
-                zt = mp.zeta(s+1, z)
-                dzt = mp.zeta(s+1, z, 1)
-                res = (dzt + (mp.euler + mp.digamma(-s)) * zt) * mp.rgamma(-s)
+                zt = ctx.zeta(s+1, z)
+                dzt = ctx.zeta(s+1, z, 1)
+                res = (dzt + (ctx.euler + ctx.digamma(-s)) * zt) * ctx.rgamma(-s)
         return Expr._from_mpmath(res, prec)
 
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -15,6 +15,7 @@ from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Dummy
 
 from sympy.external.gmpy import lcm
+from sympy.external.mpmath import local_workprec
 from sympy.functions import (sqrt, exp, log, sin, cos, asin, atan,
         sinh, cosh, asinh, acosh, atanh, acoth)
 from sympy.functions import factorial, RisingFactorial
@@ -699,7 +700,6 @@ class meijerg(TupleParametersBase):
         # less than (say) n*pi, we put r=1/n, compute z' = root(z, n)
         # (carefully so as not to loose the branch information), and evaluate
         # G(z'**(1/r)) = G(z'**n) = G(z).
-        import mpmath
         znum = self.argument._eval_evalf(prec)
         if znum.has(exp_polar):
             znum, branch = znum.as_coeff_mul(exp_polar)
@@ -718,10 +718,11 @@ class meijerg(TupleParametersBase):
         except ValueError:
             return
 
-        with mpmath.workprec(prec):
-            v = mpmath.meijerg(ap, bq, z, r)
+        with local_workprec(prec) as ctx:
+            v = ctx.meijerg(ap, bq, z, r)
+            v_expr = Expr._from_mpmath(v, prec)
 
-        return Expr._from_mpmath(v, prec)
+        return v_expr
 
     def _eval_as_leading_term(self, x, logx, cdir):
         from sympy.simplify.hyperexpand import hyperexpand

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin, cos, cot
+from sympy.external.mpmath import local_workprec
 
 _x = Dummy("x")
 
@@ -211,13 +212,12 @@ class Ynm(DefinedFunction):
         # Note: works without this function by just calling
         #       mpmath for Legendre polynomials. But using
         #       the dedicated function directly is cleaner.
-        from mpmath import mp, workprec
         n = self.args[0]._to_mpmath(prec)
         m = self.args[1]._to_mpmath(prec)
         theta = self.args[2]._to_mpmath(prec)
         phi = self.args[3]._to_mpmath(prec)
-        with workprec(prec):
-            res = mp.spherharm(n, m, theta, phi)
+        with local_workprec(prec) as ctx:
+            res = ctx.spherharm(n, m, theta, phi)
         return Expr._from_mpmath(res, prec)
 
 

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -10,6 +10,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
+from sympy.external.mpmath import mp
 from sympy.functions.combinatorial.factorials import binomial, factorial, rf
 from sympy.functions.elementary.exponential import exp_polar, exp, log
 from sympy.functions.elementary.hyperbolic import (cosh, sinh)
@@ -2535,9 +2536,6 @@ def DMFsubs(frac, x0, mpm=False):
     q = frac.den
     sol_p = S.Zero
     sol_q = S.Zero
-
-    if mpm:
-        from mpmath import mp
 
     for i, j in enumerate(reversed(p)):
         if mpm:

--- a/sympy/holonomic/numerical.py
+++ b/sympy/holonomic/numerical.py
@@ -1,9 +1,8 @@
 """Numerical Methods for Holonomic Functions"""
 
 from sympy.core.sympify import sympify
+from sympy.external.mpmath import mp
 from sympy.holonomic.holonomic import DMFsubs
-
-from mpmath import mp
 
 
 def _evalf(func, points, derivatives=False, method='RK4'):

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .cartan_type import CartanType
-from mpmath import fac
+from sympy.external.mpmath import fac
 from sympy.core.backend import Matrix, eye, Rational, igcd
 from sympy.core.basic import Atom
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -5,15 +5,13 @@ from typing import TYPE_CHECKING, overload
 from types import FunctionType
 from collections import Counter
 
-from mpmath import mp, workprec
-
 from sympy.core.sorting import default_sort_key
 from sympy.core.evalf import DEFAULT_MAXPREC, PrecisionExhausted
 from sympy.core.logic import fuzzy_and, fuzzy_or
 from sympy.core.numbers import AlgebraicNumber, Float
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
-from sympy.external.mpmath import prec_to_dps
+from sympy.external.mpmath import prec_to_dps, local_workprec
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.polys import roots, CRootOf, ZZ, QQ, EX
 from sympy.polys.matrices import DomainMatrix
@@ -51,7 +49,7 @@ def _eigenvals_eigenvects_mpmath(M):
     eps = 2**-prec
 
     while prec < DEFAULT_MAXPREC:
-        with workprec(prec):
+        with local_workprec(prec) as mp:
             A = mp.matrix(M.evalf(n=prec_to_dps(prec)))
             E, ER = mp.eig(A)
             v2 = norm2([i for e in E for i in (mp.re(e), mp.im(e))])

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -28,7 +28,6 @@ from .utilities import _iszero, _simplify
 
 if TYPE_CHECKING:
     from typing import TypeVar, Callable, Any, Literal
-    from sympy.core.expr import Expr
     from sympy.matrices.matrixbase import MatrixBase
     Tmat = TypeVar('Tmat', bound=MatrixBase)
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, overload
 from types import FunctionType
 from collections import Counter
 
+from sympy.core.expr import Expr
 from sympy.core.sorting import default_sort_key
 from sympy.core.evalf import DEFAULT_MAXPREC, PrecisionExhausted
 from sympy.core.logic import fuzzy_and, fuzzy_or
@@ -45,8 +46,12 @@ def _eigenvals_eigenvects_mpmath(M):
     norm2 = lambda v: mp.sqrt(sum(i**2 for i in v))
 
     v1 = None
-    prec = max(x._prec for x in M.atoms(Float))
-    eps = 2**-prec
+    prec_orig = max(x._prec for x in M.atoms(Float))
+    eps = 2**-prec_orig
+
+    prec = prec_orig
+
+    to_expr = lambda e: Expr._from_mpmath(e, prec_orig)
 
     while prec < DEFAULT_MAXPREC:
         with local_workprec(prec) as mp:
@@ -54,6 +59,8 @@ def _eigenvals_eigenvects_mpmath(M):
             E, ER = mp.eig(A)
             v2 = norm2([i for e in E for i in (mp.re(e), mp.im(e))])
             if v1 is not None and mp.fabs(v1 - v2) < eps:
+                E = [to_expr(e) for e in E]
+                ER = [[to_expr(e) for e in row] for row in ER.transpose().tolist()]
                 return E, ER
             v1 = v2
         prec *= 2
@@ -69,19 +76,19 @@ def _eigenvals_eigenvects_mpmath(M):
 
 def _eigenvals_mpmath(M, multiple=False):
     """Compute eigenvalues using mpmath"""
-    E, _ = _eigenvals_eigenvects_mpmath(M)
-    result = [_sympify(x) for x in E]
+    result, _ = _eigenvals_eigenvects_mpmath(M)
     if multiple:
         return result
     return dict(Counter(result))
 
 
 def _eigenvects_mpmath(M):
+    from sympy import ImmutableMatrix
     E, ER = _eigenvals_eigenvects_mpmath(M)
     result = []
     for i in range(M.rows):
         eigenval = _sympify(E[i])
-        eigenvect = _sympify(ER[:, i])
+        eigenvect = ImmutableMatrix(ER[i])
         result.append((eigenval, 1, [eigenvect]))
 
     return result

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,9 +1,8 @@
-from mpmath.matrices.matrices import _matrix
-
 from sympy.core import Basic, Dict, Tuple
 from sympy.core.numbers import Integer
 from sympy.core.cache import cacheit
 from sympy.core.sympify import _sympy_converter as sympify_converter, _sympify
+from sympy.external.mpmath import _matrix
 from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.matrixbase import MatrixBase

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -16,6 +16,7 @@ from sympy.core.mod import Mod
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.sympify import sympify, _sympify
 from sympy.core.function import diff
+from sympy.external.mpmath import _matrix as _mpmath_matrix
 from sympy.polys import cancel
 from sympy.functions.elementary.complexes import Abs, re, im
 from sympy.printing import sstr
@@ -27,7 +28,6 @@ from sympy.printing.str import StrPrinter
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.combinatorial.factorials import binomial, factorial
 
-import mpmath as mp
 from collections.abc import Callable
 from sympy.utilities.iterables import reshape
 from sympy.core.expr import Expr
@@ -4219,7 +4219,7 @@ class MatrixBase(Printable):
             elif isinstance(arg1, Basic) and arg1.is_Matrix:
                 return arg1.rows, arg1.cols, arg1.as_explicit().flat() # type: ignore
 
-            elif isinstance(args[0], mp.matrix):
+            elif isinstance(args[0], _mpmath_matrix):
                 M = args[0]
                 flat_list = [cls._sympify(x) for x in M]
                 return M.rows, M.cols, flat_list

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -1,16 +1,15 @@
 """Implementation of :class:`ComplexField` class. """
 
 
-from sympy.external.gmpy import SYMPY_INTS
 from sympy.core.numbers import Float, I
+from sympy.external.gmpy import SYMPY_INTS
+from sympy.external.mpmath import MPContext
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.gaussiandomains import QQ_I
 from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.polyerrors import DomainError, CoercionFailed
 from sympy.utilities import public
-
-from mpmath import MPContext
 
 
 @public

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -2,15 +2,13 @@
 
 
 from sympy.external.gmpy import SYMPY_INTS, MPQ
-from sympy.external.mpmath import to_rational as _mpmath_to_rational
+from sympy.external.mpmath import to_rational as _mpmath_to_rational, MPContext
 from sympy.core.numbers import Float
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
-
-from mpmath import MPContext
 
 
 def to_rational(s, max_denom, limit=True):

--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -1,4 +1,5 @@
 from sympy.core.symbol import Dummy
+from sympy.external.mpmath import sqrt
 from sympy.ntheory import nextprime
 from sympy.ntheory.modular import crt
 from sympy.polys.domains import PolynomialRing
@@ -6,7 +7,6 @@ from sympy.polys.galoistools import (
     gf_gcd, gf_from_dict, gf_gcdex, gf_div, gf_lcm)
 from sympy.polys.polyerrors import ModularGCDFailed
 
-from mpmath import sqrt
 import random
 
 

--- a/sympy/polys/numberfields/galois_resolvents.py
+++ b/sympy/polys/numberfields/galois_resolvents.py
@@ -294,31 +294,31 @@ class Resolvent:
         list of elements of :ref:`CC`
 
         """
-        with local_workprec(53) as ctx:
+        with local_workprec(53) as mp:
             # Because sympy.polys.polyroots._integer_basis() is called when a
             # CRootOf is formed, we proactively extract the integer basis now.
             # This means that when we call T.all_roots(), every root will be a
             # CRootOf, not a Mul of Integer*CRootOf.
             coeff, T = preprocess_roots(T)
-            coeff = ctx.mpf(str(coeff))
+            coeff = mp.mpf(str(coeff))
 
             scaled_roots = T.all_roots(radicals=False)
 
             # Since we're going to be approximating the roots of T anyway, we
             # can get a good upper bound on the magnitude of the roots by
             # starting with a very low precision approx.
-            approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0)) for r in scaled_roots]
+            approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0), mp) for r in scaled_roots]
             # Here we add 1 to account for the possible error in our initial
             # approximation.
-            M = max(abs(b) for b in approx0) + 1
+            M = mp.fadd(max(mp.fabs(b) for b in approx0), 1)
             m = self.get_prec(M, target=target)
             n = fastlog(M._mpf_) + 1
             p = m + n + 1
-            ctx.prec = p
+            mp.prec = p
             d = prec_to_dps(p)
 
             approx1 = [r.eval_approx(d, return_mpmath=True) for r in scaled_roots]
-            approx1 = [coeff*ctx.mpc(r) for r in approx1]
+            approx1 = [mp.fmul(coeff, mp.mpc(r)) for r in approx1]
 
             return approx1
 

--- a/sympy/polys/numberfields/galois_resolvents.py
+++ b/sympy/polys/numberfields/galois_resolvents.py
@@ -23,7 +23,7 @@ from sympy.core.evalf import (
     evalf, fastlog, _evalf_with_bounded_error, quad_to_mpmath,
 )
 from sympy.core.symbol import symbols, Dummy
-from sympy.external.mpmath import prec_to_dps
+from sympy.external.mpmath import prec_to_dps, local_workprec
 from sympy.polys.densetools import dup_eval
 from sympy.polys.domains import ZZ
 from sympy.polys.orderings import lex
@@ -32,8 +32,6 @@ from sympy.polys.polytools import Poly
 from sympy.polys.rings import xring
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.lambdify import lambdify
-
-from mpmath import MPContext
 
 
 class GaloisGroupException(Exception):
@@ -296,32 +294,33 @@ class Resolvent:
         list of elements of :ref:`CC`
 
         """
-        ctx = MPContext()
-        # Because sympy.polys.polyroots._integer_basis() is called when a CRootOf
-        # is formed, we proactively extract the integer basis now. This means that
-        # when we call T.all_roots(), every root will be a CRootOf, not a Mul
-        # of Integer*CRootOf.
-        coeff, T = preprocess_roots(T)
-        coeff = ctx.mpf(str(coeff))
+        with local_workprec(53) as ctx:
+            # Because sympy.polys.polyroots._integer_basis() is called when a
+            # CRootOf is formed, we proactively extract the integer basis now.
+            # This means that when we call T.all_roots(), every root will be a
+            # CRootOf, not a Mul of Integer*CRootOf.
+            coeff, T = preprocess_roots(T)
+            coeff = ctx.mpf(str(coeff))
 
-        scaled_roots = T.all_roots(radicals=False)
+            scaled_roots = T.all_roots(radicals=False)
 
-        # Since we're going to be approximating the roots of T anyway, we can
-        # get a good upper bound on the magnitude of the roots by starting with
-        # a very low precision approx.
-        approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0)) for r in scaled_roots]
-        # Here we add 1 to account for the possible error in our initial approximation.
-        M = max(abs(b) for b in approx0) + 1
-        m = self.get_prec(M, target=target)
-        n = fastlog(M._mpf_) + 1
-        p = m + n + 1
-        ctx.prec = p
-        d = prec_to_dps(p)
+            # Since we're going to be approximating the roots of T anyway, we
+            # can get a good upper bound on the magnitude of the roots by
+            # starting with a very low precision approx.
+            approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0)) for r in scaled_roots]
+            # Here we add 1 to account for the possible error in our initial
+            # approximation.
+            M = max(abs(b) for b in approx0) + 1
+            m = self.get_prec(M, target=target)
+            n = fastlog(M._mpf_) + 1
+            p = m + n + 1
+            ctx.prec = p
+            d = prec_to_dps(p)
 
-        approx1 = [r.eval_approx(d, return_mpmath=True) for r in scaled_roots]
-        approx1 = [coeff*ctx.mpc(r) for r in approx1]
+            approx1 = [r.eval_approx(d, return_mpmath=True) for r in scaled_roots]
+            approx1 = [coeff*ctx.mpc(r) for r in approx1]
 
-        return approx1
+            return approx1
 
     @staticmethod
     def round_mpf(a):

--- a/sympy/polys/numberfields/subfield.py
+++ b/sympy/polys/numberfields/subfield.py
@@ -37,6 +37,7 @@ from sympy.core.numbers import AlgebraicNumber
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import sympify, _sympify
+from sympy.external.mpmath import local_workprec
 from sympy.ntheory import sieve
 from sympy.polys.densetools import dup_eval
 from sympy.polys.domains import QQ
@@ -44,8 +45,6 @@ from sympy.polys.numberfields.minpoly import _choose_factor, minimal_polynomial
 from sympy.polys.polyerrors import IsomorphismFailed
 from sympy.polys.polytools import Poly, PurePoly, factor_list
 from sympy.utilities import public
-
-from mpmath import MPContext
 
 
 def is_isomorphism_possible(a, b):
@@ -88,51 +87,52 @@ def field_isomorphism_pslq(a, b):
     g = b.minpoly.replace(f.gen)
 
     n, m, prev = 100, b.minpoly.degree(), None
-    ctx = MPContext()
 
-    for i in range(1, 5):
-        A = a.root.evalf(n)
-        B = b.root.evalf(n)
+    with local_workprec(53) as ctx:
 
-        basis = [1, B] + [ B**i for i in range(2, m) ] + [-A]
+        for i in range(1, 5):
+            A = a.root.evalf(n)
+            B = b.root.evalf(n)
 
-        ctx.dps = n
-        coeffs = ctx.pslq(basis, maxcoeff=10**10, maxsteps=1000)
+            basis = [1, B] + [ B**i for i in range(2, m) ] + [-A]
 
-        if coeffs is None:
-            # PSLQ can't find an integer linear combination. Give up.
-            break
+            ctx.dps = n
+            coeffs = ctx.pslq(basis, maxcoeff=10**10, maxsteps=1000)
 
-        if coeffs != prev:
-            prev = coeffs
-        else:
-            # Increasing precision didn't produce anything new. Give up.
-            break
+            if coeffs is None:
+                # PSLQ can't find an integer linear combination. Give up.
+                break
 
-        # We have
-        #   c0 + c1*B + c2*B^2 + ... + cm-1*B^(m-1) - cm*A ~ 0.
-        # So bring cm*A to the other side, and divide through by cm,
-        # for an approximate representation of A as a polynomial in B.
-        # (We know cm != 0 since `b.minpoly` is irreducible.)
-        coeffs = [S(c)/coeffs[-1] for c in coeffs[:-1]]
+            if coeffs != prev:
+                prev = coeffs
+            else:
+                # Increasing precision didn't produce anything new. Give up.
+                break
 
-        # Throw away leading zeros.
-        while not coeffs[-1]:
-            coeffs.pop()
+            # We have
+            #   c0 + c1*B + c2*B^2 + ... + cm-1*B^(m-1) - cm*A ~ 0.
+            # So bring cm*A to the other side, and divide through by cm,
+            # for an approximate representation of A as a polynomial in B.
+            # (We know cm != 0 since `b.minpoly` is irreducible.)
+            coeffs = [S(c)/coeffs[-1] for c in coeffs[:-1]]
 
-        coeffs = list(reversed(coeffs))
-        h = Poly(coeffs, f.gen, domain='QQ')
+            # Throw away leading zeros.
+            while not coeffs[-1]:
+                coeffs.pop()
 
-        # We only have A ~ h(B). We must check whether the relation is exact.
-        if f.compose(h).rem(g).is_zero:
-            # Now we know that h(b) is in fact equal to _some conjugate of_ a.
-            # But from the very precise approximation A ~ h(B) we can assume
-            # the conjugate is a itself.
-            return coeffs
-        else:
-            n *= 2
+            coeffs = list(reversed(coeffs))
+            h = Poly(coeffs, f.gen, domain='QQ')
 
-    return None
+            # We only have A ~ h(B). We must check whether the relation is exact.
+            if f.compose(h).rem(g).is_zero:
+                # Now we know that h(b) is in fact equal to _some conjugate of_ a.
+                # But from the very precise approximation A ~ h(B) we can assume
+                # the conjugate is a itself.
+                return coeffs
+            else:
+                n *= 2
+
+        return None
 
 
 def field_isomorphism_factor(a, b):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -82,6 +82,17 @@ def _get_mpmath_ctx():
     return _mpmath_ctx
 
 
+_mpmath_ctx: MPContext | None = None
+
+
+def _get_mpmath_ctx():
+    """Get the mpmath context, creating it if necessary."""
+    global _mpmath_ctx
+    if _mpmath_ctx is None:
+        _mpmath_ctx = MPContext()
+    return _mpmath_ctx
+
+
 def _polifyit(func):
     @wraps(func)
     def wrapper(f, g):
@@ -3776,6 +3787,10 @@ class Poly(Basic):
             msg = 'convergence to root failed; try n < %s or maxsteps > %s'
             raise ctx.NoConvergence(msg % (n, maxsteps))
 
+        # Mpmath puts real roots first, then complex ones (as does all_roots)
+        # so we make sure this convention holds here, too.
+        key = lambda r: (1 if r.imag else 0, r.real, abs(r.imag), sign(r.imag))
+        roots = [sympify(r) for r in sorted(roots, key=key)]
 
         return roots
 

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -48,6 +48,7 @@ from sympy.polys.polyerrors import DomainError
 from sympy.polys.monomials import (monomial_min, monomial_mul, monomial_div,
                                    monomial_ldiv)
 from sympy.external.gmpy import factorial as ifac
+from sympy.external.mpmath import _giant_steps_mpmath
 from sympy.core import PoleError, Function, Expr
 from sympy.core.numbers import Rational
 from sympy.core.intfunc import igcd
@@ -87,34 +88,6 @@ def _invert_monoms(p1):
     for mvi, cvi in zip(mv, cv):
         p[(deg - mvi[0],)] = cvi
     return p
-
-def _giant_steps_mpmath(start, target, n=2):
-    """
-    Return a list of integers ~=
-
-    [start, n*start, ..., target/n^2, target/n, target]
-
-    but conservatively rounded so that the quotient between two
-    successive elements is actually slightly less than n.
-
-    With n = 2, this describes suitable precision steps for a
-    quadratically convergent algorithm such as Newton's method;
-    with n = 3 steps for cubic convergence (Halley's method), etc.
-
-        >>> from sympy.polys.ring_series import _giant_steps_mpmath
-        >>> _giant_steps_mpmath(50,1000)
-        [66, 128, 253, 502, 1000]
-        >>> _giant_steps_mpmath(50,1000,4)
-        [65, 252, 1000]
-
-    """
-    # This function is copied from mpmath to avoid depending on mpmath
-    # internals. This implementation could possibly be improved for the
-    # particular purpose here though. purpose here though.
-    L = [target]
-    while L[-1] > start*n:
-        L = L + [L[-1]//n + 2]
-    return L[::-1]
 
 def _giant_steps(target):
     """Return a list of precision steps for the Newton's method"""

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -48,7 +48,6 @@ from sympy.polys.polyerrors import DomainError
 from sympy.polys.monomials import (monomial_min, monomial_mul, monomial_div,
                                    monomial_ldiv)
 from sympy.external.gmpy import factorial as ifac
-from sympy.external.mpmath import giant_steps
 from sympy.core import PoleError, Function, Expr
 from sympy.core.numbers import Rational
 from sympy.core.intfunc import igcd
@@ -89,10 +88,38 @@ def _invert_monoms(p1):
         p[(deg - mvi[0],)] = cvi
     return p
 
+def _giant_steps_mpmath(start, target, n=2):
+    """
+    Return a list of integers ~=
+
+    [start, n*start, ..., target/n^2, target/n, target]
+
+    but conservatively rounded so that the quotient between two
+    successive elements is actually slightly less than n.
+
+    With n = 2, this describes suitable precision steps for a
+    quadratically convergent algorithm such as Newton's method;
+    with n = 3 steps for cubic convergence (Halley's method), etc.
+
+        >>> from sympy.polys.ring_series import _giant_steps_mpmath
+        >>> _giant_steps_mpmath(50,1000)
+        [66, 128, 253, 502, 1000]
+        >>> _giant_steps_mpmath(50,1000,4)
+        [65, 252, 1000]
+
+    """
+    # This function is copied from mpmath to avoid depending on mpmath
+    # internals. This implementation could possibly be improved for the
+    # particular purpose here though. purpose here though.
+    L = [target]
+    while L[-1] > start*n:
+        L = L + [L[-1]//n + 2]
+    return L[::-1]
+
 def _giant_steps(target):
     """Return a list of precision steps for the Newton's method"""
     # We use ceil here because giant_steps cannot handle flint.fmpq
-    res = giant_steps(2, math.ceil(target))
+    res = _giant_steps_mpmath(2, math.ceil(target))
     if res[0] != 2:
         res = [2] + res
     return res

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -48,7 +48,7 @@ from sympy.polys.polyerrors import DomainError
 from sympy.polys.monomials import (monomial_min, monomial_mul, monomial_div,
                                    monomial_ldiv)
 from sympy.external.gmpy import factorial as ifac
-from sympy.external.mpmath import _giant_steps_mpmath
+from sympy.external.mpmath import giant_steps
 from sympy.core import PoleError, Function, Expr
 from sympy.core.numbers import Rational
 from sympy.core.intfunc import igcd
@@ -92,7 +92,7 @@ def _invert_monoms(p1):
 def _giant_steps(target):
     """Return a list of precision steps for the Newton's method"""
     # We use ceil here because giant_steps cannot handle flint.fmpq
-    res = _giant_steps_mpmath(2, math.ceil(target))
+    res = giant_steps(2, math.ceil(target))
     if res[0] != 2:
         res = [2] + res
     return res

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -8,6 +8,8 @@ from sympy.core import (S, Expr, Integer, Float, I, oo, Add, Lambda,
 from sympy.core.cache import cacheit
 from sympy.core.relational import is_le
 from sympy.core.sorting import ordered
+from sympy.external.mpmath import (mpf, mpc, local_workprec, dps_to_prec,
+                                   prec_to_dps)
 from sympy.polys.domains import QQ
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -25,8 +27,6 @@ from sympy.polys.rootisolation import (
     dup_isolate_real_roots_sqf)
 from sympy.utilities import lambdify, public, sift, numbered_symbols
 
-from mpmath import mpf, mpc, findroot, workprec
-from sympy.external.mpmath import dps_to_prec, prec_to_dps
 from sympy.multipledispatch import dispatch
 from itertools import chain
 
@@ -910,7 +910,7 @@ class ComplexRootOf(RootOf):
         root bounds, the bounds will be made smaller and updated.
         """
         prec = dps_to_prec(n)
-        with workprec(prec):
+        with local_workprec(prec) as mp:
             g = self.poly.gen
             if not g.is_Symbol:
                 d = Dummy('x')
@@ -954,7 +954,7 @@ class ComplexRootOf(RootOf):
                 try:
                     # without a tolerance, this will return when (to within
                     # the given precision) x_i == x_{i-1}
-                    root = findroot(func, (x0, x1))
+                    root = mp.findroot(func, (x0, x1))
                     # If the (real or complex) root is not in the 'interval',
                     # then keep refining the interval. This happens if findroot
                     # accidentally finds a different root outside of this

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -8,8 +8,7 @@ from sympy.core import (S, Expr, Integer, Float, I, oo, Add, Lambda,
 from sympy.core.cache import cacheit
 from sympy.core.relational import is_le
 from sympy.core.sorting import ordered
-from sympy.external.mpmath import (mpf, mpc, local_workprec, dps_to_prec,
-                                   prec_to_dps)
+from sympy.external.mpmath import local_workprec, dps_to_prec, prec_to_dps
 from sympy.polys.domains import QQ
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -916,41 +915,41 @@ class ComplexRootOf(RootOf):
                 d = Dummy('x')
                 if self.is_imaginary:
                     d *= I
-                func = lambdify(d, self.expr.subs(g, d))
+                func = lambdify(d, self.expr.subs(g, d), modules=mp)
             else:
                 expr = self.expr
                 if self.is_imaginary:
                     expr = self.expr.subs(g, I*g)
-                func = lambdify(g, expr)
+                func = lambdify(g, expr, modules=mp)
 
             interval = self._get_interval()
             while True:
                 if self.is_real:
-                    a = mpf(str(interval.a))
-                    b = mpf(str(interval.b))
+                    a = mp.mpf(str(interval.a))
+                    b = mp.mpf(str(interval.b))
                     if a == b:
                         root = a
                         break
-                    x0 = mpf(str(interval.center))
-                    x1 = x0 + mpf(str(interval.dx))/4
+                    x0 = mp.mpf(str(interval.center))
+                    x1 = mp.fadd(x0, mp.fdiv(mp.mpf(str(interval.dx)), 4))
                 elif self.is_imaginary:
-                    a = mpf(str(interval.ay))
-                    b = mpf(str(interval.by))
+                    a = mp.mpf(str(interval.ay))
+                    b = mp.mpf(str(interval.by))
                     if a == b:
-                        root = mpc(mpf('0'), a)
+                        root = mp.mpc(mp.mpf('0'), a)
                         break
-                    x0 = mpf(str(interval.center[1]))
-                    x1 = x0 + mpf(str(interval.dy))/4
+                    x0 = mp.mpf(str(interval.center[1]))
+                    x1 = mp.fadd(x0, mp.fdiv(mp.mpf(str(interval.dy)), 4))
                 else:
-                    ax = mpf(str(interval.ax))
-                    bx = mpf(str(interval.bx))
-                    ay = mpf(str(interval.ay))
-                    by = mpf(str(interval.by))
+                    ax = mp.mpf(str(interval.ax))
+                    bx = mp.mpf(str(interval.bx))
+                    ay = mp.mpf(str(interval.ay))
+                    by = mp.mpf(str(interval.by))
                     if ax == bx and ay == by:
-                        root = mpc(ax, ay)
+                        root = mp.mpc(ax, ay)
                         break
-                    x0 = mpc(*map(str, interval.center))
-                    x1 = x0 + mpc(*map(str, (interval.dx, interval.dy)))/4
+                    x0 = mp.mpc(*map(str, interval.center))
+                    x1 = mp.fadd(x0, mp.fdiv(mp.mpc(*map(str, (interval.dx, interval.dy))), 4))
                 try:
                     # without a tolerance, this will return when (to within
                     # the given precision) x_i == x_{i-1}
@@ -973,7 +972,7 @@ class ComplexRootOf(RootOf):
                         if not bool(root.imag) == self.is_real and (
                                 a <= root <= b):
                             if self.is_imaginary:
-                                root = mpc(mpf('0'), root.real)
+                                root = mp.mpc(mp.mpf('0'), root.real)
                             break
                     elif (ax <= root.real <= bx and ay <= root.imag <= by):
                         break

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -23,6 +23,7 @@ from sympy.core.singleton import Singleton, S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import symbols, Symbol, Dummy, uniquely_named_symbol
 from sympy.core.sympify import _sympify, sympify, _sympy_converter
+from sympy.external.mpmath import prec_to_dps, mpf, mpi
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import And, Or, Not, Xor, true, false, Boolean
@@ -31,10 +32,6 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import (iproduct, sift, roundrobin, iterable,
                                        subsets)
 from sympy.utilities.misc import func_name, filldedent
-
-from mpmath import mpi, mpf
-
-from sympy.external.mpmath import prec_to_dps
 
 
 tfn: dict[bool | Boolean | None, Boolean | None] = defaultdict(lambda: None, {

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -49,8 +49,12 @@ from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import has_variety, sift, subsets, iterable
 from sympy.utilities.misc import as_int
 
-from sympy.external.mpmath import prec_to_dps
-import mpmath
+from sympy.external.mpmath import (
+    prec_to_dps,
+    local_workprec,
+    inf as _mpmath_inf,
+    ninf as _mpmath_ninf,
+)
 
 
 if TYPE_CHECKING:
@@ -1490,17 +1494,16 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
         return expr
 
     def nsimplify_real(x):
-        orig = mpmath.mp.dps
         xv = x._to_mpmath(bprec)
-        try:
+        with local_workprec(prec) as ctx:
             # We'll be happy with low precision if a simple fraction
             if not (tolerance or full):
-                mpmath.mp.dps = 15
-                rat = mpmath.pslq([xv, 1])
+                ctx.dps = 15
+                rat = ctx.pslq([xv, 1])
                 if rat is not None:
                     return Rational(-int(rat[1]), int(rat[0]))
-            mpmath.mp.dps = prec
-            newexpr = mpmath.identify(xv, constants=constants_dict,
+            ctx.dps = prec
+            newexpr = ctx.identify(xv, constants=constants_dict,
                 tol=tolerance, full=full)
             if not newexpr:
                 raise ValueError
@@ -1509,13 +1512,9 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
             expr = sympify(newexpr)
             if x and not expr:  # don't let x become 0
                 raise ValueError
-            if expr.is_finite is False and xv not in [mpmath.inf, mpmath.ninf]:
+            if expr.is_finite is False and xv not in [_mpmath_inf, _mpmath_ninf]:
                 raise ValueError
             return expr
-        finally:
-            # even though there are returns above, this is executed
-            # before leaving
-            mpmath.mp.dps = orig
     try:
         if re:
             re = nsimplify_real(re)
@@ -1588,10 +1587,12 @@ def _real_to_rational(expr, tolerance=None, rational_conversion='base10'):
                     r = S.ComplexInfinity
                 elif fl < 0:
                     fl = -fl
-                    d = Pow(10, int(mpmath.log(fl)/mpmath.log(10)))
+                    with local_workprec(53) as ctx:
+                        d = Pow(10, int(ctx.log(fl)/ctx.log(10)))
                     r = -Rational(str(fl/d))*d
                 elif fl > 0:
-                    d = Pow(10, int(mpmath.log(fl)/mpmath.log(10)))
+                    with local_workprec(53) as ctx:
+                        d = Pow(10, int(ctx.log(fl)/ctx.log(10)))
                     r = Rational(str(fl/d))*d
                 else:
                     r = S.Zero

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -54,9 +54,7 @@ from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent, debugf
 from sympy.utilities.iterables import (connected_components,
     generate_bell, uniq, iterable, is_sequence, subsets, flatten, sift)
-from sympy.utilities.decorator import conserve_mpmath_dps
-
-from mpmath import findroot
+from sympy.external.mpmath import conserve_mpmath_dps, findroot
 
 from sympy.solvers.polysys import solve_poly_system
 
@@ -3022,6 +3020,8 @@ def nsolve(*args, dict=False, **kwargs):
             "solver".'''))
 
     if 'prec' in kwargs:
+        # XXX: This should use local_workprec instead of changing the global
+        # precision.
         import mpmath
         mpmath.mp.dps = kwargs.pop('prec')
 

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -11,7 +11,7 @@ from mpmath import mnorm, mpf
 from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
 from sympy.testing.pytest import raises, XFAIL
-from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.external.mpmath import conserve_mpmath_dps
 
 @XFAIL
 def test_nsolve_fail():

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -4,7 +4,10 @@ from typing import TypeVar
 import sys
 import types
 import inspect
-from functools import wraps, update_wrapper
+from functools import wraps
+
+# Keep this import for backwards compatibility:
+from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
@@ -80,22 +83,6 @@ def xthreaded(func):
 
     """
     return threaded_factory(func, False)
-
-
-def conserve_mpmath_dps(func):
-    """After the function finishes, resets the value of ``mpmath.mp.dps`` to
-    the value it had before the function was run."""
-    import mpmath
-
-    def func_wrapper(*args, **kwargs):
-        dps = mpmath.mp.dps
-        try:
-            return func(*args, **kwargs)
-        finally:
-            mpmath.mp.dps = dps
-
-    func_wrapper = update_wrapper(func_wrapper, func)
-    return func_wrapper
 
 
 class no_attrs_in_subclass:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -55,7 +55,7 @@ from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.printing.numpy import NumPyPrinter
 from sympy.utilities.lambdify import implemented_function, lambdastr
 from sympy.testing.pytest import skip
-from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.external.mpmath import conserve_mpmath_dps
 from sympy.utilities.exceptions import ignore_warnings
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import uppergamma, lowergamma


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/mpmath/mpmath/issues/704#issuecomment-1732273893

#### Brief description of what is fixed or changed

Reduce references to mpmath internals throughout the codebase. Many places use some particular functions such as prec_to_dps so we import those in one place in a new `sympy.external.mpmath` module. If needed those functions could be copied from mpmath to avoid importing from libmp.

Also Poly.nroots is changed to use a local context rather than messing around with the global precision. Other places in the codebase that use mpmath directly even if not using the libmp stuff should often be changed to use local contexts so that is maybe something that could be standardised a bit better with perhaps helpers in the mpmath module.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Various parts of the codebase have been changed to avoid manipulating mpmath's global precision. This should improve thread-safety for SymPy's core functionality like evalf.
<!-- END RELEASE NOTES -->
