### PR TITLE
Add Y_lm() function to hydrogen.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -457,7 +457,7 @@ Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
 Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>
-Charles Weiss <charles.weiss@augie.edu>
+Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@users.noreply.github.com>
 Chetna Gupta <cheta.gup@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -457,6 +457,7 @@ Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
 Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>
+Charles Weiss <charles.weiss@augie.edu>
 Chetna Gupta <cheta.gup@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -122,7 +122,7 @@ class Ynm(DefinedFunction):
     See Also
     ========
 
-    Ynm_c, Znm
+    Ynm_c, Znm, sympy.physics.hydrogen.Y_lm, sympy.physics.hydrogen.Z_lm
 
     References
     ==========
@@ -251,7 +251,7 @@ def Ynm_c(n, m, theta, phi):
     See Also
     ========
 
-    Ynm, Znm
+    Ynm, Znm, sympy.physics.hydrogen.Y_lm, sympy.physics.hydrogen.Z_lm
 
     References
     ==========
@@ -311,7 +311,7 @@ class Znm(DefinedFunction):
     See Also
     ========
 
-    Ynm, Ynm_c
+    Ynm, Ynm_c, sympy.physics.hydrogen.Y_lm, sympy.physics.hydrogen.Z_lm
 
     References
     ==========

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -114,8 +114,7 @@ def Y_lm(l, m, phi, theta):
     =====
 
     This function follows the Condon-Shortley phase convention and may return
-    real or complex values depending on values for ``l`` and ``m``. See Z_lm()
-    for real-valued spherical harmonics.
+    real or complex values depending on values for ``l`` and ``m``.
 
     Examples
     ========
@@ -138,6 +137,22 @@ def Y_lm(l, m, phi, theta):
     >>> dz2 = Y_lm(2, 0, phi, theta)**2
     >>> [sol.evalf() for sol in sympy.solve(dz2)]
     [4.0969092717143, 5.32786868905508, 2.18627603546528, 0.955316618124509]
+
+    See Also
+    ========
+
+    Z_lm, sympy.functions.special.spherical_harmonics.Ynm,
+    sympy.functions.special.spherical_harmonics.Ynm_c,
+    sympy.functions.special.spherical_harmonics.Znm
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Spherical_harmonics
+    .. [2] https://en.wikipedia.org/wiki/Table_of_spherical_harmonics
+    .. [3] https://mathworld.wolfram.com/SphericalHarmonic.html
+    .. [4] https://functions.wolfram.com/Polynomials/SphericalHarmonicY/
+    .. [5] https://dlmf.nist.gov/14.30
 
     """
     return Ynm(l, m, theta, phi).expand(func=True)
@@ -190,6 +205,22 @@ def Z_lm(l, m, phi, theta):
     >>> dz2 = Z_lm(2, 0, phi, theta)**2
     >>> [sol.evalf() for sol in sympy.solve(dz2)]
     [4.0969092717143, 5.32786868905508, 2.18627603546528, 0.955316618124509]
+
+    See Also
+    ========
+
+    Y_lm, sympy.functions.special.spherical_harmonics.Ynm,
+    sympy.functions.special.spherical_harmonics.Ynm_c,
+    sympy.functions.special.spherical_harmonics.Znm
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Spherical_harmonics
+    .. [2] https://en.wikipedia.org/wiki/Table_of_spherical_harmonics
+    .. [3] https://mathworld.wolfram.com/SphericalHarmonic.html
+    .. [4] https://functions.wolfram.com/Polynomials/SphericalHarmonicY/
+    .. [5] https://dlmf.nist.gov/14.30
 
     """
     return Znm(l, m, theta, phi).expand(func=True)

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -117,6 +117,7 @@ def Y_lm(l, m, phi, theta, complex=False):
     ========
 
     >>> import sympy
+    >>> from sympy.physics.hydrogen import Y_lm
     >>> phi, theta = sympy.symbols('phi theta')
     >>> Y_lm(1, 0, phi, theta)
     sqrt(3)*cos(theta)/(2*sqrt(pi))

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -4,7 +4,7 @@ from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.polynomials import assoc_laguerre
-from sympy.functions.special.spherical_harmonics import Ynm
+from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c
 
 
 def R_nl(n, l, r, Z=1):
