### PR TITLE
Fixed GE Inverse for noncommutative elements, added test

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1182,8 +1182,7 @@ Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
 Paul Mandel <paulmandel@google.com>
-Paul Scofield <cerebral.paul@gmail.com> Paul Scofield <Cerebral.Paul@gmail.com>
-Paul Scofield <cerebral.paul@gmail.com> CerebralPaulZ <Cerebral.Paul@gmail.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
 Paul Strickland <p.e.strickland@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1182,6 +1182,7 @@ Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
 Paul Mandel <paulmandel@google.com>
+Paul Scofield <cerebral.paul@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
 Paul Strickland <p.e.strickland@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1182,7 +1182,11 @@ Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
 Paul Mandel <paulmandel@google.com>
+Paul Scofield <cerebral.paul@gmail.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
 Paul Scofield <cerebral.paul@gmail.com> Paul Scofield <Cerebral.Paul@gmail.com>
+Paul Scofield <cerebral.paul@gmail.com> <Cerebral.Paul@gmail.com>
+Paul Scofield <cerebral.paul@gmail.com> CerebralPaulZ <Cerebral.Paul@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
 Paul Strickland <p.e.strickland@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1182,8 +1182,7 @@ Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
 Paul Mandel <paulmandel@google.com>
-Paul Scofield <cerebral.paul@gmail.com>
-Paul Scofield <Cerebral.Paul@gmail.com>
+Paul Scofield <cerebral.paul@gmail.com> Paul Scofield <Cerebral.Paul@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
 Paul Strickland <p.e.strickland@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1182,10 +1182,7 @@ Pastafarianist <mr.pastafarianist@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
 Paul Mandel <paulmandel@google.com>
-Paul Scofield <cerebral.paul@gmail.com>
-Paul Scofield <Cerebral.Paul@gmail.com>
 Paul Scofield <cerebral.paul@gmail.com> Paul Scofield <Cerebral.Paul@gmail.com>
-Paul Scofield <cerebral.paul@gmail.com> <Cerebral.Paul@gmail.com>
 Paul Scofield <cerebral.paul@gmail.com> CerebralPaulZ <Cerebral.Paul@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1183,6 +1183,7 @@ Patrick Lacasse <patrick.m.lacasse@gmail.com>
 Patrick Poitras <acebulf@gmail.com>
 Paul Mandel <paulmandel@google.com>
 Paul Scofield <cerebral.paul@gmail.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
 Paul Strickland <p.e.strickland@gmail.com>

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -97,13 +97,14 @@ def _row_reduce_list(mat, rows, cols, one, iszerofunc, simpfunc,
             row_swap(piv_row, pivot_offset + piv_row)
             swaps.append((piv_row, pivot_offset + piv_row))
 
-        # if we aren't normalizing last, we normalize
-        # before we zero the other rows
-        if normalize_last is False:
+        # if we aren't normalizing last
+        # or the pivot_val is non-commutative,
+        # we normalize before we zero the other rows
+        if normalize_last is False or not pivot_val.is_commutative:
             i, j = piv_row, piv_col
             mat[i*cols + j] = one
             for p in range(i*cols + j + 1, (i + 1)*cols):
-                mat[p] = isimp(mat[p] / pivot_val)
+                mat[p] = isimp(pivot_val**(-1) * mat[p])
             # after normalizing, the pivot value is 1
             pivot_val = one
 
@@ -129,7 +130,7 @@ def _row_reduce_list(mat, rows, cols, one, iszerofunc, simpfunc,
             pivot_val = mat[piv_i*cols + piv_j]
             mat[piv_i*cols + piv_j] = one
             for p in range(piv_i*cols + piv_j + 1, (piv_i + 1)*cols):
-                mat[p] = isimp(mat[p] / pivot_val)
+                mat[p] = isimp(pivot_val**(-1) * mat[p])
 
     return mat, tuple(pivot_cols), tuple(swaps)
 

--- a/sympy/matrices/tests/test_reductions.py
+++ b/sympy/matrices/tests/test_reductions.py
@@ -5,7 +5,7 @@ from sympy.matrices import Matrix, zeros, eye
 from sympy.core.symbol import Symbol
 from sympy.core.numbers import Rational
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.simplify.simplify import simplify
+from sympy.simplify.simplify import simplify, expand
 from sympy.abc import x
 
 
@@ -267,6 +267,43 @@ def test_rref():
             [1, 0, sqrt(x)*(-x + 1)/(-x**Rational(5, 2) + x),
                 0, 1, 1/(sqrt(x) + x + 1)]):
         assert simplify(i - j).is_zero
+
+
+def test_inverse_GE_noncommutative():
+    a, b, c, d = symbols('a, b, c, d', commutative=False)
+    m = Matrix([
+                [a, b],
+                [c, d]])
+
+    m_inverse_calculated = (m).inverse_GE()
+
+    #Appealing to convenient authority,
+    #https://en.wikipedia.org/wiki/Schur_complement
+    m_inverse_expected = Matrix([
+                    [a**(-1) + a**(-1)*b*(-c*a**(-1)*b + d)**(-1)*c*a**(-1), -a**(-1)*b*(-c*a**(-1)*b + d)**(-1)],
+                    [-(-c*a**(-1)*b + d)**(-1)*c*a**(-1), (-c*a**(-1)*b + d)**(-1)]])
+    assert m_inverse_calculated == m_inverse_expected
+
+    #This result also agrees with Block inverse, upon expansion:
+    assert m_inverse_calculated == m.inverse_BLOCK().expand()
+
+    # More definitively, we expect the products of m and its inverse (in either order)
+    # to be the identity matrix. However, the results are not simple and
+    # because sympy simplification is limited for noncommutative expressions,
+    # current simplify() can only usefully apply expand() in this context.
+    # Consequently (in each case) only 2 of the 4 elements of the
+    # resulting product matrix can be asserted to be 1 or 0.
+    m_m_inverse = (m*m_inverse_calculated).expand()
+
+    assert (m_m_inverse)[0, 0] == 1
+
+    assert (m_m_inverse)[0, 1] == 0
+
+    m_inverse_m = (m_inverse_calculated*m).expand()
+
+    assert (m_inverse_m)[0, 0] == 1
+
+    assert (m_inverse_m)[1, 0] == 0
 
 
 def test_rref_rhs():

--- a/sympy/matrices/tests/test_reductions.py
+++ b/sympy/matrices/tests/test_reductions.py
@@ -5,7 +5,7 @@ from sympy.matrices import Matrix, zeros, eye
 from sympy.core.symbol import Symbol
 from sympy.core.numbers import Rational
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.simplify.simplify import simplify, expand
+from sympy.simplify.simplify import simplify
 from sympy.abc import x
 
 


### PR DESCRIPTION
GE multiplication of rows by noncommutative scalars must be applied on left side and immediately, not "last".

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixed inverse_GE for noncommutative elements as inverse_LU was fixed for noncommutative elements in pull https://github.com/sympy/sympy/pull/27437. 
Mentioned as possibility in context of 
https://github.com/sympy/sympy/pull/27422#issuecomment-2571438633
#### Brief description of what is fixed or changed
GE multiplication of rows by noncommutative scalars must be applied on left side and immediately, not "last".

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed inverse_GE for noncommutative elements.
<!-- END RELEASE NOTES -->
