### PR TITLE
Replaced absolute `https://docs.sympy.org` links with relative Sphinx links in biomechanics tutorial and explanation file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1793,3 +1793,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+devBitt <adithyanscodes@gmail.com>  devBitt <your_email@example.com>

--- a/bin/doctest
+++ b/bin/doctest
@@ -12,10 +12,10 @@ from __future__ import print_function
 # files listed here can be in unix forward slash format with paths
 # listed relative to sympy (which contains bin, etc...)
 blacklist = [
-    'doc/src/tutorials/physics/biomechanics/biomechanical-model-example.rst',
-    'doc/src/explanation/modules/physics/biomechanics/biomechanics.rst',
-    'doc/src/explanation/modules/physics/mechanics/autolev_parser.rst',
-    'doc/src/tutorials/physics/biomechanics/biomechanics.rst',
+    ':doc:`biomechanics`',
+    ':doc:`../../../tutorials/physics/biomechanics/biomechanical-model-example`',
+    ':doc:`../../tutorials/physics/biomechanics/biomechanics`'
+    ':doc:`biomechanical-model-example`',
 ]
 
 import sys


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Replace absolute docs.sympy.org links with relative Sphinx links in biomechanics tutorials and explanations
<!-- END RELEASE NOTES -->

Files updated:
- doc/src/tutorials/physics/biomechanics/biomechanical-model-example.rst
- doc/src/tutorials/physics/biomechanics/biomechanics.rst
- doc/src/explanation/modules/physics/biomechanics/biomechanics.rst
- doc/src/explanation/modules/physics/mechanics/autolev_parser.rst

Why:
- Relative links work locally and in GitHub CI, improving documentation reliability.

Example:

Before:
`Biomechanics tutorial <https://docs.sympy.org/latest/tutorials/physics/biomechanics/biomechanics.html>`_

After:
:doc:`../../tutorials/physics/biomechanics/biomechanics`
