### PR TITLE
Update util.py line 111 so convert_to function returns proper types

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -527,6 +527,7 @@ David Roberts <dvdr18@gmail.com> David Roberts (dvdr18 [at] gmail [dot] com) <de
 David T <derDavidT@users.noreply.github.com>
 Davide Sandonà <sandona.davide@gmail.com>
 Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
+ddcvb1 <22andersenmb@gmail.com>
 Dean Price <dean1357price1357@gmail.com>
 Demian Wassermann <demian@bwh.harvard.edu>
 Denis Ivanenko <ivanenko@ucu.edu.ua> Jack <ivanenko@ucu.edu.ua>

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -108,7 +108,10 @@ def convert_to(expr, target_units, unit_system="SI"):
     elif isinstance(expr, Pow) and isinstance(expr.base, Add):
         return handle_Adds(expr.base) ** expr.exp
 
-    expr = sympify(expr)
+    if isinstance(expr, int):
+        expr = sympify(expr)
+    else:
+        expr = expr.simplify()
     target_units = sympify(target_units)
 
     if isinstance(expr, Function):


### PR DESCRIPTION
Update util.py line 111 so convert_to function returns proper types
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28077 

#### Brief description of what is fixed or changed
convert_to function would often return the wrong type, fixed formatting from expr = sympify(expr) to expr = expr.sympify() for non integer data types in order to return proper data type.

#### Other comments
NONE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
