### PR TITLE
Apply recursive printing for Indexed in PythonCodePrinter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -483,6 +483,8 @@ Christopher J. Wright <cjwright4242gh@gmail.com>
 Clayton Rabideau <claytonrabideau@gmail.com> Zer0Credibility <cmr57@cam.ac.uk>
 Clemens Novak <clemens@familie-novak.net>
 Clément M.T. Robert <cr52@protonmail.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>  Teskann <47865674+Teskann@users.noreply.github.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>  Teskann <teskann.dev@protonmail.com>
 Coder-RG <rgoel1999@gmail.com> Rishabh Goel <rgoel1999@gmail.com>
 Cody Herbst <cyherbst@gmail.com>
 Colin B. Macdonald <cbm@m.fsf.org>

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -563,7 +563,7 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
     def _print_Indexed(self, expr):
         base = expr.args[0]
         index = expr.args[1:]
-        return "{}[{}]".format(str(base), ", ".join([self._print(ind) for ind in index]))
+        return "{}[{}]".format(self._print(base), ", ".join([self._print(ind) for ind in index]))
 
     def _print_Pow(self, expr, rational=False):
         return self._hprint_Pow(expr, rational=rational)

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -74,6 +74,27 @@ def test_PythonCodePrinter():
     assert prntr.doprint(Min(x, y)) == "min(x, y)"
     assert prntr.doprint(Max(x, y)) == "max(x, y)"
 
+def test_PythonCodePrinter_print_Indexed():
+    from sympy import Symbol
+
+    class CustomIndex(Symbol):
+        def __str__(self):
+            return f"not_printed_recursively({self.name})"
+
+    class CustomIndexed(IndexedBase):
+        def __str__(self):
+            return f"not_printed_recursively({self.name})"
+
+    class CustomPrinter(PythonCodePrinter):
+        def _print_CustomIndexed(self, expr):
+            return f"printed_recursively({expr.name})"
+        def _print_CustomIndex(self, expr):
+            return f"printed_recursively({expr.name})"
+
+    printer = CustomPrinter()
+    assert (printer.doprint(CustomIndexed('foo')[CustomIndex("a"), CustomIndex("b")]) ==
+            "printed_recursively(foo)[printed_recursively(a), printed_recursively(b)]")
+
 
 def test_PythonCodePrinter_standard():
     prntr = PythonCodePrinter()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28247 


#### Brief description of what is fixed or changed

- Previously, `PythonCodePrinter` did not apply recursive printing for the `base` part of the `Indexed` expressions
- Now printing is applied recursively on the base as well, not only on the indexes

#### Other comments

*(None)*

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY


See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug in `PythonCodePrinter` when printing `Indexed` expressions.
<!-- END RELEASE NOTES -->
