### PR TITLE
Remove docstring from SeriesBase._ith_point

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1049,6 +1049,7 @@ Mayank Singh <mayank.singh081997@gmail.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
+Merin Theres Jose <merintheresjose@gmail.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>

--- a/sympy/series/series_class.py
+++ b/sympy/series/series_class.py
@@ -59,29 +59,6 @@ class SeriesBase(Expr):
                                   % self.func)
 
     def _ith_point(self, i):
-        """
-        Returns the i'th point of a series
-        If start point is negative infinity, point is returned from the end.
-        Assumes the first point to be indexed zero.
-
-        Examples
-        ========
-
-        >>> from sympy.series.series_class import SeriesBase
-        >>> class DummySeries(SeriesBase):
-        ...     @property
-        ...     def start(self): return 0
-        ...     @property
-        ...     def stop(self): return 5
-        ...     @property
-        ...     def length(self): return 6
-        ...     def _eval_term(self, pt): return pt
-        >>> s = DummySeries()
-        >>> s._ith_point(0)
-        0
-        >>> s._ith_point(3)
-        3
-        """
         if self.start is S.NegativeInfinity:
             initial = self.stop
             step = -1

--- a/sympy/series/series_class.py
+++ b/sympy/series/series_class.py
@@ -67,7 +67,20 @@ class SeriesBase(Expr):
         Examples
         ========
 
-        TODO
+        >>> from sympy.series.series_class import SeriesBase
+        >>> class DummySeries(SeriesBase):
+        ...     @property
+        ...     def start(self): return 0
+        ...     @property
+        ...     def stop(self): return 5
+        ...     @property
+        ...     def length(self): return 6
+        ...     def _eval_term(self, pt): return pt
+        >>> s = DummySeries()
+        >>> s._ith_point(0)
+        0
+        >>> s._ith_point(3)
+        3
         """
         if self.start is S.NegativeInfinity:
             initial = self.stop


### PR DESCRIPTION
This PR removes the docstring from the private helper method `_ith_point` in `SeriesBase`.  
Since `_ith_point` is an internal method, having a docstring (especially with examples) could be misleading.  
The implementation remains unchanged.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
