### PR TITLE
JDBetteridge/as_independent fix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -746,6 +746,7 @@ Ivan Petuhov <ivan@ostrovok.ru>
 Ivan Petukhov <satels@gmail.com>
 Ivan Tkachenko <me@ratijas.tk> ivan tkachenko <ratijas@users.noreply.github.com>
 Ivan Tkachenko <me@ratijas.tk> ratijas <ratijas@users.noreply.github.com>
+JDBetteridge <jack@devitocodes.com> <43041811+JDBetteridge@users.noreply.github.com>
 JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk> <kempj@tplxdt003.nat.physics.ox.ac.uk>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1941,14 +1941,14 @@ class Expr(Basic, EvalfMixin):
                 return has_other
             return has_other or e.has(*(e.free_symbols & sym))
 
-        if (want is not func or
-                func is not Add and func is not Mul):
+        if (not issubclass(func, want) or
+            not issubclass(func, Add) and not issubclass(func, Mul)):
             if has(self):
                 return (want.identity, self)
             else:
                 return (self, want.identity)
         else:
-            if func is Add:
+            if issubclass(func, Add):
                 args = list(self.args)
             else:
                 args, nc = self.args_cnc()
@@ -1956,15 +1956,15 @@ class Expr(Basic, EvalfMixin):
         d = sift(args, has)
         depend = d[True]
         indep = d[False]
-        if func is Add:  # all terms were treated as commutative
-            return (Add(*indep), _unevaluated_Add(*depend))
+        if issubclass(func, Add):  # all terms were treated as commutative
+            return (func(*indep), _unevaluated_Add(*depend))
         else:  # handle noncommutative by stopping at first dependent term
             for i, n in enumerate(nc):
                 if has(n):
                     depend.extend(nc[i:])
                     break
                 indep.append(n)
-            return Mul(*indep), _unevaluated_Mul(*depend)
+            return func(*indep), _unevaluated_Mul(*depend)
 
     def as_real_imag(self, deep=True, **hints) -> tuple[Expr, Expr]:
         """Performs complex expansion on 'self' and returns a tuple

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1941,12 +1941,16 @@ class Expr(Basic, EvalfMixin):
                 return has_other
             return has_other or e.has(*(e.free_symbols & sym))
 
-        if (not issubclass(func, want) or
-            not issubclass(func, Add) and not issubclass(func, Mul)):
+        if want is Add and not self.is_Add:
             if has(self):
-                return (want.identity, self)
+                return (S.Zero, self)
             else:
-                return (self, want.identity)
+                return (self, S.Zero)
+        elif want is Mul and not self.is_Mul:
+            if has(self):
+                return (S.One, self)
+            else:
+                return (self, S.One)
         else:
             if issubclass(func, Add):
                 args = list(self.args)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -17,7 +17,7 @@ from .sorting import default_sort_key
 from .kind import NumberKind
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.misc import as_int, func_name, filldedent
-from sympy.utilities.iterables import has_variety, sift, _sift_true_false
+from sympy.utilities.iterables import has_variety, _sift_true_false
 from mpmath.libmp import mpf_log, prec_to_dps
 from mpmath.libmp.libintmath import giant_steps
 
@@ -1775,36 +1775,45 @@ class Expr(Basic, EvalfMixin):
         else:
             return None
 
-    def as_independent(self, *deps, **hint) -> tuple[Expr, Expr]:
+    def as_independent(
+        self,
+        *deps: Basic | type[Basic],
+        as_Add: bool | None = None,
+        strict: bool = True,
+    ) -> tuple[Expr, Expr]:
         """
         A mostly naive separation of a Mul or Add into arguments that are not
         are dependent on deps. To obtain as complete a separation of variables
         as possible, use a separation method first, e.g.:
 
-        * separatevars() to change Mul, Add and Pow (including exp) into Mul
-        * .expand(mul=True) to change Add or Mul into Add
-        * .expand(log=True) to change log expr into an Add
+        * ``separatevars()`` to change Mul, Add and Pow (including exp) into Mul
+        * ``.expand(mul=True)`` to change Add or Mul into Add
+        * ``.expand(log=True)`` to change log expr into an Add
 
         The only non-naive thing that is done here is to respect noncommutative
