### PR TITLE
Fixed int complex cast #28221

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -358,28 +358,42 @@ class Expr(Basic, EvalfMixin):
     def __int__(self) -> int:
         if not self.is_number:
             raise TypeError("Cannot convert symbols to int")
+        if self.is_complex and not self.is_real:
+            raise TypeError("Cannot convert complex to int")
+
         r = self.round(2)
         if not r.is_Number:
-            raise TypeError("Cannot convert complex to int")
+            raise TypeError("Cannot convert %s to int" % r)
         if r in (S.NaN, S.Infinity, S.NegativeInfinity):
             raise TypeError("Cannot convert %s to int" % r)
+
         i = int(r)
         if not i:
             return i
+
         if int_valued(r):
-            # non-integer self should pass one of these tests
-            if (self > i) is S.true:
-                return i
-            if (self < i) is S.true:
-                return i - 1
-            ok = self.equals(i)
-            if ok is None:
-                raise TypeError('cannot compute int value accurately')
-            if ok:
-                return i
-            # off by one
-            return i - (1 if i > 0 else -1)
+            return self._handle_int_valued_case(i)
+
         return i
+
+    def _handle_int_valued_case(self, i):
+        """Handle the case where the rounded value is integer-valued."""
+        # Check if self is greater than the rounded integer
+        if (self > i) is S.true:
+            return i
+        # Check if self is less than the rounded integer
+        if (self < i) is S.true:
+            return i - 1
+
+        # Check if self equals the rounded integer
+        ok = self.equals(i)
+        if ok is None:
+            raise TypeError('cannot compute int value accurately')
+        if ok:
+            return i
+
+        # Handle off-by-one case
+        return i - (1 if i > 0 else -1)
 
     def __float__(self) -> float:
         # Don't bother testing if it's a number; if it's not this is going

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -45,10 +45,10 @@ from sympy.simplify.trigsimp import trigsimp
 from sympy.tensor.indexed import Indexed
 from sympy.physics.units import meter
 
+import pytest
 from sympy.testing.pytest import raises, XFAIL
 
 from sympy.abc import a, b, c, n, t, u, x, y, z
-
 
 f, g, h = symbols('f,g,h', cls=Function)
 
@@ -2222,6 +2222,11 @@ def test_issue_10755():
     x = symbols('x')
     raises(TypeError, lambda: int(log(x)))
     raises(TypeError, lambda: log(x).round(2))
+
+@pytest.mark.parametrize('expr', [I / 3, I / 200])
+def test_issue_28221(expr):
+    with pytest.raises(TypeError, match="Cannot convert complex to int"):
+        int(expr)
 
 
 def test_issue_11877():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fix __int__ to raise `TypeError `for complex numbers with zero real part

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixed #28221

#### Brief description of what is fixed or changed
- Previously, __int__ did not raise a `TypeError `for complex numbers like I/200, because round(2) returned 0 and bypassed the complex number check.
- This fix ensures that complex expressions with zero real part are correctly rejected, making `__int__ `behavior consistent for all complex inputs.

#### Quality Checks ✅
- [x] Primary linting passed with `ruff check sympy`
- [x] Legacy linting passed with `flake8 sympy`
- [x] Type checking passed with `mypy sympy`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
