### PR TITLE
Implement `dup_series_*` Functions for Series Manipulation

### DIFF
--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -180,7 +180,9 @@ may be slightly more efficient.)
 .. autofunction:: dmp_lift
 .. autofunction:: dup_sign_variations
 .. autofunction:: dmp_clear_denoms
+.. autofunction:: dup_revert
 .. autofunction:: dmp_revert
+.. autofunction:: dup_reversion
 
 Manipulation of dense, univariate polynomials with finite field coefficients
 ****************************************************************************

--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -112,6 +112,8 @@ may be slightly more efficient.)
 .. autofunction:: dmp_slice
 .. autofunction:: dup_truncate
 .. autofunction:: dup_random
+.. autofunction:: dup_from_list
+.. autofunction:: dup_print
 
 **Arithmetic operations:**
 

--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -182,7 +182,7 @@ may be slightly more efficient.)
 .. autofunction:: dmp_clear_denoms
 .. autofunction:: dup_revert
 .. autofunction:: dmp_revert
-.. autofunction:: dup_reversion
+.. autofunction:: dup_series_reversion
 
 Manipulation of dense, univariate polynomials with finite field coefficients
 ****************************************************************************

--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -108,7 +108,9 @@ may be slightly more efficient.)
 .. autofunction:: dmp_terms_gcd
 .. autofunction:: dmp_list_terms
 .. autofunction:: dmp_apply_pairs
+.. autofunction:: dup_slice
 .. autofunction:: dmp_slice
+.. autofunction:: dup_truncate
 .. autofunction:: dup_random
 
 **Arithmetic operations:**
@@ -131,9 +133,12 @@ may be slightly more efficient.)
 .. autofunction:: dmp_sub
 .. autofunction:: dmp_add_mul
 .. autofunction:: dmp_sub_mul
+.. autofunction:: dup_mul
 .. autofunction:: dmp_mul
+.. autofunction:: dup_series_mul
 .. autofunction:: dmp_sqr
 .. autofunction:: dmp_pow
+.. autofunction:: dup_series_pow
 .. autofunction:: dmp_pdiv
 .. autofunction:: dmp_prem
 .. autofunction:: dmp_pquo
@@ -175,7 +180,9 @@ may be slightly more efficient.)
 .. autofunction:: dup_scale
 .. autofunction:: dup_shift
 .. autofunction:: dup_transform
+.. autofunction:: dup_compose
 .. autofunction:: dmp_compose
+.. autofunction:: dup_series_compose
 .. autofunction:: dup_decompose
 .. autofunction:: dmp_lift
 .. autofunction:: dup_sign_variations

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -837,14 +837,11 @@ def _dup_series_mul_base(f, g, n, K):
     """
     Helper function for dup_series_mul that uses a naive O(n^2) algorithm
     """
-    if not f or not g or n <= 0:
-        return []
-
-    f = dup_truncate(f, n, K)[::-1]
-    g = dup_truncate(g, n, K)[::-1]
+    f = f[::-1]
+    g = g[::-1]
 
     h = [K.zero] * n
-    for i in range(len(f)):
+    for i in range(min(len(f), n)):
         for j in range(min(len(g), n - i)):
             h[i + j] += f[i] * g[j]
 
@@ -855,9 +852,6 @@ def _dup_series_mul_karatsuba(f, g, prec, K):
     """
     Helper function for dup_series_mul that uses Karatsuba's algorithm
     """
-    if not f or not g or prec <= 0:
-        return []
-
     df = dup_degree(f)
     dg = dup_degree(g)
 

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -845,9 +845,7 @@ def _dup_series_mul_base(f, g, n, K):
 
     h = [K.zero] * n
     for i in range(len(f)):
-        for j in range(len(g)):
-            if i+j >= n:
-                break
+        for j in range(min(len(g), n - i)):
             h[i + j] += f[i] * g[j]
 
     return dup_reverse(h)

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -845,22 +845,25 @@ def dup_series_mul(f, g, prec, K):
     >>> dup_series_mul(f, g, 4, ZZ)
     [2, 1, 2, 1]
     """
-    if not f or not g:
+    if not f or not g or prec <= 0:
         return []
 
     df = dup_degree(f)
     dg = dup_degree(g)
-    max_deg = min(df + dg, prec - 1)
+    h = [K.zero] * prec
 
-    h = [K.zero] * (max_deg + 1)
+    for i in range(len(f)):
+        deg_i = df - i
+        for j in range(len(g)):
+            deg_j = dg - j
+            deg_total = deg_i + deg_j
+            if deg_total >= prec:
+                continue
 
-    for i in range(0, max_deg + 1):
-        coeff = K.zero
-        for j in range(max(0, i - dg), min(i, df) + 1):
-            coeff += f[j] * g[i - j]
-        h[i] = coeff
+            k = prec - 1 - deg_total
+            h[k] += f[i] * g[j]
 
-    return dup_truncate(h, prec, K)
+    return dup_strip(h)
 
 
 def dup_sqr(f, K):

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -903,10 +903,13 @@ def dup_series_mul(f, g, n, K):
     ========
     >>> from sympy import ZZ
     >>> from sympy.polys.densearith import dup_series_mul
-    >>> f = [1, 0, 1]
-    >>> g = [2, 1]
-    >>> dup_series_mul(f, g, 4, ZZ)
-    [2, 1, 2, 1]
+    >>> from sympy.polys.densebasic import dup_from_list, dup_print
+    >>> f = dup_from_list([1, 0, 1], ZZ)
+    >>> g = dup_from_list([2, 1], ZZ)
+    >>> h = dup_series_mul(f, g, 4, ZZ)
+    >>> dup_print(h, 'x')
+    2*x**3 + x**2 + 2*x + 1
+
     """
     if not f or not g or n <= 0:
         return []
@@ -1106,9 +1109,12 @@ def dup_series_pow(f, n, prec, K):
     ========
     >>> from sympy import ZZ
     >>> from sympy.polys.densearith import dup_series_pow
-    >>> f = [1, 2, 3]
-    >>> dup_series_pow(f, 2, 5, ZZ)
-    [1, 4, 10, 12, 9]
+    >>> from sympy.polys.densebasic import dup_from_list, dup_print
+    >>> f = dup_from_list([1, 2, 3], ZZ)
+    >>> p = dup_series_pow(f, 2, 5, ZZ)
+    >>> dup_print(p, 'x')
+    x**4 + 4*x**3 + 10*x**2 + 12*x + 9
+
     """
     if not f:
         return []

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1841,6 +1841,23 @@ def dmp_slice(f, m, n, u, K):
     return dmp_slice_in(f, m, n, 0, u, K)
 
 
+def dup_truncate(f, n, K):
+    """
+    Truncate ``f`` to the first ``n`` terms in ``K[x]``.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densebasic import dup_truncate
+
+    >>> dup_truncate([1, 2, 3, 4, 5], 3, ZZ)
+    [3, 4, 5]
+
+    """
+    return dup_slice(f, 0, n, K)
+
+
 def dmp_slice_in(f, m, n, j, u, K):
     """Take a continuous subsequence of terms of ``f`` in ``x_j`` in ``K[X]``. """
     if j < 0 or j > u:

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1850,9 +1850,11 @@ def dup_truncate(f, n, K):
 
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dup_truncate
-
-    >>> dup_truncate([1, 2, 3, 4, 5], 3, ZZ)
-    [3, 4, 5]
+    >>> from sympy.polys.densebasic import dup_from_list, dup_print
+    >>> f = dup_from_list([1, 2, 3, 4, 5], ZZ)
+    >>> t = dup_truncate(f, 3, ZZ)
+    >>> dup_print(t, 'x')
+    3*x**2 + 4*x + 5
 
     """
     return dup_slice(f, 0, n, K)
