### PR TITLE
Fix limit evaluation for 2**x and E**x at -oo

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -781,8 +781,8 @@ Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
 Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
-Jatin Gaur <jatin22101@iiitnr.edu.in> <jatin22101@iiitnr.edu.in>
-Jatin Gaur <jatingaur18@users.noreply.github.com> <134034110+jatingaur18@users.noreply.github.com>
+Jatin Gaur <jatingaurchess@gmail.com> 
+Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -781,7 +781,7 @@ Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
 Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
-Jatin Gaur <jatingaur18@users.noreply.github.com> <jatin22101@iiitnr.edu.in>
+Jatin Gaur <jatin22101@iiitnr.edu.in> <jatin22101@iiitnr.edu.in>
 Jatin Gaur <jatingaur18@users.noreply.github.com> <134034110+jatingaur18@users.noreply.github.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -781,7 +781,7 @@ Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
 Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
-Jatin Gaur <jatingaurchess@gmail.com> 
+Jatin Gaur <jatingaurchess@gmail.com> <134034110+jatingaur18@users.noreply.github.com>
 Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -781,6 +781,8 @@ Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
 Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
+Jatin Gaur <jatingaur18@users.noreply.github.com> <jatin22101@iiitnr.edu.in>
+Jatin Gaur <jatingaur18@users.noreply.github.com> <134034110+jatingaur18@users.noreply.github.com>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -177,8 +177,7 @@ class Limit(Expr):
         return isyms
 
 
-    def pow_heuristics(self, e):
-        _, z, z0, _ = self.args
+    def pow_heuristics(self, e, z, z0):
         b1, e1 = e.base, e.exp
         if not b1.has(z):
             res = limit(e1*log(b1), z, z0)
@@ -339,7 +338,7 @@ class Limit(Expr):
             from sympy.simplify.powsimp import powsimp
             e = powsimp(e)
             if e.is_Pow:
-                r = self.pow_heuristics(e)
+                r = self.pow_heuristics(e, z, z0)
                 if r is not None:
                     return r
             try:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1318,6 +1318,7 @@ def test_issue_24276():
     assert fx.rewrite(sin).limit(x, oo) == 2
     assert fx.rewrite(sin).simplify().limit(x, oo) == 2
 
+
 def test_issue_25230():
     a = Symbol('a', real = True)
     b = Symbol('b', positive = True)
@@ -1434,6 +1435,7 @@ def test_issue_22982_15323():
 
 def test_issue_26991():
     assert limit(x/((x - 6)*sinh(tanh(0.03*x)) + tanh(x) - 0.5), x, oo) == 1/sinh(1)
+
 
 def test_issue_27278():
     expr = (1/(x*log((x + 3)/x)))**x*((x + 1)*log((x + 4)/(x + 1)))**(x + 1)/3

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1438,3 +1438,11 @@ def test_issue_26991():
 def test_issue_27278():
     expr = (1/(x*log((x + 3)/x)))**x*((x + 1)*log((x + 4)/(x + 1)))**(x + 1)/3
     assert limit(expr, x, oo) == 1
+
+def test_issue_28130():
+    #https://github.com/sympy/sympy/issues/28130
+    x = symbols('x')
+    assert limit(2**x, x, -oo) == 0
+    assert limit(3**x, x, -oo) == 0
+    assert limit(E**x, x, -oo) == 0
+    assert limit((0.3)**x, x, -oo) == oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1439,6 +1439,7 @@ def test_issue_27278():
     expr = (1/(x*log((x + 3)/x)))**x*((x + 1)*log((x + 4)/(x + 1)))**(x + 1)/3
     assert limit(expr, x, oo) == 1
 
+
 def test_issue_28130():
     #https://github.com/sympy/sympy/issues/28130
     x = symbols('x')


### PR DESCRIPTION
Fix incorrect limit for exponential functions with numeric base

#### References to other Issues or PRs

Fixes #28130

#### Brief description of what is fixed or changed

This PR fixes a bug in the evaluation of limits for exponential expressions like `2**x` as `x → -oo`, which previously returned `oo` instead of the correct result `0`.

The root cause was that the `pow_heuristics` method retrieved `z0` from `self.args`, which does not reflect the transformed value of `z0` (e.g., `-oo` → `oo`) inside `doit()`. This led to incorrect behavior for expressions with numeric (non-`E`) bases.

The fix involves modifying `doit()` to pass the updated `z` and `z0` explicitly to `pow_heuristics()`:

```python
# In Limit.doit():
if e.is_Pow:
    r = self.pow_heuristics(e, z, z0)
    if r is not None:
        return r
```

```python
# pow_heuristics updated to:
def pow_heuristics(self, e, z, z0):
    b1, e1 = e.base, e.exp
    if not b1.has(z):
        res = limit(e1 * log(b1), z, z0)
        return exp(res)
```

#### Other comments

After this change, both symbolic and numeric exponential limits now behave consistently:

```python
>>> from sympy import E, exp, simplify, limit, symbols, oo, S, log, Dummy
>>> x = symbols('x')
>>> limit(2**x, x, -oo)
0
>>> limit(E**x, x, -oo)
0
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* series

  * Fixed incorrect result for `limit(2**x, x, -oo)` which previously returned `oo` instead of `0`.

<!-- END RELEASE NOTES -->

