### PR TITLE
Fix: ask(Q.real(sqrt(x)), Q.real(x)) should return None

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -339,15 +339,12 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
-            if ask(Q.zero(expr.base), assumptions) is not False:
-                if ask(Q.positive(expr.exp), assumptions):
-                    return True
-                return
             if expr.exp.is_Rational and \
                     ask(Q.even(expr.exp.q), assumptions):
                 return ask(Q.positive(expr.base), assumptions)
             elif ask(Q.integer(expr.exp), assumptions):
-                return True
+                is_not_real = ask_all(Q.zero(expr.base), Q.negative(expr.exp), assumptions=assumptions)
+                return fuzzy_not(is_not_real)
             elif ask(Q.positive(expr.base), assumptions):
                 return True
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2052,6 +2052,16 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.zero(x) & Q.real(y)) is None
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
+    # https://github.com/sympy/sympy/issues/28142
+    from sympy.core import Mul, Pow
+    assert ask(Q.real(sqrt(x)), Q.real(x)) is None
+    one_half = Mul((S.One / 2), 1, evaluate=False)
+    assert ask(Q.real(x ** one_half), Q.real(x)) is None
+    zero = symbols("zero", zero=True)
+    assert ask(Q.real(Pow(zero, 1, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, zero, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, -1, evaluate=False))) is False
+
 
 @_both_exp_pow
 def test_real_functions():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2055,16 +2055,16 @@ def test_real_pow():
     # https://github.com/sympy/sympy/issues/28142
     from sympy.core import Mul, Pow
     assert ask(Q.real(sqrt(x)), Q.real(x)) is None
-    one_half = Mul((S.One / 2), 1, evaluate=False)
+    one_half = Mul(S.Half, 1, evaluate=False)
     assert ask(Q.real(x ** one_half), Q.real(x)) is None
-    zero = symbols("zero", zero=True)
-    assert ask(Q.real(Pow(zero, 1, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, zero, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, -1, evaluate=False))) is False
+    assert ask(Q.real(Pow(x, 1, evaluate=False)), Q.zero(x)) is True
+    assert ask(Q.real(x**x), Q.zero(x)) is True
+    assert ask(Q.real(Pow(x, -1, evaluate=False)), Q.zero(x)) is False
     two_thirds = Rational(2, 3)
-    assert ask(Q.real(Pow(zero, two_thirds, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, pi, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, sqrt(2), evaluate=False))) is True
+    assert ask(Q.real(x**two_thirds), Q.zero(x)) is True
+    assert ask(Q.real(x**pi), Q.zero(x)) is True
+    assert ask(Q.real(x**sqrt(2)), Q.zero(x)) is True
+
 
 @_both_exp_pow
 def test_real_functions():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2061,7 +2061,10 @@ def test_real_pow():
     assert ask(Q.real(Pow(zero, 1, evaluate=False))) is True
     assert ask(Q.real(Pow(zero, zero, evaluate=False))) is True
     assert ask(Q.real(Pow(zero, -1, evaluate=False))) is False
-
+    two_thirds = Rational(2, 3)
+    assert ask(Q.real(Pow(zero, two_thirds, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, pi, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, sqrt(2), evaluate=False))) is True
 
 @_both_exp_pow
 def test_real_functions():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/28142


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  *  Make `ask(Q.real(sqrt(x)), Q.real(x))` give None instead of True

<!-- END RELEASE NOTES -->
