### PR TITLE
feat(polys): Add abstract RingExtension Domain

### DIFF
--- a/doc/src/modules/polys/domainsref.rst
+++ b/doc/src/modules/polys/domainsref.rst
@@ -73,6 +73,9 @@ Abstract Domains
 .. autoclass:: sympy.polys.domains.compositedomain.CompositeDomain
    :members:
 
+.. autoclass:: sympy.polys.domains.ringextension.RingExtension
+   :members:
+
 
 .. _GF(p):
 
@@ -152,6 +155,17 @@ when available.
    :members:
    :exclude-members: dtype, tp
 
+
+MPZ
+===
+
+The ``MPZ`` type is either ``int`` or otherwise the ``gmpy2.mpz`` type or if
+python-flint is installed then it is the :class:`~.fmpz` type. The ``MPZ``
+type is the type of the elements in the :ref:`ZZ` domain.
+
+.. py:class:: sympy.polys.domains.integerring.MPZ
+.. py:class:: flint.types.fmpz.fmpz
+
 .. _QQ:
 
 
@@ -218,7 +232,11 @@ MPQ
 ===
 
 The ``MPQ`` type is either :py:class:`~.PythonMPQ` or otherwise the ``mpq``
-type from ``gmpy2``.
+type from ``gmpy2`` or ``flint.fmpq`` if python-flint is installed. The ``MPQ``
+type is the type of the elements in the :ref:`QQ` domain.
+
+.. py:class:: sympy.polys.domains.rationalfield.MPQ
+.. py:class:: flint.types.fmpq.fmpq
 
 
 Gaussian domains
@@ -261,6 +279,8 @@ QQ_I
 
 QQ<a>
 =====
+
+.. py:class:: sympy.polys.domains.algebraicfield.Alg
 
 .. autoclass:: AlgebraicField
    :members:

--- a/doc/src/modules/polys/ringseries.rst
+++ b/doc/src/modules/polys/ringseries.rst
@@ -212,6 +212,4 @@ by ``polys.ring.ring``.
     :members:
 
 .. autoclass:: Map
-.. py:class:: MPQ
 .. py:class:: MonQ
-.. py:class:: flint.types.fmpq.fmpq

--- a/doc/src/modules/polys/series.rst
+++ b/doc/src/modules/polys/series.rst
@@ -89,8 +89,6 @@ Python Implementation
     :members:
 
 .. py:class:: USeries
-.. py:class:: MPZ
-.. py:class:: MPQ
 
 Flint Implementation
 ====================
@@ -105,5 +103,8 @@ Flint Implementation
 
 .. py:class:: ZZSeries
 .. py:class:: QQSeries
-.. py:class:: MPZ
-.. py:class:: MPQ
+
+.. py:class:: flint.types.fmpz_poly.fmpz_poly
+.. py:class:: flint.types.fmpq_poly.fmpq_poly
+.. py:class:: flint.types.fmpz_series.fmpz_series
+.. py:class:: flint.types.fmpq_series.fmpq_series

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, TypeVar, Iterable, Callable, Any
 from sympy.core import igcd
 from sympy.core.expr import Expr
 from sympy.polys.domains.domain import Domain, Er, Es, Eg
-from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.monomials import monomial_min, monomial_ldiv
 from sympy.polys.orderings import monomial_key, MonomialOrder
 
@@ -33,9 +32,10 @@ monom: TypeAlias = "tuple[int, ...]"
 if TYPE_CHECKING:
     from typing import TypeAlias
     from sympy.polys.rings import PolyElement
-    from sympy.polys.domains.algebraicfield import AlgebraicField
-    from sympy.polys.polyclasses import ANP
-    Epa = TypeVar("Epa", PolyElement, ANP)
+    from sympy.polys.domains.polynomialring import PolynomialRing
+    from sympy.polys.domains.ringextension import (
+        RingExtension,
+    )
 
     def _dup(p: dmp[_T], /) -> dup[_T]:
         """Convert level 0 dmp to dup."""
@@ -1719,11 +1719,8 @@ def dmp_include(f: dmp[Er], J: list[int], u: int, K: Domain[Er]) -> dmp[Er]:
     return dmp_from_dict(d, u, K)
 
 
-# XXX: K could be a PolynomialRing or an AlgebraicField or ...
 def dmp_inject(
-    f: dmp[Epa]
-    , u: int, K: PolynomialRing[Eg] | AlgebraicField[Epa, Eg]
-    , front: bool = False
+    f: dmp[Er], u: int, K: RingExtension[Er, Eg], front: bool = False
 ) -> tuple[dmp[Eg], int]:
     """
     Convert ``f`` from ``K[X][Y]`` to ``K[X,Y]``.
@@ -1743,7 +1740,7 @@ def dmp_inject(
     ([[[1]], [[1, 2]]], 2)
 
     """
