### PR TITLE
Move return to avoid SyntaxWarning in 3.14

### DIFF
--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -256,8 +256,8 @@ def run_in_subprocess_with_hash_randomization(
                      (module, function, function, repr(function_args),
                       repr(function_kwargs)))
 
+    p = subprocess.Popen([command, "-R", "-c", commandstring], cwd=cwd)
     try:
-        p = subprocess.Popen([command, "-R", "-c", commandstring], cwd=cwd)
         p.communicate()
     except KeyboardInterrupt:
         p.wait()
@@ -268,7 +268,7 @@ def run_in_subprocess_with_hash_randomization(
             del os.environ["PYTHONHASHSEED"]
         else:
             os.environ["PYTHONHASHSEED"] = hash_seed
-        return p.returncode
+    return p.returncode
 
 
 def run_all_tests(test_args=(), test_kwargs=None,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-27192

#### Brief description of what is fixed or changed

Move return outside of the finally block because otherwise `bin/test` gives a SyntaxWarning under Python 3.14:
```console
$ git clean -fdx sympy/testing # remove .pyc files
$ bin/test -s sympy/polys/tests/test_ring_series.py 
~/sympy/sympy/testing/runtests.py:271: SyntaxWarning: 'return' in a 'finally' block
  return p.returncode
======================================== test process starts ========================================
...
```
Note that the warning is emitted when compiling the .py file to .pyc so you have to delete the .pyc file to see it again. This change is from PEP 765:
https://peps.python.org/pep-0765/

The warning does not show up immediately if running `isympy` or if doing `import sympy`. It does show up if you import the testing module:
```python
In [1]: import sympy.testing
~/sympy/sympy/testing/runtests.py:271: SyntaxWarning: 'return' in a 'finally' block
  return p.returncode
```
Or if you use the `sympy.test` function:
```python
In [1]: import sympy

In [2]: sympy.test()
~/sympy/sympy/testing/runtests.py:271: SyntaxWarning: 'return' in a 'finally' block
  return p.returncode
```

Using `return` in finally as this code did swallows exceptions:
```python
In [3]: def f():
   ...:     try:
   ...:         raise ValueError
   ...:     finally:
   ...:         return 2
<>:5: SyntaxWarning: 'return' in a 'finally' block
<ipython-input-3-2d04a102a178>:5: SyntaxWarning: 'return' in a 'finally' block
  return 2
<ipython-input-3-2d04a102a178>:5: SyntaxWarning: 'return' in a 'finally' block
  return 2

In [4]: f()
Out[4]: 2
```
I think the exception swallowing here was intentional but I don't think it was ever needed apart from KeyboardInterrupt. The subprocess gets the KeyboardInterrupt first and already displays the traceback so we don't need to do that here and we just want to return the nonzero exit status. I don't think it makes sense to swallow any other exception though because that would be a problem in this process (e.g. if the command line given to subprocess was wrong).

#### Other comments

This code is part of the old test runner which is not used any more in CI. I don't know how many contributors would run `bin/test` with the `-s` flag. There are many pytest parametrised tests now that fail under the old test runner. The exact details of this code likely don't matter and the worst that could happen under this change is that sometimes the test runner prints more of a traceback if anything goes wrong.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
