### PR TITLE
[GSoC]Changed the point_cflexure method 

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1315,8 +1315,6 @@ class Beam:
             return []
 
         for i, point in enumerate(roots):
-            if point in jumps:
-                continue
             if i == 0:
                 left_mid = (0 + point) / 2
                 right_mid = (point + roots[i + 1]) / 2

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1242,7 +1242,8 @@ class Beam:
         # Filter out singularity terms with order < 0
         terms = []
         for term in bm.args:
-            sfs = [atom for atom in term.atoms(SingularityFunction)]
+            sfs = list(term.atoms(SingularityFunction))
+
             if not sfs:
                 terms.append(term)
             else:

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1272,36 +1272,18 @@ class Beam:
         # Solve for roots in each interval
         roots = set()
         for interval in intervals:
+            # adding singularity points as default roots for temporary
+            roots.add(interval.start)
+            roots.add(interval.end)
             expr = non_singular_bending_moment
-            for sf in expr.atoms(SingularityFunction):
-                loc, order = sf.args[1], sf.args[2]
-                if interval.end <= loc:
-                    expr = expr.subs(sf, 0)
-                elif interval.start > loc:
-                    expr = expr.subs(sf, (x - loc)**order)
-                else:
-                    if not (loc == interval.start or loc == interval.end):
-                        continue
 
             sol = solveset(expr, x, domain=interval)
             if isinstance(sol, FiniteSet):
                 for r in sol:
                     roots.add(r)
-            elif isinstance(sol, Union):
-                for part in sol.args:
-                    if isinstance(part, FiniteSet):
-                        for r in part:
-                            roots.add(r)
-                    elif isinstance(part, Interval):
-                        roots.add(part.start)
-                        roots.add(part.end)
-
             elif isinstance(sol, Interval):
                 roots.add(sol.start)
                 roots.add(sol.end)
-
-        for loc, _ in self.bc_slope:
-            roots.add(loc)
 
         roots = sorted(roots)
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1283,7 +1283,6 @@ class Beam:
                     if not (loc == interval.start or loc == interval.end):
                         continue
 
-            expr = expr.simplify()
             sol = solveset(expr, x, domain=interval)
             if isinstance(sol, FiniteSet):
                 for r in sol:
@@ -1301,11 +1300,8 @@ class Beam:
                 roots.add(sol.start)
                 roots.add(sol.end)
 
-        # Add boundary condition locations for jumps
-        jumps = set()
         for loc, _ in self.bc_slope:
             roots.add(loc)
-            jumps.add(loc)
 
         roots = sorted(roots)
 
@@ -1325,8 +1321,8 @@ class Beam:
                 left_mid = (roots[i - 1] + point) / 2
                 right_mid = (point + roots[i + 1]) / 2
 
-            left_val = bm.subs(x, left_mid).evalf()
-            right_val = bm.subs(x, right_mid).evalf()
+            left_val = bm.subs(x, left_mid)
+            right_val = bm.subs(x, right_mid)
 
             product=left_val*right_val
             if isinstance(product,Expr):

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -20,7 +20,7 @@ from sympy.series import limit
 from sympy.plotting import plot, PlotGrid
 from sympy.geometry.entity import GeometryEntity
 from sympy.external import import_module
-from sympy.sets.sets import Interval, FiniteSet, Union
+from sympy.sets.sets import Interval, FiniteSet
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import iterable

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -623,7 +623,7 @@ def test_point_cflexure():
     b.apply_load(-10, 6, -1)
     b.apply_load(7,3,-1)
     b.solve_for_reaction_loads(r0, m0, r4,m4, r7,m7)
-    assert b.point_cflexure() == [Rational(13,16),2,Rational(482,129),5,Rational(83,13)]
+    assert b.point_cflexure() == [Rational(13,16),2,Rational(482,129),4,5,Rational(83,13)]
 
 
 def test_remove_load():

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -428,6 +428,7 @@ def test_composite_beam():
     c=Beam(6, E, I)
     with raises(ValueError, match="Invalid joining method. Choose from 'fixed' or 'hinge'."):
         b.join(c, "hige")
+
 def test_point_cflexure():
     #single contraflexure
     E = Symbol('E')


### PR DESCRIPTION
## Enhanced the `point_cflexure` method

Fixes  #26634

### Brief description of what is fixed or changed
The previous `point_cflexure` implementation simply returned all algebraic roots of the bending-moment expression and did not verify that the moment actually changes sign at those points. It also failed (raising `NotImplementedError`) when an entire span of the beam or a region  had M(x)=0

### The new version
- Uses `solveset` on each piecewise segment to find isolated roots or intervals.  
- Skips flat-zero regions before solving.

### Other comments
None.

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics

  * Fixed incorrect point_cflexure() that can now handle zero or constant over regions and strictly checks the sign change across the points
<!-- END RELEASE NOTES -->
