### PR TITLE
Add Series Expansion Support for Transcendental Functions in `poly/series`.

### DIFF
--- a/doc/src/explanation/gotchas.rst
+++ b/doc/src/explanation/gotchas.rst
@@ -581,9 +581,10 @@ Inverse Trig Functions
 
 SymPy uses different names for some functions than most computer algebra
 systems.  In particular, the inverse trig functions use the python names
-of :obj:`~.asin`, :obj:`~.acos` and so on instead of the usual ``arcsin``
-and ``arccos``.  Use the methods described in :ref:`Symbols <symbols>`
-above to see the names of all SymPy functions.
+of :obj:`~sympy.functions.elementary.trigonometric.asin`,
+:obj:`~sympy.functions.elementary.trigonometric.acos` and so on instead
+of the usual ``arcsin`` and ``arccos``.  Use the methods described in
+:ref:`Symbols <symbols>` above to see the names of all SymPy functions.
 
 Sqrt is not a Function
 ----------------------

--- a/doc/src/modules/polys/series.rst
+++ b/doc/src/modules/polys/series.rst
@@ -102,3 +102,8 @@ Flint Implementation
 
 .. autoclass:: FlintPowerSeriesRingQQ
     :members:
+
+.. py:class:: ZZSeries
+.. py:class:: QQSeries
+.. py:class:: MPZ
+.. py:class:: MPQ

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sympy.core.expr import Expr
 from typing import Protocol, Sequence, TypeVar
 from sympy.polys.domains import Domain
 from sympy.polys.domains.domain import Ef, Er
@@ -99,6 +100,10 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
 
     def series_prec(self, s: TSeries, /) -> int | None:
         """Return the precision of a power series."""
+        ...
+
+    def as_expr(self, s: TSeries, symbol: str, /) -> Expr:
+        """Return a power series as an expression."""
         ...
 
     def equal(self, s1: TSeries, s2: TSeries, /) -> bool | None:

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -93,6 +93,10 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
         """Return the coefficients of a power series as a list."""
         ...
 
