### PR TITLE
typing: add annotations in densebasic.py

### DIFF
--- a/doc/src/modules/polys/domainsref.rst
+++ b/doc/src/modules/polys/domainsref.rst
@@ -41,6 +41,9 @@ Abstract Domains
 
 .. autoclass:: sympy.polys.domains.domain.Er
 .. autoclass:: sympy.polys.domains.domain.Es
+.. autoclass:: sympy.polys.domains.domain.Et
+.. autoclass:: sympy.polys.domains.domain.Eg
+.. py:class:: sympy.polys.densebasic.Epa
 .. autoclass:: sympy.polys.domains.domain.Ef
 .. py:class:: sympy.polys.domains.domain.TypeIs
 

--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -64,6 +64,18 @@ may be slightly more efficient.)
 
 .. currentmodule:: sympy.polys.densebasic
 
+.. py:class:: dup
+.. py:class:: dmp
+.. py:class:: dmp_tup
+.. py:class:: monom
+
+The ``dup`` representation is a list of coefficients that are themselves domain
+elements. The ``dmp`` type represents dense, multivariate polynomials
+recursively as a list of lists. See :ref:`polys-domainsintro` for an
+introductory explanation of the domain system and the ``dup`` and ``dmp``
+representations. Many functions are available to manipulate polynomials in the
+``dup`` and ``dmp`` representations. This section lists some of them.
+
 .. autofunction:: dmp_LC
 .. autofunction:: dmp_TC
 .. autofunction:: dmp_ground_LC

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -1,7 +1,11 @@
 """Arithmetics for dense recursive polynomials in ``K[x]`` or ``K[X]``. """
 
