### PR TITLE
polys: have dup_degree() return -1 for zero poly

### DIFF
--- a/sympy/physics/control/routh_table.py
+++ b/sympy/physics/control/routh_table.py
@@ -49,7 +49,7 @@ def negative_real_part_conditions(polynomial, var, /, *, domain=None):
     [a + 1 > 0, a*(a + 1)**3 > 0]
 
     """
-    p: Poly = Poly(polynomial, var, domain = domain)
+    p = Poly(polynomial, var, domain = domain)
 
     _, p = p.clear_denoms(convert=True)
 
@@ -266,7 +266,7 @@ class RouthHurwitz(MutableDenseMatrix):
         self._coeffs = self._polynomial.all_coeffs()
 
         self._zero_row_case = False
-        self._zero_col_infos: list[tuple] = []
+        self._zero_col_infos = []
         self._aux_poly_degrees = []
 
         if self._poly_degree < 1:

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -534,8 +534,8 @@ def dup_add(f: dup[Er], g: dup[Er], K: Domain[Er]) -> dup[Er]:
     if not g:
         return f
 
-    df: int = dup_degree(f) # type: ignore
-    dg: int = dup_degree(g) # type: ignore
+    df = dup_degree(f)
+    dg = dup_degree(g)
 
     if df == dg:
         return dup_strip([ a + b for a, b in zip(f, g) ])
@@ -567,12 +567,12 @@ def dmp_add(f: dmp[Er], g: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
     if not u:
         return _dmp(dup_add(_dup(f), _dup(g), K))
 
-    df: int = dmp_degree(f, u) # type: ignore
+    df = dmp_degree(f, u)
 
     if df < 0:
         return g
 
-    dg: int = dmp_degree(g, u) # type: ignore
+    dg = dmp_degree(g, u)
 
     if dg < 0:
         return f

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -42,7 +42,6 @@ from sympy.polys.densebasic import (
     dmp,
     dmp_tup,
     monom,
-    ninf,
     dmp_validate,
     dup_normal, dmp_normal,
     dup_convert, dmp_convert,
@@ -410,7 +409,7 @@ class DMP(CantSympify, Generic[Er]):
         if f.lev:
             raise PolynomialError('multivariate polynomials not supported')
 
-        n: int = f.degree() # type: ignore
+        n = f.degree()
 
         if n < 0:
             return [(0,)]
@@ -422,7 +421,7 @@ class DMP(CantSympify, Generic[Er]):
         if f.lev:
             raise PolynomialError('multivariate polynomials not supported')
 
-        n: int = f.degree() # type: ignore
+        n = f.degree()
 
         if n < 0:
             return [((0,), f.dom.zero)]
@@ -643,28 +642,28 @@ class DMP(CantSympify, Generic[Er]):
     def _exquo(f, g: Self, /) -> Self:
         raise NotImplementedError
 
-    def degree(f, j: int = 0) -> int | float:
+    def degree(f, j: int = 0) -> int:
         """Returns the leading degree of ``f`` in ``x_j``. """
         if not isinstance(j, int):
             raise TypeError("``int`` expected, got %s" % type(j))
 
         return f._degree(j)
 
-    def _degree(f, j: int, /) -> int | float:
+    def _degree(f, j: int, /) -> int:
         raise NotImplementedError
 
-    def degree_list(f) -> tuple[int | float, ...]:
+    def degree_list(f) -> tuple[int, ...]:
         """Returns a list of degrees of ``f``. """
         raise NotImplementedError
 
-    def total_degree(f) -> int | float:
+    def total_degree(f) -> int:
         """Returns the total degree of ``f``. """
         raise NotImplementedError
 
     def homogenize(f, s: int) -> DMP[Er]:
         """Return homogeneous polynomial of ``f``"""
         # XXX: Handle the zero polynomial case?
-        td: int = f.total_degree() # type: ignore
+        td = f.total_degree()
         result: dict[monom, Er] = {}
         new_symbol = (s == len(f.terms()[0][0]))
         for term in f.terms():
@@ -1557,11 +1556,11 @@ class DMP_Python(DMP[Er]):
         """Computes polynomial exact quotient of ``f`` and ``g``. """
         return f.per(dmp_exquo(f._rep, g._rep, f.lev, f.dom))
 
-    def _degree(f, j: int) -> int | float:
+    def _degree(f, j: int) -> int:
         """Returns the leading degree of ``f`` in ``x_j``. """
         return dmp_degree_in(f._rep, j, f.lev)
 
-    def degree_list(f) -> tuple[int | float, ...]:
+    def degree_list(f) -> tuple[int, ...]:
         """Returns a list of degrees of ``f``. """
         return dmp_degree_list(f._rep, f.lev)
 
@@ -2091,28 +2090,28 @@ class DUP_Flint(DMP[Er]):
     def _pdiv(f, g: Self, /) -> tuple[Self, Self]:
         """Polynomial pseudo-division of ``f`` and ``g``. """
         # XXX: Handle the zero polynomial cases?
-        d: int = f.degree() - g.degree() + 1 # type: ignore
+        d = f.degree() - g.degree() + 1
         q, r = divmod(g.LC()**d * f._rep, g._rep)
         return f.from_rep(q, f.dom), f.from_rep(r, f.dom)
 
     def _prem(f, g: Self, /) -> Self:
         """Polynomial pseudo-remainder of ``f`` and ``g``. """
         # XXX: Handle the zero polynomial cases?
-        d: int = f.degree() - g.degree() + 1 # type: ignore
+        d = f.degree() - g.degree() + 1
         q = (g.LC()**d * f._rep) % g._rep
         return f.from_rep(q, f.dom)
 
     def _pquo(f, g: Self, /) -> Self:
         """Polynomial pseudo-quotient of ``f`` and ``g``. """
         # XXX: Handle the zero polynomial cases?
-        d: int = f.degree() - g.degree() + 1 # type: ignore
+        d = f.degree() - g.degree() + 1
         r = (g.LC()**d * f._rep) // g._rep
         return f.from_rep(r, f.dom)
 
     def _pexquo(f, g: Self, /) -> Self:
         """Polynomial exact pseudo-quotient of ``f`` and ``g``. """
         # XXX: Handle the zero polynomial cases?
-        d: int = f.degree() - g.degree() + 1 # type: ignore
+        d = f.degree() - g.degree() + 1
         q, r = divmod(g.LC()**d * f._rep, g._rep)
         if r:
             raise ExactQuotientFailed(f, g)
@@ -2143,20 +2142,17 @@ class DUP_Flint(DMP[Er]):
             raise ExactQuotientFailed(f, g)
         return q
 
-    def _degree(f, j: int) -> int | float:
+    def _degree(f, j: int) -> int:
         """Returns the leading degree of ``f`` in ``x_j``. """
-        d = f._rep.degree()
-        if d == -1:
-            d = ninf
-        return d
+        return f._rep.degree()
 
-    def degree_list(f) -> tuple[int | float, ...]:
+    def degree_list(f) -> tuple[int, ...]:
         """Returns a list of degrees of ``f``. """
-        return ( f._degree(0) ,)
+        return ( f._rep.degree() ,)
 
-    def total_degree(f) -> int | float:
+    def total_degree(f) -> int:
         """Returns the total degree of ``f``. """
-        return f._degree(0)
+        return f._rep.degree()
 
     def LC(f) -> Er:
         """Returns the leading coefficient of ``f``. """

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1898,11 +1898,11 @@ class Poly(Basic):
             d = f.rep.degree(j)
             if d < 0:
                 return S.NegativeInfinity
-            return d # type: ignore
+            return d
         else:  # pragma: no cover
             raise OperationNotSupported(f, 'degree')
 
-    def degree_list(f):
+    def degree_list(f) -> tuple[int | NegativeInfinity, ...]:
         """
         Returns a list of degrees of ``f``.
 
