### PR TITLE
Follow up for PR-28119 (Improved test formatting, test coverage expansion, bug fix in PolyElement.cofactor)

### DIFF
--- a/sympy/polys/numberfields/minpoly.py
+++ b/sympy/polys/numberfields/minpoly.py
@@ -274,7 +274,7 @@ def _minpoly_op_algebraic_element(op, ex1, ex2, x, dom, mp1=None, mp2=None):
         r = resultant(mp1a, mp2, gens=[y, x])
     else:
         r = rs_compose_add(p1, p2)
-        r = expr_from_dict(r._as_expr_dict(), x)
+        r = expr_from_dict(r.as_expr_dict(), x)
 
     deg1 = degree(mp1, x)
     deg2 = degree(mp2, y)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -876,7 +876,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             try:
                 cp2 = ring.ring_new(other)
             except CoercionFailed:
-                return NotImplemented
+                return NotImplemented # unreachable
             else:
                 return self._mul(cp2)
 
@@ -1152,7 +1152,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
                 f"got {len(symbols)}"
             )
 
-        return expr_from_dict(self._as_expr_dict(), *symbols)
+        return expr_from_dict(self.as_expr_dict(), *symbols)
 
     def set_ring(self, new_ring):
         """Change the ring of this polynomial."""
@@ -1911,8 +1911,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         return self._symmetrize()
 
-    # <--------------------------INTERFACE / IMPLEMENTATION DIVIDER-------------------------->#
-
     def __eq__(self, other):
         """Equality test for polynomials.
 
@@ -2402,7 +2400,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         else:
             return new_ring.from_dict(self, self.ring.domain)
 
-    def _as_expr_dict(self):
+    def as_expr_dict(self):
         # Can just use self.flint_poly.to_dict() in case of python-flint
         # Or this can just directly go into the baseclass as is since iterterms
         # will be implemented separately for pure python and flint versions anyways
@@ -2807,7 +2805,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         elif len(self) == 1:
             h, cff, cfg = self._gcd_monom(other)
             return h, cff, cfg
-        elif len(self) == 1:
+        elif len(other) == 1:
             h, cfg, cff = other._gcd_monom(self)
             return h, cff, cfg
 


### PR DESCRIPTION
This is a follow up PR for gh-28119 that improves upon test formatting, a bug fix in `PolyElement.cofactor` and further expansion of test coverage through `sympy/polys/tests/test_rings.py`. 
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