@@ -1902,3 +1904,75 @@ def dup_random(n, a, b, K):
         f[0] = K.convert(random.randint(a, b))
 
     return f
+
+
+def dup_from_list(f, K):
+    """
+    Create a ``K[x]`` polynomial from a list.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.densebasic import dup_from_list
+
+    >>> dup_from_list([1, 0, 5, 0, 7], QQ)
+     [1, 0, 5, 0, 7]
+
+    """
+    if not f:
+        return []
+
+    return dup_strip([K.convert(c) for c in f])
+
+
+def dup_print(f, sym):
+    """
+    Print a polynomial in ``K[x]``.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densebasic import dup_print, dup_from_list
+    >>> f = dup_from_list([1, 0, 5, 0, 7], ZZ)
+    >>> dup_print(f, 'x')
+    x**4 + 5*x**2 + 7
+
+    """
+    if isinstance(sym, tuple):
+        sym = sym[0]
+
+    if not f:
+        return "0"
+
+    deg = dup_degree(f)
+    terms = []
+
+    for i, coeff in enumerate(f):
+        d = deg - i
+
+        if coeff == 0:
+            continue
+
+        if d == 0:
+            term = f"{coeff}"
+        elif d == 1:
+            if coeff == 1:
+                term = f"{sym}"
+            elif coeff == -1:
+                term = f"-{sym}"
+            else:
+                term = f"{coeff}*{sym}"
+        else:
+            if coeff == 1:
+                term = f"{sym}**{d}"
+            elif coeff == -1:
+                term = f"-{sym}**{d}"
+            else:
+                term = f"{coeff}*{sym}**{d}"
+
+        terms.append(term)
+
+    poly = " + ".join(terms).replace("+ -", "- ")
+    print(poly)

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1916,8 +1916,15 @@ def dup_from_list(f, K):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.densebasic import dup_from_list
 
-    >>> dup_from_list([1, 0, 5, 0, 7], QQ)
-     [1, 0, 5, 0, 7]
+    >>> p = dup_from_list([1, 0, 5, 0, 7], QQ); p
+    [1, 0, 5, 0, 7]
+    >>> QQ.of_type(1)
+    False
+    >>> QQ.of_type(p[0])
+    True
+
+    >>> dup_from_list([0, 0, 0, 2, 1, 0, 0], QQ)
+    [2, 1, 0, 0]
 
     """
     if not f:

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1505,17 +1505,16 @@ def dup_series_reversion(f, n, K):
     g = [K.revert(a), K.zero]
 
     for k in range(2, n + 1):
-        fg = dup_compose(f, g, K)
-        fg = dup_slice(fg, 0, k, K)
+        fg = dup_series_compose(f, g, n, K)
 
         x_poly = [K.zero] * k
         x_poly[-2] = K.one
 
         delta = dup_sub(fg, x_poly, K)
-        delta = dup_slice(delta, 0, k, K)
+        delta = dup_truncate(delta, k, K)
         delta_div = [K.quo(c, a) for c in delta]
 
         g_new = dup_sub(g, delta_div, K)
-        g = dup_slice(g_new, 0, k, K)
+        g = dup_truncate(g_new, k, K)
 
     return dup_slice(g, 0, n, K)

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1433,33 +1433,38 @@ def dmp_revert(f, g, u, K):
     else:
         raise MultivariatePolynomialError(f, g)
 
+
 def dup_reversion(f, n, K):
-    """
+    r"""
     Computes the compositional inverse of f using Newton iteration.
     The result is computed modulo x**n.
 
     Algorithm
     =========
 
-    Let $f(x) = a_1 x + a_2 x^2 + \dots$ with $a_1$ invertible.
+    Given $f(x) = a_1 x + a_2 x^2 + \dots$ with $a_1$ invertible.
 
-    We seek $g(x)$ such that:
-    $$
+    The goal is to find $g(x)$ such that:
+    $
     f(g(x)) = x \mod x^n
-    $$
+    $
 
-    Let $g_i$ be the approximation at step $i$.
-    Then Newton iteration updates via:
-    $$
-    g_{i+1}(x) = g_i(x) - \frac{f(g_i(x)) - x}{a_1}
-    $$
+    The algorithm uses iterative refinement where $g_k$ is the approximation modulo $x^k$.
 
-    Starting from:
-    $$
-    g_1(x) = \frac{x}{a_1}
-    $$
+    Initial approximation:
+    $
+    g_1(x) = x/a_1
+    $
 
-    Each update improves the precision by one term modulo $x^k$ for $k = 2, 3, \dots, n$.
+    Iterative step for $k = 2, 3, \dots, n$:
+    $
+    \delta = f(g_{k-1}(x)) - x \mod x^k
+    $
+    $
+    g_k(x) = g_{k-1}(x) - \delta/a_1 \mod x^k
+    $
+
+    This process incrementally builds the correct coefficients of the compositional inverse.
 
     Examples
     ========

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1057,10 +1057,13 @@ def dup_series_compose(f, g, n, K):
     ========
     >>> from sympy import ZZ
     >>> from sympy.polys.densetools import dup_series_compose
-    >>> f = [1, 1, 1]
-    >>> g = [1, 1]
-    >>> dup_series_compose(f, g, 3, ZZ)
-    [1, 3, 3]
+    >>> from sympy.polys.densebasic import dup_from_list, dup_print
+    >>> f = dup_from_list([1, 1, 1], ZZ)
+    >>> g = dup_from_list([1, 1], ZZ)
+    >>> comp = dup_series_compose(f, g, 3, ZZ)
+    >>> dup_print(comp, 'x')
+    x**2 + 3*x + 3
+
     """
     f = dup_truncate(f, n, K)
     g = dup_truncate(g, n, K)
@@ -1522,9 +1525,11 @@ def dup_series_reversion(f, n, K):
     ========
     >>> from sympy.polys import QQ
     >>> from sympy.polys.densetools import dup_series_reversion
