### PR TITLE
test_failing_integrals: drop passing XFAIL test

### DIFF
--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -86,12 +86,6 @@ def test_issue_4891():
 
 
 @XFAIL
-@slow
-def test_issue_1796a():
-    assert not integrate(exp(2*b*x)*exp(-a*x**2), x).has(Integral)
-
-
-@XFAIL
 def test_issue_4895b():
     assert not integrate(exp(2*b*x)*exp(-a*x**2), (x, -oo, 0)).has(Integral)
 
@@ -175,12 +169,6 @@ def test_issue_14709a():
     i = integrate(x*acos(1 - 2*x/h), (x, 0, h))
     assert not i.has(Integral)
     # assert i == 5*h**2*pi/16
-
-
-@slow
-@XFAIL
-def test_issue_14398():
-    assert not integrate(exp(x**2)*cos(x), x).has(Integral)
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Based on #27839 #28295
Closes #14398 

#### Brief description of what is fixed or changed
Some XFAIL test cases in integrals are passing now because of previous PRs that improved integration. I believe it is suitable now to remove them as there are already tests elsewhere that covers them.

#### Other comments
N/A

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
