### PR TITLE
fix: Simplify atanh(tanh(x)) for real numbers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1794,4 +1794,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-cp50 <chrispaul68002@gmail.com>
+Chris Paul <chrispaul68002@gmail.com> cp50 <chrispaul68002@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1794,4 +1794,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Chris Paul <chrispaul68002@gmail.com> cp50 <chrispaul68002@gmail.com>
+cp50 <chrispaul68002@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1701,6 +1701,7 @@ carstimon <carstimon@gmail.com>
 ck Lux <lux.r.ck@gmail.com>
 cocolato <haiizhu@outlook.com> Hai Zhu <35182391+cocolato@users.noreply.github.com>
 codecruisader <nnisarg55@gmail.com>
+cp50 <chrispaul68002@gmail.com>
 cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1794,3 +1794,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Chris Paul <chrispaul68002@gmail.com> cp50 <chrispaul68002@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -470,6 +470,7 @@ Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>
 Chris Kerr <chris.kerr@mykolab.ch>
+Chris Paul <chrispaul68002@gmail.com> cp50 <chrispaul68002@gmail.com>
 Chris Smith <smichr@gmail.com>
 Chris Smith <smichr@gmail.com> <Donna Smith@.(none)>
 Chris Swierczewski <cswiercz@gmail.com>
@@ -1794,4 +1795,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Chris Paul <chrispaul68002@gmail.com> cp50 <chrispaul68002@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1377,3 +1377,4 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+cp50 <chrispaul68002@gmail.com>

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1652,19 +1652,20 @@ class atanh(InverseHyperbolicFunction):
         if arg.is_zero:
             return S.Zero
 
-        if isinstance(arg, tanh) and arg.args[0].is_number:
+        if isinstance(arg, tanh):
             z = arg.args[0]
             if z.is_real:
                 return z
-            r, i = match_real_imag(z)
-            if r is not None and i is not None:
-                f = floor(2*i/pi)
-                even = f.is_even
-                m = z - I*f*pi/2
-                if even is True:
-                    return m
-                elif even is False:
-                    return m - I*pi/2
+            if z.is_number:
+                r, i = match_real_imag(z)
+                if r is not None and i is not None:
+                    f = floor(2*i/pi)
+                    even = f.is_even
+                    m = z - I*f*pi/2
+                    if even is True:
+                        return m
+                    elif even is False:
+                        return m - I*pi/2
 
     @staticmethod
     @cacheit

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1106,6 +1106,7 @@ def test_atanh():
     assert atanh(tanh(-3 + 7*I)) == -3 - 2*I*pi + 7*I
     assert atanh(tanh(9 - I*2/3)) == 9 - I*2/3
     assert atanh(tanh(-32 - 123*I)) == -32 - 123*I + 39*I*pi
+    assert atanh(tanh(x, evaluate=False)) == x
 
 
 def test_atanh_rewrite():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1106,7 +1106,8 @@ def test_atanh():
     assert atanh(tanh(-3 + 7*I)) == -3 - 2*I*pi + 7*I
     assert atanh(tanh(9 - I*2/3)) == 9 - I*2/3
     assert atanh(tanh(-32 - 123*I)) == -32 - 123*I + 39*I*pi
-    assert atanh(tanh(x, evaluate=False)) == x
+    x = Symbol('x', real=True)
+    assert atanh(tanh(x)) == x
 
 
 def test_atanh_rewrite():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28376

#### Brief description of what is fixed or changed
This change fixes a bug where `atanh(tanh(x))` was not correctly simplifying to `x` when `x` was a generic real symbol. The simplification now correctly applies the mathematical identity, which was previously only working for numerical inputs.

#### Other comments
_Leave this blank, as you have no other comments._

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug where `atanh(tanh(x))` was not simplifying for real number inputs.
<!-- END RELEASE NOTES -->