### PR TITLE
polys: Fixes made in ring_series (separated out from PR-28110) 

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -233,7 +233,7 @@ def rs_mul(p1, p2, x, prec):
     """
     R = p1.ring
     p = {}
-    if R.__class__ != p2.ring.__class__ or R != p2.ring:
+    if R != p2.ring:
         raise ValueError('p1 and p2 must have the same ring')
     iv = R.gens.index(x)
     if not isinstance(p2, (PolyElement, PuiseuxPoly)):
@@ -398,7 +398,7 @@ def rs_subs(p, rules, x, prec):
     """
     R = p.ring
     ngens = R.ngens
-    d = R(0)
+    d = {}
     for i in range(ngens):
         d[(i, 1)] = R.gens[i]
     for var in rules:
@@ -1892,10 +1892,10 @@ def rs_hadamard_exp(p1, inverse=False):
     p = R.zero
     if not inverse:
         for exp1, v1 in p1.items():
-            p[exp1] = v1/int(ifac(exp1[0]))
+            p[exp1] = v1/int(ifac(int(exp1[0])))
     else:
         for exp1, v1 in p1.items():
-            p[exp1] = v1*int(ifac(exp1[0]))
+            p[exp1] = v1*int(ifac(int(exp1[0])))
     return p
 
 def rs_compose_add(p1, p2):


### PR DESCRIPTION
This PR separates out changes to the `ring_series` code to have them in a separate part of the commit history instead of burying them down in gh-28110

Changes made:

- `rs_subs`: mutates an empty dict now instead of a sparse zero polynomial

- `rs_mul`: ring comparison for input validation now only compares rings and not their parent classes

- `rs_hadamard_exp`: converted `exp1[0]` to `int` to resolve potential conflict between `gmpy2` and `flint`

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
