### PR TITLE
Sets: Changed old-style string formatting to f-strings

### DIFF
--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -93,7 +93,7 @@ class ConditionSet(Set):
         base_set = _sympify(base_set)
         if not isinstance(base_set, Set):
             raise TypeError(
-                'base set should be a Set object, not %s' % base_set)
+                f"base set should be a Set object, not {base_set}")
         condition = _sympify(condition)
 
         if isinstance(condition, FiniteSet):
@@ -131,10 +131,10 @@ with
         # no simple answers, so now check syms
         for i in flat:
             if not getattr(i, '_diff_wrt', False):
-                raise ValueError('`%s` is not symbol-like' % i)
+                raise ValueError(f"`{i}` is not symbol-like")
 
         if base_set.contains(sym) is S.false:
-            raise TypeError('sym `%s` is not in base_set `%s`' % (sym, base_set))
+            raise TypeError(f"sym `{sym}` is not in base_set `{base_set}`")
 
         know = None
         if isinstance(base_set, FiniteSet):

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -36,7 +36,7 @@ class Contains(Boolean):
             evaluate = global_parameters.evaluate
 
         if not isinstance(s, Set):
-            raise TypeError('expecting Set, not %s' % func_name(s))
+            raise TypeError(f"expecting Set, not {func_name(s)}")
 
         if evaluate:
             # _contains can return symbolic booleans that would be returned by

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -359,7 +359,7 @@ class ImageSet(Set):
             raise TypeError("Set arguments to ImageSet should of type Set")
 
         if not all(cls._check_sig(sg, st) for sg, st in zip(signature, sets)):
-            raise ValueError("Signature %s does not match sets %s" % (signature, sets))
+            raise ValueError(f"Signature {signature} does not match sets {sets}")
 
         if flambda is S.IdentityFunction and len(sets) == 1:
             return sets[0]
@@ -603,7 +603,7 @@ class Range(Set):
         if len(args) == 1:
             if isinstance(args[0], range):
                 raise TypeError(
-                    'use sympify(%s) to convert range to Range' % args[0])
+                    f"use sympify({args[0]}) to convert range to Range")
 
         # expand range
         slc = slice(*args)
@@ -657,8 +657,8 @@ class Range(Set):
             if span is S.NaN or span <= 0:
                 null = True
             elif step.is_Integer and stop.is_infinite and abs(step) != 1:
-                raise ValueError(filldedent('''
-                    Step size must be %s in this case.''' % (1 if step > 0 else -1)))
+                raise ValueError(filldedent(f'''
+                    Step size must be {(1 if step > 0 else -1)} in this case.'''))
             else:
                 end = stop
         else:
@@ -1101,10 +1101,10 @@ def normalize_theta_set(theta):
         return Union(*[normalize_theta_set(interval) for interval in theta.args])
 
     elif theta.is_subset(S.Reals):
-        raise NotImplementedError("Normalizing theta when, it is of type %s is not "
-                                  "implemented" % type(theta))
+        raise NotImplementedError(f"Normalizing theta when, it is of type {type(theta)} "
+                                  "is not implemented")
     else:
-        raise ValueError(" %s is not a real set" % (theta))
+        raise ValueError(f"{theta} is not a real set")
 
 
 class ComplexRegion(Set):

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -169,12 +169,12 @@ class Ordinal(Basic):
             elif i.exp == 1:
                 net_str += 'w'
             elif len(i.exp.terms) > 1 or i.exp.is_limit_ordinal:
-                net_str += 'w**(%s)'%i.exp
+                net_str += f"w**({i.exp})"
             else:
-                net_str += 'w**%s'%i.exp
+                net_str += f"w**{i.exp}"
 
             if not i.mult == 1 and not i.exp == ord0:
-                net_str += '*%s'%i.mult
+                net_str += f"*{i.mult}"
         return(net_str)
 
     __repr__ = __str__

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -315,7 +315,7 @@ class Set(Basic, EvalfMixin):
 
     @property
     def _inf(self):
-        raise NotImplementedError("(%s)._inf" % self)
+        raise NotImplementedError(f"({self})._inf")
 
     @property
     def sup(self):
@@ -336,7 +336,7 @@ class Set(Basic, EvalfMixin):
 
     @property
     def _sup(self):
-        raise NotImplementedError("(%s)._sup" % self)
+        raise NotImplementedError(f"({self})._sup")
 
     def contains(self, other):
         """
@@ -431,7 +431,7 @@ class Set(Basic, EvalfMixin):
 
         """
         if not isinstance(other, Set):
-            raise ValueError("Unknown argument '%s'" % other)
+            raise ValueError(f"Unknown argument '{other}'")
 
         # Handle the trivial cases
         if self == other:
@@ -493,7 +493,7 @@ class Set(Basic, EvalfMixin):
                 fuzzy_not(other.is_subset(self)),
             ])
         else:
