### PR TITLE
manualintegrate: add support for integrals resulting in Dilogarithm

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2014,9 +2014,33 @@ def substitution_rule(integral):
             return ways[0]
 
 
+def is_fraction(expr):
+    if not expr.is_Mul:
+        return False
+    numer, denom = expr.as_numer_denom()
+    # Should be a non trivial denominator
+    if denom.is_constant() or not denom.is_polynomial():
+        return False
+    return True
+
+def decompose_fraction(expr, var):
+    numer, denom = expr.as_numer_denom()
+    numer_factors = factor_terms(numer).as_ordered_factors()
+
+    numer_poly_factors = [f for f in numer_factors if f.is_polynomial(var)]
+    numer_trans_factors = [f for f in numer_factors if not f.is_polynomial(var)]
+
+    numer_poly = Mul(*numer_poly_factors)
+    numer_trans = Mul(*numer_trans_factors)
+
+    frac = numer_poly / denom
+    part_frac = frac.apart(var)
+    return (numer_trans * part_frac).expand()
+
+
 partial_fractions_rule = rewriter(
-    lambda integrand, symbol: integrand.is_rational_function(),
-    lambda integrand, symbol: integrand.apart(symbol))
+    lambda integrand, symbol: is_fraction(integrand),
+    lambda integrand, symbol: decompose_fraction(integrand, symbol))
 
 cancel_rule = rewriter(
     # lambda integrand, symbol: integrand.is_algebraic_expr(),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -706,6 +706,17 @@ class PolylogRule(AtomicRule):
 
 
 @dataclass
+class DilogRule(AtomicRule):
+    a: Expr
+    b: Expr
+    c: Expr
+
+    def eval(self) -> Expr:
+        a, b, c, x = self.a, self.b, self.c, self.variable
+        return log(a)*log(abs(x)) - polylog(2, b*x**c/a)/c
+
+
+@dataclass
 class UpperGammaRule(AtomicRule):
     a: Expr
     e: Expr
@@ -1054,6 +1065,7 @@ def special_function_rule(integral):
             (cos, cos(quadratic_pattern, evaluate=False), None, FresnelCRule),
             (Mul, _symbol**e*exp(a*_symbol, evaluate=False), None, UpperGammaRule),
             (Mul, polylog(b, a*_symbol, evaluate=False)/_symbol, None, PolylogRule),
+            (Mul, log(a-b*_symbol**c)/_symbol, None, DilogRule),
             (Pow, 1/sqrt(a - d*sin(_symbol, evaluate=False)**2),
                 lambda a, d: a != d, EllipticFRule),
             (Pow, sqrt(a - d*sin(_symbol, evaluate=False)**2),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2035,6 +2035,11 @@ def decompose_fraction(expr, var):
 
     frac = numer_poly / denom
     part_frac = frac.apart(var)
+
+    # If no partial fraction decomposition was done, return the original
+    # expression
+    if not part_frac.is_Add or part_frac == frac:
+        return expr
     return (numer_trans * part_frac).expand()
 
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1311,7 +1311,7 @@ def test_powers():
 def test_manual_option():
     raises(ValueError, lambda: integrate(1/x, x, manual=True, meijerg=True))
     # an example of a function that manual integration cannot handle
-    assert integrate(log(1+x)/x, (x, 0, 1), manual=True).has(Integral)
+    assert integrate(erf(x)/x, (x, 0, 1), manual=True).has(Integral)
 
 
 def test_meijerg_option():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -676,7 +676,7 @@ def test_quadratic_denom():
     f = (5*x + 2)/(3*x**2 - 2*x + 8)
     assert manualintegrate(f, x) == 5*log(3*x**2 - 2*x + 8)/6 + 11*sqrt(23)*atan(3*sqrt(23)*(x - Rational(1, 3))/23)/69
     g = 3/(2*x**2 + 3*x + 1)
-    assert manualintegrate(g, x) == 3*log(4*x + 2) - 3*log(4*x + 4)
+    assert manualintegrate(g, x) == 3*log(x + 1/S(2)) - 3*log(x + 1)
 
 def test_issue_22757():
     assert manualintegrate(sin(x), y) == y * sin(x)
@@ -731,7 +731,7 @@ def test_manualintegrate_sqrt_linear():
     assert_is_integral_of((sqrt(3*x+3)+1)/((2*x+2)**(1/S(3))+1),
                           3*sqrt(6)*(2*x + 2)**(S(7)/6)/14 - 3*sqrt(6)*(2*x + 2)**(S(5)/6)/10 -
                           3*sqrt(6)*(2*x + 2)**(S.One/6)/2 + 3*(2*x + 2)**(S(2)/3)/4 - 3*(2*x + 2)**(S.One/3)/2 +
-                          sqrt(6)*sqrt(2*x + 2)/2 + 3*log((2*x + 2)**(S.One/3) + 1)/2 +
+                          sqrt(6)*sqrt(2*x + 2)/2 + 3*log(2*(2*x + 2)**(S.One/3) + 2)/2 +
                           3*sqrt(6)*atan((2*x + 2)**(S.One/6))/2)
     assert_is_integral_of(sqrt(x+sqrt(x)),
                           2*sqrt(sqrt(x) + x)*(sqrt(x)/12 + x/3 - S(1)/8) + log(2*sqrt(x) + 2*sqrt(sqrt(x) + x) + 1)/8)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #28358 

#### Brief description of what is fixed or changed
1. Defined Dilog Rule
2. Improved partial fraction logic
3. Updated failing tests

#### Other comments
One unfixed failed test is `test_variable_moment` in `sympy/physics/continuum_mechanics/tests/test_beam.py` for a reason I do not know it gives `IndexError: list index out of range` after my changes, which does not make sense to me.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Improve partial fraction decomposition.
  * Add dilogarithm support.
<!-- END RELEASE NOTES -->
