### PR TITLE
Quantum: Fix printing of tensor products of bras and kets.

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -1247,15 +1247,15 @@ class JzKet(SpinState, Ket):
         >>> from sympy.physics.quantum.tensorproduct import TensorProduct
         >>> j1,m1,j2,m2 = symbols('j1 m1 j2 m2')
         >>> TensorProduct(JzKet(1,0), JzKet(1,1))
-        |1,0>x|1,1>
+        |1,0>|1,1>
         >>> TensorProduct(JzKet(j1,m1), JzKet(j2,m2))
-        |j1,m1>x|j2,m2>
+        |j1,m1>|j2,m2>
 
     A TensorProduct can be rewritten, in which case the eigenstates that make
     up the tensor product is rewritten to the new basis:
 
         >>> TensorProduct(JzKet(1,1),JxKet(1,1)).rewrite('Jz')
-        |1,1>x|1,-1>/2 + sqrt(2)*|1,1>x|1,0>/2 + |1,1>x|1,1>/2
+        |1,1>|1,-1>/2 + sqrt(2)*|1,1>|1,0>/2 + |1,1>|1,1>/2
 
     The represent method for TensorProduct's gives the vector representation of
     the state. Note that the state in the product basis is the equivalent of the
@@ -1725,7 +1725,7 @@ class JzKetCoupled(CoupledSpinState, Ket):
     state. This is done by passing coupled=False to the rewrite function:
 
         >>> JzKetCoupled(1, 0, (1, 1)).rewrite('Jz', coupled=False)
-        -sqrt(2)*|1,-1>x|1,1>/2 + sqrt(2)*|1,1>x|1,-1>/2
+        -sqrt(2)*|1,-1>|1,1>/2 + sqrt(2)*|1,1>|1,-1>/2
 
     Get the vector representation of a state in terms of the basis elements
     of the Jx operator:
@@ -2015,35 +2015,35 @@ def uncouple(expr, jn=None, jcoupling_list=None):
         >>> from sympy.physics.quantum.spin import JzKetCoupled, uncouple
         >>> from sympy import S
         >>> uncouple(JzKetCoupled(1, 0, (S(1)/2, S(1)/2)))
-        sqrt(2)*|1/2,-1/2>x|1/2,1/2>/2 + sqrt(2)*|1/2,1/2>x|1/2,-1/2>/2
+        sqrt(2)*|1/2,-1/2>|1/2,1/2>/2 + sqrt(2)*|1/2,1/2>|1/2,-1/2>/2
 
     Perform the same calculation using a SpinState state:
 
         >>> from sympy.physics.quantum.spin import JzKet
         >>> uncouple(JzKet(1, 0), (S(1)/2, S(1)/2))
-        sqrt(2)*|1/2,-1/2>x|1/2,1/2>/2 + sqrt(2)*|1/2,1/2>x|1/2,-1/2>/2
+        sqrt(2)*|1/2,-1/2>|1/2,1/2>/2 + sqrt(2)*|1/2,1/2>|1/2,-1/2>/2
 
     Uncouple a numerical state of three coupled spaces using a CoupledSpinState state:
 
         >>> uncouple(JzKetCoupled(1, 1, (1, 1, 1), ((1,3,1),(1,2,1)) ))
-        |1,-1>x|1,1>x|1,1>/2 - |1,0>x|1,0>x|1,1>/2 + |1,1>x|1,0>x|1,0>/2 - |1,1>x|1,1>x|1,-1>/2
+        |1,-1>|1,1>|1,1>/2 - |1,0>|1,0>|1,1>/2 + |1,1>|1,0>|1,0>/2 - |1,1>|1,1>|1,-1>/2
 
     Perform the same calculation using a SpinState state:
 
         >>> uncouple(JzKet(1, 1), (1, 1, 1), ((1,3,1),(1,2,1)) )
-        |1,-1>x|1,1>x|1,1>/2 - |1,0>x|1,0>x|1,1>/2 + |1,1>x|1,0>x|1,0>/2 - |1,1>x|1,1>x|1,-1>/2
+        |1,-1>|1,1>|1,1>/2 - |1,0>|1,0>|1,1>/2 + |1,1>|1,0>|1,0>/2 - |1,1>|1,1>|1,-1>/2
 
     Uncouple a symbolic state using a CoupledSpinState state:
 
         >>> from sympy import symbols
         >>> j,m,j1,j2 = symbols('j m j1 j2')
         >>> uncouple(JzKetCoupled(j, m, (j1, j2)))