-    >>> f = [QQ(1, 2), QQ(1, 3), QQ(1, 4), QQ(1, 5), QQ(1, 6), QQ(1, 7), 0]
-    >>> dup_series_reversion(f, 7, QQ)
-    [-7812952441/32400, 467419477/16200, -789929/216, 40817/90, -343/6, 7, 0]
+    >>> from sympy.polys.densebasic import dup_from_list, dup_print
+    >>> f = dup_from_list([QQ(1, 3), QQ(1, 4), QQ(1, 5), QQ(1, 6), QQ(1, 7), 0], QQ)
+    >>> rev = dup_series_reversion(f, 7, QQ)
+    >>> dup_print(rev, 'x')
+    5528444159/32400*x**6 + 467419477/16200*x**5 - 789929/216*x**4 + 40817/90*x**3 - 343/6*x**2 + 7*x
 
     References
     ==========

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -29,6 +29,7 @@ from sympy.polys.densebasic import (
     dmp_zeros,
     dmp_include,
     dup_nth,
+    dup_normal,
 )
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -1496,9 +1497,6 @@ def _dup_series_reversion_small(f, n, K):
     f = [K.zero] * (4 - len(f)) + f
     a, b, c, d = f
 
-    if not K.is_zero(d):
-        raise ValueError("f must have zero constant term")
-
     cinv = K.revert(c)
     g = [K.zero] * n
 
@@ -1511,7 +1509,7 @@ def _dup_series_reversion_small(f, n, K):
     if n >= 4:
         g[-4] = (2 * b ** 2 - a * c) * cinv ** 5
 
-    return dup_strip(g)
+    return dup_normal(g, K)
 
 
 def dup_series_reversion(f, n, K):

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1498,8 +1498,6 @@ def _dup_series_reversion_small(f, n, K):
 
     if not K.is_zero(d):
         raise ValueError("f must have zero constant term")
-    if K.is_zero(c):
-        raise ValueError("f must have nonzero linear term")
 
     cinv = K.revert(c)
     g = [K.zero] * n
@@ -1543,8 +1541,6 @@ def dup_series_reversion(f, n, K):
 
     if f[-1] != K.zero:
         raise ValueError("f must have zero constant term")
-    if len(f) < 2 or f[-2] == K.zero:
-        raise ValueError("f must have nonzero linear term")
     if n<=4:
         return _dup_series_reversion_small(f, n, K)
 

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1434,7 +1434,7 @@ def dmp_revert(f, g, u, K):
         raise MultivariatePolynomialError(f, g)
 
 
-def dup_reversion(f, n, K):
+def dup_series_reversion(f, n, K):
     r"""
     Computes the compositional inverse of f using Newton iteration.
     The result is computed modulo x**n.
@@ -1469,9 +1469,9 @@ def dup_reversion(f, n, K):
     Examples
     ========
     >>> from sympy.polys import QQ
-    >>> from sympy.polys.densetools import dup_reversion
+    >>> from sympy.polys.densetools import dup_series_reversion
     >>> f = [QQ(1, 2), QQ(1, 3), QQ(1, 4), QQ(1, 5), QQ(1, 6), QQ(1, 7), 0]
-    >>> dup_reversion(f, 7, QQ)
+    >>> dup_series_reversion(f, 7, QQ)
     [-7812952441/32400, 467419477/16200, -789929/216, 40817/90, -343/6, 7, 0]
     """
     if len(f) < 2 or f[-1] != K.zero:

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1471,7 +1471,7 @@ def dup_reversion(f, n, K):
     >>> from sympy.polys import QQ
     >>> from sympy.polys.densetools import dup_reversion
     >>> f = [QQ(1, 2), QQ(1, 3), QQ(1, 4), QQ(1, 5), QQ(1, 6), QQ(1, 7), 0]
-    >>> dup_reversion(f, 8, QQ)
+    >>> dup_reversion(f, 7, QQ)
     [-7812952441/32400, 467419477/16200, -789929/216, 40817/90, -343/6, 7, 0]
     """
     if len(f) < 2 or f[-1] != K.zero:
@@ -1484,16 +1484,16 @@ def dup_reversion(f, n, K):
 
     for k in range(2, n + 1):
         fg = dup_compose(f, g, K)
-        fg = dup_slice(fg, 0, k - 1, K)
+        fg = dup_slice(fg, 0, k, K)
 
         x_poly = [K.zero] * k
         x_poly[-2] = K.one
 
         delta = dup_sub(fg, x_poly, K)
-        delta = dup_slice(delta, 0, k - 1, K)
+        delta = dup_slice(delta, 0, k, K)
         delta_div = [K.quo(c, a) for c in delta]
 
         g_new = dup_sub(g, delta_div, K)
-        g = dup_slice(g_new, 0, k - 1, K)
+        g = dup_slice(g_new, 0, k, K)
 
     return dup_slice(g, 0, n, K)

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1042,13 +1042,8 @@ def _dup_series_compose(f, g, n, K):
     comp0 = _dup_series_compose(f_low, g, n, K)
     comp1 = _dup_series_compose(f_high, g, n, K)
 
-    g_rev = list(reversed(g))
-    comp1_rev = list(reversed(comp1))
-
-    g_power = dup_series_pow(g_rev, m, n, K)
-    high_term_rev = dup_series_mul(comp1_rev, g_power, n, K)
-
-    high_term = list(reversed(high_term_rev))
+    g_power = dup_series_pow(g, m, n, K)
+    high_term = dup_series_mul(comp1, g_power, n, K)
 
     result = dup_add(high_term, comp0, K)
     return dup_truncate(result, n, K)
@@ -1492,33 +1487,6 @@ def dup_series_reversion(f, n, K):
     r"""
     Computes the compositional inverse of f using Newton iteration.
     The result is computed modulo x**n.
-
-    Algorithm
-    =========
-
-    Given $f(x) = a_1 x + a_2 x^2 + \dots$ with $a_1$ invertible.
-
-    The goal is to find $g(x)$ such that:
-    $
-    f(g(x)) = x \mod x^n
-    $
-
-    The algorithm uses iterative refinement where $g_k$ is the approximation modulo $x^k$.
-
-    Initial approximation:
-    $
-    g_1(x) = x/a_1
-    $
-
-    Iterative step for $k = 2, 3, \dots, n$:
-    $
-    \delta = f(g_{k-1}(x)) - x \mod x^k
-    $
-    $
-    g_k(x) = g_{k-1}(x) - \delta/a_1 \mod x^k
-    $
-
-    This process incrementally builds the correct coefficients of the compositional inverse.
 
     Examples
     ========

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -21,6 +21,7 @@ from sympy.polys.densearith import (
     dup_neg, dmp_neg,
     dup_add, dmp_add,
     dup_sub, dmp_sub,
+    _dup_series_mul_base, _dup_series_mul_karatsuba,
     dup_mul, dmp_mul, dup_series_mul,
     dup_sqr, dmp_sqr,
     dup_pow, dmp_pow, dup_series_pow,
@@ -686,30 +687,28 @@ def test_dmp_mul():
         [[K(2)], [K(1)]], [[K(3)], [K(4)]], 1, K) == [[K(5)], [K(4)]]
 
 
-def test_dup_series_mul(trials=100):
-    for i in range(trials):
-        deg = randint(2, 10)
+def test_dup_series_mul():
+
+    # Check correctness against dup_mul with truncation
+    for i in range(50):
+        deg = randint(2, 200)
         f = _dup_random(-20, 0, deg, ZZ)
-        g = _dup_random(0, 20, randint(1, 10), ZZ)
+        g = _dup_random(0, 20, randint(1, 200), ZZ)
 
         mul = dup_series_mul(f, g, deg, ZZ)
         expected = dup_truncate(dup_mul(f, g, ZZ), deg, ZZ)
         assert mul == expected
 
