### PR TITLE
[GSoC] Modify point_on_surface methods in wrapping geometries

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,21 +76,7 @@ SymPy deprecation warnings.
 
 ## Version 1.15
 
-(deprecated-point-on-surface-check-sphere)=
-### Deprecated point_on_surface method in WrappingSphere
-
-This method has been deprecated as it is deemed no longer necessary
-to check whether input points to ``WrappingSphere.geodesic_length`` and
-``WrappingSphere.geodesic_end_vectors`` lie on the surface of the sphere
-or not. These methods now rely on the user to supply valid points.
-
-(deprecated-point-on-surface-check-cylinder)=
-### Deprecated point_on_surface method in WrappingCylinder
-
-This method has been deprecated as it is deemed no longer necessary
-to check whether input points to ``WrappingCylinder.geodesic_length`` and
-``WrappingCylinder.geodesic_end_vectors`` lie on the surface of the cylinder
-or not. These methods now rely on the user to supply valid points.
+There are no deprecations yet for SymPy 1.15.
 
 ## Version 1.14
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,7 +76,21 @@ SymPy deprecation warnings.
 
 ## Version 1.15
 
-There are no deprecations yet for SymPy 1.15.
+(deprecated-point-on-surface-check-sphere)=
+### Deprecated point_on_surface method in WrappingSphere
+
+This method has been deprecated as it is deemed no longer necessary
+to check whether input points to ``WrappingSphere.geodesic_length`` and
+``WrappingSphere.geodesic_end_vectors`` lie on the surface of the sphere
+or not. These methods now rely on the user to supply valid points.
+
+(deprecated-point-on-surface-check-cylinder)=
+### Deprecated point_on_surface method in WrappingCylinder
+
+This method has been deprecated as it is deemed no longer necessary
+to check whether input points to ``WrappingCylinder.geodesic_length`` and
+``WrappingCylinder.geodesic_end_vectors`` lie on the surface of the cylinder
+or not. These methods now rely on the user to supply valid points.
 
 ## Version 1.14
 

--- a/sympy/physics/mechanics/tests/test_wrapping_geometry.py
+++ b/sympy/physics/mechanics/tests/test_wrapping_geometry.py
@@ -22,7 +22,7 @@ from sympy.physics.mechanics import (
     dynamicsymbols,
 )
 from sympy.simplify.simplify import simplify
-
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 r = Symbol('r', positive=True)
 x = Symbol('x')
@@ -42,22 +42,6 @@ class TestWrappingSphere:
         assert sphere.radius == r
         assert hasattr(sphere, 'point')
         assert sphere.point == pO
-
-    @staticmethod
-    @pytest.mark.parametrize('position', [S.Zero, Integer(2)*r*N.x])
-    def test_geodesic_length_point_not_on_surface_invalid(position):
-        r = Symbol('r', positive=True)
-        pO = Point('pO')
-        sphere = WrappingSphere(r, pO)
-
-        p1 = Point('p1')
-        p1.set_pos(pO, position)
-        p2 = Point('p2')
-        p2.set_pos(pO, position)
-
-        error_msg = r'point .* does not lie on the surface of'
-        with pytest.raises(ValueError, match=error_msg):
-            sphere.geodesic_length(p1, p2)
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -213,23 +197,13 @@ class TestWrappingCylinder:
         p1 = Point('p1')
         p1.set_pos(pO, position)
 
-        assert cylinder.point_on_surface(p1) is expected
+        deprecation_warning = (
+            r"Checking if a Point lies on cylinder's surface by\s+"
+            r"calling point_on_surface\(\) is deprecated\."
+        )
 
