### PR TITLE
New function in `densearith` to calculate the square of dense polynomial to modulo `x**n`

### DIFF
--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -151,7 +151,9 @@ representations. Many functions are available to manipulate polynomials in the
 .. autofunction:: dup_mul
 .. autofunction:: dmp_mul
 .. autofunction:: dup_series_mul
+.. autofunction:: dup_sqr
 .. autofunction:: dmp_sqr
+.. autofunction:: dup_series_sqr
 .. autofunction:: dmp_pow
 .. autofunction:: dup_series_pow
 .. autofunction:: dmp_pdiv

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -1004,6 +1004,54 @@ def dmp_sqr(f, u, K):
     return dmp_strip(h, u)
 
 
+def dup_series_sqr(f, n, K):
+    """
+    Square dense polynomials in ``K[[x]]`` modulo ``x**n``.
+
+    Examples
+    ========
+    >>> from sympy import ZZ
+    >>> from sympy.polys.densearith import dup_series_sqr
+    >>> from sympy.polys.densebasic import dup_from_list, dup_print
+    >>> f = dup_from_list([1, 2, 3], ZZ)
+    >>> p = dup_series_sqr(f, 5, ZZ)
+    >>> dup_print(p, 'x')
+    x**4 + 4*x**3 + 10*x**2 + 12*x + 9
+
+    """
+    if not f or n<=0:
+        return []
+
+    df = dup_degree(f)
+
+    if df > 100:
+        # Use Karatsuba's algorithm for larger polynomials
+        return dup_series_mul(f, f, n, K)
+
+
+    h = []
+
+    for i in range(n):
+        c = K.zero
+
+        j_min = max(0, i - df)
+        j_max = (i + 1) // 2
+
+        for j in range(j_min, j_max):
+            c += f[df - j] * f[df - (i - j)]
+
+        c += c
+
+        if i % 2 == 0:
+            j = i // 2
+            if j <= df:
+                c += f[df - j]**2
+
+        h.append(c)
+
+    return dup_strip(h[::-1])
+
+
 def dup_pow(f, n, K):
     """
     Raise ``f`` to the ``n``-th power in ``K[x]``.

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -22,7 +22,7 @@ from sympy.polys.densearith import (
     dup_add, dmp_add,
     dup_sub, dmp_sub,
     dup_mul, dmp_mul, dup_series_mul,
-    dup_sqr, dmp_sqr,
+    dup_sqr, dmp_sqr, dup_series_sqr,
     dup_pow, dmp_pow, dup_series_pow,
     dup_add_mul, dmp_add_mul,
     dup_sub_mul, dmp_sub_mul,
@@ -747,6 +747,22 @@ def test_dmp_sqr():
     K = FF(9)
 
     assert dmp_sqr([[K(3)], [K(4)]], 1, K) == [[K(6)], [K(7)]]
+
+
+def test_dup_series_sqr():
+    assert dup_series_sqr([], 2, ZZ) == []
+
+    f = dup_from_list([2, 0, 0, 1, 7], ZZ)
+    assert dup_series_sqr(f, 10, ZZ) == dup_series_mul(f, f, 10, ZZ)
+
+    f2 = dup_from_list([QQ(1, 2), QQ(0), QQ(1, 3), QQ(1, 4)], QQ)
+    assert dup_series_sqr(f2, 4, QQ) == dup_series_mul(f2, f2, 4, QQ)
+
+    f3 = dup_from_list([QQ(3, 4), QQ(-1, 2), QQ(1, 6)], QQ)
+    assert dup_series_sqr(f3, 3, QQ) == dup_series_mul(f3, f3, 3, QQ)
+
+    f4 = dup_from_list([QQ(1, 3), QQ(2, 3), QQ(1, 4), QQ(1, 5), QQ(1, 6), QQ(1, 2)], QQ)
+    assert dup_series_sqr(f4, 7, QQ) == dup_series_mul(f4, f4, 7, QQ)
 
 
 def test_dup_pow():


### PR DESCRIPTION
#### References to other Issues or PRs
Needed for: #28109
Other comment: https://github.com/sympy/sympy/pull/28273#discussion_r2254567218

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added `dup_series_sqr` to square dense poly to modulo `x**n`.

<!-- END RELEASE NOTES -->