-        ordering of variables and to always return (0, 0) for `self` of zero
-        regardless of hints.
+        ordering of variables and to always return ``(0, 0)`` for ``self`` of
+        zero regardless of hints.
 
-        For nonzero `self`, the returned tuple (i, d) has the
-        following interpretation:
+        For nonzero ``self``, the returned tuple ``(i, d)`` has the following
+        interpretation:
 
-        * i will has no variable that appears in deps
-        * d will either have terms that contain variables that are in deps, or
-          be equal to 0 (when self is an Add) or 1 (when self is a Mul)
-        * if self is an Add then self = i + d
-        * if self is a Mul then self = i*d
-        * otherwise (self, S.One) or (S.One, self) is returned.
+        * ``i`` has no variable that appears in deps
+        * ``d`` will either have terms that contain variables that are in deps,
+          or be equal to ``0`` (when ``self`` is an ``Add``) or ``1`` (when
+          ``self`` is a ``Mul``)
+        * if ``self`` is an Add then ``self = i + d``
+        * if ``self`` is a Mul then ``self = i*d``
+        * otherwise ``(self, S.One)`` or ``(S.One, self)`` is returned.
 
-        To force the expression to be treated as an Add, use the hint as_Add=True
+        To force the expression to be treated as an Add, use the argument
+        ``as_Add=True``.
+
+        The ``strict`` argument is deprecated and has no effect.
 
         Examples
         ========
 
-        -- self is an Add
+        -- ``self`` is an Add
 
         >>> from sympy import sin, cos, exp
         >>> from sympy.abc import x, y, z
@@ -1818,12 +1827,13 @@ class Expr(Basic, EvalfMixin):
         >>> (2*x*sin(x) + y + x + z).as_independent(x, y)
         (z, 2*x*sin(x) + x + y)
 
-        -- self is a Mul
+        -- ``self`` is a Mul
 
         >>> (x*sin(x)*cos(y)).as_independent(x)
         (cos(y), x*sin(x))
 
-        non-commutative terms cannot always be separated out when self is a Mul
+        Non-commutative terms cannot always be separated out when ``self`` is a
+        Mul
 
         >>> from sympy import symbols
         >>> n1, n2, n3 = symbols('n1 n2 n3', commutative=False)
@@ -1838,7 +1848,7 @@ class Expr(Basic, EvalfMixin):
         >>> ((x-n1)*(x-y)).as_independent(x)
         (1, (x - y)*(x - n1))
 
-        -- self is anything else:
+        -- ``self`` is anything else:
 
         >>> (sin(x)).as_independent(x)
         (1, sin(x))
@@ -1847,12 +1857,12 @@ class Expr(Basic, EvalfMixin):
         >>> exp(x+y).as_independent(x)
         (1, exp(x + y))
 
-        -- force self to be treated as an Add:
+        -- force ``self`` to be treated as an Add:
 
         >>> (3*x).as_independent(x, as_Add=True)
         (0, 3*x)
 
-        -- force self to be treated as a Mul:
+        -- force ``self`` to be treated as a Mul:
 
         >>> (3+x).as_independent(x, as_Add=False)
         (1, x + 3)
@@ -1865,9 +1875,9 @@ class Expr(Basic, EvalfMixin):
         >>> (y*(-3+x)).as_independent(x)
         (y, x - 3)
 
-        -- use .as_independent() for true independence testing instead
-           of .has(). The former considers only symbols in the free
-           symbols while the latter considers all symbols
+        -- use ``.as_independent()`` for true independence testing instead of
+           ``.has()``. The former considers only symbols in the free symbols
+           while the latter considers all symbols
 
         >>> from sympy import Integral
         >>> I = Integral(x, (x, 1, 2))
@@ -1880,10 +1890,10 @@ class Expr(Basic, EvalfMixin):
         >>> (I + x).as_independent(x) == (I, x)
         True
 
