### PR TITLE
fix(functions): don't evaluate atan(zoo)

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1009,7 +1009,10 @@ def evalf_log(expr: 'log', prec: int, options: OPT_DICT) -> TMP_RES:
 
 def evalf_atan(v: 'atan', prec: int, options: OPT_DICT) -> TMP_RES:
     arg = v.args[0]
-    xre, xim, reacc, imacc = evalf(arg, prec + 5, options)
+    result = evalf(arg, prec + 5, options)
+    if result is S.ComplexInfinity:
+        return result
+    xre, xim, reacc, imacc = result
     if xre is xim is None:
         return (None,)*4
     if xim:

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1080,7 +1080,7 @@ def test_atan():
     assert atan.nargs == FiniteSet(1)
     assert atan(oo) == pi/2
     assert atan(-oo) == -pi/2
-    assert atan(zoo) == AccumBounds(-pi/2, pi/2)
+    assert unchanged(atan, zoo)
 
     assert atan(0) == 0
     assert atan(1) == pi/4

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2747,8 +2747,7 @@ class atan(InverseTrigonometricFunction):
                 return -pi/4
 
         if arg is S.ComplexInfinity:
-            from sympy.calculus.accumulationbounds import AccumBounds
-            return AccumBounds(-pi/2, pi/2)
+            return
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -276,6 +276,8 @@ def test_atan():
     x = Symbol("x", real=True)
     assert limit(atan(x)*sin(1/x), x, 0) == 0
     assert limit(atan(x) + sqrt(x + 1) - sqrt(x), x, oo) == pi/2
+    # https://github.com/sympy/sympy/issues/28360
+    assert limit(tan(k*atan(x) - pi*(k - 1)/2)/x, x, oo) == 1/k
 
 
 def test_set_signs():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-28360

#### Brief description of what is fixed or changed

Don't evaluate `atan(zoo)`:
```
In [1]: atan(zoo)
Out[1]: atan(zoo)
```
Behaviour on master is
```
In [1]: atan(zoo)
Out[1]:
╱-π   π╲
│───, ─│
╲ 2   2╱

In [2]: print(atan(zoo))
AccumBounds(-pi/2, pi/2)
```
Evaluating functions at zoo makes things seem well defined that are not well defined which should be avoided.

#### Other comments

The `tan._eval_as_leading_term` code should not naively substitute `x = 0` into the argument. It seems that this is a common pattern but really it should compute the series of the argument.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `atan(zoo)` no longer evaluates to `AccumBounds`. This fixed a bug causing incorrect limit evaluations.
<!-- END RELEASE NOTES -->
