### PR TITLE
Fix exp and e**x is_zero and is_extended_positive for maybe -inf 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -849,6 +849,7 @@ Julien Palard <julien@palard.fr>
 Julien Rioux <julien.rioux@gmail.com>
 Julio Idichekop Filho <idichekop@yahoo.com.br>
 Jun Lin <junlin0604@gmail.com> wate123 <junlin0604@gmail.com>
+Juniper Tyree <juniper.tyree@helsinki.fi> Juniper Tyree <50025784+juntyr@users.noreply.github.com>
 Jurjen N.E. Bos <jnebos@gmail.com> <jnebos@gmail.com>
 Jurjen N.E. Bos <jnebos@gmail.com> Jurjen N.E. Bos <devnull@localhost>
 Justin Blythe <jblythe29@gmail.com>

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -456,7 +456,11 @@ class Pow(Expr):
             elif self.exp.is_extended_nonpositive:
                 return False
         elif self.base == S.Exp1:
-            return self.exp is S.NegativeInfinity
+            if self.exp is S.NegativeInfinity:
+                return True
+            if self.exp.is_extended_real:
+                if self.exp.is_real or self.exp.is_extended_nonnegative:
+                    return False
         elif self.base.is_zero is False:
             if self.base.is_finite and self.exp.is_finite:
                 return False

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -117,7 +117,11 @@ class ExpBase(DefinedFunction):
             return s.is_rational
 
     def _eval_is_zero(self):
-        return self.exp is S.NegativeInfinity
+        if self.exp is S.NegativeInfinity:
+            return True
+        if self.exp.is_extended_real:
+            if self.exp.is_real or self.exp.is_extended_nonnegative:
+                return False
 
     def _eval_power(self, other):
         """exp(arg)**e -> exp(arg*e) if assumptions allow it.

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -473,7 +473,8 @@ class exp(ExpBase, metaclass=ExpMeta):
 
     def _eval_is_extended_positive(self):
         if self.exp.is_extended_real:
-            return self.args[0] is not S.NegativeInfinity
+            if self.args[0].is_real or self.args[0].is_extended_nonnegative:
+                return True
         elif self.exp.is_imaginary:
             arg2 = -I * self.args[0] / pi
             return arg2.is_even

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -428,6 +428,31 @@ def test_exp_assumptions():
 
 
 @_both_exp_pow
+def test_exp_sign_assumptions():
+    r = Symbol('r', real=True)
+    er = Symbol('er', extended_real=True)
+    enn = Symbol('enn', extended_nonnegative=True)
+
+    # https://github.com/sympy/sympy/issues/28141
+    assert exp(x).is_positive is None
+    assert exp(r).is_positive is True
+    assert exp(er).is_positive is None
+    assert exp(enn).is_positive is None
+    assert exp(x).is_extended_positive is None
+    assert exp(r).is_extended_positive is True
+    assert exp(er).is_extended_positive is None
+    assert exp(enn).is_extended_positive is True
+    assert exp(x).is_zero is None
+    assert exp(r).is_zero is False
+    assert exp(er).is_zero is None
+    assert exp(enn).is_zero is False
+    assert sign(exp(x)) == sign(exp(x), evaluate=False)
+    assert sign(exp(r)) == 1
+    assert sign(exp(er)) == sign(exp(er), evaluate=False)
+    assert sign(exp(enn)) == 1
+
+
+@_both_exp_pow
 def test_exp_AccumBounds():
     assert exp(AccumBounds(1, 2)) == AccumBounds(E, E**2)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28141

CC @oscarbenjamin


#### Brief description of what is fixed or changed

For an extended real expression, I.e. one that can be -inf, exp previously returned is_extended_positive = True if the expression was not literally -inf.

This PR fixes the logic to ensure that expressions where -inf is possible return is_extended_positive = None.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug with assumptions of the exponential function. exp(x) where x may be -inf will now correctly assume that exp(x) may be zero.
<!-- END RELEASE NOTES -->
