### PR TITLE
Incorrect index permutation in tensor contraction with metric

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1776,4 +1776,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -357,6 +357,8 @@ Arie Bovenberg <a.c.bovenberg@gmail.com>
 Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
 Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
 Arihant Parsoya <parsoyaarihant@gmail.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arek <131872816+arkadiusz-trawinski@users.noreply.github.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>
 Arnab Nandi <arnabnandi2002@gmail.com>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
@@ -1776,5 +1778,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arek <131872816+arkadiusz-trawinski@users.noreply.github.com>
-Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1776,4 +1776,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arek <131872816+arkadiusz-trawinski@users.noreply.github.com>
 Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1776,3 +1776,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2210,7 +2210,7 @@ class TensExpr(Expr, ABC):
 
         array = tensorcontraction(tensorproduct(metric, array), (1, 2+pos))
         permu = list(range(dim))
-        permu[0], permu[pos] = permu[pos], permu[0]
+        permu.insert(pos, permu.pop(0))
         return permutedims(array, permu)
 
     @staticmethod

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1943,7 +1943,7 @@ def test_tensor_replacement():
     expr = K(i, j, k, -l)
     repl = {K(i,j,k,l): Array([ (i+1) for i in range(2**4)]).reshape(2,2,2,2), L: diag(1, -1)}
     assert expr.replace_with_arrays(repl) == Array([(i+1)*(-1)**i for i in range(2**4)]).reshape(2,2,2,2)
-    
+
     expr = H(j, k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     raises(ValueError, lambda: expr._extract_data(repl))

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1938,8 +1938,12 @@ def test_tensor_replacement():
 
     expr = K(i, j, -j, k)*A(-i)*A(-k)
     repl = {A(i): [1, 2], K(i,j,k,l): Array([1]*2**4).reshape(2,2,2,2), L: diag(1, -1)}
-    assert expr._extract_data(repl)
+    assert expr._extract_data(repl) == ([], 0)
 
+    expr = K(i, j, k, -l)
+    repl = {K(i,j,k,l): Array([ (i+1) for i in range(2**4)]).reshape(2,2,2,2), L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl) == Array([(i+1)*(-1)**i for i in range(2**4)]).reshape(2,2,2,2)
+    
     expr = H(j, k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     raises(ValueError, lambda: expr._extract_data(repl))


### PR DESCRIPTION
This pull request fixes a bug in the `_contract_and_permute_with_metric` method in [tensor.py](https://github.com/sympy/sympy/blob/master/sympy/tensor/tensor.py). The method is responsible for handling tensor contractions involving a metric tensor and permuting the resulting indices.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #15676
Fixes #17168
Fixes #17328
Fixes #17404
Fixes #27410

#### Brief description of what is fixed or changed
The original implementation used a simple swap `permu[0], permu[pos] = permu[pos], permu[0]` to position the index resulting from the contraction. This is incorrect as it only swaps the first element with the element at `pos`, rather than inserting the contracted index at the desired position while shifting the other indices.

This change replaces the incorrect swap with `permu.insert(pos, permu.pop(0))`. This correctly removes the first element (which represents the contracted index) and inserts it at the specified `pos`, shifting the subsequent elements to the right. This ensures that the resulting array from the contraction has the correct index ordering.

#### Other comments
This fix is necessary for accurate tensor contractions with metrics in SymPy's tensor module, particularly when using `replace_with_arrays`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fix incorrect index permutation in tensor contraction with metric
<!-- END RELEASE NOTES -->
