### PR TITLE
Fix LaTeX parser docs which suggested invalid backend args due to case-sensitivity and improve error

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1346,6 +1346,7 @@ Rupesh Harode <rupeshharode@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
 Russell Fordyce <rfordyce@expressive-py.org> <6064285+rfordyce@users.noreply.github.com>
+Russell Fordyce <rfordyce@expressive-py.org> <rfordyce@users.noreply.github.com>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
 S. Hanko <suzy.hanko@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1345,6 +1345,7 @@ Rudr Tiwari <rudrtiwari@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
+Russell Fordyce <rfordyce@expressive-py.org> rfordyce <6064285+rfordyce@users.noreply.github.com>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
 S. Hanko <suzy.hanko@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1345,7 +1345,7 @@ Rudr Tiwari <rudrtiwari@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
-Russell Fordyce <rfordyce@expressive-py.org> rfordyce <6064285+rfordyce@users.noreply.github.com>
+Russell Fordyce <rfordyce@expressive-py.org> <6064285+rfordyce@users.noreply.github.com>
 Ryan Krauss <ryanlists@gmail.com>
 Rémy Léone <rleone@online.net>
 S. Hanko <suzy.hanko@gmail.com>

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -106,11 +106,11 @@ and it does not try to fix any sort of common mistakes that may have occurred. F
 example, as mentioned in :ref:`the earlier section <ANTLR parser caveats>`, the
 ANTLR-based parser would simply find ``x`` if we run::
 
-    parse_latex(r'x -', backend='ANTLR')
+    parse_latex(r'x -', backend='antlr')
 
 However, running::
 
-    parse_latex(r'x -', backend='Lark')
+    parse_latex(r'x -', backend='lark')
 
 will raise an ``lark.exceptions.UnexpectedEOF`` exception.
 

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -212,7 +212,7 @@ def parse_latex(s, strict=False, backend="antlr"):
             return _latex.parse_latex(s, strict)
     elif backend == "lark":
         return parse_latex_lark(s)
-    else:  # TODO consider typing.get_args() for names from Literal
+    else:
         raise NotImplementedError(f"Using the '{backend}' backend in the LaTeX" \
                                    " parser is not supported, backend must be one of" \
                                    " ('antlr', 'lark')")

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -213,6 +213,6 @@ def parse_latex(s, strict=False, backend="antlr"):
     elif backend == "lark":
         return parse_latex_lark(s)
     else:  # TODO consider typing.get_args() for names from Literal/StringLiteral
-        raise ValueError(f"Using the '{backend}' backend in the LaTeX" \
-                         " parser is not supported, backend must be one of" \
-                         " ('antlr', 'lark')")
+        raise NotImplementedError(f"Using the '{backend}' backend in the LaTeX" \
+                                   " parser is not supported, backend must be one of" \
+                                   " ('antlr', 'lark')")

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -212,7 +212,7 @@ def parse_latex(s, strict=False, backend="antlr"):
             return _latex.parse_latex(s, strict)
     elif backend == "lark":
         return parse_latex_lark(s)
-    else:  # TODO consider typing.get_args() for names from Literal/StringLiteral
+    else:  # TODO consider typing.get_args() for names from Literal
         raise NotImplementedError(f"Using the '{backend}' backend in the LaTeX" \
                                    " parser is not supported, backend must be one of" \
                                    " ('antlr', 'lark')")

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -176,7 +176,8 @@ def parse_latex(s, strict=False, backend="antlr"):
         Use ``backend="antlr"`` for the ANTLR-based parser, and
         ``backend="lark"`` for the Lark-based parser.
 
-        The ``backend`` option is case-insensitive.
+        The ``backend`` option is case-sensitive, and must be in
+        all lowercase.
     strict : bool, optional
         This option is only available with the ANTLR backend.
 
