### PR TITLE
Fix reversed load handling in Beam (Fixes #28174)

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -41,7 +41,6 @@ __doctest_requires__ = {
 numpy = import_module('numpy', import_kwargs={'fromlist':['arange']})
 
 
-
 class Beam:
     """
     A Beam is a structural element that is capable of withstanding load
@@ -700,6 +699,7 @@ class Beam:
         self.apply_load(E * I * deflection_jump, loc, -4)
         self.bc_shear_force.append((loc, 0))
         return deflection_jump
+
     def apply_load(self, value, start, order, end=None):
         """
         This method adds up the loads given to a particular beam object.
@@ -847,7 +847,6 @@ class Beam:
                 term = coeff * SingularityFunction(x, end, i) / factorial(i)
                 self._load += term
                 self._original_load += term
-
 
     @property
     def load(self):

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -5,7 +5,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.sets.sets import Interval
 from sympy.simplify.simplify import simplify
 from sympy.physics.continuum_mechanics.beam import Beam
-from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log,sqrt,factorial
+from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log, sqrt, factorial
 from sympy.testing.pytest import raises
 from sympy.physics.units import meter, newton, kilo, giga, milli
 from sympy.physics.continuum_mechanics.beam import Beam3D

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -5,7 +5,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.sets.sets import Interval
 from sympy.simplify.simplify import simplify
 from sympy.physics.continuum_mechanics.beam import Beam
-from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log, sqrt
+from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log,sqrt,factorial
 from sympy.testing.pytest import raises
 from sympy.physics.units import meter, newton, kilo, giga, milli
 from sympy.physics.continuum_mechanics.beam import Beam3D
@@ -1125,6 +1125,57 @@ def test_ild_with_sliding_hinge():
     assert b.ild_shear.subs(a, 8) == -Rational(200, 343)
     b.solve_for_ild_moment(8, 1, r0, r6, r13, m13)
     assert b.ild_moment.subs(a, 3) == -Rational(12, 7)
+
+
+def test_apply_load_ramp_start_greater_than_end():
+    # issue #28174
+
+    E, I = symbols('E I')
+
+    # order 1 - fullbeam
+    b = Beam(10, E, I)
+    b.apply_load(5, 10, 1, end=0)
+    expected_load = 50*SingularityFunction(x, 0, 0) \
+                    - 5*SingularityFunction(x, 0, 1) \
+                    + 5*SingularityFunction(x, 10, 1)
+    assert simplify(b.load - expected_load) == 0
+
+    # order 3 - full beam
+    b1 = Beam(10, E, I)
+    b1.apply_load(5, 10, 3, end=0)
+    expected_load = 5000*SingularityFunction(x, 0, 0) \
+                    - 1500*SingularityFunction(x, 0, 1) \
+                    + 150*SingularityFunction(x, 0, 2) \
+                    - 5*SingularityFunction(x, 0, 3) \
+                    + 5*SingularityFunction(x, 10, 3)
+    assert simplify(b1.load - expected_load) == 0
+
+    # order 1 - section of beam
+    b2 = Beam(10, E, I)
+    b2.apply_load(5, 6, 1, end=2)
+    expected_load = 20*SingularityFunction(x, 2, 0) \
+                    - 5*SingularityFunction(x, 2, 1) \
+                    + 5*SingularityFunction(x, 6, 1)
+    assert simplify(b2.load - expected_load) == 0
+
+
+def test_apply_load_symbolic_start_end():
+    # Symbolic test for start > end case
+    E, I = symbols('E I')
+    a, b_ = symbols('a b', real=True)
+
+    beam = Beam(b_, E, I)
+    beam.apply_load(5, b_, 1, end=a)
+
+    f = 5 * x**1
+    expected_load = (
+        f.subs(x, b_ - a) * SingularityFunction(x, a, 0)
+        - f.diff(x, 1).subs(x, b_ - a) * SingularityFunction(x, a, 1) / factorial(1)
+        + 5 * SingularityFunction(x, b_, 1)
+    )
+
+    assert simplify(beam.load - expected_load) == 0
+
 
 def test_Beam3D():
     l, E, G, I, A = symbols('l, E, G, I, A')


### PR DESCRIPTION
This PR fixes [[#28174](https://github.com/sympy/sympy/issues/28174)] by correctly handling cases where a load is applied in the reverse direction (when `start > end`) in the `Beam.apply_load` method.

### What’s done:

* Fixed the logic in `apply_load` to properly account for reversed loads.
* Added tests that cover reverse loads for different orders and positions on the beam.

### Code Change:

```python
if end != None:
    if start - end > 0:
        # If load is applied in reverse (start > end), reverse the effect by applying a negative load at the end.
        self._handle_end(x, -value, start, order, end, type="remove")
    # load has an end point within the length of the beam.
    else:
        self._handle_end(x, value, start, order, end, type="apply")
```

I have added these tests

```python
def test_apply_load_ramp_start_greater_than_end():
    # issue #28174

    E, I = symbols('E I')
    
    # order 1 – full beam
    b = Beam(10, E, I)
    b.apply_load(5, 10, 1, end=0)
    expected_load = 50*SingularityFunction(x, 0, 0) \
                    - 5*SingularityFunction(x, 0, 1) \
                    + 5*SingularityFunction(x, 10, 1)
    assert simplify(b.load - expected_load) == 0

    # order 3 – full beam
    b1 = Beam(10, E, I)
    b1.apply_load(5, 10, 3, end=0)
    expected_load = 5000*SingularityFunction(x, 0, 0) \
                    - 1500*SingularityFunction(x, 0, 1) \
                    + 150*SingularityFunction(x, 0, 2) \
                    - 5*SingularityFunction(x, 0, 3) \
                    + 5*SingularityFunction(x, 10, 3)
    assert simplify(b1.load - expected_load) == 0

    # order 1 – section of beam
    b2 = Beam(10, E, I)
    b2.apply_load(5, 6, 1, end=2)
    expected_load = 20*SingularityFunction(x, 2, 0) \
                    - 5*SingularityFunction(x, 2, 1) \
                    + 5*SingularityFunction(x, 6, 1)
    assert simplify(b2.load - expected_load) == 0

```
The new tests as well as all existing tests have passed successfully.
Let me know if any other tests are supposed to be added 

### Note:

The maintainer suggested applying this fix to both `beam.py` and `column.py`.
However, the `column.py` file is not present in the main SymPy repo yet, so I am opening this PR for `beam.py` only.

I will be happy to contribute to `column.py` as well once it is merged into the main branch.


Release Notes
<!-- BEGIN RELEASE NOTES -->

* physics.continuum_mechanics

  * Fixed incorrect handling of reversed loads (when start > end) in `Beam.apply_load`. Now such loads are correctly applied with appropriate load distribution.

<!-- END RELEASE NOTES -->


---