-        Note: when trying to get independent terms, a separation method
-        might need to be used first. In this case, it is important to keep
-        track of what you send to this routine so you know how to interpret
-        the returned values
+        Note: when trying to get independent terms, a separation method might
+        need to be used first. In this case, it is important to keep track of
+        what you send to this routine so you know how to interpret the returned
+        values
 
         >>> from sympy import separatevars, log
         >>> separatevars(exp(x+y)).as_independent(x)
@@ -1916,59 +1926,47 @@ class Expr(Basic, EvalfMixin):
         if self is S.Zero:
             return (self, self)
 
-        func = self.func
-        want: type[Add] | type[Mul]
-        if hint.get('as_Add', self.is_Add):
-            want = Add
+        if as_Add is None:
+            as_Add = self.is_Add
+
+        syms, other = _sift_true_false(deps, lambda d: isinstance(d, Symbol))
+        syms_set = set(syms)
+
+        if other:
+            def has(e):
+                return e.has_xfree(syms_set) or e.has(*other)
         else:
-            want = Mul
+            def has(e):
+                return e.has_xfree(syms_set)
 
-        # sift out deps into symbolic and other and ignore
-        # all symbols but those that are in the free symbols
-        sym = set()
-        other = []
-        for d in deps:
-            if isinstance(d, Symbol):  # Symbol.is_Symbol is True
-                sym.add(d)
-            else:
-                other.append(d)
+        if as_Add:
+            if not self.is_Add:
+                if has(self):
+                    return (S.Zero, self)
+                else:
+                    return (self, S.Zero)
 
-        def has(e):
-            """return the standard has() if there are no literal symbols, else
-            check to see that symbol-deps are in the free symbols."""
-            has_other = e.has(*other)
-            if not sym:
-                return has_other
-            return has_other or e.has(*(e.free_symbols & sym))
+            depend, indep = _sift_true_false(self.args, has)
+            return (self.func(*indep), _unevaluated_Add(*depend))
 
-        if want is Add and not self.is_Add:
-            if has(self):
-                return (S.Zero, self)
-            else:
-                return (self, S.Zero)
-        elif want is Mul and not self.is_Mul:
-            if has(self):
-                return (S.One, self)
-            else:
-                return (self, S.One)
         else:
-            if func.is_Add:
-                args = list(self.args)
-            else:
-                args, nc = self.args_cnc()
+            if not self.is_Mul:
+                if has(self):
+                    return (S.One, self)
+                else:
+                    return (self, S.One)
 
-        d = sift(args, has)
-        depend = d[True]
-        indep = d[False]
-        if func.is_Add:  # all terms were treated as commutative
-            return (func(*indep), _unevaluated_Add(*depend))
-        else:  # handle noncommutative by stopping at first dependent term
+            args, nc = self.args_cnc()
+            depend, indep = _sift_true_false(args, has)
+
+            # handle noncommutative by stopping at first dependent term
             for i, n in enumerate(nc):
                 if has(n):
                     depend.extend(nc[i:])
                     break
                 indep.append(n)
