### PR TITLE
Fix performance issues in get_asymptotic_stability_conditions in StateSpace

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5165,7 +5165,7 @@ class StateSpace(LinearTimeInvariant):
         (1/3 < k) & (k < 1)
 
         """
-        s = Symbol('s', dummy = True)
+        s = Symbol('s')
         domain = None if simplify is True else EXRAW
         # if domain is None, to_DM will find the domain automatically
         _A = self.A.to_DM(domain = domain)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5133,17 +5133,31 @@ class StateSpace(LinearTimeInvariant):
         """
         return self.controllability_matrix().rank() == self.num_states
 
-    def get_asymptotic_stability_conditions(self, simplify=True):
+    def get_asymptotic_stability_conditions(self, canonical=True):
         """
         Returns the asymptotic stability conditions for
         the state space.
 
         Note: Computing the inequalities for matrices with many symbols
-        can take a long time, so it is recommended to set ``simplify=False``.
+        can take a long time, so it is recommended to set ``canonical=False``.
+
+        Explanation
+        ===========
+
+        ``canonical`` controls how the calculation is performed.
+        If ``canonical=True``, the algorithm will use domains.
+        This allows it to simplify inequalities as much as possible.
+        If ``canonical=False``, the algorithm will instead use the ``EXRAW``
+        domain.
+        In this mode, calculations are done directly on the expression form,
+        and fewer simplifications and cancellations are performed.
+        This is useful when the matrix contains many symbolic elements,
+        since computing the full domain and performing all simplifications can
+        be very time-consuming.
 
         Parameters
         ==========
-        simplify : bool, default=True
+        canonical : bool, default=True
             If True, the inequalities will be in a simplified form.
 
         Examples
@@ -5166,7 +5180,7 @@ class StateSpace(LinearTimeInvariant):
 
         """
         s = Symbol('s')
-        domain = None if simplify is True else EXRAW
+        domain = None if canonical is True else EXRAW
         # if domain is None, to_DM will find the domain automatically
         _A = self.A.to_DM(domain = domain)
 

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5171,5 +5171,5 @@ class StateSpace(LinearTimeInvariant):
         _A = self.A.to_DM(domain = domain)
 
         charpoly = _A.charpoly()
-        charpoly = Poly(charpoly, s, domain = domain)
-        return negative_real_part_conditions(charpoly, s, domain = domain)
+        charpoly = Poly(charpoly, s, domain = _A.domain)
+        return negative_real_part_conditions(charpoly, s, domain = _A.domain)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28180

#### Brief description of what is fixed or changed
The function `get_asymptotic_stability_conditions` now has a new parameter `simplify`.
If it is set to `False`, the characteristic polynomial of the matrix `A` is computed with the domain `EXRAW`, avoiding simplifications.
This makes the computation of the characteristic polynomial faster.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added the parameter `simplify` to `get_asymptotic_stability_conditions` in state spaces. If it is set to `False`, the method computes faster by avoiding polynomial simplification.
<!-- END RELEASE NOTES -->
