### PR TITLE
 assumptions: Fix 0**negative incorrectly returning real

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2053,6 +2053,10 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
 
+def test_zero_base_negative_exponent_not_real():
+    expr = Pow(S.Zero, S.NegativeOne, evaluate=False)
+    assert ask(Q.real(expr)) is False
+
 @_both_exp_pow
 def test_real_functions():
     # trigonometric functions


### PR DESCRIPTION
 assumptions: Fix 0**negative incorrectly returning real
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #28150


#### Brief description of what is fixed or changed
Previously, Pow(S.Zero, negative_exponent) was incorrectly considered real by the assumptions system.
This PR updates @RealPredicate.register(Pow) in ask.py to explicitly handle the case of a zero base with a negative exponent, returning False instead of True.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed a bug where `0**negative` was incorrectly considered real.
<!-- END RELEASE NOTES -->
