### PR TITLE
Tensor: Changed old-style string formatting to f-strings

### DIFF
--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -122,8 +122,7 @@ class DenseNDimArray(NDimArray):
         """
         new_total_size = functools.reduce(lambda x,y: x*y, newshape)
         if new_total_size != self._loop_size:
-            raise ValueError('Expecting reshape size to %d but got prod(%s) = %d' % (
-                self._loop_size, str(newshape), new_total_size))
+            raise ValueError(f"Expecting reshape size to {self._loop_size} but got prod({newshape}) = {new_total_size}")
 
         # there is no `.func` as this class does not subtype `Basic`:
         return type(self)(self._array, newshape)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1598,8 +1598,7 @@ class _ArgE:
             self.indices = indices
 
     def __str__(self):
-        return "_ArgE(%s, %s)" % (self.element, self.indices)
-
+        return f"_ArgE({self.element}, {self.indices})"
     __repr__ = __str__
 
 
@@ -1615,7 +1614,7 @@ class _IndPos:
         self.rel = rel
 
     def __str__(self):
-        return "_IndPos(%i, %i)" % (self.arg, self.rel)
+        return f"_IndPos({self.arg}, {self.rel})"
 
     __repr__ = __str__
 

--- a/sympy/tensor/array/expressions/from_indexed_to_array.py
+++ b/sympy/tensor/array/expressions/from_indexed_to_array.py
@@ -126,7 +126,7 @@ def _convert_indexed_to_array(expr):
             for ind, istart, iend in expr.limits:
                 i = _get_argindex(subindices, ind)
                 if istart != 0 or iend+1 != shape[i]:
-                    raise ValueError("summation index and array dimension mismatch: %s" % ind)
+                    raise ValueError(f"summation index and array dimension mismatch: {ind}")
         contraction_indices = []
         subindices = list(subindices)
         if isinstance(subexpr, ArrayDiagonal):

--- a/sympy/tensor/array/expressions/utils.py
+++ b/sympy/tensor/array/expressions/utils.py
@@ -60,7 +60,7 @@ def _get_argindex(subindices, ind):
             return i
         if isinstance(sind, (set, frozenset)) and ind in sind:
             return i
-    raise IndexError("%s not found in %s" % (ind, subindices))
+    raise IndexError(f"{ind} not found in {subindices}")
 
 
 def _apply_recursively_over_nested_lists(func, arr):

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -71,7 +71,7 @@ class ArrayKind(Kind):
         return obj
 
     def __repr__(self):
-        return "ArrayKind(%s)" % self.element_kind
+        return f"ArrayKind({self.element_kind})"
 
     @classmethod
     def _union(cls, kinds) -> 'ArrayKind':

--- a/sympy/tensor/functions.py
+++ b/sympy/tensor/functions.py
@@ -132,7 +132,7 @@ def shape(expr):
     if hasattr(expr, "shape"):
         return expr.shape
     raise NoShapeError(
-        "%s does not have shape, or its type is not registered to shape()." % expr)
+        f"{expr} does not have shape, or its type is not registered to shape().")
 
 
 class NoShapeError(Exception):

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -189,7 +189,7 @@ def _get_indices_Add(expr):
         return set(), {}
 
     if not all(x == non_scalars[0] for x in non_scalars[1:]):
-        raise IndexConformanceException("Indices are not consistent: %s" % expr)
+        raise IndexConformanceException(f"Indices are not consistent: {expr}")
     if not reduce(lambda x, y: x != y or y, syms):
         symmetries = syms[0]
     else:
@@ -292,7 +292,7 @@ def get_indices(expr):
         elif not expr.has(Indexed):
             return set(), {}
         raise NotImplementedError(
-            "FIXME: No specialized handling of type %s" % type(expr))
+            f"FIXME: No specialized handling of type {type(expr)}")
 
 
 def get_contraction_structure(expr):
@@ -466,4 +466,4 @@ def get_contraction_structure(expr):
     elif not expr.has(Indexed):
         return {None: {expr}}
     raise NotImplementedError(
-        "FIXME: No specialized handling of type %s" % type(expr))
+        f"FIXME: No specialized handling of type {type(expr)}")

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -290,14 +290,14 @@ class Indexed(Expr):
             upper = getattr(i, 'upper', None)
             lower = getattr(i, 'lower', None)
             if None in (upper, lower):
-                raise IndexException(filldedent("""
-                    Range is not defined for all indices in: %s""" % self))
+                raise IndexException(filldedent(f"""
+                    Range is not defined for all indices in: {self}"""))
             try:
                 size = upper - lower + 1
             except TypeError:
-                raise IndexException(filldedent("""
+                raise IndexException(filldedent(f"""
                     Shape cannot be inferred from Idx with
-                    undefined range: %s""" % self))
+                    undefined range: {self}"""))
             sizes.append(size)
         return Tuple(*sizes)
 
@@ -334,7 +334,7 @@ class Indexed(Expr):
 
     def _sympystr(self, p):
         indices = list(map(p.doprint, self.indices))
-        return "%s[%s]" % (p.doprint(self.base), ", ".join(indices))
+        return f"{p.doprint(self.base)}[{', '.join(indices)}]"
 
     @property
     def free_symbols(self):
@@ -657,8 +657,8 @@ class Idx(Expr):
 
         elif is_sequence(range):
             if len(range) != 2:
-                raise ValueError(filldedent("""
-                    Idx range tuple must have length 2, but got %s""" % len(range)))
+                raise ValueError(filldedent(f"""
+                    Idx range tuple must have length 2, but got {len(range)}"""))
             for bound in range:
                 if (bound.is_integer is False and bound is not S.Infinity
                         and bound is not S.NegativeInfinity):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -189,7 +189,7 @@ class _IndexStructure(CantSympify):
                 # check consistency and update free
                 if is_contr:
                     if contr:
-                        raise ValueError('two equal contravariant indices in slots %d and %d' %(pos, i))
+                        raise ValueError(f"two equal contravariant indices in slots {pos} and {i}")
                     else:
                         free[pos] = False
                         free[i] = False
@@ -198,7 +198,7 @@ class _IndexStructure(CantSympify):
                         free[pos] = False
                         free[i] = False
                     else:
-                        raise ValueError('two equal covariant indices in slots %d and %d' %(pos, i))
+                        raise ValueError(f"two equal covariant indices in slots {pos} and {i}")
                 if contr:
                     dum.append((i, pos))
                 else:
@@ -1347,7 +1347,7 @@ class TensorIndex(Basic):
     def _print(self):
         s = self.name
         if not self.is_up:
-            s = '-%s' % s
+            s = f'-{s}'
         return s
 
     def __lt__(self, other):
@@ -1636,7 +1636,7 @@ class TensorType(Basic):
         return sorted(set(self.index_types), key=lambda x: x.name)
 
     def __str__(self):
-        return 'TensorType(%s)' % ([str(x) for x in self.index_types])
+        return f"TensorType({[str(x) for x in self.index_types]})"
 
     def __call__(self, s, comm=0):
         """