-            return func(*indep), _unevaluated_Mul(*depend)
+
+            return self.func(*indep), _unevaluated_Mul(*depend)
 
     def as_real_imag(self, deep=True, **hints) -> tuple[Expr, Expr]:
         """Performs complex expansion on 'self' and returns a tuple

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1918,7 +1918,7 @@ class Expr(Basic, EvalfMixin):
 
         func = self.func
         want: type[Add] | type[Mul]
-        if hint.get('as_Add', isinstance(self, Add) ):
+        if hint.get('as_Add', self.is_Add):
             want = Add
         else:
             want = Mul
@@ -1952,7 +1952,7 @@ class Expr(Basic, EvalfMixin):
             else:
                 return (self, S.One)
         else:
-            if issubclass(func, Add):
+            if func.is_Add:
                 args = list(self.args)
             else:
                 args, nc = self.args_cnc()
@@ -1960,7 +1960,7 @@ class Expr(Basic, EvalfMixin):
         d = sift(args, has)
         depend = d[True]
         indep = d[False]
-        if issubclass(func, Add):  # all terms were treated as commutative
+        if func.is_Add:  # all terms were treated as commutative
             return (func(*indep), _unevaluated_Add(*depend))
         else:  # handle noncommutative by stopping at first dependent term
             for i, n in enumerate(nc):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -860,6 +860,14 @@ def test_trunc():
     raises(TypeError, lambda: math.trunc(oo))
 
 
+class CustomAdd(Add):
+    pass
+
+
+class CustomMul(Mul):
+    pass
+
+
 def test_as_independent():
     assert S.Zero.as_independent(x, as_Add=True) == (0, 0)
     assert S.Zero.as_independent(x, as_Add=False) == (0, 0)
@@ -916,6 +924,22 @@ def test_as_independent():
     assert eq.as_independent(x) == (-6, Mul(x, 1/x, evaluate=False))
 
     assert (x*y).as_independent(z, as_Add=True) == (x*y, 0)
+
+    # subclassing Add and Mul
+    eq = CustomAdd(y, CustomMul(x, y), z)
+    ind, dep = eq.as_independent(x)
+    assert ind - (y + z) == 0
+    assert isinstance(ind, CustomAdd)
+    assert dep/(x*y) == 1
+    assert isinstance(dep, CustomMul)
+
+    eq = CustomMul(y, CustomAdd(x, y), z)
+    ind, dep = eq.as_independent(x)
+    assert ind/(y*z) == 1
+    assert isinstance(ind, CustomMul)
+    assert dep - (x + y) == 0
+    assert isinstance(dep, CustomAdd)
+
 
 @XFAIL
 def test_call_2():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -61,7 +61,7 @@ def test_issue_5223():
     assert D(x**2 + x**3*y**2, x, 2, y, 1).series(x).doit() == 12*x*y
     assert next(D(cos(x), x).lseries()) == D(1, x)
     assert D(
-        exp(x), x).series(n=3) == D(1, x) + D(x, x) + D(x**2/2, x) + D(x**3/6, x) + O(x**3)
+        exp(x), x).series(n=3) == D(x, x) + D(x**2/2, x) + D(x**3/6, x) + O(x**3)
 
     assert Integral(x, (x, 1, 3), (y, 1, x)).series(x) == -4 + 4*x
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
(External work in https://github.com/devitocodes/devito/pull/2559 requires reimplementing `as_independent` to work around this limitation)

#### Brief description of what is fixed or changed
Currently the `as_independent` method doesn't handle the case where subclasses of `Add` or `Mul` are used. This PR would extend the current functionality to support this.

#### Other comments
Consider this short script `example.py`:
```python
import sympy as sym
from sympy.abc import a, b, c

from textwrap import dedent

expr = [
    sym.Add(a, b), sym.Mul(a, b), b + a*b, b + a*b + c, b*(a + b),
    b*c*(a + b)
]

for e in expr:
    i, d = e.as_independent(a)
    print(dedent(f'''\
        expression: {e} ({type(e)})
        \tindependent of a: {i} ({type(i)})
        \tdependent on a  : {d} ({type(d)})
        '''
    ))
print('='*80 + '\n')

class MyCoolAdd(sym.Add):
    pass

class MyCoolMul(sym.Mul):
    pass

for e in expr:
    e = e.replace(sym.Mul, MyCoolMul).replace(sym.Add, MyCoolAdd)
    i, d = e.as_independent(a)
    print(dedent(f'''\
        expression: {e} ({type(e)})
        \tindependent of a: {i} ({type(i)})
        \tdependent on a  : {d} ({type(d)})
        '''
    ))
```
The output on master is:
```
$ python example.py 
expression: a + b (<class 'sympy.core.add.Add'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a (<class 'sympy.core.symbol.Symbol'>)

expression: a*b (<class 'sympy.core.mul.Mul'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a (<class 'sympy.core.symbol.Symbol'>)

expression: a*b + b (<class 'sympy.core.add.Add'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a*b (<class 'sympy.core.mul.Mul'>)

expression: a*b + b + c (<class 'sympy.core.add.Add'>)
	independent of a: b + c (<class 'sympy.core.add.Add'>)
	dependent on a  : a*b (<class 'sympy.core.mul.Mul'>)

expression: b*(a + b) (<class 'sympy.core.mul.Mul'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a + b (<class 'sympy.core.add.Add'>)

expression: b*c*(a + b) (<class 'sympy.core.mul.Mul'>)
	independent of a: b*c (<class 'sympy.core.mul.Mul'>)
	dependent on a  : a + b (<class 'sympy.core.add.Add'>)

================================================================================

expression: a + b (<class '__main__.MyCoolAdd'>)
	independent of a: 0 (<class 'sympy.core.numbers.Zero'>)
	dependent on a  : a + b (<class '__main__.MyCoolAdd'>)

expression: a*b (<class '__main__.MyCoolMul'>)
	independent of a: 1 (<class 'sympy.core.numbers.One'>)
	dependent on a  : a*b (<class '__main__.MyCoolMul'>)

expression: a*b + b (<class '__main__.MyCoolAdd'>)
	independent of a: 0 (<class 'sympy.core.numbers.Zero'>)
	dependent on a  : a*b + b (<class '__main__.MyCoolAdd'>)

expression: a*b + b + c (<class '__main__.MyCoolAdd'>)
	independent of a: 0 (<class 'sympy.core.numbers.Zero'>)
	dependent on a  : a*b + b + c (<class '__main__.MyCoolAdd'>)

expression: b*(a + b) (<class '__main__.MyCoolMul'>)
	independent of a: 1 (<class 'sympy.core.numbers.One'>)
	dependent on a  : b*(a + b) (<class '__main__.MyCoolMul'>)

expression: b*c*(a + b) (<class '__main__.MyCoolMul'>)
	independent of a: 1 (<class 'sympy.core.numbers.One'>)
	dependent on a  : b*c*(a + b) (<class '__main__.MyCoolMul'>)
```
With this PR one now obtains:
```
$ python example.py 
expression: a + b (<class 'sympy.core.add.Add'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a (<class 'sympy.core.symbol.Symbol'>)

expression: a*b (<class 'sympy.core.mul.Mul'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a (<class 'sympy.core.symbol.Symbol'>)

expression: a*b + b (<class 'sympy.core.add.Add'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a*b (<class 'sympy.core.mul.Mul'>)

expression: a*b + b + c (<class 'sympy.core.add.Add'>)
	independent of a: b + c (<class 'sympy.core.add.Add'>)
	dependent on a  : a*b (<class 'sympy.core.mul.Mul'>)

expression: b*(a + b) (<class 'sympy.core.mul.Mul'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a + b (<class 'sympy.core.add.Add'>)

expression: b*c*(a + b) (<class 'sympy.core.mul.Mul'>)
	independent of a: b*c (<class 'sympy.core.mul.Mul'>)
	dependent on a  : a + b (<class 'sympy.core.add.Add'>)

================================================================================

expression: a + b (<class '__main__.MyCoolAdd'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a (<class 'sympy.core.symbol.Symbol'>)

expression: a*b (<class '__main__.MyCoolMul'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a (<class 'sympy.core.symbol.Symbol'>)

expression: a*b + b (<class '__main__.MyCoolAdd'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a*b (<class '__main__.MyCoolMul'>)

expression: a*b + b + c (<class '__main__.MyCoolAdd'>)
	independent of a: b + c (<class '__main__.MyCoolAdd'>)
	dependent on a  : a*b (<class '__main__.MyCoolMul'>)

expression: b*(a + b) (<class '__main__.MyCoolMul'>)
	independent of a: b (<class 'sympy.core.symbol.Symbol'>)
	dependent on a  : a + b (<class '__main__.MyCoolAdd'>)

expression: b*c*(a + b) (<class '__main__.MyCoolMul'>)
	independent of a: b*c (<class '__main__.MyCoolMul'>)
	dependent on a  : a + b (<class '__main__.MyCoolAdd'>)
```
The latter seems to be the more desirable behaviour.

Feedback welcome :slightly_smiling_face: 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Extend `as_independent` method to handle subclasses of `Add` or `Mul`,
<!-- END RELEASE NOTES -->
