### PR TITLE
fix(polys): add missing domain parameter to dmp_zero

### DIFF
--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -66,6 +66,7 @@ may be slightly more efficient.)
 
 .. py:class:: dup
 .. py:class:: dmp
+.. py:class:: idmp
 .. py:class:: dmp_tup
 .. py:class:: monom
 

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -124,7 +124,7 @@ def _rec_integrate_in(g: dmp[Ef], m: int, v: int, i: int, j: int, K: Field[Ef]) 
 
     w, i = v - 1, i + 1
 
-    return dmp_strip([ _rec_integrate_in(c, m, w, i, j, K) for c in g ], v)
+    return dmp_strip([ _rec_integrate_in(c, m, w, i, j, K) for c in g ], v, K)
 
 
 def dmp_integrate_in(f: dmp[Ef], m: int, j: int, u: int, K: Field[Ef]) -> dmp[Ef]:
@@ -189,7 +189,7 @@ def dup_diff(f: dup[Er], m: int, K: Domain[Er]) -> dup[Er]:
             deriv.append(K(k)*coeff)
             n -= 1
 
-    return dup_strip(deriv)
+    return dup_strip(deriv, K)
 
 
 def dmp_diff(f: dmp[Er], m: int, u: int, K: Domain[Er]) -> dmp[Er]:
@@ -218,7 +218,7 @@ def dmp_diff(f: dmp[Er], m: int, u: int, K: Domain[Er]) -> dmp[Er]:
     n = dmp_degree(f, u)
 
     if n < m:
-        return dmp_zero(u)
+        return dmp_zero(u, K)
 
     deriv: list[dmp[Er]] = []
     v = u - 1
@@ -237,7 +237,7 @@ def dmp_diff(f: dmp[Er], m: int, u: int, K: Domain[Er]) -> dmp[Er]:
             deriv.append(dmp_mul_ground(coeff, K(k), v, K))
             n -= 1
 
-    return dmp_strip(deriv, u)
+    return dmp_strip(deriv, u, K)
 
 
 def _rec_diff_in(g: dmp[Er], m: int, v: int, i: int, j: int, K: Domain[Er]) -> dmp[Er]:
@@ -247,7 +247,7 @@ def _rec_diff_in(g: dmp[Er], m: int, v: int, i: int, j: int, K: Domain[Er]) -> d
 
     w, i = v - 1, i + 1
 
