### PR TITLE
Backport gh-28157 to 1.14

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -766,6 +766,7 @@ James Titus <titusjames299@gmail.com> <jamestitus299@gmail.com>
 James Titus <titusjames299@gmail.com> <titusjames299@gmail.com>
 James Whitehead <whiteheadj@gmail.com> jcwhitehead <whiteheadj@gmail.com>
 Jan Jancar <johny@neuromancer.sk> J08nY <johny@neuromancer.sk>
+Jan Jancar <johny@neuromancer.sk> Ján Jančár <J08nY@users.noreply.github.com>
 Jan Kruse <janckruse@t-online.de>
 Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com> Jan-Philipp Hoffmann <90828785+jan-philipp-hoffmann@users.noreply.github.com>
 Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import MutableSet
-from typing import Any, Callable
 
 from .basic import Basic
 from .sorting import default_sort_key, ordered
@@ -331,7 +330,8 @@ class Dict(Basic):
             return self == Dict(other)
         return super().__eq__(other)
 
-    __hash__ : Callable[[Basic], Any] = Basic.__hash__
+    def __hash__(self):
+        return Basic.__hash__(self)
 
 # this handles dict, defaultdict, OrderedDict
 _sympy_converter[dict] = lambda d: Dict(*d.items())

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -16,7 +16,6 @@ from mpmath.libmp import (from_int, from_man_exp, from_rational, fhalf,
                           mpf_atan, mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt,
                           mpf_mul, mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin,
                           mpf_sqrt, normalize, round_nearest, to_int, to_str, mpf_tan)
-from mpmath.libmp import bitcount as mpmath_bitcount
 from mpmath.libmp.backend import MPZ
 from mpmath.libmp.libmpc import _infs_nan
 from mpmath.libmp.libmpf import dps_to_prec, prec_to_dps
@@ -50,7 +49,7 @@ rnd = round_nearest
 def bitcount(n):
     """Return smallest integer, b, such that |n|/2**b < 1.
     """
-    return mpmath_bitcount(abs(int(n)))
+    return MPZ(abs(int(n))).bit_length()
 
 # Used in a few places as placeholder values to denote exponents and
 # precision levels, e.g. of exact numbers. Must be careful to avoid

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -553,7 +553,7 @@ def add_terms(terms: list, prec: int, target_prec: int) -> \
             # first: quick test
             if ((delta > working_prec) and
                 ((not sum_man) or
-                 delta - MPZ(sum_man).bit_length() > working_prec)):
+                 delta - sum_man.bit_length() > working_prec)):
                 sum_man = man
                 sum_exp = exp
             else:
@@ -575,7 +575,7 @@ def add_terms(terms: list, prec: int, target_prec: int) -> \
         sum_man = -sum_man
     else:
         sum_sign = 0
-    sum_bc = MPZ(sum_man).bit_length()
+    sum_bc = sum_man.bit_length()
     sum_accuracy = sum_exp + sum_bc - absolute_error
     r = normalize(sum_sign, sum_man, sum_exp, sum_bc, target_prec,
         rnd), sum_accuracy
@@ -715,7 +715,7 @@ def evalf_mul(v: 'Mul', prec: int, options: OPT_DICT) -> TMP_RES:
         acc = min(acc, w_acc)
     sign = (direction & 2) >> 1
     if not complex_factors:
-        v = normalize(sign, man, exp, MPZ(man).bit_length(), prec, rnd)
+        v = normalize(sign, man, exp, man.bit_length(), prec, rnd)
         # multiply by i
         if direction & 1:
             return None, v, None, acc
@@ -725,7 +725,7 @@ def evalf_mul(v: 'Mul', prec: int, options: OPT_DICT) -> TMP_RES:
         # initialize with the first term
         if (man, exp, bc) != start:
             # there was a real part; give it an imaginary part
-            re, im = (sign, man, exp, MPZ(man).bit_length()), (0, MPZ(0), 0, 0)
+            re, im = (sign, man, exp, man.bit_length()), (0, MPZ(0), 0, 0)
             i0 = 0
         else:
             # there is no real part to start (other than the starting 1)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -83,10 +83,9 @@ MPF_TUP = tuple[int, int, int, int]  # mpf value tuple
 Explanation
 ===========
 
->>> from sympy.core.evalf import bitcount
 >>> sign, man, exp, bc = 0, 5, 1, 3
 >>> n = [1, -1][sign]*man*2**exp
->>> n, bitcount(man)
+>>> n, man.bit_length()
 (10, 3)
 
 A temporary result is a tuple (re, im, re_acc, im_acc) where
@@ -133,9 +132,9 @@ def fastlog(x: MPF_TUP | None) -> int | Any:
     ========
 
     >>> from sympy import log
