### PR TITLE
[GSoC] Updated Column to support application of manual supports using boundary conditions

### DIFF
--- a/sympy/physics/continuum_mechanics/column.py
+++ b/sympy/physics/continuum_mechanics/column.py
@@ -222,8 +222,8 @@ class Column:
         >>> c = Column(10, E, A)
         >>> c.apply_load(R_0,0,-1)   # Reaction applied as a point load
         >>> c.apply_load(R_10,10,-1) # Reaction applied as a poinnt load
-        >>> c.bc_extension.append(0) # boundary conditions are added manually
-        >>> c.bc_extension.append(10) # boundary conditions are added manually
+        >>> c._bc_extension.append(0) # boundary conditions are added manually
+        >>> c._bc_extension.append(10) # boundary conditions are added manually
         >>> c.apply_load(-10, 10, -1)
         >>> print(c.load)
         R_0*SingularityFunction(x, 0, -1) + R_10*SingularityFunction(x, 10, -1)
@@ -508,8 +508,8 @@ class Column:
         >>> c = Column(10, A, E)
         >>> c.apply_load(R,0,-1) # applied reaction load as a point load
         >>> c.apply_load(G,10,-1) # applied reaction load as a point load
-        >>> c.bc_extension.append(0) # boundary conditions are added manually
-        >>> c.bc_extension.append(10) # boundary conditions are added manually
+        >>> c._bc_extension.append(0) # boundary conditions are added manually
+        >>> c._bc_extension.append(10) # boundary conditions are added manually
         >>> c.apply_load(-5, 0, 0, end=10)
         >>> c.apply_load(-10, 4, -1)
         >>> c.solve_for_reaction_loads(R,G) # Reaction loads need to be passed.

--- a/sympy/physics/continuum_mechanics/column.py
+++ b/sympy/physics/continuum_mechanics/column.py
@@ -514,7 +514,7 @@ class Column:
         >>> c.apply_load(-10, 4, -1)
         >>> c.solve_for_reaction_loads(R,G) # Reaction loads need to be passed.
         >>> c.reaction_loads
