### PR TITLE
Added minimal pre checks for apply_support(), join() functions to avoid misleading errors

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -471,6 +471,13 @@ class Beam:
         else:
             new_second_moment = self.second_moment
 
+        if via== "fixed" or via=="hinge":
+            pass
+        else:
+            raise ValueError(
+                "Invalid joining method. Choose from 'fixed' or 'hinge'."
+            )
+
         if via == "fixed":
             new_beam = Beam(new_length, E, new_second_moment, x)
             new_beam._joined_beam = True
@@ -534,6 +541,13 @@ class Beam:
         + 10*SingularityFunction(x, 20, -1)
         """
         loc = sympify(loc)
+
+        if type == "fixed" or type=="roller" or type=="pin":
+            pass
+        else:
+            raise ValueError(
+                "Invalid support type. Choose from 'pin', 'roller', or 'fixed'."
+            )
 
         self._applied_supports.append((loc, type))
         if type in ("pin", "roller"):
@@ -2887,6 +2901,12 @@ class Beam3D(Beam):
             self._load_Singularity[0] += value*SingularityFunction(x, start, order)
 
     def apply_support(self, loc, type="fixed"):
+        if type in ("pin", "roller", "fixed"):
+            pass
+        else:
+            raise ValueError(
+                "Invalid support type. Choose from 'pin', 'roller', or 'fixed'."
+            )
         if type in ("pin", "roller"):
             reaction_load = Symbol('R_'+str(loc))
             self._reaction_loads[reaction_load] = reaction_load

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -422,6 +422,12 @@ def test_composite_beam():
                     - 133*SingularityFunction(x, 1, 3)/405000 + SingularityFunction(x, 3, 3)/3000\
                     - 37*SingularityFunction(x, 4, 3)/202500
 
+    E = Symbol('E')
+    I = Symbol('I')
+    b=Beam(6, E, I)
+    c=Beam(6, E, I)
+    with raises(ValueError, match="Invalid joining method. Choose from 'fixed' or 'hinge'."):
+        b.join(c, "hige")
 
 def test_point_cflexure():
     E = Symbol('E')
@@ -548,6 +554,12 @@ def test_apply_support():
     R_0, R_L, M_0, M_L = symbols('R_0, R_L, M_0, M_L')
     b.solve_for_reaction_loads(R_0, R_L, M_0, M_L)
     assert b.reaction_loads == {R_0: P/2, R_L: P/2, M_0: -L*P/8, M_L: L*P/8}
+
+    E = Symbol('E')
+    I = Symbol('I')
+    b=Beam(6, E, I)
+    with raises(ValueError, match="Invalid support type. Choose from 'pin', 'roller', or 'fixed'."):
+        b.apply_support(0,"pen")
 
 def test_apply_rotation_hinge():
     b = Beam(15, 20, 20)

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -500,7 +500,7 @@ def test_apply_support():
     I = Symbol('I')
 
     b = Beam(4, E, I)
-    b.apply_support(0, "cantilever")
+    b.apply_support(0, "fixed")
     b.apply_load(20, 4, -1)
     M_0, R_0 = symbols('M_0, R_0')
     b.solve_for_reaction_loads(R_0, M_0)


### PR DESCRIPTION


#### References to other Issues or PRs
Fixes #28192 


#### Brief description of what is fixed or changed
Added checks just to ensure the support types entered are valid for both apply_support(), join() functions which handled a wrong input from user as fixed support. before 


#### Other comments


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * Added basic checks to handle input types better for apply_support(), join functionalities.


<!-- END RELEASE NOTES -->
