### PR TITLE
Fix: Ensure radii remain positive after reflect for Circle and Ellipse (GH#28285)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -327,7 +327,7 @@ Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
 Angadh Nanjangud <angadh.n@gmail.com>
 Angus Griffith <16sn6uv@gmail.com>
 Anibal M. Medina-Mardones <ammedmar@gmail.com>
-Aniket Singh Yadav <singhyadavaniket43@gmail.com>
+Aniket Singh Yadav <singhyadavaniket43@gmail.com> Aniket <148300120+Aniketsy@users.noreply.github.com>
 Animesh Sinha <animeshsinha1309@gmail.com>
 Anish Shah <shah.anish07@gmail.com>
 Anjul Kumar Tyagi <anjul.ten@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1785,3 +1785,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Aniket Singh Yadav <singhyadavaniket43@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -327,6 +327,7 @@ Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
 Angadh Nanjangud <angadh.n@gmail.com>
 Angus Griffith <16sn6uv@gmail.com>
 Anibal M. Medina-Mardones <ammedmar@gmail.com>
+Aniket Singh Yadav <singhyadavaniket43@gmail.com>
 Animesh Sinha <animeshsinha1309@gmail.com>
 Anish Shah <shah.anish07@gmail.com>
 Anjul Kumar Tyagi <anjul.ten@gmail.com>
@@ -1785,4 +1786,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Aniket Singh Yadav <singhyadavaniket43@gmail.com>

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1162,7 +1162,7 @@ class Ellipse(GeometrySet):
         if line.slope in (0, oo):
             c = self.center
             c = c.reflect(line)
-            return self.func(c, abs(self.hradius), abs(self.vradius))
+            return self.func(c, self.hradius, self.vradius)
         else:
             x, y = [uniquely_named_symbol(
                 name, (self, line), modify=lambda s: '_' + s, real=True)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1717,7 +1717,7 @@ class Circle(Ellipse):
         """
         c = self.center
         c = c.reflect(line)
-        return self.func(c, abs(self.radius))
+        return self.func(c, self.radius)
 
     def scale(self, x=1, y=1, pt=None):
         """Override GeometryEntity.scale since the radius

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1140,7 +1140,7 @@ class Ellipse(GeometrySet):
 
         >>> from sympy import Circle, Line
         >>> Circle((0, 1), 1).reflect(Line((0, 0), (1, 1)))
-        Circle(Point2D(1, 0), -1)
+        Circle(Point2D(1, 0), 1)
         >>> from sympy import Ellipse, Line, Point
         >>> Ellipse(Point(3, 4), 1, 3).reflect(Line(Point(0, -4), Point(5, 0)))
         Traceback (most recent call last):
@@ -1713,7 +1713,7 @@ class Circle(Ellipse):
 
         >>> from sympy import Circle, Line
         >>> Circle((0, 1), 1).reflect(Line((0, 0), (1, 1)))
-        Circle(Point2D(1, 0), -1)
+        Circle(Point2D(1, 0), 1)
         """
         c = self.center
         c = c.reflect(line)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1162,7 +1162,7 @@ class Ellipse(GeometrySet):
         if line.slope in (0, oo):
             c = self.center
             c = c.reflect(line)
-            return self.func(c, -self.hradius, self.vradius)
+            return self.func(c, abs(self.hradius), abs(self.vradius))
         else:
             x, y = [uniquely_named_symbol(
                 name, (self, line), modify=lambda s: '_' + s, real=True)
@@ -1717,7 +1717,7 @@ class Circle(Ellipse):
         """
         c = self.center
         c = c.reflect(line)
-        return self.func(c, -self.radius)
+        return self.func(c, abs(self.radius))
 
     def scale(self, x=1, y=1, pt=None):
         """Override GeometryEntity.scale since the radius

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -387,7 +387,7 @@ class GeometryEntity(Basic, EvalfMixin):
         >>> circ = Circle(Point(0, 0), 5)
         >>> rcirc = circ.reflect(l)
         >>> rcirc
-        Circle(Point2D(-pi, pi), -5)
+        Circle(Point2D(-pi, pi), 5)
 
         """
         from sympy.geometry.point import Point

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -431,8 +431,8 @@ def test_reflect():
     t1 = Triangle((0, 0), (1, 0), (2, 3))
     assert t1.area == -t1.reflect(l).area
     e = Ellipse((1, 0), 1, 2)
-    assert e.area == -e.reflect(Line((1, 0), slope=0)).area
-    assert e.area == -e.reflect(Line((1, 0), slope=oo)).area
+    assert e.area == e.reflect(Line((1, 0), slope=0)).area
+    assert e.area == e.reflect(Line((1, 0), slope=oo)).area
     raises(NotImplementedError, lambda: e.reflect(Line((1, 0), slope=m)))
     assert Circle((0, 1), 1).reflect(Line((0, 0), (1, 1))) == Circle(Point2D(1, 0), 1)
 

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -434,7 +434,7 @@ def test_reflect():
     assert e.area == -e.reflect(Line((1, 0), slope=0)).area
     assert e.area == -e.reflect(Line((1, 0), slope=oo)).area
     raises(NotImplementedError, lambda: e.reflect(Line((1, 0), slope=m)))
-    assert Circle((0, 1), 1).reflect(Line((0, 0), (1, 1))) == Circle(Point2D(1, 0), -1)
+    assert Circle((0, 1), 1).reflect(Line((0, 0), (1, 1))) == Circle(Point2D(1, 0), 1)
 
 
 def test_is_tangent():

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -80,7 +80,7 @@ def test_reflect_entity_overrides():
     c = Circle((x, y), 3)
     cr = c.reflect(l)
     assert cr == Circle(r, 3)
-    assert c.area == -cr.area
+    assert c.area == cr.area
 
     pent = RegularPolygon((1, 2), 1, 5)
     slope = S.ComplexInfinity

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -97,7 +97,7 @@ def test_reflect_entity_overrides():
                 rvert.remove(ri)
                 break
     assert not rvert
-    assert pent.area.equals(rpent.area)
+    assert pent.area.equals(abs(rpent.area))
 
 
 def test_geometry_EvalfMixin():

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -97,7 +97,7 @@ def test_reflect_entity_overrides():
                 rvert.remove(ri)
                 break
     assert not rvert
-    assert pent.area.equals(-rpent.area)
+    assert pent.area.equals(rpent.area)
 
 
 def test_geometry_EvalfMixin():

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -79,7 +79,7 @@ def test_reflect_entity_overrides():
     r = p.reflect(l)
     c = Circle((x, y), 3)
     cr = c.reflect(l)
-    assert cr == Circle(r, -3)
+    assert cr == Circle(r, 3)
     assert c.area == -cr.area
 
     pent = RegularPolygon((1, 2), 1, 5)

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -97,7 +97,7 @@ def test_reflect_entity_overrides():
                 rvert.remove(ri)
                 break
     assert not rvert
-    assert pent.area.equals(abs(rpent.area))
+    assert pent.area.equals(rpent.area)
 
 
 def test_geometry_EvalfMixin():


### PR DESCRIPTION
Fixes [#28285](https://github.com/sympy/sympy/issues/28285) — ensures that reflecting a Circle or Ellipse across a line always results in non-negative radii.

Updated the reflect methods of both Circle and Ellipse to wrap the radius/radii in abs() after reflection.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->