@@ -90,6 +90,61 @@ def R_nl(n, l, r, Z=1):
     # some books. Both coefficients seem to be the same fast:
     # C =  S(2)/n**2 * sqrt(1/a**3 * factorial(n_r) / (factorial(n+l)))
     return C * r0**l * assoc_laguerre(n_r, 2*l + 1, r0).expand() * exp(-r0/2)
+
+
+def Y_lm(l, m, phi, theta, complex=False):
+    """
+    Returns the spherical harmonic or angular function Y_{l}^{m} of atomic
+    orbitals.
+
+    Parameters
+    ==========
+
+    l : integer
+        ``l`` is the Angular Momentum Quantum Number with
+        values ranging from 0 to ``n-1``.
+    m : integer
+        ``m`` is the Magnetic Quantum Number with values
+        ranging from ``-l`` to ``l``.
+    phi :
+        azimuthal angle
+    theta :
+        polar angle
+    complex : bool
+        whether the function is complex or not
+
+    Examples
+    ========
+
+    >>> phi, theta = sympy.symbols('phi theta')
+    >>> Y_lm(1, 0, phi, theta)
+    sqrt(3)*cos(theta)/(2*sqrt(pi))
+    >>> Y_lm(2, 0, phi, theta).simplify()
+    sqrt(5)*(3*cos(theta)**2 - 1)/(4*sqrt(pi))
+    >>> Y_lm(2, 1, phi, theta, complex=False)
+    -sqrt(30)*exp(I*phi)*sin(theta)*cos(theta)/(4*sqrt(pi))
+    >>> Y_lm(2, 1, phi, theta, complex=True)
+    -sqrt(30)*exp(-I*phi)*sin(theta)*cos(theta)/(4*sqrt(pi))
+    >>> Y_lm(1, 1, 1, 1).evalf()
+    -0.157078470548806 - 0.244635223409689*I
+
+    Find angular nodes in dz2 atomic orbital by solving for zero probability.
+
+    >>> dz2 = Y_lm(2, 0, phi, theta)**2
+    >>> [sol.evalf() for sol in sympy.solve(dz2)]
+    [4.09690927171430, 5.32786868905508, 2.18627603546528, 0.955316618124509]
+
+    """
+    l, m, theta, phi = map(S, [l, m, theta, phi])
+    if abs(m) > l:
+        raise ValueError("|'m'| must be less or equal 'l'")
+    elif m.is_integer and l.is_integer:
+        if complex:
+            return Ynm_c(l, m, theta, phi).expand(func=True)
+        else:
+            return Ynm(l, m, theta, phi).expand(func=True)
+    else:
+        raise ValueError("'m' and 'l' must be integers")
 
 
 def Psi_nlm(n, l, m, r, phi, theta, Z=1):

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -134,7 +134,7 @@ def Y_lm(l, m, phi, theta, complex=False):
 
     >>> dz2 = Y_lm(2, 0, phi, theta)**2
     >>> [sol.evalf() for sol in sympy.solve(dz2)]
-    [4.09690927171430, 5.32786868905508, 2.18627603546528, 0.955316618124509]
+    [4.0969092717143, 5.32786868905508, 2.18627603546528, 0.955316618124509]
 
     """
     l, m, theta, phi = map(S, [l, m, theta, phi])

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -138,15 +138,12 @@ def Y_lm(l, m, phi, theta, complex=False):
 
     """
     l, m, theta, phi = map(S, [l, m, theta, phi])
-    if abs(m) > l:
+    if m.is_integer and l.is_integer and abs(m) > l:
         raise ValueError("|'m'| must be less or equal 'l'")
-    elif m.is_integer and l.is_integer:
-        if complex:
-            return Ynm_c(l, m, theta, phi).expand(func=True)
-        else:
-            return Ynm(l, m, theta, phi).expand(func=True)
+    elif complex:
+        return Ynm_c(l, m, theta, phi).expand(func=True)
     else:
