### PR TITLE
quality: Add ruff rule to disallow catching Exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ lint.select = [
     "SIM101",
     "SLOT",
     "TRY002",
+    "BLE001", # except Exception or except BaseException
 ]
 
 # Ignore rules that currently fail on the SymPy codebase
@@ -85,6 +86,9 @@ exclude = [
     "sympy/parsing/latex/_antlr/*",
     "sympy/parsing/autolev/_antlr/*",
     "sympy/parsing/autolev/test-examples/*",
+    "sympy/plotting/pygletplot/*",
+    "sympy/parsing/latex/_parse_latex_antlr.py",
+    "sympy/parsing/autolev/_listener_autolev_antlr.py",
     "sympy/integrals/rubi/*",
 ]
 

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -483,7 +483,7 @@ def init_session(console_backend=None, pretty_print=True, order=None,
             # Enable interactive plotting using pylab.
             try:
                 ip.enable_pylab(import_all=False)
-            except Exception:
+            except Exception: # noqa: BLE001
                 # Causes an import error if matplotlib is not installed.
                 # Causes other errors (depending on the backend) if there
                 # is no display, or if there is some problem in the

--- a/sympy/parsing/autolev/_parse_autolev_antlr.py
+++ b/sympy/parsing/autolev/_parse_autolev_antlr.py
@@ -20,11 +20,11 @@ def parse_autolev(autolev_code, include_numeric):
         raise ImportError("Autolev parsing requires the antlr4 Python package,"
                           " provided by pip (antlr4-python3-runtime)"
                           " conda (antlr-python-runtime), version 4.11")
-    try:
-        l = autolev_code.readlines()
-        input_stream = antlr4.InputStream("".join(l))
-    except Exception:
-        input_stream = antlr4.InputStream(autolev_code)
+
+    if not isinstance(autolev_code, str):
+        autolev_code = "".join(autolev_code.readlines())
+
+    input_stream = antlr4.InputStream(autolev_code)
 
     if AutolevListener:
         from ._listener_autolev_antlr import MyListener

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1083,7 +1083,7 @@ def parse_expr(s: str, local_dict: DICT | None = None,
         for i in local_dict.pop(null, ()):
             local_dict[i] = null
         return rv
-    except Exception as e:
+    except Exception as e: # noqa: BLE001
         # restore neutral definitions for names
         for i in local_dict.pop(null, ()):
             local_dict[i] = null

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -30,7 +30,7 @@ def _test_examples(in_filename, out_filename, test_name=""):
             try:
                 line2 = generated_code.split('\n')[idx]
                 assert line1.rstrip() == line2.rstrip()
-            except Exception:
+            except (IndexError, AssertionError):
                 msg = 'mismatch in ' + test_name + ' in line no: {0}'
                 raise AssertionError(msg.format(idx+1))
 

--- a/sympy/plotting/series.py
+++ b/sympy/plotting/series.py
@@ -84,7 +84,7 @@ def _uniform_eval(f1, f2, *args, modules=None,
 
     try:
         return wrapper_func(f1, *args)
-    except Exception as err:
+    except Exception as err: # noqa: BLE001
         return _eval_with_sympy(err)
 
 
@@ -1365,7 +1365,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
             else:
                 f = lambdify([self.var], self.expr, self.modules)
             x, y = self._adaptive_sampling_helper(f)
-        except Exception as err:
+        except Exception as err: # noqa: BLE001
             warnings.warn(
                 "The evaluation with %s failed.\n" % (
                     "NumPy/SciPy" if not self.modules else self.modules) +
@@ -1638,7 +1638,7 @@ class Parametric2DLineSeries(ParametricLineBaseSeries):
                 f_x = lambdify([self.var], self.expr_x)
                 f_y = lambdify([self.var], self.expr_y)
             x, y, p = self._adaptive_sampling_helper(f_x, f_y)
-        except Exception as err:
+        except Exception as err: # noqa: BLE001
             warnings.warn(
                 "The evaluation with %s failed.\n" % (
                     "NumPy/SciPy" if not self.modules else self.modules) +

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -417,7 +417,7 @@ class ArrayPrinter:
         from sympy.tensor.array.expressions.from_indexed_to_array import convert_indexed_to_array
         try:
             return convert_indexed_to_array(indexed)
-        except Exception:
+        except Exception: # noqa: BLE001
             return indexed
 
     def _get_einsum_string(self, subranks, contraction_indices):

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -189,7 +189,7 @@ else:
         def wrapper():
             try:
                 func()
-            except Exception as e:
+            except Exception as e: # noqa: BLE001
                 message = str(e)
                 if message != "Timeout":
                     raise XFail(func.__name__)

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -1234,7 +1234,7 @@ class SymPyTests:
             except ImportError:
                 reporter.import_error(filename, sys.exc_info())
                 return
-            except Exception:
+            except Exception: # noqa: BLE001
                 reporter.test_exception(sys.exc_info())
 
             clear_cache()
@@ -1304,7 +1304,7 @@ class SymPyTests:
                     reporter.test_skip("KeyboardInterrupt")
                 else:
                     raise
-            except Exception:
+            except Exception: # noqa: BLE001
                 if timeout:
                     signal.alarm(0)  # Disable the alarm. It could not be handled before.
                 t, v, tr = sys.exc_info()


### PR DESCRIPTION
It is almost always incorrect to use bare except or to catch Exception or BaseException. This commit adds a ruff rule to disallow this. A bare `except:` is already disallowed by rule E722 but this extends that to `except Exception` and `except BaseException`.

Some existing cases in the codebase are left as is because they are exceptional such as handling exceptions in the old test runner. Some cases are left because it just is not clear what exceptions they are intended to catch (precisely why except Exception should not be used).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
