### PR TITLE
Fix duplicate keyword argument error for evaluate=False

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1216,10 +1216,13 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         return node
 
     def visit_Call(self, node):
-        new_node = self.generic_visit(node)
         if isinstance(node.func, ast.Name) and node.func.id in self.functions:
-            new_node.keywords.append(ast.keyword(arg='evaluate', value=ast.Constant(value=False)))
-        return new_node
+            func = self.visit(node.func)
+            args = [self.visit(arg) for arg in node.args]
+            keywords = [ast.keyword(arg=keyword.arg, value=self.visit(keyword.value)) for keyword in node.keywords]
+            keywords.append(ast.keyword(arg='evaluate', value=ast.Constant(value=False)))
+            return ast.Call(func=func, args=args, keywords=keywords)
+        return self.generic_visit(node)
 
 
 _transformation = {  # items can be added but never re-ordered

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -6,6 +6,7 @@ import types
 
 from sympy.assumptions import Q
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq, Lt, Le, Gt, Ge, Ne
+from sympy.core.singleton import S
 from sympy.functions import exp, factorial, factorial2, sin, Min, Max
 from sympy.logic import And, Xor
 from sympy.series import Limit
@@ -294,6 +295,16 @@ def test_issue_24288():
     raises(ValueError, lambda: parse_expr("1 is 2", evaluate=False))
     raises(ValueError, lambda: parse_expr("1 not in 2", evaluate=False))
     raises(ValueError, lambda: parse_expr("1 is not 2", evaluate=False))
+
+    x = Symbol('x')
+    assert parse_expr("1 < sin(x) < 2", evaluate=False) == \
+        And(Lt(1, sin(x), evaluate=False), Lt(sin(x), 2, evaluate=False), evaluate=False)
+    assert parse_expr("1 < sin(pi) < 2", evaluate=False) == \
+        And(
+            Lt(1, sin(S.Pi, evaluate=False), evaluate=False),
+            Lt(sin(S.Pi, evaluate=False), 2, evaluate=False),
+            evaluate=False
+        )
 
 def test_split_symbols_numeric():
     transformations = (


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/pull/27102#issuecomment-3019085021

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - Fixed an issue that `parse_expr` with `evaluate=False` gives syntax error for keyword argument being duplicated. For example: `parse_expr("1 < sin(x) < 2", evaluate=False)`.
<!-- END RELEASE NOTES -->
