### PR TITLE
Fixed failed coercion of rational into finite field.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -665,6 +665,7 @@ Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>
 Gina <Dr-G@users.noreply.github.com>
+Giuseppe De Laurentis <g.dl@hotmail.it> GDeLaurentis <g.dl@hotmail.it>
 Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -268,7 +268,7 @@ class FiniteField(Field, SimpleDomain):
         if a.is_Integer or int_valued(a):
             return self.dtype(self.dom.dtype(int(a)))
         elif a.is_Rational:
-            return self.dtype(self.dom.dtype(int(a.numerator))) / self.dtype(self.dom.dtype(int(a.denominator)))
+            return self.dtype(self.dom.dtype(a.numerator)) / self.dtype(self.dom.dtype(a.denominator))
         raise CoercionFailed("expected an integer, got %s" % a)
 
     def to_int(self, a):

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -267,6 +267,8 @@ class FiniteField(Field, SimpleDomain):
         """Convert SymPy's Integer to SymPy's ``Integer``. """
         if a.is_Integer or int_valued(a):
             return self.dtype(self.dom.dtype(int(a)))
+        elif a.is_Rational:
+            return self.dtype(self.dom.dtype(int(a.numerator))) / self.dtype(self.dom.dtype(int(a.denominator)))
         raise CoercionFailed("expected an integer, got %s" % a)
 
     def to_int(self, a):


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #20327 

#### Brief description of what is fixed or changed
Casting from rational numbers ($\mathbb{Q}$) to finite fields ($\mathbb{F}_p$) is now supported, except in cases where the denominator is divisible by the prime. In those cases, a `NotInvertible: zero divisor` exception is raised.

#### Other comments
An alternative would be to pre-check whether the denominator is divisible by the prime and raise a `CoercionFailed` error. However, that would follow a look-before-you-leap (LBYL) approach, which is less Pythonic than the current easier-to-ask-for-forgiveness (EAFP) pattern.

Another option — and arguably a better one —  would be to raise `ZeroDivisionError` from the standard library instead of SymPy's `NotInvertible` exception, though I'm not sure how well this would integrate with the rest of SymPy's exception handling conventions.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed coercion from rational numbers to finite fields.
<!-- END RELEASE NOTES -->
