### PR TITLE
Fix `nc_simplify` adjoint bug

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1824,13 +1824,16 @@ def nc_simplify(expr, deep=True):
                             not isinstance(args[i].args[0], _Symbol)):
                 subterm = args[i].args[0].args
                 l = len(subterm)
-                if args[i-l:i] == subterm:
+                # Only apply optimization if power base matches subterm pattern
+                if (args[i-l:i] == subterm and
+                    args[i].args[0] == _Mul(*subterm)):
                     # e.g. a*b in a*b*(a*b)**2 is not repeated
                     # in args (= [a, b, (a*b)**2]) but it
                     # can be matched here
                     p += 1
                     start -= l
-                if args[i+1:i+1+l] == subterm:
+                if (args[i+1:i+1+l] == subterm and
+                    args[i].args[0] == _Mul(*subterm)):
                     # e.g. a*b in (a*b)**2*a*b
                     p += 1
                     end += l

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -869,6 +869,9 @@ def test_nc_simplify():
     _check(a*b*(c*d)**2, a*b*(c*d)**2)
     expr = b**-1*(a**-1*b**-1 - a**-1*c*b**-1)**-1*a**-1
     assert nc_simplify(expr) == (1-c)**-1
+    # test that powers of adjoint are correctly handled
+    assert nc_simplify(a*a.adjoint()**2*a) == a*a.adjoint()**2*a
+    assert nc_simplify(a.adjoint()*a*a.adjoint()) == a.adjoint()*a*a.adjoint()
     # commutative expressions should be returned without an error
     assert nc_simplify(2*x**2) == 2*x**2
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28001

#### Brief description of what is fixed or changed

Added a check in `nc_simplify` to ensure the power base is a mul expression to avoid treating `adjoint(x)` as `x`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Fixed nc_simplify() incorrectly simplifying expressions involving powers of adjoint().
<!-- END RELEASE NOTES -->