@@ -1917,11 +1917,12 @@ class Poly(Basic):
 
         """
         if hasattr(f.rep, 'degree_list'):
-            return f.rep.degree_list()
+            degrees = f.rep.degree_list()
+            return tuple(d if d >= 0 else S.NegativeInfinity for d in degrees)
         else:  # pragma: no cover
             raise OperationNotSupported(f, 'degree_list')
 
-    def total_degree(f):
+    def total_degree(f) -> int | NegativeInfinity:
         """
         Returns the total degree of ``f``.
 
@@ -1938,7 +1939,8 @@ class Poly(Basic):
 
         """
         if hasattr(f.rep, 'total_degree'):
-            return f.rep.total_degree()
+            d = f.rep.total_degree()
+            return d if d >= 0 else S.NegativeInfinity
         else:  # pragma: no cover
             raise OperationNotSupported(f, 'total_degree')
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -16,7 +16,7 @@ from sympy.core.sympify import CantSympify, sympify
 from sympy.ntheory.multinomial import multinomial_coefficients
 from sympy.polys.compatibility import IPolys
 from sympy.polys.constructor import construct_domain
-from sympy.polys.densebasic import ninf, dmp_to_dict, dmp_from_dict
+from sympy.polys.densebasic import dmp_to_dict, dmp_from_dict
 from sympy.polys.domains.compositedomain import CompositeDomain
 from sympy.polys.domains.domain import Domain, Er, Es
 from sympy.polys.domains.domainelement import DomainElement
@@ -52,6 +52,9 @@ if TYPE_CHECKING:
 
 
 Mon = tuple[int, ...]
+
+
+ninf = float('-inf')
 
 
 @public

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -1,7 +1,6 @@
 """Tests for dense recursive polynomials' basic tools. """
 
 from sympy.polys.densebasic import (
-    ninf,
     dup_LC, dmp_LC,
     dup_TC, dmp_TC,
     dmp_ground_LC, dmp_ground_TC,
@@ -44,9 +43,9 @@ from sympy.polys.rings import ring
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises
 
-from sympy.core.numbers import oo
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
+
 
 def test_dup_LC():
     assert dup_LC([], ZZ) == 0
@@ -96,25 +95,24 @@ def test_dmp_true_LT():
 
 
 def test_dup_degree():
-    assert ninf == float('-inf')
-    assert dup_degree([]) is ninf
+    assert dup_degree([]) == -1
     assert dup_degree([1]) == 0
     assert dup_degree([1, 0]) == 1
     assert dup_degree([1, 0, 0, 0, 1]) == 4
 
 
 def test_dmp_degree():
-    assert dmp_degree([[]], 1) is ninf
-    assert dmp_degree([[[]]], 2) is ninf
+    assert dmp_degree([[]], 1) == -1
+    assert dmp_degree([[[]]], 2) == -1
 
     assert dmp_degree([[1]], 1) == 0
     assert dmp_degree([[2], [1]], 1) == 1
 
 
 def test_dmp_degree_in():
-    assert dmp_degree_in([[[]]], 0, 2) is ninf
-    assert dmp_degree_in([[[]]], 1, 2) is ninf
-    assert dmp_degree_in([[[]]], 2, 2) is ninf
+    assert dmp_degree_in([[[]]], 0, 2) == -1
+    assert dmp_degree_in([[[]]], 1, 2) == -1
+    assert dmp_degree_in([[[]]], 2, 2) == -1
 
     assert dmp_degree_in([[[1]]], 0, 2) == 0
     assert dmp_degree_in([[[1]]], 1, 2) == 0
@@ -133,7 +131,7 @@ def test_dmp_degree_in():
 
 
 def test_dmp_degree_list():
-    assert dmp_degree_list([[[[ ]]]], 3) == (-oo, -oo, -oo, -oo)
+    assert dmp_degree_list([[[[ ]]]], 3) == (-1, -1, -1, -1)
     assert dmp_degree_list([[[[1]]]], 3) == ( 0, 0, 0, 0)
 
     assert dmp_degree_list(f_0, 2) == (2, 2, 2)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -5,9 +5,8 @@ from functools import reduce
 from operator import add, mul
 
 from sympy.polys.domains import ZZ_I
-from sympy.polys.rings import ring, xring, sring, PolyRing, PolyElement, vring
+from sympy.polys.rings import ring, xring, sring, PolyRing, PolyElement, vring, ninf
 from sympy.polys.fields import field, FracField
-from sympy.polys.densebasic import ninf
 from sympy.polys.domains import ZZ, QQ, RR, FF, EX
 from sympy.polys.orderings import lex, grlex
 from sympy.polys.polyerrors import GeneratorsError, \


### PR DESCRIPTION
Previously dup_degree returned float('-inf') for zero polynomials along with all related functions like dmp_degree, dmp_degree_list, dmp_total_degree and similar methods on DMP. This commit changes all of these to return -1 instead.

The Poly class still returns -oo for zero polynomials. Also the sparse polynomials have not been changed. It probably makes sense to change those as well but they are somewhat more public than the dup_degree function and DMP class.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Follows gh-28236 adding type annotations to dup_degree etc.
Also follows gh-25784 which changed this from `-oo` to `float('-inf')`.


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The functions `dup_degree`, `dmp_degree`, etc now return `-1` for the zero polynomial rather than `float('-inf')`. Also the `DMP` class methods such as `degree` not return `-1` as well. This ensures that all of these functions have the well-defined return type `int` rather than `int | float`.
<!-- END RELEASE NOTES -->