+    def series_prec(self, s: TSeries, /) -> int | None:
+        """Return the precision of a power series."""
+        ...
+
     def equal(self, s1: TSeries, s2: TSeries, /) -> bool | None:
         """Check if two power series are equal."""
         ...

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -179,8 +179,16 @@ class PowerSeriesRingProtoQQ(PowerSeriesRingProto[TSeries, Ef], Protocol[TSeries
         """Return the logarithm of a power series."""
         ...
 
+    def log1p(self, s: TSeries, /) -> TSeries:
+        """Return the logarithm of (1 + s) for a power series with constant term."""
+        ...
+
     def exp(self, s: TSeries, /) -> TSeries:
         """Return the exponential of a power series."""
+        ...
+
+    def expm1(self, s: TSeries, /) -> TSeries:
+        """Return the exponential of a power series minus 1."""
         ...
 
     def atan(self, s: TSeries, /) -> TSeries:
@@ -221,4 +229,8 @@ class PowerSeriesRingProtoQQ(PowerSeriesRingProto[TSeries, Ef], Protocol[TSeries
 
     def cosh(self, s: TSeries, /) -> TSeries:
         """Return the hyperbolic cosine of a power series."""
+        ...
+
+    def hypot(self, s1: TSeries, s2: TSeries, /) -> TSeries:
+        """Return the hypotenuse of two power series."""
         ...

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol, Sequence, TypeVar
 from sympy.polys.domains import Domain
-from sympy.polys.domains.domain import Er
+from sympy.polys.domains.domain import Ef, Er
 from sympy.polys.densebasic import dup, dup_pretty
 
 
@@ -135,4 +135,92 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
 
     def truncate(self, s: TSeries, n: int, /) -> TSeries:
         """Truncate a power series to the first n terms."""
+        ...
+
+
+class PowerSeriesRingProtoZZ(PowerSeriesRingProto[TSeries, Er], Protocol[TSeries, Er]):
+    """A protocol for a power series ring over ZZ."""
+
+    def __call__(self, coeffs: Sequence[Er | int], prec: int | None = None) -> TSeries:
+        """Return a power series element over ZZ."""
+        ...
+
+    def compose(self, s1: TSeries, s2: TSeries, /) -> TSeries:
+        """Compose two power series."""
+        ...
+
+    def inverse(self, s: TSeries, /) -> TSeries:
+        """Return the inverse of a power series."""
+        ...
+
+    def reversion(self, s: TSeries, /) -> TSeries:
+        """Return the reversion of a power series."""
+        ...
+
+    def derivative(self, s: TSeries, /) -> TSeries:
+        """Return the derivative of a power series."""
+        ...
+
+
+class PowerSeriesRingProtoQQ(
+    PowerSeriesRingProtoZZ[TSeries, Ef], Protocol[TSeries, Ef]
+):
+    """A protocol for a power series ring over QQ."""
+
+    def __call__(
+        self, coeffs: Sequence[Ef | int | tuple[int, int]], prec: int | None = None
+    ) -> TSeries:
+        """Return a power series element over QQ."""
+        ...
+
+    def sqrt(self, s: TSeries, /) -> TSeries:
+        """Return the square root of a power seris."""
+        ...
+
+    def log(self, s: TSeries, /) -> TSeries:
+        """Return the logarithm of a power series."""
+        ...
+
+    def exp(self, s: TSeries, /) -> TSeries:
+        """Return the exponential of a power series."""
+        ...
+
+    def atan(self, s: TSeries, /) -> TSeries:
+        """Return the arctangent of a power series."""
+        ...
+
+    def atanh(self, s: TSeries, /) -> TSeries:
+        """Return the hyperbolic arctangent of a power series."""
+        ...
+
+    def asin(self, s: TSeries, /) -> TSeries:
+        """Return the arcsine of a power series."""
+        ...
+
+    def asinh(self, s: TSeries, /) -> TSeries:
+        """Return the hyperbolic arcsine of a power series."""
+        ...
+
+    def tan(self, s: TSeries, /) -> TSeries:
+        """Return the tangent of a power series."""
+        ...
+
+    def tanh(self, s: TSeries, /) -> TSeries:
+        """Return the hyperbolic tangent of a power series."""
+        ...
+
+    def sin(self, s: TSeries, /) -> TSeries:
+        """Return the sine of a power series."""
+        ...
+
+    def sinh(self, s: TSeries, /) -> TSeries:
+        """Return the hyperbolic sine of a power series."""
+        ...
+
+    def cos(self, s: TSeries, /) -> TSeries:
+        """Return the cosine of a power series."""
+        ...
+
+    def cosh(self, s: TSeries, /) -> TSeries:
+        """Return the hyperbolic cosine of a power series."""
         ...

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -44,8 +44,8 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
         """Return string representation of the ring."""
         ...
 
-    def __call__(self, coeffs: Sequence, prec: int | None = None) -> TSeries:
-        """Return a power series element."""
+    def __call__(self, coeffs: Sequence[Er | int], prec: int | None = None) -> TSeries:
+        """Return a power series element over ZZ."""
         ...
 
     @property
@@ -145,14 +145,6 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
         """Truncate a power series to the first n terms."""
         ...
 
-
-class PowerSeriesRingProtoZZ(PowerSeriesRingProto[TSeries, Er], Protocol[TSeries, Er]):
-    """A protocol for a power series ring over ZZ."""
-
-    def __call__(self, coeffs: Sequence[Er | int], prec: int | None = None) -> TSeries:
-        """Return a power series element over ZZ."""
-        ...
-
     def compose(self, s1: TSeries, s2: TSeries, /) -> TSeries:
         """Compose two power series."""
         ...
@@ -165,14 +157,12 @@ class PowerSeriesRingProtoZZ(PowerSeriesRingProto[TSeries, Er], Protocol[TSeries
         """Return the reversion of a power series."""
         ...
 
-    def derivative(self, s: TSeries, /) -> TSeries:
+    def differentiate(self, s: TSeries, /) -> TSeries:
         """Return the derivative of a power series."""
         ...
 
 
-class PowerSeriesRingProtoQQ(
-    PowerSeriesRingProtoZZ[TSeries, Ef], Protocol[TSeries, Ef]
-):
+class PowerSeriesRingProtoQQ(PowerSeriesRingProto[TSeries, Ef], Protocol[TSeries, Ef]):
     """A protocol for a power series ring over QQ."""
 
     def __call__(

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -93,6 +93,10 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
         """Return the coefficients of a power series as a list."""
         ...
 
+    def to_dense(self, s: TSeries, /) -> dup[Er]:
+        """Return the coefficients of a power series as a dense list."""
+        ...
+
     def series_prec(self, s: TSeries, /) -> int | None:
         """Return the precision of a power series."""
         ...

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from sympy.core.expr import Expr
 from typing import Protocol, Sequence, TypeVar
 from sympy.polys.domains import Domain
 from sympy.polys.domains.domain import Ef, Er
@@ -100,10 +99,6 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
 
     def series_prec(self, s: TSeries, /) -> int | None:
         """Return the precision of a power series."""
-        ...
-
-    def as_expr(self, s: TSeries, symbol: str, /) -> Expr:
-        """Return a power series as an expression."""
         ...
 
     def equal(self, s1: TSeries, s2: TSeries, /) -> bool | None:

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -833,3 +833,19 @@ class FlintPowerSeriesRingQQ:
             return fmpq_series(poly, prec=self._prec)
         with _global_cap(self._prec):
             return s.integral()
+
+    def log(self, s: QQSeries) -> QQSeries:
+        """Compute the logarithm of a power series."""
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.log()
+
+    def exp(self, s: QQSeries) -> QQSeries:
+        """Compute the exponential of a power series."""
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.exp()

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -842,6 +842,8 @@ class FlintPowerSeriesRingQQ:
     def log(self, s: QQSeries) -> QQSeries:
         """Compute the logarithm of a power series."""
         if isinstance(s, fmpq_poly):
+            if s == 1:
+                return fmpq_poly([])
             s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):
@@ -849,8 +851,33 @@ class FlintPowerSeriesRingQQ:
 
     def exp(self, s: QQSeries) -> QQSeries:
         """Compute the exponential of a power series."""
+        if not s:
+            return s
+
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):
             return s.exp()
+
+    def atan(self, s: QQSeries) -> QQSeries:
+        """Compute the arctangent of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.atan()
+
+    def tan(self, s: QQSeries) -> QQSeries:
+        """Compute the tangent of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.tan()

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Sequence, Union, TYPE_CHECKING
 
-from sympy.core.expr import Expr
 from sympy.polys.densebasic import dup, dup_reverse
 from sympy.polys.domains import Domain, QQ, ZZ
-from sympy.polys.series.ringpython import _useries_valuation, _useries_to_sympy_expr
+from sympy.polys.series.ringpython import _useries_valuation
 from sympy.polys.series.base import series_pprint
 from sympy.external.gmpy import GROUND_TYPES, MPZ, MPQ
 from sympy.utilities.decorator import doctest_depends_on
@@ -220,15 +219,6 @@ class FlintPowerSeriesRingZZ:
         if isinstance(s, fmpz_poly):
             return None
         return _get_series_precision(s)
-
-    def as_expr(self, s: ZZSeries, symbol: str = "x") -> Expr:
-        """Convert a power series to a SymPy expression."""
-        coeffs = self.to_dense(s)
-        if isinstance(s, fmpz_poly):
-            s = coeffs, None
-        else:
-            s = coeffs, _get_series_precision(s)
-        return _useries_to_sympy_expr(s, symbol)
 
     def equal(self, s1: ZZSeries, s2: ZZSeries) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""
@@ -663,15 +653,6 @@ class FlintPowerSeriesRingQQ:
         if isinstance(s, fmpq_poly):
             return None
         return _get_series_precision(s)
-
-    def as_expr(self, s: QQSeries, symbol: str = "x") -> Expr:
-        """Convert a power series to a SymPy expression."""
-        coeffs = self.to_dense(s)
-        if isinstance(s, fmpq_poly):
-            s = coeffs, None
-        else:
-            s = coeffs, _get_series_precision(s)
-        return _useries_to_sympy_expr(s, symbol)
 
     def equal(self, s1: QQSeries, s2: QQSeries) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Sequence, Union, TYPE_CHECKING
 
-from sympy.polys.densebasic import dup_reverse
+from sympy.polys.densebasic import dup, dup_reverse
 from sympy.polys.domains import Domain, QQ, ZZ
 from sympy.polys.series.ringpython import _useries_valuation
 from sympy.polys.series.base import series_pprint
@@ -196,6 +196,10 @@ class FlintPowerSeriesRingZZ:
     def to_list(self, s: ZZSeries) -> list[MPZ]:
         """Returns the list of series coefficients."""
         return s.coeffs()
+
+    def to_dense(self, s: ZZSeries) -> dup[MPZ]:
+        """Return the coefficients of a power series as a dense list."""
+        return s.coeffs()[::-1]
 
     def series_prec(self, s: ZZSeries) -> int | None:
         """Return the precision of the series."""
@@ -596,6 +600,10 @@ class FlintPowerSeriesRingQQ:
         """Returns the list of series coefficients."""
         return s.coeffs()
 
+    def to_dense(self, s: QQSeries) -> dup[MPQ]:
+        """Return the coefficients of a power series as a dense list."""
+        return s.coeffs()[::-1]
+
     def series_prec(self, s: QQSeries) -> int | None:
         """Return the precision of the series."""
         if isinstance(s, fmpq_poly):
@@ -972,10 +980,9 @@ class FlintPowerSeriesRingQQ:
 
     def cos(self, s: QQSeries) -> QQSeries:
         """Compute the cosine of a power series."""
-        if not s:
-            return s
-
         if isinstance(s, fmpq_poly):
+            if not s:
+                return fmpq_poly([1])
             s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):
@@ -983,10 +990,9 @@ class FlintPowerSeriesRingQQ:
 
     def cosh(self, s: QQSeries) -> QQSeries:
         """Compute the hyperbolic cosine of a power series."""
-        if not s:
-            return s
-
         if isinstance(s, fmpq_poly):
+            if not s:
+                return fmpq_poly([1])
             s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -729,6 +729,17 @@ class FlintPowerSeriesRingQQ:
         """Compute the square of a power series."""
         return self.pow_int(s, 2)
 
+    def sqrt(self, s: QQSeries) -> QQSeries:
+        """Compute the square root of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.sqrt()
+
     def compose(self, s1: QQSeries, s2: QQSeries) -> QQSeries:
         """Compose two power series, `s1(s2)`."""
         dom: Domain[MPQ] = self._domain
@@ -870,6 +881,39 @@ class FlintPowerSeriesRingQQ:
         with _global_cap(self._prec):
             return s.atan()
 
+    def atanh(self, s: QQSeries) -> QQSeries:
+        """Compute the hyperbolic arctangent of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.atanh()
+
+    def asin(self, s: QQSeries) -> QQSeries:
+        """Compute the arcsine of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.asin()
+
+    def asinh(self, s: QQSeries) -> QQSeries:
+        """Compute the hyperbolic arcsine of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.asinh()
+
     def tan(self, s: QQSeries) -> QQSeries:
         """Compute the tangent of a power series."""
         if not s:
@@ -880,6 +924,17 @@ class FlintPowerSeriesRingQQ:
 
         with _global_cap(self._prec):
             return s.tan()
+
+    def tanh(self, s: QQSeries) -> QQSeries:
+        """Compute the hyperbolic tangent of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.tanh()
 
     def sin(self, s: QQSeries) -> QQSeries:
         """Compute the sine of a power series."""
@@ -892,6 +947,17 @@ class FlintPowerSeriesRingQQ:
         with _global_cap(self._prec):
             return s.sin()
 
+    def sinh(self, s: QQSeries) -> QQSeries:
+        """Compute the hyperbolic sine of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.sinh()
+
     def cos(self, s: QQSeries) -> QQSeries:
         """Compute the cosine of a power series."""
         if not s:
@@ -902,3 +968,14 @@ class FlintPowerSeriesRingQQ:
 
         with _global_cap(self._prec):
             return s.cos()
+
+    def cosh(self, s: QQSeries) -> QQSeries:
+        """Compute the hyperbolic cosine of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.cosh()

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -851,10 +851,9 @@ class FlintPowerSeriesRingQQ:
 
     def exp(self, s: QQSeries) -> QQSeries:
         """Compute the exponential of a power series."""
-        if not s:
-            return s
-
         if isinstance(s, fmpq_poly):
+            if not s:
+                return fmpq_poly([1])
             s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):
@@ -881,3 +880,25 @@ class FlintPowerSeriesRingQQ:
 
         with _global_cap(self._prec):
             return s.tan()
+
+    def sin(self, s: QQSeries) -> QQSeries:
+        """Compute the sine of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.sin()
+
+    def cos(self, s: QQSeries) -> QQSeries:
+        """Compute the cosine of a power series."""
+        if not s:
+            return s
+
+        if isinstance(s, fmpq_poly):
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.cos()

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -920,7 +920,7 @@ class FlintPowerSeriesRingQQ:
         """Compute the exponential of a power series minus 1."""
         if isinstance(s, fmpq_poly):
             if not s:
-                return fmpq_poly([-1])
+                return fmpq_poly([])
             s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -184,7 +184,7 @@ class FlintPowerSeriesRingZZ:
         if isinstance(s, fmpz_poly):
             return series_pprint(coeffs, None)
 
-        prec = _get_series_precision(s)
+        prec = self.series_prec(s)
         return series_pprint(coeffs, prec, sym=symbol, ascending=ascending)
 
     def print(self, s: ZZSeries, *, symbol: str = "x", ascending: bool = True) -> None:
@@ -225,9 +225,9 @@ class FlintPowerSeriesRingZZ:
         if isinstance(s1, fmpz_poly) and isinstance(s2, fmpz_poly):
             return s1 == s2
         elif isinstance(s1, fmpz_poly):
-            min_prec = _get_series_precision(s2)
+            min_prec = self.series_prec(s2)
         elif isinstance(s2, fmpz_poly):
-            min_prec = _get_series_precision(s1)
+            min_prec = self.series_prec(s1)
         else:
             min_prec = min(_get_series_precision(s1), _get_series_precision(s2))
 
@@ -406,13 +406,13 @@ class FlintPowerSeriesRingZZ:
                     return s1(s2)
 
         if isinstance(s1, fmpz_poly):
-            prec2: int = _get_series_precision(s2)
+            prec2 = self.series_prec(s2)
             s1 = fmpz_series(s1, prec=prec2)
         else:
             s1 = _cap_series_prec(s1, ring_prec)
 
         if isinstance(s2, fmpz_poly):
-            prec1: int = _get_series_precision(s1)
+            prec1 = self.series_prec(s1)
             s2 = fmpz_series(s2, prec=prec1)
         else:
             s2 = _cap_series_prec(s2, ring_prec)
@@ -618,7 +618,7 @@ class FlintPowerSeriesRingQQ:
         if isinstance(s, fmpq_poly):
             return series_pprint(coeffs, None)
 
-        prec = _get_series_precision(s)
+        prec = self.series_prec(s)
         return series_pprint(coeffs, prec, sym=symbol, ascending=ascending)
 
     def print(self, s: QQSeries, *, symbol: str = "x", ascending: bool = True) -> None:
@@ -659,9 +659,9 @@ class FlintPowerSeriesRingQQ:
         if isinstance(s1, fmpq_poly) and isinstance(s2, fmpq_poly):
             return s1 == s2
         elif isinstance(s1, fmpq_poly):
-            min_prec = _get_series_precision(s2)
+            min_prec = self.series_prec(s2)
         elif isinstance(s2, fmpq_poly):
-            min_prec = _get_series_precision(s1)
+            min_prec = self.series_prec(s1)
         else:
             min_prec = min(_get_series_precision(s1), _get_series_precision(s2))
 
@@ -851,13 +851,13 @@ class FlintPowerSeriesRingQQ:
                     return s1(s2)
 
         if isinstance(s1, fmpq_poly):
-            prec2: int = _get_series_precision(s2)
+            prec2 = self.series_prec(s2)
             s1 = fmpq_series(s1, prec=prec2)
         else:
             s1 = _cap_series_prec(s1, ring_prec)
 
         if isinstance(s2, fmpq_poly):
-            prec1: int = _get_series_precision(s1)
+            prec1 = self.series_prec(s1)
             s2 = fmpq_series(s2, prec=prec1)
         else:
             s2 = _cap_series_prec(s2, ring_prec)

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -197,6 +197,12 @@ class FlintPowerSeriesRingZZ:
         """Returns the list of series coefficients."""
         return s.coeffs()
 
+    def series_prec(self, s: ZZSeries) -> int | None:
+        """Return the precision of the series."""
+        if isinstance(s, fmpz_poly):
+            return None
+        return _get_series_precision(s)
+
     def equal(self, s1: ZZSeries, s2: ZZSeries) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""
         if isinstance(s1, fmpz_poly) and isinstance(s2, fmpz_poly):
@@ -589,6 +595,12 @@ class FlintPowerSeriesRingQQ:
     def to_list(self, s: QQSeries) -> list[MPQ]:
         """Returns the list of series coefficients."""
         return s.coeffs()
+
+    def series_prec(self, s: QQSeries) -> int | None:
+        """Return the precision of the series."""
+        if isinstance(s, fmpq_poly):
+            return None
+        return _get_series_precision(s)
 
     def equal(self, s1: QQSeries, s2: QQSeries) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -894,6 +894,18 @@ class FlintPowerSeriesRingQQ:
         with _global_cap(self._prec):
             return s.log()
 
+    def log1p(self, s: QQSeries) -> QQSeries:
+        """Compute the logarithm of (1 + s) for a power series with zero constant term."""
+        if s[0] != 0:
+            raise ValueError(
+                "Log1p requires the constant term of the input series to be zero."
+            )
+
+        with _global_cap(self._prec):
+            s = s + 1
+
+        return self.log(s)
+
     def exp(self, s: QQSeries) -> QQSeries:
         """Compute the exponential of a power series."""
         if isinstance(s, fmpq_poly):
@@ -903,6 +915,16 @@ class FlintPowerSeriesRingQQ:
 
         with _global_cap(self._prec):
             return s.exp()
+
+    def expm1(self, s: QQSeries) -> QQSeries:
+        """Compute the exponential of a power series minus 1."""
+        if isinstance(s, fmpq_poly):
+            if not s:
+                return fmpq_poly([-1])
+            s = fmpq_series(s, prec=self._prec)
+
+        with _global_cap(self._prec):
+            return s.exp() - 1
 
     def atan(self, s: QQSeries) -> QQSeries:
         """Compute the arctangent of a power series."""
@@ -1011,3 +1033,13 @@ class FlintPowerSeriesRingQQ:
 
         with _global_cap(self._prec):
             return s.cosh()
+
+    def hypot(self, s1: QQSeries, s2: QQSeries) -> QQSeries:
+        """Compute the hypotenuse of two power series."""
+
+        with _global_cap(self._prec):
+            sqr_s1 = s1**2
+            sqr_s2 = s2**2
+            add = sqr_s1 + sqr_s2
+
+        return self.sqrt(add)

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -37,17 +37,6 @@ def _get_series_precision(s: fmpz_series | fmpq_series) -> int:
     return prec
 
 
-def _cap_series_prec(
-    s: fmpz_series | fmpq_series, ring_prec: int
-) -> fmpz_series | fmpq_series:
-    """Coerce a series to the specified precision."""
-    series_prec = _get_series_precision(s)
-    if series_prec > ring_prec:
-        return fmpz_series(s, prec=ring_prec)
-    else:
-        return s
-
-
 @contextmanager
 def _global_cap(cap: int):
     """Temporarily set the global series cap within a context."""
@@ -273,10 +262,6 @@ class FlintPowerSeriesRingZZ:
             if poly.degree() < ring_prec:
                 return poly
             return fmpz_series(poly, prec=ring_prec)
-        elif isinstance(s1, fmpz_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpz_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 + s2
@@ -289,10 +274,6 @@ class FlintPowerSeriesRingZZ:
             if poly.degree() < ring_prec:
                 return poly
             return fmpz_series(poly, prec=ring_prec)
-        elif isinstance(s1, fmpz_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpz_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 - s2
@@ -313,10 +294,6 @@ class FlintPowerSeriesRingZZ:
                     s2 = self.truncate(s2, ring_prec)
 
                 return fmpz_series(s1 * s2, prec=ring_prec)
-        elif isinstance(s1, fmpz_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpz_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 * s2
@@ -329,8 +306,6 @@ class FlintPowerSeriesRingZZ:
             if poly.degree() < ring_prec:
                 return poly
             return fmpz_series(poly, prec=ring_prec)
-        else:
-            s = _cap_series_prec(s, ring_prec)
 
         with _global_cap(ring_prec):
             return s * n
@@ -347,10 +322,6 @@ class FlintPowerSeriesRingZZ:
                 )
                 s1 = fmpz_series(s1, prec=ring_prec)
                 s2 = fmpz_series(s2, prec=ring_prec)
-        elif isinstance(s1, fmpz_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpz_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 / s2
@@ -369,8 +340,6 @@ class FlintPowerSeriesRingZZ:
                 s = self.truncate(s, ring_prec)
             poly = s**n
             return fmpz_series(poly, prec=ring_prec)
-        else:
-            s = _cap_series_prec(s, ring_prec)
 
         with _global_cap(ring_prec):
             return s**n
@@ -408,14 +377,10 @@ class FlintPowerSeriesRingZZ:
         if isinstance(s1, fmpz_poly):
             prec2 = self.series_prec(s2)
             s1 = fmpz_series(s1, prec=prec2)
-        else:
-            s1 = _cap_series_prec(s1, ring_prec)
 
         if isinstance(s2, fmpz_poly):
             prec1 = self.series_prec(s1)
             s2 = fmpz_series(s2, prec=prec1)
-        else:
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1(s2)
@@ -434,8 +399,6 @@ class FlintPowerSeriesRingZZ:
             if len(s) == 1:
                 return 1 / s
             s = fmpz_series(s, prec=ring_prec)
-        else:
-            s = _cap_series_prec(s, ring_prec)
 
         with _global_cap(ring_prec):
             return 1 / s
@@ -456,8 +419,6 @@ class FlintPowerSeriesRingZZ:
 
         if isinstance(s, fmpz_poly):
             s = fmpz_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.reversion()
@@ -707,10 +668,6 @@ class FlintPowerSeriesRingQQ:
             if poly.degree() < ring_prec:
                 return poly
             return fmpq_series(poly, prec=ring_prec)
-        elif isinstance(s1, fmpq_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpq_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 + s2
@@ -723,10 +680,6 @@ class FlintPowerSeriesRingQQ:
             if poly.degree() < ring_prec:
                 return poly
             return fmpq_series(poly, prec=ring_prec)
-        elif isinstance(s1, fmpq_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpq_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 - s2
@@ -747,10 +700,6 @@ class FlintPowerSeriesRingQQ:
                     s2 = self.truncate(s2, ring_prec)
 
                 return fmpq_series(s1 * s2, prec=ring_prec)
-        elif isinstance(s1, fmpq_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpq_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 * s2
@@ -763,8 +712,6 @@ class FlintPowerSeriesRingQQ:
             if poly.degree() < ring_prec:
                 return poly
             return fmpq_series(poly, prec=ring_prec)
-        else:
-            s = _cap_series_prec(s, ring_prec)
 
         with _global_cap(ring_prec):
             return s * n
@@ -781,10 +728,6 @@ class FlintPowerSeriesRingQQ:
                 )
                 s1 = fmpq_series(s1, prec=ring_prec)
                 s2 = fmpq_series(s2, prec=ring_prec)
-        elif isinstance(s1, fmpq_series):
-            s1 = _cap_series_prec(s1, ring_prec)
-        elif isinstance(s2, fmpq_series):
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1 / s2
@@ -803,8 +746,6 @@ class FlintPowerSeriesRingQQ:
                 s = self.truncate(s, ring_prec)
             poly = s**n
             return fmpq_series(poly, prec=ring_prec)
-        else:
-            s = _cap_series_prec(s, ring_prec)
 
         with _global_cap(ring_prec):
             return s**n
@@ -819,7 +760,10 @@ class FlintPowerSeriesRingQQ:
             return s
 
         if isinstance(s, fmpq_poly):
-            s = fmpq_series(s, prec=self._prec)
+            try:
+                return s.sqrt()
+            except DomainError:
+                s = fmpq_series(s, prec=self._prec)
 
         with _global_cap(self._prec):
             return s.sqrt()
@@ -853,14 +797,10 @@ class FlintPowerSeriesRingQQ:
         if isinstance(s1, fmpq_poly):
             prec2 = self.series_prec(s2)
             s1 = fmpq_series(s1, prec=prec2)
-        else:
-            s1 = _cap_series_prec(s1, ring_prec)
 
         if isinstance(s2, fmpq_poly):
             prec1 = self.series_prec(s1)
             s2 = fmpq_series(s2, prec=prec1)
-        else:
-            s2 = _cap_series_prec(s2, ring_prec)
 
         with _global_cap(ring_prec):
             return s1(s2)
@@ -879,8 +819,6 @@ class FlintPowerSeriesRingQQ:
             if len(s) == 1:
                 return 1 / s
             s = fmpq_series(s, prec=ring_prec)
-        else:
-            s = _cap_series_prec(s, ring_prec)
 
         with _global_cap(ring_prec):
             return s.inv()
@@ -901,8 +839,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.reversion()
@@ -954,8 +890,6 @@ class FlintPowerSeriesRingQQ:
             if s == 1:
                 return fmpq_poly([])
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.log()
@@ -966,8 +900,6 @@ class FlintPowerSeriesRingQQ:
             if not s:
                 return fmpq_poly([1])
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.exp()
@@ -979,8 +911,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.atan()
@@ -992,8 +922,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.atanh()
@@ -1005,8 +933,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.asin()
@@ -1018,8 +944,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.asinh()
@@ -1031,8 +955,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.tan()
@@ -1044,8 +966,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.tanh()
@@ -1057,8 +977,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.sin()
@@ -1070,8 +988,6 @@ class FlintPowerSeriesRingQQ:
 
         if isinstance(s, fmpq_poly):
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.sinh()
@@ -1082,8 +998,6 @@ class FlintPowerSeriesRingQQ:
             if not s:
                 return fmpq_poly([1])
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.cos()
@@ -1094,8 +1008,6 @@ class FlintPowerSeriesRingQQ:
             if not s:
                 return fmpq_poly([1])
             s = fmpq_series(s, prec=self._prec)
-        else:
-            s = _cap_series_prec(s, self._prec)
 
         with _global_cap(self._prec):
             return s.cosh()

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Sequence, Union, TYPE_CHECKING
 
+from sympy.core.expr import Expr
 from sympy.polys.densebasic import dup, dup_reverse
 from sympy.polys.domains import Domain, QQ, ZZ
-from sympy.polys.series.ringpython import _useries_valuation
+from sympy.polys.series.ringpython import _useries_valuation, _useries_to_sympy_expr
 from sympy.polys.series.base import series_pprint
 from sympy.external.gmpy import GROUND_TYPES, MPZ, MPQ
 from sympy.utilities.decorator import doctest_depends_on
@@ -206,6 +207,15 @@ class FlintPowerSeriesRingZZ:
         if isinstance(s, fmpz_poly):
             return None
         return _get_series_precision(s)
+
+    def as_expr(self, s: ZZSeries, symbol: str = "x") -> Expr:
+        """Convert a power series to a SymPy expression."""
+        coeffs = self.to_dense(s)
+        if isinstance(s, fmpz_poly):
+            s = coeffs, None
+        else:
+            s = coeffs, _get_series_precision(s)
+        return _useries_to_sympy_expr(s, symbol)
 
     def equal(self, s1: ZZSeries, s2: ZZSeries) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""
@@ -609,6 +619,15 @@ class FlintPowerSeriesRingQQ:
         if isinstance(s, fmpq_poly):
             return None
         return _get_series_precision(s)
+
+    def as_expr(self, s: QQSeries, symbol: str = "x") -> Expr:
+        """Convert a power series to a SymPy expression."""
+        coeffs = self.to_dense(s)
+        if isinstance(s, fmpq_poly):
+            s = coeffs, None
+        else:
+            s = coeffs, _get_series_precision(s)
+        return _useries_to_sympy_expr(s, symbol)
 
     def equal(self, s1: QQSeries, s2: QQSeries) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -5,10 +5,6 @@ from typing import Sequence, TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import TypeAlias, Union
 
-from sympy.core import Add, Mul, Pow
-from sympy.series.order import Order
-from sympy.core.expr import Expr
-from sympy.core.symbol import Symbol
 
 from sympy.polys.densearith import (
     dup_add,
@@ -78,27 +74,6 @@ def _useries_valuation(s: USeries[Er], dom: Domain) -> int:
         i -= 1
 
     return -i - 1
-
-
-def _useries_to_sympy_expr(s: USeries[Er], gen: str) -> Expr:
-    coeffs, prec = s
-    coeffs = coeffs[::-1]
-    result: list[Expr] = []
-    g: Symbol = Symbol(gen)
-
-    if coeffs and coeffs[0] != 0:
-        result.append(coeffs[0])  # type: ignore
-
-    for i, coeff in enumerate(coeffs[1:], start=1):
-        if coeff == 0:
-            continue
-        result.append(Mul(coeff, Pow(g, i)))  # type: ignore
-
-    p = Add(*result)
-    if prec is None:
-        return p
-    else:
-        return p + Order(g**prec)
 
 
 def _unify_prec(
@@ -1111,10 +1086,6 @@ class PythonPowerSeriesRingZZ:
         _, prec = s
         return prec
 
-    def as_expr(self, s: USeries[MPZ], symbol: str = "x") -> Expr:
-        """Convert a power series to a expression."""
-        return _useries_to_sympy_expr(s, symbol)
-
     def equal(self, s1: USeries[MPZ], s2: USeries[MPZ]) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""
         return _useries_equality(s1, s2, self._domain, self._prec)
@@ -1347,10 +1318,6 @@ class PythonPowerSeriesRingQQ:
         """Return the precision of a power series."""
         _, prec = s
         return prec
-
-    def as_expr(self, s: USeries[MPQ], symbol: str = "x") -> Expr:
-        """Convert a power series to a expression."""
-        return _useries_to_sympy_expr(s, symbol)
 
     def equal(self, s1: USeries[MPQ], s2: USeries[MPQ]) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -516,13 +516,13 @@ def _useries_atan(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     ds = _useries_derivative(s, dom, ring_prec)
     s2 = _useries_square(s, dom, ring_prec)
     s2 = _useries_add_ground(s2, dom.one, dom, ring_prec)  # 1 + s^2
     inv_s2 = _useries_inverse(s2, dom, ring_prec)
     dv_s = _useries_mul(ds, inv_s2, dom, ring_prec)
-    dv_s = dv_s[0], prec - 1
     return _useries_integrate(dv_s, dom, ring_prec)
 
 
@@ -539,7 +539,8 @@ def _useries_atanh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef
         )
 
     if prec is None:
-        s = coeffs, ring_prec
+        prec = ring_prec
+        s = coeffs, prec
 
     ds = _useries_derivative(s, dom, ring_prec)
     s2 = _useries_square(s, dom, ring_prec)
@@ -564,6 +565,7 @@ def _useries_asin(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     if len(coeffs) > 20:
         ds = _useries_derivative(s, dom, ring_prec)
@@ -598,7 +600,8 @@ def _useries_asinh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef
         )
 
     if prec is None:
-        s = coeffs, ring_prec
+        prec = ring_prec
+        s = coeffs, prec
 
     ds = _useries_derivative(s, dom, ring_prec)
     s2 = _useries_square(s, dom, ring_prec)
@@ -624,6 +627,7 @@ def _useries_tan(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     y: USeries[Ef] = ([], prec)
     # y_{n+1} = y_n + (s - \arctan(y_n)) * (1 + y_n^2)
@@ -656,6 +660,7 @@ def _useries_tanh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     y: USeries[Ef] = ([], prec)
     # y_{n+1} = y_n + (s - \arctanh(y_n)) * (1 - y_n^2)
@@ -689,6 +694,7 @@ def _useries_sin(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     if len(coeffs) > 20:
         # t = tan(s/2)
@@ -730,6 +736,7 @@ def _useries_sinh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     e = _useries_exp(s, dom, ring_prec)
     e_inv = _useries_inverse(e, dom, ring_prec)
@@ -751,6 +758,7 @@ def _useries_cos(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
 
     if prec is None:
         prec = ring_prec
+        s = coeffs, prec
 
     if len(coeffs) > 20:
         # t = tan(s/2)

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -443,7 +443,7 @@ def _useries_log(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
     if not coeffs:
         raise ValueError("Logarithm of a zero series is undefined.")
 
-    if not dom.is_one(coeffs[0]):
+    if not dom.is_one(coeffs[-1]):
         raise ValueError(
             "Logarithm of a power series requires the constant term to be one."
         )

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -948,6 +948,11 @@ class PythonPowerSeriesRingZZ:
         coeffs, _ = s
         return coeffs[::-1]
 
+    def series_prec(self, s: USeries[MPZ]) -> int | None:
+        """Return the precision of a power series."""
+        _, prec = s
+        return prec
+
     def equal(self, s1: USeries[MPZ], s2: USeries[MPZ]) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""
         return _useries_equality(s1, s2, self._domain)
@@ -1164,6 +1169,11 @@ class PythonPowerSeriesRingQQ:
         """Return the list of series coefficients."""
         coeffs, _ = s
         return coeffs[::-1]
+
+    def series_prec(self, s: USeries[MPQ]) -> int | None:
+        """Return the precision of a power series."""
+        _, prec = s
+        return prec
 
     def equal(self, s1: USeries[MPQ], s2: USeries[MPQ]) -> bool | None:
         """Check if two power series are equal up to their minimum precision."""

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -15,6 +15,7 @@ from sympy.polys.densearith import (
     dup_sub,
     dup_exquo,
     dup_series_mul,
+    dup_series_sqr,
     dup_series_pow,
     dup_rshift,
 )
@@ -237,7 +238,16 @@ def _useries_mul_ground(
 
 def _useries_square(s: USeries[Er], dom: Domain[Er], ring_prec: int) -> USeries[Er]:
     """Compute the square of a power series."""
-    return _useries_mul(s, s, dom, ring_prec)
+    coeffs, prec = s
+
+    if prec is None:
+        d = dup_degree(coeffs) * 2
+        if d < ring_prec:
+            return dup_series_sqr(coeffs, ring_prec, dom), None
+        else:
+            prec = ring_prec
+
+    return dup_series_sqr(coeffs, prec, dom), prec
 
 
 def _useries_sqrt_newton(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -103,7 +103,9 @@ def _unify_prec(
     coeffs1, prec1 = s1
     coeffs2, prec2 = s2
 
-    if prec1 == prec2:
+    if prec1 == prec2 == ring_prec:
+        return coeffs1, coeffs2, ring_prec
+    elif prec1 == prec2:
         unified_prec = prec1
     elif prec1 is None:
         unified_prec = prec2
@@ -115,8 +117,14 @@ def _unify_prec(
     if unified_prec is None:
         unified_prec = ring_prec
 
-    coeffs1 = dup_truncate(coeffs1, unified_prec, dom)
-    coeffs2 = dup_truncate(coeffs2, unified_prec, dom)
+    d1 = dup_degree(coeffs1)
+    d2 = dup_degree(coeffs2)
+
+    if d1 >= unified_prec:
+        coeffs1 = dup_truncate(coeffs1, unified_prec, dom)
+    if d2 >= unified_prec:
+        coeffs2 = dup_truncate(coeffs2, unified_prec, dom)
+
     return coeffs1, coeffs2, unified_prec
 
 

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -525,6 +525,7 @@ def _useries_log(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
     s = coeffs, prec
 
     if len(coeffs) > 20:
+        # log(f(x))' = f'(x) / f(x)
         dv_s = _useries_derivative(s, dom, ring_prec)
         inverse_s = _useries_inverse(s, dom, ring_prec)
         log_derivative = _useries_mul(dv_s, inverse_s, dom, ring_prec)
@@ -577,7 +578,6 @@ def _useries_exp(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
         exp = one
 
         for precx in _giant_steps(prec):
-            # log(f(x))' = f'(x) / f(x)
             exp = exp[0], precx
             log_exp = _useries_log(exp, dom, ring_prec)
             diff = _useries_sub(s, log_exp, dom, ring_prec)

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -17,9 +17,8 @@ from sympy.polys.densearith import (
     dup_series_pow,
     dup_rshift,
 )
-from sympy.polys.densebasic import dup_degree, dup_reverse, dup_truncate
+from sympy.polys.densebasic import dup, dup_degree, dup_reverse, dup_truncate
 from sympy.polys.densetools import (
-    dup,
     dup_diff,
     dup_integrate,
     dup_revert,
@@ -749,7 +748,7 @@ def _useries_cos(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
     coeffs, prec = s
 
     if not coeffs:
-        return s
+        return ([dom.one], prec)
 
     if not dom.is_zero(coeffs[-1]):
         raise ValueError(
@@ -792,7 +791,7 @@ def _useries_cosh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
     coeffs, prec = s
 
     if not coeffs:
-        return s
+        return ([dom.one], prec)
 
     if not dom.is_zero(coeffs[-1]):
         raise ValueError(
@@ -955,6 +954,10 @@ class PythonPowerSeriesRingZZ:
         """Returns the list of series coefficients."""
         coeffs, _ = s
         return coeffs[::-1]
+
+    def to_dense(self, s: USeries[MPZ]) -> dup[MPZ]:
+        """Return the coefficients of a power series as a dense list."""
+        return s[0]
 
     def series_prec(self, s: USeries[MPZ]) -> int | None:
         """Return the precision of a power series."""
@@ -1177,6 +1180,10 @@ class PythonPowerSeriesRingQQ:
         """Return the list of series coefficients."""
         coeffs, _ = s
         return coeffs[::-1]
+
+    def to_dense(self, s: USeries[MPQ]) -> dup[MPQ]:
+        """Return the coefficients of a power series as a dense list."""
+        return s[0]
 
     def series_prec(self, s: USeries[MPQ]) -> int | None:
         """Return the precision of a power series."""

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -362,8 +362,8 @@ def _useries_div(
 
 
 def _useries_div_ground(
-    s: USeries[Er], n: Er, dom: Domain[Er], ring_prec: int
-) -> USeries[Er]:
+    s: USeries[Ef], n: Ef, dom: Domain[Ef], ring_prec: int
+) -> USeries[Ef]:
     coeffs, prec = s
 
     if n == 0:
@@ -577,6 +577,7 @@ def _useries_exp(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
         exp = one
 
         for precx in _giant_steps(prec):
+            # log(f(x))' = f'(x) / f(x)
             exp = exp[0], precx
             log_exp = _useries_log(exp, dom, ring_prec)
             diff = _useries_sub(s, log_exp, dom, ring_prec)
@@ -623,6 +624,7 @@ def _useries_atan(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
 
     s = coeffs, prec
 
+    # atan(f(x))' = f'(x) / (1 + f(x)**2)
     ds = _useries_derivative(s, dom, ring_prec)
     s2 = _useries_square(s, dom, ring_prec)
     s2 = _useries_add_ground(s2, dom.one, dom, ring_prec)  # 1 + s^2
@@ -650,6 +652,7 @@ def _useries_atanh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef
 
     s = coeffs, prec
 
+    # atanh(f(x))' = f'(x) / (1 - f(x)**2)
     ds = _useries_derivative(s, dom, ring_prec)
     s2 = _useries_square(s, dom, ring_prec)
     neg_s2 = _useries_neg(s2, dom, ring_prec)
@@ -679,6 +682,7 @@ def _useries_asin(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
     s = coeffs, prec
 
     if len(coeffs) > 20:
+        # asin(f(x))' = f'(x) / sqrt(1 - f(x)**2)
         ds = _useries_derivative(s, dom, ring_prec)
         s2 = _useries_square(s, dom, ring_prec)
         neg_s2 = _useries_neg(s2, dom, ring_prec)
@@ -721,6 +725,7 @@ def _useries_asinh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef
     s = coeffs, prec
 
     if len(coeffs) > 20:
+        # asinh(f(x))' = f'(x) / sqrt(1 + f(x)**2)
         ds = _useries_derivative(s, dom, ring_prec)
         s2 = _useries_square(s, dom, ring_prec)
         q = _useries_add_ground(s2, dom.one, dom, ring_prec)
@@ -836,8 +841,9 @@ def _useries_sin(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
     s = coeffs, prec
 
     if len(coeffs) > 20:
-        # t = tan(s/2)
+        # sin(f(x)) = 2 * tan(f(x)/2) / (1 + tan(f(x)/2)**2)
         s = _useries_div_ground(s, dom(2), dom, ring_prec)
+        # t = tan(s/2)
         t = _useries_tan(s, dom, ring_prec)
         t_sq = _useries_square(t, dom, ring_prec)
 
@@ -881,6 +887,7 @@ def _useries_sinh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
     s = coeffs, prec
 
     if len(coeffs) > 40:
+        # sinh(f(x)) = (exp(f(x)) - exp(-f(x))) / 2
         e = _useries_exp(s, dom, ring_prec)
         e_inv = _useries_inverse(e, dom, ring_prec)
         diff = _useries_sub(e, e_inv, dom, ring_prec)
@@ -920,8 +927,9 @@ def _useries_cos(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]:
     s = coeffs, prec
 
     if len(coeffs) > 20:
-        # t = tan(s/2)
+        # cos(f(x)) = (1 - tan(f(x)/2)**2) / (1 + tan(f(x)/2)**2)
         s = _useries_div_ground(s, dom(2), dom, ring_prec)
+        # t = tan(s/2)
         t = _useries_tan(s, dom, ring_prec)
 
         t_sq = _useries_square(t, dom, ring_prec)  # t_sq = tan^2(s/2)
@@ -966,6 +974,7 @@ def _useries_cosh(s: USeries[Ef], dom: Field[Ef], ring_prec: int) -> USeries[Ef]
     s = coeffs, prec
 
     if len(coeffs) > 40:
+        # cosh(f(x)) = (exp(f(x)) + exp(-f(x))) / 2
         e = _useries_exp(s, dom, ring_prec)
         e_inv = _useries_inverse(e, dom, ring_prec)
         diff = _useries_add(e, e_inv, dom, ring_prec)
@@ -988,7 +997,7 @@ def _useries_hypot(
     s1: USeries[Ef], s2: USeries[Ef], dom: Field[Ef], ring_prec: int
 ) -> USeries[Ef]:
     """Compute the hypotenuse of two power series."""
-
+    # hypot(f(x), g(x)) = sqrt(f(x)**2 + g(x)**2)
     sqr_s1 = _useries_square(s1, dom, ring_prec)
     sqr_s2 = _useries_square(s2, dom, ring_prec)
     add = _useries_add(sqr_s1, sqr_s2, dom, ring_prec)

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -61,8 +61,8 @@ def as_expr(s, ring):
     return Add(*result)
 
 
-def dup_QQ():
-    # This is a strategy of creating random dup_QQ elements.
+def _dup_QQ():
+    """This is a strategy of creating random dup_QQ elements."""
     elems = st.tuples(
         st.integers(min_value=-100, max_value=100),
         st.integers(min_value=1, max_value=100),
@@ -74,7 +74,7 @@ def dup_QQ():
 @composite
 def dup_zero_const(draw, min_size=3, max_size=25):
     """DUP zero constant strategy."""
-    element_strategy = dup_QQ()
+    element_strategy = _dup_QQ()
 
     lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
     lst[-1] = QQ.zero
@@ -83,8 +83,8 @@ def dup_zero_const(draw, min_size=3, max_size=25):
 
 @composite
 def dup_one_const(draw, min_size=3, max_size=25):
-    """DUP zero constant strategy."""
-    element_strategy = dup_QQ()
+    """DUP one constant strategy."""
+    element_strategy = _dup_QQ()
 
     lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
     lst[-1] = QQ.one

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -1,0 +1,77 @@
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.strategies import composite
+
+from sympy import ring, QQ
+from sympy.polys.series import power_series_ring
+from sympy.polys.ring_series import (
+    rs_log,
+    rs_exp,
+    rs_atan,
+    rs_atanh,
+    rs_asin,
+    rs_asinh,
+    rs_tan,
+    rs_tanh,
+    rs_sin,
+    rs_sinh,
+    rs_cos,
+)
+
+
+@composite
+def dup_zero_const(draw, min_size=3, max_size=25):
+    """DUP zero constant strategy."""
+    element_strategy = st.tuples(st.integers(), st.integers(min_value=1)).map(
+        lambda t: QQ(t[0], t[1])
+    )
+
+    lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
+    lst[-1] = QQ.zero
+    return lst
+
+
+@composite
+def dup_one_const(draw, min_size=3, max_size=25):
+    """DUP zero constant strategy."""
+    element_strategy = st.tuples(st.integers(), st.integers(min_value=1)).map(
+        lambda t: QQ(t[0], t[1])
+    )
+
+    lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
+    lst[-1] = QQ.one
+    return lst
+
+
+@given(f=dup_zero_const())
+def test_trancendental_function_zero(f):
+    Rs = power_series_ring(QQ, 25)
+    Rp, x = ring("x", QQ)
+
+    s = Rs(f[::-1])
+    p = Rp.from_list(f)
+
+    assert Rs.to_dense(Rs.exp(s)) == (rs_exp(p, x, 25)).to_dense()
+
+    assert Rs.to_dense(Rs.atan(s)) == (rs_atan(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.atanh(s)) == (rs_atanh(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.asin(s)) == (rs_asin(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.asinh(s)) == (rs_asinh(p, x, 25)).to_dense()
+
+    assert Rs.to_dense(Rs.tan(s)) == (rs_tan(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.tanh(s)) == (rs_tanh(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.sin(s)) == (rs_sin(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.sinh(s)) == (rs_sinh(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.cos(s)) == (rs_cos(p, x, 25)).to_dense()
+    # assert Rs.to_dense(Rs.cosh(s)) == (rs_cosh(p, x, 25)).to_dense()
+
+
+@given(f=dup_one_const())
+def test_trancendental_function_one(f):
+    Rs = power_series_ring(QQ, 25)
+    Rp, x = ring("x", QQ)
+
+    s = Rs(f[::-1])
+    p = Rp.from_list(f)
+
+    assert Rs.to_dense(Rs.log(s)) == (rs_log(p, x, 25)).to_dense()

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -61,13 +61,20 @@ def as_expr(s, ring):
     return Add(*result)
 
 
-@composite
-def dup_zero_const(draw, min_size=3, max_size=25):
-    """DUP zero constant strategy."""
-    element_strategy = st.tuples(
+def dup_QQ():
+    # This is a strategy of creating random dup_QQ elements.
+    elems = st.tuples(
         st.integers(min_value=-100, max_value=100),
         st.integers(min_value=1, max_value=100),
     ).map(lambda t: QQ(t[0], t[1]))
+
+    return elems
+
+
+@composite
+def dup_zero_const(draw, min_size=3, max_size=25):
+    """DUP zero constant strategy."""
+    element_strategy = dup_QQ()
 
     lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
     lst[-1] = QQ.zero
@@ -77,10 +84,7 @@ def dup_zero_const(draw, min_size=3, max_size=25):
 @composite
 def dup_one_const(draw, min_size=3, max_size=25):
     """DUP zero constant strategy."""
-    element_strategy = st.tuples(
-        st.integers(min_value=-100, max_value=100),
-        st.integers(min_value=1, max_value=100),
-    ).map(lambda t: QQ(t[0], t[1]))
+    element_strategy = dup_QQ()
 
     lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
     lst[-1] = QQ.one

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -43,16 +43,17 @@ def as_expr(s, ring):
     else:
         coeffs, prec = s
         coeffs = coeffs[::-1]
-
+    
+    dom = ring.domain
     result = []
 
     if coeffs and coeffs[0] != 0:
-        result.append(coeffs[0])
+        result.append(dom.to_sympy(coeffs[0]))
 
     for i, coeff in enumerate(coeffs[1:], start=1):
         if coeff == 0:
             continue
-        result.append(Mul(coeff, Pow(x, i)))
+        result.append(Mul(dom.to_sympy(coeff), Pow(x, i)))
 
     if prec is not None:
         result.append(Order(x**prec))

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -3,7 +3,13 @@ from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
 from sympy import ring, QQ
+from sympy.abc import x
+from sympy.functions.elementary.trigonometric import atan, asin, sin, cos, tan
+from sympy.functions.elementary.hyperbolic import atanh, asinh, sinh, cosh, tanh
+from sympy.functions.elementary.exponential import exp, log
 from sympy.polys.series import power_series_ring
+from sympy.polys.polyutils import expr_from_dict
+from sympy.polys.densebasic import dup_to_dict
 from sympy.polys.ring_series import (
     rs_log,
     rs_exp,
@@ -16,7 +22,10 @@ from sympy.polys.ring_series import (
     rs_sin,
     rs_sinh,
     rs_cos,
+    rs_cosh,
 )
+
+from sympy.testing.pytest import slow
 
 
 @composite
@@ -44,7 +53,7 @@ def dup_one_const(draw, min_size=3, max_size=25):
 
 
 @given(f=dup_zero_const())
-def test_trancendental_function_zero(f):
+def test_rs_series_zero(f):
     Rs = power_series_ring(QQ, 25)
     Rp, x = ring("x", QQ)
 
@@ -63,11 +72,11 @@ def test_trancendental_function_zero(f):
     assert Rs.to_dense(Rs.sin(s)) == (rs_sin(p, x, 25)).to_dense()
     assert Rs.to_dense(Rs.sinh(s)) == (rs_sinh(p, x, 25)).to_dense()
     assert Rs.to_dense(Rs.cos(s)) == (rs_cos(p, x, 25)).to_dense()
-    # assert Rs.to_dense(Rs.cosh(s)) == (rs_cosh(p, x, 25)).to_dense()
+    assert Rs.to_dense(Rs.cosh(s)) == (rs_cosh(p, x, 25)).to_dense()
 
 
 @given(f=dup_one_const())
-def test_trancendental_function_one(f):
+def test_rs_series_one(f):
     Rs = power_series_ring(QQ, 25)
     Rp, x = ring("x", QQ)
 
@@ -75,3 +84,35 @@ def test_trancendental_function_one(f):
     p = Rp.from_list(f)
 
     assert Rs.to_dense(Rs.log(s)) == (rs_log(p, x, 25)).to_dense()
+
+
+@slow
+@given(f=dup_zero_const(max_size=5))
+def test_global_series_zero(f):
+    Rs = power_series_ring(QQ, 5)
+
+    s = Rs(f[::-1])
+    e = expr_from_dict(dup_to_dict(f), x)
+    assert Rs.as_expr(Rs.exp(s)) == exp(e).series(x, 0, 5)
+
+    assert Rs.as_expr(Rs.atan(s)) == atan(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.atanh(s)) == atanh(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.asin(s)) == asin(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.asinh(s)) == asinh(e).series(x, 0, 5)
+
+    assert Rs.as_expr(Rs.tan(s)) == tan(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.tanh(s)) == tanh(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.sin(s)) == sin(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.sinh(s)) == sinh(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.cos(s)) == cos(e).series(x, 0, 5)
+    assert Rs.as_expr(Rs.cosh(s)) == cosh(e).series(x, 0, 5)
+
+
+@given(f=dup_one_const(max_size=5))
+def test_global_series_one(f):
+    Rs = power_series_ring(QQ, 5)
+
+    s = Rs(f[::-1])
+    e = expr_from_dict(dup_to_dict(f), x)
+
+    assert Rs.as_expr(Rs.log(s)) == log(e).series(x, 0, 5)

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -31,9 +31,10 @@ from sympy.testing.pytest import slow
 @composite
 def dup_zero_const(draw, min_size=3, max_size=25):
     """DUP zero constant strategy."""
-    element_strategy = st.tuples(st.integers(), st.integers(min_value=1)).map(
-        lambda t: QQ(t[0], t[1])
-    )
+    element_strategy = st.tuples(
+        st.integers(min_value=-100, max_value=100),
+        st.integers(min_value=1, max_value=100),
+    ).map(lambda t: QQ(t[0], t[1]))
 
     lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
     lst[-1] = QQ.zero
@@ -43,9 +44,10 @@ def dup_zero_const(draw, min_size=3, max_size=25):
 @composite
 def dup_one_const(draw, min_size=3, max_size=25):
     """DUP zero constant strategy."""
-    element_strategy = st.tuples(st.integers(), st.integers(min_value=1)).map(
-        lambda t: QQ(t[0], t[1])
-    )
+    element_strategy = st.tuples(
+        st.integers(min_value=-100, max_value=100),
+        st.integers(min_value=1, max_value=100),
+    ).map(lambda t: QQ(t[0], t[1]))
 
     lst = draw(st.lists(element_strategy, min_size=min_size, max_size=max_size))
     lst[-1] = QQ.one

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -43,7 +43,7 @@ def as_expr(s, ring):
     else:
         coeffs, prec = s
         coeffs = coeffs[::-1]
-    
+
     dom = ring.domain
     result = []
 

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -580,3 +580,74 @@ def test_rational_reversion(rd_rational):
             10,
         ),
     )
+
+
+# Tests for log and exp
+
+
+def test_log(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(
+        R.log(R.add(R.one, R.gen)),
+        R([(0, 1), (1, 1), (-1, 2), (1, 3), (-1, 4), (1, 5)], 6),
+    )
+    assert R3.equal_repr(
+        R3.log(R3.add(R3.one, R3.gen)),
+        R3([(0, 1), (1, 1), (-1, 2)], 3),
+    )
+    assert R10.equal_repr(
+        R10.log(R10.add(R10.one, R10.gen)),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (-1, 2),
+                (1, 3),
+                (-1, 4),
+                (1, 5),
+                (-1, 6),
+                (1, 7),
+                (-1, 8),
+                (1, 9),
+            ],
+            10,
+        ),
+    )
+
+
+def test_exp(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(
+        R.exp(R.gen),
+        R([(1, 1), (1, 1), (1, 2), (1, 6), (1, 24), (1, 120)], 6),
+    )
+    assert R3.equal_repr(
+        R3.exp(R3.gen),
+        R3([(1, 1), (1, 1), (1, 2)], 3),
+    )
+    assert R10.equal_repr(
+        R10.exp(R10.gen),
+        R10(
+            [
+                (1, 1),
+                (1, 1),
+                (1, 2),
+                (1, 6),
+                (1, 24),
+                (1, 120),
+                (1, 720),
+                (1, 5040),
+                (1, 40320),
+                (1, 362880),
+            ],
+            10,
+        ),
+    )

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -8,6 +8,22 @@ from sympy.external.gmpy import GROUND_TYPES
 import pytest
 from sympy.testing.pytest import raises
 from sympy.polys.polyerrors import NotReversible
+from sympy.polys.rings import ring
+from sympy.polys.ring_series import (
+    rs_log,
+    rs_exp,
+    rs_atan,
+    rs_atanh,
+    rs_asin,
+    rs_asinh,
+    rs_tan,
+    rs_tanh,
+    rs_sin,
+    rs_sinh,
+    rs_cos,
+    rs_cosh,
+)
+from sympy.polys.densebasic import dup_random
 
 # Rings
 Ring_ZZ: list[type[PowerSeriesRingProto]] = [PythonPowerSeriesRingZZ]
@@ -251,6 +267,9 @@ def test_sqrt(rd_rational):
     SeriesRing = rd_rational
     R = SeriesRing()
     R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.sqrt(R([])), R([]))
+    raises(ValueError, lambda: R.sqrt(R([2, 2])))
 
     assert not R.equal_repr(
         R.sqrt(R.add(R.gen, R.one)), R([(1, 1), (1, 1), (1, 1)], None)
@@ -616,6 +635,7 @@ def test_log(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    assert R.equal_repr(R.log(R([1])), R([]))
     raises(ValueError, lambda: R.log(R([])))
     raises(ValueError, lambda: R.log(R([(0, 1)])))
     raises(ValueError, lambda: R.log(R([(2, 1)])))
@@ -1006,3 +1026,33 @@ def test_cosh(rd_rational):
             10,
         ),
     )
+
+
+def test_high_deg(rd_rational):
+    SeriesRing = rd_rational
+    Rs = SeriesRing(30)
+    Rp, x = ring("x", QQ)
+
+    rand = dup_random(30, 0, 10, QQ)
+    rand[0] = 0
+    s = Rs(rand)
+    p = Rp.from_list(rand[::-1])
+
+    assert Rs.to_list(Rs.exp(s)) == (rs_exp(p, x, 30)).to_dense()[::-1]
+
+    assert Rs.to_list(Rs.atan(s)) == (rs_atan(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.atanh(s)) == (rs_atanh(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.asin(s)) == (rs_asin(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.asinh(s)) == (rs_asinh(p, x, 30)).to_dense()[::-1]
+
+    assert Rs.to_list(Rs.tan(s)) == (rs_tan(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.tanh(s)) == (rs_tanh(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.sin(s)) == (rs_sin(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.sinh(s)) == (rs_sinh(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.cos(s)) == (rs_cos(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_list(Rs.cosh(s)) == (rs_cosh(p, x, 30)).to_dense()[::-1]
+
+    rand[0] = 1
+    s = Rs(rand)
+    p = Rp.from_list(rand[::-1])
+    assert Rs.to_list(Rs.log(s)) == (rs_log(p, x, 30)).to_dense()[::-1]

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -275,11 +275,12 @@ def test_sqrt(rd_rational):
     R10 = SeriesRing(10)
 
     assert R.equal_repr(R.sqrt(R([])), R([]))
-    raises(ValueError, lambda: R.sqrt(R([2, 2])))
+    raises(ValueError, lambda: R.sqrt(R([3, 2])))
 
-    assert not R.equal_repr(
-        R.sqrt(R.add(R.gen, R.one)), R([(1, 1), (1, 1), (1, 1)], None)
-    )
+    assert R.equal_repr(R.sqrt(R([1, 2, 1])), R([1, 1], None))
+    assert R.equal_repr(R.sqrt(R([4, 4, 1])), R([2, 1], None))
+    assert R.equal_repr(R.sqrt(R([9])), R([3], None))
+
     assert R10.equal_repr(
         R10.sqrt(R10.subtract(R10.one, R10.gen)),
         R10(
@@ -294,6 +295,25 @@ def test_sqrt(rd_rational):
                 (-33, 2048),
                 (-429, 32768),
                 (-715, 65536),
+            ],
+            10,
+        ),
+    )
+
+    assert R10.equal_repr(
+        R10.sqrt(R10([1, 0, 0, 1])),
+        R10(
+            [
+                (1, 1),
+                (0, 1),
+                (0, 1),
+                (1, 2),
+                (0, 1),
+                (0, 1),
+                (-1, 8),
+                (0, 1),
+                (0, 1),
+                (1, 16),
             ],
             10,
         ),

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -1065,6 +1065,7 @@ def test_high_deg(rd_rational):
     p = Rp.from_list(rand[::-1])
 
     assert Rs.to_dense(Rs.exp(s)) == rs_exp(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.expm1(s)) == (rs_exp(p, x, 30) - 1).to_dense()
 
     assert Rs.to_dense(Rs.atan(s)) == rs_atan(p, x, 30).to_dense()
     assert Rs.to_dense(Rs.atanh(s)) == rs_atanh(p, x, 30).to_dense()
@@ -1079,6 +1080,43 @@ def test_high_deg(rd_rational):
     assert Rs.to_dense(Rs.cosh(s)) == rs_cosh(p, x, 30).to_dense()
 
     rand[0] = QQ.one
-    s = Rs(rand)
-    p = Rp.from_list(rand[::-1])
-    assert Rs.to_dense(Rs.log(s)) == rs_log(p, x, 30).to_dense()
+    s2 = Rs(rand)
+    p2 = Rp.from_list(rand[::-1])
+    assert Rs.to_dense(Rs.log(s2)) == rs_log(p2, x, 30).to_dense()
+    assert Rs.to_dense(Rs.log1p(s)) == rs_log(p2, x, 30).to_dense()
+
+
+def test_hypot(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.hypot(R([(3, 1)]), R([(4, 1)])), R([(5, 1)], None))
+
+    assert R.equal_repr(
+        R.hypot(R([(1, 1), (0, 1), (-1, 1)]), R([(0, 1), (2, 1)])),
+        R([(1, 1), (0, 1), (1, 1)], None),
+    )
+
+    assert R10.equal_repr(
+        R10.hypot(R10([(1, 1)]), R10.gen),
+        R10(
+            [
+                (1, 1),
+                (0, 1),
+                (1, 2),
+                (0, 1),
+                (-1, 8),
+                (0, 1),
+                (1, 16),
+                (0, 1),
+                (-5, 128),
+                (0, 1),
+            ],
+            10,
+        ),
+    )
+
+    assert R.equal_repr(
+        R.hypot(R([(1, 1), (1, 1)]), R([(0, 1)])), R([(1, 1), (1, 1)], None)
+    )

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -83,7 +83,7 @@ def test_basics(rd_int):
     assert R.series_prec(R([1, 2, 3])) == None
     assert R.series_prec(R([1, 2, 3], None)) == None
     assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7])) == 6
-    assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 10
+    assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 6
 
 
 def test_positive(rd_int):

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -73,6 +73,7 @@ def test_basics(rd_int):
     assert R == SeriesRing(6)
     assert hash(R) == hash(SeriesRing(6))
     assert R.to_list(R.gen) == [0, 1], None
+    assert R.to_dense(R.gen) == [1, 0], None
     assert R0.equal_repr(R0.zero, R0.one)
     assert R0.pretty(R0.gen) == "O(x**0)"
     assert R0.equal_repr(R0.gen, R0([], 0))
@@ -973,7 +974,7 @@ def test_cos(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(R.cos(R([])), R([]))
+    assert R.equal_repr(R.cos(R([])), R([1]))
     raises(ValueError, lambda: R.cos(R([1, 1])))
 
     assert R3.equal_repr(
@@ -1006,7 +1007,7 @@ def test_cosh(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(R.cosh(R([])), R([]))
+    assert R.equal_repr(R.cosh(R([])), R([1]))
     raises(ValueError, lambda: R.cosh(R([1, 1])))
 
     assert R3.equal_repr(
@@ -1043,21 +1044,21 @@ def test_high_deg(rd_rational):
     s = Rs(rand)
     p = Rp.from_list(rand[::-1])
 
-    assert Rs.to_list(Rs.exp(s)) == (rs_exp(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_dense(Rs.exp(s)) == (rs_exp(p, x, 30)).to_dense()
 
-    assert Rs.to_list(Rs.atan(s)) == (rs_atan(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.atanh(s)) == (rs_atanh(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.asin(s)) == (rs_asin(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.asinh(s)) == (rs_asinh(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_dense(Rs.atan(s)) == (rs_atan(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.atanh(s)) == (rs_atanh(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.asin(s)) == (rs_asin(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.asinh(s)) == (rs_asinh(p, x, 30)).to_dense()
 
-    assert Rs.to_list(Rs.tan(s)) == (rs_tan(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.tanh(s)) == (rs_tanh(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.sin(s)) == (rs_sin(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.sinh(s)) == (rs_sinh(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.cos(s)) == (rs_cos(p, x, 30)).to_dense()[::-1]
-    assert Rs.to_list(Rs.cosh(s)) == (rs_cosh(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_dense(Rs.tan(s)) == (rs_tan(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.tanh(s)) == (rs_tanh(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.sin(s)) == (rs_sin(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.sinh(s)) == (rs_sinh(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.cos(s)) == (rs_cos(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.cosh(s)) == (rs_cosh(p, x, 30)).to_dense()
 
     rand[0] = 1
     s = Rs(rand)
     p = Rp.from_list(rand[::-1])
-    assert Rs.to_list(Rs.log(s)) == (rs_log(p, x, 30)).to_dense()[::-1]
+    assert Rs.to_dense(Rs.log(s)) == (rs_log(p, x, 30)).to_dense()

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -582,9 +582,6 @@ def test_rational_reversion(rd_rational):
     )
 
 
-# Tests for log and exp
-
-
 def test_log(rd_rational):
     SeriesRing = rd_rational
     R = SeriesRing()
@@ -647,6 +644,74 @@ def test_exp(rd_rational):
                 (1, 5040),
                 (1, 40320),
                 (1, 362880),
+            ],
+            10,
+        ),
+    )
+
+
+def test_atan(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(
+        R.atan(R.gen),
+        R([(0, 1), (1, 1), (0, 1), (-1, 3), (0, 1), (1, 5)], 6),
+    )
+    assert R3.equal_repr(
+        R3.atan(R3.gen),
+        R3([(0, 1), (1, 1)], 3),
+    )
+
+    assert R10.equal_repr(
+        R10.atan(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (-1, 3),
+                (0, 1),
+                (1, 5),
+                (0, 1),
+                (-1, 7),
+                (0, 1),
+                (1, 9),
+            ],
+            10,
+        ),
+    )
+
+
+def test_tan(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(
+        R.tan(R.gen), R([(0, 1), (1, 1), (0, 1), (1, 3), (0, 1), (2, 15)], 6)
+    )
+    assert R3.equal_repr(
+        R3.tan(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.tan(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (1, 3),
+                (0, 1),
+                (2, 15),
+                (0, 1),
+                (17, 315),
+                (0, 1),
+                (62, 2835),
             ],
             10,
         ),

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -76,7 +76,9 @@ def test_basics(ring_int):
     assert R.to_dense(R.gen) == [1, 0], None
     assert R0.equal_repr(R0.zero, R0.one)
     assert R0.pretty(R0.gen) == "O(x**0)"
+    assert R.pretty(R([1, 2, 3])) == "1 + 2*x + 3*x**2"
     assert R0.equal_repr(R0.gen, R0([], 0))
+    assert not R.equal_repr(R([1, 2, 3]), R([1, 2, 3], 5))
     assert R0.equal_repr(R0.multiply(R0.gen, R0.gen), R0([], 0))
     assert R.equal_repr(R.add(R([2, 4, 5], 3), R([5], 2)), R([7, 4], 2))
 
@@ -89,12 +91,15 @@ def test_basics(ring_int):
 def test_positive(ring_int):
     SeriesRing = ring_int
     R = SeriesRing()
+    R3 = SeriesRing(3)
     assert R.equal_repr(
         R.positive(R([1, 2, 3, 4, 5, 6, 7], None)), R([1, 2, 3, 4, 5, 6], 6)
     )
     assert R.equal_repr(
         R.positive(R([1, 2, 3, 4, 5, 6, 7, 8, 9], 8)), R([1, 2, 3, 4, 5, 6], 6)
     )
+    assert R3.equal_repr(R3.positive(R([1, 2, 7, 9, 12])), R3([1, 2, 7], 3))
+    assert R3.equal_repr(R3.positive(R([1, 2, 7, 9, 12], 6)), R3([1, 2, 7], 3))
 
 
 def test_negative(ring_int):
@@ -113,15 +118,18 @@ def test_negative(ring_int):
 
 def test_add(ring_int):
     SeriesRing = ring_int
+    R = SeriesRing()
     R3 = SeriesRing(3)
     assert R3.equal_repr(R3.add(R3.gen, R3.one), R3([1, 1], None))
     assert R3.equal_repr(R3.add(R3.one, R3.pow_int(R3.gen, 4)), R3([1], 3))
+    assert R3.equal_repr(R3.add(R([1, 2, 4, 2, 1, 1]), R3.one), R3([2, 2, 4], 3))
 
 
 def test_int_subtract(ring_int):
     SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
+    assert R3.equal_repr(R3.subtract(R([1, 2, 4, 2, 1, 1]), R3.one), R3([0, 2, 4], 3))
     assert R.equal_repr(
         R.subtract(R.multiply(R.gen, R.gen), R.gen), R([0, -1, 1], None)
     )
@@ -136,6 +144,9 @@ def test_int_multiply(ring_int):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
     assert R.equal_repr(R.multiply(R.gen, R.gen), R([0, 0, 1], None))
+    assert R3.equal_repr(
+        R3.multiply(R([1, 1, 2, 1, 1]), R([1, 1, 2, 1, 1])), R3([1, 2, 5], 3)
+    )
     assert R3.equal_repr(
         R3.multiply(R3.square(R3.add(R3.gen, R3.one)), R3.add(R3.gen, R3.one)),
         R3([1, 3, 3], 3),
@@ -168,6 +179,7 @@ def test_rational_multiply(ring_rational):
 def test_int_multiply_ground(ring_int):
     SeriesRing = ring_int
     R = SeriesRing()
+    R3 = SeriesRing(3)
     assert R.equal_repr(R.multiply_ground(R.one, ZZ(1)), R([1], None))
     assert R.equal_repr(R.multiply_ground(R.gen, ZZ(-1)), R([0, -1], None))
     assert R.equal_repr(R.multiply_ground(R.gen, ZZ(0)), R([], None))
@@ -176,6 +188,9 @@ def test_int_multiply_ground(ring_int):
     assert R.equal_repr(
         R.multiply_ground(R.inverse(R.add(R.one, R.gen)), ZZ(7)),
         R([7, -7, 7, -7, 7, -7], 6),
+    )
+    assert R3.equal_repr(
+        R3.multiply_ground(R([1, 2, 1, 1, 1]), ZZ(2)), R3([2, 4, 2], 3)
     )
 
 
@@ -276,6 +291,7 @@ def test_sqrt(ring_rational):
 
     assert R.equal_repr(R.sqrt(R([])), R([]))
     raises(ValueError, lambda: R.sqrt(R([3, 2])))
+    raises(ValueError, lambda: R.sqrt(R([0, 1, 7])))
 
     assert R.equal_repr(R.sqrt(R([1, 2, 1])), R([1, 1], None))
     assert R.equal_repr(R.sqrt(R([4, 4, 1])), R([2, 1], None))
@@ -326,9 +342,11 @@ def test_int_pow(ring_int):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
     assert R.equal_repr(R.pow_int(R.gen, 0), R([1], None))
+    assert R.equal_repr(R.pow_int(R([1, 2, 1], 5), 3), R([1, 6, 15, 20, 15], 5))
     assert R.equal_repr(R.pow_int(R.add(R.gen, R.one), 6), R([1, 6, 15, 20, 15, 6], 6))
     assert R.equal_repr(R.pow_int(R.gen, 10), R([], 6))
     assert R3.equal_repr(R3.pow_int(R3.add(R3.gen, R3.one), 5), R3([1, 5, 10], 3))
+    assert R3.equal_repr(R3.pow_int(R([1, 1, 1, 1, 1]), 2), R3([1, 2, 3], 3))
     assert R3.equal_repr(
         R3.pow_int(R3.pow_int(R3.add(R3.one, R3.gen), 2), 2), R3([1, 4, 6], 3)
     )
@@ -399,6 +417,7 @@ def test_int_differentiate(ring_int):
         R3.differentiate(SeriesRing(3).pow_int(R3.add(R3.gen, R3.one), 4)),
         R3([4, 12], 2),
     )
+    assert R3.equal_repr(R3.differentiate(R([2, 6, 2, 1, 2, 3])), R3([6, 4, 3], 3))
     assert R10.equal_repr(
         R10.differentiate(R10.pow_int(R10.gen, 4)), R10([0, 0, 0, 4], None)
     )
@@ -455,6 +474,7 @@ def test_rational_integrate(ring_rational):
         R3.integrate(R3.multiply(R3.gen, R3.gen)),
         R3([(0, 1), (0, 1), (0, 1), (1, 3)], None),
     )
+    assert R3.equal_repr(R3.integrate(R([2, 4, 1, 1], 5)), R3([0, 2, 2], 3))
     assert R10.equal_repr(
         R10.integrate(R10.add(R10.gen, R10.one)), R10([(0, 1), (1, 1), (1, 2)], None)
     )
@@ -488,6 +508,14 @@ def test_int_compose(ring_int):
         R.compose(R([1, 1, 1]), R.square(R.gen)), R([1, 0, 1, 0, 1], None)
     )
     assert R3.equal_repr(R3.compose(R3([1, 2, 3]), R3([0, 1, 1])), R3([1, 2, 5], 3))
+    assert R3.equal_repr(R3.compose(R3([7, 5, 8], 3), R3([0, 1, 1])), R3([7, 5, 13], 3))
+    assert R3.equal_repr(
+        R3.compose(R3([1, 2, 3]), R3([0, 9, 1], 3)), R3([1, 18, 245], 3)
+    )
+    assert R3.equal_repr(
+        R3.compose(R([7, 1, 1, 2, 3]), R([0, 2, 2, 1, 1])), R3([7, 2, 6], 3)
+    )
+
     assert R10.equal_repr(
         R10.compose(R10([2, 4, 5, 1, 6, 2], 7), R10([0, 1, 1, 2, 3, 4], 7)),
         R10([2, 4, 9, 19, 46, 101, 206], 7),
@@ -666,6 +694,8 @@ def test_log(ring_rational):
     raises(ValueError, lambda: R.log(R([(0, 1)])))
     raises(ValueError, lambda: R.log(R([(2, 1)])))
 
+    raises(ValueError, lambda: R.log1p(R([1, 1])))
+
     assert R3.equal_repr(
         R3.log(R3.add(R3.one, R3.gen)),
         R3([(0, 1), (1, 1), (-1, 2)], 3),
@@ -698,6 +728,11 @@ def test_exp(ring_rational):
 
     raises(ValueError, lambda: R.exp(R([1, 1])))
     assert R.equal_repr(R.exp(R([])), R([1]))
+    assert R.equal_repr(R.expm1(R([])), R([]))
+    assert R.equal_repr(
+        R.expm1(R([0, 2, 8, 1])),
+        R([(0, 1), (2, 1), (10, 1), (55, 3), (152, 3), (1274, 15)], 6),
+    )
 
     assert R3.equal_repr(
         R3.exp(R3.gen),
@@ -1057,12 +1092,17 @@ def test_cosh(ring_rational):
 def test_high_deg(ring_rational):
     SeriesRing = ring_rational
     Rs = SeriesRing(30)
+    Rs50 = SeriesRing(50)
     Rp, x = ring("x", QQ)
 
     rand = dup_random(30, 0, 10, QQ)
+    rand50 = dup_random(50, 0, 10, QQ)
     rand[0] = QQ.zero
+    rand50[0] = QQ.zero
     s = Rs(rand)
+    s50 = Rs50(rand50)
     p = Rp.from_list(rand[::-1])
+    p50 = Rp.from_list(rand50[::-1])
 
     assert Rs.to_dense(Rs.exp(s)) == rs_exp(p, x, 30).to_dense()
     assert Rs.to_dense(Rs.expm1(s)) == (rs_exp(p, x, 30) - 1).to_dense()
@@ -1075,9 +1115,9 @@ def test_high_deg(ring_rational):
     assert Rs.to_dense(Rs.tan(s)) == rs_tan(p, x, 30).to_dense()
     assert Rs.to_dense(Rs.tanh(s)) == rs_tanh(p, x, 30).to_dense()
     assert Rs.to_dense(Rs.sin(s)) == rs_sin(p, x, 30).to_dense()
-    assert Rs.to_dense(Rs.sinh(s)) == rs_sinh(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs50.sinh(s50)) == rs_sinh(p50, x, 50).to_dense()
     assert Rs.to_dense(Rs.cos(s)) == rs_cos(p, x, 30).to_dense()
-    assert Rs.to_dense(Rs.cosh(s)) == rs_cosh(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs50.cosh(s50)) == rs_cosh(p50, x, 50).to_dense()
 
     rand[0] = QQ.one
     s2 = Rs(rand)

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -40,17 +40,17 @@ if GROUND_TYPES == "flint":
 
 
 @pytest.fixture(params=Ring_ZZ + Ring_QQ)
-def rd_int(request):
+def ring_int(request):
     return request.param
 
 
 @pytest.fixture(params=Ring_QQ)
-def rd_rational(request):
+def ring_rational(request):
     return request.param
 
 
-def test_equal(rd_int):
-    SeriesRing = rd_int
+def test_equal(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     assert R.equal(R([1, 2, 3]), R([1, 2, 3])) is True
     assert R.equal(R([1, 21, 3]), R([1, 2, 3])) is False
@@ -65,8 +65,8 @@ def test_equal(rd_int):
     assert R.equal(R([1, 2], None), R([1, 2, 3], 3)) is False
 
 
-def test_basics(rd_int):
-    SeriesRing = rd_int
+def test_basics(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R0 = SeriesRing(0)
 
@@ -86,8 +86,8 @@ def test_basics(rd_int):
     assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 6
 
 
-def test_positive(rd_int):
-    SeriesRing = rd_int
+def test_positive(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     assert R.equal_repr(
         R.positive(R([1, 2, 3, 4, 5, 6, 7], None)), R([1, 2, 3, 4, 5, 6], 6)
@@ -97,8 +97,8 @@ def test_positive(rd_int):
     )
 
 
-def test_negative(rd_int):
-    SeriesRing = rd_int
+def test_negative(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     assert R.equal_repr(R.negative(R.gen), R([0, -1], None))
     assert R.equal_repr(
@@ -111,15 +111,15 @@ def test_negative(rd_int):
     )
 
 
-def test_add(rd_int):
-    SeriesRing = rd_int
+def test_add(ring_int):
+    SeriesRing = ring_int
     R3 = SeriesRing(3)
     assert R3.equal_repr(R3.add(R3.gen, R3.one), R3([1, 1], None))
     assert R3.equal_repr(R3.add(R3.one, R3.pow_int(R3.gen, 4)), R3([1], 3))
 
 
-def test_int_subtract(rd_int):
-    SeriesRing = rd_int
+def test_int_subtract(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     assert R.equal_repr(
@@ -130,8 +130,8 @@ def test_int_subtract(rd_int):
     )
 
 
-def test_int_multiply(rd_int):
-    SeriesRing = rd_int
+def test_int_multiply(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -146,8 +146,8 @@ def test_int_multiply(rd_int):
     )
 
 
-def test_rational_multiply(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_multiply(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     assert R.equal_repr(R.multiply(R.gen, R.gen), R([(0, 1), (0, 1), (1, 1)], None))
@@ -165,8 +165,8 @@ def test_rational_multiply(rd_rational):
     )
 
 
-def test_int_multiply_ground(rd_int):
-    SeriesRing = rd_int
+def test_int_multiply_ground(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     assert R.equal_repr(R.multiply_ground(R.one, ZZ(1)), R([1], None))
     assert R.equal_repr(R.multiply_ground(R.gen, ZZ(-1)), R([0, -1], None))
@@ -179,8 +179,8 @@ def test_int_multiply_ground(rd_int):
     )
 
 
-def test_rational_multiply_ground(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_multiply_ground(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     assert R.equal_repr(R.multiply_ground(R.gen, QQ(1, 2)), R([(0, 1), (1, 2)], None))
     assert R.equal_repr(R.multiply_ground(R.one, QQ(3, 4)), R([(3, 4)], None))
@@ -192,8 +192,8 @@ def test_rational_multiply_ground(rd_rational):
     )
 
 
-def test_int_divide(rd_int):
-    SeriesRing = rd_int
+def test_int_divide(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -223,8 +223,8 @@ def test_int_divide(rd_int):
     raises(ValueError, lambda: R.divide(R([0, 1]), R([0, 0, 2])))
 
 
-def test_rational_divide(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_divide(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     assert R.equal_repr(
         R.divide(R.add(R.one, R.gen), R.subtract(R.one, R.gen)),
@@ -247,8 +247,8 @@ def test_rational_divide(rd_rational):
     )
 
 
-def test_int_square(rd_int):
-    SeriesRing = rd_int
+def test_int_square(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     assert not R.equal_repr(R.square(R.add(R.gen, R.one)), R([1, 1, 1], None))
@@ -257,8 +257,8 @@ def test_int_square(rd_int):
     )
 
 
-def test_rational_square(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_square(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R10 = SeriesRing(10)
     assert not R.equal_repr(
@@ -269,8 +269,8 @@ def test_rational_square(rd_rational):
     )
 
 
-def test_sqrt(rd_rational):
-    SeriesRing = rd_rational
+def test_sqrt(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R10 = SeriesRing(10)
 
@@ -320,8 +320,8 @@ def test_sqrt(rd_rational):
     )
 
 
-def test_int_pow(rd_int):
-    SeriesRing = rd_int
+def test_int_pow(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -339,8 +339,8 @@ def test_int_pow(rd_int):
     )
 
 
-def test_rational_pow(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_pow(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -373,8 +373,8 @@ def test_rational_pow(rd_rational):
     )
 
 
-def test_truncate(rd_int):
-    SeriesRing = rd_int
+def test_truncate(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     assert R.equal_repr(R.truncate(R.pow_int(R.gen, 3), 4), R([0, 0, 0, 1], None))
     assert R.equal_repr(
@@ -382,8 +382,8 @@ def test_truncate(rd_int):
     )
 
 
-def test_int_differentiate(rd_int):
-    SeriesRing = rd_int
+def test_int_differentiate(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -408,8 +408,8 @@ def test_int_differentiate(rd_int):
     )
 
 
-def test_rational_differentiate(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_differentiate(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -437,8 +437,8 @@ def test_rational_differentiate(rd_rational):
     )
 
 
-def test_rational_integrate(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_integrate(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -468,16 +468,16 @@ def test_rational_integrate(rd_rational):
     )
 
 
-def test_error(rd_int):
-    SeriesRing = rd_int
+def test_error(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     raises(ValueError, lambda: SeriesRing(-1))
     raises(ValueError, lambda: R.pow_int(R.gen, -1))
     raises(ValueError, lambda: R.truncate(R.gen, -1))
 
 
-def test_int_compose(rd_int):
-    SeriesRing = rd_int
+def test_int_compose(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -496,8 +496,8 @@ def test_int_compose(rd_int):
     raises(ValueError, lambda: R.compose(R([1, 2], 2), R([1, 2, 3], 2)))
 
 
-def test_rational_compose(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_compose(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -521,8 +521,8 @@ def test_rational_compose(rd_rational):
     )
 
 
-def test_int_inverse(rd_int):
-    SeriesRing = rd_int
+def test_int_inverse(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -543,8 +543,8 @@ def test_int_inverse(rd_int):
     raises(NotReversible, lambda: R.inverse(R([0, 1, 2])))
 
 
-def test_rational_inverse(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_inverse(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -591,8 +591,8 @@ def test_rational_inverse(rd_rational):
     )
 
 
-def test_int_reversion(rd_int):
-    SeriesRing = rd_int
+def test_int_reversion(ring_int):
+    SeriesRing = ring_int
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -619,8 +619,8 @@ def test_int_reversion(rd_int):
     raises(NotReversible, lambda: R.reversion(R([0, 0, 2])))
 
 
-def test_rational_reversion(rd_rational):
-    SeriesRing = rd_rational
+def test_rational_reversion(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -655,8 +655,8 @@ def test_rational_reversion(rd_rational):
     )
 
 
-def test_log(rd_rational):
-    SeriesRing = rd_rational
+def test_log(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -690,8 +690,8 @@ def test_log(rd_rational):
     )
 
 
-def test_exp(rd_rational):
-    SeriesRing = rd_rational
+def test_exp(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -723,8 +723,8 @@ def test_exp(rd_rational):
     )
 
 
-def test_atan(rd_rational):
-    SeriesRing = rd_rational
+def test_atan(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -757,8 +757,8 @@ def test_atan(rd_rational):
     )
 
 
-def test_atanh(rd_rational):
-    SeriesRing = rd_rational
+def test_atanh(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -790,8 +790,8 @@ def test_atanh(rd_rational):
     )
 
 
-def test_asin(rd_rational):
-    SeriesRing = rd_rational
+def test_asin(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -823,8 +823,8 @@ def test_asin(rd_rational):
     )
 
 
-def test_asinh(rd_rational):
-    SeriesRing = rd_rational
+def test_asinh(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -856,8 +856,8 @@ def test_asinh(rd_rational):
     )
 
 
-def test_tan(rd_rational):
-    SeriesRing = rd_rational
+def test_tan(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -889,8 +889,8 @@ def test_tan(rd_rational):
     )
 
 
-def test_tanh(rd_rational):
-    SeriesRing = rd_rational
+def test_tanh(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -922,8 +922,8 @@ def test_tanh(rd_rational):
     )
 
 
-def test_sin(rd_rational):
-    SeriesRing = rd_rational
+def test_sin(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -955,8 +955,8 @@ def test_sin(rd_rational):
     )
 
 
-def test_sinh(rd_rational):
-    SeriesRing = rd_rational
+def test_sinh(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -988,8 +988,8 @@ def test_sinh(rd_rational):
     )
 
 
-def test_cos(rd_rational):
-    SeriesRing = rd_rational
+def test_cos(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -1021,8 +1021,8 @@ def test_cos(rd_rational):
     )
 
 
-def test_cosh(rd_rational):
-    SeriesRing = rd_rational
+def test_cosh(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
@@ -1054,8 +1054,8 @@ def test_cosh(rd_rational):
     )
 
 
-def test_high_deg(rd_rational):
-    SeriesRing = rd_rational
+def test_high_deg(ring_rational):
+    SeriesRing = ring_rational
     Rs = SeriesRing(30)
     Rp, x = ring("x", QQ)
 
@@ -1086,8 +1086,8 @@ def test_high_deg(rd_rational):
     assert Rs.to_dense(Rs.log1p(s)) == rs_log(p2, x, 30).to_dense()
 
 
-def test_hypot(rd_rational):
-    SeriesRing = rd_rational
+def test_hypot(ring_rational):
+    SeriesRing = ring_rational
     R = SeriesRing()
     R10 = SeriesRing(10)
 

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -79,6 +79,11 @@ def test_basics(rd_int):
     assert R0.equal_repr(R0.multiply(R0.gen, R0.gen), R0([], 0))
     assert R.equal_repr(R.add(R([2, 4, 5], 3), R([5], 2)), R([7, 4], 2))
 
+    assert R.series_prec(R([1, 2, 3])) == None
+    assert R.series_prec(R([1, 2, 3], None)) == None
+    assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7])) == 6
+    assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 10
+
 
 def test_positive(rd_int):
     SeriesRing = rd_int

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -250,7 +250,6 @@ def test_rational_square(rd_rational):
 def test_sqrt(rd_rational):
     SeriesRing = rd_rational
     R = SeriesRing()
-    R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
     assert not R.equal_repr(
@@ -617,6 +616,10 @@ def test_log(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    raises(ValueError, lambda: R.log(R([])))
+    raises(ValueError, lambda: R.log(R([(0, 1)])))
+    raises(ValueError, lambda: R.log(R([(2, 1)])))
+
     assert R3.equal_repr(
         R3.log(R3.add(R3.one, R3.gen)),
         R3([(0, 1), (1, 1), (-1, 2)], 3),
@@ -647,6 +650,9 @@ def test_exp(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    raises(ValueError, lambda: R.exp(R([1, 1])))
+    assert R.equal_repr(R.exp(R([])), R([1]))
+
     assert R3.equal_repr(
         R3.exp(R3.gen),
         R3([(1, 1), (1, 1), (1, 2)], 3),
@@ -676,6 +682,9 @@ def test_atan(rd_rational):
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.atan(R([])), R([]))
+    raises(ValueError, lambda: R.atan(R([2])))
 
     assert R3.equal_repr(
         R3.atan(R3.gen),
@@ -708,6 +717,9 @@ def test_atanh(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    assert R.equal_repr(R.atanh(R([])), R([]))
+    raises(ValueError, lambda: R.atanh(R([1, 1])))
+
     assert R3.equal_repr(
         R3.atanh(R3.gen),
         R3([(0, 1), (1, 1), (0, 1)], 3),
@@ -737,6 +749,9 @@ def test_asin(rd_rational):
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.asin(R([])), R([]))
+    raises(ValueError, lambda: R.asin(R([1, 1])))
 
     assert R3.equal_repr(
         R3.asin(R3.gen),
@@ -768,35 +783,8 @@ def test_asinh(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R3.equal_repr(
-        R3.asinh(R3.gen),
-        R3([(0, 1), (1, 1), (0, 1)], 3),
-    )
-    assert R10.equal_repr(
-        R10.asinh(R10.gen),
-        R10(
-            [
-                (0, 1),
-                (1, 1),
-                (0, 1),
-                (1, 3),
-                (0, 1),
-                (17, 315),
-                (0, 1),
-                (62, 2835),
-                (0, 1),
-                (262, 42525),
-            ],
-            10,
-        ),
-    )
-
-
-def test_asinh(rd_rational):
-    SeriesRing = rd_rational
-    R = SeriesRing()
-    R3 = SeriesRing(3)
-    R10 = SeriesRing(10)
+    assert R.equal_repr(R.asinh(R([])), R([]))
+    raises(ValueError, lambda: R.asinh(R([1, 1])))
 
     assert R3.equal_repr(
         R3.asinh(R3.gen),
@@ -828,6 +816,9 @@ def test_tan(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    assert R.equal_repr(R.tan(R([])), R([]))
+    raises(ValueError, lambda: R.tan(R([1, 1])))
+
     assert R3.equal_repr(
         R3.tan(R3.gen),
         R3([(0, 1), (1, 1), (0, 1)], 3),
@@ -857,6 +848,9 @@ def test_tanh(rd_rational):
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.tanh(R([])), R([]))
+    raises(ValueError, lambda: R.tanh(R([1, 1])))
 
     assert R3.equal_repr(
         R3.tanh(R3.gen),
@@ -888,6 +882,9 @@ def test_sin(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    assert R.equal_repr(R.sin(R([])), R([]))
+    raises(ValueError, lambda: R.sin(R([1, 1])))
+
     assert R3.equal_repr(
         R3.sin(R3.gen),
         R3([(0, 1), (1, 1), (0, 1)], 3),
@@ -917,6 +914,9 @@ def test_sinh(rd_rational):
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.sinh(R([])), R([]))
+    raises(ValueError, lambda: R.sinh(R([1, 1])))
 
     assert R3.equal_repr(
         R3.sinh(R3.gen),
@@ -948,6 +948,9 @@ def test_cos(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
+    assert R.equal_repr(R.cos(R([])), R([]))
+    raises(ValueError, lambda: R.cos(R([1, 1])))
+
     assert R3.equal_repr(
         R3.cos(R3.gen),
         R3([(1, 1), (0, 1), (-1, 2)], 3),
@@ -977,6 +980,9 @@ def test_cosh(rd_rational):
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
+
+    assert R.equal_repr(R.cosh(R([])), R([]))
+    raises(ValueError, lambda: R.cosh(R([1, 1])))
 
     assert R3.equal_repr(
         R3.cosh(R3.gen),

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -1040,25 +1040,25 @@ def test_high_deg(rd_rational):
     Rp, x = ring("x", QQ)
 
     rand = dup_random(30, 0, 10, QQ)
-    rand[0] = 0
+    rand[0] = QQ.zero
     s = Rs(rand)
     p = Rp.from_list(rand[::-1])
 
-    assert Rs.to_dense(Rs.exp(s)) == (rs_exp(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.exp(s)) == rs_exp(p, x, 30).to_dense()
 
-    assert Rs.to_dense(Rs.atan(s)) == (rs_atan(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.atanh(s)) == (rs_atanh(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.asin(s)) == (rs_asin(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.asinh(s)) == (rs_asinh(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.atan(s)) == rs_atan(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.atanh(s)) == rs_atanh(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.asin(s)) == rs_asin(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.asinh(s)) == rs_asinh(p, x, 30).to_dense()
 
-    assert Rs.to_dense(Rs.tan(s)) == (rs_tan(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.tanh(s)) == (rs_tanh(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.sin(s)) == (rs_sin(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.sinh(s)) == (rs_sinh(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.cos(s)) == (rs_cos(p, x, 30)).to_dense()
-    assert Rs.to_dense(Rs.cosh(s)) == (rs_cosh(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.tan(s)) == rs_tan(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.tanh(s)) == rs_tanh(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.sin(s)) == rs_sin(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.sinh(s)) == rs_sinh(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.cos(s)) == rs_cos(p, x, 30).to_dense()
+    assert Rs.to_dense(Rs.cosh(s)) == rs_cosh(p, x, 30).to_dense()
 
-    rand[0] = 1
+    rand[0] = QQ.one
     s = Rs(rand)
     p = Rp.from_list(rand[::-1])
-    assert Rs.to_dense(Rs.log(s)) == (rs_log(p, x, 30)).to_dense()
+    assert Rs.to_dense(Rs.log(s)) == rs_log(p, x, 30).to_dense()

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -247,6 +247,35 @@ def test_rational_square(rd_rational):
     )
 
 
+def test_sqrt(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert not R.equal_repr(
+        R.sqrt(R.add(R.gen, R.one)), R([(1, 1), (1, 1), (1, 1)], None)
+    )
+    assert R10.equal_repr(
+        R10.sqrt(R10.subtract(R10.one, R10.gen)),
+        R10(
+            [
+                (1, 1),
+                (-1, 2),
+                (-1, 8),
+                (-1, 16),
+                (-5, 128),
+                (-7, 256),
+                (-21, 1024),
+                (-33, 2048),
+                (-429, 32768),
+                (-715, 65536),
+            ],
+            10,
+        ),
+    )
+
+
 def test_int_pow(rd_int):
     SeriesRing = rd_int
     R = SeriesRing()
@@ -588,10 +617,6 @@ def test_log(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(
-        R.log(R.add(R.one, R.gen)),
-        R([(0, 1), (1, 1), (-1, 2), (1, 3), (-1, 4), (1, 5)], 6),
-    )
     assert R3.equal_repr(
         R3.log(R3.add(R3.one, R3.gen)),
         R3([(0, 1), (1, 1), (-1, 2)], 3),
@@ -622,10 +647,6 @@ def test_exp(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(
-        R.exp(R.gen),
-        R([(1, 1), (1, 1), (1, 2), (1, 6), (1, 24), (1, 120)], 6),
-    )
     assert R3.equal_repr(
         R3.exp(R3.gen),
         R3([(1, 1), (1, 1), (1, 2)], 3),
@@ -656,10 +677,6 @@ def test_atan(rd_rational):
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(
-        R.atan(R.gen),
-        R([(0, 1), (1, 1), (0, 1), (-1, 3), (0, 1), (1, 5)], 6),
-    )
     assert R3.equal_repr(
         R3.atan(R3.gen),
         R3([(0, 1), (1, 1)], 3),
@@ -685,15 +702,132 @@ def test_atan(rd_rational):
     )
 
 
+def test_atanh(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.atanh(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.atanh(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (1, 3),
+                (0, 1),
+                (1, 5),
+                (0, 1),
+                (1, 7),
+                (0, 1),
+                (1, 9),
+            ],
+            10,
+        ),
+    )
+
+
+def test_asin(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.asin(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.asin(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (1, 6),
+                (0, 1),
+                (3, 40),
+                (0, 1),
+                (5, 112),
+                (0, 1),
+                (35, 1152),
+            ],
+            10,
+        ),
+    )
+
+
+def test_asinh(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.asinh(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.asinh(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (1, 3),
+                (0, 1),
+                (17, 315),
+                (0, 1),
+                (62, 2835),
+                (0, 1),
+                (262, 42525),
+            ],
+            10,
+        ),
+    )
+
+
+def test_asinh(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.asinh(R3.gen),
+        R3([(0, 1), (1, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.asinh(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (-1, 6),
+                (0, 1),
+                (3, 40),
+                (0, 1),
+                (-5, 112),
+                (0, 1),
+                (35, 1152),
+            ],
+            10,
+        ),
+    )
+
+
 def test_tan(rd_rational):
     SeriesRing = rd_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(
-        R.tan(R.gen), R([(0, 1), (1, 1), (0, 1), (1, 3), (0, 1), (2, 15)], 6)
-    )
     assert R3.equal_repr(
         R3.tan(R3.gen),
         R3([(0, 1), (1, 1), (0, 1)], 3),
@@ -718,16 +852,42 @@ def test_tan(rd_rational):
     )
 
 
+def test_tanh(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.tanh(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.tanh(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (-1, 3),
+                (0, 1),
+                (2, 15),
+                (0, 1),
+                (-17, 315),
+                (0, 1),
+                (62, 2835),
+            ],
+            10,
+        ),
+    )
+
+
 def test_sin(rd_rational):
     SeriesRing = rd_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(
-        R.sin(R.gen),
-        R([(0, 1), (1, 1), (0, 1), (-1, 6), (0, 1), (1, 120)], 6),
-    )
     assert R3.equal_repr(
         R3.sin(R3.gen),
         R3([(0, 1), (1, 1), (0, 1)], 3),
@@ -752,16 +912,42 @@ def test_sin(rd_rational):
     )
 
 
+def test_sinh(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.sinh(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.sinh(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (1, 6),
+                (0, 1),
+                (1, 120),
+                (0, 1),
+                (1, 5040),
+                (0, 1),
+                (1, 362880),
+            ],
+            10,
+        ),
+    )
+
+
 def test_cos(rd_rational):
     SeriesRing = rd_rational
     R = SeriesRing()
     R3 = SeriesRing(3)
     R10 = SeriesRing(10)
 
-    assert R.equal_repr(
-        R.cos(R.gen),
-        R([(1, 1), (0, 1), (-1, 2), (0, 1), (1, 24), (0, 1)], 6),
-    )
     assert R3.equal_repr(
         R3.cos(R3.gen),
         R3([(1, 1), (0, 1), (-1, 2)], 3),
@@ -786,4 +972,31 @@ def test_cos(rd_rational):
     )
 
 
-#
+def test_cosh(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R3.equal_repr(
+        R3.cosh(R3.gen),
+        R3([(1, 1), (0, 1), (1, 2)], 3),
+    )
+    assert R10.equal_repr(
+        R10.cosh(R10.gen),
+        R10(
+            [
+                (1, 1),
+                (0, 1),
+                (1, 2),
+                (0, 1),
+                (1, 24),
+                (0, 1),
+                (1, 720),
+                (0, 1),
+                (1, 40320),
+                (0, 1),
+            ],
+            10,
+        ),
+    )

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -716,3 +716,74 @@ def test_tan(rd_rational):
             10,
         ),
     )
+
+
+def test_sin(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(
+        R.sin(R.gen),
+        R([(0, 1), (1, 1), (0, 1), (-1, 6), (0, 1), (1, 120)], 6),
+    )
+    assert R3.equal_repr(
+        R3.sin(R3.gen),
+        R3([(0, 1), (1, 1), (0, 1)], 3),
+    )
+    assert R10.equal_repr(
+        R10.sin(R10.gen),
+        R10(
+            [
+                (0, 1),
+                (1, 1),
+                (0, 1),
+                (-1, 6),
+                (0, 1),
+                (1, 120),
+                (0, 1),
+                (-1, 5040),
+                (0, 1),
+                (1, 362880),
+            ],
+            10,
+        ),
+    )
+
+
+def test_cos(rd_rational):
+    SeriesRing = rd_rational
+    R = SeriesRing()
+    R3 = SeriesRing(3)
+    R10 = SeriesRing(10)
+
+    assert R.equal_repr(
+        R.cos(R.gen),
+        R([(1, 1), (0, 1), (-1, 2), (0, 1), (1, 24), (0, 1)], 6),
+    )
+    assert R3.equal_repr(
+        R3.cos(R3.gen),
+        R3([(1, 1), (0, 1), (-1, 2)], 3),
+    )
+    assert R10.equal_repr(
+        R10.cos(R10.gen),
+        R10(
+            [
+                (1, 1),
+                (0, 1),
+                (-1, 2),
+                (0, 1),
+                (1, 24),
+                (0, 1),
+                (-1, 720),
+                (0, 1),
+                (1, 40320),
+                (0, 1),
+            ],
+            10,
+        ),
+    )
+
+
+#


### PR DESCRIPTION
#### References to other Issues or PRs
#28109

This PR adds support for transcendental functions in PowerSeriesRing for functions that have well-defined series expansions over the rational field (QQ).

#### Other Works
- [x] Add a method to retrieve the  series precision  
- [x] Optimize the `unify_prec` routine  
- [x] Improve overall test coverage for the module
- [x] Fix Protocol

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