-        raise ValueError("'m' and 'l' must be integers")
+        return Ynm(l, m, theta, phi).expand(func=True)
 
 
 def Psi_nlm(n, l, m, r, phi, theta, Z=1):

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -116,6 +116,7 @@ def Y_lm(l, m, phi, theta, complex=False):
     Examples
     ========
 
+    >>> import sympy
     >>> phi, theta = sympy.symbols('phi theta')
     >>> Y_lm(1, 0, phi, theta)
     sqrt(3)*cos(theta)/(2*sqrt(pi))

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -92,7 +92,7 @@ def R_nl(n, l, r, Z=1):
     return C * r0**l * assoc_laguerre(n_r, 2*l + 1, r0).expand() * exp(-r0/2)
 
 
-def Y_lm(l, m, phi, theta, real=False):
+def Y_lm(l, m, phi, theta):
     """
     Returns the spherical harmonic or angular function Y_{l}^{m}.
 
@@ -109,17 +109,13 @@ def Y_lm(l, m, phi, theta, real=False):
         azimuthal angle
     theta :
         polar angle
-    real : bool
-        return the real spherical harmonic if True instead of complex
 
     Notes
     =====
 
-    This function follows the Condon-Shortley phase convention.
-
-    If the imaginary component does not cancel for real representations of
-    the spherical harmonic, try setting your phi and theta symbol assumptions
-    to real.
+    This function follows the Condon-Shortley phase convention and may return
+    real or complex values depending on values for ``l`` and ``m``. See Z_lm()
+    for real-valued spherical harmonics.
 
     Examples
     ========
@@ -129,14 +125,12 @@ def Y_lm(l, m, phi, theta, real=False):
     >>> phi, theta = sympy.symbols('phi theta', real=True)
     >>> Y_lm(1, 0, phi, theta)
     sqrt(3)*cos(theta)/(2*sqrt(pi))
-    >>> Y_lm(2, 0, phi, theta).simplify()
-    sqrt(5)*(3*cos(theta)**2 - 1)/(4*sqrt(pi))
-    >>> Y_lm(1, -1, phi, theta, real=True).simplify()
-    -sqrt(3)*sin(phi)*sin(theta)/(2*sqrt(pi))
-    >>> Y_lm(1, -1, phi, theta, real=False).simplify()
+    >>> Y_lm(2, -1, phi, theta).simplify()
+    sqrt(30)*exp(-I*phi)*sin(2*theta)/(8*sqrt(pi))
+    >>> Y_lm(1, -1, phi, theta).simplify()
     sqrt(6)*exp(-I*phi)*sin(theta)/(4*sqrt(pi))
-    >>> Y_lm(1, 1, 1, 1).evalf()
-    -0.157078470548806 - 0.244635223409689*I
+    >>> Y_lm(1, 1, 0, 1).evalf()
+    -0.290723302201011
 
     Find angular nodes in dz2 atomic orbital by solving for zero probability.
     This returns the node theta angles in radians.
@@ -146,13 +140,59 @@ def Y_lm(l, m, phi, theta, real=False):
     [4.0969092717143, 5.32786868905508, 2.18627603546528, 0.955316618124509]
 
     """
