### PR TITLE
Fix Poly from_rep using Flint fmpz_mod_poly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -768,6 +768,7 @@ James Titus <titusjames299@gmail.com> <jamestitus299@gmail.com>
 James Titus <titusjames299@gmail.com> <titusjames299@gmail.com>
 James Whitehead <whiteheadj@gmail.com> jcwhitehead <whiteheadj@gmail.com>
 Jan Jancar <johny@neuromancer.sk> J08nY <johny@neuromancer.sk>
+Jan Jancar <johny@neuromancer.sk> Ján Jančár <J08nY@users.noreply.github.com>
 Jan Kruse <janckruse@t-online.de>
 Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com> Jan-Philipp Hoffmann <90828785+jan-philipp-hoffmann@users.noreply.github.com>
 Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1764,7 +1764,7 @@ class DUP_Flint(DMP):
             return flint.fmpz_poly
         elif dom.is_QQ:
             return flint.fmpq_poly
-        elif dom.is_FF:
+        elif dom.is_FF and dom._is_flint:
             return dom._poly_ctx
         else:
             raise RuntimeError("Domain %s is not supported with flint" % dom)
@@ -1773,19 +1773,7 @@ class DUP_Flint(DMP):
     def from_rep(cls, rep, dom):
         """Create a DMP from the given representation. """
 
-        if dom.is_ZZ:
-            assert isinstance(rep, flint.fmpz_poly)
-            _cls = flint.fmpz_poly
-        elif dom.is_QQ:
-            assert isinstance(rep, flint.fmpq_poly)
-            _cls = flint.fmpq_poly
-        elif dom.is_FF:
-            assert isinstance(rep, (flint.nmod_poly, flint.fmpz_mod_poly))
-            c = dom.characteristic()
-            __cls = type(rep)
-            _cls = lambda e: __cls(e, c)
-        else:
-            raise RuntimeError("Domain %s is not supported with flint" % dom)
+        _cls = cls._get_flint_poly_cls(dom)
 
         obj = object.__new__(cls)
         obj.dom = dom

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -4068,3 +4068,17 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_issue_28156():
+    from sympy.core.symbol import symbols
+
+    ax = symbols("a")
+    field = FF(340282366762482138434845932244680310783)
+    rhs = Poly(
+        ax**3 + field(3) * ax + field(5),
+        ax,
+        domain=field,
+    )
+    roots = rhs.ground_roots()
+    assert roots


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28156.


#### Brief description of what is fixed or changed
This fixes the init call for `fmpz_mod_poly` in the `from_rep` method. It requires not just
the field characteristic but a `fmpz_mod_poly_ctx` object wrapping it.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a Flint TypeError when working with fmpz_mod_poly rep.
<!-- END RELEASE NOTES -->
