### PR TITLE
Fix limit evaluation for periodic functions by reducing arguments modulo their period (#28313)

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -412,7 +412,8 @@ class Limit(Expr):
 
         try:
             # Reduce periodic function arguments modulo their period before gruntz
-            e = _reduce_periodic_arg(e, z)
+            if z0 in (S.Infinity, S.NegativeInfinity):
+                e = _reduce_periodic_arg(e, z)
             r = gruntz(e, z, z0, dir)
             if r is S.NaN or l is S.NaN:
                 raise PoleError()

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1455,3 +1455,4 @@ def test_issue_28313():
     n = Symbol('n')
     expr = (1 + sin(pi * sqrt(4 * n**2 + 1)))**n
     assert limit(expr, n, oo) == exp(pi/4)
+    

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1449,3 +1449,9 @@ def test_issue_28130():
     assert limit(3**x, x, -oo) == 0
     assert limit(E**x, x, -oo) == 0
     assert limit((0.3)**x, x, -oo) == oo
+
+def test_issue_28313():
+    # https://github.com/sympy/sympy/issues/28313
+    n = Symbol('n')
+    expr = (1 + sin(pi * sqrt(4 * n**2 + 1)))**n
+    assert limit(expr, n, oo) == exp(pi/4)


### PR DESCRIPTION
(#28313)
This PR fixes incorrect limit evaluation for expressions with periodic (oscillatory) functions whose arguments grow unbounded.

Added a helper _reduce_periodic_arg(expr, var) that reduces arguments of sin, cos, tan, cot modulo their period before computing limits.

Integrated this reduction step before calling the Gruntz algorithm.

Added a unit test 

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
