### PR TITLE
Fix bug in Series.doit()

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -2507,7 +2507,7 @@ class Series(SISOLinearTimeInvariant):
                     arg = arg.doit()
                 arg = arg.doit()
                 res = arg * res
-                return res
+            return res
 
         _num_arg = (arg.doit().num for arg in self.args)
         _den_arg = (arg.doit().den for arg in self.args)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -3620,6 +3620,26 @@ def test_StateSpace_series():
     ser3 = Series(ser2, ss2)
     assert ser3.doit() == ser1.doit()
 
+    # test issue #28326
+    ss_issue = StateSpace(a2, b1+b2, c1+c2, d1)
+    assert Series(ss_issue, ss_issue, ss_issue).doit() == StateSpace(
+        Matrix([
+        [1, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [1, 1, 1, 0, 0, 0],
+        [1, 1, 0, 1, 0, 0],
+        [0, 0, 1, 1, 1, 0],
+        [0, 0, 1, 1, 0, 1]]),
+        Matrix([
+        [1],
+        [1],
+        [0],
+        [0],
+        [0],
+        [0]]),
+        Matrix([[0, 0, 0, 0, 1, 1]]),
+        Matrix([[0]]))
+
     # TransferFunction interconnection with StateSpace
     ser_tf = Series(tf1, ss1)
     assert ser_tf == Series(TransferFunction(s, s + 1, s), StateSpace(Matrix([


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28220

#### Brief description of what is fixed or changed
Unindent a return statement and add a test.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Fixed a bug with `Series.doit()` in state space objects.
<!-- END RELEASE NOTES -->
