### PR TITLE
Make the view source link in the docs link back to github

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -303,7 +303,6 @@ html_theme_options = {
             "class": "",
         },
     ],
-    "source_view_link": "https://github.com/sympy/sympy/blob/master/doc/src/{filename}?plain=1",
 }
 
 # Add a header for PR preview builds. See the Circle CI configuration.
@@ -493,8 +492,9 @@ if not commit_hash:
 
 fork = 'sympy'
 blobpath = \
-    "https://github.com/{}/sympy/blob/{}/sympy/".format(fork, commit_hash)
+    "https://github.com/{}/sympy/blob/{}/".format(fork, commit_hash)
 
+html_theme_options["source_view_link"] = blobpath + "doc/src/{filename}?plain=1"
 
 def linkcode_resolve(domain, info):
     """Determine the URL corresponding to Python object."""
@@ -533,7 +533,7 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     fn = os.path.relpath(fn, start=os.path.dirname(sympy.__file__))
-    return blobpath + fn + linespec
+    return blobpath + "sympy/" + fn + linespec
 
 
 def resolve_type_aliases(app, env, node, contnode):

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -303,6 +303,7 @@ html_theme_options = {
             "class": "",
         },
     ],
+    "source_view_link": "https://github.com/sympy/sympy/blob/master/doc/src/{filename}?plain=1",
 }
 
 # Add a header for PR preview builds. See the Circle CI configuration.

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -342,7 +342,7 @@ html_css_files = ['custom.css']
 html_domain_indices = ['py-modindex']
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-# html_copy_source = True
+html_copy_source = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'SymPydoc'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Specifically this button at the top of the page 
<img width="136" height="59" alt="image" src="https://github.com/user-attachments/assets/189b55d6-a0bf-4b20-a457-1843dd593c60" />

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This also removes the included `_source` RST sources in the docs because they should no longer be needed. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- other
  - The "show source" link at the top of the documentation now links to GitHub. 
<!-- END RELEASE NOTES -->
