### PR TITLE
manualintegrate: extend support for products involving special functions

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1232,6 +1232,9 @@ def mul_rule(integral: IntegralInfo):
             return ConstantTimesRule(integrand, symbol, coeff, f, next_step)
 
 
+special_error_functions = (erf, erfc, erfi, fresnelc, fresnels, Ci, Chi, Si, Shi, Ei, li)
+
+
 def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None:
     # LIATE rule:
     # log, inverse trig, algebraic, trigonometric, exponential
@@ -1258,7 +1261,7 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
 
         return pull_out_u_rl
 
-    liate_rules = [pull_out_u(erf, erfc, erfi), pull_out_u(log),
+    liate_rules = [pull_out_u(*special_error_functions), pull_out_u(log),
                    pull_out_u(*inverse_trig_functions), pull_out_algebraic,
                    pull_out_u(sin, cos), pull_out_u(sinh, cosh),
                    pull_out_u(exp)]

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -329,6 +329,52 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
 
 
+@slow
+def test_manualintegrate_parts_special():
+    f = fresnelc(x)*log(x)
+    F = ((x*log(x) - x)*fresnelc(x) - (log(x) - 1)*sin(pi*x**2/2)/pi +
+        Si(pi*x**2/2)/(2*pi))
+    assert_is_integral_of(f, F)
+    f = fresnels(x)*log(x)
+    F = ((x*log(x) - x)*fresnels(x) + (log(x) - 1)*cos(pi*x**2/2)/pi -
+        Ci(pi*x**2/2)/(2*pi))
+    assert_is_integral_of(f, F)
+    f = Ci(x)*log(x)
+    F = (x*log(x) - x)*Ci(x) - (log(x) - 1)*sin(x) + Si(x)
+    assert_is_integral_of(f, F)
+    f = Si(x)*log(x)
+    F = (x*log(x) - x)*Si(x) + (log(x) - 1)*cos(x) - Ci(x)
+    assert_is_integral_of(f, F)
+    f = Chi(x)*log(x)
+    F = (x*log(x) - x)*Chi(x) - (log(x) - 1)*sinh(x) + Shi(x)
+    assert_is_integral_of(f, F)
+    f = Shi(x)*log(x)
+    F = (x*log(x) - x)*Shi(x) - (log(x) - 1)*cosh(x) + Chi(x)
+    assert_is_integral_of(f, F)
+    f = Ei(x)*log(x)
+    F = (x*log(x) - x)*Ei(x) - (log(x) - 1)*exp(x) + Ei(x)
+    assert_is_integral_of(f, F)
+    f = li(x)*log(x)
+    F = -x**2/2 + (x*log(x) - x)*li(x) + Ei(2*log(x))
+    assert_is_integral_of(f, F)
+    f = Ci(x)*Si(x)
+    F = (x*Ci(x)*Si(x) - sin(x)*Si(x) + cos(x)*Ci(x) +
+        Integral(sin(x)**2/x, x) - Integral(cos(x)**2/x, x))
+    assert_is_integral_of(f, F)
+    f = Chi(x)*Shi(x)
+    F = (x*Chi(x)*Shi(x) - sinh(x)*Shi(x) - cosh(x)*Chi(x) +
+        Integral(sinh(x)**2/x, x) + Integral(cosh(x)**2/x, x))
+    assert_is_integral_of(f, F)
+    f = Ei(x)*Si(x)
+    F = (x*Ei(x)*Si(x) - I*(-Ei(x*(1 - I)) + Ei(x*(1 + I)))/2 -
+        exp(x)*Si(x) + cos(x)*Ei (x) - Ei(x*(1 - I))/2 - Ei(x*(1 +
+            I))/2)
+    assert_is_integral_of(f, F)
+    f = Ei(x)*Shi(x)
+    F = x*Ei(x)*Shi(x) - exp(x)*Shi(x) - cosh(x)*Ei(x) + Ei(2*x)
+    assert_is_integral_of(f, F)
+
+
 def test_manualintegrate_derivative():
     assert manualintegrate(pi * Derivative(x**2 + 2*x + 3), x) == \
         pi * (x**2 + 2*x + 3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#28350 #27862 

#### Brief description of what is fixed or changed
This PR extends the LIATE-based integration by parts heuristic in `manualintegrate` to handle a family of special functions (`erf`, `erfc`, `erfi`, Fresnel integrals, sine and cosine integrals, hyperbolic sine and cosine integrals, exponential integral `Ei`, and logarithmic integral `li`).  

```python

In [6]: integrate(Ei(x)*log(x), manual=True)
Out[6]:
                                     x
(x⋅log(x) - x)⋅Ei(x) - (log(x) - 1)⋅ℯ  + Ei(x)

```

#### Other comments
- New tests got separated and marked as slow because of how computationally expensive some of them are.
- Some test results intentionally contain unevaluated `Integral(...)` terms.
- The ordering in LIATE was chosen because cases like `fresnelc(x)*log(x)` and `Si(x)*Ei(x)` behave more naturally when the special function is selected as `u`. This may be revisited if conflicts arise.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Extend support for products involving special functions.
<!-- END RELEASE NOTES -->
