### PR TITLE
[GSoC] Updated max_bmoment() function to handle zero constant regions

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1148,7 +1148,7 @@ class Beam:
         >>> b.apply_load(50000, 10, -1)
         >>> b.solve_for_reaction_loads(p0, m0, p8)
         >>> b.max_bmoment()
-        (0, 233125/2)
+        ([0], 233125/2)
         """
         x = self.variable
         l = self.length


### PR DESCRIPTION
## Enhanced the `max_bmoment method

Fixes  #28211  

### Brief description of what is fixed or changed
The previous `max_bmoment` implementation failed to return desired result when there are zero constant regions it instead ran infinite loops.

### The new version
- Skips flat-zero regions 
- finds all points and intervals where maximum bending moment occurs and returns the result to give user to easily study his/her beam systems behaviour.

### Other comments
None.

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics

  * Updated max_bmoment() that can now handle zero or constant over regions and can return all points and intervals where maximum bending moment occurs.
<!-- END RELEASE NOTES -->