-    assert dup_series_mul([], [], 0, ZZ) == []
-    assert dup_series_mul([ZZ(1), ZZ(0), ZZ(1)], [ZZ(2), ZZ(1)], 5, ZZ) == [ZZ(2),
-        ZZ(1), ZZ(2), ZZ(1)]
-    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(4), ZZ(5)], 3, ZZ) == [
-        ZZ(13), ZZ(22), ZZ(15)]
-    assert dup_series_mul([QQ(2, 3), QQ(1, 2)], [QQ(1, 4), QQ(3, 5)], 4, QQ) == [
-        QQ(1, 6), QQ(21, 40), QQ(3, 10)]
+    # Compare base case with Karatsuba multiplication
+    for i in range(50):
+        deg = randint(2, 200)
+        f = _dup_random(-20, 0, deg, ZZ)
+        g = _dup_random(0, 20, randint(1, 200), ZZ)
 
-    K = FF(7)
-    assert dup_series_mul([K(2), K(3)], [K(5), K(1)], 4, K) == [K(3), K(3), K(3)]
+        b = _dup_series_mul_base(f, g, deg, ZZ)
+        k = _dup_series_mul_karatsuba(f, g, deg, ZZ)
 
-    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(1), ZZ(0)], 2, ZZ) == [ZZ(3), ZZ(0)]
-    assert dup_series_mul([ZZ(0), ZZ(0), ZZ(1)], [ZZ(1)], 5, ZZ) == [ZZ(1)]
-
+        assert b == k
 
 def test_dup_sqr():
     assert dup_sqr([], ZZ) == []
@@ -798,8 +797,8 @@ def test_dmp_pow():
 
 def test_dup_series_pow(trials=100):
     for i in range(trials):
-        deg = randint(2, 10)
-        f = _dup_random(-20, 0, randint(1, 10), ZZ)
+        deg = randint(2, 100)
+        f = _dup_random(-20, 0, randint(1, 100), ZZ)
         n = randint(1, 5)
 
         pow = dup_series_pow(f, n, deg, ZZ)

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -703,6 +703,17 @@ def test_dup_series_mul():
     expected = dup_truncate(dup_mul(f, g, QQ), 100, QQ)
     assert dup_series_mul(f, g, 100, QQ) == expected
 
+    f = dup_from_list([QQ(3, 4), QQ(-1, 2), QQ(1, 6)], QQ)
+    g = dup_from_list([QQ(1, 3), QQ(2, 5)], QQ)
+    assert dup_series_mul(f, g, 3, QQ) == dup_from_list(
+        [QQ(2, 15), QQ(-13, 90), QQ(1, 15)], QQ)
+
+    f = dup_from_list([QQ(1, 2), QQ(0), QQ(1, 3), QQ(1, 4)], QQ)
+    g = dup_from_list([QQ(2), QQ(1, 2)], QQ)
+    assert dup_series_mul(f, g, 4, QQ) == dup_from_list(
+        [QQ(1, 4), QQ(2, 3), QQ(2, 3), QQ(1, 8)], QQ)
+
+
 def test_dup_sqr():
     assert dup_sqr([], ZZ) == []
     assert dup_sqr([ZZ(2)], ZZ) == [ZZ(4)]
@@ -812,6 +823,14 @@ def test_dup_series_pow():
     assert dup_series_pow([K(2), K(1)], 4, 5, K) == [K(2), K(4), K(3), K(1), K(1)]
 
     raises(ValueError, lambda: dup_series_pow([ZZ(1), ZZ(1)], -1, 4, ZZ))
+
+    f = dup_from_list([QQ(1, 2), QQ(1, 3)], QQ)
+    assert dup_series_pow(f, 2, 3, QQ) == dup_from_list(
+        [QQ(1, 4), QQ(1, 3), QQ(1, 9)], QQ)
+
+    g = dup_from_list([QQ(2, 3), QQ(1, 4)], QQ)
+    assert dup_series_pow(g, 3, 4, QQ) == dup_from_list(
+        [QQ(8, 27), QQ(1, 3), QQ(1, 8), QQ(1, 64)], QQ)
 
 
 def test_dup_pdiv():

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -688,9 +688,9 @@ def test_dmp_mul():
 
 def test_dup_series_mul(trials=100):
     for i in range(trials):
-        deg = randint(1, 10)
-        f = _dup_random(-20, 0,deg, ZZ)
-        g = _dup_random(0, 20,deg, ZZ)
+        deg = randint(2, 10)
+        f = _dup_random(-20, 0, deg, ZZ)
+        g = _dup_random(0, 20, randint(1, 10), ZZ)
 
         mul = dup_series_mul(f, g, deg, ZZ)
         expected = dup_truncate(dup_mul(f, g, ZZ), deg, ZZ)
@@ -798,8 +798,8 @@ def test_dmp_pow():
 
 def test_dup_series_pow(trials=100):
     for i in range(trials):
-        deg = randint(1, 10)
-        f = _dup_random(-20, 0, deg, ZZ)
+        deg = randint(2, 10)
+        f = _dup_random(-20, 0, randint(1, 10), ZZ)
         n = randint(1, 5)
 
         pow = dup_series_pow(f, n, deg, ZZ)

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -1,9 +1,10 @@
 """Tests for dense recursive polynomials' arithmetics. """
+from random import randint
 
 from sympy.external.gmpy import GROUND_TYPES
 
 from sympy.polys.densebasic import (
-    dup_normal, dmp_normal,
+    dup_normal, dmp_normal, dup_truncate,
 )
 
 from sympy.polys.densearith import (
@@ -48,6 +49,12 @@ from sympy.testing.pytest import raises
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
 F_0 = dmp_mul_ground(dmp_normal(f_0, 2, QQ), QQ(1, 7), 2, QQ)
+
+
+def _dup_random(lo, hi, deg, domain):
+    """Generate a random dense polynomial of given degree and domain."""
+    return dup_normal([domain(randint(lo, hi)) for _ in range(deg)], domain)
+
 
 def test_dup_add_term():
     f = dup_normal([], ZZ)
@@ -679,7 +686,16 @@ def test_dmp_mul():
         [[K(2)], [K(1)]], [[K(3)], [K(4)]], 1, K) == [[K(5)], [K(4)]]
 
 
-def test_dup_series_mul():
+def test_dup_series_mul(trials=100):
+    for i in range(trials):
+        deg = randint(1, 10)
+        f = _dup_random(-20, 0,deg, ZZ)
+        g = _dup_random(0, 20,deg, ZZ)
+
+        mul = dup_series_mul(f, g, deg, ZZ)
+        expected = dup_truncate(dup_mul(f, g, ZZ), deg, ZZ)
+        assert mul == expected
+
     assert dup_series_mul([], [], 0, ZZ) == []
     assert dup_series_mul([ZZ(1), ZZ(0), ZZ(1)], [ZZ(2), ZZ(1)], 5, ZZ) == [ZZ(2),
         ZZ(1), ZZ(2), ZZ(1)]