-    @staticmethod
-    @pytest.mark.parametrize('position', [S.Zero, Integer(2)*r*N.y])
-    def test_geodesic_length_point_not_on_surface_invalid(position):
-        r = Symbol('r', positive=True)
-        pO = Point('pO')
-        cylinder = WrappingCylinder(r, pO, N.x)
-
-        p1 = Point('p1')
-        p1.set_pos(pO, position)
-        p2 = Point('p2')
-        p2.set_pos(pO, position)
-
-        error_msg = r'point .* does not lie on the surface of'
-        with pytest.raises(ValueError, match=error_msg):
-            cylinder.geodesic_length(p1, p2)
+        with pytest.warns(SymPyDeprecationWarning, match=deprecation_warning):
+            assert cylinder.point_on_surface(p1) is expected
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/sympy/physics/mechanics/tests/test_wrapping_geometry.py
+++ b/sympy/physics/mechanics/tests/test_wrapping_geometry.py
@@ -22,7 +22,6 @@ from sympy.physics.mechanics import (
     dynamicsymbols,
 )
 from sympy.simplify.simplify import simplify
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 r = Symbol('r', positive=True)
 x = Symbol('x')
@@ -178,15 +177,15 @@ class TestWrappingCylinder:
     @pytest.mark.parametrize(
         'position, expected',
         [
-            (S.Zero, False),
-            (r*N.y, True),
-            (r*N.z, True),
-            (r*(N.y + N.z).normalize(), True),
-            (Integer(2)*r*N.y, False),
-            (r*(N.x + N.y), True),
-            (r*(Integer(2)*N.x + N.y), True),
-            (Integer(2)*N.x + r*(Integer(2)*N.y + N.z).normalize(), True),
-            (r*(cos(q)*N.y + sin(q)*N.z), True)
+            (S.Zero, Eq(0, r**2, evaluate=False)),
+            (r*N.y, Eq(r**2, r**2, evaluate=False)),
+            (r*N.z, Eq(r**2, r**2, evaluate=False)),
+            (r*(N.y + N.z).normalize(), Eq(r**2, r**2, evaluate=False)),
+            (Integer(2)*r*N.y, Eq(4*r**2, r**2, evaluate=False)),
+            (r*(N.x + N.y), Eq(r**2, r**2, evaluate=False)),
+            (r*(Integer(2)*N.x + N.y), Eq(r**2, r**2, evaluate=False)),
+            (Integer(2)*N.x + r*(Integer(2)*N.y + N.z).normalize(), Eq(r**2, r**2, evaluate=False)),
+            (r*(cos(q)*N.y + sin(q)*N.z), Eq(r**2, r**2, evaluate=False))
         ]
     )
     def test_point_is_on_surface(position, expected):
@@ -197,13 +196,7 @@ class TestWrappingCylinder:
         p1 = Point('p1')
         p1.set_pos(pO, position)
 
-        deprecation_warning = (
-            r"Checking if a Point lies on cylinder's surface by\s+"
-            r"calling point_on_surface\(\) is deprecated\."
-        )
-
-        with pytest.warns(SymPyDeprecationWarning, match=deprecation_warning):
-            assert cylinder.point_on_surface(p1) is expected
+        assert cylinder.point_on_surface(p1) == expected
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/sympy/physics/mechanics/tests/test_wrapping_geometry.py
+++ b/sympy/physics/mechanics/tests/test_wrapping_geometry.py
@@ -23,6 +23,7 @@ from sympy.physics.mechanics import (
 )
 from sympy.simplify.simplify import simplify
 
+
 r = Symbol('r', positive=True)
 x = Symbol('x')
 q = dynamicsymbols('q')

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -8,7 +8,6 @@ from sympy.functions.elementary.trigonometric import atan2
 from sympy.polys.polytools import cancel
 from sympy.physics.vector import Vector, dot
 from sympy.simplify.simplify import trigsimp
