### PR TITLE
fix(printing): handle python printing of piecewise with "assign_to"

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -467,6 +467,7 @@ Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
+Chris Cameron <chrisjamescameron1@gmail.com>
 Chris Conley <chrisconley15@gmail.com>
 Chris Kerr <chris.kerr@mykolab.ch>
 Chris Smith <smichr@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -467,7 +467,7 @@ Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
-Chris Cameron <chrisjamescameron1@gmail.com>
+Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>
 Chris Kerr <chris.kerr@mykolab.ch>
 Chris Smith <smichr@gmail.com>

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -592,6 +592,16 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         else:
             return name
 
+    def _print_Assignment(self, expr):
+        # Emit a single outer assignment when rhs is piecewise to avoid
+        # invalid python like "((x = a) if cond else (x = b))"
+        from sympy.functions.elementary.piecewise import Piecewise
+        lhs = expr.lhs
+        rhs = expr.rhs
+        if isinstance(rhs, Piecewise):
+            return f"{self._print(lhs)} = {self._print(rhs)}"
+        return super()._print_Assignment(expr)
+
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported
     _print_fresnelc = CodePrinter._print_not_supported

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -200,6 +200,16 @@ class AbstractPythonCodePrinter(CodePrinter):
     def _print_ComplexInfinity(self, expr):
         return self._print_NaN(expr)
 
+    def _print_Assignment(self, expr):
+        # Emit a single outer assignment when rhs is piecewise to avoid
+        # invalid python like "((x = a) if cond else (x = b))"
+        from sympy.functions.elementary.piecewise import Piecewise
+        lhs = expr.lhs
+        rhs = expr.rhs
+        if isinstance(rhs, Piecewise):
+            return f"{self._print(lhs)} = {self._print(rhs)}"
+        return super()._print_Assignment(expr)
+
     def _print_Mod(self, expr):
         PREC = precedence(expr)
         return ('{} % {}'.format(*(self.parenthesize(x, PREC) for x in expr.args)))
@@ -591,16 +601,6 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
             return name.replace('{', '').replace('}', '')
         else:
             return name
-
-    def _print_Assignment(self, expr):
-        # Emit a single outer assignment when rhs is piecewise to avoid
-        # invalid python like "((x = a) if cond else (x = b))"
-        from sympy.functions.elementary.piecewise import Piecewise
-        lhs = expr.lhs
-        rhs = expr.rhs
-        if isinstance(rhs, Piecewise):
-            return f"{self._print(lhs)} = {self._print(rhs)}"
-        return super()._print_Assignment(expr)
 
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -512,3 +512,10 @@ def test_custom_Derivative_methods():
         assert '_print_Derivative(' in repr(e)
     else:
         assert False  # should have thrown
+
+def test_piecewise_assign_to():
+    x, a, b, c = symbols('x a b c')
+    prntr = PythonCodePrinter()
+    expr = Piecewise((a + b, c), (0, True))
+    out = prntr.doprint(expr, assign_to=x)
+    assert out == 'x = ((a + b) if c else (0))'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -515,7 +515,12 @@ def test_custom_Derivative_methods():
 
 def test_piecewise_assign_to():
     x, a, b, c = symbols('x a b c')
-    prntr = PythonCodePrinter()
+    pyprinter = PythonCodePrinter()
+    symprinter = SymPyPrinter()
+
     expr = Piecewise((a + b, c), (0, True))
-    out = prntr.doprint(expr, assign_to=x)
-    assert out == 'x = ((a + b) if c else (0))'
+    pyprint = pyprinter.doprint(expr, assign_to=x)
+    symprint = symprinter.doprint(expr, assign_to=x)
+
+    assert pyprint == 'x = ((a + b) if c else (0))'
+    assert symprint == 'x = ((a + b) if c else (0))'


### PR DESCRIPTION
#### References to other Issues or PRs
None

#### Brief description of what is fixed or changed
When printing an assignment where the RHS is a piecewise assignment, the current PythonCodePrinter prints two assignments in the ternary if-else form, which is invalid Python. This commit adds a check in _print_Assignment which tests whether the RHS is a Piecewise expression, and if so, returns "lhs = rhs", letting the Piecewise operator be correctly processed as an expression in the next round.

Example:
```python
from sympy import symbols, Piecewise
from sympy.printing.pycode import PythonCodePrinter

x, k, c = symbols('x k c')
p = PythonCodePrinter()
piecewise_expr = Piecewise((x, k), (0, True))
pycode_assign_to = p.doprint(piecewise_expr, assign_to=x)

print("Assign to:        ", pycode_assign_to)
print("Expected:   ", "x = (k) if k else (0))")
```
#### Other comments
I don't *think* this shortcuts any important steps elsewhere in the printers, however I'm not super familiar with Sympy. All python and pycode printing tests are passing with this edit on my machine. Please let me know if a different approach is required!

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed handling of assignments from Piecewise expressions in PythonCodePrinter
<!-- END RELEASE NOTES -->