-        {R: 31, G: 29}
+        {G: 29, R: 31}
         """
         x = self.variable
         qx = self._load

--- a/sympy/physics/continuum_mechanics/column.py
+++ b/sympy/physics/continuum_mechanics/column.py
@@ -218,6 +218,7 @@ class Column:
         >>> from sympy.physics.continuum_mechanics.column import Column
         >>> from sympy.core.symbol import symbols
         >>> E, A = symbols('E A ')
+        >>> R_0, R_10 = symbols('R_0 R_10')
         >>> c = Column(10, E, A)
         >>> c.apply_load(R_0,0,-1)   # Reaction applied as a point load
         >>> c.apply_load(R_10,10,-1) # Reaction applied as a poinnt load

--- a/sympy/physics/continuum_mechanics/tests/test_column.py
+++ b/sympy/physics/continuum_mechanics/tests/test_column.py
@@ -85,6 +85,66 @@ def test_column():
 
 test_column()
 
+
+def test_supports_using_manual_method():
+    # Test the load equation for column with a support
+    E = Symbol('E')
+    A = Symbol('A')
+    R_0 = Symbol('R_0')
+    c5 = Column(10, E, A)
+    c5.apply_load(R_0,0,-1)
+    c5._bc_extension.append(0)
+    c5.apply_load(10, 0, -1)
+    c5.apply_load(10, 5, -1)
+
+    p = c5.load
+    q = R_0 * SingularityFunction(x, 0, -1) + 10 * SingularityFunction(x, 0, -1) + 10 * SingularityFunction(x, 5, -1)
+    assert p == q
+
+    # Test for one fixed support at x=0
+    E, A = symbols('E A')
+    R_0 = Symbol('R_0')
+
+    c = Column(5, E, A)
+    c.apply_load(R_0,0,-1)
+    c._bc_extension.append(0)
+    c.apply_load(-1, 2.5, -1)
+    c.apply_load(2, 5, -1)
+
+    c.solve_for_reaction_loads(R_0)
+    p = c.reaction_loads
+    q = {R_0: -1}
+    assert p == q
+
+    # Test for one fixed support at x=L
+    c1 = Column(5, E, A)
+    R_5 = Symbol('R_5')
+    c1.apply_load(R_5,5,-1)
+    c1._bc_extension.append(5)
+    c1.apply_load(-4, 2.5, -1)
+    c1.apply_load(2, 5, -1)
+
+    c1.solve_for_reaction_loads(R_5)
+    p = c1.reaction_loads
+    q = {R_5: 2}
+    assert p == q
+
+    # Test for two supports at ends
+    c2 = Column(10, E, A)
+    R_0 = Symbol('R_0')
+    R_10 = Symbol('R_10')
+    c2.apply_load(R_10,10,-1)
+    c2.apply_load(R_0,0,-1)
+    c2._bc_extension.append(0)
+    c2._bc_extension.append(10)
+    c2.apply_load(-1, 5, -1)
+
+    c2.solve_for_reaction_loads(R_0,R_10)
+    p = c2.reaction_loads
+    q = {R_0: Rational(1,2), R_10: Rational(1,2)}
+    assert p == q
+
+
 def test_distributed_loads():
     E, A = symbols('E A')
     c = Column(10, E, A)
@@ -135,6 +195,7 @@ def test_distributed_loads():
     assert p == q
 
 test_distributed_loads()
+
 
 def test_remove_load():
     E, A = symbols('E A')
@@ -203,6 +264,7 @@ def test_remove_load():
     assert p == q
 
 test_remove_load()
+
 
 def test_reactions_point_loads():
     E, A = symbols('E A')
@@ -342,6 +404,7 @@ def test_reactions_point_loads():
 
 test_reactions_point_loads()
 
+
 def test_reactions_higher_orders():
     E, A = symbols('E A')
 
@@ -442,6 +505,7 @@ def test_reactions_higher_orders():
 
 test_reactions_higher_orders()
 
+
 def test_telescope_hinge():
     E, A = symbols('E A')
     c = Column(10, E, A)
@@ -500,6 +564,7 @@ def test_telescope_hinge():
     assert p == q
 
 test_telescope_hinge()
+
 
 def test_equations():
     c = Column(10, 210000, 1)

--- a/sympy/physics/continuum_mechanics/tests/test_column.py
+++ b/sympy/physics/continuum_mechanics/tests/test_column.py
@@ -42,11 +42,11 @@ def test_column():
     # Test applying supports
     c2 = Column(10, E, A)
     c2.apply_support(0)
-    assert c2._bc_deflection == [0]
+    assert c2._bc_extension == [0]
     c2.apply_support(10)
-    assert c2._bc_deflection == [0, 10]
+    assert c2._bc_extension == [0, 10]
     c2.apply_support(5)
-    assert c2._bc_deflection == [0, 10, 5]
+    assert c2._bc_extension == [0, 10, 5]
 
     # Test applying a load
     c3 = Column(10, E, A)
@@ -476,7 +476,7 @@ def test_telescope_hinge():
     q = {R_0: -10, R_10: 0}
     assert p == q
 
-    p = c.hinge_deflections
+    p = c.hinge_extensions
     q = {Symbol('u_7.5'): 50/(E*A)}
     assert p == q
 
@@ -494,7 +494,7 @@ def test_telescope_hinge():
     q = {R_0: 5, R_10: 10}
     assert p == q
 
-    p = c2.hinge_deflections
+    p = c2.hinge_extensions
     u_4 = Symbol('u_4')
     q = {u_4: Rational(1, 2000)}
     assert p == q
@@ -519,7 +519,7 @@ def test_equations():
     )
     assert p == q
 
-    p = c.deflection()
+    p = c.extension()
     q = (
         C_N*x + C_u
         - R_0*SingularityFunction(x, 0, 1)/210000
@@ -539,7 +539,7 @@ def test_equations():
     )
     assert p == q
 
-    p = c.deflection()
+    p = c.extension()
     q = (
         SingularityFunction(x, 0, 1)/210000
         - SingularityFunction(x, 8, 1)/42000


### PR DESCRIPTION
#### References to other Issues
Fixes #28306 

#### What is fixed or changed
Updated the module to support **manual support application** in addition to the existing `apply_support()` workflow.

Previously, supports were primarily added using `apply_support()`, which automatically generated reaction symbols and applied all necessary boundary conditions internally.  
This PR extends the functionality so that users can now also **manually add supports** by:
- Adding a reaction symbol as a load via `apply_load()`
- Manually specifying the corresponding boundary conditions

**Changes Made:**
- Enhanced support-handling logic to recognize and process manually applied supports
- Updated docstrings to describe both methods (`apply_support()` and manual method)
- Added internal checks to ensure manually defined supports work seamlessly with reaction solving
- Refactored related methods to handle both workflows consistently

**Test Cases Added:**
- Added tests for manual support application workflow

#### Other comments
This builds upon #28304 and the changes are highlighted here saiudayagiri#5

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics

  * Added support for manual definition of supports using `apply_load()` and explicit boundary conditions, alongside the existing `apply_support()` method.
<!-- END RELEASE NOTES -->