-        Sum(CG(j1, m1, j2, m2, j, m)*|j1,m1>x|j2,m2>, (m1, -j1, j1), (m2, -j2, j2))
+        Sum(CG(j1, m1, j2, m2, j, m)*|j1,m1>|j2,m2>, (m1, -j1, j1), (m2, -j2, j2))
 
     Perform the same calculation using a SpinState state
 
         >>> uncouple(JzKet(j, m), (j1, j2))
-        Sum(CG(j1, m1, j2, m2, j, m)*|j1,m1>x|j2,m2>, (m1, -j1, j1), (m2, -j2, j2))
+        Sum(CG(j1, m1, j2, m2, j, m)*|j1,m1>|j2,m2>, (m1, -j1, j1), (m2, -j2, j2))
 
     """
     a = expr.atoms(SpinState)

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -22,7 +22,7 @@ from sympy.physics.quantum.matrixutils import (
     scipy_sparse_matrix,
     matrix_tensor_product
 )
-from sympy.physics.quantum.state import Ket, Bra
+from sympy.physics.quantum.state import Ket, Bra, KetBase, BraBase
 from sympy.physics.quantum.trace import Tr
 
 
@@ -172,7 +172,7 @@ class TensorProduct(Expr):
             s = s + printer._print(self.args[i])
             if isinstance(self.args[i], (Add, Pow, Mul)):
                 s = s + ')'
-            if i != length - 1:
+            if i != length - 1 and not isinstance(self.args[i], (KetBase, BraBase)):
                 s = s + 'x'
         return s
 
@@ -213,7 +213,7 @@ class TensorProduct(Expr):
                     *next_pform.parens(left='(', right=')')
                 )
             pform = prettyForm(*pform.right(next_pform))
-            if i != length - 1:
+            if i != length - 1 and not isinstance(self.args[i], (KetBase, BraBase)):
                 if printer._use_unicode:
                     pform = prettyForm(*pform.right('\N{N-ARY CIRCLED TIMES OPERATOR}' + ' '))
                 else:
@@ -245,7 +245,7 @@ class TensorProduct(Expr):
             s = s + '{' + printer._print(self.args[i], *args) + '}'
             if isinstance(self.args[i], (Add, Mul)):
                 s = s + '\\right)'
-            if i != length - 1:
+            if i != length - 1 and not isinstance(self.args[i], (KetBase, BraBase)):
                 s = s + '\\otimes '
         return s
 

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -799,12 +799,16 @@ def test_state():
 
 def test_tensorproduct():
     tp = TensorProduct(JzKet(1, 1), JzKet(1, 0))
-    assert str(tp) == '|1,1>x|1,0>'
-    assert pretty(tp) == '|1,1>x |1,0>'
-    assert upretty(tp) == '❘1,1⟩⨂ ❘1,0⟩'
-    assert latex(tp) == \
-        r'{{\left|1,1\right\rangle }}\otimes {{\left|1,0\right\rangle }}'
+    assert str(tp) == '|1,1>|1,0>'
+    assert pretty(tp) == '|1,1>|1,0>'
+    assert upretty(tp) == '❘1,1⟩❘1,0⟩'
+    assert latex(tp) == r'{{\left|1,1\right\rangle }}{{\left|1,0\right\rangle }}'
     sT(tp, "TensorProduct(JzKet(Integer(1),Integer(1)), JzKet(Integer(1),Integer(0)))")
+    tp = TensorProduct(Operator('A'), Operator('B'))
+    assert str(tp) == 'AxB'
+    assert pretty(tp) == 'Ax B'
+    assert upretty(tp) == 'A⨂ B'
+    assert latex(tp) == r'{A}\otimes {B}'
 
 
 def test_big_expr():


### PR DESCRIPTION
Tensor products of bras and kets were using additional symbols that, while needed to resolve ambiguities in operators, are not needed in the case of bras and kets.

#### References to other Issues or PRs

Fixes #28039

#### Brief description of what is fixed or changed

Summary
  - Removes unnecessary tensor product symbols (⊗, x) from the printed representation
  of tensor products containing bras and kets
  - Maintains existing tensor product symbols for operators where disambiguation is
  needed
  - Updates tests to verify the simplified printing behavior

  Changes
  - Modified TensorProduct._sympystr(), TensorProduct._pretty(), and
  TensorProduct._latex() methods in sympy/physics/quantum/tensorproduct.py to check if
  arguments are instances of KetBase or BraBase before adding tensor product symbols
  - Added import for KetBase and BraBase from sympy.physics.quantum.state
  - Updated test_tensorproduct() in sympy/physics/quantum/tests/test_printing.py to
  reflect new simplified printing format
  - Added test case for operator tensor products to verify symbols are still used when
  needed

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Simplify tensor product printing for bras and kets  
<!-- END RELEASE NOTES -->