-    return dmp_strip([ _rec_diff_in(c, m, w, i, j, K) for c in g ], v)
+    return dmp_strip([ _rec_diff_in(c, m, w, i, j, K) for c in g ], v, K)
 
 
 def dmp_diff_in(f: dmp[Er], m: int, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
@@ -336,7 +336,7 @@ def _rec_eval_in(g: dmp[Er], a: Er, v: int, i: int, j: int, K: Domain[Er]) -> dm
 
     v, i = v - 1, i + 1
 
-    return dmp_strip([ _rec_eval_in(c, a, v, i, j, K) for c in g ], v)
+    return dmp_strip([ _rec_eval_in(c, a, v, i, j, K) for c in g ], v, K)
 
 
 def dmp_eval_in(f: dmp[Er], a: Er, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
@@ -398,14 +398,14 @@ def dmp_eval_tail(f: dmp[Er], A: list[Er], u: int, K: Domain[Er]) -> dmp[Er]:
         return f
 
     if dmp_zero_p(f, u):
-        return dmp_zero(u - len(A))
+        return dmp_zero(u - len(A), K)
 
     e = _rec_eval_tail(f, 0, A, u, K)
 
     if u == len(A) - 1:
         return e
     else:
-        return dmp_strip(e, u - len(A))
+        return dmp_strip(e, u - len(A), K)
 
 
 def _rec_diff_eval(g: dmp[Er], m: int, a: Er, v: int, i: int, j: int, K: Domain[Er]) -> dmp[Er]:
@@ -415,7 +415,7 @@ def _rec_diff_eval(g: dmp[Er], m: int, a: Er, v: int, i: int, j: int, K: Domain[
 
     v, i = v - 1, i + 1
 
-    return dmp_strip([ _rec_diff_eval(c, m, a, v, i, j, K) for c in g ], v)
+    return dmp_strip([ _rec_diff_eval(c, m, a, v, i, j, K) for c in g ], v, K)
 
 
 def dmp_diff_eval_in(f: dmp[Er], m: int, a: Er, j: int, u: int, K: Domain[Er]) -> dmp[Er]:
@@ -475,7 +475,7 @@ def dup_trunc(f: dup[Eeuclid], p: Eeuclid, K: Domain[Eeuclid]) -> dup[Eeuclid]:
     else:
         g = [ c % p for c in f ]
 
-    return dup_strip(g)
+    return dup_strip(g, K)
 
 
 def dmp_trunc(f: dmp[Er], p: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
@@ -495,7 +495,7 @@ def dmp_trunc(f: dmp[Er], p: dmp[Er], u: int, K: Domain[Er]) -> dmp[Er]:
     11*x**2 + 11*x + 5
 
     """
-    return dmp_strip([ dmp_rem(c, p, u - 1, K) for c in f ], u)
+    return dmp_strip([ dmp_rem(c, p, u - 1, K) for c in f ], u, K)
 
 
 def dmp_ground_trunc(f: dmp[Eeuclid], p: Eeuclid, u: int, K: Domain[Eeuclid]) -> dmp[Eeuclid]:
@@ -519,7 +519,7 @@ def dmp_ground_trunc(f: dmp[Eeuclid], p: Eeuclid, u: int, K: Domain[Eeuclid]) ->
 
     v = u - 1
 
-    return dmp_strip([ dmp_ground_trunc(c, p, v, K) for c in f ], u)
+    return dmp_strip([ dmp_ground_trunc(c, p, v, K) for c in f ], u, K)
 
 
 def dup_monic(f: dup[Ef], K: Field[Ef]) -> dup[Ef]:
@@ -820,18 +820,18 @@ def dup_real_imag(f: dup[Er], K: Domain[Er]) -> tuple[dmp[Er], dmp[Er]]:
     if not K.is_ZZ and not K.is_QQ:
         raise DomainError("computing real and imaginary parts is not supported over %s" % K)
 
-    f1 = dmp_zero(1)
-    f2 = dmp_zero(1)
+    f1 = dmp_zero(1, K)
+    f2 = dmp_zero(1, K)
 
     if not f:
         return f1, f2
 
     g = _dmp2([[[K.one, K.zero]], [[K.one], []]])
-    h = dmp_ground(f[0], 2)
+    h = dmp_ground(f[0], 2, K)
 
     for c in f[1:]:
         h = dmp_mul(h, g, 2, K)
-        h = dmp_add_term(h, dmp_ground(c, 1), 0, 2, K)
+        h = dmp_add_term(h, dmp_ground(c, 1, K), 0, 2, K)
 
     H = dmp_to_raw_dict(h, 2, K)
 
@@ -957,7 +957,7 @@ def dmp_shift(f: dmp[Er], a: list[Er], u: int, K: Domain[Er]) -> dmp[Er]:
                 afj = dmp_mul_ground(f[j], a0, u-1, K)
                 f[j + 1] = dmp_add(f[j + 1], afj, u-1, K)
 
-    return dmp_strip(f, u)
+    return dmp_strip(f, u, K)
 
 
 def dup_transform(f: dup[Er], p: dup[Er], q: dup[Er], K: Domain[Er]) -> dup[Er]:
@@ -1006,7 +1006,7 @@ def dup_compose(f: dup[Er], g: dup[Er], K: Domain[Er]) -> dup[Er]:
 
     """
     if len(g) <= 1:
-        return dup_strip([dup_eval(f, dup_LC(g, K), K)])
+        return dup_strip([dup_eval(f, dup_LC(g, K), K)], K)
 
     if not f:
         return []
@@ -1090,7 +1090,7 @@ def dup_series_compose(f: dup[Er], g: dup[Er], n: int, K: Domain[Er]) -> dup[Er]
     g = dup_truncate(g, n, K)
 
     if len(g) <= 1:
-        return dup_strip([dup_eval(f, dup_LC(g, K), K)])
+        return dup_strip([dup_eval(f, dup_LC(g, K), K)], K)
 
     if not f:
         return []
@@ -1510,7 +1510,7 @@ def _dup_series_reversion_small(f: dup[Er], n: int, K: Domain[Er]) -> dup[Er]:
     if n >= 4:
         g[-4] = (2 * b ** 2 - a * c) * cinv ** 5
 
-    return dup_strip(g)
+    return dup_strip(g, K)
 
 
 def dup_series_reversion(f: dup[Er], n: int, K: Domain[Er]) -> dup[Er]:
@@ -1591,4 +1591,4 @@ def dup_series_reversion(f: dup[Er], n: int, K: Domain[Er]) -> dup[Er]:
         # t = t * h^m mod x**(n-1)
         t = dup_series_mul(t, H[m - 1], n, K)
 
-    return dup_strip(g)
+    return dup_strip(g, K)

--- a/sympy/polys/domains/field.py
+++ b/sympy/polys/domains/field.py
@@ -29,7 +29,7 @@ class Field(Ring[Ef]):
         """Returns a field associated with ``self``. """
         return self
 
-    def exquo(self, a, b):
+    def exquo(self, a: Ef, b: Ef) -> Ef:
         """Exact quotient of ``a`` and ``b``, implies ``__truediv__``.  """
         return a / b
 

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -489,12 +489,12 @@ def dmp_inner_subresultants(f, g, u, K):
 
     v = u - 1
     if dmp_zero_p(g, u):
-        return [f], [dmp_ground(K.one, v)]
+        return [f], [dmp_ground(K.one, v, K)]
 
     R = [f, g]
     d = n - m
 
-    b = dmp_pow(dmp_ground(-K.one, v), d + 1, v, K)
+    b = dmp_pow(dmp_ground(-K.one, v, K), d + 1, v, K)
 
     h = dmp_prem(f, g, u, K)
     h = dmp_mul_term(h, b, 0, u, K)
@@ -502,7 +502,7 @@ def dmp_inner_subresultants(f, g, u, K):
     lc = dmp_LC(g, K)
     c = dmp_pow(lc, d, v, K)
 
-    S = [dmp_ground(K.one, v), c]
+    S = [dmp_ground(K.one, v, K), c]
     c = dmp_neg(c, v, K)
 
     while not dmp_zero_p(h, u):
@@ -584,12 +584,12 @@ def dmp_prs_resultant(f, g, u, K):
         return dup_prs_resultant(f, g, K)
 
     if dmp_zero_p(f, u) or dmp_zero_p(g, u):
-        return (dmp_zero(u - 1), [])
+        return (dmp_zero(u - 1, K), [])
 
     R, S = dmp_inner_subresultants(f, g, u, K)
 
     if dmp_degree(R[-1], u) > 0:
-        return (dmp_zero(u - 1), R)
+        return (dmp_zero(u - 1, K), R)
 
     return S[-1], R
 
@@ -625,7 +625,7 @@ def dmp_zz_modular_resultant(f, g, p, u, K):
     B = n*M + m*N
 
     D, a = [K.one], -K.one
-    r = dmp_zero(v)
+    r = dmp_zero(v, K)
 
     while dup_degree(D) <= B:
         while True:
@@ -646,8 +646,8 @@ def dmp_zz_modular_resultant(f, g, p, u, K):
         e = dmp_eval(r, a, v, K)
 
         if not v:
-            R = dup_strip([R])
-            e = dup_strip([e])
+            R = dup_strip([R], K)
+            e = dup_strip([e], K)
         else:
             R = [R]
             e = [e]
@@ -694,7 +694,7 @@ def dmp_zz_collins_resultant(f, g, u, K):
     m = dmp_degree(g, u)
 
     if n < 0 or m < 0:
-        return dmp_zero(u - 1)
+        return dmp_zero(u - 1, K)
 
     A = dmp_max_norm(f, u, K)
     B = dmp_max_norm(g, u, K)
@@ -705,7 +705,7 @@ def dmp_zz_collins_resultant(f, g, u, K):
     v = u - 1
 
     B = K(2)*K.factorial(K(n + m))*A**m*B**n
-    r, p, P = dmp_zero(v), K.one, K.one
+    r, p, P = dmp_zero(v, K), K.one, K.one
 
     from sympy.ntheory import nextprime
 
@@ -754,7 +754,7 @@ def dmp_qq_collins_resultant(f, g, u, K0):
     m = dmp_degree(g, u)
 
     if n < 0 or m < 0:
-        return dmp_zero(u - 1)
+        return dmp_zero(u - 1, K0)
 
     K1 = K0.get_ring()
 
@@ -870,7 +870,7 @@ def dmp_discriminant(f, u, K):
     d, v = dmp_degree(f, u), u - 1
 
     if d <= 0:
-        return dmp_zero(v)
+        return dmp_zero(v, K)
     else:
         s = (-1)**((d*(d - 1)) // 2)
         c = dmp_LC(f, K)
@@ -921,14 +921,14 @@ def _dmp_rr_trivial_gcd(f, g, u, K):
         return tuple(dmp_zeros(3, u, K))
     elif zero_f:
         if K.is_nonnegative(dmp_ground_LC(g, u, K)):
-            return g, dmp_zero(u), dmp_one(u, K)
+            return g, dmp_zero(u, K), dmp_one(u, K)
         else:
-            return dmp_neg(g, u, K), dmp_zero(u), dmp_ground(-K.one, u)
+            return dmp_neg(g, u, K), dmp_zero(u, K), dmp_ground(-K.one, u, K)
     elif zero_g:
         if K.is_nonnegative(dmp_ground_LC(f, u, K)):
-            return f, dmp_one(u, K), dmp_zero(u)
+            return f, dmp_one(u, K), dmp_zero(u, K)
         else:
-            return dmp_neg(f, u, K), dmp_ground(-K.one, u), dmp_zero(u)
+            return dmp_neg(f, u, K), dmp_ground(-K.one, u, K), dmp_zero(u, K)
     elif if_contain_one:
         return dmp_one(u, K), f, g
     elif query('USE_SIMPLIFY_GCD'):
@@ -946,12 +946,12 @@ def _dmp_ff_trivial_gcd(f, g, u, K):
         return tuple(dmp_zeros(3, u, K))
     elif zero_f:
         return (dmp_ground_monic(g, u, K),
-                dmp_zero(u),
-                dmp_ground(dmp_ground_LC(g, u, K), u))
+                dmp_zero(u, K),
+                dmp_ground(dmp_ground_LC(g, u, K), u, K))
     elif zero_g:
         return (dmp_ground_monic(f, u, K),
-                dmp_ground(dmp_ground_LC(f, u, K), u),
-                dmp_zero(u))
+                dmp_ground(dmp_ground_LC(f, u, K), u, K),
+                dmp_zero(u, K))
     elif query('USE_SIMPLIFY_GCD'):
         return _dmp_simplify_gcd(f, g, u, K)
     else:
@@ -1677,7 +1677,7 @@ def dup_rr_lcm(f, g, K):
 
     """
     if not f or not g:
-        return dmp_zero(0)
+        return dmp_zero(0, K)
 
     fc, f = dup_primitive(f, K)
     gc, g = dup_primitive(g, K)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -508,8 +508,8 @@ def dup_cyclotomic_p(f, K, irreducible=False):
     for i in range(n - 1, -1, -2):
         h.insert(0, f[i])
 
-    g = dup_sqr(dup_strip(g), K)
-    h = dup_sqr(dup_strip(h), K)
+    g = dup_sqr(dup_strip(g, K), K)
+    h = dup_sqr(dup_strip(h, K), K)
 
     F = dup_sub(g, dup_lshift(h, 1, K), K)
 
@@ -1525,7 +1525,7 @@ def dup_factor_list_include(f, K):
     coeff, factors = dup_factor_list(f, K)
 
     if not factors:
-        return [(dup_strip([coeff]), 1)]
+        return [(dup_strip([coeff], K), 1)]
     else:
         g = dup_mul_ground(factors[0][0], coeff, K)
         return [(g, factors[0][1])] + factors[1:]
@@ -1616,7 +1616,7 @@ def dmp_factor_list_include(f, u, K):
     coeff, factors = dmp_factor_list(f, u, K)
 
     if not factors:
-        return [(dmp_ground(coeff, u), 1)]
+        return [(dmp_ground(coeff, u, K), 1)]
     else:
         g = dmp_mul_ground(factors[0][0], coeff, u, K)
         return [(g, factors[0][1])] + factors[1:]

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -173,7 +173,7 @@ class DMP(CantSympify, Generic[Er]):
     def __new__(cls, rep: dmp[Er], dom: Domain[Er], lev: int | None = None):
 
         if lev is None:
-            rep, lev = dmp_validate(rep)
+            rep, lev = dmp_validate(rep, dom)
         elif not isinstance(rep, list):
             raise CoercionFailed("expected list, got %s" % type(rep))
 
@@ -279,7 +279,7 @@ class DMP(CantSympify, Generic[Er]):
 
     @classmethod
     def zero(cls, lev: int, dom: Domain[Er]) -> DMP[Er]:
-        return DMP(dmp_zero(lev), dom, lev)
+        return DMP(dmp_zero(lev, dom), dom, lev)
 
     @classmethod
     def one(cls, lev: int, dom: Domain[Er]) -> DMP[Er]:
@@ -1390,8 +1390,7 @@ class DMP_Python(DMP[Er]):
 
     def ground_new(f, coeff: Er) -> DMP_Python[Er]:
         """Construct a new ground instance of ``f``. """
-        poly: dmp[Er] = dmp_ground(coeff, f.lev) # type: ignore
-        return f._new(poly, f.dom, f.lev)
+        return f._new(dmp_ground(coeff, f.lev, f.dom), f.dom, f.lev)
 
     def _one(f) -> Self:
         return f._new(dmp_one(f.lev, f.dom), f.dom, f.lev) # type: ignore
@@ -2673,8 +2672,8 @@ class DMF(PicklableWithSlots, CantSympify):
                 if isinstance(den, dict):
                     den = dmp_from_dict(den, lev, dom)
             else:
-                num, num_lev = dmp_validate(num)
-                den, den_lev = dmp_validate(den)
+                num, num_lev = dmp_validate(num, dom)
+                den, den_lev = dmp_validate(den, dom)
 
                 if num_lev == den_lev:
                     lev = num_lev
@@ -2697,9 +2696,9 @@ class DMF(PicklableWithSlots, CantSympify):
                 if isinstance(num, dict):
                     num = dmp_from_dict(num, lev, dom)
                 elif not isinstance(num, list):
-                    num = dmp_ground(dom.convert(num), lev)
+                    num = dmp_ground(dom.convert(num), lev, dom)
             else:
-                num, lev = dmp_validate(num)
+                num, lev = dmp_validate(num, dom)
 
             den = dmp_one(lev, dom)
 
@@ -3057,14 +3056,14 @@ class ANP(CantSympify, Generic[Eg]):
                 rep = [dom.convert(a) for a in rep]
             else:
                 rep = [dom.convert(rep)]
-            rep = DMP(dup_strip(rep), dom, 0)
+            rep = DMP(dup_strip(rep, dom), dom, 0)
 
         if isinstance(mod, DMP):
             pass
         elif isinstance(mod, dict):
             mod = DMP(dup_from_raw_dict(mod, dom), dom, 0)
         else:
-            mod = DMP(dup_strip(mod), dom, 0)
+            mod = DMP(dup_strip(mod, dom), dom, 0)
 
         rep = rep.rem(mod)
 
@@ -3201,7 +3200,7 @@ class ANP(CantSympify, Generic[Eg]):
 
     @classmethod
     def from_list(cls, rep, mod, dom):
-        return ANP(dup_strip(list(map(dom.convert, rep))), mod, dom)
+        return ANP(dup_strip(list(map(dom.convert, rep)), dom), mod, dom)
 
     def add_ground(f, c):
         """Add an element of the ground domain to ``f``. """

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -121,7 +121,7 @@ def dup_root_lower_bound(f, K):
               Values of the Positive Roots of Polynomials"
               Journal of Universal Computer Science, Vol. 15, No. 3, 523-537, 2009.
     """
-    bound = dup_root_upper_bound(dup_reverse(f), K)
+    bound = dup_root_upper_bound(dup_reverse(f, K), K)
 
     if bound is not None:
         return 1/bound
@@ -163,7 +163,7 @@ def dup_cauchy_upper_bound(f, K):
 def dup_cauchy_lower_bound(f, K):
     """Compute the Cauchy lower bound on the absolute value of all non-zero
        roots of f, real or complex."""
-    g = dup_reverse(f)
+    g = dup_reverse(f, K)
     if len(g) < 2:
         raise PolynomialError('Polynomial has no non-zero roots.')
     if K.is_ZZ:
@@ -257,7 +257,7 @@ def dup_step_refine_real_root(f, M, K, fast=False):
     if k == 1:
         a, b, c, d = a1, b1, c1, d1
     else:
-        f = dup_shift(dup_reverse(g), K.one, K)
+        f = dup_shift(dup_reverse(g, K), K.one, K)
 
         if not dup_eval(f, K.zero, K):
             f = dup_rshift(f, 1, K)
@@ -312,8 +312,8 @@ def dup_outer_refine_real_root(f, s, t, K, eps=None, steps=None, disjoint=None, 
     """Refine a positive root of `f` given an interval `(s, t)`. """
     a, b, c, d = _mobius_from_interval((s, t), K.get_field())
 
-    f = dup_transform(f, dup_strip([a, b]),
-                         dup_strip([c, d]), K)
+    f = dup_transform(f, dup_strip([a, b], K),
+                         dup_strip([c, d], K), K)
 
     if dup_sign_variations(f, K) != 1:
         raise RefinementFailed("there should be exactly one root in (%s, %s) interval" % (s, t))
@@ -423,7 +423,7 @@ def dup_inner_isolate_real_roots(f, K, eps=None, fast=False):
             a2, b2, c2, d2 = b, a + b, d, c + d
 
             if k2 > 1:
-                f2 = dup_shift(dup_reverse(f), K.one, K)
+                f2 = dup_shift(dup_reverse(f, K), K.one, K)
 
                 if not dup_TC(f2, K):
                     f2 = dup_rshift(f2, 1, K)
@@ -441,7 +441,7 @@ def dup_inner_isolate_real_roots(f, K, eps=None, fast=False):
                 continue
 
             if f1 is None:
-                f1 = dup_shift(dup_reverse(f), K.one, K)
+                f1 = dup_shift(dup_reverse(f, K), K.one, K)
 
                 if not dup_TC(f1, K):
                     f1 = dup_rshift(f1, 1, K)
@@ -456,7 +456,7 @@ def dup_inner_isolate_real_roots(f, K, eps=None, fast=False):
                 continue
 
             if f2 is None:
-                f2 = dup_shift(dup_reverse(f), K.one, K)
+                f2 = dup_shift(dup_reverse(f, K), K.one, K)
 
                 if not dup_TC(f2, K):
                     f2 = dup_rshift(f2, 1, K)
@@ -1743,8 +1743,8 @@ class RealInterval:
 
             a, b, c, d = _mobius_from_interval((s, t), dom.get_field())
 
-            f = dup_transform(f, dup_strip([a, b]),
-                                 dup_strip([c, d]), dom)
+            f = dup_transform(f, dup_strip([a, b], dom),
+                                 dup_strip([c, d], dom), dom)
 
             self.mobius = a, b, c, d
         else:

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -168,7 +168,7 @@ class FlintPowerSeriesRingZZ:
 
     def pretty(self, s: ZZSeries, *, symbol: str = "x", ascending: bool = True) -> str:
         """Return a pretty-printed string representation of a power series."""
-        coeffs = dup_reverse(s.coeffs())
+        coeffs = dup_reverse(s.coeffs(), ZZ)
 
         if isinstance(s, fmpz_poly):
             return series_pprint(coeffs, None)
@@ -574,7 +574,7 @@ class FlintPowerSeriesRingQQ:
 
     def pretty(self, s: QQSeries, *, symbol: str = "x", ascending: bool = True) -> str:
         """Return a pretty-printed string representation of a power series."""
-        coeffs = dup_reverse(s.coeffs())
+        coeffs = dup_reverse(s.coeffs(), QQ)
 
         if isinstance(s, fmpq_poly):
             return series_pprint(coeffs, None)

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -1160,7 +1160,7 @@ class PythonPowerSeriesRingZZ:
 
         If `prec` is not specified, it defaults to the ring's precision.
         """
-        coeffs = dup_reverse(coeffs)
+        coeffs = dup_reverse(coeffs, ZZ)
         if prec is None:
             if len(coeffs) <= self._prec:
                 return coeffs, None
@@ -1393,7 +1393,7 @@ class PythonPowerSeriesRingQQ:
 
         If `prec` is not specified, it defaults to the ring's precision.
         """
-        coeffs = dup_reverse(coeffs)
+        coeffs = dup_reverse(coeffs, QQ)
         if prec is None:
             if len(coeffs) <= self._prec:
                 return coeffs, None

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -201,16 +201,16 @@ def dmp_fateman_poly_F_1(n, K):
     v = [K(1), K(0), K(0)]
 
     for i in range(0, n):
-        v = [dmp_one(i, K), dmp_zero(i), v]
+        v = [dmp_one(i, K), dmp_zero(i, K), v]
 
     m = n - 1
 
-    U = dmp_add_term(u, dmp_ground(K(1), m), 0, n, K)
-    V = dmp_add_term(u, dmp_ground(K(2), m), 0, n, K)
+    U = dmp_add_term(u, dmp_ground(K(1), m, K), 0, n, K)
+    V = dmp_add_term(u, dmp_ground(K(2), m, K), 0, n, K)
 
     f = [[-K(3), K(0)], [], [K(1), K(0), -K(1)]]
 
-    W = dmp_add_term(v, dmp_ground(K(1), m), 0, n, K)
+    W = dmp_add_term(v, dmp_ground(K(1), m, K), 0, n, K)
     Y = dmp_raise(f, m, 1, K)
 
     F = dmp_mul(U, V, n, K)
@@ -246,7 +246,7 @@ def dmp_fateman_poly_F_2(n, K):
 
     m = n - 1
 
-    v = dmp_add_term(u, dmp_ground(K(2), m - 1), 0, n, K)
+    v = dmp_add_term(u, dmp_ground(K(2), m - 1, K), 0, n, K)
 
     f = dmp_sqr([dmp_one(m, K), dmp_neg(v, m, K)], n, K)
     g = dmp_sqr([dmp_one(m, K), v], n, K)
@@ -281,7 +281,7 @@ def dmp_fateman_poly_F_3(n, K):
     for i in range(0, n - 1):
         u = dmp_add_term([u], dmp_one(i, K), n + 1, i + 1, K)
 
-    v = dmp_add_term(u, dmp_ground(K(2), n - 2), 0, n, K)
+    v = dmp_add_term(u, dmp_ground(K(2), n - 2, K), 0, n, K)
 
     f = dmp_sqr(
         dmp_add_term([dmp_neg(v, n - 1, K)], dmp_one(n - 1, K), n + 1, n, K), n, K)

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -615,7 +615,7 @@ def dup_sqf_list_include(f, K, all=False):
         g = dup_mul_ground(factors[0][0], coeff, K)
         return [(g, 1)] + factors[1:]
     else:
-        g = dup_strip([coeff])
+        g = dup_strip([coeff], K)
         return [(g, 1)] + factors
 
 
@@ -754,7 +754,7 @@ def dmp_sqf_list_include(f, u, K, all=False):
         g = dmp_mul_ground(factors[0][0], coeff, u, K)
         return [(g, 1)] + factors[1:]
     else:
-        g = dmp_ground(coeff, u)
+        g = dmp_ground(coeff, u, K)
         return [(g, 1)] + factors
 
 

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -144,48 +144,48 @@ def test_dmp_degree_list():
 
 
 def test_dup_strip():
-    assert dup_strip([]) == []
-    assert dup_strip([0]) == []
-    assert dup_strip([0, 0, 0]) == []
+    assert dup_strip([], ZZ) == []
+    assert dup_strip([0], ZZ) == []
+    assert dup_strip([0, 0, 0], ZZ) == []
 
-    assert dup_strip([1]) == [1]
-    assert dup_strip([0, 1]) == [1]
-    assert dup_strip([0, 0, 0, 1]) == [1]
+    assert dup_strip([1], ZZ) == [1]
+    assert dup_strip([0, 1], ZZ) == [1]
+    assert dup_strip([0, 0, 0, 1], ZZ) == [1]
 
-    assert dup_strip([1, 2, 0]) == [1, 2, 0]
-    assert dup_strip([0, 1, 2, 0]) == [1, 2, 0]
-    assert dup_strip([0, 0, 0, 1, 2, 0]) == [1, 2, 0]
+    assert dup_strip([1, 2, 0], ZZ) == [1, 2, 0]
+    assert dup_strip([0, 1, 2, 0], ZZ) == [1, 2, 0]
+    assert dup_strip([0, 0, 0, 1, 2, 0], ZZ) == [1, 2, 0]
 
 
 def test_dmp_strip():
-    assert dmp_strip([0, 1, 0], 0) == [1, 0]
+    assert dmp_strip([0, 1, 0], 0, ZZ) == [1, 0]
 
-    assert dmp_strip([[]], 1) == [[]]
-    assert dmp_strip([[], []], 1) == [[]]
-    assert dmp_strip([[], [], []], 1) == [[]]
+    assert dmp_strip([[]], 1, ZZ) == [[]]
+    assert dmp_strip([[], []], 1, ZZ) == [[]]
+    assert dmp_strip([[], [], []], 1, ZZ) == [[]]
 
-    assert dmp_strip([[[]]], 2) == [[[]]]
-    assert dmp_strip([[[]], [[]]], 2) == [[[]]]
-    assert dmp_strip([[[]], [[]], [[]]], 2) == [[[]]]
+    assert dmp_strip([[[]]], 2, ZZ) == [[[]]]
+    assert dmp_strip([[[]], [[]]], 2, ZZ) == [[[]]]
+    assert dmp_strip([[[]], [[]], [[]]], 2, ZZ) == [[[]]]
 
-    assert dmp_strip([[[1]]], 2) == [[[1]]]
-    assert dmp_strip([[[]], [[1]]], 2) == [[[1]]]
-    assert dmp_strip([[[]], [[1]], [[]]], 2) == [[[1]], [[]]]
+    assert dmp_strip([[[1]]], 2, ZZ) == [[[1]]]
+    assert dmp_strip([[[]], [[1]]], 2, ZZ) == [[[1]]]
+    assert dmp_strip([[[]], [[1]], [[]]], 2, ZZ) == [[[1]], [[]]]
 
 
 def test_dmp_validate():
-    assert dmp_validate([]) == ([], 0)
-    assert dmp_validate([0, 0, 0, 1, 0]) == ([1, 0], 0)
+    assert dmp_validate([], ZZ) == ([], 0)
+    assert dmp_validate([0, 0, 0, 1, 0], ZZ) == ([1, 0], 0)
 
-    assert dmp_validate([[[]]]) == ([[[]]], 2)
-    assert dmp_validate([[0], [], [0], [1], [0]]) == ([[1], []], 1)
+    assert dmp_validate([[[]]], ZZ) == ([[[]]], 2)
+    assert dmp_validate([[0], [], [0], [1], [0]], ZZ) == ([[1], []], 1)
 
-    raises(ValueError, lambda: dmp_validate([[0], 0, [0], [1], [0]]))
+    raises(ValueError, lambda: dmp_validate([[0], 0, [0], [1], [0]], ZZ))
 
 
 def test_dup_reverse():
-    assert dup_reverse([1, 2, 0, 3]) == [3, 0, 2, 1]
-    assert dup_reverse([1, 2, 3, 0]) == [3, 2, 1]
+    assert dup_reverse([1, 2, 0, 3], ZZ) == [3, 0, 2, 1]
+    assert dup_reverse([1, 2, 3, 0], ZZ) == [3, 2, 1]
 
 
 def test_dup_copy():
@@ -289,8 +289,8 @@ def test_dmp_zero_p():
 
 
 def test_dmp_zero():
-    assert dmp_zero(0) == []
-    assert dmp_zero(2) == [[[]]]
+    assert dmp_zero(0, ZZ) == []
+    assert dmp_zero(2, ZZ) == [[[]]]
 
 
 def test_dmp_one_p():
@@ -326,11 +326,11 @@ def test_dmp_ground_p():
 
 
 def test_dmp_ground():
-    assert dmp_ground(ZZ(0), 2) == [[[]]]
+    assert dmp_ground(ZZ(0), 2, ZZ) == [[[]]]
 
-    assert dmp_ground(ZZ(7), -1) == ZZ(7)
-    assert dmp_ground(ZZ(7), 0) == [ZZ(7)]
-    assert dmp_ground(ZZ(7), 2) == [[[ZZ(7)]]]
+    assert dmp_ground(ZZ(7), -1, ZZ) == ZZ(7)
+    assert dmp_ground(ZZ(7), 0, ZZ) == [ZZ(7)]
+    assert dmp_ground(ZZ(7), 2, ZZ) == [[[ZZ(7)]]]
 
 
 def test_dmp_zeros():
@@ -345,13 +345,13 @@ def test_dmp_zeros():
 
 
 def test_dmp_grounds():
-    assert dmp_grounds(ZZ(7), 0, 2) == []
+    assert dmp_grounds(ZZ(7), 0, 2, ZZ) == []
 
-    assert dmp_grounds(ZZ(7), 1, 2) == [[[[7]]]]
-    assert dmp_grounds(ZZ(7), 2, 2) == [[[[7]]], [[[7]]]]
-    assert dmp_grounds(ZZ(7), 3, 2) == [[[[7]]], [[[7]]], [[[7]]]]
+    assert dmp_grounds(ZZ(7), 1, 2, ZZ) == [[[[7]]]]
+    assert dmp_grounds(ZZ(7), 2, 2, ZZ) == [[[[7]]], [[[7]]]]
+    assert dmp_grounds(ZZ(7), 3, 2, ZZ) == [[[[7]]], [[[7]]], [[[7]]]]
 
-    assert dmp_grounds(ZZ(7), 3, -1) == [7, 7, 7]
+    assert dmp_grounds(ZZ(7), 3, -1, ZZ) == [7, 7, 7]
 
 
 def test_dmp_negative_p():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Main issue gh-27360

#### Brief description of what is fixed or changed

Add missing domain parameter to some functions such as `dmp_zero`. This is needed so that the type of `dmp_zero(2, K)` can resolve to `dmp[E]` where `E` is the element type of the domain `K`.

Some other functions don't need the domain parameter for that reason but they are added for consistency and also because it might make sense to require them in future. For example `dup_strip` needs to test if elements are equivalent to zero and it potentially makes sense to use a domain method for that rather than `if c`.

The domain parameters are added as optional although all places in the sympy codebase that call these functions now provide the parameter.

The `dmp_validate` function allowed passing a domain or not and if given a domain it does additional validation. I have changed it so that it has a `strict = False` boolean parameter to control this validation so that the domain can always be passed without necessarily doing the extra validation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * Some polys functions such as `dmp_zero`, `dmp_ground`, `dmp_strip`, and `dup_strip` now take a domain argument. For compatibility this parameter is optional but it may become required in future.
<!-- END RELEASE NOTES -->