-    >>> from sympy.core.evalf import fastlog, bitcount
+    >>> from sympy.core.evalf import fastlog
     >>> s, m, e = 0, 5, 1
-    >>> bc = bitcount(m)
+    >>> bc = m.bit_length()
     >>> n = [1, -1][s]*m*2**e
     >>> n, (log(n)/log(2)).evalf(2), fastlog((s, m, e, bc))
     (10, 3.3, 4)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -627,9 +627,9 @@ def evalf_add(v: 'Add', prec: int, options: OPT_DICT) -> TMP_RES:
 
     options['maxprec'] = oldmaxprec
     if iszero(re, scaled=True):
-        re = scaled_zero(re)
+        re = scaled_zero(re) # type: ignore
     if iszero(im, scaled=True):
-        im = scaled_zero(im)
+        im = scaled_zero(im) # type: ignore
     return re, im, re_acc, im_acc
 
 
@@ -916,7 +916,7 @@ def evalf_trig(v: Expr, prec: int, options: OPT_DICT) -> TMP_RES:
     if im:
         if 'subs' in options:
             v = v.subs(options['subs'])
-        return evalf(v._eval_evalf(prec), prec, options)
+        return evalf(v._eval_evalf(prec), prec, options) # type: ignore
     if not re:
         if isinstance(v, cos):
             return fone, None, prec, None

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -553,7 +553,7 @@ def add_terms(terms: list, prec: int, target_prec: int) -> \
             # first: quick test
             if ((delta > working_prec) and
                 ((not sum_man) or
-                 delta - bitcount(abs(sum_man)) > working_prec)):
+                 delta - MPZ(sum_man).bit_length() > working_prec)):
                 sum_man = man
                 sum_exp = exp
             else:
@@ -575,7 +575,7 @@ def add_terms(terms: list, prec: int, target_prec: int) -> \
         sum_man = -sum_man
     else:
         sum_sign = 0
-    sum_bc = bitcount(sum_man)
+    sum_bc = MPZ(sum_man).bit_length()
     sum_accuracy = sum_exp + sum_bc - absolute_error
     r = normalize(sum_sign, sum_man, sum_exp, sum_bc, target_prec,
         rnd), sum_accuracy
@@ -715,7 +715,7 @@ def evalf_mul(v: 'Mul', prec: int, options: OPT_DICT) -> TMP_RES:
         acc = min(acc, w_acc)
     sign = (direction & 2) >> 1
     if not complex_factors:
-        v = normalize(sign, man, exp, bitcount(man), prec, rnd)
+        v = normalize(sign, man, exp, MPZ(man).bit_length(), prec, rnd)
         # multiply by i
         if direction & 1:
             return None, v, None, acc
@@ -725,7 +725,7 @@ def evalf_mul(v: 'Mul', prec: int, options: OPT_DICT) -> TMP_RES:
         # initialize with the first term
         if (man, exp, bc) != start:
             # there was a real part; give it an imaginary part