@@ -1855,7 +1855,7 @@ class TensorHead(Basic):
         return r
 
     def _print(self):
-        return '%s(%s)' %(self.name, ','.join([str(x) for x in self.index_types]))
+        return f"{self.name}({','.join([str(x) for x in self.index_types])})"
 
     def __call__(self, *indices, **kw_args):
         """
@@ -2239,7 +2239,7 @@ class TensExpr(Expr, ABC):
             else:
                 index2 = free2remaining[pos1]
                 if index2 is None:
-                    raise ValueError("incompatible indices: %s and %s" % (free_ind1, free_ind2))
+                    raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")
                 free2remaining[pos1] = None
                 free_ind2[pos1] = index1
                 if index1.is_up ^ index2.is_up:
@@ -2249,8 +2249,7 @@ class TensExpr(Expr, ABC):
                         pos2down.append(pos1)
 
         if len(set(free_ind1) & set(free_ind2)) < len(free_ind1):
-            raise ValueError("incompatible indices: %s and %s" % (free_ind1, free_ind2))
-
+            raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")
         # Raise indices:
         for pos in pos2up:
             index_type_pos = index_types1[pos]
@@ -2364,9 +2363,8 @@ class TensExpr(Expr, ABC):
             if len(expected_shape) != array.rank() or (not all(dim1 == dim2 if
                 dim1.is_number else True for dim1, dim2 in zip(expected_shape,
                 array.shape))):
-                raise ValueError("shapes for tensor %s expected to be %s, "\
-                    "replacement array shape is %s" % (tensor, expected_shape,
-                    array.shape))
+                raise ValueError(f"shapes for tensor {tensor} expected to be {expected_shape}, "\
+                    "replacement array shape is {array.shape}")
 
         ret_indices, array = self._extract_data(replacement_dict)
 
@@ -2962,7 +2960,7 @@ class Tensor(TensExpr):
     @staticmethod
     def _parse_indices(tensor_head, indices):
         if not isinstance(indices, (tuple, list, Tuple)):
-            raise TypeError("indices should be an array, got %s" % type(indices))
+            raise TypeError(f"indices should be an array, got {type(indices)}")
         indices = list(indices)
         for i, index in enumerate(indices):
             if isinstance(index, Symbol):
@@ -2972,9 +2970,9 @@ class Tensor(TensExpr):
                 if c == -1 and isinstance(e, Symbol):
                     indices[i] = TensorIndex(e, tensor_head.index_types[i], False)
                 else:
-                    raise ValueError("index not understood: %s" % index)
+                    raise ValueError(f"index not understood: {index}")
             elif not isinstance(index, TensorIndex):
-                raise TypeError("wrong type for index: %s is %s" % (index, type(index)))
+                raise TypeError(f"wrong type for index: {index} is {type(index)}")
         return indices
 
     def _set_new_index_structure(self, im, is_canon_bp=False):
@@ -3220,7 +3218,7 @@ class Tensor(TensExpr):
                 array = v
                 break
         else:
-            raise ValueError("%s not found in %s" % (self, replacement_dict))
+            raise ValueError(f"{self} not found in {replacement_dict}")
 
         # TODO: inefficient, this should be done at root level only:
         replacement_dict = {k: Array(v) for k, v in replacement_dict.items()}
@@ -3233,7 +3231,7 @@ class Tensor(TensExpr):
             for pair in dum2:
                 # allow `dum2` if the contained values are also in `dum1`.
                 if pair not in dum1:
-                    raise NotImplementedError("%s with contractions is not implemented" % other)
+                    raise NotImplementedError(f"{other} with contractions is not implemented")
             # Remove elements in `dum2` from `dum1`:
             dum1 = [pair for pair in dum1 if pair not in dum2]
         if len(dum1) > 0:
@@ -3282,9 +3280,9 @@ class Tensor(TensExpr):
         indices = [str(ind) for ind in self.indices]
         component = self.component
         if component.rank > 0:
-            return ('%s(%s)' % (component.name, ', '.join(indices)))
+            return (f"{component.name}({', '.join(indices)})")
         else:
-            return ('%s' % component.name)
+            return (f"{component.name}")
 
     def equals(self, other):
         if other == 0:
@@ -3522,7 +3520,7 @@ class TensMul(TensExpr, AssocOp):
                         dummy_data.append((-index, other_pos1, pos1, other_pos2, pos2))
                     indices.append(index)
                 elif index in free2pos1:
-                    raise ValueError("Repeated index: %s" % index)
+                    raise ValueError(f"Repeated index: {index}")
                 else:
                     free2pos1[index] = pos1
                     free2pos2[index] = pos2
@@ -4517,7 +4515,7 @@ class TensorElement(TensExpr):
         if not isinstance(expr, Tensor):
             # remap
             if not isinstance(expr, TensExpr):
-                raise TypeError("%s is not a tensor expression" % expr)
+                raise TypeError(f"{expr} is not a tensor expression")
             return expr.func(*[TensorElement(arg, index_map) for arg in expr.args])
         expr_free_indices = expr.get_free_indices()
         name_translation = {i.args[0]: i for i in expr_free_indices}
@@ -5125,7 +5123,7 @@ def get_lines(ex, index_type):
             if index_types[i] is index_type:
                 a.append(i)
         if len(a) > 2:
-            raise ValueError('at most two indices of type %s allowed' % index_type)
+            raise ValueError(f"at most two indices of type {index_type} allowed")
         if len(a) == 2:
             dt[c] = a
     #dum = ex.dum


### PR DESCRIPTION


#### References to other Issues or PRs
See #28031 


#### Brief description of what is fixed or changed
This commit changes the old-style string formatting to f-strings as mentioned in issue #28031 which recommends the use of newer f-strings in Python.

#### Other comments


#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
