### PR TITLE
Fix: Invalid inputs in BlockDiagMatrix (fixes #28225)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -458,6 +458,8 @@ Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@us
 Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>
 Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@users.noreply.github.com>
+Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
+Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -584,13 +584,13 @@ class BlockDiagMatrix(BlockMatrix):
     sympy.matrices.dense.diag
     """
     def __new__(cls, *mats):
-        # Validate that all arguments are matrix-like objects
+        mats = [_sympify(m) for m in mats]
         for mat in mats:
-            if not hasattr(mat, 'rows') or not hasattr(mat, 'cols'):
+            if not isinstance(mat, MatrixExpr):
                 raise ValueError(
-                    f"BlockDiagMatrix requires matrix-like objects with 'rows' and 'cols' "
-                    f"attributes. Got {type(mat).__name__} with value {mat}")
-        return Basic.__new__(BlockDiagMatrix, *[_sympify(m) for m in mats])
+                    f"BlockDiagMatrix requires matrix-like objects. "
+                    f"Got {type(mat).__name__} with value {mat}")
+        return Basic.__new__(BlockDiagMatrix, *mats)
 
     @property
     def diag(self):

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -584,6 +584,12 @@ class BlockDiagMatrix(BlockMatrix):
     sympy.matrices.dense.diag
     """
     def __new__(cls, *mats):
+        # Validate that all arguments are matrix-like objects
+        for mat in mats:
+            if not hasattr(mat, 'rows') or not hasattr(mat, 'cols'):
+                raise ValueError(
+                    f"BlockDiagMatrix requires matrix-like objects with 'rows' and 'cols' "
+                    f"attributes. Got {type(mat).__name__} with value {mat}")
         return Basic.__new__(BlockDiagMatrix, *[_sympify(m) for m in mats])
 
     @property

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -122,6 +122,9 @@ def test_issue_18618():
     A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert A == Matrix(BlockDiagMatrix(A))
 
+def test_issue_28225():
+    raises(ValueError, lambda: BlockDiagMatrix(2, 2))
+
 def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']
     X = BlockMatrix([[A, B], [C, D]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes Issue : #28225

#### Brief description of what is fixed or changed
- This PR adds argument validation to `BlockDiagMatrix.__new__`, raising `ValueError` if the inputs are not matrix-like (i.e., do not have .rows and .cols).
- Adds a regression test.


#### Quality Checks ✅

- [x] Primary linting passed with `ruff check sympy`
- [x] Legacy linting passed with `flake8 sympy`
- [x] Type checking passed with `mypy sympy`

#### Other comments



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