@@ -780,7 +796,16 @@ def test_dmp_pow():
     assert dmp_pow(f, 2, 0, ZZ) == dup_pow(f, 2, ZZ)
 
 
-def test_dup_series_pow():
+def test_dup_series_pow(trials=100):
+    for i in range(trials):
+        deg = randint(1, 10)
+        f = _dup_random(-20, 0, deg, ZZ)
+        n = randint(1, 5)
+
+        pow = dup_series_pow(f, n, deg, ZZ)
+        expected = dup_truncate(dup_pow(f, n, ZZ), deg, ZZ)
+        assert pow == expected
+
     assert dup_series_pow([ZZ(1), ZZ(1)], 3, 4, ZZ) == [ZZ(1), ZZ(3), ZZ(3), ZZ(1)]
     assert dup_series_pow([ZZ(2), ZZ(0), ZZ(1)], 2, 5, ZZ) == [ZZ(4), ZZ(0), ZZ(4),
         ZZ(0), ZZ(1)]

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -20,9 +20,9 @@ from sympy.polys.densearith import (
     dup_neg, dmp_neg,
     dup_add, dmp_add,
     dup_sub, dmp_sub,
-    dup_mul, dmp_mul,
+    dup_mul, dmp_mul, dup_series_mul,
     dup_sqr, dmp_sqr,
-    dup_pow, dmp_pow,
+    dup_pow, dmp_pow, dup_series_pow,
     dup_add_mul, dmp_add_mul,
     dup_sub_mul, dmp_sub_mul,
     dup_pdiv, dup_prem, dup_pquo, dup_pexquo,
@@ -679,6 +679,22 @@ def test_dmp_mul():
         [[K(2)], [K(1)]], [[K(3)], [K(4)]], 1, K) == [[K(5)], [K(4)]]
 
 
+def test_dup_series_mul():
+    assert dup_series_mul([], [], 0, ZZ) == []
+    assert dup_series_mul([ZZ(1), ZZ(0), ZZ(1)], [ZZ(2), ZZ(1)], 5, ZZ) == [ZZ(2),
+        ZZ(1), ZZ(2), ZZ(1)]
+    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(4), ZZ(5)], 3, ZZ) == [ZZ(4),
+        ZZ(13), ZZ(22)]
+    assert dup_series_mul([QQ(2, 3), QQ(1, 2)], [QQ(1, 4), QQ(3, 5)], 4, QQ) == [
+        QQ(1, 6), QQ(21, 40), QQ(3, 10)]
+
+    K = FF(7)
+    assert dup_series_mul([K(2), K(3)], [K(5), K(1)], 4, K) == [K(3), K(3), K(3)]
+
+    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(1), ZZ(0)], 2, ZZ) == [ZZ(1), ZZ(2)]
+    assert dup_series_mul([ZZ(0), ZZ(0), ZZ(1)], [ZZ(1)], 5, ZZ) == [ZZ(1)]
+
+
 def test_dup_sqr():
     assert dup_sqr([], ZZ) == []
     assert dup_sqr([ZZ(2)], ZZ) == [ZZ(4)]
@@ -762,6 +778,25 @@ def test_dmp_pow():
     f = dup_normal([2, 0, 0, 1, 7], ZZ)
 
     assert dmp_pow(f, 2, 0, ZZ) == dup_pow(f, 2, ZZ)
+
+
+def test_dup_series_pow():
+    assert dup_series_pow([ZZ(1), ZZ(1)], 3, 4, ZZ) == [ZZ(1), ZZ(3), ZZ(3), ZZ(1)]
+    assert dup_series_pow([ZZ(2), ZZ(0), ZZ(1)], 2, 5, ZZ) == [ZZ(4), ZZ(0), ZZ(4),
+        ZZ(0), ZZ(1)]
+    assert dup_series_pow([ZZ(1), ZZ(1)], 5, 6, ZZ) == [ZZ(1), ZZ(5), ZZ(10), ZZ(10),
+        ZZ(5), ZZ(1)]
+    assert dup_series_pow([ZZ(1), ZZ(0), ZZ(1)], 3, 7, ZZ) == [ZZ(1), ZZ(0), ZZ(3),
+        ZZ(0), ZZ(3), ZZ(0), ZZ(1)]
+
+    assert dup_series_pow([QQ(1, 2), QQ(1, 2)], 2, 3, QQ) == [
+        QQ(1, 4), QQ(1, 2), QQ(1, 4)]
+    assert dup_series_pow([QQ(2), QQ(0), QQ(1)], 2, 5, QQ) == [QQ(4), QQ(0), QQ(4),
+        QQ(0), QQ(1)]
+
+    K = FF(7)
+    assert dup_series_pow([K(1), K(1)], 3, 4, K) == [K(1), K(3), K(3), K(1)]
+    assert dup_series_pow([K(2), K(1)], 4, 5, K) == [K(2), K(4), K(3), K(1), K(1)]
 
 
 def test_dup_pdiv():

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -683,15 +683,15 @@ def test_dup_series_mul():
     assert dup_series_mul([], [], 0, ZZ) == []
     assert dup_series_mul([ZZ(1), ZZ(0), ZZ(1)], [ZZ(2), ZZ(1)], 5, ZZ) == [ZZ(2),
         ZZ(1), ZZ(2), ZZ(1)]
-    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(4), ZZ(5)], 3, ZZ) == [ZZ(4),
-        ZZ(13), ZZ(22)]
+    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(4), ZZ(5)], 3, ZZ) == [
+        ZZ(13), ZZ(22), ZZ(15)]
     assert dup_series_mul([QQ(2, 3), QQ(1, 2)], [QQ(1, 4), QQ(3, 5)], 4, QQ) == [
         QQ(1, 6), QQ(21, 40), QQ(3, 10)]
 
     K = FF(7)
     assert dup_series_mul([K(2), K(3)], [K(5), K(1)], 4, K) == [K(3), K(3), K(3)]
 
-    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(1), ZZ(0)], 2, ZZ) == [ZZ(1), ZZ(2)]
+    assert dup_series_mul([ZZ(1), ZZ(2), ZZ(3)], [ZZ(1), ZZ(0)], 2, ZZ) == [ZZ(3), ZZ(0)]
     assert dup_series_mul([ZZ(0), ZZ(0), ZZ(1)], [ZZ(1)], 5, ZZ) == [ZZ(1)]
 
 

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -30,7 +30,7 @@ from sympy.polys.densetools import (
     dmp_lift,
     dup_sign_variations,
     dup_revert, dmp_revert,
-    dup_reversion
+    dup_series_reversion
 )
 from sympy.polys.polyclasses import ANP
 
@@ -54,6 +54,12 @@ from sympy.abc import x
 from sympy.testing.pytest import raises
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
+
+
+def _dup_random(lo, hi, deg, domain):
+    """Generate a random dense polynomial of given degree and domain."""
+    return dup_normal([domain(randint(lo, hi)) for _ in range(deg)], domain)
+
 
 def test_dup_integrate():
     assert dup_integrate([], 1, QQ) == []
