### PR TITLE
Fix Latex printing of logarithm with base

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1406,6 +1406,7 @@ Sebastian Krause <sebastian.krause@gmx.de>
 Sebastian Kreft <skreft@gmail.com>
 Sebastian Krämer <basti.kr@gmail.com> basti.kr <devnull@localhost>
 Segev Finer <segev208@gmail.com>
+Ser Kim <serk.kmh@gmail.com> SK <78915702+sskserk@users.noreply.github.com>
 Sergey B Kirpichev <skirpichev@gmail.com>
 Sergey Pestov <pestov-sa@yandex.ru>
 Sergiu Ivanov <unlimitedscolobb@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1076,16 +1076,15 @@ class LatexPrinter(Printer):
             return tex
 
     def _print_log(self, expr, exp=None):
-        if not self._settings["ln_notation"]:
-            if len(expr.args) == 2:
-                argument = self._print(expr.args[0])
-                base = self._print(expr.args[1])
-                if len(base) == 1:
-                    tex = r"\log_%s{\left(%s \right)}" % (base, argument)
-                else:
-                    tex = r"\log_{%s}{\left(%s \right)}" % (base, argument)
+        if len(expr.args) == 2:
+            argument = self._print(expr.args[0])
+            base = self._print(expr.args[1])
+            if len(base) == 1:
+                tex = r"\log_%s{\left(%s \right)}" % (base, argument)
             else:
-                tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
+                tex = r"\log_{%s}{\left(%s \right)}" % (base, argument)
+        elif not self._settings["ln_notation"]:
+            tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
         else:
             tex = r"\ln{\left(%s \right)}" % self._print(expr.args[0])
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1077,7 +1077,15 @@ class LatexPrinter(Printer):
 
     def _print_log(self, expr, exp=None):
         if not self._settings["ln_notation"]:
-            tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
+            if len(expr.args) == 2:
+                argument = self._print(expr.args[0])
+                base = self._print(expr.args[1])
+                if len(base) == 1:
+                    tex = r"\log_%s{\left(%s \right)}" % (base, argument)
+                else:
+                    tex = r"\log_{%s}{\left(%s \right)}" % (base, argument)
+            else:
+                tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
         else:
             tex = r"\ln{\left(%s \right)}" % self._print(expr.args[0])
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1411,6 +1411,8 @@ def test_latex_log():
         r"\ln{\left(x \right)}^{x}"
     assert latex(log(x, y, evaluate=False)) == r"\log_y{\left(x \right)}"
     assert latex(log(x, 10, evaluate=False)) == r"\log_{10}{\left(x \right)}"
+    assert latex(log(x, y, evaluate=False), ln_notation=True) == r"\log_y{\left(x \right)}"
+    assert latex(log(x, 10, evaluate=False), ln_notation=True) == r"\log_{10}{\left(x \right)}"
 
 
 def test_issue_3568():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1409,6 +1409,8 @@ def test_latex_log():
     assert latex(pow(log(x), x)) == r"\log{\left(x \right)}^{x}"
     assert latex(pow(log(x), x), ln_notation=True) == \
         r"\ln{\left(x \right)}^{x}"
+    assert latex(log(x, y, evaluate=False)) == r"\log_y{\left(x \right)}"
+    assert latex(log(x, 10, evaluate=False)) == r"\log_{10}{\left(x \right)}"
 
 
 def test_issue_3568():


### PR DESCRIPTION
Continuation of the MR: https://github.com/sympy/sympy/pull/27078

Other comments
Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
   * Fix a bug where logarithm's base is not correctly printed in Latex.
<!-- END RELEASE NOTES -->

