### PR TITLE
Fix `Mul.is_zero` returning `False` for unevaluated zero products

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1272,6 +1272,7 @@ Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
 Riccardo Gori <goriccardo@gmail.com>
 Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
 Rich LaSota <rjlasota@gmail.com>
+Richard Osborn <richardosborn@mac.com>
 Richard Otis <richard.otis@outlook.com> <ovolve@users.noreply.github.com>
 Richard Otis <richard.otis@outlook.com> <richard.otis@jpl.nasa.gov>
 Richard Rodenbusch <rrodenbusch@gmail.com> rrodenbusch <rrodenbusch@gmail.com>

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1668,7 +1668,7 @@ class Mul(Expr, AssocOp):
 
     def _eval_is_even(self):
         from sympy.simplify.radsimp import fraction
-        n, d = fraction(self)
+        n, d = fraction(self, exact=True)
         if n.is_Integer and n.is_even:
             # if minimal power of 2 in den vs num is not
             # negative then this is not an integer and

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2481,3 +2481,24 @@ def test_issue_22613():
 
 def test_issue_25176():
     assert sqrt(-4*3**(S(3)/4)*I/3) == 2*3**(S(7)/8)*sqrt(-I)/3
+
+
+def test_Mul_is_zero_with_zero_factor():
+    # When evaluate=False, 0 * unknown should return None (conservative)
+    # since the unknown could potentially be infinite
+    x = symbols('x')
+    assert Mul(0, x, evaluate=False).is_zero is None
+    assert Mul(x, 0, evaluate=False).is_zero is None
+    # Definite cases
+    assert Mul(0, 1, evaluate=False).is_zero is True
+    assert Mul(0, 0, evaluate=False).is_zero is True
+    assert Mul(0, oo, evaluate=False).is_zero is None
+    assert Mul(0, -oo, evaluate=False).is_zero is None
+    assert Mul(0, zoo, evaluate=False).is_zero is None
+    # Multiple args with unknowns
+    assert Mul(0, x, x, evaluate=False).is_zero is None
+    assert Mul(x, 0, x, evaluate=False).is_zero is None
+    assert Mul(x, x, 0, evaluate=False).is_zero is None
+    # No zero
+    assert Mul(x, x, evaluate=False).is_zero is None
+    assert Mul(1, x, evaluate=False).is_zero is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28006 

#### Brief description of what is fixed or changed

`__eval_is_even` was evaluating the multiplication with `fraction` causing incorrect behavior. Passing `exact=True` to `fraction` fixes this. Tests were added to verify the correct behavior.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `Mul.is_zero` returning `False` instead of `None` for products created with `evaluate=False`.
  <!-- END RELEASE NOTES -->