-    d: dict[monom, Epa]
+    d: dict[monom, Er]
     h: dict[monom, Eg]
 
     d = dmp_to_dict(f, u)
@@ -1751,8 +1748,8 @@ def dmp_inject(
 
     v = K.ngens - 1
 
-    for f_monom, g in d.items():
-        g = g.to_dict()
+    for f_monom, gd in d.items():
+        g = K.to_dict(gd)
 
         for g_monom, c in g.items():
             if front:

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -2,23 +2,27 @@
 
 from __future__ import annotations
 
-from typing import Generic
-
 from sympy.core.add import Add
 from sympy.core.mul import Mul
+from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, symbols
-from sympy.polys.domains.domain import Domain, Er, Eg
+from sympy.external.gmpy import MPQ
+from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.ringextension import RingExtension
 from sympy.polys.polyclasses import ANP
 from sympy.polys.polyerrors import CoercionFailed, DomainError, NotAlgebraic, IsomorphismFailed
 from sympy.utilities import public
 
 
+Alg = ANP[MPQ]
+
+
 @public
-class AlgebraicField(Field, CharacteristicZero, SimpleDomain[Er], Generic[Er, Eg]):
+class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg], RingExtension[Alg, MPQ]):
     r"""Algebraic number field :ref:`QQ(a)`
 
     A :ref:`QQ(a)` domain represents an `algebraic number field`_
@@ -247,7 +251,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain[Er], Generic[Er, Eg
     .. _primitive element: https://en.wikipedia.org/wiki/Primitive_element_theorem
     """
 
-    dtype: type[ANP[Eg]] = ANP
+    dtype: type[Alg] = ANP
 
     is_AlgebraicField = is_Algebraic = True
     is_Numerical = True
