### PR TITLE
Refactored conditions for checking 'realness' 

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -339,14 +339,14 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
+            if expr.exp.is_Rational and \
+                    ask(Q.even(expr.exp.q), assumptions):
+                return ask(Q.positive(expr.base), assumptions)
             if ask(Q.zero(expr.base), assumptions) is not False:
                 if ask(Q.positive(expr.exp), assumptions):
                     return True
                 return
-            if expr.exp.is_Rational and \
-                    ask(Q.even(expr.exp.q), assumptions):
-                return ask(Q.positive(expr.base), assumptions)
-            elif ask(Q.integer(expr.exp), assumptions):
+            if ask(Q.integer(expr.exp), assumptions):
                 return True
             elif ask(Q.positive(expr.base), assumptions):
                 return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -343,7 +343,7 @@ def _(expr, assumptions):
                     ask(Q.even(expr.exp.q), assumptions):
                 return ask(Q.positive(expr.base), assumptions)
             if ask(Q.zero(expr.base), assumptions) is not False:
-                if ask(Q.positive(expr.exp), assumptions):
+                if ask(Q.nonnegative(expr.exp), assumptions) and ask(Q.nonnegative(expr.base), assumptions):
                     return True
                 return
             if ask(Q.integer(expr.exp), assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -341,15 +341,18 @@ def _(expr, assumptions):
         if ask(Q.real(expr.exp), assumptions):
             if expr.exp.is_Rational and \
                     ask(Q.even(expr.exp.q), assumptions):
-                return ask(Q.positive(expr.base), assumptions)
-            if ask(Q.zero(expr.base), assumptions) is not False:
-                if ask(Q.nonnegative(expr.exp), assumptions) and ask(Q.nonnegative(expr.base), assumptions):
-                    return True
-                return
-            if ask(Q.integer(expr.exp), assumptions):
-                return True
+                return ask(Q.nonnegative(expr.base), assumptions)
             elif ask(Q.positive(expr.base), assumptions):
                 return True
+            is_base_zero = ask(Q.zero(expr.base), assumptions)
+            if is_base_zero:
+                return ask(Q.nonnegative(expr.exp), assumptions)
+            elif is_base_zero is None:
+                if ask(Q.nonnegative(expr.exp) & Q.integer(expr.exp), assumptions):
+                    return True
+                return
+            elif ask(Q.integer(expr.exp), assumptions):
+                return fuzzy_not(is_base_zero)
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2052,6 +2052,9 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.zero(x) & Q.real(y)) is None
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
+    # https://github.com/sympy/sympy/issues/28142
+    assert ask(Q.real(sqrt(x)), Q.real(x)) is None
+
 
 @_both_exp_pow
 def test_real_functions():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2053,7 +2053,21 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
     # https://github.com/sympy/sympy/issues/28142
+    from sympy.core import Mul, Pow
     assert ask(Q.real(sqrt(x)), Q.real(x)) is None
+    assert ask(Q.real(sqrt(x)), Q.real(x)) is None
+    one_half = Mul(S.Half, 1, evaluate=False)
+    assert ask(Q.real(x ** one_half), Q.real(x)) is None
+    assert ask(Q.real(Pow(x, 1, evaluate=False)), Q.zero(x)) is True
+    assert ask(Q.real(x**x), Q.zero(x)) is True
+    assert ask(Q.real(Pow(x, -1, evaluate=False)), Q.zero(x)) is False
+    zero = symbols("zero", zero=True)
+    ask(Q.real(Pow(zero, S.Half, evaluate=False)))
+    ask(Q.real(Pow(zero, Rational(3, 2), evaluate=False)))
+    two_thirds = Rational(2, 3)
+    assert ask(Q.real(x**two_thirds), Q.zero(x)) is True
+    assert ask(Q.real(x**pi), Q.zero(x)) is True
+    assert ask(Q.real(x**sqrt(2)), Q.zero(x)) is True
 
 
 @_both_exp_pow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28142
Fixes #28151

#### Brief description of what is fixed or changed
Refactored conditions causing the bug when checking for realness of sqrt(x) when x is real.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * ```ask(Q.real(sqrt(x)), Q.real(x))``` returns ```None``` instead of ```True```.

<!-- END RELEASE NOTES -->
