### PR TITLE
Fix a documentation plurality typo in expr.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -776,6 +776,8 @@ Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>
 Jaroslaw Tworek <dev.jrx@gmail.com>
 Jashanpreet Singh <jashansingh.4398@gmail.com>
 Jason Gedge <inferno1386@gmail.com> inferno1386 <devnull@localhost>
+Jason Gross <jasongross9@gmail.com>
+Jason Gross <jasongross9@gmail.com> Jason Gross <jgross@mit.edu>
 Jason Ly <jason.ly@gmail.com>
 Jason Moore <moorepants@gmail.com>
 Jason Ross <jasonross1024@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3844,7 +3844,7 @@ class Expr(Basic, EvalfMixin):
     def round(self, n=None):
         """Return x rounded to the given decimal place.
 
-        If a complex number would results, apply round to the real
+        If a complex number would result, apply round to the real
         and imaginary components of the number.
 
         Examples


### PR DESCRIPTION

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
