### PR TITLE
[GSoC] Improve documentation for EncodedCNF class

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -727,6 +727,7 @@ Hwayeon Kang <hwayeonniii@gmail.com> eh111eh <hwayeonniii@gmail.com>
 Håkon Kvernmoen <haakon.kvernmoen@gmail.com> hkve <haakon.kvernmoen@gmail.com>
 Ian Swire <oversizedpenguin@gmail.com>
 Idan Pazi <idan.kp@gmail.com>
+Ihor Olkhovatyi <98093195+NaturalStupidlty@users.noreply.github.com> Ihor Olkhovatyi <98093195+NaturalStupldity@users.noreply.github.com>
 Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>

--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -397,22 +397,29 @@ class EncodedCNF:
     EncodedCNF is used to represent logical expressions in CNF using integer-based
     encodings, where each symbol (variable) is assigned a unique positive integer,
     and its negation is represented by the corresponding negative integer.
+
     Attributes
     ==========
+
     data : list[set[int]]
         A list of clauses, where each clause is a set of integers representing
         literals. Positive integers correspond to variables, and negative integers
         represent their negations. For example, `{1, -2}` encodes "x1 OR NOT x2".
+
     encoding : dict
         A dictionary mapping SymPy symbols to unique positive integers, used for
         converting symbolic clauses to encoded integer form.
+
     symbols : list
         The list of symbols (variables) used in the CNF. The order of symbols
         determines their assigned encoding. For example, if `symbols = [b, a, c]`,
         then `encoding = {b: 1, a: 2, c: 3}`.
+
     Examples
     ========
+
     Note: Encoding order is not deterministic and depends on symbol discovery order.
+
     >>> from sympy.assumptions.cnf import CNF, EncodedCNF
     >>> from sympy.abc import a, b
     >>> from sympy.logic.boolalg import Or, Not

--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -479,7 +479,7 @@ class EncodedCNF:
 
     def encode(self, clause):
         return {self.encode_arg(arg) if not arg.lit == S.false else 0 for arg in clause}
-    
+
     def decode_literal(self, encoded_arg):
         symbol = self._symbols[abs(encoded_arg) - 1]
         literal = ~symbol if encoded_arg < 0 else symbol

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -20,7 +20,7 @@ from sympy.logic.boolalg import (
     anf_coeffs, ANFform, bool_minterm, bool_maxterm, bool_monomial,
     _check_pair, _convert_to_varsSOP, _convert_to_varsPOS, Exclusive,
     gateinputcount)
-from sympy.assumptions.cnf import CNF
+from sympy.assumptions.cnf import CNF, EncodedCNF
 
 from sympy.testing.pytest import raises, XFAIL, slow
 
@@ -1457,3 +1457,21 @@ def test_evaluate_false():
     expr = Equivalent(x, x, x, evaluate=False)
     assert isinstance(expr, Equivalent)
     assert expr.args == (x, x, x)
+
+
+def test_encoded_cnf():
+    encoded_cnf = EncodedCNF()
+    prop = Or(Or(a, Not(b)), Or(Not(c), b))
+    cnf = CNF.from_prop(prop)
+    encoded_cnf.add_from_cnf(cnf)
+    expected_literals = list(encoded_cnf.encoding.keys())
+
+    # Test decode_literal()
+    for i in range(len(expected_literals)):
+        decoded_literal = encoded_cnf.decode_literal(i + 1)
+        assert decoded_literal == expected_literals[i], f"Expected: {expected_literals[i]}, Decoded: {decoded_literal}"
+
+    # Test decode()
+    decoded_prop = encoded_cnf.decode()
+    original_prop = Or(Or(a, Not(b)), Or(Not(c), b))
+    assert decoded_prop == original_prop, "Decoded prop is not equal to the original prop"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR improves the documentation of the ```EncodedCNF``` class in ```sympy.assumptions.cnf``` to make it more informative, technically accurate, and user-friendly.

**Changes made:**
- Clarified the purpose of ```EncodedCNF``` and how it represents CNF expressions using integer encodings.
- Explained the meaning of positive and negative integers in the data attribute.
- Reworded the description of the symbols and encoding attributes.

This is a documentation-only change and does not affect functionality.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
