### PR TITLE
fix the bug cosh(0)=1

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1706,7 +1706,7 @@ def rs_cosh(p, x, prec):
         return rs_puiseux(rs_cosh, p, x, prec)
     R = p.ring
     if not p:
-        return R(0)
+        return R(1)
     c = _get_constant_term(p, x)
     if c:
         try:

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -499,6 +499,7 @@ def test_sinh():
 
 def test_cosh():
     R, x, y = ring('x, y', QQ)
+    assert rs_cosh(R(0), x, 9) == 1
     assert rs_cosh(x, x, 9) == 1 + x**2/2 + x**4/24 + x**6/720 + x**8/40320
     assert rs_cosh(x*y + x**2*y**3, x, 9) == x**8*y**12/24 + \
         x**8*y**10/48 + x**8*y**8/40320 + x**7*y**10/6 + \


### PR DESCRIPTION
Fixes #28282 


### Release Notes
<!-- BEGIN RELEASE NOTES -->
* polys
   * Fixed: rs_cosh(0) now correctly returns 1 instead of 0.
<!-- END RELEASE NOTES -->
