### PR TITLE
Integration of error functions and trigonometric/hyperbolic functions combinations

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -40,6 +40,7 @@ from sympy.core.power import Pow
 from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol, Wild
+from sympy.core.exprtools import factor_terms
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
@@ -2231,4 +2232,12 @@ def manualintegrate(f, var):
             result = result.func(
                 (result.args[1][0], Ne(*cond.args)),
                 (result.args[0][0], True))
+    # Factor terms like erf(x)*sin(x) that may have been expanded
+    def _has_erf_trig_mul(expr):
+        for sub in expr.find(Mul):
+            if sub.has(erf, erfc, erfi) and sub.has(sin, cos, sinh, cosh):
+                return True
+        return False
+    if _has_erf_trig_mul(f) and _has_erf_trig_mul(result):
+        result = factor_terms(result)
     return result

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1257,7 +1257,8 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
         return pull_out_u_rl
 
     liate_rules = [pull_out_u(log), pull_out_u(*inverse_trig_functions),
-                   pull_out_u(erf, erfc, erfi), pull_out_algebraic, pull_out_u(sin, cos),
+                   pull_out_u(erf, erfc, erfi), pull_out_algebraic,
+                   pull_out_u(sin, cos), pull_out_u(sinh, cosh),
                    pull_out_u(exp)]
 
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1441,7 +1441,13 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
     """
     integrand, symbol = integral
 
-    if not integrand.has(erf, erfc, erfi):
+    if not integrand.has(erf, erfc, erfi, exp):
+        return
+
+    a = Wild('a', exclude=[symbol, 0])
+    b = Wild('b', exclude=[symbol])
+    pattern = exp(a * symbol**2 + b * symbol)
+    if not any(term.match(pattern) for term in integrand.atoms(exp)):
         return
 
     # Replace trig and hyperbolic functions with their exponential forms

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -66,7 +66,7 @@ from sympy.polys.polytools import degree, lcm_list, gcd_list, Poly
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.simplify.powsimp import powsimp
-from sympy.simplify.trigsimp import trigsimp
+from sympy.simplify.trigsimp import trigsimp, exptrigsimp
 from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
@@ -2056,24 +2056,6 @@ def has_cmplx_exp_pair(expr):
     return False
 
 
-def rewrite_exp_hyperbolic(expr):
-    a = Wild('a')
-    def sinh_replacement(expr):
-        return expr.replace(
-            exp(a) - exp(-a),
-            lambda a: 2*sinh(a)
-        )
-    def cosh_replacement(expr):
-        return expr.replace(
-            exp(a) + exp(-a),
-            lambda a: 2*cosh(a)
-        )
-
-    expr = cosh_replacement(expr)
-    expr = sinh_replacement(expr)
-    return expr
-
-
 # Cache is used to break cyclic integrals.
 # Need to use the same dummy variable in cached expressions for them to match.
 # Also record "u" of integration by parts, to avoid infinite repetition.
@@ -2263,7 +2245,7 @@ def manualintegrate(f, var):
     if has_cmplx_exp_pair(result):
         if result.has(erf):
             result = result.rewrite(exp, cos).expand().rewrite([sinh, cosh], exp).collect(result.atoms(erf)).collect(result.atoms(exp), factor_terms)
-            result = rewrite_exp_hyperbolic(result)
+            result = exptrigsimp(result)
     # Clear the cache of u-parts
     _parts_u_cache.clear()
     # If we got Piecewise with two parts, put generic first

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2047,6 +2047,25 @@ def has_cmplx_exp_pair(expr):
             return True
     return False
 
+
+def rewrite_exp_hyperbolic(expr):
+    a = Wild('a')
+    def sinh_replacement(expr):
+        return expr.replace(
+            exp(a) - exp(-a),
+            lambda a: 2*sinh(a)
+        )
+    def cosh_replacement(expr):
+        return expr.replace(
+            exp(a) + exp(-a),
+            lambda a: 2*cosh(a)
+        )
+
+    expr = cosh_replacement(expr)
+    expr = sinh_replacement(expr)
+    return expr
+
+
 # Cache is used to break cyclic integrals.
 # Need to use the same dummy variable in cached expressions for them to match.
 # Also record "u" of integration by parts, to avoid infinite repetition.
@@ -2237,6 +2256,7 @@ def manualintegrate(f, var):
     if has_cmplx_exp_pair(result):
         if result.has(erf):
             result = result.rewrite(exp, cos).expand().rewrite([sinh, cosh], exp).collect(result.atoms(erf)).collect(result.atoms(exp), factor_terms)
+            result = rewrite_exp_hyperbolic(result)
     # Clear the cache of u-parts
     _parts_u_cache.clear()
     # If we got Piecewise with two parts, put generic first

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -32,7 +32,7 @@ from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
-from sympy.core.function import Derivative
+from sympy.core.function import Derivative, expand
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer, Number, E
@@ -66,6 +66,7 @@ from sympy.polys.polytools import degree, lcm_list, gcd_list, Poly
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.simplify.powsimp import powsimp
+from sympy.simplify.trigsimp import trigsimp
 from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
@@ -2039,7 +2040,7 @@ def has_cmplx_exp_pair(expr):
 
     for sub in preorder_traversal(expr):
         if sub.func == exp:
-            arg = simplify(sub.args[0])
+            arg = trigsimp(powsimp(factor_terms(expand(sub.args[0]))))
             exp_args.add(arg)
 
     for a in exp_args:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1444,11 +1444,12 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
     if not integrand.has(erf, erfc, erfi, exp):
         return
 
-    a = Wild('a', exclude=[symbol, 0])
-    b = Wild('b', exclude=[symbol])
-    pattern = exp(a * symbol**2 + b * symbol)
-    if not any(term.match(pattern) for term in integrand.atoms(exp)):
-        return
+    if integrand.has(exp):
+        a = Wild('a', exclude=[symbol, 0])
+        b = Wild('b', exclude=[symbol])
+        pattern = exp(a * symbol**2 + b * symbol)
+        if not any(term.match(pattern) for term in integrand.atoms(exp)):
+            return
 
     # Replace trig and hyperbolic functions with their exponential forms
     rewritten = integrand.rewrite([sin, cos, sinh, cosh], exp)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2168,7 +2168,7 @@ def integral_steps(integrand, symbol, **options):
             Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_linear_rule),
-                        null_safe(sqrt_quadratic_rule)),
+                        null_safe(sqrt_quadratic_rule), null_safe(trig_cmplx_exp_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,
@@ -2199,8 +2199,7 @@ def integral_steps(integrand, symbol, **options):
                     integral_is_subclass(Mul, Pow),
                     distribute_expand_rule),
                 trig_powers_products_rule,
-                trig_expand_rule,
-                trig_cmplx_exp_rule
+                trig_expand_rule
             )),
             null_safe(condition(integral_is_subclass(Mul, Pow), nested_pow_rule)),
             null_safe(trig_substitution_rule)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -21,7 +21,6 @@ from sympy.logic.boolalg import And
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
     _parts_rule, integral_steps, manual_subs)
 from sympy.testing.pytest import raises, slow
-from sympy.testing.pytest import XFAIL
 
 x, y, z, u, n, a, b, c, d, e = symbols('x y z u n a b c d e')
 f = Function('f')
@@ -301,21 +300,25 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
     f, F = erfi(7*x)*exp(6*x), exp(6*x)*erfi(7*x)/6 - exp(-Rational(9,49))*erfi(7*x + Rational(3,7))/6
     assert_is_integral_of(f, F)
-    f, F = sin(2*x)*exp(-3*x**2), -I*(sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/6 - sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/6)/2
+    f = sin(2*x)*exp(-3*x**2)
+    F = -I*(sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/6 -
+        sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/6)/2
     assert_is_integral_of(f, F)
-    f, F = cos(2*x)*exp(-3*x**2), sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/12 + sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/12
+    f = cos(2*x)*exp(-3*x**2)
+    F = (sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/12 +
+        sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/12)
     assert_is_integral_of(f, F)
-
-
-@XFAIL
-def test_pull_request_28295():
-    f, F = sin(x)*erf(x), (erf(x - I/2) + erf(x + I/2))*exp(-Rational(1,4))/2 - cos(x)*erf(x)
+    f = sin(x)*erf(x)
+    F = (erf(x - I/2) + erf(x + I/2))*exp(-Rational(1,4))/2 - cos(x)*erf(x)
     assert_is_integral_of(f, F)
-    f, F = cos(x)*erf(x), I*(erf(x - I/2) - erf(x + I/2))*exp(-Rational(1,4))/2 + sin(x)*erf(x)
+    f = cos(x)*erf(x)
+    F = I*(erf(x - I/2) - erf(x + I/2))*exp(-Rational(1,4))/2 + sin(x)*erf(x)
     assert_is_integral_of(f, F)
-    f, F = sinh(-x)*erf(x), (erf(x - Rational(1,2)) + erf(x + Rational(1,2)))*exp(Rational(1,4))/2 - cosh(x)*erf(x)
+    f = sinh(-x)*erf(x)
+    F = (erf(x - Rational(1,2)) + erf(x + Rational(1,2)))*exp(Rational(1,4))/2 - cosh(x)*erf(x)
     assert_is_integral_of(f, F)
-    f, F = -cosh(x/2)*erf(x), (erf(x - Rational(1,4)) - erf(x + Rational(1,4)))*exp(Rational(1,16)) - 2*sinh(x/2)*erf(x)
+    f = -cosh(x/2)*erf(x)
+    F = (erf(x - Rational(1,4)) - erf(x + Rational(1,4)))*exp(Rational(1,16)) - 2*sinh(x/2)*erf(x)
     assert_is_integral_of(f, F)
 
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -21,6 +21,7 @@ from sympy.logic.boolalg import And
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
     _parts_rule, integral_steps, manual_subs)
 from sympy.testing.pytest import raises, slow
+from sympy.testing.pytest import XFAIL
 
 x, y, z, u, n, a, b, c, d, e = symbols('x y z u n a b c d e')
 f = Function('f')
@@ -303,6 +304,18 @@ def test_manualintegrate_special():
     f, F = sin(2*x)*exp(-3*x**2), -I*(sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/6 - sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/6)/2
     assert_is_integral_of(f, F)
     f, F = cos(2*x)*exp(-3*x**2), sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/12 + sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/12
+    assert_is_integral_of(f, F)
+
+
+@XFAIL
+def test_pull_request_28295():
+    f, F = sin(x)*erf(x), (erf(x - I/2) + erf(x + I/2))*exp(-Rational(1,4))/2 - cos(x)*erf(x)
+    assert_is_integral_of(f, F)
+    f, F = cos(x)*erf(x), I*(erf(x - I/2) - erf(x + I/2))*exp(-Rational(1,4))/2 + sin(x)*erf(x)
+    assert_is_integral_of(f, F)
+    f, F = sinh(-x)*erf(x), (erf(x - Rational(1,2)) + erf(x + Rational(1,2)))*exp(Rational(1,4))/2 - cosh(x)*erf(x)
+    assert_is_integral_of(f, F)
+    f, F = -cosh(x/2)*erf(x), (erf(x - Rational(1,4)) - erf(x + Rational(1,4)))*exp(Rational(1,16)) - 2*sinh(x/2)*erf(x)
     assert_is_integral_of(f, F)
 
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -300,6 +300,10 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
     f, F = erfi(7*x)*exp(6*x), exp(6*x)*erfi(7*x)/6 - exp(-Rational(9,49))*erfi(7*x + Rational(3,7))/6
     assert_is_integral_of(f, F)
+    f, F = sin(2*x)*exp(-3*x**2), -I*(sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/6 - sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/6)/2
+    assert_is_integral_of(f, F)
+    f, F = cos(2*x)*exp(-3*x**2), sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x - 2*I)/6)/12 + sqrt(3)*sqrt(pi)*exp(-Rational(1,3))*erf(sqrt(3)*(6*x + 2*I)/6)/12
+    assert_is_integral_of(f, F)
 
 
 def test_manualintegrate_derivative():

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -590,7 +590,13 @@ def exptrigsimp(expr):
         # functions
         choices = [e]
         if e.has(*_trigs):
-            choices.append(e.rewrite(exp))
+            op = e.rewrite(exp)
+            # if e is an Add, we can try to factor it
+            # helps with expressions with leading factors
+            if e.is_Add:
+                choices.append(factor_terms(op))
+            else:
+                choices.append(op)
         choices.append(e.rewrite(cos))
         return min(*choices, key=count_ops)
     newexpr = bottom_up(expr, exp_trig)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1421,15 +1421,50 @@ def test_sysode_linear_neq_order1_type4():
     eqs4 = [Eq(Derivative(f(x), x), x*(f(x) + g(x) + h(x)) + sin(x)),
             Eq(Derivative(g(x), x), x*(f(x) + g(x) + h(x)) + sin(x)),
             Eq(Derivative(h(x), x), x*(f(x) + g(x) + h(x)) + sin(x))]
-    sol4 = [Eq(f(x), C1*Rational(-1, 3) + C2*Rational(-1, 3) + C3*Rational(2, 3) + (C1/3 + C2/3 +
-             C3/3)*exp(x**2*Rational(3, 2)) + Integral(sin(x)*exp(x**2*Rational(-3, 2)), x)*exp(x**2*Rational(3,
-             2))),
-            Eq(g(x), C1*Rational(2, 3) + C2*Rational(-1, 3) + C3*Rational(-1, 3) + (C1/3 + C2/3 +
-             C3/3)*exp(x**2*Rational(3, 2)) + Integral(sin(x)*exp(x**2*Rational(-3, 2)), x)*exp(x**2*Rational(3,
-             2))),
-            Eq(h(x), C1*Rational(-1, 3) + C2*Rational(2, 3) + C3*Rational(-1, 3) + (C1/3 + C2/3 +
-             C3/3)*exp(x**2*Rational(3, 2)) + Integral(sin(x)*exp(x**2*Rational(-3, 2)), x)*exp(x**2*Rational(3,
-             2)))]
+    sol4 = [
+        Eq(
+            f(x),
+            -C1*Rational(1, 3)
+            - C2*Rational(1, 3)
+            + 2*C3*Rational(1, 3)
+            + (C1*Rational(1, 3) + C2*Rational(1, 3) + C3*Rational(1, 3))
+              * exp(3*x**2/2)
+            - sqrt(6)*I*sqrt(pi)*exp(-Rational(1, 6))*exp(3*x**2/2)
+              * erf(sqrt(6)*x/2 - sqrt(6)*I/6)
+              * Rational(1, 12)
+            + sqrt(6)*I*sqrt(pi)*exp(-Rational(1, 6))*exp(3*x**2/2)
+              * erf(sqrt(6)*x/2 + sqrt(6)*I/6)
+              * Rational(1, 12)
+        ),
+        Eq(
+            g(x),
+            2*C1*Rational(1, 3)
+            - C2*Rational(1, 3)
+            - C3*Rational(1, 3)
+            + (C1*Rational(1, 3) + C2*Rational(1, 3) + C3*Rational(1, 3))
+              * exp(3*x**2/2)
+            - sqrt(6)*I*sqrt(pi)*exp(-Rational(1, 6))*exp(3*x**2/2)
+              * erf(sqrt(6)*x/2 - sqrt(6)*I/6)
+              * Rational(1, 12)
+            + sqrt(6)*I*sqrt(pi)*exp(-Rational(1, 6))*exp(3*x**2/2)
+              * erf(sqrt(6)*x/2 + sqrt(6)*I/6)
+              * Rational(1, 12)
+        ),
+        Eq(
+            h(x),
+            -C1*Rational(1, 3)
+            + 2*C2*Rational(1, 3)
+            - C3*Rational(1, 3)
+            + (C1*Rational(1, 3) + C2*Rational(1, 3) + C3*Rational(1, 3))
+              * exp(3*x**2/2)
+            - sqrt(6)*I*sqrt(pi)*exp(-Rational(1, 6))*exp(3*x**2/2)
+              * erf(sqrt(6)*x/2 - sqrt(6)*I/6)
+              * Rational(1, 12)
+            + sqrt(6)*I*sqrt(pi)*exp(-Rational(1, 6))*exp(3*x**2/2)
+              * erf(sqrt(6)*x/2 + sqrt(6)*I/6)
+              * Rational(1, 12)
+        )
+    ]
     assert dsolve(eqs4) == sol4
     assert checksysodesol(eqs4, sol4) == (True, [0, 0, 0])
 


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Solves some more integrals in #27586. 

#### Brief description of what is fixed or changed

Added a new rewriting strategy `trig_cmplx_exp_rule` to `manualintegrate.py`. This rule rewrites `sin`, `cos`, `sinh`, and `cosh` in terms of complex exponentials when the integrand contains `erf`, `erfc`, `erfi`. This solves problems of the form `integrate erf(x)*sin(x)` as they cannot be solved in any other implemented way. It is easy to solve it when turned into complex exponentials as erf rule is already implemented.
The reason error functions are a condition is to avoid messing with other integrals where cyclic integration happens, they still give correct results but they fail tests because of the different answer form.


#### Other comments

It will be better if there is a way to simplify the final answer back into trigonometric/hyperbolic functions instead of the ugly complex exponentials form. When I try to use `rewrite` it adds `cosh` and `sinh` terms to the expression which is even uglier.

```
In [2]: integrate(erf(x)*sin(x), manual=True)
Out[2]: 
   ⎛     ⅈ⋅x             -1/4    ⎛    ⅈ⎞      -1/4    ⎛    ⅈ⎞      -ⅈ⋅x       ⎞ 
-ⅈ⋅⎜- ⅈ⋅ℯ   ⋅erf(x) + ⅈ⋅ℯ    ⋅erf⎜x - ─⎟ + ⅈ⋅ℯ    ⋅erf⎜x + ─⎟ - ⅈ⋅ℯ    ⋅erf(x)⎟ 
   ⎝                             ⎝    2⎠              ⎝    2⎠                 ⎠ 
────────────────────────────────────────────────────────────────────────────────
                                       2                                        

In [3]: integrate(erf(x)*sin(x), manual=True).simplify()
Out[3]: 
                 -1/4    ⎛    ⅈ⎞    -1/4    ⎛    ⅈ⎞               
   ⅈ⋅x          ℯ    ⋅erf⎜x - ─⎟   ℯ    ⋅erf⎜x + ─⎟    -ⅈ⋅x       
  ℯ   ⋅erf(x)            ⎝    2⎠            ⎝    2⎠   ℯ    ⋅erf(x)
- ─────────── + ──────────────── + ──────────────── - ────────────
       2               2                  2                2      

In [4]: integrate(erf(x)*sin(x), manual=True).simplify().rewrite(cos)
Out[4]: 
                                                                                         ⎛    ⅈ⎞                               ⎛    ⅈ⎞
                                                             (-sinh(1/4) + cosh(1/4))⋅erf⎜x - ─⎟   (-sinh(1/4) + cosh(1/4))⋅erf⎜x + ─⎟
  (-ⅈ⋅sin(x) + cos(x))⋅erf(x)   (ⅈ⋅sin(x) + cos(x))⋅erf(x)                               ⎝    2⎠                               ⎝    2⎠
- ─────────────────────────── - ────────────────────────── + ─────────────────────────────────── + ───────────────────────────────────
               2                            2                                 2                                     2                 

``` 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added support for combinations of error functions and trigonometric/hyperbolic functions.
<!-- END RELEASE NOTES -->