-            raise ValueError("Unknown argument '%s'" % other)
+            raise ValueError(f"Unknown argument '{other}'")
 
     def is_superset(self, other):
         """
@@ -512,7 +512,7 @@ class Set(Basic, EvalfMixin):
         if isinstance(other, Set):
             return other.is_subset(self)
         else:
-            raise ValueError("Unknown argument '%s'" % other)
+            raise ValueError(f"Unknown argument '{other}'")
 
     # This should be deprecated:
     def issuperset(self, other):
@@ -538,7 +538,7 @@ class Set(Basic, EvalfMixin):
         if isinstance(other, Set):
             return other.is_proper_subset(self)
         else:
-            raise ValueError("Unknown argument '%s'" % other)
+            raise ValueError(f"Unknown argument '{other}'")
 
     def _eval_powerset(self):
         from .powerset import PowerSet
@@ -797,7 +797,7 @@ class Set(Basic, EvalfMixin):
 
     @property
     def _measure(self):
-        raise NotImplementedError("(%s)._measure" % self)
+        raise NotImplementedError(f"({self})._measure")
 
     def _kind(self):
         return SetKind(UndefinedKind)
@@ -829,7 +829,7 @@ class Set(Basic, EvalfMixin):
     @sympify_return([('exp', Expr)], NotImplemented)
     def __pow__(self, exp):
         if not (exp.is_Integer and exp >= 0):
-            raise ValueError("%s: Exponent must be a positive Integer" % exp)
+            raise ValueError(f"{exp}: Exponent must be a positive Integer")
         return ProductSet(*[self]*exp)
 
     @sympify_return([('other', 'Set')], NotImplemented)
@@ -843,7 +843,7 @@ class Set(Basic, EvalfMixin):
         if b is None:
             # x in y must evaluate to T or F; to entertain a None
             # result with Set use y.contains(x)
-            raise TypeError('did not evaluate to a bool: %r' % c)
+            raise TypeError('did not evaluate to a bool: {c!r}')
         return b
 
 
@@ -1083,7 +1083,7 @@ class Interval(Set):
             for a in [left_open, right_open]):
             raise NotImplementedError(
                 "left_open and right_open can have only true/false values, "
-                "got %s and %s" % (left_open, right_open))
+                f"got {left_open} and {right_open}")
 
         # Only allow real intervals
         if fuzzy_not(fuzzy_and(i.is_extended_real for i in (start, end, end-start))):
@@ -2165,22 +2165,22 @@ class FiniteSet(Set):
 
     def __ge__(self, other):
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            raise TypeError(f"Invalid comparison of set with {func_name(other)}")
         return other.is_subset(self)
 
     def __gt__(self, other):
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            raise TypeError(f"Invalid comparison of set with {func_name(other)}")
         return self.is_proper_superset(other)
 
     def __le__(self, other):
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            raise TypeError(f"Invalid comparison of set with {func_name(other)}")
         return self.is_subset(other)
 
     def __lt__(self, other):
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            raise TypeError(f"Invalid comparison of set with {func_name(other)}")
         return self.is_proper_subset(other)
 
     def __eq__(self, other):
@@ -2297,8 +2297,8 @@ class DisjointUnion(Set):
             if isinstance(set_i, Set):
                 dj_collection.append(set_i)
             else:
-                raise TypeError("Invalid input: '%s', input args \
-                    to DisjointUnion must be Sets" % set_i)
+                raise TypeError(f"Invalid input: '{set_i}', input args "
+                    "to DisjointUnion must be Sets")
         obj = Basic.__new__(cls, *dj_collection)
         return obj
 
@@ -2388,7 +2388,7 @@ class DisjointUnion(Set):
 
             return iter(roundrobin(*iters))
         else:
-            raise ValueError("'%s' is not iterable." % self)
+            raise ValueError(f"'{self}' is not iterable.")
 
     def __len__(self):
         """
@@ -2417,7 +2417,7 @@ class DisjointUnion(Set):
                 size += len(set)
             return size
         else:
-            raise ValueError("'%s' is not a finite set." % self)
+            raise ValueError(f"'{self}' is not a finite set.")
 
 
 def imageset(*args):
@@ -2471,7 +2471,7 @@ def imageset(*args):
     from .setexpr import set_function
 
     if len(args) < 2:
-        raise ValueError('imageset expects at least 2 args, got: %s' % len(args))
+        raise ValueError(f"imageset expects at least 2 args, got: {len(args)}")
 
     if isinstance(args[0], (Symbol, tuple)) and len(args) > 2:
         f = Lambda(args[0], args[1])
@@ -2496,7 +2496,7 @@ def imageset(*args):
             if N == 1:
                 s = 'x'
             else:
-                s = [Symbol('x%i' % i) for i in range(1, N + 1)]
+                s = [Symbol(f"x{i}") for i in range(1, N + 1)]
         else:
             s = inspect.signature(f).parameters
 
@@ -2507,12 +2507,12 @@ def imageset(*args):
     else:
         raise TypeError(filldedent('''
             expecting lambda, Lambda, or FunctionClass,
-            not \'%s\'.''' % func_name(f)))
+            not '{func_name(f)}'.'''))
 
     if any(not isinstance(s, Set) for s in set_list):
         name = [func_name(s) for s in set_list]
         raise ValueError(
-            'arguments after mapping should be sets, not %s' % name)
+            f"arguments after mapping should be sets, not {name}")
 
     if len(set_list) == 1:
         set = set_list[0]
@@ -2808,4 +2808,4 @@ class SetKind(Kind):
         if not self.element_kind:
             return "SetKind()"
         else:
-            return "SetKind(%s)" % self.element_kind
+            return f"SetKind({self.element_kind})"

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -331,8 +331,7 @@ def test_Range_set():
                 R = R.reversed
                 result = list(R[a:b:c])
                 ans = r[a:b:c]
-                txt = ('\n%s[%s:%s:%s] = %s -> %s' % (
-                R, a, b, c, result, ans))
+                txt = (f"\n{R}[{a}:{b}:{c}] = {result} -> {ans}")
                 check = ans == result
                 assert check, txt
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
See #28031


#### Brief description of what is fixed or changed
This commit changes the old-style string formatting to f-strings as mentioned in issue #28031 which recommends the use of newer f-strings in Python.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
