### PR TITLE
fix(polys): remove special zero handling in dup_to_dict

### DIFF
--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -147,8 +147,6 @@ def dmp_LC(f: dmp[Er], K: Domain[Er]) -> dmp[Er]:
 
     """
     if not f:
-        # XXX: Remove this. It should not be needed since a zero dmp is
-        # represented like [[[]]].
         return K.zero # type: ignore
     else:
         return f[0]
@@ -1170,6 +1168,9 @@ def dup_to_dict(
     >>> dup_to_dict([], ZZ)
     {}
 
+    .. versionchanged:: 1.15.0
+        The ``zero`` parameter was removed.
+
     """
     return {(k,): fk for k, fk in enumerate(f[::-1]) if fk}
 
@@ -1188,6 +1189,9 @@ def dup_to_raw_dict(
 
     >>> dup_to_raw_dict(ZZ.map([1, 0, 5, 0, 7]), ZZ)
     {0: 7, 2: 5, 4: 1}
+
+    .. versionchanged:: 1.15.0
+        The ``zero`` parameter was removed.
 
     """
     return {k: fk for k, fk in enumerate(f[::-1]) if fk}
@@ -1209,6 +1213,9 @@ def dmp_to_dict(
     {(0, 0): 3, (0, 1): 2, (2, 1): 1}
     >>> dmp_to_dict([], 0, ZZ)
     {}
+
+    .. versionchanged:: 1.15.0
+        The ``zero`` parameter was removed.
 
     """
     if not u:

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -147,7 +147,7 @@ def dmp_LC(f: dmp[Er], K: Domain[Er]) -> dmp[Er]:
 
     """
     if not f:
-        return K.zero # type: ignore
+        return _ground_dmp(K.zero)
     else:
         return f[0]
 
@@ -1732,9 +1732,7 @@ def dmp_inject(
     d: dict[monom, Er]
     h: dict[monom, Eg]
 
-    # XXX: Not clear what the domain should be here...
-    # d = dmp_to_dict(f, u, K)
-    d = dmp_to_dict(f, u)
+    d = dmp_to_dict(f, u, K)
     h = {}
 
     v = K.ngens - 1
@@ -1772,9 +1770,7 @@ def dmp_eject(
     d: dict[monom, Er]
     h: dict[monom, dict[monom, Er]]
 
-    # XXX: Not clear what the domain should be here...
-    # d = dmp_to_dict(f, u, K)
-    d = dmp_to_dict(f, u)
+    d = dmp_to_dict(f, u, K.dom)
     h = {}
 
     n = K.ngens

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -2096,7 +2096,7 @@ def dup_random(n: int, a: int, b: int, K: Domain[Er]) -> dup[Er]:
     return f
 
 
-def dup_from_list(f: list[Er], K: Domain[Er]) -> dup[Er]:
+def dup_from_list(f: list[int] | list[Er], K: Domain[Er]) -> dup[Er]:
     """
     Create a ``K[x]`` polynomial from a list.
 

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -19,7 +19,7 @@ from sympy.polys.densearith import (
     dup_exquo_ground, dmp_exquo_ground,
 )
 from sympy.polys.densebasic import (
-    dup, dmp, _dup, _dmp, _ground_dmp,
+    dup, dmp, _dup, _dmp, _dmp2, _ground_dmp,
     dup_strip, dmp_strip, dup_truncate,
     dup_convert, dmp_convert,
     dup_degree, dmp_degree,
@@ -34,7 +34,6 @@ from sympy.polys.densebasic import (
     dmp_zeros,
     dmp_include,
     dup_nth,
-    dup_normal,
 )
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -46,7 +45,9 @@ from math import ceil as _ceil, log2 as _log2, sqrt
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sympy.external.gmpy import MPQ
     from sympy.polys.domains.ringextension import RingExtension
+    from sympy.polys.domains.algebraicfield import AlgebraicField, Alg
 
 
 def dup_integrate(f: dup[Ef], m: int, K: Field[Ef]) -> dup[Ef]:
@@ -172,7 +173,7 @@ def dup_diff(f: dup[Er], m: int, K: Domain[Er]) -> dup[Er]:
     if n < m:
         return []
 
-    deriv = []
+    deriv: list[Er] = []
 
     if m == 1:
         for coeff in f[:-m]:
@@ -219,7 +220,8 @@ def dmp_diff(f: dmp[Er], m: int, u: int, K: Domain[Er]) -> dmp[Er]:
     if n < m:
         return dmp_zero(u)
 
-    deriv, v = [], u - 1
+    deriv: list[dmp[Er]] = []
+    v = u - 1
 
     if m == 1:
         for coeff in f[:-m]:
@@ -457,7 +459,7 @@ def dup_trunc(f: dup[Eeuclid], p: Eeuclid, K: Domain[Eeuclid]) -> dup[Eeuclid]:
 
     """
     if K.is_ZZ:
-        g = []
+        g: list[Eeuclid] = []
 
         for c in f:
             c = c % p
@@ -824,7 +826,7 @@ def dup_real_imag(f: dup[Er], K: Domain[Er]) -> tuple[dmp[Er], dmp[Er]]:
     if not f:
         return f1, f2
 
-    g = [[[K.one, K.zero]], [[K.one], []]]
+    g = _dmp2([[[K.one, K.zero]], [[K.one], []]])
     h = dmp_ground(f[0], 2)
 
     for c in f[1:]:
@@ -1126,7 +1128,8 @@ def _dup_right_decompose(f: dup[Er], s: int, K: Domain[Er]) -> dup[Er]:
 
 def _dup_left_decompose(f: dup[Er], h: dup[Er], K: Domain[Er]) -> dup[Er] | None:
     """Helper function for :func:`_dup_decompose`."""
-    g, i = {}, 0
+    g: dict[int, Er] = {}
+    i = 0
 
     while f:
         q, r = dup_div(f, h, K)
@@ -1149,12 +1152,10 @@ def _dup_decompose(f: dup[Er], K: Domain[Er]) -> tuple[dup[Er], dup[Er]] | None:
             continue
 
         h = _dup_right_decompose(f, s, K)
+        g = _dup_left_decompose(f, h, K)
 
-        if h is not None:
-            g = _dup_left_decompose(f, h, K)
-
-            if g is not None:
-                return g, h
+        if g is not None:
+            return g, h
 
     return None
 
@@ -1238,7 +1239,7 @@ def dmp_alg_inject(
     if not (K.is_Algebraic or K.is_GaussianRing or K.is_GaussianField):
         raise DomainError('computation can be done only in an algebraic domain')
 
-    fd: dict[tuple[int, ...], Er] = dmp_to_dict(f, u)
+    fd: dict[tuple[int, ...], Er] = dmp_to_dict(f, u, K)
     h: dict[tuple[int, ...], Eg] = {}
 
     for f_monom, g in fd.items():
@@ -1250,7 +1251,7 @@ def dmp_alg_inject(
     return F, u + 1, K.dom
 
 
-def dmp_lift(f, u, K):
+def dmp_lift(f: dmp[Alg], u: int, K: AlgebraicField) -> dmp[MPQ]:
     """
     Convert algebraic coefficients to integers in ``K[X]``.
 
@@ -1277,7 +1278,7 @@ def dmp_lift(f, u, K):
     p_a = K.mod.to_list()
     P_A = dmp_include(p_a, list(range(1, v + 1)), 0, K2)
 
-    return dmp_resultant(F, P_A, v, K2)
+    return dmp_resultant(F, P_A, v, K2) # type: ignore
 
 
 def dup_sign_variations(f, K):
@@ -1509,7 +1510,7 @@ def _dup_series_reversion_small(f: dup[Er], n: int, K: Domain[Er]) -> dup[Er]:
     if n >= 4:
         g[-4] = (2 * b ** 2 - a * c) * cinv ** 5
 
-    return dup_normal(g, K)
+    return dup_strip(g)
 
 
 def dup_series_reversion(f: dup[Er], n: int, K: Domain[Er]) -> dup[Er]:

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -1101,7 +1101,7 @@ def _dup_right_decompose(f: dup[Er], s: int, K: Domain[Er]) -> dup[Er]:
     n = len(f) - 1
     lc = dup_LC(f, K)
 
-    fd: dict[int, Er] = dup_to_raw_dict(f)
+    fd: dict[int, Er] = dup_to_raw_dict(f, K)
     g = { s: K.one }
 
     r = n // s

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -13,7 +13,7 @@ from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.domains.ringextension import RingExtension
-from sympy.polys.polyclasses import ANP
+from sympy.polys.polyclasses import ANP, DMP
 from sympy.polys.polyerrors import CoercionFailed, DomainError, NotAlgebraic, IsomorphismFailed
 from sympy.utilities import public
 
@@ -260,6 +260,7 @@ class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg], RingExte
     has_assoc_Field = True
 
     dom: Domain[MPQ]
+    mod: DMP[MPQ]
 
     def __init__(self, dom: Domain[MPQ], *ext: Expr, alias: str | None = None) -> None:
         r"""

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -6,7 +6,7 @@ from typing import Any, Generic, TypeVar, Protocol, Callable, Iterable, TYPE_CHE
 from sympy.core.numbers import AlgebraicNumber
 from sympy.core import Basic, Expr, sympify
 from sympy.core.sorting import ordered
-from sympy.external.gmpy import GROUND_TYPES
+from sympy.external.gmpy import GROUND_TYPES, MPZ
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.orderings import lex, MonomialOrder
 from sympy.polys.polyerrors import UnificationFailed, CoercionFailed, DomainError
@@ -278,6 +278,7 @@ class Domain(Generic[Er]):
 
     """
 
+    # XXX: Should this be Callable[[int | MPZ], Er]?
     dtype: type[Er] | Callable[..., Er]
     """The type (class) of the elements of this :py:class:`~.Domain`:
 
@@ -541,7 +542,7 @@ class Domain(Generic[Er]):
         """Construct an element of ``self`` domain from ``args``. """
         return self.new(*args)
 
-    def normal(self, *args) -> Er:
+    def normal(self, *args: int | MPZ) -> Er:
         return self.dtype(*args)
 
     def convert_from(self, element: Es, base: Domain[Es]) -> Er:

--- a/sympy/polys/orderings.py
+++ b/sympy/polys/orderings.py
@@ -38,6 +38,7 @@ class MonomialOrder:
     def __ne__(self, other):
         return not (self == other)
 
+
 class LexOrder(MonomialOrder):
     """Lexicographic order of monomials. """
 
@@ -48,6 +49,7 @@ class LexOrder(MonomialOrder):
     def __call__(self, monomial):
         return monomial
 
+
 class GradedLexOrder(MonomialOrder):
     """Graded lexicographic order of monomials. """
 
@@ -57,6 +59,7 @@ class GradedLexOrder(MonomialOrder):
     def __call__(self, monomial):
         return (sum(monomial), monomial)
 
+
 class ReversedGradedLexOrder(MonomialOrder):
     """Reversed graded lexicographic order of monomials. """
 
@@ -65,6 +68,7 @@ class ReversedGradedLexOrder(MonomialOrder):
 
     def __call__(self, monomial):
         return (sum(monomial), tuple(reversed([-m for m in monomial])))
+
 
 class ProductOrder(MonomialOrder):
     """
@@ -186,12 +190,14 @@ class InverseOrder(MonomialOrder):
     def __hash__(self):
         return hash((self.__class__, self.O))
 
+
 lex = LexOrder()
 grlex = GradedLexOrder()
 grevlex = ReversedGradedLexOrder()
 ilex = InverseOrder(lex)
 igrlex = InverseOrder(grlex)
 igrevlex = InverseOrder(grevlex)
+
 
 _monomial_key: dict[str, MonomialOrder] = {
     'lex': lex,
@@ -207,12 +213,18 @@ _monomial_key: dict[str, MonomialOrder] = {
 def monomial_key(
     order: str | Symbol | None = None, gens: None = None
 ) -> MonomialOrder: ...
+
+
 @overload
 def monomial_key(order: MonomKey, gens: None = None) -> MonomKey: ...
 @overload
+
+
 def monomial_key(
     order: str | Symbol | MonomKey | None = None, *, gens: Sequence[Symbol]
 ) -> Callable[[Expr], Any]: ...
+
+
 @overload
 def monomial_key(
     order: str | Symbol | MonomKey | None, gens: Sequence[Symbol]
@@ -268,6 +280,7 @@ def monomial_key(
 
     return func
 
+
 class _ItemGetter:
     """Helper class to return a subsequence of values."""
 
@@ -281,6 +294,7 @@ class _ItemGetter:
         if not isinstance(other, _ItemGetter):
             return False
         return self.seq == other.seq
+
 
 def build_product_order(arg, gens):
     """

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1445,7 +1445,7 @@ class DMP_Python(DMP[Er]):
     def _lift(f) -> DMP:
         """Convert algebraic coefficients to rationals. """
         # XXX: This is only for AlgebraicField domains
-        r = dmp_lift(f._rep, f.lev, f.dom)
+        r = dmp_lift(f._rep, f.lev, f.dom) # type: ignore
         return f._new(r, f.dom.dom, f.lev) # type: ignore
 
     def deflate(f) -> tuple[monom, DMP_Python[Er]]:

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -323,7 +323,10 @@ class DMP(CantSympify, Generic[Er]):
 
     def to_dict(f, zero: bool = False) -> dict[monom, Er]:
         """Convert ``f`` to a dict representation with native coefficients. """
-        return dmp_to_dict(f.to_list(), f.lev, f.dom, zero=zero)
+        if zero and not f:
+            return {(0,)*(f.lev + 1): f.dom.zero}
+        else:
+            return dmp_to_dict(f.to_list(), f.lev, f.dom)
 
     def to_sympy_dict(f, zero: bool = False) -> dict[monom, Expr]:
         """Convert ``f`` to a dict representation with SymPy coefficients. """

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -131,7 +131,7 @@ def test_global_series_zero(f):
     Rs = power_series_ring(QQ, 5)
 
     s = Rs(f[::-1])
-    e = expr_from_dict(dup_to_dict(f), x)
+    e = expr_from_dict(dup_to_dict(f, QQ), x)
     assert as_expr(Rs.exp(s), Rs) == exp(e).series(x, 0, 5)
 
     assert as_expr(Rs.atan(s), Rs) == atan(e).series(x, 0, 5)
@@ -152,6 +152,6 @@ def test_global_series_one(f):
     Rs = power_series_ring(QQ, 5)
 
     s = Rs(f[::-1])
-    e = expr_from_dict(dup_to_dict(f), x)
+    e = expr_from_dict(dup_to_dict(f, QQ), x)
 
     assert as_expr(Rs.log(s), Rs) == log(e).series(x, 0, 5)

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -370,21 +370,18 @@ def test_dup_from_to_dict():
     assert dup_from_raw_dict({}, ZZ) == []
     assert dup_from_dict({}, ZZ) == []
 
-    assert dup_to_raw_dict([]) == {}
-    assert dup_to_dict([]) == {}
+    assert dup_to_raw_dict([], ZZ) == {}
+    assert dup_to_dict([], ZZ) == {}
 
-    assert dup_to_raw_dict([], ZZ, zero=True) == {0: ZZ(0)}
-    assert dup_to_dict([], ZZ, zero=True) == {(0,): ZZ(0)}
-
-    f = [3, 0, 0, 2, 0, 0, 0, 0, 8]
-    g = {8: 3, 5: 2, 0: 8}
-    h = {(8,): 3, (5,): 2, (0,): 8}
+    f = ZZ.map([3, 0, 0, 2, 0, 0, 0, 0, 8])
+    g = {8: ZZ(3), 5: ZZ(2), 0: ZZ(8)}
+    h = {(8,): ZZ(3), (5,): ZZ(2), (0,): ZZ(8)}
 
     assert dup_from_raw_dict(g, ZZ) == f
     assert dup_from_dict(h, ZZ) == f
 
-    assert dup_to_raw_dict(f) == g
-    assert dup_to_dict(f) == h
+    assert dup_to_raw_dict(f, ZZ) == g
+    assert dup_to_dict(f, ZZ) == h
 
     R, x,y = ring("x,y", ZZ)
     K = R.to_domain()
@@ -396,22 +393,19 @@ def test_dup_from_to_dict():
     assert dup_from_raw_dict(g, K) == f
     assert dup_from_dict(h, K) == f
 
-    assert dup_to_raw_dict(f) == g
-    assert dup_to_dict(f) == h
+    assert dup_to_raw_dict(f, K) == g
+    assert dup_to_dict(f, K) == h
 
 
 def test_dmp_from_to_dict():
     assert dmp_from_dict({}, 1, ZZ) == [[]]
-    assert dmp_to_dict([[]], 1) == {}
-
-    assert dmp_to_dict([], 0, ZZ, zero=True) == {(0,): ZZ(0)}
-    assert dmp_to_dict([[]], 1, ZZ, zero=True) == {(0, 0): ZZ(0)}
+    assert dmp_to_dict([[]], 1, ZZ) == {}
 
     f = [[3], [], [], [2], [], [], [], [], [8]]
-    g = {(8, 0): 3, (5, 0): 2, (0, 0): 8}
+    g = {(8, 0): ZZ(3), (5, 0): ZZ(2), (0, 0): ZZ(8)}
 
     assert dmp_from_dict(g, 1, ZZ) == f
-    assert dmp_to_dict(f, 1) == g
+    assert dmp_to_dict(f, 1, ZZ) == g
 
 
 def test_dmp_swap():

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -289,7 +289,7 @@ def test_dmp_revert():
 
 def test_dup_series_reversion():
     assert dup_series_reversion([], 3, QQ) == []
-    assert dup_series_reversion([ZZ(12), ZZ(1), ZZ(0)], 3, QQ) == \
+    assert dup_series_reversion([ZZ(12), ZZ(1), ZZ(0)], 3, ZZ) == \
            dup_from_list([-12, 1, 0], QQ)
 
     f = dup_from_list([4, 3, 4, 1, 0], QQ)


### PR DESCRIPTION
Main issue: gh-27360

The functions `dup_to_dict`, `dup_to_raw_dict` and `dmp_to_dict` are changed to no longer have a zero parameter that changes how the zero polynomial is handled. Places that call these functions are also changed to pass the domain parameter explicitly although there are two places in densebasic where it is not clear what the correct domain should be.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The internal functions `dup_to_dict`, `dup_to_raw_dict` and `dmp_to_dict` are changed to no longer have a zero parameter that changes how the zero polynomial is handled. Also the domain parameter is now required and is no longer an optional parameter.
<!-- END RELEASE NOTES -->
