### PR TITLE
Improve handling of multi-variable predicates in assumptions; add relational inference for inequalities

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -347,17 +347,18 @@ def _extract_all_facts(assump, exprs):
     for clause in assump.clauses:
         args = []
         for literal in clause:
-            if isinstance(literal.lit, AppliedPredicate) and len(literal.lit.arguments) == 1:
+            if isinstance(literal.lit, AppliedPredicate):
+              if len(literal.lit.arguments) == 1:
                 if literal.lit.arg in exprs:
                     # Add literal if it has matching in it
                     args.append(Literal(literal.lit.function, literal.is_Not))
                 else:
                     # If any of the literals doesn't have matching expr don't add the whole clause.
                     break
-            else:
-                # If any of the literals aren't unary predicate don't add the whole clause.
+              else:
+                args.append(Literal(literal.lit.function, literal.is_Not))
+            else: 
                 break
-
         else:
             if args:
                 facts.add(frozenset(args))

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -357,7 +357,7 @@ def _extract_all_facts(assump, exprs):
                     break
               else:
                 args.append(Literal(literal.lit.function, literal.is_Not))
-            else: 
+            else:
                 break
         else:
             if args:

--- a/sympy/assumptions/ask_generated.py
+++ b/sympy/assumptions/ask_generated.py
@@ -176,7 +176,7 @@ def get_all_known_number_facts():
 @cacheit
 def get_known_facts_dict():
     """
-    Logical relations between unary predicates as dictionary.
+    Logical relations between predicates as dictionary.
 
     Each key is a predicate, and item is two groups of predicates.
     First group contains the predicates which are implied by the key, and
@@ -184,6 +184,8 @@ def get_known_facts_dict():
 
     """
     return {
+        Q.gt: (set([Q.ge]),set([Q.le,Q.lt])),
+        Q.lt: (set([Q.le]),set([Q.ge,Q.gt])),
         Q.algebraic: (set([Q.algebraic, Q.commutative, Q.complex, Q.finite]),
         set([Q.infinite, Q.negative_infinite, Q.positive_infinite,
         Q.transcendental])),

--- a/sympy/assumptions/ask_generated.py
+++ b/sympy/assumptions/ask_generated.py
@@ -184,8 +184,6 @@ def get_known_facts_dict():
 
     """
     return {
-        Q.gt: (set([Q.ge]),set([Q.le,Q.lt])),
-        Q.lt: (set([Q.le]),set([Q.ge,Q.gt])),
         Q.algebraic: (set([Q.algebraic, Q.commutative, Q.complex, Q.finite]),
         set([Q.infinite, Q.negative_infinite, Q.positive_infinite,
         Q.transcendental])),

--- a/sympy/assumptions/facts.py
+++ b/sympy/assumptions/facts.py
@@ -31,7 +31,9 @@ def get_composite_predicates():
         Q.extended_nonzero: Q.negative_infinite | Q.negative | Q.positive | Q.positive_infinite,
         Q.extended_nonpositive: Q.negative_infinite | Q.negative | Q.zero,
         Q.extended_nonnegative: Q.zero | Q.positive | Q.positive_infinite,
-        Q.complex : Q.algebraic | Q.transcendental
+        Q.complex : Q.algebraic | Q.transcendental,
+        Q.ge : Q.gt | Q.eq,
+        Q.le : Q.lt | Q.eq
     }
 
 

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -159,6 +159,13 @@ def test_equality():
     assert ask(Q.eq(x,z), Q.eq(x,y) & Q.eq(y,z)) is True
 
 
+def test_inequality_implications():
+    # Basic implication checks
+    a,b,c = symbols('a b c')
+    assert ask(Q.ge(a, b), Q.gt(a, b)) is True
+    assert ask(Q.le(a, b), Q.lt(a, b)) is True
+
+
 @XFAIL
 def test_equality_failing():
     # Note that implementing the substitution property of equality


### PR DESCRIPTION

#### Brief description of what is fixed or changed
This PR extends the capabilities of the assumptions system by:
- Enabling extraction of multi-variable predicate facts (e.g., Q.gt(a, b)) in ```_extract_all_facts```, allowing better propagation of known conditions in multi-variable contexts.
- Adding implication rules for inequality predicates (Q.gt, Q.ge, Q.lt, Q.le) in ```get_known_facts_dict```, so logical inference between relational comparisons is now possible.
- Adding new tests to validate these implication relationships under ```test_inequality_implications```.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * ```ask(Q.ge(x),Q.gt(x))``` returns ```True``` instead of ```None```
  * ```ask(Q.le(x),Q.lt(x))``` returns ```True``` instead of ```None```
<!-- END RELEASE NOTES -->