-            re, im = (sign, man, exp, bitcount(man)), (0, MPZ(0), 0, 0)
+            re, im = (sign, man, exp, MPZ(man).bit_length()), (0, MPZ(0), 0, 0)
             i0 = 0
         else:
             # there is no real part to start (other than the starting 1)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -910,7 +910,7 @@ class Float(Number):
                     # don't compute number or else it may
                     # over/underflow
                     return Float._new(
-                        (num[0], num[1], num[2], MPZ(num[1]).bit_length()),
+                        (num[0], num[1], num[2], num[1].bit_length(),
                         precision)
         elif isinstance(num, (Number, NumberSymbol)):
             _mpf_ = num._as_mpf_val(precision)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -24,7 +24,7 @@ from sympy.external.gmpy import SYMPY_INTS, gmpy, flint
 from sympy.multipledispatch import dispatch
 import mpmath
 import mpmath.libmp as mlib
-from mpmath.libmp import bitcount, round_nearest as rnd
+from mpmath.libmp import round_nearest as rnd
 from mpmath.libmp.backend import MPZ
 from mpmath.libmp import mpf_pow, mpf_pi, mpf_e, phi_fixed
 from mpmath.ctx_mp_python import mpnumeric
@@ -910,7 +910,7 @@ class Float(Number):
                     # don't compute number or else it may
                     # over/underflow
                     return Float._new(
-                        (num[0], num[1], num[2], bitcount(num[1])),
+                        (num[0], num[1], num[2], MPZ(num[1]).bit_length()),
                         precision)
         elif isinstance(num, (Number, NumberSymbol)):
             _mpf_ = num._as_mpf_val(precision)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -910,7 +910,7 @@ class Float(Number):
                     # don't compute number or else it may
                     # over/underflow
                     return Float._new(
-                        (num[0], num[1], num[2], num[1].bit_length(),
+                        (num[0], num[1], num[2], num[1].bit_length()),
                         precision)
         elif isinstance(num, (Number, NumberSymbol)):
             _mpf_ = num._as_mpf_val(precision)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -202,11 +202,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     ...
     TypeError: unbound method...
 
-    In order to have ``bitcount`` be recognized it can be imported into a
+    In order to have ``bitcount`` be recognized it can be defined in a
     namespace dictionary and passed as locals:
 
     >>> ns = {}
-    >>> exec('from sympy.core.evalf import bitcount', ns)
+    >>> exec('bitcount = lambda n: int(n).bit_length()', ns)
     >>> sympify(s, locals=ns)
     6
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -810,9 +810,9 @@ class Piecewise(DefinedFunction):
     _eval_is_positive = lambda self: self._eval_template_is_attr('is_positive')
     _eval_is_extended_real = lambda self: self._eval_template_is_attr(
             'is_extended_real')
-    _eval_is_extended_positive = lambda self: self._eval_template_is_attr(
+    _eval_is_extended_positive = lambda self: self._eval_template_is_attr( # type: ignore
             'is_extended_positive')
-    _eval_is_extended_negative = lambda self: self._eval_template_is_attr(
+    _eval_is_extended_negative = lambda self: self._eval_template_is_attr( # type: ignore
             'is_extended_negative')
     _eval_is_extended_nonzero = lambda self: self._eval_template_is_attr(
             'is_extended_nonzero')

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -1,7 +1,8 @@
 from mpmath.libmp import (fzero, from_int, from_rational,
-    fone, fhalf, bitcount, to_int, mpf_mul, mpf_div, mpf_sub,
+    fone, fhalf, to_int, mpf_mul, mpf_div, mpf_sub,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, mpf_cos, mpf_sin)
 from .residue_ntheory import _sqrt_mod_prime_power, is_quad_residue
+from sympy.core.evalf import bitcount
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.memoization import recurrence_memo
 
@@ -236,7 +237,7 @@ def _partition(n: int) -> int:
         # On average, the terms decrease rapidly in magnitude.
         # Dynamically reducing the precision greatly improves
         # performance.
-        p = bitcount(abs(to_int(d))) + 50
+        p = bitcount(to_int(d)) + 50
     return int(to_int(mpf_add(s, fhalf, prec)))
 
 

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -2,7 +2,6 @@ from mpmath.libmp import (fzero, from_int, from_rational,
     fone, fhalf, to_int, mpf_mul, mpf_div, mpf_sub,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, mpf_cos, mpf_sin)
 from .residue_ntheory import _sqrt_mod_prime_power, is_quad_residue
-from sympy.core.evalf import bitcount
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.memoization import recurrence_memo
 
@@ -237,7 +236,7 @@ def _partition(n: int) -> int:
         # On average, the terms decrease rapidly in magnitude.
         # Dynamically reducing the precision greatly improves
         # performance.
-        p = bitcount(to_int(d)) + 50
+        p = to_int(d).bit_length() + 50
     return int(to_int(mpf_add(s, fhalf, prec)))
 
 

--- a/sympy/physics/biomechanics/musculotendon.py
+++ b/sympy/physics/biomechanics/musculotendon.py
@@ -1413,7 +1413,7 @@ class MusculotendonDeGroote2016(MusculotendonBase):
 
     """
 
-    curves = CharacteristicCurveCollection(
+    curves = CharacteristicCurveCollection( # type: ignore
         tendon_force_length=TendonForceLengthDeGroote2016,
         tendon_force_length_inverse=TendonForceLengthInverseDeGroote2016,
         fiber_force_length_passive=FiberForceLengthPassiveDeGroote2016,

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -10,7 +10,6 @@ Todo:
 import math
 
 from sympy.core.add import Add
-from sympy.core.evalf import bitcount
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer
 from sympy.core.power import Pow
@@ -307,7 +306,7 @@ class IntQubitState(QubitState):
         # that integer with the minimal number of bits.
         if len(args) == 1 and args[0] > 1:
             #rvalues is the minimum number of bits needed to express the number
-            rvalues = reversed(range(bitcount(args[0])))
+            rvalues = reversed(range(int(args[0]).bit_length()))
             qubit_values = [(args[0] >> i) & 1 for i in rvalues]
             return QubitState._eval_args(qubit_values)
         # For two numbers, the second number is the number of bits
@@ -319,7 +318,7 @@ class IntQubitState(QubitState):
 
     @classmethod
     def _eval_args_with_nqubits(cls, number, nqubits):
-        need = bitcount(number)
+        need = int(number).bit_length()
         if nqubits < need:
             raise ValueError(
                 'cannot represent %s with %s bits' % (number, nqubits))

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -10,6 +10,7 @@ Todo:
 import math
 
 from sympy.core.add import Add
+from sympy.core.evalf import bitcount
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer
 from sympy.core.power import Pow
@@ -29,7 +30,6 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.matrixutils import (
     numpy_ndarray, scipy_sparse_matrix
 )
-from mpmath.libmp.libintmath import bitcount
 
 __all__ = [
     'Qubit',
@@ -307,7 +307,7 @@ class IntQubitState(QubitState):
         # that integer with the minimal number of bits.
         if len(args) == 1 and args[0] > 1:
             #rvalues is the minimum number of bits needed to express the number
-            rvalues = reversed(range(bitcount(abs(args[0]))))
+            rvalues = reversed(range(bitcount(args[0])))
             qubit_values = [(args[0] >> i) & 1 for i in rvalues]
             return QubitState._eval_args(qubit_values)
         # For two numbers, the second number is the number of bits
@@ -319,7 +319,7 @@ class IntQubitState(QubitState):
 
     @classmethod
     def _eval_args_with_nqubits(cls, number, nqubits):
-        need = bitcount(abs(number))
+        need = bitcount(number)
         if nqubits < need:
             raise ValueError(
                 'cannot represent %s with %s bits' % (number, nqubits))

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1764,7 +1764,7 @@ class DUP_Flint(DMP):
             return flint.fmpz_poly
         elif dom.is_QQ:
             return flint.fmpq_poly
-        elif dom.is_FF:
+        elif dom.is_FF and dom._is_flint:
             return dom._poly_ctx
         else:
             raise RuntimeError("Domain %s is not supported with flint" % dom)
@@ -1773,19 +1773,7 @@ class DUP_Flint(DMP):
     def from_rep(cls, rep, dom):
         """Create a DMP from the given representation. """
 
-        if dom.is_ZZ:
-            assert isinstance(rep, flint.fmpz_poly)
-            _cls = flint.fmpz_poly
-        elif dom.is_QQ:
-            assert isinstance(rep, flint.fmpq_poly)
-            _cls = flint.fmpq_poly
-        elif dom.is_FF:
-            assert isinstance(rep, (flint.nmod_poly, flint.fmpz_mod_poly))
-            c = dom.characteristic()
-            __cls = type(rep)
-            _cls = lambda e: __cls(e, c)
-        else:
-            raise RuntimeError("Domain %s is not supported with flint" % dom)
+        _cls = cls._get_flint_poly_cls(dom)
 
         obj = object.__new__(cls)
         obj.dom = dom

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3974,3 +3974,17 @@ def test_issue_20985():
     w, R = symbols('w R')
     poly = Poly(1.0 + I*w/R, w, 1/R)
     assert poly.degree() == S(1)
+
+
+def test_issue_28156():
+    from sympy.core.symbol import symbols
+
+    ax = symbols("a")
+    field = FF(340282366762482138434845932244680310783)
+    rhs = Poly(
+        ax**3 + field(3) * ax + field(5),
+        ax,
+        domain=field,
+    )
+    roots = rhs.ground_roots()
+    assert roots

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -485,7 +485,7 @@ class CodePrinter(StrPrinter):
         return pmeth(obj.args, seq_orders)
 
     # Don't inherit the str-printer method for Heaviside to the code printers
-    _print_Heaviside = None
+    _print_Heaviside = None # type: ignore
 
     def _print_NumberSymbol(self, expr):
         if self._settings.get("inline", False):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, TYPE_CHECKING, overload
+from typing import Any, TYPE_CHECKING, overload
 from functools import reduce
 from collections import defaultdict
 from collections.abc import Mapping, Iterable
@@ -2183,7 +2183,9 @@ class FiniteSet(Set):
             return self._args_set == other
         return super().__eq__(other)
 
-    __hash__ : Callable[[Basic], Any] = Basic.__hash__
+    def __hash__(self):
+        return Basic.__hash__(self)
+
 
 _sympy_converter[set] = lambda x: FiniteSet(*x)
 _sympy_converter[frozenset] = lambda x: FiniteSet(*x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Backport of gh-28157 to 1.14 release branch.

Fix for gh-28156.

Also backport gh-28100 and gh-28060

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a TypeError when working with finite fields of large characteristic with python-flint installed. Some functions like factor and ground_roots would fail with an exception. This was a regression in SymPy 1.14.0.
* other
  * SymPy no longer uses mpmath's deprecated bitcount function.
  * Some type annotations were changed to stop errors reported under the latest mypy release.
<!-- END RELEASE NOTES -->
