### PR TITLE
Added __format__ method to rational

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1513,7 +1513,7 @@ Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>
 Sudeep Sidhu <sudeepmanilsidhu@gmail.com> sidhu1012 <sudeepmanilsidhu@gmail.com>
 Sudhanshu Mishra <mrsud94@gmail.com>
-Sujal Kumar <sujaljayantkumar06@gmail.com>
+Sujal Kumar <sujaljayantkumar06@gmail.com> Sujal Kumar <91939382+SujalKumar06@users.noreply.github.com>
 Suman mondal <smondal.qwerty@gmail.com>
 Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
 Sumith Kulal <sumith1896@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1513,6 +1513,7 @@ Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>
 Sudeep Sidhu <sudeepmanilsidhu@gmail.com> sidhu1012 <sudeepmanilsidhu@gmail.com>
 Sudhanshu Mishra <mrsud94@gmail.com>
+Sujal Kumar <sujaljayantkumar06@gmail.com>
 Suman mondal <smondal.qwerty@gmail.com>
 Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
 Sumith Kulal <sumith1896@gmail.com>

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1691,6 +1691,9 @@ class Rational(Number):
     def __hash__(self):
         return super().__hash__()
 
+    def __format__(self, format_spec):
+        return format(fractions.Fraction(self.p, self.q), format_spec)
+
     def factors(self, limit=None, use_trial=True, use_rho=False,
                 use_pm1=False, verbose=False, visual=False):
         """A wrapper to factorint which return factors of self that are

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -46,6 +46,7 @@ from sympy.tensor.indexed import Indexed
 from sympy.physics.units import meter
 
 import pytest
+import sys
 from sympy.testing.pytest import raises, XFAIL
 
 from sympy.abc import a, b, c, n, t, u, x, y, z
@@ -2340,7 +2341,10 @@ def test_21494():
 def test_Expr__eq__iterable_handling():
     assert x != range(3)
 
-
+@pytest.mark.skipif(
+        sys.version_info < (3, 12),
+        reason = "Format works for Python version >= 3.12"
+)
 def test_format():
     assert '{:1.2f}'.format(S.Zero) == '0.00'
     assert '{:+3.0f}'.format(S(3)) == ' +3'


### PR DESCRIPTION
**References to other Issues or PRs**

Issue https://github.com/sympy/sympy/issues/28217

**Release Notes**
<!-- BEGIN RELEASE NOTES -->
* core
    * Added `__format__` to the Rational class in core. (#28217). This new functionality would only work on Python versions >= 3.12
<!-- END RELEASE NOTES -->
