### PR TITLE
polys: Removed unreachable branch in PolyElement.div

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1561,10 +1561,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         if expv == ring.zero_monom:
             r += p
         if ret_single:
-            if not qv:
-                return ring.zero, r
-            else:
-                return qv[0], r
+            return qv[0], r
         else:
             return qv, r
 


### PR DESCRIPTION

`PolyElement.div` has a branch that can't be logically hit by any test case and hence is dead code. It should be removed. For context, see this [comment](https://github.com/sympy/sympy/pull/28119#issuecomment-3004613028).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
