### PR TITLE
Use a better error message and exception type for Q.ge(x)

### DIFF
--- a/sympy/assumptions/relation/binrel.py
+++ b/sympy/assumptions/relation/binrel.py
@@ -79,7 +79,7 @@ class BinaryRelation(Predicate):
 
     def __call__(self, *args):
         if not len(args) == 2:
-            raise ValueError(f"Binary relation takes two arguments, but got {len(args)}.")
+            raise TypeError(f"Q.{self.name} takes two arguments, but got {len(args)}.")
         return AppliedBinaryRelation(self, *args)
 
     @property


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