@@ -286,16 +292,18 @@ def test_dmp_revert():
     raises(MultivariatePolynomialError, lambda: dmp_revert([[1]], 2, 1, QQ))
 
 
-def test_dup_reversion(trials=50):
+def test_dup_series_reversion(trials=50):
     for _ in range(trials):
         deg = randint(2, 10)
-        f = [QQ(randint(-10, 10), randint(1, 10)) for _ in range(deg)]
+        f = _dup_random(-10, 10, deg, QQ)
+        if len(f) < 2:
+            continue
 
         f[-1] = QQ(0)
         if f[-2] == 0:
             f[-2] = QQ(1, 1)
 
-        g = dup_reversion(f, deg, QQ)
+        g = dup_series_reversion(f, deg, QQ)
         composed = dup_slice(dup_compose(f, g, QQ), 0, deg, QQ)
 
         expected = [QQ(1), QQ(0)]
@@ -304,10 +312,10 @@ def test_dup_reversion(trials=50):
     f = [QQ(4), QQ(3), QQ(4), QQ(1), QQ(0)]
     g = [QQ(49313847), -QQ(4043832), QQ(340156), -QQ(29596), QQ(2699), -QQ(264),
         QQ(29), -QQ(4), QQ(1), QQ(0)]
-    assert dup_reversion(f, 10, QQ) == g
+    assert dup_series_reversion(f, 10, QQ) == g
 
-    raises(ValueError, lambda: dup_reversion([QQ(1), QQ(1)], 5, QQ))
-    raises(ValueError, lambda: dup_reversion([QQ(1), QQ(0), QQ(0)], 5, QQ))
+    raises(ValueError, lambda: dup_series_reversion([QQ(1), QQ(1)], 5, QQ))
+    raises(ValueError, lambda: dup_series_reversion([QQ(1), QQ(0), QQ(0)], 5, QQ))
 
 
 def test_dup_trunc():

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -300,6 +300,14 @@ def test_dup_series_reversion():
     raises(ValueError, lambda: dup_series_reversion([QQ(1), QQ(1)], 0, QQ))
     raises(NotReversible, lambda: dup_series_reversion([QQ(1), QQ(0), QQ(0)], 5, QQ))
 
+    f = dup_from_list([QQ(1, 2), QQ(1, 3), QQ(0)], QQ)
+    assert dup_series_reversion(f, 4, QQ) == dup_from_list(
+        [QQ(243, 2), QQ(-27, 2), QQ(3), QQ(0)], QQ)
+
+    g = dup_from_list([QQ(2, 3), QQ(1, 4), QQ(1, 6), QQ(0)], QQ)
+    assert dup_series_reversion(g, 5, QQ) == dup_from_list(
+        [QQ(17010), QQ(108), QQ(-54), QQ(6), QQ(0)], QQ)
+
 
 def test_dup_series_reversion_small():
     assert _dup_series_reversion_small(ZZ.map([1, 1, 0]), 3, ZZ) == [-1, 1, 0]
@@ -611,6 +619,17 @@ def test_dup_series_compose():
 
     assert dup_series_compose(f, g, 8, ZZ) == \
         dup_from_list([72414, 76477, 14638, 8539, 9250, 883, 380, 453], ZZ)
+
+    f = dup_from_list([QQ(1, 2), QQ(1, 3), QQ(1, 4)], QQ)
+    g = dup_from_list([QQ(2, 3), QQ(1, 5)], QQ)
+    assert dup_series_compose(f, g, 4, QQ) == dup_from_list(
+        [QQ(2, 9), QQ(16, 45), QQ(101, 300)], QQ)
+
+    f = dup_from_list([QQ(1, 3), QQ(-1, 2), QQ(1, 6)], QQ)
+    g = dup_from_list([QQ(1, 4), QQ(1, 2), QQ(1, 3)], QQ)
+    assert dup_series_compose(f, g, 5, QQ) == dup_from_list(
+        [QQ(1, 48), QQ(1, 12), QQ(1, 72), QQ(-5, 36), QQ(1, 27)], QQ)
+
 
 def test_dup_decompose():
     assert dup_decompose([1], ZZ) == [[1]]

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -27,6 +27,7 @@ from sympy.polys.densetools import (
     dmp_lift,
     dup_sign_variations,
     dup_revert, dmp_revert,
+    dup_reversion
 )
 from sympy.polys.polyclasses import ANP
 
@@ -280,6 +281,19 @@ def test_dmp_revert():
     assert dmp_revert(f, 8, 0, QQ) == g
 
     raises(MultivariatePolynomialError, lambda: dmp_revert([[1]], 2, 1, QQ))
