### PR TITLE
Add fix and tests for NaN error when one of the points is apex

### DIFF
--- a/sympy/physics/mechanics/tests/test_wrapping_geometry.py
+++ b/sympy/physics/mechanics/tests/test_wrapping_geometry.py
@@ -397,6 +397,9 @@ class TestWrappingCone:
             (N.z, pi/6, (N.x + N.y)/(sqrt(2)*sqrt(3)) + N.z, (3*N.x - 3*N.y)/(sqrt(2)*sqrt(3)) + 3*N.z, sqrt(Rational(40, 3) - 4*sqrt(2))),
             (N.z, pi/4, (cos(pi/6)*N.x + sin(pi/6)*N.y + N.z)/sqrt(2), (3*cos(2*pi/3)*N.x + 3*sin(2*pi/3)*N.y + 3*N.z)/sqrt(2), sqrt(10 - 6*cos(pi/(2*sqrt(2))))),
             (N.z, pi/4, (N.x + N.z)/sqrt(2), (2*N.y + 2*N.z)/sqrt(2), sqrt(5 - 4*cos(pi/(2*sqrt(2))))),
+            (N.z, pi/6, S.Zero, N.x/sqrt(3) + N.z, sqrt(Rational(4, 3))),
+            (N.z, pi/4, (N.x + N.z)/sqrt(2), S.Zero, S.One),
+            (N.z, pi/3, S.Zero, S.Zero, S.Zero),
         ]
     )
     def test_geodesic_length(axis, alpha, position_1, position_2, expected):

--- a/sympy/physics/mechanics/wrapping_geometry.py
+++ b/sympy/physics/mechanics/wrapping_geometry.py
@@ -724,6 +724,13 @@ class WrappingCone(WrappingGeometryBase):
         """
         pos1 = point_1.pos_from(self.apex)
         pos2 = point_2.pos_from(self.apex)
+
+        # Handle case where one of the points is the apex itself
+        if pos1.magnitude() == 0:
+            return pos2.magnitude()
+        if pos2.magnitude() == 0:
+            return pos1.magnitude()
+
         z1 = pos1.dot(self.axis)
         z2 = pos2.dot(self.axis)
         s1 = z1 / cos(self.alpha)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR is created due to PR [#28317](https://github.com/sympy/sympy/pull/28317) having a doctest failure due to this very bug.

#### Brief description of what is fixed or changed
I have simply added an edge case check to handle the case where one of the points is the `apex` in the `geodesic_length` method of the `WrappingCone` class. Tests have also been added. 

#### Other comments
This PR is a part of my GSoC 2025 work on the project "Implement Wrapping Geometries and Pathways for Musculoskeletal Modeling".

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
