### PR TITLE
fix(polys): Fix PolyElement.__rmul__ to use domain_new instead of ring_new (separated out from PR-28110)

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -923,11 +923,11 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict[tuple[int, .
         ring = self.ring
         if isinstance(other, PolyElement):
             try:
-                p2 = ring.ring_new(other)
+                p2 = ring.domain_new(other)
             except CoercionFailed:
                 return NotImplemented # unreachable
             else:
-                return self._mul(p2)
+                return self.mul_ground(p2)
 
         try:
             cp2 = ring.domain_new(other)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -841,7 +841,7 @@ def test_PolyElement___mul__():
 
     R, x = ring("x", ZZ)
     r, a = ring("a", ZZ)
-    raises(NotImplementedError, lambda: x.__rmul__(a))
+    assert x.__rmul__(a) is NotImplemented
 
     _, x, y = ring("x,y", ZZ)
     p = x + y


### PR DESCRIPTION
This PR separates out the fix made in `PolyElement.__rmul__` to have them it a separate part of the commit history instead of burying it down in https://github.com/sympy/sympy/pull/28110

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