-    l, m, theta, phi = map(S, [l, m, theta, phi])
-    if m.is_integer and l.is_integer and abs(m) > l:
-        raise ValueError("|'m'| must be less or equal 'l'")
-    if real:
-        return Znm(l, m, theta, phi).expand(func=True)
-    else:
-        return Ynm(l, m, theta, phi).expand(func=True)
+    return Ynm(l, m, theta, phi).expand(func=True)
+
+
+def Z_lm(l, m, phi, theta):
+    """
+    Returns the real spherical harmonic or angular function Y_{l}^{m}.
+
+    Parameters
+    ==========
+
+    l : integer
+        ``l`` is the Angular Momentum Quantum Number with
+        values ranging from 0 to ``n-1``.
+    m : iteger
+        ``m`` is the Magnetic Quantum Number with values
+        ranging from ``-l`` to ``l``.
+    phi :
+        azimuthal angle
+    theta :
+        polar angle
+
+    Notes
+    =====
+
+    This function follows the Condon-Shortley phase convention.
+
+    If the imaginary components do not cancel, try setting your phi and theta
+    symbol assumptions to real. See below.
+
+    Examples
+    ========
+
+    >>> import sympy
+    >>> from sympy.physics.hydrogen import Z_lm
+    >>> phi, theta = sympy.symbols('phi theta', real=True)
+    >>> Z_lm(1, 0, phi, theta)
+    sqrt(3)*cos(theta)/(2*sqrt(pi))
+    >>> Z_lm(2, -1, phi, theta).simplify()
+    -sqrt(15)*sin(phi)*sin(2*theta)/(4*sqrt(pi))
+    >>> Z_lm(1, -1, phi, theta).simplify()
+    -sqrt(3)*sin(phi)*sin(theta)/(2*sqrt(pi))
+    >>> Z_lm(1, 1, 0, 1).evalf()
+    -0.411144836870562
+
+    Find angular nodes in dz2 atomic orbital by solving for zero probability.
+    This returns the node theta angles in radians.
+
+    >>> dz2 = Z_lm(2, 0, phi, theta)**2
+    >>> [sol.evalf() for sol in sympy.solve(dz2)]
+    [4.0969092717143, 5.32786868905508, 2.18627603546528, 0.955316618124509]
+
+    """
+    return Znm(l, m, theta, phi).expand(func=True)
 
 
 def Psi_nlm(n, l, m, r, phi, theta, Z=1):

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -4,7 +4,7 @@ from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.polynomials import assoc_laguerre
-from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c
+from sympy.functions.special.spherical_harmonics import Ynm, Znm
 
 
 def R_nl(n, l, r, Z=1):
@@ -92,10 +92,9 @@ def R_nl(n, l, r, Z=1):
     return C * r0**l * assoc_laguerre(n_r, 2*l + 1, r0).expand() * exp(-r0/2)
 
 
