### PR TITLE
[GSoC] Refactor assumption normalization to use ```.replace()``` for canonical inequality forms

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -377,13 +377,27 @@ def _normalize_applied_predicates(expr):
     return expr
 
 def _normalize_relations(expr):
-    expr = expr.replace(Gt, lambda a, b: Q.lt(b, a))
-    expr = expr.replace(Ge, lambda a, b: Q.le(b, a))
-    expr = expr.replace(Lt, lambda a, b: Q.lt(a, b))
-    expr = expr.replace(Le, lambda a, b: Q.le(a, b))
-    expr = expr.replace(Eq, lambda a, b: Q.eq(a, b))
-    expr = expr.replace(Ne, lambda a, b: Q.ne(a, b))
-    return expr
+    def _filter(e):
+        return isinstance(e, (Gt, Ge, Lt, Le, Eq, Ne))
+
+    def _replace(e):
+        a, b = e.args
+        if isinstance(e, Gt):
+            return Q.lt(b, a)
+        elif isinstance(e, Ge):
+            return Q.le(b, a)
+        elif isinstance(e, Lt):
+            return Q.lt(a, b)
+        elif isinstance(e, Le):
+            return Q.le(a, b)
+        elif isinstance(e, Eq):
+            return Q.eq(a, b)
+        elif isinstance(e, Ne):
+            return Q.ne(a, b)
+        return e
+
+    return expr.replace(_filter, _replace)
+
 
 def _normalize_expr(expr):
     expr = _normalize_relations(expr)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2569,3 +2569,10 @@ def test_issue_25221():
 def test_issue_27440():
     nan = S.NaN
     assert ask(Q.negative(nan)) is None
+
+def test_issue_28127():
+    assert ask(Q.le(x,y), Q.gt(x,y)) is False
+    assert ask(Q.ge(x,y), Q.lt(x,y)) is False
+    assert ask(Q.gt(y,x), Q.lt(x,y)) is True
+    assert ask(Q.lt(y,x), Q.gt(x,y)) is True
+    assert ask(Q.le(y,x), Q.ge(x,y)) is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Partially fixes #28127
#### PR Description
- Convert all inequality forms (```Q.gt```, ```Q.ge```, ```Gt```, ```Ge```) to canonical ```Q.lt```/```Q.le```.
- Handle relational operators by converting them to Q predicates
- Maintains full backward compatibility while simplifying the code


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