-from sympy.utilities.decorator import deprecated
 
 
 __all__ = [
@@ -147,27 +146,15 @@ class WrappingSphere(WrappingGeometryBase):
     def point(self, point):
         self._point = point
 
-    @deprecated(
-        """
-        Checking if a Point lies on sphere's surface by
-        calling point_on_surface() is deprecated.
-        """,
-        deprecated_since_version="1.15.0",
-        active_deprecations_target="deprecated-point-on-surface-check-sphere"
-    )
     def point_on_surface(self, point):
-        """Returns ``True`` if a point is on the sphere's surface.
-
-        .. deprecated:: <1.15.0>
+        """Returns a symbolic equality for whether a point is on the sphere's
+        surface.
 
         Parameters
         ==========
 
         point : Point
-            The point for which it's to be ascertained if it's on the sphere's
-            surface or not. This point's position relative to the sphere's
-            center must be a simple expression involving the radius of the
-            sphere, otherwise this check will likely not work.
+            The point for which the expression is to be generated.
 
         """
         point_vector = point.pos_from(self.point)
@@ -175,7 +162,7 @@ class WrappingSphere(WrappingGeometryBase):
             point_radius_squared = dot(point_vector, point_vector)
         else:
             point_radius_squared = point_vector**2
-        return Eq(point_radius_squared, self.radius**2) == True
+        return Eq(point_radius_squared, self.radius**2, evaluate=False)
 
     def geodesic_length(self, point_1, point_2):
         r"""Returns the shortest distance between two points on the sphere's
@@ -389,27 +376,15 @@ class WrappingCylinder(WrappingGeometryBase):
     def axis(self, axis):
         self._axis = axis.normalize()
 
-    @deprecated(
-        """
-        Checking if a Point lies on cylinder's surface by
-        calling point_on_surface() is deprecated.
-        """,
-        deprecated_since_version="1.15.0",
-        active_deprecations_target="deprecated-point-on-surface-check-cylinder"
-    )
     def point_on_surface(self, point):
-        """Returns ``True`` if a point is on the cylinder's surface.
-
-        .. deprecated:: <1.15.0>
+        """Returns a symbolic equality for whether a point is on the cylinder's
+        surface.
 
         Parameters
         ==========
 
         point : Point
-            The point for which it's to be ascertained if it's on the
-            cylinder's surface or not. This point's position relative to the
-            cylinder's axis must be a simple expression involving the radius of
-            the sphere, otherwise this check will likely not work.
+            The point for which the expression is to be generated.
 
         """
         relative_position = point.pos_from(self.point)
@@ -419,7 +394,7 @@ class WrappingCylinder(WrappingGeometryBase):
             point_radius_squared = dot(point_vector, point_vector)
         else:
             point_radius_squared = point_vector**2
-        return Eq(trigsimp(point_radius_squared), self.radius**2) == True
+        return Eq(trigsimp(point_radius_squared), self.radius**2, evaluate=False)
 
     def geodesic_length(self, point_1, point_2):
         """The shortest distance between two points on a geometry's surface.

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -8,6 +8,7 @@ from sympy.functions.elementary.trigonometric import atan2
 from sympy.polys.polytools import cancel
 from sympy.physics.vector import Vector, dot
 from sympy.simplify.simplify import trigsimp
+from sympy.utilities.decorator import deprecated
 
 
 __all__ = [
@@ -32,19 +33,6 @@ class WrappingGeometryBase(ABC):
     @abstractmethod
     def point(cls):
         """The point with which the geometry is associated."""
-        pass
-
-    @abstractmethod
-    def point_on_surface(self, point):
-        """Returns ``True`` if a point is on the geometry's surface.
-
-        Parameters
-        ==========
-        point : Point
-            The point for which it's to be ascertained if it's on the
-            geometry's surface or not.
-
-        """
         pass
 
     @abstractmethod
@@ -159,8 +147,18 @@ class WrappingSphere(WrappingGeometryBase):
     def point(self, point):
         self._point = point
 
+    @deprecated(
+        """
+        Checking if a Point lies on sphere's surface by
+        calling point_on_surface() is deprecated. 
+        """,
+        deprecated_since_version="1.15.0",
+        active_deprecations_target="deprecated-point-on-surface-check-sphere"
+    )
     def point_on_surface(self, point):
         """Returns ``True`` if a point is on the sphere's surface.
+
+        .. deprecated:: <1.15.0>
 
         Parameters
         ==========
@@ -247,15 +245,6 @@ class WrappingSphere(WrappingGeometryBase):
             Point to which the geodesic length should be calculated.
 
         """
-        for point in (point_1, point_2):
-            if not self.point_on_surface(point):
-                msg = (
-                    f'Geodesic length cannot be calculated as point {point} '
-                    f'with radius {point.pos_from(self.point).magnitude()} '
-                    f'from the sphere\'s center {self.point} does not lie on '
-                    f'the surface of {self} with radius {self.radius}.'
-                )
-                raise ValueError(msg)
         point_1_vector = point_1.pos_from(self.point).normalize()
         point_2_vector = point_2.pos_from(self.point).normalize()
         central_angle = acos(point_2_vector.dot(point_1_vector))
@@ -278,14 +267,6 @@ class WrappingSphere(WrappingGeometryBase):
         pO = self.point
         pA_vec = pA.pos_from(pO)
         pB_vec = pB.pos_from(pO)
-
-        if pA_vec.cross(pB_vec) == 0:
-            msg = (
-                f'Can\'t compute geodesic end vectors for the pair of points '
-                f'{pA} and {pB} on a sphere {self} as they are diametrically '
-                f'opposed, thus the geodesic is not defined.'
-            )
-            raise ValueError(msg)
 
         return (
             pA_vec.cross(pB.pos_from(pA)).cross(pA_vec).normalize(),
@@ -399,8 +380,18 @@ class WrappingCylinder(WrappingGeometryBase):
     def axis(self, axis):
         self._axis = axis.normalize()
 
+    @deprecated(
+        """
+        Checking if a Point lies on cylinder's surface by
+        calling point_on_surface() is deprecated. 
+        """,
+        deprecated_since_version="1.15.0",
+        active_deprecations_target="deprecated-point-on-surface-check-cylinder"
+    )
     def point_on_surface(self, point):
         """Returns ``True`` if a point is on the cylinder's surface.
+
+        .. deprecated:: <1.15.0>
 
         Parameters
         ==========
@@ -476,8 +467,7 @@ class WrappingCylinder(WrappingGeometryBase):
         sqrt(r**2*q(t)**2 + 1)
 
         If the ``geodesic_length`` method is passed an argument ``Point`` that
-        doesn't lie on the sphere's surface then a ``ValueError`` is raised
-        because it's not possible to calculate a value in this case.
+        doesn't lie on the sphere's surface then unexpected results may occur.
 
         Parameters
         ==========
@@ -488,17 +478,6 @@ class WrappingCylinder(WrappingGeometryBase):
             Point to which the geodesic length should be calculated.
 
         """
-        for point in (point_1, point_2):
-            if not self.point_on_surface(point):
-                msg = (
-                    f'Geodesic length cannot be calculated as point {point} '
-                    f'with radius {point.pos_from(self.point).magnitude()} '
-                    f'from the cylinder\'s center {self.point} does not lie on '
-                    f'the surface of {self} with radius {self.radius} and axis '
-                    f'{self.axis}.'
-                )
-                raise ValueError(msg)
-
         relative_position = point_2.pos_from(point_1)
         parallel_length = relative_position.dot(self.axis)
 
@@ -539,13 +518,6 @@ class WrappingCylinder(WrappingGeometryBase):
         """
         point_1_from_origin_point = point_1.pos_from(self.point)
         point_2_from_origin_point = point_2.pos_from(self.point)
-
-        if point_1_from_origin_point == point_2_from_origin_point:
-            msg = (
-                f'Cannot compute geodesic end vectors for coincident points '
-                f'{point_1} and {point_2} as no geodesic exists.'
-            )
-            raise ValueError(msg)
 
         point_1_parallel = point_1_from_origin_point.dot(self.axis) * self.axis
         point_2_parallel = point_2_from_origin_point.dot(self.axis) * self.axis

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -150,7 +150,7 @@ class WrappingSphere(WrappingGeometryBase):
     @deprecated(
         """
         Checking if a Point lies on sphere's surface by
-        calling point_on_surface() is deprecated. 
+        calling point_on_surface() is deprecated.
         """,
         deprecated_since_version="1.15.0",
         active_deprecations_target="deprecated-point-on-surface-check-sphere"
@@ -383,7 +383,7 @@ class WrappingCylinder(WrappingGeometryBase):
     @deprecated(
         """
         Checking if a Point lies on cylinder's surface by
-        calling point_on_surface() is deprecated. 
+        calling point_on_surface() is deprecated.
         """,
         deprecated_since_version="1.15.0",
         active_deprecations_target="deprecated-point-on-surface-check-cylinder"

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -232,9 +232,10 @@ class WrappingSphere(WrappingGeometryBase):
         >>> sphere.geodesic_length(p1, p2)
         pi*r/2
 
-        If the ``geodesic_length`` method is passed an argument, the ``Point``
-        that doesn't lie on the sphere's surface then a ``ValueError`` is
-        raised because it's not possible to calculate a value in this case.
+        If the ``geodesic_length`` method is passed an argument that doesn't
+        lie on the sphere's surface then unexpected results may be obtained.
+        It is the user's responsibility to ensure that the points lie on the
+        sphere's surface.
 
         Parameters
         ==========
@@ -267,6 +268,14 @@ class WrappingSphere(WrappingGeometryBase):
         pO = self.point
         pA_vec = pA.pos_from(pO)
         pB_vec = pB.pos_from(pO)
+
+        if pA_vec.cross(pB_vec) == 0:
+            msg = (
+                f'Can\'t compute geodesic end vectors for the pair of points '
+                f'{pA} and {pB} on a sphere {self} as they are diametrically '
+                f'opposed, thus the geodesic is not defined.'
+            )
+            raise ValueError(msg)
 
         return (
             pA_vec.cross(pB.pos_from(pA)).cross(pA_vec).normalize(),
@@ -467,7 +476,9 @@ class WrappingCylinder(WrappingGeometryBase):
         sqrt(r**2*q(t)**2 + 1)
 
         If the ``geodesic_length`` method is passed an argument ``Point`` that
-        doesn't lie on the sphere's surface then unexpected results may occur.
+        doesn't lie on the cylinder's surface then unexpected results may occur.
+        It is the user's responsibility to ensure that the points lie on the
+        cylinder's surface.
 
         Parameters
         ==========
@@ -518,6 +529,13 @@ class WrappingCylinder(WrappingGeometryBase):
         """
         point_1_from_origin_point = point_1.pos_from(self.point)
         point_2_from_origin_point = point_2.pos_from(self.point)
+
+        if point_1_from_origin_point == point_2_from_origin_point:
+            msg = (
+                f'Cannot compute geodesic end vectors for coincident points '
+                f'{point_1} and {point_2} as no geodesic exists.'
+            )
+            raise ValueError(msg)
 
         point_1_parallel = point_1_from_origin_point.dot(self.axis) * self.axis
         point_2_parallel = point_2_from_origin_point.dot(self.axis) * self.axis


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR is a result of the [discussion](https://github.com/sympy/sympy/pull/28135/files#r2156208314) between @moorepants and I upon the use of ``point_on_surface`` method
in both ``WrappingSphere`` and ``WrappingCylinder`` classes.

#### Brief description of what is fixed or changed
I have modified it to return an unevaluated symbolic equality rather than a forced boolean.  
Additionally I have removed the calls to it in all other methods i.e ``geodesic_length`` and ``geodesic_end_vectors``.

#### Other comments
This PR is a part of my GSoC 2025 work on the project "Implement Wrapping Geometries and Pathways for Musculoskeletal Modeling".

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