-def Y_lm(l, m, phi, theta, complex=False):
+def Y_lm(l, m, phi, theta, real=False):
     """
-    Returns the spherical harmonic or angular function Y_{l}^{m} of atomic
-    orbitals.
+    Returns the spherical harmonic or angular function Y_{l}^{m}.
 
     Parameters
     ==========
@@ -103,34 +102,44 @@ def Y_lm(l, m, phi, theta, complex=False):
     l : integer
         ``l`` is the Angular Momentum Quantum Number with
         values ranging from 0 to ``n-1``.
-    m : integer
+    m : iteger
         ``m`` is the Magnetic Quantum Number with values
         ranging from ``-l`` to ``l``.
     phi :
         azimuthal angle
     theta :
         polar angle
-    complex : bool
-        whether the function is complex or not
+    real : bool
+        return the real spherical harmonic if True instead of complex
+
+    Notes
+    =====
+
+    This function follows the Condon-Shortley phase convention.
+
+    If the imaginary component does not cancel for real representations of
+    the spherical harmonic, try setting your phi and theta symbol assumptions
+    to real.
 
     Examples
     ========
 
     >>> import sympy
     >>> from sympy.physics.hydrogen import Y_lm
-    >>> phi, theta = sympy.symbols('phi theta')
+    >>> phi, theta = sympy.symbols('phi theta', real=True)
     >>> Y_lm(1, 0, phi, theta)
     sqrt(3)*cos(theta)/(2*sqrt(pi))
     >>> Y_lm(2, 0, phi, theta).simplify()
     sqrt(5)*(3*cos(theta)**2 - 1)/(4*sqrt(pi))
-    >>> Y_lm(2, 1, phi, theta, complex=False)
-    -sqrt(30)*exp(I*phi)*sin(theta)*cos(theta)/(4*sqrt(pi))
-    >>> Y_lm(2, 1, phi, theta, complex=True)
-    -sqrt(30)*exp(-I*phi)*sin(theta)*cos(theta)/(4*sqrt(pi))
+    >>> Y_lm(1, -1, phi, theta, real=True).simplify()
+    -sqrt(3)*sin(phi)*sin(theta)/(2*sqrt(pi))
+    >>> Y_lm(1, -1, phi, theta, real=False).simplify()
+    sqrt(6)*exp(-I*phi)*sin(theta)/(4*sqrt(pi))
     >>> Y_lm(1, 1, 1, 1).evalf()
     -0.157078470548806 - 0.244635223409689*I
 
     Find angular nodes in dz2 atomic orbital by solving for zero probability.
+    This returns the node theta angles in radians.
 
     >>> dz2 = Y_lm(2, 0, phi, theta)**2
     >>> [sol.evalf() for sol in sympy.solve(dz2)]
@@ -140,8 +149,8 @@ def Y_lm(l, m, phi, theta, complex=False):
     l, m, theta, phi = map(S, [l, m, theta, phi])
     if m.is_integer and l.is_integer and abs(m) > l:
         raise ValueError("|'m'| must be less or equal 'l'")
-    elif complex:
-        return Ynm_c(l, m, theta, phi).expand(func=True)
+    if real:
+        return Znm(l, m, theta, phi).expand(func=True)
     else:
         return Ynm(l, m, theta, phi).expand(func=True)
 

--- a/sympy/physics/tests/test_hydrogen.py
+++ b/sympy/physics/tests/test_hydrogen.py
@@ -6,7 +6,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.integrals.integrals import integrate
 from sympy.simplify.simplify import simplify
-from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac, Psi_nlm, Y_lm
+from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac, Psi_nlm, Y_lm, Z_lm
 from sympy.testing.pytest import raises
 
 n, r, Z = symbols('n r Z')
@@ -129,7 +129,6 @@ def test_hydrogen_energies_relat():
 def test_y_lm():
     # https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#
     l, m, phi, theta = symbols('l, m, phi, theta', real=True)
-    # complex spherical harmonics
     assert Y_lm(1, 0, 0, pi) == -sqrt(3)/(2*sqrt(pi))
     assert Y_lm(0, 0, 0, 0) == 1/(2*sqrt(pi))
     assert Y_lm(0, 0, phi, theta) == 1/(2*sqrt(pi))
@@ -137,10 +136,13 @@ def test_y_lm():
     assert Y_lm(1, 1, phi, theta) == -sqrt(6)*exp(I*phi)*sin(theta)/(4*sqrt(pi))
     assert Y_lm(1, -1, phi, theta) == sqrt(6)*exp(-I*phi)*sin(theta)/(4*sqrt(pi))
 
-    # real spherical harmonics
-    assert Y_lm(2, 0, 0, 0, real=True) == sqrt(5)/(2*sqrt(pi))
-    assert Y_lm(1, -1, pi/2, pi/2, real=True) == -sqrt(3)/(2*sqrt(pi))
-    assert Y_lm(2, 2, phi, theta, real=True).simplify() == (
+
+def test_z_lm():
+    # https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#
+    l, m, phi, theta = symbols('l, m, phi, theta', real=True)
+    assert Z_lm(2, 0, 0, 0) == sqrt(5)/(2*sqrt(pi))
+    assert Z_lm(1, -1, pi/2, pi/2) == -sqrt(3)/(2*sqrt(pi))
+    assert Z_lm(2, 2, phi, theta).simplify() == (
         sqrt(15)*sin(theta)**2*cos(2*phi)/(4*sqrt(pi)))
-    assert Y_lm(2, -2, phi, theta, real=True).simplify() == (
+    assert Z_lm(2, -2, phi, theta).simplify() == (
         -sqrt(15)*sin(2*phi)*sin(theta)**2/(4*sqrt(pi)))

--- a/sympy/physics/tests/test_hydrogen.py
+++ b/sympy/physics/tests/test_hydrogen.py
@@ -6,7 +6,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.integrals.integrals import integrate
 from sympy.simplify.simplify import simplify
-from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac, Psi_nlm
+from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac, Psi_nlm, Y_lm
 from sympy.testing.pytest import raises
 
 n, r, Z = symbols('n r Z')
@@ -124,3 +124,23 @@ def test_hydrogen_energies_relat():
     raises(ValueError, lambda: E_nl_dirac(0, 0))
     raises(ValueError, lambda: E_nl_dirac(1, -1))
     raises(ValueError, lambda: E_nl_dirac(1, 0, False))
+
+
+def test_y_lm():
+    # https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#
+    l, m, phi, theta = symbols('l, m, phi, theta', real=True)
+    # complex spherical harmonics
+    assert Y_lm(1, 0, 0, pi) == -sqrt(3)/(2*sqrt(pi))
+    assert Y_lm(0, 0, 0, 0) == 1/(2*sqrt(pi))
+    assert Y_lm(0, 0, phi, theta) == 1/(2*sqrt(pi))
+    assert Y_lm(1, 0, phi, theta) == sqrt(3)*cos(theta)/(2*sqrt(pi))
+    assert Y_lm(1, 1, phi, theta) == -sqrt(6)*exp(I*phi)*sin(theta)/(4*sqrt(pi))
+    assert Y_lm(1, -1, phi, theta) == sqrt(6)*exp(-I*phi)*sin(theta)/(4*sqrt(pi))
+
+    # real spherical harmonics
+    assert Y_lm(2, 0, 0, 0, real=True) == sqrt(5)/(2*sqrt(pi))
+    assert Y_lm(1, -1, pi/2, pi/2, real=True) == -sqrt(3)/(2*sqrt(pi))
+    assert Y_lm(2, 2, phi, theta, real=True).simplify() == (
+        sqrt(15)*sin(theta)**2*cos(2*phi)/(4*sqrt(pi)))
+    assert Y_lm(2, -2, phi, theta, real=True).simplify() == (
+        -sqrt(15)*sin(2*phi)*sin(theta)**2/(4*sqrt(pi)))


### PR DESCRIPTION
Adds the spherical harmonic function Y_lm() to sympy.physics.hydrogen.py. 

### What's Done:
- Added the spherical harmonic function Y_lm() to sympy.physics.hydrogen.py to provides easy user access to angular wave functions with a signature consistent with Psi_nlm() and R_nl() in physics.hydrogen.py and adds documentation and examples.

### Code Added:

`from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c`

```
def Y_lm(l, m, phi, theta, complex=False):
    """
    Returns the spherical harmonic or angular function Y_{l}^{m} of atomic
    orbitals.

    Parameters
    ==========

    l : integer
        ``l`` is the Angular Momentum Quantum Number with
        values ranging from 0 to ``n-1``.
    m : integer
        ``m`` is the Magnetic Quantum Number with values
        ranging from ``-l`` to ``l``.
    phi :
        azimuthal angle
    theta :
        polar angle
    complex : bool
        whether the function is complex or not

    Examples
    ========

    >>> import sympy
    >>> from sympy.physics.hydrogen import Y_lm
    >>> phi, theta = sympy.symbols('phi theta')
    >>> Y_lm(1, 0, phi, theta)
    sqrt(3)*cos(theta)/(2*sqrt(pi))
    >>> Y_lm(2, 0, phi, theta).simplify()
    sqrt(5)*(3*cos(theta)**2 - 1)/(4*sqrt(pi))
    >>> Y_lm(2, 1, phi, theta, complex=False)
    -sqrt(30)*exp(I*phi)*sin(theta)*cos(theta)/(4*sqrt(pi))
    >>> Y_lm(2, 1, phi, theta, complex=True)
    -sqrt(30)*exp(-I*phi)*sin(theta)*cos(theta)/(4*sqrt(pi))
    >>> Y_lm(1, 1, 1, 1).evalf()
    -0.157078470548806 - 0.244635223409689*I

    Find angular nodes in dz2 atomic orbital by solving for zero probability.

    >>> dz2 = Y_lm(2, 0, phi, theta)**2
    >>> [sol.evalf() for sol in sympy.solve(dz2)]
    [4.0969092717143, 5.32786868905508, 2.18627603546528, 0.955316618124509]

    """
    l, m, theta, phi = map(S, [l, m, theta, phi])
    if abs(m) > l:
        raise ValueError("|'m'| must be less or equal 'l'")
    elif m.is_integer and l.is_integer:
        if complex:
            return Ynm_c(l, m, theta, phi).expand(func=True)
        else:
            return Ynm(l, m, theta, phi).expand(func=True)
    else:
        raise ValueError("'m' and 'l' must be integers")
```
Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.hydrogen
    * Added the spherical harmonic function Y_lm() to sympy.physics.hydrogen.py
<!-- END RELEASE NOTES -->