@@ -255,9 +259,9 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain[Er], Generic[Er, Eg
     has_assoc_Ring = False
     has_assoc_Field = True
 
-    dom: Domain[Eg]
+    dom: Domain[MPQ]
 
-    def __init__(self, dom: Domain[Eg], *ext, alias=None):
+    def __init__(self, dom: Domain[MPQ], *ext: Expr, alias: str | None = None) -> None:
         r"""
         Parameters
         ==========
@@ -350,6 +354,9 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain[Er], Generic[Er, Eg
     def algebraic_field(self, *extension, alias=None):
         r"""Returns an algebraic field, i.e. `\mathbb{Q}(\alpha, \ldots)`. """
         return AlgebraicField(self.dom, *((self.ext,) + extension), alias=alias)
+
+    def to_dict(self, element: Alg) -> dict[tuple[int, ...], MPQ]:
+        return element.to_dict()
 
     def to_alg_num(self, a):
         """Convert ``a`` of ``dtype`` to an :py:class:`~.AlgebraicNumber`. """

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -492,6 +492,9 @@ class Domain(Generic[Er]):
     is_Composite: bool = False
     """Boolean flag indicating if the domain is a composite domain."""
 
+    is_RingExtension: bool = False
+    """Boolean flag indicating if the domain is a ring extension domain."""
+
     is_PID: bool = False
     """Boolean flag indicating if the domain is a `principal ideal domain`_.
 
@@ -1031,7 +1034,7 @@ class Domain(Generic[Er]):
         """Returns a ring associated with ``self``. """
         raise DomainError('there is no ring associated with %s' % self)
 
-    def get_field(self) -> Field[Ef]:
+    def get_field(self) -> Field:
         """Returns a field associated with ``self``. """
         raise DomainError('there is no field associated with %s' % self)
 

--- a/sympy/polys/domains/field.py
+++ b/sympy/polys/domains/field.py
@@ -1,10 +1,17 @@
 """Implementation of :class:`Field` class. """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from sympy.polys.domains.domain import Ef
 from sympy.polys.domains.ring import Ring
 from sympy.polys.polyerrors import NotReversible, DomainError
 from sympy.utilities import public
+
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 @public
@@ -18,7 +25,7 @@ class Field(Ring[Ef]):
         """Returns a ring associated with ``self``. """
         raise DomainError('there is no ring associated with %s' % self)
 
-    def get_field(self):
+    def get_field(self) -> Self:
         """Returns a field associated with ``self``. """
         return self
 
@@ -38,7 +45,7 @@ class Field(Ring[Ef]):
         """Division of ``a`` and ``b``, implies ``__truediv__``. """
         return a / b, self.zero
 
-    def gcd(self, a, b):
+    def gcd(self, a, b) -> Ef:
         """
         Returns GCD of ``a`` and ``b``.
 
@@ -70,7 +77,7 @@ class Field(Ring[Ef]):
 
         return self.convert(p, ring)/q
 
-    def gcdex(self, a, b):
+    def gcdex(self, a, b) -> tuple[Ef, Ef, Ef]:
         """
         Returns x, y, g such that a * x + b * y == g == gcd(a, b)
         """

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -8,6 +8,7 @@ from sympy.core.expr import Expr
 from sympy.polys.orderings import MonomialOrder
 from sympy.polys.domains.domain import Er, Domain
 from sympy.polys.domains.ring import Ring
+from sympy.polys.domains.ringextension import RingExtension
 from sympy.polys.domains.compositedomain import CompositeDomain
 
 from sympy.polys.polyerrors import CoercionFailed, GeneratorsError
@@ -20,7 +21,9 @@ if TYPE_CHECKING:
 
 
 @public
-class PolynomialRing(Ring['PolyElement[Er]'], CompositeDomain):
+class PolynomialRing(
+    Ring["PolyElement[Er]"], RingExtension["PolyElement[Er]", Er], CompositeDomain
+):
     """A class for representing multivariate polynomial rings. """
 
     is_PolynomialRing = is_Poly = True
@@ -50,6 +53,9 @@ class PolynomialRing(Ring['PolyElement[Er]'], CompositeDomain):
 
         # TODO: remove this
         self.dom = self.domain
+
+    def to_dict(self, element: PolyElement[Er]) -> dict[tuple[int, ...], Er]:
+        return element.to_dict()
 
     def new(self, element) -> PolyElement[Er]:
         return self.ring.ring_new(element)

--- a/sympy/polys/domains/ringextension.py
+++ b/sympy/polys/domains/ringextension.py
@@ -1,0 +1,56 @@
+"""Abstract :class:`RingExtension` domain type. """
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Generic
+from sympy.polys.domains.domain import Domain, Er, Eg
+
+from sympy.utilities import public
+
+
+@public
+class RingExtension(Domain[Er], Generic[Er, Eg]):
+    """Represents a ring extension.
+
+    Examples are polynomial rings :ref:`K[x]`, algebraic number fields
+    :ref:`QQ(a)`, the Guassian domains :ref:`ZZ_I` and :ref:`QQ_I`.
+
+    A ``RingExtension`` domain has a ground domain and a set of generators
+    and provides a ``.to_dict()`` method to convert elements to a dict
+    representation over the ground domain.
+
+    Examples
+    ========
+
+    >>> from sympy import QQ, Symbol
+    >>> x = Symbol('x')
+    >>> R = QQ[x]
+    >>> R.to_dict(R(2))
+    {(0,): 2}
+
+    See Also
+    ========
+
+    AlgebraicField
+    PolynomialRing
+    GaussianIntegerRing
+    GaussianRationalField
+    """
+
+    is_RingExtension = True
+
+    dom: Domain[Eg]
+    """The ground domain of the ring extension."""
+
+    ngens: int
+    """The number of generators of the ring extension."""
+
+    # XXX: For polynomial rings gens is a tuple of domain elements whereas for
+    # algebraic number fields gens is a tuple of Expr.
+    # gens: tuple[ER, ...]
+
+    @abstractmethod
+    def to_dict(self, element: Er) -> dict[tuple[int, ...], Eg]:
+        """Convert ``element`` to a dict over the ground domain."""
+        raise NotImplementedError

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -3018,6 +3018,10 @@ class ANP(CantSympify, Generic[Eg]):
 
     __slots__ = ('_rep', '_mod', 'dom')
 
+    _rep: DMP[Eg]
+    _mod: DMP[Eg]
+    dom: Domain[Eg]
+
     def __new__(cls, rep, mod, dom):
         if isinstance(rep, DMP):
             pass
@@ -3144,7 +3148,7 @@ class ANP(CantSympify, Generic[Eg]):
     def one(cls, mod, dom):
         return ANP(1, mod, dom)
 
-    def to_dict(f):
+    def to_dict(f) -> dict[monom, Eg]:
         """Convert ``f`` to a dict representation with native coefficients. """
         return f._rep.to_dict()
 
@@ -3331,6 +3335,14 @@ class ANP(CantSympify, Generic[Eg]):
             return NotImplemented
         else:
             return f.quo_ground(g)
+
+    def __rtruediv__(f, g):
+        try:
+            g = f.dom.convert(g)
+        except CoercionFailed:
+            return NotImplemented
+        else:
+            return f.pow(-1).mul_ground(g)
 
     def __eq__(f, g):
         try:

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -3,13 +3,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterator
 
 if TYPE_CHECKING:
-    from sympy.polys.domains.algebraicfield import AlgebraicField
-    from sympy.polys.polyclasses import ANP
+    from sympy.polys.domains.algebraicfield import AlgebraicField, Alg
+    from sympy.external.gmpy import MPQ
 
-from sympy.polys.domains.domain import Eg
 from sympy.polys.densearith import (
     dup_neg, dmp_neg,
     dup_sub, dmp_sub,
@@ -112,7 +111,7 @@ def dmp_sqf_p(f, u, K):
     return True
 
 
-def dup_sqf_norm(f: dup[ANP[Eg]], K: AlgebraicField[ANP[Eg], Eg]) -> tuple[int, dup[ANP[Eg]], dup[Eg]]:
+def dup_sqf_norm(f: dup[Alg], K: AlgebraicField) -> tuple[int, dup[Alg], dup[MPQ]]:
     r"""
     Find a shift of `f` in `K[x]` that has square-free norm.
 
@@ -186,7 +185,7 @@ def dup_sqf_norm(f: dup[ANP[Eg]], K: AlgebraicField[ANP[Eg], Eg]) -> tuple[int, 
         h, _ = dmp_inject(_dmp(f), 0, K, front=True)
         r = dmp_resultant(g, h, 1, K.dom)
 
-        r2: dmp[Eg] = r # type: ignore
+        r2: dmp[MPQ] = r # type: ignore
 
         if dup_sqf_p(r2, K.dom):
             break
@@ -196,7 +195,7 @@ def dup_sqf_norm(f: dup[ANP[Eg]], K: AlgebraicField[ANP[Eg], Eg]) -> tuple[int, 
     return s, f, _dup(r2)
 
 
-def _dmp_sqf_norm_shifts(f, u, K):
+def _dmp_sqf_norm_shifts(f: dmp[Alg], u: int, K: AlgebraicField) -> Iterator[tuple[list[int], dmp[Alg]]]:
     """Generate a sequence of candidate shifts for dmp_sqf_norm."""
     #
     # We want to find a minimal shift if possible because shifting high degree
@@ -237,8 +236,8 @@ def _dmp_sqf_norm_shifts(f, u, K):
 
 
 def dmp_sqf_norm(
-    f: dmp[ANP[Eg]], u: int, K: AlgebraicField[ANP[Eg], Eg]
-) -> tuple[list[int], dmp[ANP[Eg]], dmp[Eg]]:
+    f: dmp[Alg], u: int, K: AlgebraicField
+) -> tuple[list[int], dmp[Alg], dmp[MPQ]]:
     r"""
     Find a shift of ``f`` in ``K[X]`` that has square-free norm.
 
@@ -313,19 +312,19 @@ def dmp_sqf_norm(
 
     g = dmp_raise(K.mod.to_list(), u + 1, 0, K.dom)
 
-    for s, f in _dmp_sqf_norm_shifts(f, u, K):
+    for ss, f in _dmp_sqf_norm_shifts(f, u, K):
 
         h, _ = dmp_inject(f, u, K, front=True)
         r = dmp_resultant(g, h, u + 1, K.dom)
 
-        r2: dmp[Eg] = r # type: ignore
+        r2: dmp[MPQ] = r # type: ignore
 
         if dmp_sqf_p(r2, u, K.dom):
             break
     else:
         assert False
 
-    return s, f, r2
+    return ss, f, r2
 
 
 def dmp_norm(f, u, K):


### PR DESCRIPTION
A RingExtension is a ring whose elements are polynomials over another domain. Various operations use this kind of domain generically with the expectation that the elements have a `.to_dict()` method. This commit adds the abstract domain class `RingExtension` that has a `K.to_dict(e)` method that can be used in a well defined way in typed code.

Concrete implementations of `RingExtension` are polynomial rings, algebraic field extensions and the Gausian integers and rationals.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Main issue gh-27360

This follows gh-28292 where I found various places that were awkward for not having something like RingExtension.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * An abstract RingExtension domain class was added that incorporates polynomial rings and algebraic fields.
<!-- END RELEASE NOTES -->
