### PR TITLE
Fix: ask(Q.real(Pow(0, -1))) correctly returns False

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -230,6 +230,13 @@ def _(expr, assumptions):
 # RealPredicate
 
 def _RealPredicate_number(expr, assumptions):
+
+    # Check for undefined forms 
+    if expr.is_Pow:
+        base, exp = expr.as_base_exp()
+        if base.is_zero and exp.is_negative:
+            return False  # or None, depending on policy
+        
     # let as_real_imag() work first since the expression may
     # be simpler to evaluate
     i = expr.as_real_imag()[1].evalf(2)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2569,3 +2569,6 @@ def test_issue_25221():
 def test_issue_27440():
     nan = S.NaN
     assert ask(Q.negative(nan)) is None
+
+def test_issue_28150():
+    assert ask(Q.real(Pow(0, -1, evaluate=False))) is False


### PR DESCRIPTION
## Summary 

Previously, ask(Q.real(Pow(0, -1, evaluate=False))) incorrectly returned True. This was due to missing handling for the special case 0**-1, which is undefined and should not be considered real.

## Changes Made

Added an explicit check in _RealPredicate_number within sets.py to return False for Pow(0, -1, evaluate=False).
Introduced custom_real_pow.py to register a specialized real-handling function (can be removed later if deemed unnecessary).
Added corresponding tests in test_query.py to ensure correct behavior and prevent regressions.

## Related Issue
Closes #28150

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed: `Pow(0, -1)` is now correctly recognized as not real using `_RealPredicate_number` handler.
<!-- END RELEASE NOTES -->
