### PR TITLE
permutation groups: fix data corruption bug in coset_transversal()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1317,6 +1317,7 @@ Rizgar Mella <rizgar.mella@gmail.com> <RizgarMella rizgar.mella@gmail.com>
 Rob Drynkin <rob.drynkin@gmail.com>
 Rob Zinkov <rob@zinkov.com>
 Robert <average.programmer@gmail.com>
+Robert Brijder <rbrijder@gmail.com>
 Robert Cimrman <cimrman3@ntc.zcu.cz> <robert.cimrman@gmail.com>
 Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
 Robert Johansson <jrjohansson@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1317,7 +1317,7 @@ Rizgar Mella <rizgar.mella@gmail.com> <RizgarMella rizgar.mella@gmail.com>
 Rob Drynkin <rob.drynkin@gmail.com>
 Rob Zinkov <rob@zinkov.com>
 Robert <average.programmer@gmail.com>
-Robert Brijder <rbrijder@gmail.com>
+Robert Brijder <rbrijder@gmail.com> rbrijder <35840674+rbrijder@users.noreply.github.com>
 Robert Cimrman <cimrman3@ntc.zcu.cz> <robert.cimrman@gmail.com>
 Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
 Robert Johansson <jrjohansson@gmail.com>

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1393,7 +1393,7 @@ class PermutationGroup(Basic):
         if not self._elements:
             self._elements = list(self.generate())
 
-        return self._elements
+        return self._elements[:]
 
     def derived_series(self):
         r"""Return the derived series for the group.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The line `T += T_next` in the function `coset_transversal` has the unintended side effect of corrupting member field `basic_stabilizers`. For example, a second call to coset_transversal might give wrong output. Fix this properly by letting `elements()` return a copy. This way also other uses of this function won't result in accidental data corruption.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* combinatorics
  * Fix data corruption bug in coset_transversal().

<!-- END RELEASE NOTES -->