+from __future__ import annotations
+
+from sympy.polys.domains.domain import Domain, Er
 
 from sympy.polys.densebasic import (
+    dup, dmp, _dup, _dmp,
     dup_slice, dup_truncate,
     dup_reverse,
     dup_LC, dmp_LC,
@@ -511,7 +515,7 @@ def dmp_neg(f, u, K):
     return [ dmp_neg(cf, v, K) for cf in f ]
 
 
-def dup_add(f, g, K):
+def dup_add(f: dup[Er], g: dup[Er], K: Domain[Er]) -> dup[Er]:
     """
     Add dense polynomials in ``K[x]``.
 
@@ -530,8 +534,8 @@ def dup_add(f, g, K):
     if not g:
         return f
 
-    df = dup_degree(f)
-    dg = dup_degree(g)
+    df: int = dup_degree(f) # type: ignore
+    dg: int = dup_degree(g) # type: ignore
 
     if df == dg:
         return dup_strip([ a + b for a, b in zip(f, g) ])
@@ -546,7 +550,7 @@ def dup_add(f, g, K):
         return h + [ a + b for a, b in zip(f, g) ]
 
 
-def dmp_add(f, g, u, K):
+def dmp_add(f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Add dense polynomials in ``K[X]``.
 
@@ -561,14 +565,14 @@ def dmp_add(f, g, u, K):
 
     """
     if not u:
-        return dup_add(f, g, K)
+        return _dmp(dup_add(_dup(f), _dup(g), K))
 
-    df = dmp_degree(f, u)
+    df: int = dmp_degree(f, u) # type: ignore
 
     if df < 0:
         return g
 
-    dg = dmp_degree(g, u)
+    dg: int = dmp_degree(g, u) # type: ignore
 
     if dg < 0:
         return f
@@ -1867,7 +1871,7 @@ def dmp_max_norm(f, u, K):
     return max(dmp_max_norm(c, v, K) for c in f)
 
 
-def dup_l1_norm(f, K):
+def dup_l1_norm(f: dup[Er], K: Domain[Er]) -> Er:
     """
     Returns l1 norm of a polynomial in ``K[x]``.
 
@@ -1884,10 +1888,10 @@ def dup_l1_norm(f, K):
     if not f:
         return K.zero
     else:
-        return sum(dup_abs(f, K))
+        return K.sum(dup_abs(f, K))
 
 
-def dmp_l1_norm(f, u, K):
+def dmp_l1_norm(f: dmp[Er], u: int, K: Domain[Er]) -> Er:
     """
     Returns l1 norm of a polynomial in ``K[X]``.
 
@@ -1902,14 +1906,14 @@ def dmp_l1_norm(f, u, K):
 
     """
     if not u:
-        return dup_l1_norm(f, K)
+        return dup_l1_norm(_dup(f), K)
 
     v = u - 1
 
-    return sum(dmp_l1_norm(c, v, K) for c in f)
+    return K.sum(dmp_l1_norm(c, v, K) for c in f)
 
 
-def dup_l2_norm_squared(f, K):
+def dup_l2_norm_squared(f: dup[Er], K: Domain[Er]) -> Er:
     """
     Returns squared l2 norm of a polynomial in ``K[x]``.
 
@@ -1923,10 +1927,10 @@ def dup_l2_norm_squared(f, K):
     14
 
     """
-    return sum([coeff**2 for coeff in f], K.zero)
+    return K.sum([coeff**2 for coeff in f])
 
 
-def dmp_l2_norm_squared(f, u, K):
+def dmp_l2_norm_squared(f: dmp[Er], u: int, K: Domain[Er]) -> Er:
     """
     Returns squared l2 norm of a polynomial in ``K[X]``.
 
@@ -1941,11 +1945,11 @@ def dmp_l2_norm_squared(f, u, K):
 
     """
     if not u:
-        return dup_l2_norm_squared(f, K)
+        return dup_l2_norm_squared(_dup(f), K)
 
     v = u - 1
 
-    return sum(dmp_l2_norm_squared(c, v, K) for c in f)
+    return K.sum(dmp_l2_norm_squared(c, v, K) for c in f)
 
 
 def dup_expand(polys, K):

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -71,7 +71,7 @@ def dup_LC(f: dup[Er], K: Domain[Er]) -> Er:
     >>> from sympy.polys.densebasic import dup_LC
 
     >>> dup_LC([1, 2, 3], ZZ)
-    3
+    1
 
     """
     if not f:
@@ -110,14 +110,16 @@ def dmp_LC(f: dmp[Er], K: Domain[Er]) -> dmp[Er]:
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dmp_LC
 
-    >>> f = ZZ.map([[[1], [2, 3]]])
+    >>> f = ZZ.map([[1], [2, 3]])
 
     >>> dmp_LC(f, ZZ)
-    [[1]]
+    [1]
 
     """
     if not f:
-        return dmp_zero(1)
+        # XXX: Remove this. It should not be needed since a zero dmp is
+        # represented like [[[]]].
+        return K.zero # type: ignore
     else:
         return f[0]
 
@@ -132,14 +134,14 @@ def dmp_TC(f: dmp[Er], K: Domain[Er]) -> dmp[Er]:
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.densebasic import dmp_TC
 
-    >>> f = ZZ.map([[[1], [2, 3]]])
+    >>> f = ZZ.map([[1], [2, 3]])
 
     >>> dmp_TC(f, ZZ)
-    [[3]]
+    [2, 3]
 
     """
     if not f:
-        return dmp_zero(1)
+        return K.zero # type: ignore
     else:
         return f[-1]
 

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-from typing import TYPE_CHECKING, TypeAlias, TypeVar, Iterable, Callable, Any
+from typing import TYPE_CHECKING, TypeVar, Iterable, Callable, Any
 
 from sympy.core import igcd
 from sympy.core.expr import Expr
@@ -31,6 +31,7 @@ monom: TypeAlias = tuple[int, ...]
 
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
     from sympy.polys.rings import PolyElement
 
     def _dup(p: dmp[_T], /) -> dup[_T]: ...

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1,5 +1,4 @@
-"""Basic tools for dense recursive polynomials in ``K[x]`` or ``K[X]``. """
-
+"""Basic tools for dense recursive polynomials in ``K[x]`` or ``K[X]``."""
 
 from __future__ import annotations
 
@@ -16,7 +15,7 @@ from sympy.polys.orderings import monomial_key
 import random
 
 
-_T = TypeVar('_T')
+_T = TypeVar("_T")
 dup: TypeAlias = list[_T]
 dmp: TypeAlias = list["dmp[_T]"]
 dup_tup: TypeAlias = tuple[_T, ...]
@@ -33,21 +32,32 @@ monom: TypeAlias = tuple[int, ...]
 
 if TYPE_CHECKING:
     from sympy.polys.rings import PolyElement
+
     def _dup(p: dmp[_T], /) -> dup[_T]: ...
     def _dmp(p: dup[_T], /) -> dmp[_T]: ...
     def _dmp_tup(p: tuple[_T, ...], /) -> dmp_tup[_T]: ...
     def _idup(ps: tuple[dmp[_T], ...], /) -> tuple[dup[_T], ...]: ...
     def _idmp(ps: tuple[dup[_T], ...], /) -> tuple[dmp[_T], ...]: ...
 else:
-    def _dup(p, /): return p
-    def _dmp(p, /): return p
-    def _dmp_tup(p, /): return p
-    def _idup(ps, /): return ps
-    def _idmp(ps, /): return ps
+
+    def _dup(p, /):
+        return p
+
+    def _dmp(p, /):
+        return p
+
+    def _dmp_tup(p, /):
+        return p
+
+    def _idup(ps, /):
+        return ps
+
+    def _idmp(ps, /):
+        return ps
 
 
 # XXX: This causes lots of type: ignore. It would be better just to use -1:
-ninf = float('-inf')
+ninf = float("-inf")
 
 
 def dup_LC(f: dup[Er], K: Domain[Er]) -> Er:
@@ -327,7 +337,7 @@ def dmp_degree_list(f: dmp[Er], u: int) -> tuple[int | float, ...]:
     (1, 2)
 
     """
-    degs = [ninf]*(u + 1)
+    degs = [ninf] * (u + 1)
     _rec_degree_list(f, u, 0, degs)
     return tuple(degs)
 
@@ -392,7 +402,9 @@ def dmp_strip(f: dmp[Er], u: int) -> dmp[Er]:
         return f[i:]
 
 
-def _rec_validate(f: dmp[Er], g: dmp[Er] | Er, i: int, K: Domain[Er] | None) -> set[int]:
+def _rec_validate(
+    f: dmp[Er], g: dmp[Er] | Er, i: int, K: Domain[Er] | None
+) -> set[int]:
     """Recursive helper for :func:`dmp_validate`."""
     if not isinstance(g, list):
         if K is not None and not K.of_type(g):
@@ -417,7 +429,7 @@ def _rec_strip(g: dmp[Er], v: int) -> dmp[Er]:
 
     w = v - 1
 
-    return dmp_strip([ _rec_strip(c, w) for c in g ], v)
+    return dmp_strip([_rec_strip(c, w) for c in g], v)
 
 
 def dmp_validate(f: dmp[Er], K: Domain[Er] | None = None) -> tuple[dmp[Er], int]:
@@ -445,8 +457,7 @@ def dmp_validate(f: dmp[Er], K: Domain[Er] | None = None) -> tuple[dmp[Er], int]
     if not levels:
         return _rec_strip(f, u), u
     else:
-        raise ValueError(
-            "invalid data structure for a multivariate polynomial")
+        raise ValueError("invalid data structure for a multivariate polynomial")
 
 
 def dup_reverse(f: dup[Er]) -> dup[Er]:
@@ -508,7 +519,7 @@ def dmp_copy(f: dmp[Er], u: int) -> dmp[Er]:
 
     v = u - 1
 
-    return [ dmp_copy(c, v) for c in f ]
+    return [dmp_copy(c, v) for c in f]
 
 
 def dup_to_tuple(f: dup[Er]) -> tuple[Er, ...]:
@@ -571,7 +582,7 @@ def dup_normal(f: dup[Er], K: Domain[Er]) -> dup[Er]:
     [1, 2, 3]
 
     """
-    return dup_strip([ K.normal(c) for c in f ])
+    return dup_strip([K.normal(c) for c in f])
 
 
 def dmp_normal(f: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
@@ -593,7 +604,7 @@ def dmp_normal(f: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
 
     v = u - 1
 
-    return dmp_strip([ dmp_normal(c, v, K) for c in f ], u)
+    return dmp_strip([dmp_normal(c, v, K) for c in f], u)
 
 
 def dup_convert(f: dup[Er], K0: Domain[Er], K1: Domain[Es]) -> dup[Es]:
@@ -616,9 +627,9 @@ def dup_convert(f: dup[Er], K0: Domain[Er], K1: Domain[Es]) -> dup[Es]:
 
     """
     if K0 is not None and K0 == K1:
-        return f # type: ignore
+        return f  # type: ignore
     else:
-        return dup_strip([ K1.convert(c, K0) for c in f ])
+        return dup_strip([K1.convert(c, K0) for c in f])
 
 
 def dmp_convert(f: dmp[Er], u: int, K0: Domain[Er], K1: Domain[Es]) -> dmp[Es]:
@@ -643,11 +654,11 @@ def dmp_convert(f: dmp[Er], u: int, K0: Domain[Er], K1: Domain[Es]) -> dmp[Es]:
     if not u:
         return _dmp(dup_convert(_dup(f), K0, K1))
     if K0 is not None and K0 == K1:
-        return f # type: ignore
+        return f  # type: ignore
 
     v = u - 1
 
-    return dmp_strip([ dmp_convert(c, v, K0, K1) for c in f ], u)
+    return dmp_strip([dmp_convert(c, v, K0, K1) for c in f], u)
 
 
 def dup_from_sympy(f: list[Expr], K: Domain[Er]) -> dup[Er]:
@@ -665,7 +676,7 @@ def dup_from_sympy(f: list[Expr], K: Domain[Er]) -> dup[Er]:
     True
 
     """
-    return dup_strip([ K.from_sympy(c) for c in f ])
+    return dup_strip([K.from_sympy(c) for c in f])
 
 
 def dmp_from_sympy(f: dmp[Expr], u: int, K: Domain[Er]) -> dmp[Er]:
@@ -688,7 +699,7 @@ def dmp_from_sympy(f: dmp[Expr], u: int, K: Domain[Er]) -> dmp[Er]:
 
     v = u - 1
 
-    return dmp_strip([ dmp_from_sympy(c, v, K) for c in f ], u)
+    return dmp_strip([dmp_from_sympy(c, v, K) for c in f], u)
 
 
 def dup_nth(f: dup[Er], n: int, K: Domain[Er]) -> Er:
@@ -714,7 +725,7 @@ def dup_nth(f: dup[Er], n: int, K: Domain[Er]) -> Er:
     elif n >= len(f):
         return K.zero
     else:
-        return f[dup_degree(f) - n] # type: ignore
+        return f[dup_degree(f) - n]  # type: ignore
 
 
 def dmp_nth(f: dmp[Er], n: int, u: int, K: Domain[Er]) -> dmp[Er]:
@@ -740,7 +751,7 @@ def dmp_nth(f: dmp[Er], n: int, u: int, K: Domain[Er]) -> dmp[Er]:
     elif n >= len(f):
         return dmp_zero(u - 1)
     else:
-        return f[dmp_degree(f, u) - n] # type: ignore
+        return f[dmp_degree(f, u) - n]  # type: ignore
 
 
 def dmp_ground_nth(f: dmp[Er], N: Iterable[int], u: int, K: Domain[Er]) -> Er:
@@ -770,9 +781,9 @@ def dmp_ground_nth(f: dmp[Er], N: Iterable[int], u: int, K: Domain[Er]) -> Er:
             d = dmp_degree(f, v)
             if d == ninf:
                 d = -1
-            f, v = f[d - n], v - 1 # type: ignore
+            f, v = f[d - n], v - 1  # type: ignore
 
-    return f # type: ignore
+    return f  # type: ignore
 
 
 def dmp_zero_p(f: dmp[Er], u: int) -> bool:
@@ -934,9 +945,9 @@ def dmp_zeros(n: int, u: int, K: Domain[Er]) -> dmp[Er]:
         return []
 
     if u < 0:
-        return _dmp([K.zero]*n)
+        return _dmp([K.zero] * n)
     else:
-        return [ dmp_zero(u) for i in range(n) ]
+        return [dmp_zero(u) for i in range(n)]
 
 
 def dmp_grounds(c: Er, n: int, u: int) -> list[dmp[Er]] | list[Er]:
@@ -961,7 +972,7 @@ def dmp_grounds(c: Er, n: int, u: int) -> list[dmp[Er]] | list[Er]:
     if u < 0:
         return _dmp([c]) * n
     else:
-        return [ dmp_ground(c, u) for i in range(n) ] # type: ignore
+        return [dmp_ground(c, u) for i in range(n)]  # type: ignore
 
 
 def dmp_negative_p(f: dmp[Er], u: int, K: Domain[Er]) -> bool:
@@ -1025,12 +1036,12 @@ def dup_from_dict(f: dict[tuple[int], Er] | dict[int, Er], K: Domain[Er]) -> dup
 
     if isinstance(n, int):
         for k in range(n, -1, -1):
-            h.append(f.get(k, K.zero)) # type: ignore
+            h.append(f.get(k, K.zero))  # type: ignore
     else:
         (n,) = n
 
         for k in range(n, -1, -1):
-            h.append(f.get((k,), K.zero)) # type: ignore
+            h.append(f.get((k,), K.zero))  # type: ignore
 
     return dup_strip(h)
 
@@ -1077,7 +1088,7 @@ def dmp_from_dict(f: dict[tuple[int, ...], Er], u: int, K: Domain[Er]) -> dmp[Er
 
     """
     if not u:
-        return _dmp(dup_from_dict(f, K)) # type: ignore
+        return _dmp(dup_from_dict(f, K))  # type: ignore
     if not f:
         return dmp_zero(u)
 
@@ -1089,7 +1100,7 @@ def dmp_from_dict(f: dict[tuple[int, ...], Er], u: int, K: Domain[Er]) -> dmp[Er
         if head in coeffs:
             coeffs[head][tail] = coeff
         else:
-            coeffs[head] = { tail: coeff }
+            coeffs[head] = {tail: coeff}
 
     n, v, h = max(coeffs.keys()), u - 1, []
 
@@ -1104,7 +1115,9 @@ def dmp_from_dict(f: dict[tuple[int, ...], Er], u: int, K: Domain[Er]) -> dmp[Er
     return dmp_strip(h, u)
 
 
-def dup_to_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False) -> dict[tuple[int], Er]:
+def dup_to_dict(
+    f: dup[Er], K: Domain[Er] | None = None, zero: bool = False
+) -> dict[tuple[int], Er]:
     """
     Convert ``K[x]`` polynomial to a ``dict``.
 
@@ -1120,7 +1133,7 @@ def dup_to_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False) -> 
 
     """
     if not f and zero:
-        return {(0,): K.zero} # type: ignore
+        return {(0,): K.zero}  # type: ignore
 
     n, result = len(f) - 1, {}
 
@@ -1131,7 +1144,9 @@ def dup_to_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False) -> 
     return result
 
 
-def dup_to_raw_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False) -> dict[int, Er]:
+def dup_to_raw_dict(
+    f: dup[Er], K: Domain[Er] | None = None, zero: bool = False
+) -> dict[int, Er]:
     """
     Convert a ``K[x]`` polynomial to a raw ``dict``.
 
@@ -1145,7 +1160,7 @@ def dup_to_raw_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False)
 
     """
     if not f and zero:
-        return {0: K.zero} # type: ignore
+        return {0: K.zero}  # type: ignore
 
     n, result = len(f) - 1, {}
 
@@ -1156,7 +1171,9 @@ def dup_to_raw_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False)
     return result
 
 
-def dmp_to_dict(f: dmp[Er], u: int, K: Domain[Er] | None = None, zero: bool = False) -> dict[tuple[int, ...], Er]:
+def dmp_to_dict(
+    f: dmp[Er], u: int, K: Domain[Er] | None = None, zero: bool = False
+) -> dict[tuple[int, ...], Er]:
     """
     Convert a ``K[X]`` polynomial to a ``dict````.
 
@@ -1172,18 +1189,18 @@ def dmp_to_dict(f: dmp[Er], u: int, K: Domain[Er] | None = None, zero: bool = Fa
 
     """
     if not u:
-        return dup_to_dict(_dup(f), K, zero=zero) # type: ignore
+        return dup_to_dict(_dup(f), K, zero=zero)  # type: ignore
 
     if dmp_zero_p(f, u) and zero:
-        return {(0,)*(u + 1): K.zero} # type: ignore
+        return {(0,) * (u + 1): K.zero}  # type: ignore
 
     n, v, result = dmp_degree(f, u), u - 1, {}
 
     if n == ninf:
         n = -1
 
-    for k in range(0, n + 1): # type: ignore
-        h = dmp_to_dict(f[n - k], v) # type: ignore
+    for k in range(0, n + 1):  # type: ignore
+        h = dmp_to_dict(f[n - k], v)  # type: ignore
 
         for exp, coeff in h.items():
             result[(k,) + exp] = coeff
@@ -1220,9 +1237,7 @@ def dmp_swap(f: dmp[Er], i: int, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
     H: dict[monom, Er] = {}
 
     for exp, coeff in F.items():
-        H[exp[:i] + (exp[j],) +
-          exp[i + 1:j] +
-          (exp[i],) + exp[j + 1:]] = coeff
+        H[exp[:i] + (exp[j],) + exp[i + 1 : j] + (exp[i],) + exp[j + 1 :]] = coeff
 
     return dmp_from_dict(H, u, K)
 
@@ -1249,7 +1264,7 @@ def dmp_permute(f: dmp[Er], P: list[int], u: int, K: Domain[Er]) -> dmp[Er]:
     H: dict[monom, Er] = {}
 
     for exp, coeff in F.items():
-        new_exp = [0]*len(exp)
+        new_exp = [0] * len(exp)
 
         for e, p in zip(exp, P):
             new_exp[p] = e
@@ -1307,11 +1322,11 @@ def dmp_raise(f: dmp[Er], l: int, u: int, K: Domain[Er]) -> dmp[Er]:
 
         k = l - 1
 
-        return [ dmp_ground(c, k) for c in _dup(f) ] # type: ignore
+        return [dmp_ground(c, k) for c in _dup(f)]  # type: ignore
 
     v = u - 1
 
-    return [ dmp_raise(cp, l, v, K) for cp in f ]
+    return [dmp_raise(cp, l, v, K) for cp in f]
 
 
 def dup_deflate(f: dup[Er], K: Domain[Er]) -> tuple[int, dup[Er]]:
@@ -1364,10 +1379,10 @@ def dmp_deflate(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], dmp
 
     """
     if dmp_zero_p(f, u):
-        return (1,)*(u + 1), f
+        return (1,) * (u + 1), f
 
     F: dict[monom, Er] = dmp_to_dict(f, u)
-    B = [0]*(u + 1)
+    B = [0] * (u + 1)
 
     for M in F.keys():
         for i, m in enumerate(M):
@@ -1385,13 +1400,15 @@ def dmp_deflate(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], dmp
     H = {}
 
     for A, coeff in F.items():
-        N = [ a // b for a, b in zip(A, Bt) ]
+        N = [a // b for a, b in zip(A, Bt)]
         H[tuple(N)] = coeff
 
     return Bt, dmp_from_dict(H, u, K)
 
 
-def dup_multi_deflate(polys: tuple[dup[Er], ...], K: Domain[Er]) -> tuple[int, tuple[dup[Er], ...]]:
+def dup_multi_deflate(
+    polys: tuple[dup[Er], ...], K: Domain[Er]
+) -> tuple[int, tuple[dup[Er], ...]]:
     """
     Map ``x**m`` to ``y`` in a set of polynomials in ``K[x]``.
 
@@ -1427,10 +1444,12 @@ def dup_multi_deflate(polys: tuple[dup[Er], ...], K: Domain[Er]) -> tuple[int, t
 
         G = igcd(G, g)
 
-    return G, tuple([ p[::G] for p in polys ])
+    return G, tuple([p[::G] for p in polys])
 
 
-def dmp_multi_deflate(polys: tuple[dmp[Er], ...], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], tuple[dmp[Er], ...]]:
+def dmp_multi_deflate(
+    polys: tuple[dmp[Er], ...], u: int, K: Domain[Er]
+) -> tuple[tuple[int, ...], tuple[dmp[Er], ...]]:
     """
     Map ``x_i**m_i`` to ``y_i`` in a set of polynomials in ``K[X]``.
 
@@ -1451,7 +1470,7 @@ def dmp_multi_deflate(polys: tuple[dmp[Er], ...], u: int, K: Domain[Er]) -> tupl
         M, H = dup_multi_deflate(_idup(polys), K)
         return (M,), _idmp(H)
 
-    F, B = [], [0]*(u + 1)
+    F, B = [], [0] * (u + 1)
 
     for p in polys:
         f: dict[monom, Er] = dmp_to_dict(p, u)
@@ -1478,7 +1497,7 @@ def dmp_multi_deflate(polys: tuple[dmp[Er], ...], u: int, K: Domain[Er]) -> tupl
         h = {}
 
         for A, coeff in f.items():
-            N = [ a // b for a, b in zip(A, Bt) ]
+            N = [a // b for a, b in zip(A, Bt)]
             h[tuple(N)] = coeff
 
         H2.append(dmp_from_dict(h, u, K))
@@ -1510,7 +1529,7 @@ def dup_inflate(f: dup[Er], m: int, K: Domain[Er]) -> dup[Er]:
     result = [f[0]]
 
     for coeff in f[1:]:
-        result.extend([K.zero]*(m - 1))
+        result.extend([K.zero] * (m - 1))
         result.append(coeff)
 
     return result
@@ -1525,7 +1544,7 @@ def _rec_inflate(g: dmp[Er], M: list[int], v: int, i: int, K: Domain[Er]) -> dmp
 
     w, j = v - 1, i + 1
 
-    g = [ _rec_inflate(c, M, w, j, K) for c in g ]
+    g = [_rec_inflate(c, M, w, j, K) for c in g]
 
     result = [g[0]]
 
@@ -1647,7 +1666,9 @@ def dmp_include(f: dmp[Er], J: list[int], u: int, K: Domain[Er]) -> dmp[Er]:
     return dmp_from_dict(d, u, K)
 
 
-def dmp_inject(f: dmp[PolyElement[Er]], u: int, K: PolynomialRing[Er], front: bool = False) -> tuple[dmp[Er], int]:
+def dmp_inject(
+    f: dmp[PolyElement[Er]], u: int, K: PolynomialRing[Er], front: bool = False
+) -> tuple[dmp[Er], int]:
     """
     Convert ``f`` from ``K[X][Y]`` to ``K[X,Y]``.
 
@@ -1688,7 +1709,9 @@ def dmp_inject(f: dmp[PolyElement[Er]], u: int, K: PolynomialRing[Er], front: bo
     return dmp_from_dict(h, w, K.dom), w
 
 
-def dmp_eject(f: dmp[Er], u: int, K: PolynomialRing[Er], front: bool = False) -> dmp[PolyElement[Er]]:
+def dmp_eject(
+    f: dmp[Er], u: int, K: PolynomialRing[Er], front: bool = False
+) -> dmp[PolyElement[Er]]:
     """
     Convert ``f`` from ``K[X,Y]`` to ``K[X][Y]``.
 
@@ -1774,7 +1797,7 @@ def dmp_terms_gcd(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], d
 
     """
     if dmp_ground_TC(f, u, K) or dmp_zero_p(f, u):
-        return (0,)*(u + 1), f
+        return (0,) * (u + 1), f
 
     F: dict[monom, Er] = dmp_to_dict(f, u)
     G = monomial_min(*list(F.keys()))
@@ -1792,7 +1815,7 @@ def dmp_terms_gcd(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], d
 
 def _rec_list_terms(g: dmp[Er], v: int, monom: monom) -> list[tuple[monom, Er]]:
     """Recursive helper for :func:`dmp_list_terms`."""
-    d: int = dmp_degree(g, v) # type: ignore
+    d: int = dmp_degree(g, v)  # type: ignore
     terms: list[tuple[tuple[int, ...], Er]] = []
 
     if not v:
@@ -1811,7 +1834,9 @@ def _rec_list_terms(g: dmp[Er], v: int, monom: monom) -> list[tuple[monom, Er]]:
     return terms
 
 
-def dmp_list_terms(f: dmp[Er], u: int, K: Domain[Er], order: str | None = None) -> list[tuple[monom, Er]]:
+def dmp_list_terms(
+    f: dmp[Er], u: int, K: Domain[Er], order: str | None = None
+) -> list[tuple[monom, Er]]:
     """
     List all non-zero terms from ``f`` in the given order ``order``.
 
@@ -1837,7 +1862,7 @@ def dmp_list_terms(f: dmp[Er], u: int, K: Domain[Er], order: str | None = None) 
     terms = _rec_list_terms(f, u, ())
 
     if not terms:
-        return [((0,)*(u + 1), K.zero)]
+        return [((0,) * (u + 1), K.zero)]
 
     if order is None:
         return terms
@@ -1845,7 +1870,9 @@ def dmp_list_terms(f: dmp[Er], u: int, K: Domain[Er], order: str | None = None) 
         return sort(terms, monomial_key(order))
 
 
-def dup_apply_pairs(f: dup[Er], g: dup[Er], h: Callable[..., Er], args: tuple[Any, ...], K: Domain[Er]) -> dup[Er]:
+def dup_apply_pairs(
+    f: dup[Er], g: dup[Er], h: Callable[..., Er], args: tuple[Any, ...], K: Domain[Er]
+) -> dup[Er]:
     """
     Apply ``h`` to pairs of coefficients of ``f`` and ``g``.
 
@@ -1865,9 +1892,9 @@ def dup_apply_pairs(f: dup[Er], g: dup[Er], h: Callable[..., Er], args: tuple[An
 
     if n != m:
         if n > m:
-            g = [K.zero]*(n - m) + g
+            g = [K.zero] * (n - m) + g
         else:
-            f = [K.zero]*(m - n) + f
+            f = [K.zero] * (m - n) + f
 
     result: dup[Er] = []
 
@@ -1877,7 +1904,14 @@ def dup_apply_pairs(f: dup[Er], g: dup[Er], h: Callable[..., Er], args: tuple[An
     return dup_strip(result)
 
 
-def dmp_apply_pairs(f: dmp[Er], g: dmp[Er], h: Callable[..., Er], args: tuple[Any, ...], u: int, K: Domain[Er]) -> dmp[Er]:
+def dmp_apply_pairs(
+    f: dmp[Er],
+    g: dmp[Er],
+    h: Callable[..., Er],
+    args: tuple[Any, ...],
+    u: int,
+    K: Domain[Er],
+) -> dmp[Er]:
     """
     Apply ``h`` to pairs of coefficients of ``f`` and ``g``.
 
@@ -1913,7 +1947,7 @@ def dmp_apply_pairs(f: dmp[Er], g: dmp[Er], h: Callable[..., Er], args: tuple[An
 
 
 def dup_slice(f: dup[Er], m: int, n: int, K: Domain[Er]) -> dup[Er]:
-    """Take a continuous subsequence of terms of ``f`` in ``K[x]``. """
+    """Take a continuous subsequence of terms of ``f`` in ``K[x]``."""
     k = len(f)
 
     if k >= m:
@@ -1933,11 +1967,11 @@ def dup_slice(f: dup[Er], m: int, n: int, K: Domain[Er]) -> dup[Er]:
     if not f:
         return []
     else:
-        return f + [K.zero]*m
+        return f + [K.zero] * m
 
 
 def dmp_slice(f: dmp[Er], m: int, n: int, u: int, K: Domain[Er]) -> dmp[Er]:
-    """Take a continuous subsequence of terms of ``f`` in ``K[X]``. """
+    """Take a continuous subsequence of terms of ``f`` in ``K[X]``."""
     return dmp_slice_in(f, m, n, 0, u, K)
 
 
@@ -1961,7 +1995,7 @@ def dup_truncate(f, n, K):
 
 
 def dmp_slice_in(f: dmp[Er], m: int, n: int, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
-    """Take a continuous subsequence of terms of ``f`` in ``x_j`` in ``K[X]``. """
+    """Take a continuous subsequence of terms of ``f`` in ``x_j`` in ``K[X]``."""
     if j < 0 or j > u:
         raise IndexError("-%s <= j < %s expected, got %s" % (u, u, j))
 
@@ -1975,7 +2009,7 @@ def dmp_slice_in(f: dmp[Er], m: int, n: int, j: int, u: int, K: Domain[Er]) -> d
         k = monom[j]
 
         if k < m or k >= n:
-            monom = monom[:j] + (0,) + monom[j + 1:]
+            monom = monom[:j] + (0,) + monom[j + 1 :]
 
         if monom in g:
             g[monom] += coeff
@@ -1999,7 +2033,7 @@ def dup_random(n: int, a: int, b: int, K: Domain[Er]) -> dup[Er]:
     [-2, -8, 9, -4]
 
     """
-    f = [ K.convert(random.randint(a, b)) for _ in range(0, n + 1) ]
+    f = [K.convert(random.randint(a, b)) for _ in range(0, n + 1)]
 
     while not f[0]:
         f[0] = K.convert(random.randint(a, b))

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -16,11 +16,11 @@ import random
 
 
 _T = TypeVar("_T")
-dup: TypeAlias = list[_T]
-dmp: TypeAlias = list["dmp[_T]"]
-dup_tup: TypeAlias = tuple[_T, ...]
-dmp_tup: TypeAlias = tuple["dmp_tup[_T]", ...]
-monom: TypeAlias = tuple[int, ...]
+dup: TypeAlias = "list[_T]"
+dmp: TypeAlias = "list[dmp[_T]]"
+dup_tup: TypeAlias = "tuple[_T, ...]"
+dmp_tup: TypeAlias = "tuple[dmp_tup[_T], ...]"
+monom: TypeAlias = "tuple[int, ...]"
 
 
 # The _dup and _dmp functions do not do anything but are needed so that a type

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1,30 +1,67 @@
 """Basic tools for dense recursive polynomials in ``K[x]`` or ``K[X]``. """
 
 
+from __future__ import annotations
+
+
+from typing import TYPE_CHECKING, TypeAlias, TypeVar, Iterable, Callable, Any
+
 from sympy.core import igcd
-from sympy.polys.monomials import monomial_min, monomial_div
+from sympy.core.expr import Expr
+from sympy.polys.domains.domain import Domain, Er, Es
+from sympy.polys.domains.polynomialring import PolynomialRing
+from sympy.polys.monomials import monomial_min, monomial_ldiv
 from sympy.polys.orderings import monomial_key
 
 import random
 
 
+_T = TypeVar('_T')
+dup: TypeAlias = list[_T]
+dmp: TypeAlias = list["dmp[_T]"]
+dup_tup: TypeAlias = tuple[_T, ...]
+dmp_tup: TypeAlias = tuple["dmp_tup[_T]", ...]
+monom: TypeAlias = tuple[int, ...]
+
+
+# The _dup and _dmp functions do not do anything but are needed so that a type
+# checker can understand the conversion between the two types.
+#
+# A dup is a list of domain elements. A dmp is a list of lists of domain
+# elements of arbitrary depth.
+
+
+if TYPE_CHECKING:
+    from sympy.polys.rings import PolyElement
+    def _dup(p: dmp[_T], /) -> dup[_T]: ...
+    def _dmp(p: dup[_T], /) -> dmp[_T]: ...
+    def _dmp_tup(p: tuple[_T, ...], /) -> dmp_tup[_T]: ...
+    def _idup(ps: tuple[dmp[_T], ...], /) -> tuple[dup[_T], ...]: ...
+    def _idmp(ps: tuple[dup[_T], ...], /) -> tuple[dmp[_T], ...]: ...
+else:
+    def _dup(p, /): return p
+    def _dmp(p, /): return p
+    def _dmp_tup(p, /): return p
+    def _idup(ps, /): return ps
+    def _idmp(ps, /): return ps
+
+
+# XXX: This causes lots of type: ignore. It would be better just to use -1:
 ninf = float('-inf')
 
 
-def poly_LC(f, K):
+def dup_LC(f: dup[Er], K: Domain[Er]) -> Er:
     """
-    Return leading coefficient of ``f``.
+    Return the leading coefficient of ``f``.
 
     Examples
     ========
 
     >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.densebasic import poly_LC
+    >>> from sympy.polys.densebasic import dup_LC
 
-    >>> poly_LC([], ZZ)
-    0
-    >>> poly_LC([ZZ(1), ZZ(2), ZZ(3)], ZZ)
-    1
+    >>> dup_LC([1, 2, 3], ZZ)
+    3
 
     """
     if not f:
@@ -33,19 +70,17 @@ def poly_LC(f, K):
         return f[0]
 
 
-def poly_TC(f, K):
+def dup_TC(f: dup[Er], K: Domain[Er]) -> Er:
     """
-    Return trailing coefficient of ``f``.
+    Return the trailing coefficient of ``f``.
 
     Examples
     ========
 
     >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.densebasic import poly_TC
+    >>> from sympy.polys.densebasic import dup_TC
 
-    >>> poly_TC([], ZZ)
-    0
-    >>> poly_TC([ZZ(1), ZZ(2), ZZ(3)], ZZ)
+    >>> dup_TC([1, 2, 3], ZZ)
     3
 
     """
@@ -54,11 +89,56 @@ def poly_TC(f, K):
     else:
         return f[-1]
 
-dup_LC = dmp_LC = poly_LC
-dup_TC = dmp_TC = poly_TC
+
+def dmp_LC(f: dmp[Er], K: Domain[Er]) -> dmp[Er]:
+    """
+    Return the leading coefficient of ``f``.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densebasic import dmp_LC
+
+    >>> f = ZZ.map([[[1], [2, 3]]])
+
+    >>> dmp_LC(f, ZZ)
+    [[1]]
+
+    """
+    if not f:
+        return dmp_zero(1)
+    else:
+        return f[0]
 
 
-def dmp_ground_LC(f, u, K):
+def dmp_TC(f: dmp[Er], K: Domain[Er]) -> dmp[Er]:
+    """
+    Return the trailing coefficient of ``f``.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densebasic import dmp_TC
+
+    >>> f = ZZ.map([[[1], [2, 3]]])
+
+    >>> dmp_TC(f, ZZ)
+    [[3]]
+
+    """
+    if not f:
+        return dmp_zero(1)
+    else:
+        return f[-1]
+
+
+poly_LC = dup_LC
+poly_TC = dup_TC
+
+
+def dmp_ground_LC(f: dmp[Er], u: int, K: Domain[Er]) -> Er:
     """
     Return the ground leading coefficient.
 
@@ -78,10 +158,10 @@ def dmp_ground_LC(f, u, K):
         f = dmp_LC(f, K)
         u -= 1
 
-    return dup_LC(f, K)
+    return dup_LC(_dup(f), K)
 
 
-def dmp_ground_TC(f, u, K):
+def dmp_ground_TC(f: dmp[Er], u: int, K: Domain[Er]) -> Er:
     """
     Return the ground trailing coefficient.
 
@@ -101,10 +181,10 @@ def dmp_ground_TC(f, u, K):
         f = dmp_TC(f, K)
         u -= 1
 
-    return dup_TC(f, K)
+    return dup_TC(_dup(f), K)
 
 
-def dmp_true_LT(f, u, K):
+def dmp_true_LT(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[monom, Er]:
     """
     Return the leading term ``c * x_1**n_1 ... x_k**n_k``.
 
@@ -131,10 +211,10 @@ def dmp_true_LT(f, u, K):
     else:
         monom.append(len(f) - 1)
 
-    return tuple(monom), dup_LC(f, K)
+    return tuple(monom), dup_LC(_dup(f), K)
 
 
-def dup_degree(f):
+def dup_degree(f: dup[Er]) -> int | float:
     """
     Return the leading degree of ``f`` in ``K[x]``.
 
@@ -157,7 +237,7 @@ def dup_degree(f):
     return len(f) - 1
 
 
-def dmp_degree(f, u):
+def dmp_degree(f: dmp[Er], u: int) -> int | float:
     """
     Return the leading degree of ``f`` in ``x_0`` in ``K[X]``.
 
@@ -184,7 +264,7 @@ def dmp_degree(f, u):
         return len(f) - 1
 
 
-def _rec_degree_in(g, v, i, j):
+def _rec_degree_in(g: dmp[Er], v: int, i: int, j: int) -> int | float:
     """Recursive helper function for :func:`dmp_degree_in`."""
     if i == j:
         return dmp_degree(g, v)
@@ -194,7 +274,7 @@ def _rec_degree_in(g, v, i, j):
     return max(_rec_degree_in(c, v, i, j) for c in g)
 
 
-def dmp_degree_in(f, j, u):
+def dmp_degree_in(f: dmp[Er], j: int, u: int) -> int | float:
     """
     Return the leading degree of ``f`` in ``x_j`` in ``K[X]``.
 
@@ -220,7 +300,7 @@ def dmp_degree_in(f, j, u):
     return _rec_degree_in(f, u, 0, j)
 
 
-def _rec_degree_list(g, v, i, degs):
+def _rec_degree_list(g: dmp[Er], v: int, i: int, degs: list[int | float]) -> None:
     """Recursive helper for :func:`dmp_degree_list`."""
     degs[i] = max(degs[i], dmp_degree(g, v))
 
@@ -231,7 +311,7 @@ def _rec_degree_list(g, v, i, degs):
             _rec_degree_list(c, v, i, degs)
 
 
-def dmp_degree_list(f, u):
+def dmp_degree_list(f: dmp[Er], u: int) -> tuple[int | float, ...]:
     """
     Return a list of degrees of ``f`` in ``K[X]``.
 
@@ -252,7 +332,7 @@ def dmp_degree_list(f, u):
     return tuple(degs)
 
 
-def dup_strip(f):
+def dup_strip(f: dup[Er]) -> dup[Er]:
     """
     Remove leading zeros from ``f`` in ``K[x]``.
 
@@ -279,7 +359,7 @@ def dup_strip(f):
     return f[i:]
 
 
-def dmp_strip(f, u):
+def dmp_strip(f: dmp[Er], u: int) -> dmp[Er]:
     """
     Remove leading zeros from ``f`` in ``K[X]``.
 
@@ -293,7 +373,7 @@ def dmp_strip(f, u):
 
     """
     if not u:
-        return dup_strip(f)
+        return _dmp(dup_strip(_dup(f)))
 
     if dmp_zero_p(f, u):
         return f
@@ -312,7 +392,7 @@ def dmp_strip(f, u):
         return f[i:]
 
 
-def _rec_validate(f, g, i, K):
+def _rec_validate(f: dmp[Er], g: dmp[Er] | Er, i: int, K: Domain[Er] | None) -> set[int]:
     """Recursive helper for :func:`dmp_validate`."""
     if not isinstance(g, list):
         if K is not None and not K.of_type(g):
@@ -330,17 +410,17 @@ def _rec_validate(f, g, i, K):
         return levels
 
 
-def _rec_strip(g, v):
+def _rec_strip(g: dmp[Er], v: int) -> dmp[Er]:
     """Recursive helper for :func:`_rec_strip`."""
     if not v:
-        return dup_strip(g)
+        return _dmp(dup_strip(_dup(g)))
 
     w = v - 1
 
     return dmp_strip([ _rec_strip(c, w) for c in g ], v)
 
 
-def dmp_validate(f, K=None):
+def dmp_validate(f: dmp[Er], K: Domain[Er] | None = None) -> tuple[dmp[Er], int]:
     """
     Return the number of levels in ``f`` and recursively strip it.
 
@@ -369,7 +449,7 @@ def dmp_validate(f, K=None):
             "invalid data structure for a multivariate polynomial")
 
 
-def dup_reverse(f):
+def dup_reverse(f: dup[Er]) -> dup[Er]:
     """
     Compute ``x**n * f(1/x)``, i.e.: reverse ``f`` in ``K[x]``.
 
@@ -388,7 +468,7 @@ def dup_reverse(f):
     return dup_strip(list(reversed(f)))
 
 
-def dup_copy(f):
+def dup_copy(f: dup[Er]) -> dup[Er]:
     """
     Create a new copy of a polynomial ``f`` in ``K[x]``.
 
@@ -407,7 +487,7 @@ def dup_copy(f):
     return list(f)
 
 
-def dmp_copy(f, u):
+def dmp_copy(f: dmp[Er], u: int) -> dmp[Er]:
     """
     Create a new copy of a polynomial ``f`` in ``K[X]``.
 
@@ -431,7 +511,7 @@ def dmp_copy(f, u):
     return [ dmp_copy(c, v) for c in f ]
 
 
-def dup_to_tuple(f):
+def dup_to_tuple(f: dup[Er]) -> tuple[Er, ...]:
     """
     Convert `f` into a tuple.
 
@@ -452,7 +532,7 @@ def dup_to_tuple(f):
     return tuple(f)
 
 
-def dmp_to_tuple(f, u):
+def dmp_to_tuple(f: dmp[Er], u: int) -> dmp_tup[Er]:
     """
     Convert `f` into a nested tuple of tuples.
 
@@ -471,13 +551,13 @@ def dmp_to_tuple(f, u):
 
     """
     if not u:
-        return tuple(f)
+        return _dmp_tup(tuple(_dup(f)))
     v = u - 1
 
     return tuple(dmp_to_tuple(c, v) for c in f)
 
 
-def dup_normal(f, K):
+def dup_normal(f: dup[Er], K: Domain[Er]) -> dup[Er]:
     """
     Normalize univariate polynomial in the given domain.
 
@@ -494,7 +574,7 @@ def dup_normal(f, K):
     return dup_strip([ K.normal(c) for c in f ])
 
 
-def dmp_normal(f, u, K):
+def dmp_normal(f: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Normalize a multivariate polynomial in the given domain.
 
@@ -509,14 +589,14 @@ def dmp_normal(f, u, K):
 
     """
     if not u:
-        return dup_normal(f, K)
+        return _dmp(dup_normal(_dup(f), K))
 
     v = u - 1
 
     return dmp_strip([ dmp_normal(c, v, K) for c in f ], u)
 
 
-def dup_convert(f, K0, K1):
+def dup_convert(f: dup[Er], K0: Domain[Er], K1: Domain[Es]) -> dup[Es]:
     """
     Convert the ground domain of ``f`` from ``K0`` to ``K1``.
 
@@ -536,12 +616,12 @@ def dup_convert(f, K0, K1):
 
     """
     if K0 is not None and K0 == K1:
-        return f
+        return f # type: ignore
     else:
         return dup_strip([ K1.convert(c, K0) for c in f ])
 
 
-def dmp_convert(f, u, K0, K1):
+def dmp_convert(f: dmp[Er], u: int, K0: Domain[Er], K1: Domain[Es]) -> dmp[Es]:
     """
     Convert the ground domain of ``f`` from ``K0`` to ``K1``.
 
@@ -561,16 +641,16 @@ def dmp_convert(f, u, K0, K1):
 
     """
     if not u:
-        return dup_convert(f, K0, K1)
+        return _dmp(dup_convert(_dup(f), K0, K1))
     if K0 is not None and K0 == K1:
-        return f
+        return f # type: ignore
 
     v = u - 1
 
     return dmp_strip([ dmp_convert(c, v, K0, K1) for c in f ], u)
 
 
-def dup_from_sympy(f, K):
+def dup_from_sympy(f: list[Expr], K: Domain[Er]) -> dup[Er]:
     """
     Convert the ground domain of ``f`` from SymPy to ``K``.
 
@@ -588,7 +668,7 @@ def dup_from_sympy(f, K):
     return dup_strip([ K.from_sympy(c) for c in f ])
 
 
-def dmp_from_sympy(f, u, K):
+def dmp_from_sympy(f: dmp[Expr], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Convert the ground domain of ``f`` from SymPy to ``K``.
 
@@ -604,14 +684,14 @@ def dmp_from_sympy(f, u, K):
 
     """
     if not u:
-        return dup_from_sympy(f, K)
+        return _dmp(dup_from_sympy(_dup(f), K))
 
     v = u - 1
 
     return dmp_strip([ dmp_from_sympy(c, v, K) for c in f ], u)
 
 
-def dup_nth(f, n, K):
+def dup_nth(f: dup[Er], n: int, K: Domain[Er]) -> Er:
     """
     Return the ``n``-th coefficient of ``f`` in ``K[x]``.
 
@@ -634,10 +714,10 @@ def dup_nth(f, n, K):
     elif n >= len(f):
         return K.zero
     else:
-        return f[dup_degree(f) - n]
+        return f[dup_degree(f) - n] # type: ignore
 
 
-def dmp_nth(f, n, u, K):
+def dmp_nth(f: dmp[Er], n: int, u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Return the ``n``-th coefficient of ``f`` in ``K[x]``.
 
@@ -660,10 +740,10 @@ def dmp_nth(f, n, u, K):
     elif n >= len(f):
         return dmp_zero(u - 1)
     else:
-        return f[dmp_degree(f, u) - n]
+        return f[dmp_degree(f, u) - n] # type: ignore
 
 
-def dmp_ground_nth(f, N, u, K):
+def dmp_ground_nth(f: dmp[Er], N: Iterable[int], u: int, K: Domain[Er]) -> Er:
     """
     Return the ground ``n``-th coefficient of ``f`` in ``K[x]``.
 
@@ -690,12 +770,12 @@ def dmp_ground_nth(f, N, u, K):
             d = dmp_degree(f, v)
             if d == ninf:
                 d = -1
-            f, v = f[d - n], v - 1
+            f, v = f[d - n], v - 1 # type: ignore
 
-    return f
+    return f # type: ignore
 
 
-def dmp_zero_p(f, u):
+def dmp_zero_p(f: dmp[Er], u: int) -> bool:
     """
     Return ``True`` if ``f`` is zero in ``K[X]``.
 
@@ -720,7 +800,7 @@ def dmp_zero_p(f, u):
     return not f
 
 
-def dmp_zero(u):
+def dmp_zero(u: int) -> dmp:
     """
     Return a multivariate zero.
 
@@ -733,7 +813,7 @@ def dmp_zero(u):
     [[[[[]]]]]
 
     """
-    r = []
+    r: dmp = []
 
     for i in range(u):
         r = [r]
@@ -741,7 +821,7 @@ def dmp_zero(u):
     return r
 
 
-def dmp_one_p(f, u, K):
+def dmp_one_p(f: dmp[Er], u: int, K: Domain[Er]) -> bool:
     """
     Return ``True`` if ``f`` is one in ``K[X]``.
 
@@ -758,7 +838,7 @@ def dmp_one_p(f, u, K):
     return dmp_ground_p(f, K.one, u)
 
 
-def dmp_one(u, K):
+def dmp_one(u: int, K: Domain[Er]) -> dmp[Er] | Er:
     """
     Return a multivariate one over ``K``.
 
@@ -775,7 +855,7 @@ def dmp_one(u, K):
     return dmp_ground(K.one, u)
 
 
-def dmp_ground_p(f, c, u):
+def dmp_ground_p(f: dmp[Er], c: Er | None, u: int) -> bool:
     """
     Return True if ``f`` is constant in ``K[X]``.
 
@@ -805,7 +885,7 @@ def dmp_ground_p(f, c, u):
         return f == [c]
 
 
-def dmp_ground(c, u):
+def dmp_ground(c: Er, u: int) -> dmp[Er] | Er:
     """
     Return a multivariate constant.
 
@@ -823,13 +903,18 @@ def dmp_ground(c, u):
     if not c:
         return dmp_zero(u)
 
-    for i in range(u + 1):
-        c = [c]
+    if u < 0:
+        return c
 
-    return c
+    f = _dmp([c])
+
+    for i in range(u):
+        f = [f]
+
+    return f
 
 
-def dmp_zeros(n, u, K):
+def dmp_zeros(n: int, u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Return a list of multivariate zeros.
 
@@ -849,12 +934,12 @@ def dmp_zeros(n, u, K):
         return []
 
     if u < 0:
-        return [K.zero]*n
+        return _dmp([K.zero]*n)
     else:
         return [ dmp_zero(u) for i in range(n) ]
 
 
-def dmp_grounds(c, n, u):
+def dmp_grounds(c: Er, n: int, u: int) -> list[dmp[Er]] | list[Er]:
     """
     Return a list of multivariate constants.
 
@@ -874,12 +959,12 @@ def dmp_grounds(c, n, u):
         return []
 
     if u < 0:
-        return [c]*n
+        return _dmp([c]) * n
     else:
-        return [ dmp_ground(c, u) for i in range(n) ]
+        return [ dmp_ground(c, u) for i in range(n) ] # type: ignore
 
 
-def dmp_negative_p(f, u, K):
+def dmp_negative_p(f: dmp[Er], u: int, K: Domain[Er]) -> bool:
     """
     Return ``True`` if ``LC(f)`` is negative.
 
@@ -898,7 +983,7 @@ def dmp_negative_p(f, u, K):
     return K.is_negative(dmp_ground_LC(f, u, K))
 
 
-def dmp_positive_p(f, u, K):
+def dmp_positive_p(f: dmp[Er], u: int, K: Domain[Er]) -> bool:
     """
     Return ``True`` if ``LC(f)`` is positive.
 
@@ -917,7 +1002,7 @@ def dmp_positive_p(f, u, K):
     return K.is_positive(dmp_ground_LC(f, u, K))
 
 
-def dup_from_dict(f, K):
+def dup_from_dict(f: dict[tuple[int], Er] | dict[int, Er], K: Domain[Er]) -> dup[Er]:
     """
     Create a ``K[x]`` polynomial from a ``dict``.
 
@@ -940,17 +1025,17 @@ def dup_from_dict(f, K):
 
     if isinstance(n, int):
         for k in range(n, -1, -1):
-            h.append(f.get(k, K.zero))
+            h.append(f.get(k, K.zero)) # type: ignore
     else:
         (n,) = n
 
         for k in range(n, -1, -1):
-            h.append(f.get((k,), K.zero))
+            h.append(f.get((k,), K.zero)) # type: ignore
 
     return dup_strip(h)
 
 
-def dup_from_raw_dict(f, K):
+def dup_from_raw_dict(f: dict[int, Er], K: Domain[Er]) -> dup[Er]:
     """
     Create a ``K[x]`` polynomial from a raw ``dict``.
 
@@ -975,7 +1060,7 @@ def dup_from_raw_dict(f, K):
     return dup_strip(h)
 
 
-def dmp_from_dict(f, u, K):
+def dmp_from_dict(f: dict[tuple[int, ...], Er], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Create a ``K[X]`` polynomial from a ``dict``.
 
@@ -992,11 +1077,11 @@ def dmp_from_dict(f, u, K):
 
     """
     if not u:
-        return dup_from_dict(f, K)
+        return _dmp(dup_from_dict(f, K)) # type: ignore
     if not f:
         return dmp_zero(u)
 
-    coeffs = {}
+    coeffs: dict[int, dict[monom, Er]] = {}
 
     for monom, coeff in f.items():
         head, tail = monom[0], monom[1:]
@@ -1009,17 +1094,17 @@ def dmp_from_dict(f, u, K):
     n, v, h = max(coeffs.keys()), u - 1, []
 
     for k in range(n, -1, -1):
-        coeff = coeffs.get(k)
+        dcoeff = coeffs.get(k)
 
-        if coeff is not None:
-            h.append(dmp_from_dict(coeff, v, K))
+        if dcoeff is not None:
+            h.append(dmp_from_dict(dcoeff, v, K))
         else:
             h.append(dmp_zero(v))
 
     return dmp_strip(h, u)
 
 
-def dup_to_dict(f, K=None, zero=False):
+def dup_to_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False) -> dict[tuple[int], Er]:
     """
     Convert ``K[x]`` polynomial to a ``dict``.
 
@@ -1035,7 +1120,7 @@ def dup_to_dict(f, K=None, zero=False):
 
     """
     if not f and zero:
-        return {(0,): K.zero}
+        return {(0,): K.zero} # type: ignore
 
     n, result = len(f) - 1, {}
 
@@ -1046,7 +1131,7 @@ def dup_to_dict(f, K=None, zero=False):
     return result
 
 
-def dup_to_raw_dict(f, K=None, zero=False):
+def dup_to_raw_dict(f: dup[Er], K: Domain[Er] | None = None, zero: bool = False) -> dict[int, Er]:
     """
     Convert a ``K[x]`` polynomial to a raw ``dict``.
 
@@ -1060,7 +1145,7 @@ def dup_to_raw_dict(f, K=None, zero=False):
 
     """
     if not f and zero:
-        return {0: K.zero}
+        return {0: K.zero} # type: ignore
 
     n, result = len(f) - 1, {}
 
@@ -1071,7 +1156,7 @@ def dup_to_raw_dict(f, K=None, zero=False):
     return result
 
 
-def dmp_to_dict(f, u, K=None, zero=False):
+def dmp_to_dict(f: dmp[Er], u: int, K: Domain[Er] | None = None, zero: bool = False) -> dict[tuple[int, ...], Er]:
     """
     Convert a ``K[X]`` polynomial to a ``dict````.
 
@@ -1087,18 +1172,18 @@ def dmp_to_dict(f, u, K=None, zero=False):
 
     """
     if not u:
-        return dup_to_dict(f, K, zero=zero)
+        return dup_to_dict(_dup(f), K, zero=zero) # type: ignore
 
     if dmp_zero_p(f, u) and zero:
-        return {(0,)*(u + 1): K.zero}
+        return {(0,)*(u + 1): K.zero} # type: ignore
 
     n, v, result = dmp_degree(f, u), u - 1, {}
 
     if n == ninf:
         n = -1
 
-    for k in range(0, n + 1):
-        h = dmp_to_dict(f[n - k], v)
+    for k in range(0, n + 1): # type: ignore
+        h = dmp_to_dict(f[n - k], v) # type: ignore
 
         for exp, coeff in h.items():
             result[(k,) + exp] = coeff
@@ -1106,7 +1191,7 @@ def dmp_to_dict(f, u, K=None, zero=False):
     return result
 
 
-def dmp_swap(f, i, j, u, K):
+def dmp_swap(f: dmp[Er], i: int, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Transform ``K[..x_i..x_j..]`` to ``K[..x_j..x_i..]``.
 
@@ -1131,7 +1216,8 @@ def dmp_swap(f, i, j, u, K):
     elif i == j:
         return f
 
-    F, H = dmp_to_dict(f, u), {}
+    F: dict[monom, Er] = dmp_to_dict(f, u)
+    H: dict[monom, Er] = {}
 
     for exp, coeff in F.items():
         H[exp[:i] + (exp[j],) +
@@ -1141,7 +1227,7 @@ def dmp_swap(f, i, j, u, K):
     return dmp_from_dict(H, u, K)
 
 
-def dmp_permute(f, P, u, K):
+def dmp_permute(f: dmp[Er], P: list[int], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Return a polynomial in ``K[x_{P(1)},..,x_{P(n)}]``.
 
@@ -1159,7 +1245,8 @@ def dmp_permute(f, P, u, K):
     [[[1], []], [[2, 0], []]]
 
     """
-    F, H = dmp_to_dict(f, u), {}
+    F: dict[monom, Er] = dmp_to_dict(f, u)
+    H: dict[monom, Er] = {}
 
     for exp, coeff in F.items():
         new_exp = [0]*len(exp)
@@ -1172,7 +1259,7 @@ def dmp_permute(f, P, u, K):
     return dmp_from_dict(H, u, K)
 
 
-def dmp_nest(f, l, K):
+def dmp_nest(f: dmp[Er], l: int, K: Domain[Er]) -> dmp[Er]:
     """
     Return a multivariate value nested ``l``-levels.
 
@@ -1195,7 +1282,7 @@ def dmp_nest(f, l, K):
     return f
 
 
-def dmp_raise(f, l, u, K):
+def dmp_raise(f: dmp[Er], l: int, u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Return a multivariate polynomial raised ``l``-levels.
 
@@ -1220,14 +1307,14 @@ def dmp_raise(f, l, u, K):
 
         k = l - 1
 
-        return [ dmp_ground(c, k) for c in f ]
+        return [ dmp_ground(c, k) for c in _dup(f) ] # type: ignore
 
     v = u - 1
 
-    return [ dmp_raise(c, l, v, K) for c in f ]
+    return [ dmp_raise(cp, l, v, K) for cp in f ]
 
 
-def dup_deflate(f, K):
+def dup_deflate(f: dup[Er], K: Domain[Er]) -> tuple[int, dup[Er]]:
     """
     Map ``x**m`` to ``y`` in a polynomial in ``K[x]``.
 
@@ -1260,7 +1347,7 @@ def dup_deflate(f, K):
     return g, f[::g]
 
 
-def dmp_deflate(f, u, K):
+def dmp_deflate(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], dmp[Er]]:
     """
     Map ``x_i**m_i`` to ``y_i`` in a polynomial in ``K[X]``.
 
@@ -1279,7 +1366,7 @@ def dmp_deflate(f, u, K):
     if dmp_zero_p(f, u):
         return (1,)*(u + 1), f
 
-    F = dmp_to_dict(f, u)
+    F: dict[monom, Er] = dmp_to_dict(f, u)
     B = [0]*(u + 1)
 
     for M in F.keys():
@@ -1290,21 +1377,21 @@ def dmp_deflate(f, u, K):
         if not b:
             B[i] = 1
 
-    B = tuple(B)
+    Bt = tuple(B)
 
-    if all(b == 1 for b in B):
-        return B, f
+    if all(b == 1 for b in Bt):
+        return Bt, f
 
     H = {}
 
     for A, coeff in F.items():
-        N = [ a // b for a, b in zip(A, B) ]
+        N = [ a // b for a, b in zip(A, Bt) ]
         H[tuple(N)] = coeff
 
-    return B, dmp_from_dict(H, u, K)
+    return Bt, dmp_from_dict(H, u, K)
 
 
-def dup_multi_deflate(polys, K):
+def dup_multi_deflate(polys: tuple[dup[Er], ...], K: Domain[Er]) -> tuple[int, tuple[dup[Er], ...]]:
     """
     Map ``x**m`` to ``y`` in a set of polynomials in ``K[x]``.
 
@@ -1343,7 +1430,7 @@ def dup_multi_deflate(polys, K):
     return G, tuple([ p[::G] for p in polys ])
 
 
-def dmp_multi_deflate(polys, u, K):
+def dmp_multi_deflate(polys: tuple[dmp[Er], ...], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], tuple[dmp[Er], ...]]:
     """
     Map ``x_i**m_i`` to ``y_i`` in a set of polynomials in ``K[X]``.
 
@@ -1361,18 +1448,18 @@ def dmp_multi_deflate(polys, u, K):
 
     """
     if not u:
-        M, H = dup_multi_deflate(polys, K)
-        return (M,), H
+        M, H = dup_multi_deflate(_idup(polys), K)
+        return (M,), _idmp(H)
 
     F, B = [], [0]*(u + 1)
 
     for p in polys:
-        f = dmp_to_dict(p, u)
+        f: dict[monom, Er] = dmp_to_dict(p, u)
 
         if not dmp_zero_p(p, u):
-            for M in f.keys():
-                for i, m in enumerate(M):
-                    B[i] = igcd(B[i], m)
+            for m in f.keys():
+                for i, e in enumerate(m):
+                    B[i] = igcd(B[i], e)
 
         F.append(f)
 
@@ -1380,26 +1467,26 @@ def dmp_multi_deflate(polys, u, K):
         if not b:
             B[i] = 1
 
-    B = tuple(B)
+    Bt = tuple(B)
 
-    if all(b == 1 for b in B):
-        return B, polys
+    if all(b == 1 for b in Bt):
+        return Bt, polys
 
-    H = []
+    H2: list[dmp[Er]] = []
 
     for f in F:
         h = {}
 
         for A, coeff in f.items():
-            N = [ a // b for a, b in zip(A, B) ]
+            N = [ a // b for a, b in zip(A, Bt) ]
             h[tuple(N)] = coeff
 
-        H.append(dmp_from_dict(h, u, K))
+        H2.append(dmp_from_dict(h, u, K))
 
-    return B, tuple(H)
+    return Bt, tuple(H2)
 
 
-def dup_inflate(f, m, K):
+def dup_inflate(f: dup[Er], m: int, K: Domain[Er]) -> dup[Er]:
     """
     Map ``y`` to ``x**m`` in a polynomial in ``K[x]``.
 
@@ -1429,10 +1516,10 @@ def dup_inflate(f, m, K):
     return result
 
 
-def _rec_inflate(g, M, v, i, K):
+def _rec_inflate(g: dmp[Er], M: list[int], v: int, i: int, K: Domain[Er]) -> dmp[Er]:
     """Recursive helper for :func:`dmp_inflate`."""
     if not v:
-        return dup_inflate(g, M[i], K)
+        return _dmp(dup_inflate(_dup(g), M[i], K))
     if M[i] <= 0:
         raise IndexError("all M[i] must be positive, got %s" % M[i])
 
@@ -1451,7 +1538,7 @@ def _rec_inflate(g, M, v, i, K):
     return result
 
 
-def dmp_inflate(f, M, u, K):
+def dmp_inflate(f: dmp[Er], M: list[int], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Map ``y_i`` to ``x_i**k_i`` in a polynomial in ``K[X]``.
 
@@ -1468,7 +1555,7 @@ def dmp_inflate(f, M, u, K):
 
     """
     if not u:
-        return dup_inflate(f, M[0], K)
+        return _dmp(dup_inflate(_dup(f), M[0], K))
 
     if all(m == 1 for m in M):
         return f
@@ -1476,7 +1563,7 @@ def dmp_inflate(f, M, u, K):
         return _rec_inflate(f, M, u, 0, K)
 
 
-def dmp_exclude(f, u, K):
+def dmp_exclude(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[list[int], dmp[Er], int]:
     """
     Exclude useless levels from ``f``.
 
@@ -1497,7 +1584,8 @@ def dmp_exclude(f, u, K):
     if not u or dmp_ground_p(f, None, u):
         return [], f, u
 
-    J, F = [], dmp_to_dict(f, u)
+    J: list[int] = []
+    F: dict[monom, Er] = dmp_to_dict(f, u)
 
     for j in range(0, u + 1):
         for monom in F.keys():
@@ -1509,22 +1597,22 @@ def dmp_exclude(f, u, K):
     if not J:
         return [], f, u
 
-    f = {}
+    d = {}
 
     for monom, coeff in F.items():
-        monom = list(monom)
+        lmonom = list(monom)
 
         for j in reversed(J):
-            del monom[j]
+            del lmonom[j]
 
-        f[tuple(monom)] = coeff
+        d[tuple(lmonom)] = coeff
 
     u -= len(J)
 
-    return J, dmp_from_dict(f, u, K), u
+    return J, dmp_from_dict(d, u, K), u
 
 
-def dmp_include(f, J, u, K):
+def dmp_include(f: dmp[Er], J: list[int], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Include useless levels in ``f``.
 
@@ -1543,22 +1631,23 @@ def dmp_include(f, J, u, K):
     if not J:
         return f
 
-    F, f = dmp_to_dict(f, u), {}
+    F: dict[tuple[int, ...], Er] = dmp_to_dict(f, u)
+    d: dict[tuple[int, ...], Er] = {}
 
     for monom, coeff in F.items():
-        monom = list(monom)
+        lmonom = list(monom)
 
         for j in J:
-            monom.insert(j, 0)
+            lmonom.insert(j, 0)
 
-        f[tuple(monom)] = coeff
+        d[tuple(lmonom)] = coeff
 
     u += len(J)
 
-    return dmp_from_dict(f, u, K)
+    return dmp_from_dict(d, u, K)
 
 
-def dmp_inject(f, u, K, front=False):
+def dmp_inject(f: dmp[PolyElement[Er]], u: int, K: PolynomialRing[Er], front: bool = False) -> tuple[dmp[Er], int]:
     """
     Convert ``f`` from ``K[X][Y]`` to ``K[X,Y]``.
 
@@ -1577,11 +1666,15 @@ def dmp_inject(f, u, K, front=False):
     ([[[1]], [[1, 2]]], 2)
 
     """
-    f, h = dmp_to_dict(f, u), {}
+    d: dict[tuple[int, ...], PolyElement[Er]]
+    h: dict[tuple[int, ...], Er]
+
+    d = dmp_to_dict(f, u)
+    h = {}
 
     v = K.ngens - 1
 
-    for f_monom, g in f.items():
+    for f_monom, g in d.items():
         g = g.to_dict()
 
         for g_monom, c in g.items():
@@ -1595,7 +1688,7 @@ def dmp_inject(f, u, K, front=False):
     return dmp_from_dict(h, w, K.dom), w
 
 
-def dmp_eject(f, u, K, front=False):
+def dmp_eject(f: dmp[Er], u: int, K: PolynomialRing[Er], front: bool = False) -> dmp[PolyElement[Er]]:
     """
     Convert ``f`` from ``K[X,Y]`` to ``K[X][Y]``.
 
@@ -1609,12 +1702,16 @@ def dmp_eject(f, u, K, front=False):
     [1, x + 2]
 
     """
-    f, h = dmp_to_dict(f, u), {}
+    d: dict[monom, Er]
+    h: dict[monom, dict[monom, Er]]
+
+    d = dmp_to_dict(f, u)
+    h = {}
 
     n = K.ngens
     v = u - K.ngens + 1
 
-    for monom, c in f.items():
+    for monom, c in d.items():
         if front:
             g_monom, f_monom = monom[:n], monom[n:]
         else:
@@ -1625,13 +1722,12 @@ def dmp_eject(f, u, K, front=False):
         else:
             h[f_monom] = {g_monom: c}
 
-    for monom, c in h.items():
-        h[monom] = K(c)
+    g = {monom: K(c) for monom, c in h.items()}
 
-    return dmp_from_dict(h, v - 1, K)
+    return dmp_from_dict(g, v - 1, K)
 
 
-def dup_terms_gcd(f, K):
+def dup_terms_gcd(f: dup[Er], K: Domain[Er]) -> tuple[int, dup[Er]]:
     """
     Remove GCD of terms from ``f`` in ``K[x]``.
 
@@ -1661,7 +1757,7 @@ def dup_terms_gcd(f, K):
     return i, f[:-i]
 
 
-def dmp_terms_gcd(f, u, K):
+def dmp_terms_gcd(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[tuple[int, ...], dmp[Er]]:
     """
     Remove GCD of terms from ``f`` in ``K[X]``.
 
@@ -1680,26 +1776,28 @@ def dmp_terms_gcd(f, u, K):
     if dmp_ground_TC(f, u, K) or dmp_zero_p(f, u):
         return (0,)*(u + 1), f
 
-    F = dmp_to_dict(f, u)
+    F: dict[monom, Er] = dmp_to_dict(f, u)
     G = monomial_min(*list(F.keys()))
 
     if all(g == 0 for g in G):
         return G, f
 
-    f = {}
+    d: dict[monom, Er] = {}
 
     for monom, coeff in F.items():
-        f[monomial_div(monom, G)] = coeff
+        d[monomial_ldiv(monom, G)] = coeff
 
-    return G, dmp_from_dict(f, u, K)
+    return G, dmp_from_dict(d, u, K)
 
 
-def _rec_list_terms(g, v, monom):
+def _rec_list_terms(g: dmp[Er], v: int, monom: monom) -> list[tuple[monom, Er]]:
     """Recursive helper for :func:`dmp_list_terms`."""
-    d, terms = dmp_degree(g, v), []
+    d: int = dmp_degree(g, v) # type: ignore
+    terms: list[tuple[tuple[int, ...], Er]] = []
 
     if not v:
-        for i, c in enumerate(g):
+        c: Er
+        for i, c in enumerate(_dup(g)):
             if not c:
                 continue
 
@@ -1707,13 +1805,13 @@ def _rec_list_terms(g, v, monom):
     else:
         w = v - 1
 
-        for i, c in enumerate(g):
-            terms.extend(_rec_list_terms(c, w, monom + (d - i,)))
+        for i, cp in enumerate(g):
+            terms.extend(_rec_list_terms(cp, w, monom + (d - i,)))
 
     return terms
 
 
-def dmp_list_terms(f, u, K, order=None):
+def dmp_list_terms(f: dmp[Er], u: int, K: Domain[Er], order: str | None = None) -> list[tuple[monom, Er]]:
     """
     List all non-zero terms from ``f`` in the given order ``order``.
 
@@ -1731,6 +1829,8 @@ def dmp_list_terms(f, u, K, order=None):
     [((1, 1), 1), ((1, 0), 1), ((0, 1), 2), ((0, 0), 3)]
 
     """
+    terms: list[tuple[monom, Er]]
+
     def sort(terms, O):
         return sorted(terms, key=lambda term: O(term[0]), reverse=True)
 
@@ -1745,7 +1845,7 @@ def dmp_list_terms(f, u, K, order=None):
         return sort(terms, monomial_key(order))
 
 
-def dup_apply_pairs(f, g, h, args, K):
+def dup_apply_pairs(f: dup[Er], g: dup[Er], h: Callable[..., Er], args: tuple[Any, ...], K: Domain[Er]) -> dup[Er]:
     """
     Apply ``h`` to pairs of coefficients of ``f`` and ``g``.
 
@@ -1769,7 +1869,7 @@ def dup_apply_pairs(f, g, h, args, K):
         else:
             f = [K.zero]*(m - n) + f
 
-    result = []
+    result: dup[Er] = []
 
     for a, b in zip(f, g):
         result.append(h(a, b, *args))
@@ -1777,7 +1877,7 @@ def dup_apply_pairs(f, g, h, args, K):
     return dup_strip(result)
 
 
-def dmp_apply_pairs(f, g, h, args, u, K):
+def dmp_apply_pairs(f: dmp[Er], g: dmp[Er], h: Callable[..., Er], args: tuple[Any, ...], u: int, K: Domain[Er]) -> dmp[Er]:
     """
     Apply ``h`` to pairs of coefficients of ``f`` and ``g``.
 
@@ -1794,7 +1894,7 @@ def dmp_apply_pairs(f, g, h, args, u, K):
 
     """
     if not u:
-        return dup_apply_pairs(f, g, h, args, K)
+        return _dmp(dup_apply_pairs(_dup(f), _dup(g), h, args, K))
 
     n, m, v = len(f), len(g), u - 1
 
@@ -1812,7 +1912,7 @@ def dmp_apply_pairs(f, g, h, args, u, K):
     return dmp_strip(result, u)
 
 
-def dup_slice(f, m, n, K):
+def dup_slice(f: dup[Er], m: int, n: int, K: Domain[Er]) -> dup[Er]:
     """Take a continuous subsequence of terms of ``f`` in ``K[x]``. """
     k = len(f)
 
@@ -1836,7 +1936,7 @@ def dup_slice(f, m, n, K):
         return f + [K.zero]*m
 
 
-def dmp_slice(f, m, n, u, K):
+def dmp_slice(f: dmp[Er], m: int, n: int, u: int, K: Domain[Er]) -> dmp[Er]:
     """Take a continuous subsequence of terms of ``f`` in ``K[X]``. """
     return dmp_slice_in(f, m, n, 0, u, K)
 
@@ -1860,17 +1960,18 @@ def dup_truncate(f, n, K):
     return dup_slice(f, 0, n, K)
 
 
-def dmp_slice_in(f, m, n, j, u, K):
+def dmp_slice_in(f: dmp[Er], m: int, n: int, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
     """Take a continuous subsequence of terms of ``f`` in ``x_j`` in ``K[X]``. """
     if j < 0 or j > u:
         raise IndexError("-%s <= j < %s expected, got %s" % (u, u, j))
 
     if not u:
-        return dup_slice(f, m, n, K)
+        return _dmp(dup_slice(_dup(f), m, n, K))
 
-    f, g = dmp_to_dict(f, u), {}
+    d: dict[tuple[int, ...], Er] = dmp_to_dict(f, u)
+    g: dict[tuple[int, ...], Er] = {}
 
-    for monom, coeff in f.items():
+    for monom, coeff in d.items():
         k = monom[j]
 
         if k < m or k >= n:
@@ -1884,7 +1985,7 @@ def dmp_slice_in(f, m, n, j, u, K):
     return dmp_from_dict(g, u, K)
 
 
-def dup_random(n, a, b, K):
+def dup_random(n: int, a: int, b: int, K: Domain[Er]) -> dup[Er]:
     """
     Return a polynomial of degree ``n`` with coefficients in ``[a, b]``.
 
@@ -1906,7 +2007,7 @@ def dup_random(n, a, b, K):
     return f
 
 
-def dup_from_list(f, K):
+def dup_from_list(f: list[Er], K: Domain[Er]) -> dup[Er]:
     """
     Create a ``K[x]`` polynomial from a list.
 
@@ -1933,7 +2034,7 @@ def dup_from_list(f, K):
     return dup_strip([K.convert(c) for c in f])
 
 
-def dup_print(f, sym):
+def dup_print(f: dup[Er], sym: str) -> None:
     """
     Print a polynomial in ``K[x]``.
 
@@ -1951,7 +2052,8 @@ def dup_print(f, sym):
         sym = sym[0]
 
     if not f:
-        return "0"
+        print("0")
+        return
 
     deg = dup_degree(f)
     terms = []

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1,6 +1,8 @@
 """Advanced tools for dense recursive polynomials in ``K[x]`` or ``K[X]``. """
 
+from __future__ import annotations
 
+from sympy.polys.domains.domain import Domain, Er
 from sympy.polys.densearith import (
     dup_add_term, dmp_add_term,
     dup_lshift, dup_rshift,
@@ -16,7 +18,7 @@ from sympy.polys.densearith import (
     dup_exquo_ground, dmp_exquo_ground,
 )
 from sympy.polys.densebasic import (
-    dup_strip, dmp_strip, dup_truncate,
+    dup, dup_strip, dmp_strip, dup_truncate,
     dup_convert, dmp_convert,
     dup_degree, dmp_degree,
     dmp_to_dict,
@@ -945,7 +947,7 @@ def dmp_shift(f, a, u, K):
     return dmp_strip(f, u)
 
 
-def dup_transform(f, p, q, K):
+def dup_transform(f: dup[Er], p: dup[Er], q: dup[Er], K: Domain[Er]) -> dup[Er]:
     """
     Evaluate functional transformation ``q**n * f(p/q)`` in ``K[x]``.
 

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -1,10 +1,14 @@
 """Implementation of :class:`AlgebraicField` class. """
 
+from __future__ import annotations
+
+from typing import Generic
 
 from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, symbols
+from sympy.polys.domains.domain import Domain, Er, Eg
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -12,8 +16,9 @@ from sympy.polys.polyclasses import ANP
 from sympy.polys.polyerrors import CoercionFailed, DomainError, NotAlgebraic, IsomorphismFailed
 from sympy.utilities import public
 
+
 @public
-class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
+class AlgebraicField(Field, CharacteristicZero, SimpleDomain[Er], Generic[Er, Eg]):
     r"""Algebraic number field :ref:`QQ(a)`
 
     A :ref:`QQ(a)` domain represents an `algebraic number field`_
@@ -242,7 +247,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
     .. _primitive element: https://en.wikipedia.org/wiki/Primitive_element_theorem
     """
 
-    dtype = ANP
+    dtype: type[ANP[Eg]] = ANP
 
     is_AlgebraicField = is_Algebraic = True
     is_Numerical = True
@@ -250,7 +255,9 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
     has_assoc_Ring = False
     has_assoc_Field = True
 
-    def __init__(self, dom, *ext, alias=None):
+    dom: Domain[Eg]
+
+    def __init__(self, dom: Domain[Eg], *ext, alias=None):
         r"""
         Parameters
         ==========
@@ -322,7 +329,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
 
         self._maximal_order = None
         self._discriminant = None
-        self._nilradicals_mod_p = {}
+        self._nilradicals_mod_p: dict = {}
 
     def new(self, element):
         return self.dtype(element, self.mod.to_list(), self.dom)

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -62,6 +62,8 @@ class FieldElement(RingElement[T], Protocol[T]):
 
 Er = TypeVar('Er', bound=RingElement)
 Es = TypeVar('Es', bound=RingElement)
+Et = TypeVar('Et', bound=RingElement)
+Eg = TypeVar('Eg', bound=RingElement)
 Ef = TypeVar('Ef', bound=FieldElement)
 
 
@@ -990,7 +992,7 @@ class Domain(Generic[Er]):
         """Returns a ring associated with ``self``. """
         raise DomainError('there is no ring associated with %s' % self)
 
-    def get_field(self) -> Field:
+    def get_field(self) -> Field[Ef]:
         """Returns a field associated with ``self``. """
         raise DomainError('there is no field associated with %s' % self)
 

--- a/sympy/polys/domains/simpledomain.py
+++ b/sympy/polys/domains/simpledomain.py
@@ -1,11 +1,11 @@
 """Implementation of :class:`SimpleDomain` class. """
 
 
-from sympy.polys.domains.domain import Domain
+from sympy.polys.domains.domain import Domain, Er
 from sympy.utilities import public
 
 @public
-class SimpleDomain(Domain):
+class SimpleDomain(Domain[Er]):
     """Base class for simple domains, e.g. ZZ, QQ. """
 
     is_Simple = True

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1,6 +1,10 @@
 """Euclidean algorithms, GCDs, LCMs and polynomial remainder sequences. """
 
+from __future__ import annotations
 
+from typing import overload, Literal
+
+from sympy.polys.domains.domain import Domain, Er
 from sympy.polys.densearith import (
     dup_sub_mul,
     dup_neg, dmp_neg,
@@ -17,6 +21,7 @@ from sympy.polys.densearith import (
     dup_quo_ground, dmp_quo_ground,
     dup_max_norm, dmp_max_norm)
 from sympy.polys.densebasic import (
+    dup, dmp, _dup, _dmp,
     dup_strip, dmp_raise,
     dmp_zero, dmp_one, dmp_ground,
     dmp_one_p, dmp_zero_p,
@@ -767,7 +772,25 @@ def dmp_qq_collins_resultant(f, g, u, K0):
     return dmp_quo_ground(r, c, u - 1, K0)
 
 
-def dmp_resultant(f, g, u, K, includePRS=False):
+@overload
+def dmp_resultant(
+    f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er], includePRS: Literal[False] = ...
+) -> dmp[Er] | Er: ...
+
+
+@overload
+def dmp_resultant(
+    f: dmp[Er],
+    g: dmp[Er],
+    u: int,
+    K: Domain[Er],
+    includePRS: Literal[True],
+) -> tuple[dmp[Er] | Er, list[dmp[Er]]]: ...
+
+
+def dmp_resultant(
+    f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er], includePRS: bool = False
+) -> dmp[Er] | Er | tuple[dmp[Er] | Er, list[dmp[Er]]]:
     """
     Computes resultant of two polynomials in `K[X]`.
 
@@ -1842,7 +1865,21 @@ def dmp_primitive(f, u, K):
         return cont, [ dmp_quo(c, cont, v, K) for c in f ]
 
 
-def dup_cancel(f, g, K, include=True):
+@overload
+def dup_cancel(
+    f: dup[Er], g: dup[Er], K: Domain[Er], include: Literal[True] = ...
+) -> tuple[dup[Er], dup[Er]]: ...
+
+
+@overload
+def dup_cancel(
+    f: dup[Er], g: dup[Er], K: Domain[Er], include: Literal[False]
+) -> tuple[Er, Er, dup[Er], dup[Er]]: ...
+
+
+def dup_cancel(
+    f: dup[Er], g: dup[Er], K: Domain[Er], include: bool = True
+) -> tuple[dup[Er], dup[Er]] | tuple[Er, Er, dup[Er], dup[Er]]:
     """
     Cancel common factors in a rational function `f/g`.
 
@@ -1856,10 +1893,29 @@ def dup_cancel(f, g, K, include=True):
     (2*x + 2, x - 1)
 
     """
-    return dmp_cancel(f, g, 0, K, include=include)
+    if include:
+        F, G = dmp_cancel(_dmp(f), _dmp(g), 0, K, include=True)
+        return _dup(F), _dup(G)
+    else:
+        cf, cg, F, G = dmp_cancel(_dmp(f), _dmp(g), 0, K, include=False)
+        return cf, cg, _dup(F), _dup(G)
 
 
-def dmp_cancel(f, g, u, K, include=True):
+@overload
+def dmp_cancel(
+    f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er], include: Literal[True] = ...
+) -> tuple[dmp[Er], dmp[Er]]: ...
+
+
+@overload
+def dmp_cancel(
+    f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er], include: Literal[False]
+) -> tuple[Er, Er, dmp[Er], dmp[Er]]: ...
+
+
+def dmp_cancel(
+    f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er], include: bool = True
+) -> tuple[dmp[Er], dmp[Er]] | tuple[Er, Er, dmp[Er], dmp[Er]]:
     """
     Cancel common factors in a rational function `f/g`.
 

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -17,6 +17,7 @@ from sympy.core.sympify import CantSympify, sympify
 from sympy.functions.elementary.exponential import ExpBase
 from sympy.polys.domains.domain import Domain, Er, Es
 from sympy.polys.domains.domainelement import DomainElement
+from sympy.polys.domains.field import Field
 from sympy.polys.domains.fractionfield import FractionField
 from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.constructor import construct_domain
@@ -221,7 +222,7 @@ class FracField(DefaultPrinting, Generic[Er]):
 
             if not domain.is_Field and domain.has_assoc_Field:
                 ring = self.ring
-                ground_field = domain.get_field()
+                ground_field: Field = domain.get_field()
                 element = ground_field.convert(element)
                 numer = ring.ground_new(ground_field.numer(element))
                 denom = ring.ground_new(ground_field.denom(element))

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -1,5 +1,7 @@
 """Tools and arithmetics for monomials of distributed polynomials. """
 
+from __future__ import annotations
+
 
 from itertools import combinations_with_replacement, product
 from textwrap import dedent

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -11,6 +11,10 @@ from sympy.polys.polyutils import PicklableWithSlots, dict_from_expr
 from sympy.utilities import public
 from sympy.utilities.iterables import is_sequence, iterable
 
+
+monom = tuple[int, ...]
+
+
 @public
 def itermonomials(variables, max_degrees, min_degrees=None):
     r"""
@@ -191,7 +195,7 @@ def monomial_mul(A, B):
     """
     return tuple([ a + b for a, b in zip(A, B) ])
 
-def monomial_div(A, B):
+def monomial_div(A: monom, B: monom) -> monom | None:
     """
     Division of tuples representing monomials.
 
@@ -220,7 +224,7 @@ def monomial_div(A, B):
     else:
         return None
 
-def monomial_ldiv(A, B):
+def monomial_ldiv(A: monom, B: monom) -> monom:
     """
     Division of tuples representing monomials.
 
@@ -326,7 +330,7 @@ def monomial_max(*monoms):
 
     return tuple(M)
 
-def monomial_min(*monoms):
+def monomial_min(*monoms: monom) -> monom:
     """
     Returns minimal degree for each variable in a set of monomials.
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, Literal, Self, overload, Callable, TypeVar, TypeAlias
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Literal,
+    overload,
+    Callable,
+    TypeVar,
+)
 
 if TYPE_CHECKING:
+    from typing import Self, TypeAlias
     from sympy.polys.rings import PolyElement
 
 from sympy.external.gmpy import GROUND_TYPES, MPQ

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
-from sympy.external.gmpy import GROUND_TYPES
+from typing import TYPE_CHECKING, Any, Generic, Literal, Self, overload, Callable, TypeVar, TypeAlias
+
+if TYPE_CHECKING:
+    from sympy.polys.rings import PolyElement
+
+from sympy.external.gmpy import GROUND_TYPES, MPQ
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
-from sympy.core.numbers import oo
+from sympy.core.expr import Expr
+from sympy.core.numbers import oo, NegativeInfinity
 from sympy.core.sympify import CantSympify
 from sympy.polys.polyutils import PicklableWithSlots, _sort_factors
 from sympy.polys.domains import Domain, ZZ, QQ
+from sympy.polys.domains.domain import Er, Es, Et, Eg
+from sympy.polys.domains.polynomialring import PolynomialRing
+from sympy.polys.orderings import MonomialOrder
 
 from sympy.polys.polyerrors import (
     CoercionFailed,
@@ -19,6 +28,11 @@ from sympy.polys.polyerrors import (
 )
 
 from sympy.polys.densebasic import (
+    _dup,
+    _dmp,
+    dmp,
+    dmp_tup,
+    monom,
     ninf,
     dmp_validate,
     dup_normal, dmp_normal,
@@ -125,25 +139,30 @@ from sympy.polys.polyerrors import (
     PolynomialError)
 
 
-if GROUND_TYPES == 'flint':
+def _supported_flint_domain_flint(D: Domain) -> bool:
+    return D.is_ZZ or D.is_QQ or D.is_FF and D._is_flint # type: ignore
+
+
+_supported_flint_domain: Callable[[Domain], bool]
+
+
+if GROUND_TYPES == 'flint' or TYPE_CHECKING:
     import flint
-    def _supported_flint_domain(D):
-        return D.is_ZZ or D.is_QQ or D.is_FF and D._is_flint
+    _supported_flint_domain = _supported_flint_domain_flint
 else:
     flint = None
-    def _supported_flint_domain(D):
-        return False
+    _supported_flint_domain = lambda _: False
 
 
-class DMP(CantSympify):
+class DMP(CantSympify, Generic[Er]):
     """Dense Multivariate Polynomials over `K`. """
 
     __slots__ = ()
 
     lev: int
-    dom: Domain
+    dom: Domain[Er]
 
-    def __new__(cls, rep, dom, lev=None):
+    def __new__(cls, rep: dmp[Er], dom: Domain[Er], lev: int | None = None):
 
         if lev is None:
             rep, lev = dmp_validate(rep)
@@ -153,7 +172,7 @@ class DMP(CantSympify):
         return cls.new(rep, dom, lev)
 
     @classmethod
-    def new(cls, rep, dom, lev):
+    def new(cls, rep: dmp[Er], dom: Domain[Er], lev: int) -> DMP_Python[Er] | DUP_Flint[Er]:
         # It would be too slow to call _validate_args always at runtime.
         # Ideally this checking would be handled by a static type checker.
         #
@@ -165,7 +184,7 @@ class DMP(CantSympify):
         return DMP_Python._new(rep, dom, lev)
 
     @property
-    def rep(f):
+    def rep(f) -> dmp[Er]:
         """Get the representation of ``f``. """
 
         sympy_deprecation_warning("""
@@ -181,7 +200,7 @@ class DMP(CantSympify):
 
         return f.to_list()
 
-    def to_best(f):
+    def to_best(f) -> DMP[Er]:
         """Convert to DUP_Flint if possible.
 
         This method should be used when the domain or level is changed and it
@@ -194,11 +213,11 @@ class DMP(CantSympify):
         return f
 
     @classmethod
-    def _validate_args(cls, rep, dom, lev):
+    def _validate_args(cls, rep: dmp[Er], dom: Domain[Er], lev: int):
         assert isinstance(dom, Domain)
         assert isinstance(lev, int) and lev >= 0
 
-        def validate_rep(rep, lev):
+        def validate_rep(rep: dmp[Er], lev: int):
             assert isinstance(rep, list)
             if lev == 0:
                 assert all(dom.of_type(c) for c in rep)
@@ -209,28 +228,24 @@ class DMP(CantSympify):
         validate_rep(rep, lev)
 
     @classmethod
-    def from_dict(cls, rep, lev, dom):
-        rep = dmp_from_dict(rep, lev, dom)
-        return cls.new(rep, dom, lev)
+    def from_dict(cls, rep: dict[monom, Er], lev: int, dom: Domain[Er]) -> DMP[Er]:
+        rep_dmp = dmp_from_dict(rep, lev, dom)
+        return cls.new(rep_dmp, dom, lev)
 
     @classmethod
-    def from_list(cls, rep, lev, dom):
+    def from_list(cls, rep: dmp[Any], lev: int, dom: Domain[Er]) -> DMP[Er]:
         """Create an instance of ``cls`` given a list of native coefficients. """
         return cls.new(dmp_convert(rep, lev, None, dom), dom, lev)
 
     @classmethod
-    def from_sympy_list(cls, rep, lev, dom):
+    def from_sympy_list(cls, rep: dmp[Expr], lev: int, dom: Domain[Er]) -> DMP[Er]:
         """Create an instance of ``cls`` given a list of SymPy coefficients. """
         return cls.new(dmp_from_sympy(rep, lev, dom), dom, lev)
 
-    @classmethod
-    def from_monoms_coeffs(cls, monoms, coeffs, lev, dom):
-        return cls(dict(list(zip(monoms, coeffs))), dom, lev)
-
-    def convert(f, dom):
+    def convert(f, dom: Domain[Es]) -> DMP[Es]:
         """Convert ``f`` to a ``DMP`` over the new domain. """
         if f.dom == dom:
-            return f
+            return f # type: ignore
         elif f.lev or flint is None:
             return f._convert(dom)
         elif isinstance(f, DUP_Flint):
@@ -246,59 +261,63 @@ class DMP(CantSympify):
         else:
             raise RuntimeError("unreachable code")
 
-    def _convert(f, dom):
+    def _convert(f, dom: Domain[Es]) -> DMP[Es]:
         raise NotImplementedError
 
     @classmethod
-    def zero(cls, lev, dom):
+    def zero(cls, lev: int, dom: Domain[Er]) -> DMP[Er]:
         return DMP(dmp_zero(lev), dom, lev)
 
     @classmethod
-    def one(cls, lev, dom):
-        return DMP(dmp_one(lev, dom), dom, lev)
+    def one(cls, lev: int, dom: Domain[Er]) -> DMP[Er]:
+        one: dmp[Er] = dmp_one(lev, dom) # type: ignore
+        return DMP(one, dom, lev)
 
-    def _one(f):
+    def _one(f) -> Self:
         raise NotImplementedError
 
-    def __repr__(f):
+    def __repr__(f) -> str:
         return "%s(%s, %s)" % (f.__class__.__name__, f.to_list(), f.dom)
 
-    def __hash__(f):
+    def __hash__(f) -> int:
         return hash((f.__class__.__name__, f.to_tuple(), f.lev, f.dom))
 
-    def __getnewargs__(self):
+    def __getnewargs__(self) -> tuple[dmp[Er], Domain[Er], int]:
         return self.to_list(), self.dom, self.lev
 
-    def ground_new(f, coeff):
+    def ground_new(f, coeff: Er) -> DMP[Er]:
         """Construct a new ground instance of ``f``. """
         raise NotImplementedError
 
-    def unify_DMP(f, g):
+    @overload
+    def unify_DMP(f, g: Self) -> tuple[Self, Self]:
+        ...
+
+    @overload
+    def unify_DMP(f, g: DMP[Es]) -> tuple[DMP[Et], DMP[Et]]:
+        ...
+
+    def unify_DMP(f, g: DMP[Es]) -> tuple[DMP[Et], DMP[Et]]:
         """Unify and return ``DMP`` instances of ``f`` and ``g``. """
         if not isinstance(g, DMP) or f.lev != g.lev:
             raise UnificationFailed("Cannot unify %s with %s" % (f, g))
 
-        if f.dom != g.dom:
-            dom = f.dom.unify(g.dom)
-            f = f.convert(dom)
-            g = g.convert(dom)
+        if f.dom == g.dom:
+            return f, g # type: ignore
+        else:
+            dom: Domain[Et] = f.dom.unify(g.dom)
+            return f.convert(dom), g.convert(dom)
 
-        return f, g
-
-    def to_dict(f, zero=False):
+    def to_dict(f, zero: bool = False) -> dict[monom, Er]:
         """Convert ``f`` to a dict representation with native coefficients. """
         return dmp_to_dict(f.to_list(), f.lev, f.dom, zero=zero)
 
-    def to_sympy_dict(f, zero=False):
+    def to_sympy_dict(f, zero: bool = False) -> dict[monom, Expr]:
         """Convert ``f`` to a dict representation with SymPy coefficients. """
-        rep = f.to_dict(zero=zero)
+        to_sympy = f.dom.to_sympy
+        return {k: to_sympy(v) for k, v in f.to_dict(zero=zero).items()}
 
-        for k, v in rep.items():
-            rep[k] = f.dom.to_sympy(v)
-
-        return rep
-
-    def to_sympy_list(f):
+    def to_sympy_list(f) -> dmp[Expr]:
         """Convert ``f`` to a list representation with SymPy coefficients. """
         def sympify_nested_list(rep):
             out = []
@@ -311,11 +330,11 @@ class DMP(CantSympify):
 
         return sympify_nested_list(f.to_list())
 
-    def to_list(f):
+    def to_list(f) -> dmp[Er]:
         """Convert ``f`` to a list representation with native coefficients. """
         raise NotImplementedError
 
-    def to_tuple(f):
+    def to_tuple(f) -> dmp_tup[Er]:
         """
         Convert ``f`` to a tuple representation with native coefficients.
 
@@ -323,40 +342,40 @@ class DMP(CantSympify):
         """
         raise NotImplementedError
 
-    def to_ring(f):
+    def to_ring(f) -> DMP:
         """Make the ground domain a ring. """
         return f.convert(f.dom.get_ring())
 
-    def to_field(f):
+    def to_field(f) -> DMP:
         """Make the ground domain a field. """
         return f.convert(f.dom.get_field())
 
-    def to_exact(f):
+    def to_exact(f) -> DMP:
         """Make the ground domain exact. """
         return f.convert(f.dom.get_exact())
 
-    def slice(f, m, n, j=0):
+    def slice(f, m: int, n: int, j: int = 0) -> DMP[Er]:
         """Take a continuous subsequence of terms of ``f``. """
         if not f.lev and not j:
             return f._slice(m, n)
         else:
             return f._slice_lev(m, n, j)
 
-    def _slice(f, m, n):
+    def _slice(f, m: int, n: int) -> DMP[Er]:
         raise NotImplementedError
 
-    def _slice_lev(f, m, n, j):
+    def _slice_lev(f, m: int, n: int, j: int) -> DMP[Er]:
         raise NotImplementedError
 
-    def coeffs(f, order=None):
+    def coeffs(f, order=None) -> list[Er]:
         """Returns all non-zero coefficients from ``f`` in lex order. """
         return [ c for _, c in f.terms(order=order) ]
 
-    def monoms(f, order=None):
+    def monoms(f, order=None) -> list[monom]:
         """Returns all non-zero monomials from ``f`` in lex order. """
         return [ m for m, _ in f.terms(order=order) ]
 
-    def terms(f, order=None):
+    def terms(f, order: MonomialOrder | None = None) -> list[tuple[monom, Er]]:
         """Returns all non-zero terms from ``f`` in lex order. """
         if f.is_zero:
             zero_monom = (0,)*(f.lev + 1)
@@ -364,10 +383,10 @@ class DMP(CantSympify):
         else:
             return f._terms(order=order)
 
-    def _terms(f, order=None):
+    def _terms(f, order: MonomialOrder | None = None) -> list[tuple[monom, Er]]:
         raise NotImplementedError
 
-    def all_coeffs(f):
+    def all_coeffs(f) -> list[Er]:
         """Returns all coefficients from ``f``. """
         if f.lev:
             raise PolynomialError('multivariate polynomials not supported')
@@ -375,52 +394,52 @@ class DMP(CantSympify):
         if not f:
             return [f.dom.zero]
         else:
-            return list(f.to_list())
+            return list(_dup(f.to_list()))
 
-    def all_monoms(f):
+    def all_monoms(f) -> list[monom]:
         """Returns all monomials from ``f``. """
         if f.lev:
             raise PolynomialError('multivariate polynomials not supported')
 
-        n = f.degree()
+        n: int = f.degree() # type: ignore
 
         if n < 0:
             return [(0,)]
         else:
             return [ (n - i,) for i, c in enumerate(f.to_list()) ]
 
-    def all_terms(f):
+    def all_terms(f) -> list[tuple[monom, Er]]:
         """Returns all terms from a ``f``. """
         if f.lev:
             raise PolynomialError('multivariate polynomials not supported')
 
-        n = f.degree()
+        n: int = f.degree() # type: ignore
 
         if n < 0:
             return [((0,), f.dom.zero)]
         else:
-            return [ ((n - i,), c) for i, c in enumerate(f.to_list()) ]
+            return [ ((n - i,), c) for i, c in enumerate(_dup(f.to_list())) ]
 
-    def lift(f):
+    def lift(f) -> DMP:
         """Convert algebraic coefficients to rationals. """
         return f._lift().to_best()
 
-    def _lift(f):
+    def _lift(f) -> DMP:
         raise NotImplementedError
 
-    def deflate(f):
+    def deflate(f) -> tuple[monom, DMP[Er]]:
         """Reduce degree of `f` by mapping `x_i^m` to `y_i`. """
         raise NotImplementedError
 
-    def inject(f, front=False):
+    def inject(f, front: bool = False) -> DMP:
         """Inject ground domain generators into ``f``. """
         raise NotImplementedError
 
-    def eject(f, dom, front=False):
+    def eject(f, dom: PolynomialRing[Er], front: bool = False) -> DMP[PolyElement[Er]]:
         """Eject selected generators into the ground domain. """
         raise NotImplementedError
 
-    def exclude(f):
+    def exclude(f) -> tuple[list[int], DMP[Er]]:
         r"""
         Remove useless generators from ``f``.
 
@@ -439,10 +458,10 @@ class DMP(CantSympify):
         J, F = f._exclude()
         return J, F.to_best()
 
-    def _exclude(f):
+    def _exclude(f) -> tuple[list[int], DMP[Er]]:
         raise NotImplementedError
 
-    def permute(f, P):
+    def permute(f, P: list[int]) -> Self:
         r"""
         Returns a polynomial in `K[x_{P(1)}, ..., x_{P(n)}]`.
 
@@ -461,182 +480,183 @@ class DMP(CantSympify):
         """
         return f._permute(P)
 
-    def _permute(f, P):
+    def _permute(f, P: list[int]) -> Self:
         raise NotImplementedError
 
-    def terms_gcd(f):
+    def terms_gcd(f) -> tuple[monom, Self]:
         """Remove GCD of terms from the polynomial ``f``. """
         raise NotImplementedError
 
-    def abs(f):
+    def abs(f) -> Self:
         """Make all coefficients in ``f`` positive. """
         raise NotImplementedError
 
-    def neg(f):
+    def neg(f) -> Self:
         """Negate all coefficients in ``f``. """
         raise NotImplementedError
 
-    def add_ground(f, c):
+    def add_ground(f, c: Er, /) -> Self:
         """Add an element of the ground domain to ``f``. """
         return f._add_ground(f.dom.convert(c))
 
-    def sub_ground(f, c):
+    def sub_ground(f, c: Er, /) -> Self:
         """Subtract an element of the ground domain from ``f``. """
         return f._sub_ground(f.dom.convert(c))
 
-    def mul_ground(f, c):
+    def mul_ground(f, c: Er, /) -> Self:
         """Multiply ``f`` by a an element of the ground domain. """
         return f._mul_ground(f.dom.convert(c))
 
-    def quo_ground(f, c):
+    def quo_ground(f, c: Er, /) -> Self:
         """Quotient of ``f`` by a an element of the ground domain. """
         return f._quo_ground(f.dom.convert(c))
 
-    def exquo_ground(f, c):
+    def exquo_ground(f, c: Er, /) -> Self:
         """Exact quotient of ``f`` by a an element of the ground domain. """
         return f._exquo_ground(f.dom.convert(c))
 
-    def add(f, g):
+    def add(f, g: Self, /) -> Self:
         """Add two multivariate polynomials ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._add(G)
 
-    def sub(f, g):
+    def sub(f, g: Self, /) -> Self:
         """Subtract two multivariate polynomials ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._sub(G)
 
-    def mul(f, g):
+    def mul(f, g: Self, /) -> Self:
         """Multiply two multivariate polynomials ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._mul(G)
 
-    def sqr(f):
+    def sqr(f) -> Self:
         """Square a multivariate polynomial ``f``. """
         return f._sqr()
 
-    def pow(f, n):
+    def pow(f, n: int, /) -> Self:
         """Raise ``f`` to a non-negative power ``n``. """
         if not isinstance(n, int):
             raise TypeError("``int`` expected, got %s" % type(n))
         return f._pow(n)
 
-    def pdiv(f, g):
+    def pdiv(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial pseudo-division of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._pdiv(G)
 
-    def prem(f, g):
+    def prem(f, g: Self, /) -> Self:
         """Polynomial pseudo-remainder of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._prem(G)
 
-    def pquo(f, g):
+    def pquo(f, g: Self, /) -> Self:
         """Polynomial pseudo-quotient of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._pquo(G)
 
-    def pexquo(f, g):
+    def pexquo(f, g: Self, /) -> Self:
         """Polynomial exact pseudo-quotient of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._pexquo(G)
 
-    def div(f, g):
+    def div(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial division with remainder of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._div(G)
 
-    def rem(f, g):
+    def rem(f, g: Self, /) -> Self:
         """Computes polynomial remainder of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._rem(G)
 
-    def quo(f, g):
+    def quo(f, g: Self, /) -> Self:
         """Computes polynomial quotient of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._quo(G)
 
-    def exquo(f, g):
+    def exquo(f, g: Self, /) -> Self:
         """Computes polynomial exact quotient of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._exquo(G)
 
-    def _add_ground(f, c):
+    def _add_ground(f, c: Er, /) -> Self:
         raise NotImplementedError
 
-    def _sub_ground(f, c):
+    def _sub_ground(f, c: Er, /) -> Self:
         raise NotImplementedError
 
-    def _mul_ground(f, c):
+    def _mul_ground(f, c: Er, /) -> Self:
         raise NotImplementedError
 
-    def _quo_ground(f, c):
+    def _quo_ground(f, c: Er, /) -> Self:
         raise NotImplementedError
 
-    def _exquo_ground(f, c):
+    def _exquo_ground(f, c: Er, /) -> Self:
         raise NotImplementedError
 
-    def _add(f, g):
+    def _add(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _sub(f, g):
+    def _sub(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _mul(f, g):
+    def _mul(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _sqr(f):
+    def _sqr(f) -> Self:
         raise NotImplementedError
 
-    def _pow(f, n):
+    def _pow(f, n: int, /) -> Self:
         raise NotImplementedError
 
-    def _pdiv(f, g):
+    def _pdiv(f, g: Self, /) -> tuple[Self, Self]:
         raise NotImplementedError
 
-    def _prem(f, g):
+    def _prem(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _pquo(f, g):
+    def _pquo(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _pexquo(f, g):
+    def _pexquo(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _div(f, g):
+    def _div(f, g: Self, /) -> tuple[Self, Self]:
         raise NotImplementedError
 
-    def _rem(f, g):
+    def _rem(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _quo(f, g):
+    def _quo(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def _exquo(f, g):
+    def _exquo(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def degree(f, j=0):
+    def degree(f, j: int = 0) -> int | float:
         """Returns the leading degree of ``f`` in ``x_j``. """
         if not isinstance(j, int):
             raise TypeError("``int`` expected, got %s" % type(j))
 
         return f._degree(j)
 
-    def _degree(f, j):
+    def _degree(f, j: int, /) -> int | float:
         raise NotImplementedError
 
-    def degree_list(f):
+    def degree_list(f) -> tuple[int | float, ...]:
         """Returns a list of degrees of ``f``. """
         raise NotImplementedError
 
-    def total_degree(f):
+    def total_degree(f) -> int | float:
         """Returns the total degree of ``f``. """
         raise NotImplementedError
 
-    def homogenize(f, s):
+    def homogenize(f, s: int) -> DMP[Er]:
         """Return homogeneous polynomial of ``f``"""
-        td = f.total_degree()
-        result = {}
+        # XXX: Handle the zero polynomial case?
+        td: int = f.total_degree() # type: ignore
+        result: dict[monom, Er] = {}
         new_symbol = (s == len(f.terms()[0][0]))
         for term in f.terms():
             d = sum(term[0])
@@ -652,7 +672,7 @@ class DMP(CantSympify):
                 result[tuple(l)] = term[1]
         return DMP.from_dict(result, f.lev + int(new_symbol), f.dom)
 
-    def homogeneous_order(f):
+    def homogeneous_order(f) -> NegativeInfinity | int | None:
         """Returns the homogeneous order of ``f``. """
         if f.is_zero:
             return -oo
@@ -660,49 +680,49 @@ class DMP(CantSympify):
         monoms = f.monoms()
         tdeg = sum(monoms[0])
 
-        for monom in monoms:
-            _tdeg = sum(monom)
+        for m in monoms:
+            _tdeg = sum(m)
 
             if _tdeg != tdeg:
                 return None
 
         return tdeg
 
-    def LC(f):
+    def LC(f) -> Er:
         """Returns the leading coefficient of ``f``. """
         raise NotImplementedError
 
-    def TC(f):
+    def TC(f) -> Er:
         """Returns the trailing coefficient of ``f``. """
         raise NotImplementedError
 
-    def nth(f, *N):
+    def nth(f, *N: int) -> Er:
         """Returns the ``n``-th coefficient of ``f``. """
         if all(isinstance(n, int) for n in N):
             return f._nth(N)
         else:
             raise TypeError("a sequence of integers expected")
 
-    def _nth(f, N):
+    def _nth(f, N: tuple[int, ...]) -> Er:
         raise NotImplementedError
 
-    def max_norm(f):
+    def max_norm(f) -> Er:
         """Returns maximum norm of ``f``. """
         raise NotImplementedError
 
-    def l1_norm(f):
+    def l1_norm(f) -> Er:
         """Returns l1 norm of ``f``. """
         raise NotImplementedError
 
-    def l2_norm_squared(f):
+    def l2_norm_squared(f) -> Er:
         """Return squared l2 norm of ``f``. """
         raise NotImplementedError
 
-    def clear_denoms(f):
+    def clear_denoms(f) -> tuple[Er, Self]:
         """Clear denominators, but keep the ground domain. """
         raise NotImplementedError
 
-    def integrate(f, m=1, j=0):
+    def integrate(f, m: int = 1, j: int = 0) -> Self:
         """Computes the ``m``-th order indefinite integral of ``f`` in ``x_j``. """
         if not isinstance(m, int):
             raise TypeError("``int`` expected, got %s" % type(m))
@@ -712,10 +732,10 @@ class DMP(CantSympify):
 
         return f._integrate(m, j)
 
-    def _integrate(f, m, j):
+    def _integrate(f, m: int, j: int) -> Self:
         raise NotImplementedError
 
-    def diff(f, m=1, j=0):
+    def diff(f, m: int = 1, j: int = 0) -> Self:
         """Computes the ``m``-th order derivative of ``f`` in ``x_j``. """
         if not isinstance(m, int):
             raise TypeError("``int`` expected, got %s" % type(m))
@@ -725,10 +745,10 @@ class DMP(CantSympify):
 
         return f._diff(m, j)
 
-    def _diff(f, m, j):
+    def _diff(f, m: int, j: int) -> Self:
         raise NotImplementedError
 
-    def eval(f, a, j=0):
+    def eval(f, a: Any, j: int = 0) -> Any:
         """Evaluates ``f`` at the given point ``a`` in ``x_j``. """
         if not isinstance(j, int):
             raise TypeError("``int`` expected, got %s" % type(j))
@@ -740,13 +760,13 @@ class DMP(CantSympify):
         else:
             return f._eval(a)
 
-    def _eval(f, a):
+    def _eval(f, a: Any, /) -> Any:
         raise NotImplementedError
 
-    def _eval_lev(f, a, j):
+    def _eval_lev(f, a: Any, j: int, /) -> Any:
         raise NotImplementedError
 
-    def half_gcdex(f, g):
+    def half_gcdex(f, g: Self) -> tuple[Self, Self]:
         """Half extended Euclidean algorithm, if univariate. """
         F, G = f.unify_DMP(g)
 
@@ -755,10 +775,10 @@ class DMP(CantSympify):
 
         return F._half_gcdex(G)
 
-    def _half_gcdex(f, g):
+    def _half_gcdex(f, g: Self) -> tuple[Self, Self]:
         raise NotImplementedError
 
-    def gcdex(f, g):
+    def gcdex(f, g: Self) -> tuple[Self, Self, Self]:
         """Extended Euclidean algorithm, if univariate. """
         F, G = f.unify_DMP(g)
 
@@ -770,10 +790,10 @@ class DMP(CantSympify):
 
         return F._gcdex(G)
 
-    def _gcdex(f, g):
+    def _gcdex(f, g: Self) -> tuple[Self, Self, Self]:
         raise NotImplementedError
 
-    def invert(f, g):
+    def invert(f, g: Self) -> Self:
         """Invert ``f`` modulo ``g``, if possible. """
         F, G = f.unify_DMP(g)
 
@@ -782,28 +802,38 @@ class DMP(CantSympify):
 
         return F._invert(G)
 
-    def _invert(f, g):
+    def _invert(f, g: Self) -> Self:
         raise NotImplementedError
 
-    def revert(f, n):
+    def revert(f, n: int) -> Self:
         """Compute ``f**(-1)`` mod ``x**n``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._revert(n)
 
-    def _revert(f, n):
+    def _revert(f, n: int) -> Self:
         raise NotImplementedError
 
-    def subresultants(f, g):
+    def subresultants(f, g: Self) -> list[Self]:
         """Computes subresultant PRS sequence of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._subresultants(G)
 
-    def _subresultants(f, g):
+    def _subresultants(f, g: Self) -> list[Self]:
         raise NotImplementedError
 
-    def resultant(f, g, includePRS=False):
+    @overload
+    def resultant(
+        f, g: Self, includePRS: Literal[True]
+    ) -> tuple[DMP[Er] | Er, list[DMP[Er]]]: ...
+
+    @overload
+    def resultant(f, g: Self, includePRS: Literal[False] = ...) -> DMP[Er] | Er: ...
+
+    def resultant(
+        f, g: Self, includePRS: bool = False
+    ) -> DMP[Er] | Er | tuple[DMP[Er] | Er, list[DMP[Er]]]:
         """Computes resultant of ``f`` and ``g`` via PRS. """
         F, G = f.unify_DMP(g)
         if includePRS:
@@ -811,38 +841,49 @@ class DMP(CantSympify):
         else:
             return F._resultant(G)
 
-    def _resultant(f, g, includePRS=False):
+    def _resultant(f, g: Self) -> DMP[Er] | Er:
         raise NotImplementedError
 
-    def discriminant(f):
+    def _resultant_includePRS(f, g: Self) -> tuple[DMP[Er] | Er, list[DMP[Er]]]:
+        raise NotImplementedError
+
+    def discriminant(f) -> Self | Er:
         """Computes discriminant of ``f``. """
         raise NotImplementedError
 
-    def cofactors(f, g):
+    def cofactors(f, g: Self) -> tuple[Self, Self, Self]:
         """Returns GCD of ``f`` and ``g`` and their cofactors. """
         F, G = f.unify_DMP(g)
         return F._cofactors(G)
 
-    def _cofactors(f, g):
+    def _cofactors(f, g: Self) -> tuple[Self, Self, Self]:
         raise NotImplementedError
 
-    def gcd(f, g):
+    def gcd(f, g: Self) -> Self:
         """Returns polynomial GCD of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._gcd(G)
 
-    def _gcd(f, g):
+    def _gcd(f, g: Self) -> Self:
         raise NotImplementedError
 
-    def lcm(f, g):
+    def lcm(f, g: Self) -> Self:
         """Returns polynomial LCM of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._lcm(G)
 
-    def _lcm(f, g):
+    def _lcm(f, g: Self) -> Self:
         raise NotImplementedError
 
-    def cancel(f, g, include=True):
+    @overload
+    def cancel(f: Self, g: Self, include: Literal[True] = ...) -> tuple[Self, Self]:
+        ...
+
+    @overload
+    def cancel(f: Self, g: Self, include: Literal[False]) -> tuple[Er, Er, Self, Self]:
+        ...
+
+    def cancel(f: Self, g: Self, include: bool = True) -> tuple[Self, Self] | tuple[Er, Er, Self, Self]:
         """Cancel common factors in a rational function ``f/g``. """
         F, G = f.unify_DMP(g)
 
@@ -851,65 +892,68 @@ class DMP(CantSympify):
         else:
             return F._cancel(G)
 
-    def _cancel(f, g):
+    def _cancel(f, g: Self) -> tuple[Er, Er, Self, Self]:
         raise NotImplementedError
 
-    def _cancel_include(f, g):
+    def _cancel_include(f, g: Self) -> tuple[Self, Self]:
         raise NotImplementedError
 
-    def trunc(f, p):
+    def trunc(f, p: Er) -> Self:
         """Reduce ``f`` modulo a constant ``p``. """
         return f._trunc(f.dom.convert(p))
 
-    def _trunc(f, p):
+    def _trunc(f, p: Er) -> Self:
         raise NotImplementedError
 
-    def monic(f):
+    def monic(f) -> Self:
         """Divides all coefficients by ``LC(f)``. """
         raise NotImplementedError
 
-    def content(f):
+    def content(f) -> Er:
         """Returns GCD of polynomial coefficients. """
         raise NotImplementedError
 
-    def primitive(f):
+    def primitive(f) -> tuple[Er, Self]:
         """Returns content and a primitive form of ``f``. """
         raise NotImplementedError
 
-    def compose(f, g):
+    def compose(f, g: Self) -> Self:
         """Computes functional composition of ``f`` and ``g``. """
         F, G = f.unify_DMP(g)
         return F._compose(G)
 
-    def _compose(f, g):
+    def _compose(f, g: Self) -> Self:
         raise NotImplementedError
 
-    def decompose(f):
+    def decompose(f) -> list[Self]:
         """Computes functional decomposition of ``f``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._decompose()
 
-    def _decompose(f):
+    def _decompose(f) -> list[Self]:
         raise NotImplementedError
 
-    def shift(f, a):
+    def shift(f, a: Er) -> Self:
         """Efficiently compute Taylor shift ``f(x + a)``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._shift(f.dom.convert(a))
 
-    def shift_list(f, a):
+    def _shift(f, a: Er) -> Self:
+        raise NotImplementedError
+
+    def shift_list(f, a: list[Any]) -> Self:
         """Efficiently compute Taylor shift ``f(X + A)``. """
         a = [f.dom.convert(ai) for ai in a]
         return f._shift_list(a)
 
-    def _shift(f, a):
+    def _shift_list(f, a: list[Er]) -> Self:
         raise NotImplementedError
 
-    def transform(f, p, q):
+    def transform(f, p: Self, q: Self) -> Self:
         """Evaluate functional transformation ``q**n * f(p/q)``."""
         if f.lev:
             raise ValueError('univariate polynomial expected')
@@ -920,88 +964,123 @@ class DMP(CantSympify):
 
         return F._transform(P, Q)
 
-    def _transform(f, p, q):
+    def _transform(f, p: Self, q: Self) -> Self:
         raise NotImplementedError
 
-    def sturm(f):
+    def sturm(f) -> list[Self]:
         """Computes the Sturm sequence of ``f``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._sturm()
 
-    def _sturm(f):
+    def _sturm(f) -> list[Self]:
         raise NotImplementedError
 
-    def cauchy_upper_bound(f):
+    def cauchy_upper_bound(f) -> Er:
         """Computes the Cauchy upper bound on the roots of ``f``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._cauchy_upper_bound()
 
-    def _cauchy_upper_bound(f):
+    def _cauchy_upper_bound(f) -> Er:
         raise NotImplementedError
 
-    def cauchy_lower_bound(f):
+    def cauchy_lower_bound(f) -> Er:
         """Computes the Cauchy lower bound on the nonzero roots of ``f``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._cauchy_lower_bound()
 
-    def _cauchy_lower_bound(f):
+    def _cauchy_lower_bound(f) -> Er:
         raise NotImplementedError
 
-    def mignotte_sep_bound_squared(f):
+    def mignotte_sep_bound_squared(f) -> Er:
         """Computes the squared Mignotte bound on root separations of ``f``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._mignotte_sep_bound_squared()
 
-    def _mignotte_sep_bound_squared(f):
+    def _mignotte_sep_bound_squared(f) -> Er:
         raise NotImplementedError
 
-    def gff_list(f):
+    def gff_list(f) -> list[tuple[Self, int]]:
         """Computes greatest factorial factorization of ``f``. """
         if f.lev:
             raise ValueError('univariate polynomial expected')
 
         return f._gff_list()
 
-    def _gff_list(f):
+    def _gff_list(f) -> list[tuple[Self, int]]:
         raise NotImplementedError
 
-    def norm(f):
+    def norm(f) -> DMP:
         """Computes ``Norm(f)``."""
         raise NotImplementedError
 
-    def sqf_norm(f):
+    def sqf_norm(f) -> tuple[list[int], Self, DMP]:
         """Computes square-free norm of ``f``. """
         raise NotImplementedError
 
-    def sqf_part(f):
+    def sqf_part(f) -> Self:
         """Computes square-free part of ``f``. """
         raise NotImplementedError
 
-    def sqf_list(f, all=False):
+    def sqf_list(f, all: bool = False) -> tuple[Er, list[tuple[Self, int]]]:
         """Returns a list of square-free factors of ``f``. """
         raise NotImplementedError
 
-    def sqf_list_include(f, all=False):
+    def sqf_list_include(f, all: bool = False) -> list[tuple[Self, int]]:
         """Returns a list of square-free factors of ``f``. """
         raise NotImplementedError
 
-    def factor_list(f):
+    def factor_list(f) -> tuple[Er, list[tuple[Self, int]]]:
         """Returns a list of irreducible factors of ``f``. """
         raise NotImplementedError
 
-    def factor_list_include(f):
+    def factor_list_include(f) -> list[tuple[Self, int]]:
         """Returns a list of irreducible factors of ``f``. """
         raise NotImplementedError
 
-    def intervals(f, all=False, eps=None, inf=None, sup=None, fast=False, sqf=False):
+    @overload
+    def intervals(
+        f,
+        all: Literal[False] = ...,
+        eps: MPQ | None = ...,
+        inf: MPQ | None = ...,
+        sup: MPQ | None = ...,
+        fast: bool = ...,
+        sqf: bool = ...,
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
+        ...
+
+    @overload
+    def intervals(
+        f,
+        all: Literal[True],
+        eps: MPQ | None = ...,
+        inf: MPQ | None = ...,
+        sup: MPQ | None = ...,
+        fast: bool = ...,
+        sqf: bool = ...,
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
+        ...
+
+    def intervals(
+        f,
+        all: bool = False,
+        eps: MPQ | None = None,
+        inf: MPQ | None = None,
+        sup: MPQ | None = None,
+        fast: bool = False,
+        sqf: bool = False,
+    ) -> (
+        list[tuple[tuple[MPQ, MPQ], int]]
+        | list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]
+    ):
         """Compute isolating intervals for roots of ``f``. """
         if f.lev:
             raise PolynomialError("Cannot isolate roots of a multivariate polynomial")
@@ -1015,19 +1094,29 @@ class DMP(CantSympify):
         else:
             return f._isolate_real_roots(eps=eps, inf=inf, sup=sup, fast=fast)
 
-    def _isolate_all_roots(f, eps, inf, sup, fast):
+    def _isolate_real_roots(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
         raise NotImplementedError
 
-    def _isolate_all_roots_sqf(f, eps, inf, sup, fast):
+    def _isolate_real_roots_sqf(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
         raise NotImplementedError
 
-    def _isolate_real_roots(f, eps, inf, sup, fast):
+    def _isolate_all_roots(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
         raise NotImplementedError
 
-    def _isolate_real_roots_sqf(f, eps, inf, sup, fast):
+    def _isolate_all_roots_sqf(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
         raise NotImplementedError
 
-    def refine_root(f, s, t, eps=None, steps=None, fast=False):
+    def refine_root(
+        f, s: MPQ, t: MPQ, eps: MPQ | None, steps: int | None, fast: bool
+    ) -> tuple[MPQ, MPQ]:
         """
         Refine an isolating interval to the given precision.
 
@@ -1040,156 +1129,169 @@ class DMP(CantSympify):
 
         return f._refine_real_root(s, t, eps=eps, steps=steps, fast=fast)
 
-    def _refine_real_root(f, s, t, eps, steps, fast):
+    def _refine_real_root(
+        f, s: MPQ, t: MPQ, eps: MPQ | None, steps: int | None, fast: bool
+    ) -> tuple[MPQ, MPQ]:
         raise NotImplementedError
 
-    def count_real_roots(f, inf=None, sup=None):
+    def count_real_roots(f, inf: MPQ | None = None, sup: MPQ | None = None) -> int:
         """Return the number of real roots of ``f`` in ``[inf, sup]``. """
         raise NotImplementedError
 
-    def count_complex_roots(f, inf=None, sup=None):
+    def count_complex_roots(
+        f, inf: tuple[MPQ, MPQ] | None = None, sup: tuple[MPQ, MPQ] | None = None
+    ) -> int:
         """Return the number of complex roots of ``f`` in ``[inf, sup]``. """
         raise NotImplementedError
 
     @property
-    def is_zero(f):
+    def is_zero(f) -> bool:
         """Returns ``True`` if ``f`` is a zero polynomial. """
         raise NotImplementedError
 
     @property
-    def is_one(f):
+    def is_one(f) -> bool:
         """Returns ``True`` if ``f`` is a unit polynomial. """
         raise NotImplementedError
 
     @property
-    def is_ground(f):
+    def is_ground(f) -> bool:
         """Returns ``True`` if ``f`` is an element of the ground domain. """
         raise NotImplementedError
 
     @property
-    def is_sqf(f):
+    def is_sqf(f) -> bool:
         """Returns ``True`` if ``f`` is a square-free polynomial. """
         raise NotImplementedError
 
     @property
-    def is_monic(f):
+    def is_monic(f) -> bool:
         """Returns ``True`` if the leading coefficient of ``f`` is one. """
         raise NotImplementedError
 
     @property
-    def is_primitive(f):
+    def is_primitive(f) -> bool:
         """Returns ``True`` if the GCD of the coefficients of ``f`` is one. """
         raise NotImplementedError
 
     @property
-    def is_linear(f):
+    def is_linear(f) -> bool:
         """Returns ``True`` if ``f`` is linear in all its variables. """
         raise NotImplementedError
 
     @property
-    def is_quadratic(f):
+    def is_quadratic(f) -> bool:
         """Returns ``True`` if ``f`` is quadratic in all its variables. """
         raise NotImplementedError
 
     @property
-    def is_monomial(f):
+    def is_monomial(f) -> bool:
         """Returns ``True`` if ``f`` is zero or has only one term. """
         raise NotImplementedError
 
     @property
-    def is_homogeneous(f):
+    def is_homogeneous(f) -> bool:
         """Returns ``True`` if ``f`` is a homogeneous polynomial. """
         raise NotImplementedError
 
     @property
-    def is_irreducible(f):
+    def is_irreducible(f) -> bool:
         """Returns ``True`` if ``f`` has no factors over its domain. """
         raise NotImplementedError
 
     @property
-    def is_cyclotomic(f):
+    def is_cyclotomic(f) -> bool:
         """Returns ``True`` if ``f`` is a cyclotomic polynomial. """
         raise NotImplementedError
 
-    def __abs__(f):
+    def __abs__(f) -> Self:
         return f.abs()
 
-    def __neg__(f):
+    # XXX: Maybe remove the dunder methods like __add__? It is not clear that
+    # they are really needed e.g. Poly does not use them and for internal code
+    # it is better to use strictly typed methods like add, add_ground etc.
+    # We need type: ignore below because otherwise there is not any way to
+    # satisfy both mypy and pyright. The checks in __add__ etc are not really
+    # sufficient to know that the types are correct but are good enough given
+    # how DMP is actually used.
+
+    def __neg__(f) -> Self:
         return f.neg()
 
-    def __add__(f, g):
+    def __add__(f, g: Self | Er) -> Self:
         if isinstance(g, DMP):
-            return f.add(g)
+            return f.add(g) # type: ignore
         else:
             try:
                 return f.add_ground(g)
             except CoercionFailed:
                 return NotImplemented
 
-    def __radd__(f, g):
+    def __radd__(f, g: Er) -> Self:
         return f.__add__(g)
 
-    def __sub__(f, g):
+    def __sub__(f, g: Self | Er) -> Self:
         if isinstance(g, DMP):
-            return f.sub(g)
+            return f.sub(g) # type: ignore
         else:
             try:
                 return f.sub_ground(g)
             except CoercionFailed:
                 return NotImplemented
 
-    def __rsub__(f, g):
+    def __rsub__(f, g: Er) -> Self:
         return (-f).__add__(g)
 
-    def __mul__(f, g):
+    def __mul__(f, g: Self | Er) -> Self:
         if isinstance(g, DMP):
-            return f.mul(g)
+            return f.mul(g) # type: ignore
         else:
             try:
                 return f.mul_ground(g)
             except CoercionFailed:
                 return NotImplemented
 
-    def __rmul__(f, g):
+    def __rmul__(f, g: Er) -> Self:
         return f.__mul__(g)
 
-    def __truediv__(f, g):
+    def __truediv__(f, g: Self | Er) -> Self:
         if isinstance(g, DMP):
-            return f.exquo(g)
+            return f.exquo(g) # type: ignore
         else:
             try:
+                # XXX: This should be dividing...
                 return f.mul_ground(g)
             except CoercionFailed:
                 return NotImplemented
 
-    def __rtruediv__(f, g):
+    def __rtruediv__(f, g: Self | Er) -> Self:
         if isinstance(g, DMP):
-            return g.exquo(f)
+            return g.exquo(f) # type: ignore
         else:
             try:
                 return f._one().mul_ground(g).exquo(f)
             except CoercionFailed:
                 return NotImplemented
 
-    def __pow__(f, n):
+    def __pow__(f, n: int) -> Self:
         return f.pow(n)
 
-    def __divmod__(f, g):
+    def __divmod__(f, g: Self) -> tuple[Self, Self]:
         return f.div(g)
 
-    def __mod__(f, g):
+    def __mod__(f, g: Self) -> Self:
         return f.rem(g)
 
-    def __floordiv__(f, g):
+    def __floordiv__(f, g: Self | Er) -> Self:
         if isinstance(g, DMP):
-            return f.quo(g)
+            return f.quo(g) # type: ignore
         else:
             try:
                 return f.quo_ground(g)
             except TypeError:
                 return NotImplemented
 
-    def __eq__(f, g):
+    def __eq__(f, g: object) -> bool:
         if f is g:
             return True
         if not isinstance(g, DMP):
@@ -1201,46 +1303,57 @@ class DMP(CantSympify):
         else:
             return F._strict_eq(G)
 
-    def _strict_eq(f, g):
+    def _strict_eq(f, g: Self) -> bool:
         raise NotImplementedError
 
-    def eq(f, g, strict=False):
+    def eq(f, g: Self, strict: bool = False) -> bool:
         if not strict:
             return f == g
         else:
             return f._strict_eq(g)
 
-    def ne(f, g, strict=False):
+    def ne(f, g: Self, strict: bool = False) -> bool:
         return not f.eq(g, strict=strict)
 
-    def __lt__(f, g):
+    def __lt__(f, g: Self) -> bool:
         F, G = f.unify_DMP(g)
         return F.to_list() < G.to_list()
 
-    def __le__(f, g):
+    def __le__(f, g: Self) -> bool:
         F, G = f.unify_DMP(g)
         return F.to_list() <= G.to_list()
 
-    def __gt__(f, g):
+    def __gt__(f, g: Self) -> bool:
         F, G = f.unify_DMP(g)
         return F.to_list() > G.to_list()
 
-    def __ge__(f, g):
+    def __ge__(f, g: Self) -> bool:
         F, G = f.unify_DMP(g)
         return F.to_list() >= G.to_list()
 
-    def __bool__(f):
+    def __bool__(f) -> bool:
         return not f.is_zero
 
 
-class DMP_Python(DMP):
+# XXX: mypy complains below that dmp is not valid as a type for some reason.
+# Pretty sure this is a bug in mypy but we work around it by defining a new
+# type alias for dmp.
+_T = TypeVar("_T")
+_dmp2: TypeAlias = "list[_dmp2[_T]]"
+
+
+class DMP_Python(DMP[Er]):
     """Dense Multivariate Polynomials over `K`. """
 
     __slots__ = ('_rep', 'dom', 'lev')
 
+    _rep: _dmp2[Er]
+    dom: Domain[Er]
+    lev: int
+
     @classmethod
-    def _new(cls, rep, dom, lev):
-        obj = object.__new__(cls)
+    def _new(cls, rep: dmp[Es], dom: Domain[Es], lev: int) -> DMP_Python[Es]:
+        obj: DMP_Python[Es] = object.__new__(cls) # type: ignore
         obj._rep = rep
         obj.lev = lev
         obj.dom = dom
@@ -1251,18 +1364,19 @@ class DMP_Python(DMP):
             return False
         return f.lev == g.lev and f.dom == g.dom and f._rep == g._rep
 
-    def per(f, rep):
+    def per(f, rep: dmp[Er]) -> Self:
         """Create a DMP out of the given representation. """
-        return f._new(rep, f.dom, f.lev)
+        return f._new(rep, f.dom, f.lev) # type: ignore
 
-    def ground_new(f, coeff):
+    def ground_new(f, coeff: Er) -> DMP_Python[Er]:
         """Construct a new ground instance of ``f``. """
-        return f._new(dmp_ground(coeff, f.lev), f.dom, f.lev)
+        poly: dmp[Er] = dmp_ground(coeff, f.lev) # type: ignore
+        return f._new(poly, f.dom, f.lev)
 
-    def _one(f):
-        return f.one(f.lev, f.dom)
+    def _one(f) -> Self:
+        return f._new(dmp_one(f.lev, f.dom), f.dom, f.lev) # type: ignore
 
-    def unify(f, g):
+    def unify(f, g: DMP_Python) -> tuple[int, Domain, Callable, dmp, dmp]:
         """Unify representations of two multivariate polynomials. """
         # XXX: This function is not really used any more since there is
         # unify_DMP now.
@@ -1282,449 +1396,473 @@ class DMP_Python(DMP):
 
             return lev, dom, per, F, G
 
-    def to_DUP_Flint(f):
+    def to_DUP_Flint(f) -> DUP_Flint[Er]:
         """Convert ``f`` to a Flint representation. """
         return DUP_Flint._new(f._rep, f.dom, f.lev)
 
-    def to_list(f):
+    def to_list(f) -> dmp[Er]:
         """Convert ``f`` to a list representation with native coefficients. """
         return list(f._rep)
 
-    def to_tuple(f):
+    def to_tuple(f) -> dmp_tup[Er]:
         """Convert ``f`` to a tuple representation with native coefficients. """
         return dmp_to_tuple(f._rep, f.lev)
 
-    def _convert(f, dom):
+    def _convert(f, dom: Domain[Es]) -> DMP_Python[Es]:
         """Convert the ground domain of ``f``. """
         return f._new(dmp_convert(f._rep, f.lev, f.dom, dom), dom, f.lev)
 
-    def _slice(f, m, n):
+    def _slice(f, m: int, n: int) -> Self:
         """Take a continuous subsequence of terms of ``f``. """
-        rep = dup_slice(f._rep, m, n, f.dom)
-        return f._new(rep, f.dom, f.lev)
+        rep = dup_slice(_dup(f._rep), m, n, f.dom)
+        return f.per(_dmp(rep))
 
     def _slice_lev(f, m, n, j):
         """Take a continuous subsequence of terms of ``f``. """
         rep = dmp_slice_in(f._rep, m, n, j, f.lev, f.dom)
-        return f._new(rep, f.dom, f.lev)
+        return f.per(rep)
 
-    def _terms(f, order=None):
+    def _terms(f, order: MonomialOrder | None = None) -> list[tuple[monom, Er]]:
         """Returns all non-zero terms from ``f`` in lex order. """
         return dmp_list_terms(f._rep, f.lev, f.dom, order=order)
 
-    def _lift(f):
+    def _lift(f) -> DMP:
         """Convert algebraic coefficients to rationals. """
+        # XXX: This is only for AlgebraicField domains
         r = dmp_lift(f._rep, f.lev, f.dom)
-        return f._new(r, f.dom.dom, f.lev)
+        return f._new(r, f.dom.dom, f.lev) # type: ignore
 
-    def deflate(f):
+    def deflate(f) -> tuple[monom, DMP_Python[Er]]:
         """Reduce degree of `f` by mapping `x_i^m` to `y_i`. """
         J, F = dmp_deflate(f._rep, f.lev, f.dom)
         return J, f.per(F)
 
-    def inject(f, front=False):
+    def inject(f, front: bool = False) -> DMP_Python:
         """Inject ground domain generators into ``f``. """
-        F, lev = dmp_inject(f._rep, f.lev, f.dom, front=front)
+        # f.dom can be a PolynomialRing or AlgebraicField...
+        F, lev = dmp_inject(f._rep, f.lev, f.dom, front=front) # type: ignore
         # XXX: domain and level changed here
-        return f._new(F, f.dom.dom, lev)
+        return f._new(F, f.dom.dom, lev) # type: ignore
 
-    def eject(f, dom, front=False):
+    def eject(f, dom: PolynomialRing[Er], front: bool = False) -> DMP_Python[PolyElement[Er]]:
         """Eject selected generators into the ground domain. """
         F = dmp_eject(f._rep, f.lev, dom, front=front)
         # XXX: domain and level changed here
         return f._new(F, dom, f.lev - len(dom.symbols))
 
-    def _exclude(f):
+    def _exclude(f) -> tuple[list[int], DMP_Python[Er]]:
         """Remove useless generators from ``f``. """
         J, F, u = dmp_exclude(f._rep, f.lev, f.dom)
         # XXX: level changed here
         return J, f._new(F, f.dom, u)
 
-    def _permute(f, P):
+    def _permute(f, P: list[int]) -> DMP_Python[Er]:
         """Returns a polynomial in `K[x_{P(1)}, ..., x_{P(n)}]`. """
         return f.per(dmp_permute(f._rep, P, f.lev, f.dom))
 
-    def terms_gcd(f):
+    def terms_gcd(f) -> tuple[monom, DMP_Python[Er]]:
         """Remove GCD of terms from the polynomial ``f``. """
         J, F = dmp_terms_gcd(f._rep, f.lev, f.dom)
         return J, f.per(F)
 
-    def _add_ground(f, c):
+    def _add_ground(f, c: Er) -> Self:
         """Add an element of the ground domain to ``f``. """
         return f.per(dmp_add_ground(f._rep, c, f.lev, f.dom))
 
-    def _sub_ground(f, c):
+    def _sub_ground(f, c: Er) -> Self:
         """Subtract an element of the ground domain from ``f``. """
         return f.per(dmp_sub_ground(f._rep, c, f.lev, f.dom))
 
-    def _mul_ground(f, c):
+    def _mul_ground(f, c: Er) -> Self:
         """Multiply ``f`` by a an element of the ground domain. """
         return f.per(dmp_mul_ground(f._rep, c, f.lev, f.dom))
 
-    def _quo_ground(f, c):
+    def _quo_ground(f, c: Er) -> Self:
         """Quotient of ``f`` by a an element of the ground domain. """
         return f.per(dmp_quo_ground(f._rep, c, f.lev, f.dom))
 
-    def _exquo_ground(f, c):
+    def _exquo_ground(f, c: Er) -> Self:
         """Exact quotient of ``f`` by a an element of the ground domain. """
         return f.per(dmp_exquo_ground(f._rep, c, f.lev, f.dom))
 
-    def abs(f):
+    def abs(f) -> Self:
         """Make all coefficients in ``f`` positive. """
+        # XXX: Not defined for all domains.
         return f.per(dmp_abs(f._rep, f.lev, f.dom))
 
-    def neg(f):
+    def neg(f) -> Self:
         """Negate all coefficients in ``f``. """
         return f.per(dmp_neg(f._rep, f.lev, f.dom))
 
-    def _add(f, g):
+    def _add(f, g: Self, /) -> Self:
         """Add two multivariate polynomials ``f`` and ``g``. """
         return f.per(dmp_add(f._rep, g._rep, f.lev, f.dom))
 
-    def _sub(f, g):
+    def _sub(f, g: Self, /) -> Self:
         """Subtract two multivariate polynomials ``f`` and ``g``. """
         return f.per(dmp_sub(f._rep, g._rep, f.lev, f.dom))
 
-    def _mul(f, g):
+    def _mul(f, g: Self, /) -> Self:
         """Multiply two multivariate polynomials ``f`` and ``g``. """
         return f.per(dmp_mul(f._rep, g._rep, f.lev, f.dom))
 
-    def sqr(f):
+    def sqr(f) -> Self:
         """Square a multivariate polynomial ``f``. """
         return f.per(dmp_sqr(f._rep, f.lev, f.dom))
 
-    def _pow(f, n):
+    def _pow(f, n: int, /) -> Self:
         """Raise ``f`` to a non-negative power ``n``. """
         return f.per(dmp_pow(f._rep, n, f.lev, f.dom))
 
-    def _pdiv(f, g):
+    def _pdiv(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial pseudo-division of ``f`` and ``g``. """
         q, r = dmp_pdiv(f._rep, g._rep, f.lev, f.dom)
         return f.per(q), f.per(r)
 
-    def _prem(f, g):
+    def _prem(f, g: Self, /) -> Self:
         """Polynomial pseudo-remainder of ``f`` and ``g``. """
         return f.per(dmp_prem(f._rep, g._rep, f.lev, f.dom))
 
-    def _pquo(f, g):
+    def _pquo(f, g: Self, /) -> Self:
         """Polynomial pseudo-quotient of ``f`` and ``g``. """
         return f.per(dmp_pquo(f._rep, g._rep, f.lev, f.dom))
 
-    def _pexquo(f, g):
+    def _pexquo(f, g: Self, /) -> Self:
         """Polynomial exact pseudo-quotient of ``f`` and ``g``. """
         return f.per(dmp_pexquo(f._rep, g._rep, f.lev, f.dom))
 
-    def _div(f, g):
+    def _div(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial division with remainder of ``f`` and ``g``. """
         q, r = dmp_div(f._rep, g._rep, f.lev, f.dom)
         return f.per(q), f.per(r)
 
-    def _rem(f, g):
+    def _rem(f, g: Self, /) -> Self:
         """Computes polynomial remainder of ``f`` and ``g``. """
         return f.per(dmp_rem(f._rep, g._rep, f.lev, f.dom))
 
-    def _quo(f, g):
+    def _quo(f, g: Self, /) -> Self:
         """Computes polynomial quotient of ``f`` and ``g``. """
         return f.per(dmp_quo(f._rep, g._rep, f.lev, f.dom))
 
-    def _exquo(f, g):
+    def _exquo(f, g: Self, /) -> Self:
         """Computes polynomial exact quotient of ``f`` and ``g``. """
         return f.per(dmp_exquo(f._rep, g._rep, f.lev, f.dom))
 
-    def _degree(f, j=0):
+    def _degree(f, j: int) -> int | float:
         """Returns the leading degree of ``f`` in ``x_j``. """
         return dmp_degree_in(f._rep, j, f.lev)
 
-    def degree_list(f):
+    def degree_list(f) -> tuple[int | float, ...]:
         """Returns a list of degrees of ``f``. """
         return dmp_degree_list(f._rep, f.lev)
 
-    def total_degree(f):
+    def total_degree(f) -> int:
         """Returns the total degree of ``f``. """
+        # XXX: This would return zero for the zero polynomial ...
         return max(sum(m) for m in f.monoms())
 
-    def LC(f):
+    def LC(f) -> Er:
         """Returns the leading coefficient of ``f``. """
         return dmp_ground_LC(f._rep, f.lev, f.dom)
 
-    def TC(f):
+    def TC(f) -> Er:
         """Returns the trailing coefficient of ``f``. """
         return dmp_ground_TC(f._rep, f.lev, f.dom)
 
-    def _nth(f, N):
+    def _nth(f, N) -> Er:
         """Returns the ``n``-th coefficient of ``f``. """
         return dmp_ground_nth(f._rep, N, f.lev, f.dom)
 
-    def max_norm(f):
+    def max_norm(f) -> Er:
         """Returns maximum norm of ``f``. """
         return dmp_max_norm(f._rep, f.lev, f.dom)
 
-    def l1_norm(f):
+    def l1_norm(f) -> Er:
         """Returns l1 norm of ``f``. """
         return dmp_l1_norm(f._rep, f.lev, f.dom)
 
-    def l2_norm_squared(f):
+    def l2_norm_squared(f) -> Er:
         """Return squared l2 norm of ``f``. """
         return dmp_l2_norm_squared(f._rep, f.lev, f.dom)
 
-    def clear_denoms(f):
+    def clear_denoms(f) -> tuple[Er, Self]:
         """Clear denominators, but keep the ground domain. """
         coeff, F = dmp_clear_denoms(f._rep, f.lev, f.dom)
         return coeff, f.per(F)
 
-    def _integrate(f, m=1, j=0):
+    def _integrate(f, m: int, j: int) -> Self:
         """Computes the ``m``-th order indefinite integral of ``f`` in ``x_j``. """
         return f.per(dmp_integrate_in(f._rep, m, j, f.lev, f.dom))
 
-    def _diff(f, m=1, j=0):
+    def _diff(f, m: int, j: int) -> Self:
         """Computes the ``m``-th order derivative of ``f`` in ``x_j``. """
         return f.per(dmp_diff_in(f._rep, m, j, f.lev, f.dom))
 
-    def _eval(f, a):
+    def _eval(f, a: Any, /) -> Any:
         return dmp_eval_in(f._rep, f.dom.convert(a), 0, f.lev, f.dom)
 
-    def _eval_lev(f, a, j):
+    def _eval_lev(f, a: Any, j: int, /) -> Any:
         rep = dmp_eval_in(f._rep, f.dom.convert(a), j, f.lev, f.dom)
         return f.new(rep, f.dom, f.lev - 1)
 
-    def _half_gcdex(f, g):
+    def _half_gcdex(f, g: Self) -> tuple[Self, Self]:
         """Half extended Euclidean algorithm, if univariate. """
         s, h = dup_half_gcdex(f._rep, g._rep, f.dom)
         return f.per(s), f.per(h)
 
-    def _gcdex(f, g):
+    def _gcdex(f, g: Self) -> tuple[Self, Self, Self]:
         """Extended Euclidean algorithm, if univariate. """
         s, t, h = dup_gcdex(f._rep, g._rep, f.dom)
         return f.per(s), f.per(t), f.per(h)
 
-    def _invert(f, g):
+    def _invert(f, g: Self) -> Self:
         """Invert ``f`` modulo ``g``, if possible. """
         s = dup_invert(f._rep, g._rep, f.dom)
         return f.per(s)
 
-    def _revert(f, n):
+    def _revert(f, n: int) -> Self:
         """Compute ``f**(-1)`` mod ``x**n``. """
-        return f.per(dup_revert(f._rep, n, f.dom))
+        return f.per(_dmp(dup_revert(f._rep, n, f.dom)))
 
-    def _subresultants(f, g):
+    def _subresultants(f, g: Self) -> list[Self]:
         """Computes subresultant PRS sequence of ``f`` and ``g``. """
         R = dmp_subresultants(f._rep, g._rep, f.lev, f.dom)
         return list(map(f.per, R))
 
-    def _resultant_includePRS(f, g):
+    def _resultant_includePRS(f, g: Self) -> tuple[DMP[Er] | Er, list[DMP[Er]]]:
         """Computes resultant of ``f`` and ``g`` via PRS. """
         res, R = dmp_resultant(f._rep, g._rep, f.lev, f.dom, includePRS=True)
+        # XXX: resultant returns a domain element at level 0...
         if f.lev:
-            res = f.new(res, f.dom, f.lev - 1)
-        return res, list(map(f.per, R))
+            res = f.new(res, f.dom, f.lev - 1) # type: ignore
+        return res, list(map(f.per, R)) # type: ignore
 
-    def _resultant(f, g):
+    def _resultant(f, g: Self) -> DMP[Er] | Er:
         res = dmp_resultant(f._rep, g._rep, f.lev, f.dom)
         if f.lev:
-            res = f.new(res, f.dom, f.lev - 1)
-        return res
+            res = f.new(res, f.dom, f.lev - 1) # type: ignore
+        return res # type: ignore
 
-    def discriminant(f):
+    def discriminant(f) -> Self | Er:
         """Computes discriminant of ``f``. """
         res = dmp_discriminant(f._rep, f.lev, f.dom)
         if f.lev:
             res = f.new(res, f.dom, f.lev - 1)
-        return res
+        return res # type: ignore
 
     def _cofactors(f, g):
         """Returns GCD of ``f`` and ``g`` and their cofactors. """
         h, cff, cfg = dmp_inner_gcd(f._rep, g._rep, f.lev, f.dom)
         return f.per(h), f.per(cff), f.per(cfg)
 
-    def _gcd(f, g):
+    def _gcd(f, g: Self) -> Self:
         """Returns polynomial GCD of ``f`` and ``g``. """
         return f.per(dmp_gcd(f._rep, g._rep, f.lev, f.dom))
 
-    def _lcm(f, g):
+    def _lcm(f, g: Self) -> Self:
         """Returns polynomial LCM of ``f`` and ``g``. """
         return f.per(dmp_lcm(f._rep, g._rep, f.lev, f.dom))
 
-    def _cancel(f, g):
+    def _cancel(f, g: Self) -> tuple[Er, Er, Self, Self]:
         """Cancel common factors in a rational function ``f/g``. """
         cF, cG, F, G = dmp_cancel(f._rep, g._rep, f.lev, f.dom, include=False)
         return cF, cG, f.per(F), f.per(G)
 
-    def _cancel_include(f, g):
+    def _cancel_include(f, g: Self) -> tuple[Self, Self]:
         """Cancel common factors in a rational function ``f/g``. """
         F, G = dmp_cancel(f._rep, g._rep, f.lev, f.dom, include=True)
         return f.per(F), f.per(G)
 
-    def _trunc(f, p):
+    def _trunc(f, p: Er) -> Self:
         """Reduce ``f`` modulo a constant ``p``. """
         return f.per(dmp_ground_trunc(f._rep, p, f.lev, f.dom))
 
-    def monic(f):
+    def monic(f) -> Self:
         """Divides all coefficients by ``LC(f)``. """
         return f.per(dmp_ground_monic(f._rep, f.lev, f.dom))
 
-    def content(f):
+    def content(f) -> Er:
         """Returns GCD of polynomial coefficients. """
         return dmp_ground_content(f._rep, f.lev, f.dom)
 
-    def primitive(f):
+    def primitive(f) -> tuple[Er, Self]:
         """Returns content and a primitive form of ``f``. """
         cont, F = dmp_ground_primitive(f._rep, f.lev, f.dom)
         return cont, f.per(F)
 
-    def _compose(f, g):
+    def _compose(f, g: Self) -> Self:
         """Computes functional composition of ``f`` and ``g``. """
         return f.per(dmp_compose(f._rep, g._rep, f.lev, f.dom))
 
-    def _decompose(f):
+    def _decompose(f) -> list[Self]:
         """Computes functional decomposition of ``f``. """
         return list(map(f.per, dup_decompose(f._rep, f.dom)))
 
-    def _shift(f, a):
+    def _shift(f, a: Er) -> Self:
         """Efficiently compute Taylor shift ``f(x + a)``. """
         return f.per(dup_shift(f._rep, a, f.dom))
 
-    def _shift_list(f, a):
+    def _shift_list(f, a: list[Er]) -> Self:
         """Efficiently compute Taylor shift ``f(X + A)``. """
         return f.per(dmp_shift(f._rep, a, f.lev, f.dom))
 
-    def _transform(f, p, q):
+    def _transform(f, p: Self, q: Self) -> Self:
         """Evaluate functional transformation ``q**n * f(p/q)``."""
-        return f.per(dup_transform(f._rep, p._rep, q._rep, f.dom))
+        rep = dup_transform(_dup(f._rep), _dup(p._rep), _dup(q._rep), f.dom)
+        return f.per(_dmp(rep))
 
-    def _sturm(f):
+    def _sturm(f) -> list[Self]:
         """Computes the Sturm sequence of ``f``. """
         return list(map(f.per, dup_sturm(f._rep, f.dom)))
 
-    def _cauchy_upper_bound(f):
+    def _cauchy_upper_bound(f: Self) -> Er:
         """Computes the Cauchy upper bound on the roots of ``f``. """
         return dup_cauchy_upper_bound(f._rep, f.dom)
 
-    def _cauchy_lower_bound(f):
+    def _cauchy_lower_bound(f: Self) -> Er:
         """Computes the Cauchy lower bound on the nonzero roots of ``f``. """
         return dup_cauchy_lower_bound(f._rep, f.dom)
 
-    def _mignotte_sep_bound_squared(f):
+    def _mignotte_sep_bound_squared(f: Self) -> Er:
         """Computes the squared Mignotte bound on root separations of ``f``. """
         return dup_mignotte_sep_bound_squared(f._rep, f.dom)
 
-    def _gff_list(f):
+    def _gff_list(f: Self) -> list[tuple[Self, int]]:
         """Computes greatest factorial factorization of ``f``. """
         return [ (f.per(g), k) for g, k in dup_gff_list(f._rep, f.dom) ]
 
-    def norm(f):
+    def norm(f) -> DMP:
         """Computes ``Norm(f)``."""
-        r = dmp_norm(f._rep, f.lev, f.dom)
-        return f.new(r, f.dom.dom, f.lev)
+        #dom = f.dom
+        #if not isinstance(dom, AlgebraicField):
+        #    raise DomainError("ground domain must be algebraic")
+        r = dmp_norm(f._rep, f.lev, f.dom) # type: ignore
+        return f.new(r, f.dom.dom, f.lev) # type: ignore
 
-    def sqf_norm(f):
+    def sqf_norm(f) -> tuple[list[int], Self, DMP]:
         """Computes square-free norm of ``f``. """
-        s, g, r = dmp_sqf_norm(f._rep, f.lev, f.dom)
-        return s, f.per(g), f.new(r, f.dom.dom, f.lev)
+        #dom = f.dom
+        #if not isinstance(dom, AlgebraicField):
+        #    raise DomainError("ground domain must be algebraic")
+        s, g, r = dmp_sqf_norm(f._rep, f.lev, f.dom) # type: ignore
+        return s, f.per(g), f.new(r, f.dom.dom, f.lev) # type: ignore
 
-    def sqf_part(f):
+    def sqf_part(f) -> Self:
         """Computes square-free part of ``f``. """
         return f.per(dmp_sqf_part(f._rep, f.lev, f.dom))
 
-    def sqf_list(f, all=False):
+    def sqf_list(f, all: bool = False) -> tuple[Er, list[tuple[Self, int]]]:
         """Returns a list of square-free factors of ``f``. """
         coeff, factors = dmp_sqf_list(f._rep, f.lev, f.dom, all)
         return coeff, [ (f.per(g), k) for g, k in factors ]
 
-    def sqf_list_include(f, all=False):
+    def sqf_list_include(f, all: bool = False) -> list[tuple[Self, int]]:
         """Returns a list of square-free factors of ``f``. """
         factors = dmp_sqf_list_include(f._rep, f.lev, f.dom, all)
         return [ (f.per(g), k) for g, k in factors ]
 
-    def factor_list(f):
+    def factor_list(f) -> tuple[Er, list[tuple[Self, int]]]:
         """Returns a list of irreducible factors of ``f``. """
         coeff, factors = dmp_factor_list(f._rep, f.lev, f.dom)
         return coeff, [ (f.per(g), k) for g, k in factors ]
 
-    def factor_list_include(f):
+    def factor_list_include(f) -> list[tuple[Self, int]]:
         """Returns a list of irreducible factors of ``f``. """
         factors = dmp_factor_list_include(f._rep, f.lev, f.dom)
         return [ (f.per(g), k) for g, k in factors ]
 
-    def _isolate_real_roots(f, eps, inf, sup, fast):
-        return dup_isolate_real_roots(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast)
+    def _isolate_real_roots(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
+        return dup_isolate_real_roots(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast) # type: ignore
 
-    def _isolate_real_roots_sqf(f, eps, inf, sup, fast):
-        return dup_isolate_real_roots_sqf(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast)
+    def _isolate_real_roots_sqf(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
+        return dup_isolate_real_roots_sqf(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast) # type: ignore
 
-    def _isolate_all_roots(f, eps, inf, sup, fast):
-        return dup_isolate_all_roots(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast)
+    def _isolate_all_roots(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
+        return dup_isolate_all_roots(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast) # type: ignore
 
-    def _isolate_all_roots_sqf(f, eps, inf, sup, fast):
-        return dup_isolate_all_roots_sqf(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast)
+    def _isolate_all_roots_sqf(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
+        return dup_isolate_all_roots_sqf(f._rep, f.dom, eps=eps, inf=inf, sup=sup, fast=fast) # type: ignore
 
-    def _refine_real_root(f, s, t, eps, steps, fast):
-        return dup_refine_real_root(f._rep, s, t, f.dom, eps=eps, steps=steps, fast=fast)
+    def _refine_real_root(
+        f, s: MPQ, t: MPQ, eps: MPQ | None, steps: int | None, fast: bool
+    ) -> tuple[MPQ, MPQ]:
+        return dup_refine_real_root(f._rep, s, t, f.dom, eps=eps, steps=steps, fast=fast) # type: ignore
 
-    def count_real_roots(f, inf=None, sup=None):
+    def count_real_roots(f, inf: MPQ | None = None, sup: MPQ | None = None) -> int:
         """Return the number of real roots of ``f`` in ``[inf, sup]``. """
         return dup_count_real_roots(f._rep, f.dom, inf=inf, sup=sup)
 
-    def count_complex_roots(f, inf=None, sup=None):
+    def count_complex_roots(
+        f, inf: tuple[MPQ, MPQ] | None = None, sup: tuple[MPQ, MPQ] | None = None
+    ) -> int:
         """Return the number of complex roots of ``f`` in ``[inf, sup]``. """
         return dup_count_complex_roots(f._rep, f.dom, inf=inf, sup=sup)
 
     @property
-    def is_zero(f):
+    def is_zero(f) -> bool:
         """Returns ``True`` if ``f`` is a zero polynomial. """
         return dmp_zero_p(f._rep, f.lev)
 
     @property
-    def is_one(f):
+    def is_one(f) -> bool:
         """Returns ``True`` if ``f`` is a unit polynomial. """
         return dmp_one_p(f._rep, f.lev, f.dom)
 
     @property
-    def is_ground(f):
+    def is_ground(f) -> bool:
         """Returns ``True`` if ``f`` is an element of the ground domain. """
         return dmp_ground_p(f._rep, None, f.lev)
 
     @property
-    def is_sqf(f):
+    def is_sqf(f) -> bool:
         """Returns ``True`` if ``f`` is a square-free polynomial. """
         return dmp_sqf_p(f._rep, f.lev, f.dom)
 
     @property
-    def is_monic(f):
+    def is_monic(f) -> bool:
         """Returns ``True`` if the leading coefficient of ``f`` is one. """
         return f.dom.is_one(dmp_ground_LC(f._rep, f.lev, f.dom))
 
     @property
-    def is_primitive(f):
+    def is_primitive(f) -> bool:
         """Returns ``True`` if the GCD of the coefficients of ``f`` is one. """
         return f.dom.is_one(dmp_ground_content(f._rep, f.lev, f.dom))
 
     @property
-    def is_linear(f):
+    def is_linear(f) -> bool:
         """Returns ``True`` if ``f`` is linear in all its variables. """
         return all(sum(monom) <= 1 for monom in dmp_to_dict(f._rep, f.lev, f.dom).keys())
 
     @property
-    def is_quadratic(f):
+    def is_quadratic(f) -> bool:
         """Returns ``True`` if ``f`` is quadratic in all its variables. """
         return all(sum(monom) <= 2 for monom in dmp_to_dict(f._rep, f.lev, f.dom).keys())
 
     @property
-    def is_monomial(f):
+    def is_monomial(f) -> bool:
         """Returns ``True`` if ``f`` is zero or has only one term. """
         return len(f.to_dict()) <= 1
 
     @property
-    def is_homogeneous(f):
+    def is_homogeneous(f) -> bool:
         """Returns ``True`` if ``f`` is a homogeneous polynomial. """
         return f.homogeneous_order() is not None
 
     @property
-    def is_irreducible(f):
+    def is_irreducible(f) -> bool:
         """Returns ``True`` if ``f`` has no factors over its domain. """
         return dmp_irreducible_p(f._rep, f.lev, f.dom)
 
     @property
-    def is_cyclotomic(f):
+    def is_cyclotomic(f) -> bool:
         """Returns ``True`` if ``f`` is a cyclotomic polynomial. """
         if not f.lev:
             return dup_cyclotomic_p(f._rep, f.dom)
@@ -1732,10 +1870,15 @@ class DMP_Python(DMP):
             return False
 
 
-class DUP_Flint(DMP):
+class DUP_Flint(DMP[Er]):
     """Dense Multivariate Polynomials over `K`. """
 
     lev = 0
+
+    if TYPE_CHECKING:
+        _rep: flint.fmpz_poly | flint.fmpq_poly | flint.nmod_poly | flint.fmpz_mod_poly
+        dom: Domain[Er]
+        _cls: Any
 
     __slots__ = ('_rep', 'dom', '_cls')
 
@@ -1798,7 +1941,7 @@ class DUP_Flint(DMP):
         """Unify representations of two polynomials. """
         raise RuntimeError
 
-    def to_DMP_Python(f):
+    def to_DMP_Python(f) -> DMP_Python[Er]:
         """Convert ``f`` to a Python native representation. """
         return DMP_Python._new(f.to_list(), f.dom, f.lev)
 
@@ -1806,7 +1949,7 @@ class DUP_Flint(DMP):
         """Convert ``f`` to a tuple representation with native coefficients. """
         return tuple(f.to_list())
 
-    def _convert(f, dom):
+    def _convert(f, dom: Domain[Es]) -> DUP_Flint[Es] | DMP_Python[Es]:
         """Convert the ground domain of ``f``. """
         if dom == QQ and f.dom == ZZ:
             return f.from_rep(flint.fmpq_poly(f._rep), dom)
@@ -1826,7 +1969,7 @@ class DUP_Flint(DMP):
         # Only makes sense for multivariate polynomials
         raise NotImplementedError
 
-    def _terms(f, order=None):
+    def _terms(f, order: MonomialOrder | None = None) -> list[tuple[monom, Er]]:
         """Returns all non-zero terms from ``f`` in lex order. """
         if order is None or order.alias == 'lex':
             terms = [ ((n,), c) for n, c in enumerate(f._rep.coeffs()) if c ]
@@ -1845,7 +1988,7 @@ class DUP_Flint(DMP):
         # This is for algebraic number fields which DUP_Flint does not support
         raise NotImplementedError
 
-    def deflate(f):
+    def deflate(f) -> tuple[monom, DUP_Flint[Er]]:
         """Reduce degree of `f` by mapping `x_i^m` to `y_i`. """
         # XXX: Check because otherwise this segfaults with python-flint:
         #
@@ -1858,110 +2001,115 @@ class DUP_Flint(DMP):
         g, n = f._rep.deflation()
         return (n,), f.from_rep(g, f.dom)
 
-    def inject(f, front=False):
+    def inject(f, front: bool = False) -> DUP_Flint:
         """Inject ground domain generators into ``f``. """
         # Ground domain would need to be a poly ring
         raise NotImplementedError
 
-    def eject(f, dom, front=False):
+    def eject(f, dom: PolynomialRing[Er], front: bool = False) -> DUP_Flint[PolyElement[Er]]:
         """Eject selected generators into the ground domain. """
         # Only makes sense for multivariate polynomials
         raise NotImplementedError
 
-    def _exclude(f):
+    def _exclude(f) -> tuple[list[int], DMP_Python[Er]]:
         """Remove useless generators from ``f``. """
         # Only makes sense for multivariate polynomials
         raise NotImplementedError
 
-    def _permute(f, P):
+    def _permute(f, P: list[int]) -> DUP_Flint[Er]:
         """Returns a polynomial in `K[x_{P(1)}, ..., x_{P(n)}]`. """
         # Only makes sense for multivariate polynomials
         raise NotImplementedError
 
-    def terms_gcd(f):
+    def terms_gcd(f) -> tuple[monom, DUP_Flint[Er]]:
         """Remove GCD of terms from the polynomial ``f``. """
         # XXX: python-flint should have primitive, content, etc methods.
         J, F = f.to_DMP_Python().terms_gcd()
         return J, F.to_DUP_Flint()
 
-    def _add_ground(f, c):
+    def _add_ground(f, c: Er, /) -> Self:
         """Add an element of the ground domain to ``f``. """
         return f.from_rep(f._rep + c, f.dom)
 
-    def _sub_ground(f, c):
+    def _sub_ground(f, c: Er, /) -> Self:
         """Subtract an element of the ground domain from ``f``. """
         return f.from_rep(f._rep - c, f.dom)
 
-    def _mul_ground(f, c):
+    def _mul_ground(f, c: Er, /) -> Self:
         """Multiply ``f`` by a an element of the ground domain. """
         return f.from_rep(f._rep * c, f.dom)
 
-    def _quo_ground(f, c):
+    def _quo_ground(f, c: Er, /) -> Self:
         """Quotient of ``f`` by a an element of the ground domain. """
         return f.from_rep(f._rep // c, f.dom)
 
-    def _exquo_ground(f, c):
+    def _exquo_ground(f, c: Er, /) -> Self:
         """Exact quotient of ``f`` by an element of the ground domain. """
         q, r = divmod(f._rep, c)
         if r:
             raise ExactQuotientFailed(f, c)
         return f.from_rep(q, f.dom)
 
-    def abs(f):
+    def abs(f) -> Self:
         """Make all coefficients in ``f`` positive. """
-        return f.to_DMP_Python().abs().to_DUP_Flint()
+        # XXX: to_DUP_Flint is not understood as returning Self...
+        return f.to_DMP_Python().abs().to_DUP_Flint() # type: ignore
 
-    def neg(f):
+    def neg(f) -> Self:
         """Negate all coefficients in ``f``. """
         return f.from_rep(-f._rep, f.dom)
 
-    def _add(f, g):
+    def _add(f, g: Self, /) -> Self:
         """Add two multivariate polynomials ``f`` and ``g``. """
         return f.from_rep(f._rep + g._rep, f.dom)
 
-    def _sub(f, g):
+    def _sub(f, g: Self, /) -> Self:
         """Subtract two multivariate polynomials ``f`` and ``g``. """
         return f.from_rep(f._rep - g._rep, f.dom)
 
-    def _mul(f, g):
+    def _mul(f, g: Self, /) -> Self:
         """Multiply two multivariate polynomials ``f`` and ``g``. """
         return f.from_rep(f._rep * g._rep, f.dom)
 
-    def sqr(f):
+    def sqr(f) -> Self:
         """Square a multivariate polynomial ``f``. """
         return f.from_rep(f._rep ** 2, f.dom)
 
-    def _pow(f, n):
+    def _pow(f, n: int, /) -> Self:
         """Raise ``f`` to a non-negative power ``n``. """
         return f.from_rep(f._rep ** n, f.dom)
 
-    def _pdiv(f, g):
+    def _pdiv(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial pseudo-division of ``f`` and ``g``. """
-        d = f.degree() - g.degree() + 1
+        # XXX: Handle the zero polynomial cases?
+        d: int = f.degree() - g.degree() + 1 # type: ignore
         q, r = divmod(g.LC()**d * f._rep, g._rep)
         return f.from_rep(q, f.dom), f.from_rep(r, f.dom)
 
-    def _prem(f, g):
+    def _prem(f, g: Self, /) -> Self:
         """Polynomial pseudo-remainder of ``f`` and ``g``. """
-        d = f.degree() - g.degree() + 1
+        # XXX: Handle the zero polynomial cases?
+        d: int = f.degree() - g.degree() + 1 # type: ignore
         q = (g.LC()**d * f._rep) % g._rep
         return f.from_rep(q, f.dom)
 
-    def _pquo(f, g):
+    def _pquo(f, g: Self, /) -> Self:
         """Polynomial pseudo-quotient of ``f`` and ``g``. """
-        d = f.degree() - g.degree() + 1
+        # XXX: Handle the zero polynomial cases?
+        d: int = f.degree() - g.degree() + 1 # type: ignore
         r = (g.LC()**d * f._rep) // g._rep
         return f.from_rep(r, f.dom)
 
-    def _pexquo(f, g):
+    def _pexquo(f, g: Self, /) -> Self:
         """Polynomial exact pseudo-quotient of ``f`` and ``g``. """
-        d = f.degree() - g.degree() + 1
+        # XXX: Handle the zero polynomial cases?
+        d: int = f.degree() - g.degree() + 1 # type: ignore
         q, r = divmod(g.LC()**d * f._rep, g._rep)
         if r:
             raise ExactQuotientFailed(f, g)
         return f.from_rep(q, f.dom)
 
-    def _div(f, g):
+    def _div(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial division with remainder of ``f`` and ``g``. """
         if f.dom.is_Field:
             q, r = divmod(f._rep, g._rep)
@@ -1969,64 +2117,64 @@ class DUP_Flint(DMP):
         else:
             # XXX: python-flint defines division in ZZ[x] differently
             q, r = f.to_DMP_Python()._div(g.to_DMP_Python())
-            return q.to_DUP_Flint(), r.to_DUP_Flint()
+            return q.to_DUP_Flint(), r.to_DUP_Flint() # type: ignore
 
-    def _rem(f, g):
+    def _rem(f, g: Self, /) -> Self:
         """Computes polynomial remainder of ``f`` and ``g``. """
         return f.from_rep(f._rep % g._rep, f.dom)
 
-    def _quo(f, g):
+    def _quo(f, g: Self, /) -> Self:
         """Computes polynomial quotient of ``f`` and ``g``. """
         return f.from_rep(f._rep // g._rep, f.dom)
 
-    def _exquo(f, g):
+    def _exquo(f, g: Self, /) -> Self:
         """Computes polynomial exact quotient of ``f`` and ``g``. """
         q, r = f._div(g)
         if r:
             raise ExactQuotientFailed(f, g)
         return q
 
-    def _degree(f, j=0):
+    def _degree(f, j: int) -> int | float:
         """Returns the leading degree of ``f`` in ``x_j``. """
         d = f._rep.degree()
         if d == -1:
             d = ninf
         return d
 
-    def degree_list(f):
+    def degree_list(f) -> tuple[int | float, ...]:
         """Returns a list of degrees of ``f``. """
-        return ( f._degree() ,)
+        return ( f._degree(0) ,)
 
-    def total_degree(f):
+    def total_degree(f) -> int | float:
         """Returns the total degree of ``f``. """
-        return f._degree()
+        return f._degree(0)
 
-    def LC(f):
+    def LC(f) -> Er:
         """Returns the leading coefficient of ``f``. """
         return f._rep[f._rep.degree()]
 
-    def TC(f):
+    def TC(f) -> Er:
         """Returns the trailing coefficient of ``f``. """
         return f._rep[0]
 
-    def _nth(f, N):
+    def _nth(f, N: tuple[int, ...]) -> Er:
         """Returns the ``n``-th coefficient of ``f``. """
         [n] = N
         return f._rep[n]
 
-    def max_norm(f):
+    def max_norm(f) -> Er:
         """Returns maximum norm of ``f``. """
         return f.to_DMP_Python().max_norm()
 
-    def l1_norm(f):
+    def l1_norm(f) -> Er:
         """Returns l1 norm of ``f``. """
         return f.to_DMP_Python().l1_norm()
 
-    def l2_norm_squared(f):
+    def l2_norm_squared(f) -> Er:
         """Return squared l2 norm of ``f``. """
         return f.to_DMP_Python().l2_norm_squared()
 
-    def clear_denoms(f):
+    def clear_denoms(f) -> tuple[Er, Self]:
         """Clear denominators, but keep the ground domain. """
         R = f.dom
         if R.is_QQ:
@@ -2038,7 +2186,7 @@ class DUP_Flint(DMP):
         else:
             raise NotImplementedError
 
-    def _integrate(f, m=1, j=0):
+    def _integrate(f, m: int, j: int) -> Self:
         """Computes the ``m``-th order indefinite integral of ``f`` in ``x_j``. """
         assert j == 0
         if f.dom.is_Field:
@@ -2047,9 +2195,9 @@ class DUP_Flint(DMP):
                 rep = rep.integral()
             return f.from_rep(rep, f.dom)
         else:
-            return f.to_DMP_Python()._integrate(m=m, j=j).to_DUP_Flint()
+            return f.to_DMP_Python()._integrate(m=m, j=j).to_DUP_Flint() # type: ignore
 
-    def _diff(f, m=1, j=0):
+    def _diff(f, m: int, j: int) -> Self:
         """Computes the ``m``-th order derivative of ``f``. """
         assert j == 0
         rep = f._rep
@@ -2057,28 +2205,28 @@ class DUP_Flint(DMP):
             rep = rep.derivative()
         return f.from_rep(rep, f.dom)
 
-    def _eval(f, a):
+    def _eval(f, a: Any, /) -> Any:
         # XXX: This method is called with many different input types. Ideally
         # we could use e.g. fmpz_poly.__call__ here but more thought needs to
         # go into which types this is supposed to be called with and what types
         # it should return.
         return f.to_DMP_Python()._eval(a)
 
-    def _eval_lev(f, a, j):
+    def _eval_lev(f, a: Any, j: int, /) -> Any:
         # Only makes sense for multivariate polynomials
         raise NotImplementedError
 
-    def _half_gcdex(f, g):
+    def _half_gcdex(f, g: Self) -> tuple[Self, Self]:
         """Half extended Euclidean algorithm. """
         s, h = f.to_DMP_Python()._half_gcdex(g.to_DMP_Python())
-        return s.to_DUP_Flint(), h.to_DUP_Flint()
+        return s.to_DUP_Flint(), h.to_DUP_Flint() # type: ignore
 
-    def _gcdex(f, g):
+    def _gcdex(f, g: Self) -> tuple[Self, Self, Self]:
         """Extended Euclidean algorithm. """
         h, s, t = f._rep.xgcd(g._rep)
         return f.from_rep(s, f.dom), f.from_rep(t, f.dom), f.from_rep(h, f.dom)
 
-    def _invert(f, g):
+    def _invert(f, g: Self) -> Self:
         """Invert ``f`` modulo ``g``, if possible. """
         R = f.dom
         if R.is_Field:
@@ -2091,46 +2239,46 @@ class DUP_Flint(DMP):
         else:
             # fmpz_poly does not have xgcd or invert and this is not well
             # defined in general.
-            return f.to_DMP_Python()._invert(g.to_DMP_Python()).to_DUP_Flint()
+            return f.to_DMP_Python()._invert(g.to_DMP_Python()).to_DUP_Flint() # type: ignore
 
-    def _revert(f, n):
+    def _revert(f, n: int) -> Self:
         """Compute ``f**(-1)`` mod ``x**n``. """
         # XXX: Use fmpz_series etc for reversion?
         # Maybe python-flint should provide revert for fmpz_poly...
-        return f.to_DMP_Python()._revert(n).to_DUP_Flint()
+        return f.to_DMP_Python()._revert(n).to_DUP_Flint() # type: ignore
 
-    def _subresultants(f, g):
+    def _subresultants(f, g: Self) -> list[Self]:
         """Computes subresultant PRS sequence of ``f`` and ``g``. """
         # XXX: Maybe _fmpz_poly_pseudo_rem_cohen could be used...
         R = f.to_DMP_Python()._subresultants(g.to_DMP_Python())
-        return [ g.to_DUP_Flint() for g in R ]
+        return [ g.to_DUP_Flint() for g in R ] # type: ignore
 
     def _resultant_includePRS(f, g):
         """Computes resultant of ``f`` and ``g`` via PRS. """
         # XXX: Maybe _fmpz_poly_pseudo_rem_cohen could be used...
         res, R = f.to_DMP_Python()._resultant_includePRS(g.to_DMP_Python())
-        return res, [ g.to_DUP_Flint() for g in R ]
+        return res, [ g.to_DUP_Flint() for g in R ] # type: ignore
 
-    def _resultant(f, g):
+    def _resultant(f, g: Self) -> Self:
         """Computes resultant of ``f`` and ``g``. """
         # XXX: Use fmpz_mpoly etc when possible...
-        return f.to_DMP_Python()._resultant(g.to_DMP_Python())
+        return f.to_DMP_Python()._resultant(g.to_DMP_Python()) # type: ignore
 
-    def discriminant(f):
+    def discriminant(f: Self) -> Er:
         """Computes discriminant of ``f``. """
         # XXX: Use fmpz_mpoly etc when possible...
-        return f.to_DMP_Python().discriminant()
+        return f.to_DMP_Python().discriminant() # type: ignore
 
-    def _cofactors(f, g):
+    def _cofactors(f, g: Self) -> tuple[Self, Self, Self]:
         """Returns GCD of ``f`` and ``g`` and their cofactors. """
         h = f.gcd(g)
         return h, f.exquo(h), g.exquo(h)
 
-    def _gcd(f, g):
+    def _gcd(f, g: Self) -> Self:
         """Returns polynomial GCD of ``f`` and ``g``. """
         return f.from_rep(f._rep.gcd(g._rep), f.dom)
 
-    def _lcm(f, g):
+    def _lcm(f, g: Self) -> Self:
         """Returns polynomial LCM of ``f`` and ``g``. """
         # XXX: python-flint should have a lcm method
         if not (f and g):
@@ -2140,12 +2288,13 @@ class DUP_Flint(DMP):
 
         if l.dom.is_Field:
             l = l.monic()
-        elif l.LC() < 0:
+        # XXX: Does this fail for GF(p)[x]?
+        elif l.LC() < 0: # type: ignore
             l = l.neg()
 
         return l
 
-    def _cancel(f, g):
+    def _cancel(f, g: Self) -> tuple[Er, Er, Self, Self]:
         """Cancel common factors in a rational function ``f/g``. """
         assert f.dom == g.dom
         R = f.dom
@@ -2166,14 +2315,16 @@ class DUP_Flint(DMP):
             cG, F = R.one, f
             cF, G = R.one, g
 
-        cH = cF.gcd(cG)
+        # XXX: Does this fail for GF(p)[x]?
+        cH = cF.gcd(cG) # type: ignore
         cF, cG = cF // cH, cG // cH
 
         H = F._gcd(G)
         F, G = F.exquo(H), G.exquo(H)
 
-        f_neg = F.LC() < 0
-        g_neg = G.LC() < 0
+        # XXX: Does this fail for GF(p)[x]?
+        f_neg = F.LC() < 0 # type: ignore
+        g_neg = G.LC() < 0 # type: ignore
 
         if f_neg and g_neg:
             F, G = F.neg(), G.neg()
@@ -2184,26 +2335,26 @@ class DUP_Flint(DMP):
 
         return cF, cG, F, G
 
-    def _cancel_include(f, g):
+    def _cancel_include(f, g: Self) -> tuple[Self, Self]:
         """Cancel common factors in a rational function ``f/g``. """
         cF, cG, F, G = f._cancel(g)
         return F._mul_ground(cF), G._mul_ground(cG)
 
-    def _trunc(f, p):
+    def _trunc(f, p: Er) -> Self:
         """Reduce ``f`` modulo a constant ``p``. """
-        return f.to_DMP_Python()._trunc(p).to_DUP_Flint()
+        return f.to_DMP_Python()._trunc(p).to_DUP_Flint() # type: ignore
 
-    def monic(f):
+    def monic(f) -> Self:
         """Divides all coefficients by ``LC(f)``. """
         # XXX: python-flint should add monic
         return f._exquo_ground(f.LC())
 
-    def content(f):
+    def content(f) -> Er:
         """Returns GCD of polynomial coefficients. """
         # XXX: python-flint should have a content method
         return f.to_DMP_Python().content()
 
-    def primitive(f):
+    def primitive(f) -> tuple[Er, Self]:
         """Returns content and a primitive form of ``f``. """
         cont = f.content()
         if f.is_zero:
@@ -2211,71 +2362,71 @@ class DUP_Flint(DMP):
         prim = f._exquo_ground(cont)
         return cont, prim
 
-    def _compose(f, g):
+    def _compose(f, g: Self) -> Self:
         """Computes functional composition of ``f`` and ``g``. """
         return f.from_rep(f._rep(g._rep), f.dom)
 
-    def _decompose(f):
+    def _decompose(f) -> list[Self]:
         """Computes functional decomposition of ``f``. """
-        return [ g.to_DUP_Flint() for g in f.to_DMP_Python()._decompose() ]
+        return [ g.to_DUP_Flint() for g in f.to_DMP_Python()._decompose() ] # type: ignore
 
-    def _shift(f, a):
+    def _shift(f, a: Er) -> Self:
         """Efficiently compute Taylor shift ``f(x + a)``. """
         x_plus_a = f._cls([a, f.dom.one])
         return f.from_rep(f._rep(x_plus_a), f.dom)
 
-    def _transform(f, p, q):
+    def _transform(f, p: Self, q: Self) -> Self:
         """Evaluate functional transformation ``q**n * f(p/q)``."""
         F, P, Q = f.to_DMP_Python(), p.to_DMP_Python(), q.to_DMP_Python()
-        return F.transform(P, Q).to_DUP_Flint()
+        return F.transform(P, Q).to_DUP_Flint() # type: ignore
 
-    def _sturm(f):
+    def _sturm(f) -> list[Self]:
         """Computes the Sturm sequence of ``f``. """
-        return [ g.to_DUP_Flint() for g in f.to_DMP_Python()._sturm() ]
+        return [ g.to_DUP_Flint() for g in f.to_DMP_Python()._sturm() ] # type: ignore
 
-    def _cauchy_upper_bound(f):
+    def _cauchy_upper_bound(f) -> Er:
         """Computes the Cauchy upper bound on the roots of ``f``. """
         return f.to_DMP_Python()._cauchy_upper_bound()
 
-    def _cauchy_lower_bound(f):
+    def _cauchy_lower_bound(f) -> Er:
         """Computes the Cauchy lower bound on the nonzero roots of ``f``. """
         return f.to_DMP_Python()._cauchy_lower_bound()
 
-    def _mignotte_sep_bound_squared(f):
+    def _mignotte_sep_bound_squared(f) -> Er:
         """Computes the squared Mignotte bound on root separations of ``f``. """
         return f.to_DMP_Python()._mignotte_sep_bound_squared()
 
-    def _gff_list(f):
+    def _gff_list(f) -> list[tuple[Self, int]]:
         """Computes greatest factorial factorization of ``f``. """
         F = f.to_DMP_Python()
-        return [ (g.to_DUP_Flint(), k) for g, k in F.gff_list() ]
+        return [ (g.to_DUP_Flint(), k) for g, k in F.gff_list() ] # type: ignore
 
-    def norm(f):
+    def norm(f) -> DMP:
         """Computes ``Norm(f)``."""
         # This is for algebraic number fields which DUP_Flint does not support
         raise NotImplementedError
 
-    def sqf_norm(f):
+    def sqf_norm(f) -> tuple[list[int], Self, DMP]:
         """Computes square-free norm of ``f``. """
         # This is for algebraic number fields which DUP_Flint does not support
         raise NotImplementedError
 
-    def sqf_part(f):
+    def sqf_part(f) -> Self:
         """Computes square-free part of ``f``. """
-        return f._exquo(f._gcd(f._diff()))
+        return f._exquo(f._gcd(f._diff(1, 0)))
 
-    def sqf_list(f, all=False):
+    def sqf_list(f, all=False) -> tuple[Er, list[tuple[Self, int]]]:
         """Returns a list of square-free factors of ``f``. """
         # XXX: python-flint should provide square free factorisation.
         coeff, factors = f.to_DMP_Python().sqf_list(all=all)
-        return coeff, [ (g.to_DUP_Flint(), k) for g, k in factors ]
+        return coeff, [ (g.to_DUP_Flint(), k) for g, k in factors ] # type: ignore
 
-    def sqf_list_include(f, all=False):
+    def sqf_list_include(f, all=False) -> list[tuple[Self, int]]:
         """Returns a list of square-free factors of ``f``. """
         factors = f.to_DMP_Python().sqf_list_include(all=all)
-        return [ (g.to_DUP_Flint(), k) for g, k in factors ]
+        return [ (g.to_DUP_Flint(), k) for g, k in factors ] # type: ignore
 
-    def factor_list(f):
+    def factor_list(f) -> tuple[Er, list[tuple[Self, int]]]:
         """Returns a list of irreducible factors of ``f``. """
 
         if f.dom.is_ZZ or f.dom.is_FF:
@@ -2305,7 +2456,7 @@ class DUP_Flint(DMP):
 
         return coeff, factors
 
-    def factor_list_include(f):
+    def factor_list_include(f) -> list[tuple[Self, int]]:
         """Returns a list of irreducible factors of ``f``. """
         # XXX: factor_list_include seems to be broken in general:
         #
@@ -2314,9 +2465,9 @@ class DUP_Flint(DMP):
         #
         # Let's not try to implement it here.
         factors = f.to_DMP_Python().factor_list_include()
-        return [ (g.to_DUP_Flint(), k) for g, k in factors ]
+        return [ (g.to_DUP_Flint(), k) for g, k in factors ] # type: ignore
 
-    def _sort_factors(f, factors):
+    def _sort_factors(f, factors: list[tuple[Self, int]]) -> list[tuple[Self, int]]:
         """Sort a list of factors to canonical order. """
         # Convert the factors to lists and use _sort_factors from polys
         factors = [ (g.to_list(), k) for g, k in factors ]
@@ -2324,86 +2475,98 @@ class DUP_Flint(DMP):
         to_dup_flint = lambda g: f.from_rep(f._cls(g[::-1]), f.dom)
         return [ (to_dup_flint(g), k) for g, k in factors ]
 
-    def _isolate_real_roots(f, eps, inf, sup, fast):
+    def _isolate_real_roots(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
         return f.to_DMP_Python()._isolate_real_roots(eps, inf, sup, fast)
 
-    def _isolate_real_roots_sqf(f, eps, inf, sup, fast):
+    def _isolate_real_roots_sqf(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[MPQ, MPQ], int]]:
         return f.to_DMP_Python()._isolate_real_roots_sqf(eps, inf, sup, fast)
 
-    def _isolate_all_roots(f, eps, inf, sup, fast):
+    def _isolate_all_roots(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
         # fmpz_poly and fmpq_poly have a complex_roots method that could be
         # used here. It probably makes more sense to add analogous methods in
         # python-flint though.
         return f.to_DMP_Python()._isolate_all_roots(eps, inf, sup, fast)
 
-    def _isolate_all_roots_sqf(f, eps, inf, sup, fast):
+    def _isolate_all_roots_sqf(
+        f, eps: MPQ | None, inf: MPQ | None, sup: MPQ | None, fast: bool
+    ) -> list[tuple[tuple[tuple[MPQ, MPQ], tuple[MPQ, MPQ]], int]]:
         return f.to_DMP_Python()._isolate_all_roots_sqf(eps, inf, sup, fast)
 
-    def _refine_real_root(f, s, t, eps, steps, fast):
+    def _refine_real_root(
+        f, s: MPQ, t: MPQ, eps: MPQ | None, steps: int | None, fast: bool
+    ) -> tuple[MPQ, MPQ]:
         return f.to_DMP_Python()._refine_real_root(s, t, eps, steps, fast)
 
-    def count_real_roots(f, inf=None, sup=None):
+    def count_real_roots(f, inf: MPQ | None = None, sup: MPQ | None = None) -> int:
         """Return the number of real roots of ``f`` in ``[inf, sup]``. """
         return f.to_DMP_Python().count_real_roots(inf=inf, sup=sup)
 
-    def count_complex_roots(f, inf=None, sup=None):
+    def count_complex_roots(
+        f, inf: tuple[MPQ, MPQ] | None = None, sup: tuple[MPQ, MPQ] | None = None
+    ) -> int:
         """Return the number of complex roots of ``f`` in ``[inf, sup]``. """
         return f.to_DMP_Python().count_complex_roots(inf=inf, sup=sup)
 
     @property
-    def is_zero(f):
+    def is_zero(f) -> bool:
         """Returns ``True`` if ``f`` is a zero polynomial. """
         return not f._rep
 
     @property
-    def is_one(f):
+    def is_one(f) -> bool:
         """Returns ``True`` if ``f`` is a unit polynomial. """
         return f._rep == f.dom.one
 
     @property
-    def is_ground(f):
+    def is_ground(f) -> bool:
         """Returns ``True`` if ``f`` is an element of the ground domain. """
         return f._rep.degree() <= 0
 
     @property
-    def is_linear(f):
+    def is_linear(f) -> bool:
         """Returns ``True`` if ``f`` is linear in all its variables. """
         return f._rep.degree() <= 1
 
     @property
-    def is_quadratic(f):
+    def is_quadratic(f) -> bool:
         """Returns ``True`` if ``f`` is quadratic in all its variables. """
         return f._rep.degree() <= 2
 
     @property
-    def is_monomial(f):
+    def is_monomial(f) -> bool:
         """Returns ``True`` if ``f`` is zero or has only one term. """
         fr = f._rep
         return fr.degree() < 0 or not any(fr[n] for n in range(fr.degree()))
 
     @property
-    def is_monic(f):
+    def is_monic(f) -> bool:
         """Returns ``True`` if the leading coefficient of ``f`` is one. """
         return f.LC() == f.dom.one
 
     @property
-    def is_primitive(f):
+    def is_primitive(f) -> bool:
         """Returns ``True`` if the GCD of the coefficients of ``f`` is one. """
         return f.to_DMP_Python().is_primitive
 
     @property
-    def is_homogeneous(f):
+    def is_homogeneous(f) -> bool:
         """Returns ``True`` if ``f`` is a homogeneous polynomial. """
         return f.to_DMP_Python().is_homogeneous
 
     @property
-    def is_sqf(f):
+    def is_sqf(f) -> bool:
         """Returns ``True`` if ``f`` is a square-free polynomial. """
         g = f._rep.gcd(f._rep.derivative())
         return g.degree() <= 0
 
     @property
-    def is_irreducible(f):
+    def is_irreducible(f) -> bool:
         """Returns ``True`` if ``f`` has no factors over its domain. """
         _, factors = f._rep.factor()
         if len(factors) == 0:
@@ -2414,13 +2577,15 @@ class DUP_Flint(DMP):
             return False
 
     @property
-    def is_cyclotomic(f):
+    def is_cyclotomic(f) -> bool:
         """Returns ``True`` if ``f`` is a cyclotomic polynomial. """
         if f.dom.is_QQ:
             try:
-                f = f.convert(ZZ)
+                fz = f.convert(ZZ)
             except CoercionFailed:
                 return False
+            else:
+                return fz.is_cyclotomic
         if f.dom.is_ZZ:
             return bool(f._rep.is_cyclotomic())
         else:
@@ -2833,7 +2998,7 @@ def init_normal_ANP(rep, mod, dom):
                dup_normal(mod, dom), dom)
 
 
-class ANP(CantSympify):
+class ANP(CantSympify, Generic[Eg]):
     """Dense Algebraic Number Polynomials over a field. """
 
     __slots__ = ('_rep', '_mod', 'dom')

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1897,8 +1897,8 @@ class Poly(Basic):
         if hasattr(f.rep, 'degree'):
             d = f.rep.degree(j)
             if d < 0:
-                d = S.NegativeInfinity
-            return d
+                return S.NegativeInfinity
+            return d # type: ignore
         else:  # pragma: no cover
             raise OperationNotSupported(f, 'degree')
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Main issue gh-27360
Follows PR gh-28177

#### Brief description of what is fixed or changed

Adds type annotations to all functions in `sympy/polys/densebasic.py` and most methods in DMP in `polyclasses.py`. Some related functions also have annotations added as needed to satisfy type checkers.

#### Other comments

Mostly these functions are quite well typed so this was easy enough.

Some problematic cases are `dup_degree`:
```python
In [2]: dup_degree([])
Out[2]: -inf

In [3]: dup_degree([1])
Out[3]: 0

In [4]: dup_degree([1,2])
Out[4]: 1
```
Having `int | float` as a return type propagates through to type confusion in many other places. It is possible to use `isinstance(d, float)` but it would be better if `dup_degree` just returns `-1`. I haven't changed that here but I might do in a followup.

Another awkward case is `dmp_ground`:
```python
In [6]: dmp_ground(3, 2)
Out[6]: [[[3]]]

In [7]: dmp_ground(3, 1)
Out[7]: [[3]]

In [8]: dmp_ground(3, 0)
Out[8]: [3]

In [9]: dmp_ground(3, -1)
Out[9]: 3
```
The last case with level `-1` is awkward and means that the return type is `dmp[Er] | Er`. This also applies to `dmp_zero` and `dmp_one`. I would like to remove this special case but I am not yet sure if it is actually depended on by anything.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * Type annotations have been added in some internal functions in the polys module.
<!-- END RELEASE NOTES -->
