### PR TITLE
ANP normalization when init, fix #28182

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2854,6 +2854,8 @@ class ANP(CantSympify):
         else:
             mod = DMP(dup_strip(mod), dom, 0)
 
+        rep = rep.rem(mod)
+
         return cls.new(rep, mod, dom)
 
     @classmethod

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -485,6 +485,10 @@ def test_ANP___init__():
 
     raises(CoercionFailed, lambda: ANP([sqrt(2)], mod, QQ))
 
+    # https://github.com/sympy/sympy/issues/28182
+    f = ANP({(0,): -2, (2,): 1}, [1, 0, -2], QQ)
+    assert f.to_list() == []
+
 
 def test_ANP___eq__():
     a = ANP([QQ(1), QQ(1)], [QQ(1), QQ(0), QQ(1)], QQ)


### PR DESCRIPTION
Normalize ANP representation by taking modulus remainder

#### References to other Issues or PRs
Fixes #28182

#### Brief description of what is fixed or changed
This PR fixes an issue where ANP (Algebraic Number Polynomial) instances were not properly normalized during initialization. The ANP constructor now ensures the polynomial representation is reduced modulo the given modulus polynomial by computing the remainder, preventing redundant representations.

The fix adds `rep = rep.rem(mod)` in the ANP.__new__ method. A test for the problem is also added.

#### Other comments 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed normalization issue in ANP class where polynomial representations were not properly reduced modulo their modulus
<!-- END RELEASE NOTES -->
        