### PR TITLE
typ: fix type of dup_from_dict

### DIFF
--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1025,7 +1025,7 @@ def dmp_positive_p(f: dmp[Er], u: int, K: Domain[Er]) -> bool:
     return K.is_positive(dmp_ground_LC(f, u, K))
 
 
-def dup_from_dict(f: dict[tuple[int], Er] | dict[int, Er], K: Domain[Er]) -> dup[Er]:
+def dup_from_dict(f: dict[tuple[int], Er], K: Domain[Er]) -> dup[Er]:
     """
     Create a ``K[x]`` polynomial from a ``dict``.
 
@@ -1046,14 +1046,10 @@ def dup_from_dict(f: dict[tuple[int], Er] | dict[int, Er], K: Domain[Er]) -> dup
 
     n, h = max(f.keys()), []
 
-    if isinstance(n, int):
-        for k in range(n, -1, -1):
-            h.append(f.get(k, K.zero))  # type: ignore
-    else:
-        (n,) = n
+    (N,) = n
 
-        for k in range(n, -1, -1):
-            h.append(f.get((k,), K.zero))  # type: ignore
+    for k in range(N, -1, -1):
+        h.append(f.get((k,), K.zero))
 
     return dup_strip(h)
 

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -55,7 +55,7 @@ from sympy.polys.densebasic import (
     dmp_ground_nth,
     dmp_one, dmp_ground,
     dmp_zero, dmp_zero_p, dmp_one_p, dmp_ground_p,
-    dup_from_dict, dmp_from_dict,
+    dup_from_dict, dup_from_raw_dict, dmp_from_dict,
     dmp_to_dict,
     dmp_deflate,
     dmp_inject, dmp_eject,
@@ -239,6 +239,11 @@ class DMP(CantSympify, Generic[Er]):
     def from_dict(cls, rep: dict[monom, Er], lev: int, dom: Domain[Er]) -> DMP[Er]:
         rep_dmp = dmp_from_dict(rep, lev, dom)
         return cls.new(rep_dmp, dom, lev)
+
+    @classmethod
+    def from_raw_dict(cls, rep: dict[int, Er], dom: Domain[Er]) -> DMP[Er]:
+        rep_dup = dup_from_raw_dict(rep, dom)
+        return cls.new(_dmp(rep_dup), dom, 0)
 
     @classmethod
     def from_list(cls, rep: dmp[Any], lev: int, dom: Domain[Er]) -> DMP[Er]:
@@ -3012,7 +3017,14 @@ class ANP(CantSympify, Generic[Eg]):
         if isinstance(rep, DMP):
             pass
         elif type(rep) is dict: # don't use isinstance
-            rep = DMP(dup_from_dict(rep, dom), dom, 0)
+            # rep can be dict[tuple[int], ...] or dict[int, ...]
+            n = None
+            for n in rep:
+                break
+            if isinstance(n, int):
+                rep = DMP(dup_from_raw_dict(rep, dom), dom, 0)
+            else:
+                rep = DMP(dup_from_dict(rep, dom), dom, 0)
         else:
             if isinstance(rep, list):
                 rep = [dom.convert(a) for a in rep]
@@ -3023,7 +3035,7 @@ class ANP(CantSympify, Generic[Eg]):
         if isinstance(mod, DMP):
             pass
         elif isinstance(mod, dict):
-            mod = DMP(dup_from_dict(mod, dom), dom, 0)
+            mod = DMP(dup_from_raw_dict(mod, dom), dom, 0)
         else:
             mod = DMP(dup_strip(mod), dom, 0)
 


### PR DESCRIPTION
Previously dup_from_dict would accept either a dict with int keys or a dict with tuple-of-int keys. This commit fixes the type to be tuple-of-int leaving dup_from_raw_dict to handle the int case. The amiguous types are handled at a higher level in the Poly constructor or the ANP constructor instead.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Main issue is gh-27360. Follows gh-28250 and gh-28236.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * The `dup_from_dict` function now only accepts a dict with tuple keys rather than a dict that could have int or tuple keys. The `DMP.from_dict` function also now requires tuple keys and a `DMP.from_raw_dict` method is added that allows a function with `int` keys. The `Poly.from_dict` function still accepts both kinds of input.
<!-- END RELEASE NOTES -->