+
+
+def test_dup_reversion():
+    from sympy import QQ
+
+    f = [QQ(4), QQ(3), QQ(4), QQ(1), QQ(0)]
+    g = [-QQ(4043832), QQ(340156), -QQ(29596), QQ(2699), -QQ(264), QQ(29), -QQ(4),
+        QQ(1), QQ(0)]
+
+    assert dup_reversion(f, 10, QQ) == g
+
+    raises(ValueError, lambda: dup_reversion([QQ(1), QQ(1)], 5, QQ))
+    raises(ValueError, lambda: dup_reversion([QQ(1), QQ(0), QQ(0)], 5, QQ))
 
 
 def test_dup_trunc():

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -9,7 +9,7 @@ from sympy.polys.densebasic import (
 
 from sympy.polys.densearith import dmp_mul_ground
 
-from sympy.polys.densebasic import dup_slice
+from sympy.polys.densebasic import dup_slice, dup_truncate
 
 from sympy.polys.densetools import (
     dup_clear_denoms, dmp_clear_denoms,
@@ -25,7 +25,7 @@ from sympy.polys.densetools import (
     dup_real_imag,
     dup_mirror, dup_scale, dup_shift, dmp_shift,
     dup_transform,
-    dup_compose, dmp_compose,
+    dup_compose, dmp_compose, dup_series_compose,
     dup_decompose,
     dmp_lift,
     dup_sign_variations,
@@ -607,6 +607,19 @@ def test_dmp_compose():
 
     assert dmp_compose(
         [[1], [2], [1]], [[1], [2], [1]], 1, ZZ) == [[1], [4], [8], [8], [4]]
+
+
+def test_dup_series_compose(trials=50):
+
+    for _ in range(trials):
+        deg = randint(2, 10)
+        f = _dup_random(-10, 10, deg, QQ)
+        g = _dup_random(11, 20, deg, QQ)
+
+        series_composed = dup_series_compose(f, g, deg, QQ)
+        expected = dup_compose(f, g, QQ)
+
+        assert series_composed == dup_truncate(expected, deg, QQ)
 
 
 def test_dup_decompose():

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -1,5 +1,6 @@
 """Tests for dense recursive polynomials' tools. """
 
+from random import randint
 from sympy.polys.densebasic import (
     dup_normal, dmp_normal,
     dup_from_raw_dict,
@@ -7,6 +8,8 @@ from sympy.polys.densebasic import (
 )
 
 from sympy.polys.densearith import dmp_mul_ground
+
+from sympy.polys.densebasic import dup_slice
 
 from sympy.polys.densetools import (
     dup_clear_denoms, dmp_clear_denoms,
@@ -283,13 +286,24 @@ def test_dmp_revert():
     raises(MultivariatePolynomialError, lambda: dmp_revert([[1]], 2, 1, QQ))
 
 
-def test_dup_reversion():
-    from sympy import QQ
+def test_dup_reversion(trials=50):
+    for _ in range(trials):
+        deg = randint(2, 10)
+        f = [QQ(randint(-10, 10), randint(1, 10)) for _ in range(deg)]
+
+        f[-1] = QQ(0)
+        if f[-2] == 0:
+            f[-2] = QQ(1, 1)
+
+        g = dup_reversion(f, deg, QQ)
+        composed = dup_slice(dup_compose(f, g, QQ), 0, deg, QQ)
+
+        expected = [QQ(1), QQ(0)]
+        assert composed == expected
 
     f = [QQ(4), QQ(3), QQ(4), QQ(1), QQ(0)]
-    g = [-QQ(4043832), QQ(340156), -QQ(29596), QQ(2699), -QQ(264), QQ(29), -QQ(4),
-        QQ(1), QQ(0)]
-
+    g = [QQ(49313847), -QQ(4043832), QQ(340156), -QQ(29596), QQ(2699), -QQ(264),
+        QQ(29), -QQ(4), QQ(1), QQ(0)]
     assert dup_reversion(f, 10, QQ) == g
 
     raises(ValueError, lambda: dup_reversion([QQ(1), QQ(1)], 5, QQ))

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -316,7 +316,7 @@ def test_dup_series_reversion(trials=50):
     assert dup_series_reversion(f, 10, QQ) == g
 
     raises(ValueError, lambda: dup_series_reversion([QQ(1), QQ(1)], 5, QQ))
-    raises(ValueError, lambda: dup_series_reversion([QQ(1), QQ(0), QQ(0)], 5, QQ))
+    raises(NotReversible, lambda: dup_series_reversion([QQ(1), QQ(0), QQ(0)], 5, QQ))
 
 
 def test_dup_series_reversion_small():
@@ -324,7 +324,7 @@ def test_dup_series_reversion_small():
     assert _dup_series_reversion_small(ZZ.map([12, 7, 1, 0]), 4, ZZ) == [86, -7, 1, 0]
     assert _dup_series_reversion_small(ZZ.map([2, 1, 0]), 2, ZZ) == [1, 0]
 
-    raises(ValueError, lambda: _dup_series_reversion_small(ZZ.map([1, 1, 0]), 1, ZZ))
+    raises(NotReversible, lambda: _dup_series_reversion_small(ZZ.map([1, 1, 0]), 1, ZZ))
     raises(ValueError, lambda: _dup_series_reversion_small(ZZ.map([0]), 0, ZZ))
 
 

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -295,7 +295,7 @@ def test_dmp_revert():
 def test_dup_series_reversion(trials=50):
     for _ in range(trials):
         deg = randint(2, 10)
-        f = _dup_random(-10, 10, deg, QQ)
+        f = _dup_random(-10, 10, randint(1, 10), QQ)
         if len(f) < 2:
             continue
 
@@ -614,7 +614,7 @@ def test_dup_series_compose(trials=50):
     for _ in range(trials):
         deg = randint(2, 10)
         f = _dup_random(-10, 10, deg, QQ)
-        g = _dup_random(11, 20, deg, QQ)
+        g = _dup_random(11, 20, randint(1, 10), QQ)
 
         series_composed = dup_series_compose(f, g, deg, QQ)
         expected = dup_compose(f, g, QQ)

--- a/sympy/polys/tests/test_hypothesis.py
+++ b/sympy/polys/tests/test_hypothesis.py
@@ -1,9 +1,9 @@
 from hypothesis import given
-from hypothesis import strategies as st
+from hypothesis import settings, strategies as st
 from hypothesis.strategies import composite
 
 from sympy.abc import x
-from sympy import ZZ
+from sympy import ZZ, QQ
 from sympy.polys.polytools import Poly
 from sympy.polys.densebasic import dup_truncate, dup_from_list
 from sympy.polys.densetools import dup_compose, dup_series_compose, dup_series_reversion
@@ -28,12 +28,51 @@ def polys(*, nonzero=False, domain="ZZ"):
 
 
 @composite
-def dup(draw, unit=False, min_len=3, max_len=200):
-    lst = draw(st.lists(st.integers(), min_size=min_len, max_size=max_len))
+def dup_unit(draw, dom=ZZ, min_len=3, max_len=200):
+    if dom == ZZ:
+        elem_strategy = st.integers()
+    elif dom == QQ:
+        elem_strategy = st.tuples(
+            st.integers(min_value=-10, max_value=10),
+            st.integers(min_value=1, max_value=10),
+        ).map(lambda t: QQ(t[0], t[1]))
 
-    if unit:
-        lst[-1] = ZZ(0)
-        lst[-2] = ZZ(1)
+    lst = draw(st.lists(elem_strategy, min_size=min_len, max_size=max_len))
+
+    lst[-1] = dom(0)
+    if dom == ZZ:
+        lst[-2] = dom(1)
+    elif dom == QQ:
+        if dom.is_zero(lst[-2]):
+            lst[-2] = dom(1)
+
+    return lst
+
+
+@composite
+def dup_any(draw, dom=ZZ, min_len=3, max_len=200):
+    if dom == ZZ:
+        elem_strategy = st.integers()
+    elif dom == QQ:
+        elem_strategy = st.tuples(st.integers(), st.integers(min_value=1)).map(
+            lambda t: QQ(t[0], t[1])
+        )
+
+    return draw(st.lists(elem_strategy, min_size=min_len, max_size=max_len))
+
+
+@composite
+def dup_zero_TC(draw, dom=ZZ, min_len=3, max_len=200):
+    if dom == ZZ:
+        elem_strategy = st.integers()
+    elif dom == QQ:
+        elem_strategy = st.tuples(st.integers(), st.integers(min_value=1)).map(
+            lambda t: QQ(t[0], t[1])
+        )
+
+    lst = draw(st.lists(elem_strategy, min_size=min_len, max_size=max_len))
+
+    lst[-1] = dom(0)
 
     return lst
 
@@ -61,23 +100,23 @@ def test_poly_hypothesis_rationals(f_q, g_q):
     assert g_q.degree() >= remainder_q.degree() or remainder_q.degree() == 0
 
 
-@given(f=dup(unit=True), g=dup(unit=True), n=st.integers(min_value=3, max_value=200))
-def test_dup_series_compose(f, g, n):
+@given(f=dup_any(), g=dup_zero_TC(), n=st.integers(min_value=3, max_value=200))
+def test_dup_series_compose_int(f, g, n):
     expected = dup_truncate(dup_compose(f, g, ZZ), n, ZZ)
     assert dup_series_compose(f, g, n, ZZ) == expected
 
 
 @slow
-@given(f=dup(unit=True), n=st.integers(min_value=3, max_value=200))
-def test_dup_series_reversion(f, n):
+@given(f=dup_unit(), n=st.integers(min_value=3, max_value=200))
+def test_dup_series_reversion_int(f, n):
     rev = dup_series_reversion(f, n, ZZ)
     comp = dup_series_compose(rev, f, n, ZZ)
     expected = dup_from_list([1, 0], ZZ)
     assert comp == expected
 
 
-@given(f=dup(), g=dup(), n=st.integers(min_value=3, max_value=200))
-def test_dup_series_mul(f, g, n):
+@given(f=dup_any(), g=dup_any(), n=st.integers(min_value=3, max_value=200))
+def test_dup_series_mul_int(f, g, n):
     base = _dup_series_mul_base(f, g, n, ZZ)
     karatsuba = _dup_series_mul_karatsuba(f, g, n, ZZ)
     series_mul = dup_series_mul(f, g, n, ZZ)
@@ -88,12 +127,53 @@ def test_dup_series_mul(f, g, n):
 
 
 @given(
-    f=dup(),
+    f=dup_any(),
     pow=st.integers(min_value=0, max_value=10),
     n=st.integers(min_value=3, max_value=200),
 )
-def test_dup_series_pow(f, pow, n):
+def test_dup_series_pow_int(f, pow, n):
     Dup_pow = dup_truncate(dup_pow(f, pow, ZZ), n, ZZ)
     series_pow = dup_series_pow(f, pow, n, ZZ)
+
+    assert series_pow == Dup_pow
+
+
+@given(
+    f=dup_any(dom=QQ), g=dup_zero_TC(dom=QQ), n=st.integers(min_value=3, max_value=200)
+)
+def test_dup_series_compose_rational(f, g, n):
+    expected = dup_truncate(dup_compose(f, g, QQ), n, QQ)
+    assert dup_series_compose(f, g, n, QQ) == expected
+
+
+@slow
+@given(f=dup_unit(dom=QQ), n=st.integers(min_value=3, max_value=150))
+@settings(max_examples=100)
+def test_dup_series_reversion_rational(f, n):
+    rev = dup_series_reversion(f, n, QQ)
+    comp = dup_series_compose(rev, f, n, QQ)
+    expected = dup_from_list([1, 0], QQ)
+    assert comp == expected
+
+
+@given(f=dup_any(dom=QQ), g=dup_any(dom=QQ), n=st.integers(min_value=3, max_value=100))
+def test_dup_series_mul_rational(f, g, n):
+    base = _dup_series_mul_base(f, g, n, QQ)
+    karatsuba = _dup_series_mul_karatsuba(f, g, n, QQ)
+    series_mul = dup_series_mul(f, g, n, QQ)
+    Dup_mul = dup_truncate(dup_mul(f, g, QQ), n, QQ)
+
+    assert series_mul == Dup_mul
+    assert base == karatsuba
+
+
+@given(
+    f=dup_any(dom=QQ),
+    pow=st.integers(min_value=0, max_value=10),
+    n=st.integers(min_value=3, max_value=200),
+)
+def test_dup_series_pow_rational(f, pow, n):
+    Dup_pow = dup_truncate(dup_pow(f, pow, QQ), n, QQ)
+    series_pow = dup_series_pow(f, pow, n, QQ)
 
     assert series_pow == Dup_pow

--- a/sympy/polys/tests/test_hypothesis.py
+++ b/sympy/polys/tests/test_hypothesis.py
@@ -1,7 +1,21 @@
 from hypothesis import given
 from hypothesis import strategies as st
+from hypothesis.strategies import composite
+
 from sympy.abc import x
+from sympy import ZZ
 from sympy.polys.polytools import Poly
+from sympy.polys.densebasic import dup_truncate, dup_from_list
+from sympy.polys.densetools import dup_compose, dup_series_compose, dup_series_reversion
+from sympy.polys.densearith import (
+    dup_mul,
+    dup_series_mul,
+    _dup_series_mul_base,
+    _dup_series_mul_karatsuba,
+    dup_pow,
+    dup_series_pow,
+)
+from sympy.testing.pytest import slow
 
 
 def polys(*, nonzero=False, domain="ZZ"):
@@ -11,6 +25,17 @@ def polys(*, nonzero=False, domain="ZZ"):
     if nonzero:
         coeff_st = coeff_st.filter(any)
     return st.builds(Poly, coeff_st, st.just(x), domain=st.just(domain))
+
+
+@composite
+def dup(draw, unit=False, min_len=3, max_len=200):
+    lst = draw(st.lists(st.integers(), min_size=min_len, max_size=max_len))
+
+    if unit:
+        lst[-1] = ZZ(0)
+        lst[-2] = ZZ(1)
+
+    return lst
 
 
 @given(f=polys(), g=polys(), r=polys())
@@ -34,3 +59,41 @@ def test_poly_hypothesis_integers(f_z, g_z):
 def test_poly_hypothesis_rationals(f_q, g_q):
     remainder_q = f_q.rem(g_q)
     assert g_q.degree() >= remainder_q.degree() or remainder_q.degree() == 0
+
+
+@given(f=dup(unit=True), g=dup(unit=True), n=st.integers(min_value=3, max_value=200))
+def test_dup_series_compose(f, g, n):
+    expected = dup_truncate(dup_compose(f, g, ZZ), n, ZZ)
+    assert dup_series_compose(f, g, n, ZZ) == expected
+
+
+@slow
+@given(f=dup(unit=True), n=st.integers(min_value=3, max_value=200))
+def test_dup_series_reversion(f, n):
+    rev = dup_series_reversion(f, n, ZZ)
+    comp = dup_series_compose(rev, f, n, ZZ)
+    expected = dup_from_list([1, 0], ZZ)
+    assert comp == expected
+
+
+@given(f=dup(), g=dup(), n=st.integers(min_value=3, max_value=200))
+def test_dup_series_mul(f, g, n):
+    base = _dup_series_mul_base(f, g, n, ZZ)
+    karatsuba = _dup_series_mul_karatsuba(f, g, n, ZZ)
+    series_mul = dup_series_mul(f, g, n, ZZ)
+    Dup_mul = dup_truncate(dup_mul(f, g, ZZ), n, ZZ)
+
+    assert series_mul == Dup_mul
+    assert base == karatsuba
+
+
+@given(
+    f=dup(),
+    pow=st.integers(min_value=0, max_value=10),
+    n=st.integers(min_value=3, max_value=200),
+)
+def test_dup_series_pow(f, pow, n):
+    Dup_pow = dup_truncate(dup_pow(f, pow, ZZ), n, ZZ)
+    series_pow = dup_series_pow(f, pow, n, ZZ)
+
+    assert series_pow == Dup_pow


### PR DESCRIPTION
#### Brief description of what is fixed or changed
All series functions perform operations on the input polynomials and return the result modulo `x**prec`. These functions support development of the new poly/series module.

This is needed for gh-28109

`dup_truncate` returns the first n terms (lowest-degree terms) of a polynomial, unlike `dup_slice`, which returns a general slice.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added dup_series_reversion, dup_series_compose in `densetools.py`.
  * Added dup_series_mul, dup_series_pow in `densearith.py`.
  * Added dup_truncate, dup_from_list, dup_print in `densebasic.py`.
<!-- END RELEASE NOTES -->
