### PR TITLE
manualintegrate: add support for `exp*trig/x`

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -41,6 +41,7 @@ from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.exprtools import factor_terms
+from sympy.core.function import WildFunction
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
@@ -2132,7 +2133,9 @@ def integral_steps(integrand, symbol, **options):
             Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_linear_rule),
-                        null_safe(sqrt_quadratic_rule), null_safe(trig_cmplx_exp_rule)),
+                        null_safe(sqrt_quadratic_rule),
+                        null_safe(powsimp_rule),
+                        null_safe(trig_cmplx_exp_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,
@@ -2146,9 +2149,6 @@ def integral_steps(integrand, symbol, **options):
             null_safe(alternatives(
                 rewrites_rule,
                 substitution_rule,
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    powsimp_rule),
                 condition(
                     integral_is_subclass(Mul, Pow),
                     partial_fractions_rule),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1447,10 +1447,10 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
     a = Wild('a', exclude=[symbol, 0])
     b = Wild('b', exclude=[symbol])
     c = Wild('c', exclude=[symbol])
-    n = Wild('n', exclude=[symbol], properties=[lambda n: n > 0])
+    # n = Wild('n', exclude=[symbol], properties=[lambda n: n > 0])
     f = WildFunction('f')
     guassian_pattern = exp(a * symbol**2 + b * symbol + c)
-    trigexp_over_x_pattern = f*exp(a * symbol)/symbol**n
+    trigexp_over_x_pattern = f*exp(a * symbol)/symbol
     trigexp_over_x_match = integrand.match(trigexp_over_x_pattern)
     if not (any(term.match(guassian_pattern) for term in integrand.atoms(exp))
             or (trigexp_over_x_match and

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1446,8 +1446,15 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
 
     a = Wild('a', exclude=[symbol, 0])
     b = Wild('b', exclude=[symbol])
-    pattern = exp(a * symbol**2 + b * symbol)
-    if not any(term.match(pattern) for term in integrand.atoms(exp)):
+    c = Wild('c', exclude=[symbol])
+    n = Wild('n', exclude=[symbol], properties=[lambda n: n > 0])
+    f = WildFunction('f')
+    guassian_pattern = exp(a * symbol**2 + b * symbol + c)
+    trigexp_over_x_pattern = f*exp(a * symbol)/symbol**n
+    trigexp_over_x_match = integrand.match(trigexp_over_x_pattern)
+    if not (any(term.match(guassian_pattern) for term in integrand.atoms(exp))
+            or (trigexp_over_x_match and
+                trigexp_over_x_match[f].has(sin, cos, sinh, cosh))):
         return
 
     # Replace trig and hyperbolic functions with their exponential forms

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -320,6 +320,10 @@ def test_manualintegrate_special():
     f = -cosh(x/2)*erf(x)
     F = (erf(x - Rational(1,4)) - erf(x + Rational(1,4)))*exp(Rational(1,16)) - 2*sinh(x/2)*erf(x)
     assert_is_integral_of(f, F)
+    f, F = exp(x)*cos(x)/x, Ei(x*(1 - I))/2 + Ei(x*(1 + I))/2
+    assert_is_integral_of(f, F)
+    f, F = exp(7*x)*sinh(16*x)/x, -Ei(-9*x)/2 + Ei(23*x)/2
+    assert_is_integral_of(f, F)
 
 
 def test_manualintegrate_derivative():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#27839 powsimp_rule
#28295 trig_cmplx_exp_rule

#### Brief description of what is fixed or changed

Extended manualintegrate to handle more cases where an exponential is multiplied by a trigonometric or hyperbolic function and divided by x. This work builds on the Gaussian–exponential handling.

```python
In [83]: integrate(exp(x)*sin(x)/x, manual=True)
Out[83]: 
-ⅈ⋅(-Ei(x⋅(1 - ⅈ)) + Ei(x⋅(1 + ⅈ))) 
────────────────────────────────────
                 2                  

In [84]: integrate(exp(x)*cosh(x)/x, manual=True)
Out[84]: 
log(2⋅x)   Ei(2⋅x)
──────── + ───────
   2          2   

In [85]: integrate(exp(x)*cos(x)/x, manual=True)
Out[85]: 
Ei(x⋅(1 - ⅈ))   Ei(x⋅(1 + ⅈ))
───────────── + ─────────────
      2               2      

In [86]: integrate(exp(x)*sinh(x)/x, manual=True)
Out[86]: 
  log(2⋅x)   Ei(2⋅x)
- ──────── + ───────
     2          2   

In [87]: integrate(exp(x)*sinh(x)/x**2, manual=True)
Out[87]: 
  E₂(-2⋅x)    1 
- ──────── + ───
    2⋅x      2⋅x

```

#### Other comments

Added XFAIL tests for higher-order cases such as `exp(x)*sin(x)/x**2`, `exp(x)*sin(x)/x**3`, and `exp(x)*cosh(x)/x**2`. These document the expected results while acknowledging that current rules do not yet fully support them.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Improved manual integrate to handle cases like `exp(a*x)*cos(b*x)/x` and `exp(a*x)*sinh(b*x)/x`, returning results in terms of Ei.
<!-- END RELEASE NOTES -->
