### PR TITLE
core: fix rounding for objects implementing __int__

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -358,6 +358,8 @@ class Expr(Basic, EvalfMixin):
     def __int__(self) -> int:
         if not self.is_number:
             raise TypeError("Cannot convert symbols to int")
+        if not self.is_comparable:
+            raise TypeError("Cannot convert non-comparable expression to int")
         r = self.round(2)
         if not r.is_Number:
             raise TypeError("Cannot convert complex to int")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -45,6 +45,7 @@ from sympy.simplify.trigsimp import trigsimp
 from sympy.tensor.indexed import Indexed
 from sympy.physics.units import meter
 
+import pytest
 from sympy.testing.pytest import raises, XFAIL
 
 from sympy.abc import a, b, c, n, t, u, x, y, z
@@ -2227,6 +2228,12 @@ def test_issue_10755():
 def test_issue_11877():
     x = symbols('x')
     assert integrate(log(S.Half - x), (x, 0, S.Half)) == Rational(-1, 2) -log(2)/2
+
+
+@pytest.mark.parametrize('expr', [I / 3, I / 200])
+def test_issue_28221(expr):
+    with pytest.raises(TypeError, match="Cannot convert non-comparable expression to int"):
+        int(expr)
 
 
 def test_normal():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fix __int__ to raise `TypeError `for complex numbers with zero real part

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixed #28221

#### Brief description of what is fixed or changed
- Previously, __int__ did not raise a `TypeError `for complex numbers like I/200, because round(2) returned 0 and bypassed the complex number check.
- This fix ensures that complex expressions with zero real part are correctly rejected, making `__int__ `behavior consistent for all complex inputs.

#### Quality Checks ✅
- [x] Primary linting passed with `ruff check sympy`
- [x] Legacy linting passed with `flake8 sympy`
- [x] Type checking passed with `mypy sympy`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
