### PR TITLE
Introduced abstract base class for theory solvers and refactored ```LRASolver``` accordingly

### DIFF
--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -126,6 +126,7 @@ from sympy.core.sympify import sympify
 from sympy.core.singleton import S
 from sympy.core.numbers import Rational, oo
 from sympy.matrices.dense import Matrix
+from sympy.logic.algorithms.theory_solver import TheorySolver
 
 class UnhandledInput(Exception):
     """
@@ -139,7 +140,7 @@ ALLOWED_PRED = {Q.eq, Q.gt, Q.lt, Q.le, Q.ge}
 # if true ~Q.gt(x, y) implies Q.le(x, y)
 HANDLE_NEGATION = True
 
-class LRASolver():
+class LRASolver(TheorySolver):
     """
     Linear Arithmetic Solver for DPLL(T) implemented with an algorithm based on
     the Dual Simplex method. Uses Bland's pivoting rule to avoid cycling.

--- a/sympy/logic/algorithms/theory_solver.py
+++ b/sympy/logic/algorithms/theory_solver.py
@@ -1,0 +1,27 @@
+import abc
+
+class TheorySolver(metaclass=abc.ABCMeta):
+    @classmethod
+    @abc.abstractmethod
+    def from_encoded_cnf(cls, encoded_cnf, *args, **kwargs):
+        """
+        Construct a theory solver instance from an EncodedCNF,
+        returning a tuple (instance, conflict_clauses).
+        """
+        pass
+
+    @abc.abstractmethod
+    def assert_lit(self, literal):
+        """
+        Assert a literal/constraint into the theory solver.
+        Returns None or a conflict explanation.
+        """
+        pass
+
+    @abc.abstractmethod
+    def check(self):
+        """
+        Check consistency of the theory solver's current assignments.
+        Returns (True, model) if consistent or (False, conflict_clause) if inconsistent.
+        """
+        pass


### PR DESCRIPTION
Related to https://github.com/sympy/sympy/issues/28154#issuecomment-3071231492

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

This PR enhances the SMT satisfiability framework in SymPy by:

- Defining an abstract base class `TheorySolver` that specifies the essential interface (`from_encoded_cnf`, `assert_lit`, and `check`) for SMT theory solvers.
- Refactoring the existing LRASolver to inherit from `TheorySolver` and implement the required methods, ensuring a clean and uniform API.
- Facilitating the future integration of additional theory solvers (e.g., EUF) by enforcing a consistent solver interface.
- Maintaining backward compatibility by preserving existing LRASolver logic and method signatures while improving conceptual clarity and extensibility.
- Updating imports and internal code references to use the new abstract base class where relevant.

This improvement paves the way for a simplified, modular, and extensible architecture for theory solvers in DPLL(T), enabling easy addition of new theories without significant changes to the satisfiability checking infrastructure.

No existing functionality or API usage is broken by this change.

Closes part of the effort towards issue #28154.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
