### PR TITLE
polys: Disallowing negative generator indices in PolyRing.index 

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -485,9 +485,6 @@ class PolyRing(DefaultPrinting, IPolys):
         if isinstance(gen, int):
             if 0 <= gen < self.ngens:
                 return gen
-            elif -self.ngens <= gen <= -1:
-                gen = -gen - 1
-                return gen
             else:
                 raise ValueError(f"invalid generator index: {gen}")
         else:  # gen is a string

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -252,7 +252,8 @@ def test_PolyRing_index():
     assert ring.index(0) == 0
     assert ring.index(1) == 1
     assert ring.index(2) == 2
-    assert ring.index(-1) == 0
+
+    raises(ValueError, lambda: ring.index(-1)) # negative generator indices not allowed
 
     R = PolyRing('x,y,z', ZZ, lex)
     x, y, z = ring.gens


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27794  

#### Brief description of what is fixed or changed
`PolyRing.index` has been refactored to only allow positive generator indices in the correct range when `int` is used as the generator identifier. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * `PolyRing.index` now raises a `ValueError` for nonpositive or out-of-range integer generator indices. Previously, this method accepted negative indices as well, which is not intuitive or useful and is now disallowed.
<!-- END RELEASE NOTES -->