@@ -197,8 +198,6 @@ def parse_latex(s, strict=False, backend="antlr"):
     >>> func.evalf(subs={"alpha": 2})
     0.693147180559945
     """
-    backends_supported = ["antlr", "lark"]
-    backend = backend.lower()
 
     check_cases_env(s)
 
@@ -213,7 +212,7 @@ def parse_latex(s, strict=False, backend="antlr"):
             return _latex.parse_latex(s, strict)
     elif backend == "lark":
         return parse_latex_lark(s)
-    else:
-        raise NotImplementedError(f"Using the '{backend}' backend in the LaTeX" \
-                                  f" parser is not supported, backend must be one of" \
-                                  f" {backends_supported}")
+    else:  # TODO consider typing.get_args() for names from Literal/StringLiteral
+        raise ValueError(f"Using the '{backend}' backend in the LaTeX" \
+                         " parser is not supported, backend must be one of" \
+                         " ('antlr', 'lark')")

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -176,8 +176,7 @@ def parse_latex(s, strict=False, backend="antlr"):
         Use ``backend="antlr"`` for the ANTLR-based parser, and
         ``backend="lark"`` for the Lark-based parser.
 
-        The ``backend`` option is case-sensitive, and must be in
-        all lowercase.
+        The ``backend`` option is case-insensitive.
     strict : bool, optional
         This option is only available with the ANTLR backend.
 
@@ -197,7 +196,13 @@ def parse_latex(s, strict=False, backend="antlr"):
     >>> func = parse_latex(r"\int_1^\alpha \dfrac{\mathrm{d}t}{t}", backend="lark")
     >>> func.evalf(subs={"alpha": 2})
     0.693147180559945
+    >>> parse_latex(r"", backend="fake")
+    Traceback (most recent call last):
+    ...
+    NotImplementedError: Using the 'fake' backend ... must be one of ['antlr', 'lark']
     """
+    backends_supported = ["antlr", "lark"]
+    backend = backend.lower()
 
     check_cases_env(s)
 
@@ -214,4 +219,5 @@ def parse_latex(s, strict=False, backend="antlr"):
         return parse_latex_lark(s)
     else:
         raise NotImplementedError(f"Using the '{backend}' backend in the LaTeX" \
-                                   " parser is not supported.")
+                                  f" parser is not supported, backend must be one of" \
+                                  f" {backends_supported}")

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -196,10 +196,6 @@ def parse_latex(s, strict=False, backend="antlr"):
     >>> func = parse_latex(r"\int_1^\alpha \dfrac{\mathrm{d}t}{t}", backend="lark")
     >>> func.evalf(subs={"alpha": 2})
     0.693147180559945
-    >>> parse_latex(r"", backend="fake")
-    Traceback (most recent call last):
-    ...
-    NotImplementedError: Using the 'fake' backend ... must be one of ['antlr', 'lark']
     """
     backends_supported = ["antlr", "lark"]
     backend = backend.lower()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Original PR https://github.com/sympy/sympy/pull/25733 which adds `backend` arg to `parse_latex()` to choose Lark parser along with the associated docsx

#### Brief description of what is fixed or changed

While experimenting with LaTeX parsers, I noticed that while the docs are pretty clear that `"ANTLR"` or `"Lark"` are the expected backend options, they can't be used as-written because the argument is case-sensitive!

This original intent of this PR was to make the backend arg more flexible by lowering the passed `backend` arg such that the documentation was correct (`'ANTLR'` and `'Lark'`) respectively, however as this is rather trivial and to improve future typing via Literal (3.8+) ([thanks @sylee957 !](https://github.com/sympy/sympy/pull/28340#issuecomment-3217207030)), this now directly fixes the docs and associated error to explain the exact names.

https://docs.sympy.org/latest/modules/parsing.html#lark-mathrm-latex-parser-features

> ```none
> ANTLR-based parser would simply find ``x`` if we run::
>
>     parse_latex(r'x -', backend='ANTLR')
>
> However, running::
>
>    parse_latex(r'x -', backend='Lark')
> ```

~Rather than updating the docs, which may have been propagated elsewhere in the last 2 years and likely have the opposite to the desired effect noted in the review, consistency for code-completion tooling, I propose making this argument case-insensitive as was originally done in the PR prior to review~

~I don't believe there's a practical reason to avoid making this arg case-insensitive~
* ~trivial feature creep~
* ~might obscure a better error when passing a non-string argument~

Practically this
* ~reverts the code part of d5b2a361342d46c449087e6ebc6b6144de61a25b from the original PR~
* improves the error message
* ~adds a doctest for the improved error message~
* improves the documentation to provide the exact backend args (`'antlr'` or `'lark'`)

#### Other comments

~Plausibly this could be expanded to incorporate some more advanced features~
* ~handle or drop `_latex is None` path from ANTLR-based parser (do users really want to rely on it returning `None` here?..) .. I strongly suspect it might really be a bug path as naive use without the backend installed already raises `ImportError` with a helpful message~
* ~embed a dict to map additional future backends (at least `antlr4` -> `antlr`?)~

dropped release notes from original PR

* ~parsing~
  * ~LaTeX parser `sympy.parsing.latex.parse_latex` `backend` arg is now case-insensitive to match existing docs~

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
