### PR TITLE
Refactor qapply to use SlidingTransform and multiple dispatch

### DIFF
--- a/sympy/physics/quantum/__init__.py
+++ b/sympy/physics/quantum/__init__.py
@@ -1,6 +1,8 @@
 # Names exposed by 'from sympy.physics.quantum import *'
 
 __all__ = [
+   # 'SlidingTransform', 'DipatchingSlidingTransform'
+
     'AntiCommutator',
 
     'qapply',
@@ -31,6 +33,10 @@ __all__ = [
 
     '_postprocess_state_mul', '_postprocess_state_pow'
 ]
+
+# from .slidingtransform import (
+#     SlidingTransform, DipatchingSlidingTransform
+# )
 
 from .anticommutator import AntiCommutator
 

--- a/sympy/physics/quantum/__init__.py
+++ b/sympy/physics/quantum/__init__.py
@@ -1,7 +1,7 @@
 # Names exposed by 'from sympy.physics.quantum import *'
 
 __all__ = [
-   # 'SlidingTransform', 'DipatchingSlidingTransform'
+    'SlidingTransform',
 
     'AntiCommutator',
 
@@ -31,12 +31,12 @@ __all__ = [
 
     'hbar', 'HBar',
 
-    '_postprocess_state_mul', '_postprocess_state_pow'
+    '_postprocess_qexpr_mul', '_postprocess_state_pow'
 ]
 
-# from .slidingtransform import (
-#     SlidingTransform, DipatchingSlidingTransform
-# )
+from .slidingtransform import (
+    SlidingTransform
+)
 
 from .anticommutator import AntiCommutator
 
@@ -68,4 +68,4 @@ from .constants import hbar, HBar
 
 # These are private, but need to be imported so they are registered
 # as postprocessing transformers with Mul and Pow.
-from .transforms import _postprocess_state_mul, _postprocess_state_pow
+from .transforms import _postprocess_qexpr_mul, _postprocess_state_pow

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -10,7 +10,6 @@ from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.operator import HermitianOperator
-from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.matrixutils import numpy_ndarray, scipy_sparse_matrix, to_numpy
 from sympy.physics.quantum.trace import Tr
 
@@ -191,6 +190,7 @@ class Density(HermitianOperator):
         return Mul(*c_part1)*Mul(*c_part2) * op
 
     def _represent(self, **options):
+        from sympy.physics.quantum.represent import represent
         return represent(self.doit(), **options)
 
     def _print_operator_name_latex(self, printer, *args):
@@ -238,6 +238,7 @@ def entropy(density):
 
     """
     if isinstance(density, Density):
+        from sympy.physics.quantum.represent import represent
         density = represent(density)  # represent in Matrix
 
     if isinstance(density, scipy_sparse_matrix):
@@ -299,6 +300,7 @@ def fidelity(state1, state2):
     .. [1] https://en.wikipedia.org/wiki/Fidelity_of_quantum_states
 
     """
+    from sympy.physics.quantum.represent import represent
     state1 = represent(state1) if isinstance(state1, Density) else state1
     state2 = represent(state2) if isinstance(state2, Density) else state2
 

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -668,7 +668,7 @@ class HadamardGate(HermitianOperator, OneQubitGate):
     sqrt(2)*|0>/2 - sqrt(2)*|1>/2
     >>> # Hadamard on bell state, applied on 2 qubits.
     >>> psi = 1/sqrt(2)*(Qubit('00')+Qubit('11'))
-    >>> qapply(HadamardGate(0)*HadamardGate(1)*psi)
+    >>> qapply(HadamardGate(0)*HadamardGate(1)*psi).expand()
     sqrt(2)*|00>/2 + sqrt(2)*|11>/2
 
     """

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -340,6 +340,8 @@ def apply_grover(oracle, nqubits, iterations=None):
     iterated = superposition_basis(nqubits)
     for iter in range(iterations):
         iterated = grover_iteration(iterated, v)
-        iterated = qapply(iterated)
+        # qapply no longer does expand, so this is needed to optimize
+        # and avoid having lots of products of sums in qapply calls
+        iterated = qapply(iterated).expand()
 
     return iterated

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -295,7 +295,7 @@ def grover_iteration(qstate, oracle):
         >>> basis_states = superposition_basis(numqubits)
         >>> f = lambda qubits: qubits == IntQubit(2)
         >>> v = OracleGate(numqubits, f)
-        >>> qapply(grover_iteration(basis_states, v))
+        >>> qapply(grover_iteration(basis_states, v)).expand()
         |2>
 
     """

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -8,6 +8,7 @@ Todo:
 * Implement _represent_ZGate in OracleGate
 """
 
+from sympy.core.add import Add
 from sympy.core.numbers import pi
 from sympy.core.sympify import sympify
 from sympy.core.basic import Atom
@@ -257,8 +258,11 @@ class WGate(Gate):
         # state and phi is the superposition of basis states (see function
         # create_computational_basis above)
         basis_states = superposition_basis(self.nqubits)
-        change_to_basis = (2/sqrt(2**self.nqubits))*basis_states
-        return change_to_basis - qubits
+        terms = []
+        for term in basis_states.args:
+            terms.append(2/sqrt(2**self.nqubits)*term)
+        terms.append(-qubits)
+        return Add(*terms)
 
 
 def grover_iteration(qstate, oracle):

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -1,24 +1,40 @@
 """Logic for applying operators to states.
 
-Todo:
-* Sometimes the final result needs to be expanded, we should do this by hand.
+TODO:
+
+- Finish slidingtransform
+- Finish slidingtransform tests
+- Add extra type handlers to get rid of warnings in qapply
+- Optimize performance
+- Finish tests for qapply
+- Fix all other tests
+
 """
 
 from sympy.concrete import Sum
 from sympy.core.add import Add
+from sympy.core.expr import Expr
 from sympy.core.kind import NumberKind
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify, _sympify
+from sympy.functions.elementary.complexes import Abs
+from sympy.integrals import Integral
+from sympy.multipledispatch import Dispatcher
+
+from sympy.utilities.misc import debug
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.dagger import Dagger
+from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.operator import OuterProduct, Operator
 from sympy.physics.quantum.state import State, KetBase, BraBase, Wavefunction
 from sympy.physics.quantum.tensorproduct import TensorProduct
+from sympy.physics.quantum.slidingtransform import SlidingTransform
+
 
 __all__ = [
     'qapply'
@@ -26,207 +42,240 @@ __all__ = [
 
 
 #-----------------------------------------------------------------------------
-# Main code
+# Utilities
 #-----------------------------------------------------------------------------
 
 
-def ip_doit_func(e):
+def _ip_doit_func(e):
     """Transform the inner products in an expression by calling ``.doit()``."""
     return e.replace(InnerProduct, lambda *args: InnerProduct(*args).doit())
 
 
-def sum_doit_func(e):
+def _sum_doit_func(e):
     """Transform the sums in an expression by calling ``.doit()``."""
-    return e.replace(Sum, lambda *args: Sum(*args).doit())
+    result = e.replace(Sum, lambda *args: Sum(*args).doit())
+    result = result.replace(Integral, lambda *args: Integral(*args).doit())
+    return result
 
+
+def _handle_doit_unary(f):
+
+    def apply_doit(expr, **options):
+        sum_doit = options.get('sum_doit', False)
+        ip_doit = options.get('ip_doit', True)
+        result = f(expr, **options)
+        result = _ip_doit_func(result) if ip_doit else result
+        result = _sum_doit_func(result) if sum_doit else result
+        return result
+
+    return apply_doit
+
+
+def _flatten_mul(f):
+    
+    def g(*args, **options):
+        seq = f(*args, **options)
+        if seq is None:
+            return
+        result = []
+        for item in seq:
+            if isinstance(item, Mul):
+                result.extend(item.args)
+            else:
+                result.append(item)
+        return tuple(result)
+
+    return g
+
+
+#-----------------------------------------------------------------------------
+# Main code
+#-----------------------------------------------------------------------------
+
+# Level 0: int, float, complex
+# Level 1: Expr
+# Level 2: Mul, Add, Pow, Abs
+# Level 3: Sum, Integral
+# Level 3: Bra, Ket, Operator, Dagger
+# Level 4: InnerProduct, OuterProduct
+# Level 5: TensorProduct, Density
+
+#-----------------------------------------------------------------------------
+# _qapply_unary
+#-----------------------------------------------------------------------------
+
+_qapply_unary = Dispatcher('_qapply_unary')
+
+
+@_qapply_unary.register(Expr)
+def _qapply_unary_expr(expr, **options):
+    return None
+
+
+@_qapply_unary.register((int, float, complex))
+def _qapply_unary_number(expr, **options):
+    return sympify(expr)
+
+
+@_qapply_unary.register(Abs)
+def _qapply_unary_abs(expr, **options):
+    debug('Abs: ', expr, **options)
+    return Abs(qapply(expr.args[0], **options))
+
+
+@_qapply_unary.register(Add)
+def _qapply_unary_state(expr, **options):
+    result = 0
+    for arg in expr.args:
+        result += qapply(arg, **options)
+    return result
+
+
+@_qapply_unary.register(Pow)
+def _qapply_unary_pow(expr, **options):
+    # For a Pow, call qapply on its base.
+    base, exp = expr.as_base_exp()
+    return qapply(base, **options)**exp
+
+
+@_qapply_unary.register(Mul)
+@_handle_doit_unary
+def _qapply_unary_mul(expr, **options):
+    """We have a Mul where there might be actual operators to apply."""
+    dagger = options.get('dagger', False)
+    result = qapply_Mul(expr, **options)
+    if dagger:
+        result = Dagger(qapply_Mul(Dagger(result), **options))
+    return result
+
+
+@_qapply_unary.register(Sum)
+@_handle_doit_unary
+def _qapply_unary_sum(expr, **options):
+    """For a Sum, call qapply on its function."""
+    result = Sum(qapply(expr.function, **options), *expr.limits)
+    return result
+
+
+@_qapply_unary.register(Integral)
+@_handle_doit_unary
+def _qapply_unary_integral(expr, **options):
+    """For a Sum, call qapply on its function."""
+    result = Integral(qapply(expr.function, **options), *expr.limits)
+    return result
+
+
+@_qapply_unary.register(Dagger)
+def _qapply_unary_dagger(expr, **options):
+    return Dagger(qapply(expr, **options))
+
+
+@_qapply_unary.register(Density)
+def _qapply_unary_density(expr, **options):
+    # For a Density operator call qapply on its state
+    new_args = [(qapply(state, **options), prob) for (state,
+                     prob) in expr.args]
+    return Density(*new_args)
+
+
+@_qapply_unary.register(TensorProduct)
+def _qapply_unary_tp(expr, **options):
+    new_args = [qapply(t, **options) for t in expr.args]
+    return TensorProduct(*new_args)
+
+
+#-----------------------------------------------------------------------------
+# qapply
+#-----------------------------------------------------------------------------
 
 def qapply(e, **options):
-    """Apply operators to states in a quantum expression.
-
-    Parameters
-    ==========
-
-    e : Expr
-        The expression containing operators and states. This expression tree
-        will be walked to find operators acting on states symbolically.
-    options : dict
-        A dict of key/value pairs that determine how the operator actions
-        are carried out.
-
-        The following options are valid:
-
-        * ``dagger``: try to apply Dagger operators to the left
-          (default: False).
-        * ``ip_doit``: call ``.doit()`` in inner products when they are
-          encountered (default: True).
-        * ``sum_doit``: call ``.doit()`` on sums when they are encountered
-          (default: False). This is helpful for collapsing sums over Kronecker
-          delta's that are created when calling ``qapply``.
-
-    Returns
-    =======
-
-    e : Expr
-        The original expression, but with the operators applied to states.
-
-    Examples
-    ========
-
-        >>> from sympy.physics.quantum import qapply, Ket, Bra
-        >>> b = Bra('b')
-        >>> k = Ket('k')
-        >>> A = k * b
-        >>> A
-        |k><b|
-        >>> qapply(A * b.dual / (b * b.dual))
-        |k>
-        >>> qapply(k.dual * A / (k.dual * k))
-        <b|
-    """
-    from sympy.physics.quantum.density import Density
-
-    dagger = options.get('dagger', False)
-    sum_doit = options.get('sum_doit', False)
+    debug('qapply: ', e)
     ip_doit = options.get('ip_doit', True)
 
     e = _sympify(e)
 
     # Using the kind API here helps us to narrow what types of expressions
-    # we call ``ip_doit_func`` on.
+    # we call ``_ip_doit_func`` on. Here, we are covering the case where there
+    # is an inner product in a scalar input.
     if e.kind == NumberKind:
-        return ip_doit_func(e) if ip_doit else e
+        return _ip_doit_func(e) if ip_doit else e
 
-    # This may be a bit aggressive but ensures that everything gets expanded
-    # to its simplest form before trying to apply operators. This includes
-    # things like (A+B+C)*|a> and A*(|a>+|b>) and all Commutators and
-    # TensorProducts. The only problem with this is that if we can't apply
-    # all the Operators, we have just expanded everything.
-    # TODO: don't expand the scalars in front of each Mul.
-    e = e.expand(commutator=True, tensorproduct=True)
+    result = _qapply_unary(e, **options)
 
-    # If we just have a raw ket, return it.
-    if isinstance(e, KetBase):
-        return e
+    return e if (result is None) else result
 
-    # We have an Add(a, b, c, ...) and compute
-    # Add(qapply(a), qapply(b), ...)
-    elif isinstance(e, Add):
-        result = 0
-        for arg in e.args:
-            result += qapply(arg, **options)
-        return result.expand()
 
-    # For a Density operator call qapply on its state
-    elif isinstance(e, Density):
-        new_args = [(qapply(state, **options), prob) for (state,
-                     prob) in e.args]
-        return Density(*new_args)
+#-----------------------------------------------------------------------------
+# qapply_Mul
+#-----------------------------------------------------------------------------
 
-    # For a raw TensorProduct, call qapply on its args.
-    elif isinstance(e, TensorProduct):
-        return TensorProduct(*[qapply(t, **options) for t in e.args])
 
-    # For a Sum, call qapply on its function.
-    elif isinstance(e, Sum):
-        result = Sum(qapply(e.function, **options), *e.limits)
-        result = sum_doit_func(result) if sum_doit else result
-        return result
+qapply_Mul = SlidingTransform(
+    unary=Dispatcher('_qapply_mul_unary'),
+    binary=Dispatcher('_qapply_mul_binary'),
+    reverse=True
+)
 
-    # For a Pow, call qapply on its base.
-    elif isinstance(e, Pow):
-        return qapply(e.base, **options)**e.exp
+# Unary transformations for qapply_Mul
 
-    # We have a Mul where there might be actual operators to apply to kets.
-    elif isinstance(e, Mul):
-        c_part, nc_part = e.args_cnc()
-        c_mul = Mul(*c_part)
-        nc_mul = Mul(*nc_part)
-        if not nc_part: # If we only have a commuting part, just return it.
-            result = c_mul
-        elif isinstance(nc_mul, Mul):
-            result = c_mul*qapply_Mul(nc_mul, **options)
-        else:
-            result = c_mul*qapply(nc_mul, **options)
-        if result == e and dagger:
-            result = Dagger(qapply_Mul(Dagger(e), **options))
-        result = ip_doit_func(result) if ip_doit else result
-        result = sum_doit_func(result) if sum_doit else result
-        return result
 
-    # In all other cases (State, Operator, Pow, Commutator, InnerProduct,
-    # OuterProduct) we won't ever have operators to apply to kets.
+@qapply_Mul.unary.register((int, float, complex))
+def _qapply_mul_unary_number(expr, **options):
+    return (sympify(expr),)
+
+
+@qapply_Mul.unary.register(Expr)
+def qapply_mul_unary_expr(expr, **options):
+    return None
+
+
+@qapply_Mul.unary.register(Pow)
+@_flatten_mul
+def _qapply_mul_unary_pow(expr, **options):
+    base, exp = expr.as_base_exp()
+    if exp.is_Integer and exp > 0:
+        return tuple(expr.base for i in range(int(expr.exp)))
     else:
-        return e
+        return (qapply(expr, **options),)
 
 
-def qapply_Mul(e, **options):
+@qapply_Mul.unary.register(OuterProduct)
+def _qapply_mul_unary_op(expr, **options):
+    return (expr.ket, expr.bra)
 
-    args = list(e.args)
-    extra = S.One
-    result = None
 
-    # If we only have 0 or 1 args, we have nothing to do and return.
-    if len(args) <= 1 or not isinstance(e, Mul):
-        return e
-    rhs = args.pop()
-    lhs = args.pop()
+@qapply_Mul.unary.register((Commutator, AntiCommutator))
+@_flatten_mul
+def _qapply_mul_unary_comm(expr, **options):
+    return (expr.doit(),)
 
-    # Make sure we have two non-commutative objects before proceeding.
-    if (not isinstance(rhs, Wavefunction) and sympify(rhs).is_commutative) or \
-            (not isinstance(lhs, Wavefunction) and sympify(lhs).is_commutative):
-        return e
 
-    # For a Pow with an integer exponent, apply one of them and reduce the
-    # exponent by one.
-    if isinstance(lhs, Pow) and lhs.exp.is_Integer:
-        args.append(lhs.base**(lhs.exp - 1))
-        lhs = lhs.base
+@qapply_Mul.unary.register(TensorProduct)
+@_flatten_mul
+def _qapply_mul_unary_tp(expr, **options):
+    new_args = [qapply(t, **options) for t in expr.args]
+    return (TensorProduct(*new_args),)
 
-    # Pull OuterProduct apart
-    if isinstance(lhs, OuterProduct):
-        args.append(lhs.ket)
-        lhs = lhs.bra
 
-    if isinstance(rhs, OuterProduct):
-        extra = rhs.bra # Append to the right of the result
-        rhs = rhs.ket
+@qapply_Mul.unary.register(Density)
+def _qapply_mul_unary_density(expr, **options):
+    # For a Density operator call qapply on its state
+    new_args = [(qapply(state, **options), prob) for (state,
+                     prob) in expr.args]
+    return (Density(*new_args),)
 
-    # Call .doit() on Commutator/AntiCommutator.
-    if isinstance(lhs, (Commutator, AntiCommutator)):
-        comm = lhs.doit()
-        if isinstance(comm, Add):
-            return qapply(
-                e.func(*(args + [comm.args[0], rhs])) +
-                e.func(*(args + [comm.args[1], rhs])),
-                **options
-            )*extra
-        else:
-            return qapply(e.func(*args)*comm*rhs, **options)*extra
 
-    # Apply tensor products of operators to states
-    if isinstance(lhs, TensorProduct) and all(isinstance(arg, (Operator, State, Mul, Pow)) or arg == 1 for arg in lhs.args) and \
-            isinstance(rhs, TensorProduct) and all(isinstance(arg, (Operator, State, Mul, Pow)) or arg == 1 for arg in rhs.args) and \
-            len(lhs.args) == len(rhs.args):
-        result = TensorProduct(*[qapply(lhs.args[n]*rhs.args[n], **options) for n in range(len(lhs.args))]).expand(tensorproduct=True)
-        return qapply_Mul(e.func(*args), **options)*result*extra
+# Binary transformations for qapply_Mul
 
-    # For Sums, move the Sum to the right.
-    if isinstance(rhs, Sum):
-        if isinstance(lhs, Sum):
-            if set(lhs.variables).intersection(set(rhs.variables)):
-                raise ValueError('Duplicated dummy indices in separate sums in qapply.')
-            limits = lhs.limits + rhs.limits
-            result = Sum(qapply(lhs.function*rhs.function, **options), *limits)
-            return qapply_Mul(e.func(*args)*result, **options)
-        else:
-            result = Sum(qapply(lhs*rhs.function, **options), *rhs.limits)
-            return qapply_Mul(e.func(*args)*result, **options)
 
-    if isinstance(lhs, Sum):
-        result = Sum(qapply(lhs.function*rhs, **options), *lhs.limits)
-        return qapply_Mul(e.func(*args)*result, **options)
+@qapply_Mul.binary.register(Expr, Expr)
+def _qapply_mul_binary_expr_expr(lhs, rhs, **options):
+    return None
 
-    # Now try to actually apply the operator and build an inner product.
+
+@qapply_Mul.binary.register(Operator, KetBase)
+@_flatten_mul
+def _qapply_mul_binary_op_ket(lhs, rhs, **options):
     _apply = getattr(lhs, '_apply_operator', None)
     if _apply is not None:
         try:
@@ -244,20 +293,74 @@ def qapply_Mul(e, **options):
             except NotImplementedError:
                 result = None
 
-    if result is None:
-        if isinstance(lhs, BraBase) and isinstance(rhs, KetBase):
-            result = InnerProduct(lhs, rhs)
+    return None if result is None else (result,)
 
-    # TODO: I may need to expand before returning the final result.
-    if isinstance(result, (int, complex, float)):
-        return _sympify(result)
-    elif result is None:
-        if len(args) == 0:
-            # We had two args to begin with so args=[].
-            return e
-        else:
-            return qapply_Mul(e.func(*(args + [lhs])), **options)*rhs*extra
-    elif isinstance(result, InnerProduct):
-        return result*qapply_Mul(e.func(*args), **options)*extra
-    else:  # result is a scalar times a Mul, Add or TensorProduct
-        return qapply(e.func(*args)*result, **options)*extra
+
+@qapply_Mul.binary.register(BraBase, Operator)
+def _qapply_mul_binary_bra_op(lhs, rhs, **options):
+    """Register this to remind us that we only do this when dagger=True."""
+    return None
+
+
+@qapply_Mul.binary.register(Add, Expr)
+def _qapply_mul_binary_add_expr(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = Add(*(qapply(item*rhs, **options) for item in lhs.args))
+        return (result,)
+
+
+@qapply_Mul.binary.register(Expr, Add)
+def _qapply_mul_binary_expr_add(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = Add(*(qapply(lhs*item, **options) for item in rhs.args))
+        return (result,)
+
+
+@qapply_Mul.binary.register((Sum, Integral), Expr)
+def _qapply_mul_binary_sum_expr(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = lhs.func(qapply(lhs.function*rhs, **options), *lhs.limits)
+        return (result,)
+
+
+@qapply_Mul.binary.register(Expr, (Sum, Integral))
+def _qapply_mul_binary_expr_sum(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        result = rhs.func(qapply(lhs*rhs.function, **options), *rhs.limits)
+        return (result,)
+
+
+@qapply_Mul.binary.register(Sum, Sum)
+def _qapply_mul_binary_sum_sum(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        if set(lhs.variables).intersection(set(rhs.variables)):
+            raise ValueError(
+                'Duplicated dummy indices in separate sums in qapply.'
+            )
+        limits = lhs.limits + rhs.limits
+        result = Sum(
+            qapply(lhs.function*rhs.function, **options),
+            *limits
+        )
+        return (result,)
+
+
+@qapply_Mul.binary.register(Integral, Integral)
+def _qapply_mul_binary_integral_integral(lhs, rhs, **options):
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        if set(lhs.variables).intersection(set(rhs.variables)):
+            raise ValueError(
+                'Duplicated dummy indices in separate sums in qapply.'
+            )
+        limits = lhs.limits + rhs.limits
+        result = Integral(
+            qapply(lhs.function*rhs.function, **options),
+            *limits
+        )
+        return (result,)

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -6,7 +6,7 @@ complex quantum mechanical expressions symbolically.
 """
 
 from __future__ import annotations
-from typing import Any,  TypedDict, Unpack,  cast
+from typing import TYPE_CHECKING, Any,  TypedDict,   cast
 
 from sympy.concrete import Sum
 from sympy.core.add import Add
@@ -35,6 +35,9 @@ from sympy.physics.quantum.state import KetBase, BraBase, Wavefunction
 from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.slidingtransform import SlidingTransform
 
+
+if TYPE_CHECKING:
+    from typing import Unpack
 
 __all__ = [
     'qapply',

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -1,4 +1,36 @@
-"""Logic for applying operators to states.
+"""
+Quantum operator application system for symbolic quantum mechanics.
+
+The qapply function provides a comprehensive system for applying quantum operators
+to quantum states, handling the complex interactions between operators, states,
+and mathematical expressions in symbolic quantum mechanics.
+
+The system operates through a hierarchical dispatch mechanism:
+
+1. **Unary Transformations**: Individual expressions (Add, Mul, Pow, etc.) are
+   processed through type-specific handlers that recursively apply qapply to
+   sub-expressions while preserving mathematical structure.
+
+2. **Multiplication Processing**: For Mul expressions containing operators and
+   states, a specialized SlidingTransform processes the multiplication from
+   right-to-left, applying binary transformation rules to adjacent pairs of
+   factors.
+
+3. **Operator-State Application**: When an operator is adjacent to a compatible
+   state (ket, bra, wavefunction), the system attempts to apply the operator
+   by calling the operator's `_apply_operator` method or the state's
+   `_apply_from_right_to` method.
+
+4. **Expression Distribution**: The system handles distribution of operators
+   over sums and integrals, automatically propagating applications through
+   linear combinations of states.
+
+The qapply function preserves quantum mechanical properties like linearity
+and handles complex expressions involving tensor products, density matrices,
+commutators, and other quantum constructs while maintaining symbolic exactness.
+
+This system is also extensible so developers can add handlers for new operators
+and states through the multiple dispatch system.
 
 TODO:
 
@@ -19,6 +51,7 @@ from sympy.core.sympify import sympify, _sympify
 from sympy.functions.elementary.complexes import Abs
 from sympy.integrals import Integral
 from sympy.multipledispatch import Dispatcher
+from sympy.multipledispatch.dispatcher import ambiguity_register_error_ignore_dup
 
 from sympy.utilities.misc import debug
 
@@ -58,6 +91,7 @@ def _sum_doit_func(e):
 
 
 def _handle_doit_unary(f):
+    """Decorator that applies doit() to inner products and sums after transformation."""
 
     def apply_doit(expr, **options):
         sum_doit = options.get('sum_doit', False)
@@ -71,6 +105,7 @@ def _handle_doit_unary(f):
 
 
 def _flatten_mul(f):
+    """Decorator that flattens Mul expressions in transformation results."""
     
     def g(*args, **options):
         seq = f(*args, **options)
@@ -108,21 +143,25 @@ _qapply_unary = Dispatcher('_qapply_unary')
 
 @_qapply_unary.register(Expr)
 def _qapply_unary_expr(expr, **options):
+    """Default handler for Expr - no transformation."""
     return None
 
 
 @_qapply_unary.register((int, float, complex))
 def _qapply_unary_number(expr, **options):
+    """Convert numbers to SymPy expressions."""
     return sympify(expr)
 
 
 @_qapply_unary.register(Abs)
 def _qapply_unary_abs(expr, **options):
+    """Apply qapply to the argument of Abs."""
     return Abs(qapply(expr.args[0], **options))
 
 
 @_qapply_unary.register(Add)
 def _qapply_unary_state(expr, **options):
+    """Apply qapply to each term in a sum."""
     result = 0
     for arg in expr.args:
         result += qapply(arg, **options)
@@ -131,6 +170,7 @@ def _qapply_unary_state(expr, **options):
 
 @_qapply_unary.register(Pow)
 def _qapply_unary_pow(expr, **options):
+    """Apply qapply to the base of a power expression."""
     # For a Pow, call qapply on its base.
     base, exp = expr.as_base_exp()
     return qapply(base, **options)**exp
@@ -165,11 +205,13 @@ def _qapply_unary_integral(expr, **options):
 
 @_qapply_unary.register(Dagger)
 def _qapply_unary_dagger(expr, **options):
+    """Apply qapply to the argument of Dagger."""
     return Dagger(qapply(expr, **options))
 
 
 @_qapply_unary.register(Density)
 def _qapply_unary_density(expr, **options):
+    """Apply qapply to states in a Density matrix."""
     # For a Density operator call qapply on its state
     new_args = [(qapply(state, **options), prob) for (state,
                      prob) in expr.args]
@@ -178,6 +220,7 @@ def _qapply_unary_density(expr, **options):
 
 @_qapply_unary.register(TensorProduct)
 def _qapply_unary_tp(expr, **options):
+    """Apply qapply to each factor in a TensorProduct."""
     new_args = [qapply(t, **options) for t in expr.args]
     return TensorProduct(*new_args)
 
@@ -187,6 +230,7 @@ def _qapply_unary_tp(expr, **options):
 #-----------------------------------------------------------------------------
 
 def qapply(e, **options):
+    """Apply quantum operators to states and expressions."""
     ip_doit = options.get('ip_doit', True)
 
     e = _sympify(e)
@@ -214,22 +258,27 @@ qapply_Mul = SlidingTransform(
     from_args=False
 )
 
-# Unary transformations for qapply_Mul
+#-----------------------------------------------------------------------------
+# qapply_Mul: Unary
+#-----------------------------------------------------------------------------
 
 
 @qapply_Mul.unary.register((int, float, complex))
 def _qapply_mul_unary_number(expr, **options):
+    """Convert numbers to SymPy expressions in Mul context."""
     return (sympify(expr),)
 
 
 @qapply_Mul.unary.register(Expr)
 def qapply_mul_unary_expr(expr, **options):
+    """Default handler for Expr in Mul context - no transformation."""
     return None
 
 
 @qapply_Mul.unary.register(Pow)
 @_flatten_mul
 def _qapply_mul_unary_pow(expr, **options):
+    """Expand integer powers or apply qapply to power expressions."""
     base, exp = expr.as_base_exp()
     if exp.is_Integer and exp > 0:
         return tuple(expr.base for i in range(int(expr.exp)))
@@ -239,41 +288,90 @@ def _qapply_mul_unary_pow(expr, **options):
 
 @qapply_Mul.unary.register(OuterProduct)
 def _qapply_mul_unary_op(expr, **options):
+    """Split OuterProduct into ket and bra factors."""
     return (expr.ket, expr.bra)
 
 
 @qapply_Mul.unary.register((Commutator, AntiCommutator))
 @_flatten_mul
 def _qapply_mul_unary_comm(expr, **options):
+    """Evaluate commutators and anticommutators."""
     return (expr.doit(),)
 
 
 @qapply_Mul.unary.register(TensorProduct)
 @_flatten_mul
 def _qapply_mul_unary_tp(expr, **options):
+    """Apply qapply to each factor in TensorProduct."""
     new_args = [qapply(t, **options) for t in expr.args]
     return (TensorProduct(*new_args),)
 
 
 @qapply_Mul.unary.register(Density)
 def _qapply_mul_unary_density(expr, **options):
+    """Apply qapply to states in Density matrix."""
     # For a Density operator call qapply on its state
     new_args = [(qapply(state, **options), prob) for (state,
                      prob) in expr.args]
     return (Density(*new_args),)
 
 
-# Binary transformations for qapply_Mul
+#-----------------------------------------------------------------------------
+# qapply_Mul: Binary
+#-----------------------------------------------------------------------------
 
 
-@qapply_Mul.binary.register(Expr, Expr)
-def _qapply_mul_binary_expr_expr(lhs, rhs, **options):
-    return None
+@qapply_Mul.binary.register(Sum, Sum)
+def _qapply_mul_binary_sum_sum(lhs, rhs, **options):
+    """Combine two sums into a single sum."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        if set(lhs.variables).intersection(set(rhs.variables)):
+            raise ValueError(
+                'Duplicated dummy indices in separate sums in qapply.'
+            )
+        limits = lhs.limits + rhs.limits
+        result = Sum(
+            qapply(lhs.function*rhs.function, **options),
+            *limits
+        )
+        return (result,)
+
+
+@qapply_Mul.binary.register(Integral, Integral)
+def _qapply_mul_binary_integral_integral(lhs, rhs, **options):
+    """Combine two integrals into a single integral."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        if set(lhs.variables).intersection(set(rhs.variables)):
+            raise ValueError(
+                'Duplicated dummy indices in separate sums in qapply.'
+            )
+        limits = lhs.limits + rhs.limits
+        result = Integral(
+            qapply(lhs.function*rhs.function, **options),
+            *limits
+        )
+        return (result,)
+
+
+@qapply_Mul.binary.register(Add, Add)
+def _qapply_mul_binary_add_add(lhs, rhs, **options):
+    """Distribute product of two sums using distributive property."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        terms = []
+        for lhs_term in lhs.args:
+            for rhs_term in rhs.args:
+                terms.append(qapply(lhs_term * rhs_term, **options))
+        result = Add(*terms)
+        return (result,)
 
 
 @qapply_Mul.binary.register(Operator, (KetBase, TensorProduct, Wavefunction))
 @_flatten_mul
 def _qapply_mul_binary_op_wavefunction(lhs, rhs, **options):
+    """Apply operator to ket, tensor product, or wavefunction."""
     _apply = getattr(lhs, '_apply_operator', None)
     if _apply is not None:
         try:
@@ -294,94 +392,97 @@ def _qapply_mul_binary_op_wavefunction(lhs, rhs, **options):
     return None if result is None else (result,)
 
 
-# @qapply_Mul.binary.register(Operator, KetBase)
-# @_flatten_mul
-# def _qapply_mul_binary_op_ket(lhs, rhs, **options):
-#     _apply = getattr(lhs, '_apply_operator', None)
-#     if _apply is not None:
-#         try:
-#             result = _apply(rhs, **options)
-#         except NotImplementedError:
-#             result = None
-#     else:
-#         result = None
-
-#     if result is None:
-#         _apply_right = getattr(rhs, '_apply_from_right_to', None)
-#         if _apply_right is not None:
-#             try:
-#                 result = _apply_right(lhs, **options)
-#             except NotImplementedError:
-#                 result = None
-
-#     return None if result is None else (result,)
-
-
 @qapply_Mul.binary.register(BraBase, Operator)
 def _qapply_mul_binary_bra_op(lhs, rhs, **options):
     """Register this to remind us that we only do this when dagger=True."""
     return None
 
 
-@qapply_Mul.binary.register(Add, Expr)
+@qapply_Mul.binary.register(Sum, Add)
+def _qapply_mul_binary_sum_add(lhs, rhs, **options):
+    """Apply sum to add combination."""
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        # Implementation needed
+        pass
+
+
+@qapply_Mul.binary.register(Add, Sum)
+def _qapply_mul_binary_add_sum(lhs, rhs, **options):
+    """Apply add to sum combination."""
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        # Implementation needed
+        pass
+
+
+@qapply_Mul.binary.register(Integral, Add)
+def _qapply_mul_binary_integral_add(lhs, rhs, **options):
+    """Apply sum to add combination."""
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        # Implementation needed
+        pass
+
+
+@qapply_Mul.binary.register(Add, Integral)
+def _qapply_mul_binary_add_integral(lhs, rhs, **options):
+    """Apply add to sum combination."""
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        # Implementation needed
+        pass
+
+
+@qapply_Mul.binary.register(Sum, Integral)
+def _qapply_mul_binary_sum_integral(lhs, rhs, **options):
+    """Apply sum to integral combination."""
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        # Implementation needed
+        pass
+
+
+@qapply_Mul.binary.register(Integral, Sum)
+def _qapply_mul_binary_integral_sum(lhs, rhs, **options):
+    """Apply integral to sum combination."""
+    if lhs.kind != NumberKind and rhs.kind != NumberKind:
+        # Implementation needed
+        pass
+
+
+@qapply_Mul.binary.register(Add, Expr, on_ambiguity=ambiguity_register_error_ignore_dup)
 def _qapply_mul_binary_add_expr(lhs, rhs, **options):
+    """Distribute expression over sum terms."""
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         result = Add(*(qapply(item*rhs, **options) for item in lhs.args))
         return (result,)
 
 
-@qapply_Mul.binary.register(Expr, Add)
+@qapply_Mul.binary.register(Expr, Add, on_ambiguity=ambiguity_register_error_ignore_dup)
 def _qapply_mul_binary_expr_add(lhs, rhs, **options):
+    """Distribute expression over sum terms."""
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         result = Add(*(qapply(lhs*item, **options) for item in rhs.args))
         return (result,)
 
 
-@qapply_Mul.binary.register((Sum, Integral), Expr)
+@qapply_Mul.binary.register((Sum, Integral), Expr, on_ambiguity=ambiguity_register_error_ignore_dup)
 def _qapply_mul_binary_sum_expr(lhs, rhs, **options):
+    """Apply expression to sum/integral function."""
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         result = lhs.func(qapply(lhs.function*rhs, **options), *lhs.limits)
         return (result,)
 
 
-@qapply_Mul.binary.register(Expr, (Sum, Integral))
+@qapply_Mul.binary.register(Expr, (Sum, Integral), on_ambiguity=ambiguity_register_error_ignore_dup)
 def _qapply_mul_binary_expr_sum(lhs, rhs, **options):
+    """Apply expression to sum/integral function."""
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         result = rhs.func(qapply(lhs*rhs.function, **options), *rhs.limits)
         return (result,)
 
 
-@qapply_Mul.binary.register(Sum, Sum)
-def _qapply_mul_binary_sum_sum(lhs, rhs, **options):
-    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
-    if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        if set(lhs.variables).intersection(set(rhs.variables)):
-            raise ValueError(
-                'Duplicated dummy indices in separate sums in qapply.'
-            )
-        limits = lhs.limits + rhs.limits
-        result = Sum(
-            qapply(lhs.function*rhs.function, **options),
-            *limits
-        )
-        return (result,)
-
-
-@qapply_Mul.binary.register(Integral, Integral)
-def _qapply_mul_binary_integral_integral(lhs, rhs, **options):
-    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
-    if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        if set(lhs.variables).intersection(set(rhs.variables)):
-            raise ValueError(
-                'Duplicated dummy indices in separate sums in qapply.'
-            )
-        limits = lhs.limits + rhs.limits
-        result = Integral(
-            qapply(lhs.function*rhs.function, **options),
-            *limits
-        )
-        return (result,)
+@qapply_Mul.binary.register(Expr, Expr, on_ambiguity=ambiguity_register_error_ignore_dup)
+def _qapply_mul_binary_expr_expr(lhs, rhs, **options):
+    """Default binary handler for Expr pairs - no transformation."""
+    return None

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -100,7 +100,7 @@ def _handle_doit_unary(f):
 
 def _flatten_mul(f):
     """Decorator that flattens Mul expressions in transformation results."""
-    
+
     def g(*args, **options):
         seq = f(*args, **options)
         if seq is None:

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -275,7 +275,7 @@ def _qapply_mul_binary_expr_expr(lhs, rhs, **options):
     return None
 
 
-@qapply_Mul.binary.register(Operator, Wavefunction)
+@qapply_Mul.binary.register(Operator, (KetBase, TensorProduct, Wavefunction))
 @_flatten_mul
 def _qapply_mul_binary_op_wavefunction(lhs, rhs, **options):
     _apply = getattr(lhs, '_apply_operator', None)
@@ -298,27 +298,27 @@ def _qapply_mul_binary_op_wavefunction(lhs, rhs, **options):
     return None if result is None else (result,)
 
 
-@qapply_Mul.binary.register(Operator, KetBase)
-@_flatten_mul
-def _qapply_mul_binary_op_ket(lhs, rhs, **options):
-    _apply = getattr(lhs, '_apply_operator', None)
-    if _apply is not None:
-        try:
-            result = _apply(rhs, **options)
-        except NotImplementedError:
-            result = None
-    else:
-        result = None
+# @qapply_Mul.binary.register(Operator, KetBase)
+# @_flatten_mul
+# def _qapply_mul_binary_op_ket(lhs, rhs, **options):
+#     _apply = getattr(lhs, '_apply_operator', None)
+#     if _apply is not None:
+#         try:
+#             result = _apply(rhs, **options)
+#         except NotImplementedError:
+#             result = None
+#     else:
+#         result = None
 
-    if result is None:
-        _apply_right = getattr(rhs, '_apply_from_right_to', None)
-        if _apply_right is not None:
-            try:
-                result = _apply_right(lhs, **options)
-            except NotImplementedError:
-                result = None
+#     if result is None:
+#         _apply_right = getattr(rhs, '_apply_from_right_to', None)
+#         if _apply_right is not None:
+#             try:
+#                 result = _apply_right(lhs, **options)
+#             except NotImplementedError:
+#                 result = None
 
-    return None if result is None else (result,)
+#     return None if result is None else (result,)
 
 
 @qapply_Mul.binary.register(BraBase, Operator)

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -35,19 +35,16 @@ and states through the multiple dispatch system.
 
 from sympy.concrete import Sum
 from sympy.core.add import Add
-from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.kind import NumberKind
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
-from sympy.core.singleton import S
 from sympy.core.sympify import sympify, _sympify
 from sympy.functions.elementary.complexes import Abs
 from sympy.integrals import Integral
 from sympy.multipledispatch import Dispatcher
 from sympy.multipledispatch.dispatcher import ambiguity_register_error_ignore_dup
 
-from sympy.utilities.misc import debug
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
@@ -55,9 +52,9 @@ from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.operator import (
-    OuterProduct, Operator, IdentityOperator
+    OuterProduct, Operator
 )
-from sympy.physics.quantum.state import State, KetBase, BraBase, Wavefunction
+from sympy.physics.quantum.state import KetBase, BraBase, Wavefunction
 from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.slidingtransform import SlidingTransform
 

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -37,7 +37,8 @@ from sympy.physics.quantum.slidingtransform import SlidingTransform
 
 
 __all__ = [
-    'qapply'
+    'qapply',
+    'QApplyOptions'
 ]
 
 

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -2,13 +2,9 @@
 
 TODO:
 
-- Finish slidingtransform
 - Finish slidingtransform tests
 - Add extra type handlers to get rid of warnings in qapply
-- Optimize performance
-- Finish tests for qapply
-- Fix all other tests
-
+- Optimize _apply_operator methods
 """
 
 from sympy.concrete import Sum

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -31,12 +31,6 @@ commutators, and other quantum constructs while maintaining symbolic exactness.
 
 This system is also extensible so developers can add handlers for new operators
 and states through the multiple dispatch system.
-
-TODO:
-
-- Finish slidingtransform tests
-- Add extra type handlers to get rid of warnings in qapply
-- Optimize _apply_operator methods
 """
 
 from sympy.concrete import Sum
@@ -121,18 +115,6 @@ def _flatten_mul(f):
 
     return g
 
-
-#-----------------------------------------------------------------------------
-# Main code
-#-----------------------------------------------------------------------------
-
-# Level 0: int, float, complex
-# Level 1: Expr
-# Level 2: Mul, Add, Pow, Abs
-# Level 3: Sum, Integral
-# Level 3: Bra, Ket, Operator, Dagger
-# Level 4: InnerProduct, OuterProduct
-# Level 5: TensorProduct, Density
 
 #-----------------------------------------------------------------------------
 # _qapply_unary
@@ -401,49 +383,65 @@ def _qapply_mul_binary_bra_op(lhs, rhs, **options):
 @qapply_Mul.binary.register(Sum, Add)
 def _qapply_mul_binary_sum_add(lhs, rhs, **options):
     """Apply sum to add combination."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        # Implementation needed
-        pass
+        terms = (qapply(lhs.function*term, **options) for term in rhs.args)
+        return Sum(Add(*terms), *lhs.limits)
 
 
 @qapply_Mul.binary.register(Add, Sum)
 def _qapply_mul_binary_add_sum(lhs, rhs, **options):
     """Apply add to sum combination."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        # Implementation needed
-        pass
+        terms = (qapply(term*rhs.function, **options) for term in lhs.args)
+        return Sum(Add(*terms), *rhs.limits)
 
 
 @qapply_Mul.binary.register(Integral, Add)
 def _qapply_mul_binary_integral_add(lhs, rhs, **options):
     """Apply sum to add combination."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        # Implementation needed
-        pass
+        terms = (qapply(lhs.function*term, **options) for term in rhs.args)
+        return Integral(Add(*terms), *lhs.limits)
 
 
 @qapply_Mul.binary.register(Add, Integral)
 def _qapply_mul_binary_add_integral(lhs, rhs, **options):
     """Apply add to sum combination."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        # Implementation needed
-        pass
+        terms = (qapply(term*rhs.function, **options) for term in lhs.args)
+        return Integral(Add(*terms), *rhs.limits)
 
 
 @qapply_Mul.binary.register(Sum, Integral)
 def _qapply_mul_binary_sum_integral(lhs, rhs, **options):
     """Apply sum to integral combination."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        # Implementation needed
-        pass
+        return Sum(
+            Integral(
+                qapply(lhs.function*rhs.function, **options),
+                *rhs.limits
+            ),
+            *lhs.limits
+        )
 
 
 @qapply_Mul.binary.register(Integral, Sum)
 def _qapply_mul_binary_integral_sum(lhs, rhs, **options):
     """Apply integral to sum combination."""
+    # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        # Implementation needed
-        pass
+        return Integral(
+            Sum(
+                qapply(lhs.function*rhs.function, **options),
+                *rhs.limits
+            ),
+            *lhs.limits
+        )
 
 
 @qapply_Mul.binary.register(Add, Expr, on_ambiguity=ambiguity_register_error_ignore_dup)

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -335,7 +335,7 @@ def qapply(e: Basic | int | float | complex, **options: QApplyOptions) -> Expr:
 #-----------------------------------------------------------------------------
 
 
-qapply_Mul = SlidingTransform(
+qapply_Mul = SlidingTransform[QApplyOptions](
     unary=Dispatcher('_qapply_mul_unary'),
     binary=Dispatcher('_qapply_mul_binary'),
     reverse=True,

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -384,7 +384,8 @@ def _qapply_mul_binary_sum_add(lhs, rhs, **options):
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         terms = (qapply(lhs.function*term, **options) for term in rhs.args)
-        return Sum(Add(*terms), *lhs.limits)
+        result = Sum(Add(*terms), *lhs.limits)
+        return (result,)
 
 
 @qapply_Mul.binary.register(Add, Sum)
@@ -393,7 +394,8 @@ def _qapply_mul_binary_add_sum(lhs, rhs, **options):
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         terms = (qapply(term*rhs.function, **options) for term in lhs.args)
-        return Sum(Add(*terms), *rhs.limits)
+        result = Sum(Add(*terms), *rhs.limits)
+        return (result,)
 
 
 @qapply_Mul.binary.register(Integral, Add)
@@ -402,7 +404,8 @@ def _qapply_mul_binary_integral_add(lhs, rhs, **options):
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         terms = (qapply(lhs.function*term, **options) for term in rhs.args)
-        return Integral(Add(*terms), *lhs.limits)
+        result = Integral(Add(*terms), *lhs.limits)
+        return (result,)
 
 
 @qapply_Mul.binary.register(Add, Integral)
@@ -411,7 +414,8 @@ def _qapply_mul_binary_add_integral(lhs, rhs, **options):
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
         terms = (qapply(term*rhs.function, **options) for term in lhs.args)
-        return Integral(Add(*terms), *rhs.limits)
+        result = Integral(Add(*terms), *rhs.limits)
+        return (result,)
 
 
 @qapply_Mul.binary.register(Sum, Integral)
@@ -419,13 +423,14 @@ def _qapply_mul_binary_sum_integral(lhs, rhs, **options):
     """Apply sum to integral combination."""
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        return Sum(
+        result = Sum(
             Integral(
                 qapply(lhs.function*rhs.function, **options),
                 *rhs.limits
             ),
             *lhs.limits
         )
+        return (result,)
 
 
 @qapply_Mul.binary.register(Integral, Sum)
@@ -433,13 +438,14 @@ def _qapply_mul_binary_integral_sum(lhs, rhs, **options):
     """Apply integral to sum combination."""
     # Require that both are OperatorKind, BraKind, KetKind, or UndefinedKind
     if lhs.kind != NumberKind and rhs.kind != NumberKind:
-        return Integral(
+        result = Integral(
             Sum(
                 qapply(lhs.function*rhs.function, **options),
                 *rhs.limits
             ),
             *lhs.limits
         )
+        return (result,)
 
 
 @qapply_Mul.binary.register(Add, Expr, on_ambiguity=ambiguity_register_error_ignore_dup)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -21,7 +21,6 @@ from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.matrixutils import flatten_scalar
 from sympy.physics.quantum.state import KetBase, BraBase, StateBase
 from sympy.physics.quantum.operator import Operator, OuterProduct
-from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.operatorset import operators_to_state, state_to_operators
 
 
@@ -325,7 +324,7 @@ def rep_expectation(expr, **options):
     <px_2|*X*|px_1>
 
     """
-
+    from sympy.physics.quantum.qapply import qapply
     if "index" not in options:
         options["index"] = 1
 

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -455,7 +455,7 @@ class Hamiltonian(SHOOp):
         >>> H = Hamiltonian('H')
         >>> k = SHOKet('k')
         >>> qapply(H*k)
-        hbar*k*omega*|k> + hbar*omega*|k>/2
+        hbar*omega*(k + 1/2)*|k>
 
     Matrix Representation
 

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -1,0 +1,110 @@
+"""A sliding window tranform to process Mul-like expressions."""
+
+from sympy.core.expr import Expr
+from sympy.core.mul import Mul
+from sympy.multipledispatch.dispatcher import Dispatcher
+
+
+class SlidingTransform(object):
+ 
+    def __init__(self, unary=None, binary=None, reverse=False):
+        self._unary = unary
+        self._binary = binary
+        self._reverse = reverse
+
+    @property
+    def reverse(self):
+        return self._reverse
+
+    def __call__(self, expr):
+        if not isinstance(expr, Mul):
+            raise TypeError('The SlidingTransform only works on Mul instances.')
+
+        input = list(expr.args)
+        output = []
+
+        if self._unary is not None:
+            while len(input) > 0:
+                next = input.pop(0)
+                transformed = self._unary(next)
+                if transformed is None:
+                    output.append(next)
+                else:
+                    output.extend(transformed)
+            input = output
+            output = []
+
+
+        if self._binary is not None:
+            if not self.reverse:
+                # Continue as long as we have at least 2 elements
+                while len(input) > 1:
+                    # Get first two elements
+                    lhs = input.pop(0)
+                    rhs = input[0]  # Look at second element without popping yet
+
+                    transformed = self._binary(lhs, rhs)
+
+                    if transformed is None:
+                        # If transform returns None, append first element
+                        output.append(lhs)
+                    else:
+                        # This item was transformed, pop and discard
+                        input.pop(0)
+                        # The last item goes back to be transformed again
+                        input.insert(0, transformed[-1])
+                        # All other items go directly into the result
+                        output.extend(transformed[:-1])
+
+                # Append any remaining element
+                if input:
+                    output.append(input[0])
+
+            else:
+                while len(input) > 1:
+                    # Get first two elements
+                    rhs = input.pop(-1)
+                    lhs = input[-1]
+
+                    transformed = self._binary(lhs, rhs)
+
+                    if transformed is None:
+                        output.insert(0, rhs)
+                    else:
+                        input.pop(-1)
+                        input.append(transformed[0])
+                        output[0:0] = transformed[1:]
+
+                if input:
+                    output.insert(0, input[-1])
+
+            input = output
+            output = []
+
+        return Mul._from_args(input, is_commutative=False)
+
+
+class DipatchingSlidingTransform(SlidingTransform):
+
+    def __init__(self, unary=False, binary=True):
+        if unary:
+            unary = Dispatcher('_sliding_transform_unary')
+            unary.register((Expr), lambda x: None)
+        else:
+            unary = None
+
+        if binary:
+            binary = Dispatcher('_sliding_transform_binary')
+            binary.register((Expr, Expr), lambda x, y: None)
+        else:
+            binary = None
+
+        super().__init__(unary, binary)
+
+    @property
+    def unary(self):
+        return self._unary
+
+    @property
+    def binary(self):
+        return self._binary

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -1,8 +1,27 @@
 """A sliding window tranform to process Mul-like expressions."""
 
+from itertools import tee
+
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.multipledispatch.dispatcher import Dispatcher
+
+from sympy.utilities.misc import debug
+
+__all__ = [
+    'SlidingTransform',
+    'DipatchingSlidingTransform'
+]
+
+
+def _split_on_condition(seq, condition):
+    l1, l2 = tee((condition(item), item) for item in seq)
+    return tuple(i for p, i in l1 if p), tuple(i for p, i in l2 if not p)
+
+
+def _split_cnc(seq):
+    c, nc = _split_on_condition(seq, lambda x: x.is_commutative)
+    return c, nc
 
 
 class SlidingTransform(object):
@@ -16,25 +35,37 @@ class SlidingTransform(object):
     def reverse(self):
         return self._reverse
 
-    def __call__(self, expr):
+    @property
+    def unary(self):
+        return self._unary
+
+    @property
+    def binary(self):
+        return self._binary
+
+    def __call__(self, expr, **options):
         if not isinstance(expr, Mul):
             raise TypeError('The SlidingTransform only works on Mul instances.')
 
         input = list(expr.args)
         output = []
-
+        # if self.reverse:
+        #     debug('ST1: ', input, output)
         if self._unary is not None:
             while len(input) > 0:
                 next = input.pop(0)
-                transformed = self._unary(next)
+                transformed = self._unary(next, **options)
                 if transformed is None:
                     output.append(next)
                 else:
                     output.extend(transformed)
             input = output
             output = []
+            # debug('qapply_Mul unary: ', input)
 
-
+        # if self.reverse:
+        #     debug('ST2: ', input, output)
+        c_parts = []
         if self._binary is not None:
             if not self.reverse:
                 # Continue as long as we have at least 2 elements
@@ -43,68 +74,63 @@ class SlidingTransform(object):
                     lhs = input.pop(0)
                     rhs = input[0]  # Look at second element without popping yet
 
-                    transformed = self._binary(lhs, rhs)
+                    transformed = self._binary(lhs, rhs, **options)
 
                     if transformed is None:
                         # If transform returns None, append first element
                         output.append(lhs)
                     else:
+                        c_t, nc_t = _split_cnc(transformed)
+                        c_parts.extend(c_t)
                         # This item was transformed, pop and discard
                         input.pop(0)
-                        # The last item goes back to be transformed again
-                        input.insert(0, transformed[-1])
-                        # All other items go directly into the result
-                        output.extend(transformed[:-1])
+                        if nc_t:
+                            # The last item goes back to be transformed again
+                            input.insert(0, nc_t[-1])
+                            # All other items go directly into the result
+                            output.extend(nc_t[:-1])
 
                 # Append any remaining element
                 if input:
                     output.append(input[0])
 
-            else:
+            else: # reverse = True case
                 while len(input) > 1:
                     # Get first two elements
                     rhs = input.pop(-1)
                     lhs = input[-1]
+
+                    # Make sure that lhs and rhs are commutative
+                    if rhs.is_commutative:
+                        c_parts.append(rhs)
+                        continue
+                    if lhs.is_commutative:
+                        c_parts.append(lhs)
+                        input.pop(-1)
+                        input.append(rhs)
+                        continue
 
                     transformed = self._binary(lhs, rhs)
 
                     if transformed is None:
                         output.insert(0, rhs)
                     else:
+                        c_t, nc_t = _split_cnc(transformed)
+                        c_parts.extend(c_t)
                         input.pop(-1)
-                        input.append(transformed[0])
-                        output[0:0] = transformed[1:]
+                        if nc_t:
+                            input.append(nc_t[0])
+                            output[0:0] = nc_t[1:]
 
                 if input:
                     output.insert(0, input[-1])
+            # if self.reverse:
+            #     debug('ST3: ', c_parts, input, output)
 
             input = output
             output = []
 
-        return Mul._from_args(input, is_commutative=False)
-
-
-class DipatchingSlidingTransform(SlidingTransform):
-
-    def __init__(self, unary=False, binary=True):
-        if unary:
-            unary = Dispatcher('_sliding_transform_unary')
-            unary.register((Expr), lambda x: None)
+        if self.reverse:
+            return Mul(*c_parts)*Mul(*input)
         else:
-            unary = None
-
-        if binary:
-            binary = Dispatcher('_sliding_transform_binary')
-            binary.register((Expr, Expr), lambda x, y: None)
-        else:
-            binary = None
-
-        super().__init__(unary, binary)
-
-    @property
-    def unary(self):
-        return self._unary
-
-    @property
-    def binary(self):
-        return self._binary
+            return Mul(*c_parts)*Mul._from_args(input, is_commutative=False)

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -23,7 +23,7 @@ def _split_cnc(seq):
 
 
 class SlidingTransform(object):
- 
+
     def __init__(self, unary=None, binary=None, reverse=False, from_args=True):
         self._unary = unary
         self._binary = binary

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -258,7 +258,7 @@ class SlidingTransform(object):
             if isinstance(m, Mul):
                 c_result_args = m.args
             else:
-                c_result_args = () if m == S.One else (m,) 
+                c_result_args = () if m == S.One else (m,)
         else:
             c_result_args = () if (c_parts and c_parts[0] == S.One) else c_parts
 

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -26,8 +26,7 @@ the final multiplication expression while preserving mathematical properties.
 """
 
 from __future__ import annotations
-from typing import Any, Callable, Generic, Iterable,  TypeVar, TYPE_CHECKING
-from typing_extensions import Protocol
+from typing import Any, Callable, Generic, Iterable, TypeVar, Protocol
 
 from itertools import tee
 
@@ -37,8 +36,6 @@ from sympy.core.singleton import S
 
 from sympy.utilities.misc import debug
 
-if TYPE_CHECKING:
-    from sympy.multipledispatch import Dispatcher
 
 __all__ = [
     'SlidingTransform',

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -63,7 +63,6 @@ class UnaryTransform(Protocol[T]):
 class BinaryTransform(Protocol[T]):
     def __call__(self, __lhs: Any, __rhs: Any, **kwargs: T) -> tuple[Any, ...] | None: ...
 
-# TODO: stricter typing for the callables
 class SlidingTransform(Generic[T]):
     _unary:  UnaryTransform[T] | None
     _binary:  BinaryTransform[T] | None

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -85,28 +85,6 @@ class SlidingTransform(object):
 
         Examples
         ========
-
-        Create a transform that applies a unary function to each factor:
-
-        >>> def expand_factor(factor):
-        ...     # Custom expansion logic
-        ...     return None  # or tuple of expanded factors
-        >>> transform = SlidingTransform(unary=expand_factor)
-
-        Create a transform that simplifies adjacent pairs:
-
-        >>> def simplify_pair(lhs, rhs):
-        ...     # Custom simplification logic
-        ...     return None  # or tuple of simplified factors
-        >>> transform = SlidingTransform(binary=simplify_pair)
-
-        Create a transform with both unary and binary phases:
-
-        >>> transform = SlidingTransform(
-        ...     unary=expand_factor,
-        ...     binary=simplify_pair,
-        ...     reverse=True
-        ... )
         """
         self._unary = unary
         self._binary = binary

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -2,15 +2,13 @@
 
 from itertools import tee
 
-from sympy.core.expr import Expr
 from sympy.core.mul import Mul
-from sympy.multipledispatch.dispatcher import Dispatcher
+from sympy.core.singleton import S
 
 from sympy.utilities.misc import debug
 
 __all__ = [
     'SlidingTransform',
-    'DipatchingSlidingTransform'
 ]
 
 
@@ -26,10 +24,11 @@ def _split_cnc(seq):
 
 class SlidingTransform(object):
  
-    def __init__(self, unary=None, binary=None, reverse=False):
+    def __init__(self, unary=None, binary=None, reverse=False, from_args=True):
         self._unary = unary
         self._binary = binary
         self._reverse = reverse
+        self._from_args = from_args
 
     @property
     def reverse(self):
@@ -43,29 +42,36 @@ class SlidingTransform(object):
     def binary(self):
         return self._binary
 
+    @property
+    def from_args(self):
+        return self._from_args
+
     def __call__(self, expr, **options):
+        debug(f"SlidingTransform(): {expr} {self.reverse} {self.from_args}")
         if not isinstance(expr, Mul):
             raise TypeError('The SlidingTransform only works on Mul instances.')
 
         input = list(expr.args)
         output = []
-        # if self.reverse:
-        #     debug('ST1: ', input, output)
+        c_parts = []
         if self._unary is not None:
             while len(input) > 0:
                 next = input.pop(0)
+                if next.is_commutative:
+                    c_parts.append(next)
+                    continue
                 transformed = self._unary(next, **options)
-                if transformed is None:
+                if transformed == (S.Zero,):
+                    return S.Zero
+                elif transformed is None:
                     output.append(next)
                 else:
-                    output.extend(transformed)
+                    c, nc = _split_cnc(transformed)
+                    output.extend(nc)
+                    c_parts.extend(c)
             input = output
             output = []
-            # debug('qapply_Mul unary: ', input)
 
-        # if self.reverse:
-        #     debug('ST2: ', input, output)
-        c_parts = []
         if self._binary is not None:
             if not self.reverse:
                 # Continue as long as we have at least 2 elements
@@ -73,6 +79,15 @@ class SlidingTransform(object):
                     # Get first two elements
                     lhs = input.pop(0)
                     rhs = input[0]  # Look at second element without popping yet
+                    # Make sure that lhs and rhs are noncommutative
+                    if lhs.is_commutative:
+                        c_parts.append(lhs)
+                        continue
+                    if rhs.is_commutative:
+                        c_parts.append(rhs)
+                        input.pop(0)
+                        input.append(lhs)
+                        continue
 
                     transformed = self._binary(lhs, rhs, **options)
 
@@ -81,8 +96,11 @@ class SlidingTransform(object):
                         output.append(lhs)
                     else:
                         c_t, nc_t = _split_cnc(transformed)
+                        if S.Zero in c_parts:
+                            # Return immediately if we get a zero
+                            return S.Zero
                         c_parts.extend(c_t)
-                        # This item was transformed, pop and discard
+                        # This rhs was transformed, pop and discard
                         input.pop(0)
                         if nc_t:
                             # The last item goes back to be transformed again
@@ -92,15 +110,18 @@ class SlidingTransform(object):
 
                 # Append any remaining element
                 if input:
-                    output.append(input[0])
+                    last = input[0]
+                    if last.is_commutative:
+                        c_parts.append(last)
+                    else:
+                        output.append(input[0])
 
             else: # reverse = True case
                 while len(input) > 1:
                     # Get first two elements
                     rhs = input.pop(-1)
                     lhs = input[-1]
-
-                    # Make sure that lhs and rhs are commutative
+                    # Make sure that lhs and rhs are noncommutative
                     if rhs.is_commutative:
                         c_parts.append(rhs)
                         continue
@@ -110,27 +131,66 @@ class SlidingTransform(object):
                         input.append(rhs)
                         continue
 
-                    transformed = self._binary(lhs, rhs)
+                    transformed = self._binary(lhs, rhs, **options)
 
                     if transformed is None:
                         output.insert(0, rhs)
                     else:
                         c_t, nc_t = _split_cnc(transformed)
+                        if S.Zero in c_parts:
+                            # Return immediately if we get a zero
+                            return S.Zero
                         c_parts.extend(c_t)
+                        # The lhs item was transformed, pop and discard
                         input.pop(-1)
                         if nc_t:
+                            # The first item goes back to be transformed again
                             input.append(nc_t[0])
+                            # All other items go directly into the result
                             output[0:0] = nc_t[1:]
 
                 if input:
-                    output.insert(0, input[-1])
-            # if self.reverse:
-            #     debug('ST3: ', c_parts, input, output)
+                    last = input[-1]
+                    if last.is_commutative:
+                        c_parts.append(last)
+                    else:
+                        output.insert(0, input[-1])
 
             input = output
             output = []
 
-        if self.reverse:
-            return Mul(*c_parts)*Mul(*input)
+        nc_parts = tuple(input)
+        c_parts = tuple(c_parts)
+                        
+        # In the logic below, we go out of our ways to avoid triggering the post-processor logic
+        # unless it is absolutely needed by using Mul._from_args and always validating when we
+        # have an actual Mul
+
+        # Handle the commutative part
+        if len(c_parts) > 1:
+            m = Mul(*c_parts)
+            if isinstance(m, Mul):
+                c_result_args = m.args
+            else:
+                c_result_args = (m,)
         else:
-            return Mul(*c_parts)*Mul._from_args(input, is_commutative=False)
+            c_result_args = c_parts
+
+        # Handle the non-commutative part
+        if len(nc_parts) > 1:
+            if self.from_args:
+                nc_result_args = nc_parts
+            else:
+                # This runs post-processors and may mutate the Mul into something else
+                m = Mul(*nc_parts)
+                if isinstance(m, Mul):
+                    nc_result_args = m.args
+                else:
+                    nc_result_args = (m,)
+        else:
+            nc_result_args = nc_parts
+           
+        # Combine the commutative and non-commutative parts
+        is_commutative = False if nc_result_args else True
+        result = Mul._from_args(c_result_args + nc_result_args, is_commutative=is_commutative)
+        return result

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -204,7 +204,7 @@ class SlidingTransform(object):
                         output.append(lhs)
                     else:
                         c_t, nc_t = _split_cnc(transformed)
-                        if S.Zero in c_parts:
+                        if S.Zero in c_t:
                             # Return immediately if we get a zero
                             return S.Zero
                         c_parts.extend(c_t)
@@ -245,7 +245,7 @@ class SlidingTransform(object):
                         output.insert(0, rhs)
                     else:
                         c_t, nc_t = _split_cnc(transformed)
-                        if S.Zero in c_parts:
+                        if S.Zero in c_t:
                             # Return immediately if we get a zero
                             return S.Zero
                         c_parts.extend(c_t)
@@ -270,7 +270,7 @@ class SlidingTransform(object):
         nc_parts = tuple(input)
         c_parts = tuple(c_parts)
                         
-        # In the logic below, we go out of our ways to avoid triggering the post-processor logic
+        # In the logic below, we go out of our way to avoid triggering the post-processor logic
         # unless it is absolutely needed by using Mul._from_args and always validating when we
         # have an actual Mul
 
@@ -294,6 +294,7 @@ class SlidingTransform(object):
                 if isinstance(m, Mul):
                     nc_result_args = m.args
                 else:
+                    # The Mul mutated into something else, just include it
                     nc_result_args = (m,)
         else:
             nc_result_args = nc_parts

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -258,9 +258,9 @@ class SlidingTransform(object):
             if isinstance(m, Mul):
                 c_result_args = m.args
             else:
-                c_result_args = (m,)
+                c_result_args = () if m == S.One else (m,) 
         else:
-            c_result_args = c_parts
+            c_result_args = () if (c_parts and c_parts[0] == S.One) else c_parts
 
         # Handle the non-commutative part
         if len(nc_parts) > 1:

--- a/sympy/physics/quantum/slidingtransform.py
+++ b/sympy/physics/quantum/slidingtransform.py
@@ -97,7 +97,7 @@ class SlidingTransform(object):
 
         >>> def simplify_pair(lhs, rhs):
         ...     # Custom simplification logic
-        ...     return None  # or tuple of simplified factors  
+        ...     return None  # or tuple of simplified factors
         >>> transform = SlidingTransform(binary=simplify_pair)
 
         Create a transform with both unary and binary phases:
@@ -269,7 +269,7 @@ class SlidingTransform(object):
 
         nc_parts = tuple(input)
         c_parts = tuple(c_parts)
-                        
+
         # In the logic below, we go out of our way to avoid triggering the post-processor logic
         # unless it is absolutely needed by using Mul._from_args and always validating when we
         # have an actual Mul
@@ -298,7 +298,7 @@ class SlidingTransform(object):
                     nc_result_args = (m,)
         else:
             nc_result_args = nc_parts
-           
+
         # Combine the commutative and non-commutative parts
         is_commutative = False if nc_result_args else True
         result = Mul._from_args(c_result_args + nc_result_args, is_commutative=is_commutative)

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -7,7 +7,6 @@ from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
         OracleGate, grover_iteration, WGate)
 
 import pytest
-pytest.skip("Skipping grover tests", allow_module_level=True)
 
 def return_one_on_two(qubits):
     return qubits == IntQubit(2, qubits.nqubits)
@@ -51,10 +50,10 @@ def test_OracleGate():
 def test_WGate():
     nqubits = 2
     basis_states = superposition_basis(nqubits)
-    assert qapply(WGate(nqubits)*basis_states) == basis_states
+    assert qapply(WGate(nqubits)*basis_states).expand() == basis_states
 
     expected = ((2/sqrt(pow(2, nqubits)))*basis_states) - IntQubit(1, nqubits=nqubits)
-    assert qapply(WGate(nqubits)*IntQubit(1, nqubits=nqubits)) == expected
+    assert qapply(WGate(nqubits)*IntQubit(1, nqubits=nqubits)).expand() == expected
 
 
 def test_grover_iteration_1():
@@ -62,7 +61,7 @@ def test_grover_iteration_1():
     basis_states = superposition_basis(numqubits)
     v = OracleGate(numqubits, return_one_on_one)
     expected = IntQubit(1, nqubits=numqubits)
-    assert qapply(grover_iteration(basis_states, v)) == expected
+    assert qapply(grover_iteration(basis_states, v)).expand() == expected
 
 
 def test_grover_iteration_2():
@@ -72,23 +71,26 @@ def test_grover_iteration_2():
     # After (pi/4)sqrt(pow(2, n)), IntQubit(2) should have highest prob
     # In this case, after around pi times (3 or 4)
     iterated = grover_iteration(basis_states, v)
-    iterated = qapply(iterated)
+    iterated = qapply(iterated).expand()
     iterated = grover_iteration(iterated, v)
-    iterated = qapply(iterated)
+    iterated = qapply(iterated).expand()
     iterated = grover_iteration(iterated, v)
-    iterated = qapply(iterated)
+    iterated = qapply(iterated).expand()
     # In this case, probability was highest after 3 iterations
     # Probability of Qubit('0010') was 251/256 (3) vs 781/1024 (4)
     # Ask about measurement
     expected = (-13*basis_states)/64 + 264*IntQubit(2, numqubits)/256
-    assert qapply(expected) == iterated
+    assert qapply(expected).expand() == iterated
 
 
-def test_grover():
+def test_grover_two_qubits():
     nqubits = 2
-    assert apply_grover(return_one_on_one, nqubits) == IntQubit(1, nqubits=nqubits)
+    assert apply_grover(return_one_on_one, nqubits).expand() == IntQubit(1, nqubits=nqubits)
 
+
+@pytest.mark.slow
+def test_grover_four_qubits():
     nqubits = 4
     basis_states = superposition_basis(nqubits)
-    expected = (-13*basis_states)/64 + 264*IntQubit(2, nqubits)/256
-    assert apply_grover(return_one_on_two, 4) == qapply(expected)
+    expected = ((-13*basis_states)/64 + 264*IntQubit(2, nqubits)/256).expand()
+    assert apply_grover(return_one_on_two, 4).expand() == expected

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -6,6 +6,8 @@ from sympy.physics.quantum.qubit import IntQubit
 from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
         OracleGate, grover_iteration, WGate)
 
+import pytest
+pytest.skip("Skipping grover tests", allow_module_level=True)
 
 def return_one_on_two(qubits):
     return qubits == IntQubit(2, qubits.nqubits)

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -6,7 +6,6 @@ from sympy.physics.quantum.qubit import IntQubit
 from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
         OracleGate, grover_iteration, WGate)
 
-import pytest
 
 def return_one_on_two(qubits):
     return qubits == IntQubit(2, qubits.nqubits)
@@ -88,7 +87,6 @@ def test_grover_two_qubits():
     assert apply_grover(return_one_on_one, nqubits).expand() == IntQubit(1, nqubits=nqubits)
 
 
-@pytest.mark.slow
 def test_grover_four_qubits():
     nqubits = 4
     basis_states = superposition_basis(nqubits)

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -219,7 +219,7 @@ def test_differential_operator():
         DifferentialOperator(Derivative(d.expr, x), f(x, y))
     assert diff(d, y) == \
         DifferentialOperator(Derivative(d.expr, y), f(x, y))
-    assert qapply(d*w) == Wavefunction(2*x**3 + 6*x*y**2 + 6*x**2*y + 2*y**3,
+    assert qapply(d*w).expand() == Wavefunction(2*x**3 + 6*x*y**2 + 6*x**2*y + 2*y**3,
                                        x, y)
 
     # 2D polar Laplacian (th = theta)

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -1,32 +1,144 @@
+from sympy.concrete.summations import Sum
+from sympy.core import oo
 from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer, Rational)
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols
+from sympy.simplify import simplify
+from sympy.core.symbol import symbols, Symbol
+from sympy.core.sympify import sympify
+from sympy.integrals import Integral
+from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.special.delta_functions import DiracDelta
+from sympy.functions.special.tensor_functions import KroneckerDelta
+
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
+from sympy.physics.quantum.cartesian import X, XKet, XBra
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.gate import H, XGate, IdentityGate
-from sympy.physics.quantum.operator import Operator, IdentityOperator
+from sympy.physics.quantum.operator import (
+    Operator, IdentityOperator, OuterProduct
+)
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
 from sympy.physics.quantum.tensorproduct import TensorProduct
-from sympy.physics.quantum.state import Ket
+from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.qubit import Qubit, QubitBra
 from sympy.physics.quantum.boson import BosonOp, BosonFockKet, BosonFockBra
 from sympy.testing.pytest import warns_deprecated_sympy
 
 
+#-----------------------------------------------------------------------------
+# Variables and utilities
+#-----------------------------------------------------------------------------
+
+
 j, jp, m, mp = symbols("j j' m m'")
+p, q, r, st = symbols('p q r s', integer=True, nonnegative=True)
+x, y, z = symbols('x y z', real=True)
+omega = Symbol('omega', real=True)
+alpha = Symbol('alpha', complex=True)
 
 z = JzKet(1, 0)
 po = JzKet(1, 1)
 mo = JzKet(1, -1)
 
+a = BosonOp('a')
+
+class SimpleBra(Bra):
+    pass
+
+class SimpleKet(Ket):
+    def _eval_innerproduct_SimpleBra(self, bra, **hints):
+        return alpha*exp(I*omega)
+
+TP = TensorProduct
+
+sqa = lambda x: simplify(qapply(x))
+
 A = Operator('A')
+
+
+#-----------------------------------------------------------------------------
+# Tests for the main unary dispatcher for qapply
+#-----------------------------------------------------------------------------
+
+
+def test_unary_number():
+    assert qapply(0) == S.Zero
+    assert qapply(1.0) == sympify(1.0)
+
+
+def test_unary_abs():
+    assert qapply(Abs(alpha)) == Abs(alpha)
+
+
+def test_unary_add():
+    assert qapply(a*BosonFockKet(p) + Dagger(a)*BosonFockKet(q)) == \
+        sqrt(p)*BosonFockKet(p-1) + sqrt(q+1)*BosonFockKet(q+1)
+
+
+def test_unary_pow():
+    assert qapply((SimpleBra()*SimpleKet())**2) == alpha**2*exp(2*I*omega)
+    assert qapply(sqrt(SimpleBra()*SimpleKet())) == sqrt(alpha*exp(I*omega))
+
+
+def test_unary_sum():
+    assert qapply(Sum(a*BosonFockKet(p), (p,0,2))) == Sum(sqrt(p)*BosonFockKet(p-1), (p,0,2))
+    assert qapply(Sum(a*BosonFockKet(p), (p,0,2)), sum_doit=True) == \
+        sqrt(1)*BosonFockKet(0) + sqrt(2)*BosonFockKet(1)
+    assert qapply(Jz*po + Jz*mo) == hbar*po - hbar*mo
+
+
+def test_unary_integral():
+    assert qapply(Integral(XBra(x)*XKet(y), (x,-oo,oo))).doit() == S.One
+
+
+def test_unary_dagger():
+    assert qapply(Dagger(a*BosonFockKet(p)), dagger=True) == \
+        sqrt(p)*BosonFockBra(p-1)
+
+
+def test_unary_tensorproduct():
+    assert qapply(TP(a*BosonFockKet(p), a*BosonFockKet(q))) == \
+        TP(sqrt(p)*BosonFockKet(p-1), sqrt(q)*BosonFockKet(q-1))
+
+
+def test_unary_density():
+    d = Density([a*BosonFockKet(p), 0.5], [a*BosonFockKet(q), 0.5])
+    assert qapply(d) == \
+        Density([sqrt(p)*BosonFockKet(p-1), 0.5], [sqrt(q)*BosonFockKet(q-1), 0.5])
+    d = Density([Jz*mo, 0.5], [Jz*po, 0.5])
+    assert qapply(d) == Density([-hbar*mo, 0.5], [hbar*po, 0.5])
+
+
+#-----------------------------------------------------------------------------
+# Tests for the main unary dispatcher for qapply_Mul
+#-----------------------------------------------------------------------------
+
+
+def test_mul_unary_pow():
+    assert qapply(a**2*BosonFockKet(p)) == sqrt(p)*sqrt(p-1)*BosonFockKet(p-2)
+    assert qapply(BosonFockBra(q)*a**2*BosonFockKet(p)) == \
+        KroneckerDelta(q, p-2)*sqrt(p)*sqrt(p-1)
+    # Here we are testing the path for a Mul that has a Pow with a non-integer
+    # power
+    assert qapply(alpha*sqrt(
+        BosonFockBra(p)*a*BosonFockKet(p+1)*BosonFockBra(p+1)*Dagger(a)*BosonFockKet(p)
+    )) == \
+        simplify(alpha*sqrt(p+1))
+
+
+def test_mul_unary_op():
+    assert qapply(
+        OuterProduct(BosonFockKet(p), BosonFockBra(q))*a*BosonFockKet(q+1)
+    ) == \
+        sqrt(q+1)*BosonFockKet(p)
 
 
 class Foo(Operator):
@@ -34,12 +146,69 @@ class Foo(Operator):
         return ket
 
 
+def test_mul_unary_commutator():
+    assert qapply(Commutator(Jx, Jy)*Jz*po) == I*hbar**3*po
+    assert qapply(Commutator(J2, Jz)*Jz*po) == 0
+    assert qapply(Commutator(Jz, Foo('F'))*po) == 0
+    assert qapply(Commutator(Foo('F'), Jz)*po) == 0
+
+
+def test_mul_unary_anticommutator():
+    assert qapply(AntiCommutator(Jz, Foo('F'))*po) == 2*hbar*po
+    assert qapply(AntiCommutator(Foo('F'), Jz)*po) == 2*hbar*po
+
+
+#-----------------------------------------------------------------------------
+# Tests for the main binary dispatcher for qapply_Mul
+#-----------------------------------------------------------------------------
+
+
+def test_mul_binary_op_ket():
+    assert qapply(a*BosonFockKet(q)) == sqrt(q)*BosonFockKet(q-1)
+    assert qapply(A*BosonFockKet(q)) == A*BosonFockKet(q)
+    assert qapply(Jplus*Jplus*mo) == 2*hbar**2*po
+
+
+def test_mul_binary_bra_op():
+    assert qapply(BosonFockBra(q)*a, dagger=True) == \
+        sqrt(q+1)*BosonFockBra(q+1)
+
+
+def test_mul_binary_add():
+    assert sqa((Jplus + Jminus)*z/sqrt(2)) == \
+        hbar*(po + mo)
+    assert sqa(Jz*(po + mo)) == hbar*(po - mo)
+
+
+def test_mul_binary_sum():
+    e = qapply(Jz*Sum(JzKet(j, m), (m, -1, 1)))
+    assert e == Sum(hbar*m*JzKet(j, m), (m, -1, 1))
+    assert e.doit() == hbar*(JzKet(j,1) - JzKet(j,-1))
+    assert qapply(Sum(BosonFockBra(p),(p,0,3))*Sum(BosonFockKet(q),(q,0,3))) == \
+        Sum(KroneckerDelta(p, q), (p,0,3), (q,0,3))
+
+
+def test_mul_binary_integral():
+        e = qapply(XBra(x)*Integral(X*XKet(y), (y,-oo,oo)))
+        assert e == Integral(y*DiracDelta(y-x), (y,-oo,oo))
+        assert e.doit() == x
+
+        e = qapply(Integral(XBra(y)*X,(y,-oo,oo))*XKet(x))
+        assert e == Integral(x*DiracDelta(x-y), (y,-oo,oo))
+        assert e.doit() == x
+
+        e = qapply(Integral(XBra(x), (x,-oo,oo))*Integral(XKet(y), (y,-oo,oo)))
+        assert e == Integral(DiracDelta(y-x), (x,-oo,oo), (y,-oo,oo))
+
+
+#-----------------------------------------------------------------------------
+# Additional tests
+#-----------------------------------------------------------------------------
+
+
 def test_basic():
     assert qapply(Jz*po) == hbar*po
-    assert qapply(Jx*z) == hbar*po/sqrt(2) + hbar*mo/sqrt(2)
-    assert qapply((Jplus + Jminus)*z/sqrt(2)) == hbar*po + hbar*mo
-    assert qapply(Jz*(po + mo)) == hbar*po - hbar*mo
-    assert qapply(Jz*po + Jz*mo) == hbar*po - hbar*mo
+    assert sqa(Jx*z) == sqrt(2)*hbar*(po + mo)/sympify(2)
     assert qapply(Jminus*Jminus*po) == 2*hbar**2*mo
     assert qapply(Jplus**2*mo) == 2*hbar**2*po
     assert qapply(Jplus**2*Jminus**2*po) == 4*hbar**4*po
@@ -48,36 +217,19 @@ def test_basic():
 def test_extra():
     extra = z.dual*A*z
     assert qapply(Jz*po*extra) == hbar*po*extra
-    assert qapply(Jx*z*extra) == (hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra
-    assert qapply(
-        (Jplus + Jminus)*z/sqrt(2)*extra) == hbar*po*extra + hbar*mo*extra
-    assert qapply(Jz*(po + mo)*extra) == hbar*po*extra - hbar*mo*extra
-    assert qapply(Jz*po*extra + Jz*mo*extra) == hbar*po*extra - hbar*mo*extra
-    assert qapply(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
-    assert qapply(Jplus**2*mo*extra) == 2*hbar**2*po*extra
-    assert qapply(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
+    assert sqa(Jx*z*extra) == simplify((hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra)
+    assert sqa(
+        (Jplus + Jminus)*z/sqrt(2)*extra) == hbar*(po + mo)*extra
+    assert sqa(Jz*(po + mo)*extra) == hbar*(po - mo)*extra
+    assert sqa(Jz*po*extra + Jz*mo*extra) == hbar*(po - mo)*extra
+    assert sqa(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
+    assert sqa(Jplus**2*mo*extra) == 2*hbar**2*po*extra
+    assert sqa(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
 
 
 def test_innerproduct():
     assert qapply(po.dual*Jz*po, ip_doit=False) == hbar*(po.dual*po)
     assert qapply(po.dual*Jz*po) == hbar
-
-
-def test_zero():
-    assert qapply(0) == 0
-    assert qapply(Integer(0)) == 0
-
-
-def test_commutator():
-    assert qapply(Commutator(Jx, Jy)*Jz*po) == I*hbar**3*po
-    assert qapply(Commutator(J2, Jz)*Jz*po) == 0
-    assert qapply(Commutator(Jz, Foo('F'))*po) == 0
-    assert qapply(Commutator(Foo('F'), Jz)*po) == 0
-
-
-def test_anticommutator():
-    assert qapply(AntiCommutator(Jz, Foo('F'))*po) == 2*hbar*po
-    assert qapply(AntiCommutator(Foo('F'), Jz)*po) == 2*hbar*po
 
 
 def test_outerproduct():
@@ -117,11 +269,6 @@ def test_issue_6073():
     B = Operator('B')
     assert qapply(A) == A
     assert qapply(A.dual*B) == A.dual*B
-
-
-def test_density():
-    d = Density([Jz*mo, 0.5], [Jz*po, 0.5])
-    assert qapply(d) == Density([-hbar*mo, 0.5], [hbar*po, 0.5])
 
 
 def test_issue3044():

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -59,8 +59,6 @@ class SimpleKet(Ket):
 
 TP = TensorProduct
 
-sqa = lambda x: simplify(qapply(x))
-
 A = Operator('A')
 
 
@@ -175,9 +173,9 @@ def test_mul_binary_bra_op():
 
 
 def test_mul_binary_add():
-    assert sqa((Jplus + Jminus)*z/sqrt(2)) == \
-        hbar*(po + mo)
-    assert sqa(Jz*(po + mo)) == hbar*(po - mo)
+    assert qapply((Jplus + Jminus)*z/sqrt(2)).expand() == \
+        (hbar*(po + mo)).expand()
+    assert qapply(Jz*(po + mo)).expand() == (hbar*(po - mo)).expand()
 
 
 def test_mul_binary_sum():
@@ -208,7 +206,7 @@ def test_mul_binary_integral():
 
 def test_basic():
     assert qapply(Jz*po) == hbar*po
-    assert sqa(Jx*z) == sqrt(2)*hbar*(po + mo)/sympify(2)
+    assert qapply(Jx*z).expand() == (sqrt(2)*hbar*(po + mo)/sympify(2)).expand()
     assert qapply(Jminus*Jminus*po) == 2*hbar**2*mo
     assert qapply(Jplus**2*mo) == 2*hbar**2*po
     assert qapply(Jplus**2*Jminus**2*po) == 4*hbar**4*po
@@ -217,14 +215,14 @@ def test_basic():
 def test_extra():
     extra = z.dual*A*z
     assert qapply(Jz*po*extra) == hbar*po*extra
-    assert sqa(Jx*z*extra) == simplify((hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra)
-    assert sqa(
-        (Jplus + Jminus)*z/sqrt(2)*extra) == hbar*(po + mo)*extra
-    assert sqa(Jz*(po + mo)*extra) == hbar*(po - mo)*extra
-    assert sqa(Jz*po*extra + Jz*mo*extra) == hbar*(po - mo)*extra
-    assert sqa(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
-    assert sqa(Jplus**2*mo*extra) == 2*hbar**2*po*extra
-    assert sqa(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
+    assert qapply(Jx*z*extra).expand() == ((hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra).expand()
+    assert qapply(
+        (Jplus + Jminus)*z/sqrt(2)*extra).expand() == (hbar*(po + mo)*extra).expand()
+    assert qapply(Jz*(po + mo)*extra).expand() == (hbar*(po - mo)*extra).expand()
+    assert qapply(Jz*po*extra + Jz*mo*extra).expand() == (hbar*(po - mo)*extra).expand()
+    assert qapply(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
+    assert qapply(Jplus**2*mo*extra) == 2*hbar**2*po*extra
+    assert qapply(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
 
 
 def test_innerproduct():

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -1,7 +1,7 @@
 from sympy.concrete.summations import Sum
 from sympy.core import oo
 from sympy.core.mul import Mul
-from sympy.core.numbers import (I, Integer, Rational)
+from sympy.core.numbers import (I, Rational)
 from sympy.core.singleton import S
 from sympy.simplify import simplify
 from sympy.core.symbol import symbols, Symbol

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -1,7 +1,7 @@
 from sympy.concrete.summations import Sum
 from sympy.core import oo
 from sympy.core.mul import Mul
-from sympy.core.numbers import (I, Rational)
+from sympy.core.numbers import I, Rational
 from sympy.core.singleton import S
 from sympy.simplify import simplify
 from sympy.core.symbol import symbols, Symbol
@@ -15,14 +15,12 @@ from sympy.functions.special.tensor_functions import KroneckerDelta
 
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
-from sympy.physics.quantum.cartesian import X, XKet, XBra
+from sympy.physics.quantum.cartesian import X, XKet, XBra, PxOp
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.gate import H, XGate, IdentityGate
-from sympy.physics.quantum.operator import (
-    Operator, IdentityOperator, OuterProduct
-)
+from sympy.physics.quantum.operator import Operator, IdentityOperator, OuterProduct
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -33,211 +31,316 @@ from sympy.physics.quantum.boson import BosonOp, BosonFockKet, BosonFockBra
 from sympy.testing.pytest import warns_deprecated_sympy
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Variables and utilities
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 j, jp, m, mp = symbols("j j' m m'")
-p, q, r, st = symbols('p q r s', integer=True, nonnegative=True)
-x, y, z = symbols('x y z', real=True)
-omega = Symbol('omega', real=True)
-alpha = Symbol('alpha', complex=True)
+p, q, r, st = symbols("p q r s", integer=True, nonnegative=True)
+x, y, z = symbols("x y z", real=True)
+omega = Symbol("omega", real=True)
+alpha = Symbol("alpha", complex=True)
 
 z = JzKet(1, 0)
 po = JzKet(1, 1)
 mo = JzKet(1, -1)
 
-a = BosonOp('a')
+a = BosonOp("a")
+
 
 class SimpleBra(Bra):
     pass
 
+
 class SimpleKet(Ket):
     def _eval_innerproduct_SimpleBra(self, bra, **hints):
-        return alpha*exp(I*omega)
+        return alpha * exp(I * omega)
+
 
 TP = TensorProduct
 
-A = Operator('A')
+A = Operator("A")
 
 
-#-----------------------------------------------------------------------------
-# Tests for the main unary dispatcher for qapply
-#-----------------------------------------------------------------------------
+# =============================================================================
+# Main qapply Unary Handler Tests
+# These test the top-level _qapply_unary dispatcher that handles different
+# expression types by recursively applying qapply
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Basic Expression Types
+# -----------------------------------------------------------------------------
 
 
 def test_unary_number():
+    """Test numeric type conversion"""
     assert qapply(0) == S.Zero
     assert qapply(1.0) == sympify(1.0)
 
 
 def test_unary_abs():
+    """Test absolute value expressions"""
     assert qapply(Abs(alpha)) == Abs(alpha)
 
 
+# -----------------------------------------------------------------------------
+# Mathematical Structure Handlers
+# -----------------------------------------------------------------------------
+
+
 def test_unary_add():
-    assert qapply(a*BosonFockKet(p) + Dagger(a)*BosonFockKet(q)) == \
-        sqrt(p)*BosonFockKet(p-1) + sqrt(q+1)*BosonFockKet(q+1)
+    """Test distribution over addition"""
+    assert qapply(a * BosonFockKet(p) + Dagger(a) * BosonFockKet(q)) == sqrt(
+        p
+    ) * BosonFockKet(p - 1) + sqrt(q + 1) * BosonFockKet(q + 1)
 
 
 def test_unary_pow():
-    assert qapply((SimpleBra()*SimpleKet())**2) == alpha**2*exp(2*I*omega)
-    assert qapply(sqrt(SimpleBra()*SimpleKet())) == sqrt(alpha*exp(I*omega))
+    """Test power expression handling"""
+    assert qapply((SimpleBra() * SimpleKet()) ** 2) == alpha**2 * exp(2 * I * omega)
+    assert qapply(sqrt(SimpleBra() * SimpleKet())) == sqrt(alpha * exp(I * omega))
+    assert qapply((po.dual * Jz * po) ** 2) == hbar**2
+    assert qapply((BosonFockBra(1) * a * BosonFockKet(1)) ** 2) == S.Zero
 
 
 def test_unary_sum():
-    assert qapply(Sum(a*BosonFockKet(p), (p,0,2))) == Sum(sqrt(p)*BosonFockKet(p-1), (p,0,2))
-    assert qapply(Sum(a*BosonFockKet(p), (p,0,2)), sum_doit=True) == \
-        sqrt(1)*BosonFockKet(0) + sqrt(2)*BosonFockKet(1)
-    assert qapply(Jz*po + Jz*mo) == hbar*po - hbar*mo
+    """Test Sum expression handling"""
+    assert qapply(Sum(a * BosonFockKet(p), (p, 0, 2))) == Sum(
+        sqrt(p) * BosonFockKet(p - 1), (p, 0, 2)
+    )
+    assert qapply(Sum(a * BosonFockKet(p), (p, 0, 2)), sum_doit=True) == sqrt(
+        1
+    ) * BosonFockKet(0) + sqrt(2) * BosonFockKet(1)
+    assert qapply(Jz * po + Jz * mo) == hbar * po - hbar * mo
 
 
 def test_unary_integral():
-    assert qapply(Integral(XBra(x)*XKet(y), (x,-oo,oo))).doit() == S.One
+    """Test Integral expression handling"""
+    assert qapply(Integral(XBra(x) * XKet(y), (x, -oo, oo))).doit() == S.One
+
+
+# -----------------------------------------------------------------------------
+# Quantum-Specific Structure Handlers
+# -----------------------------------------------------------------------------
 
 
 def test_unary_dagger():
-    assert qapply(Dagger(a*BosonFockKet(p)), dagger=True) == \
-        sqrt(p)*BosonFockBra(p-1)
+    """Test Dagger expression handling"""
+    assert qapply(Dagger(a * BosonFockKet(p)), dagger=True) == sqrt(p) * BosonFockBra(
+        p - 1
+    )
 
 
 def test_unary_tensorproduct():
-    assert qapply(TP(a*BosonFockKet(p), a*BosonFockKet(q))) == \
-        TP(sqrt(p)*BosonFockKet(p-1), sqrt(q)*BosonFockKet(q-1))
+    """Test TensorProduct expression handling"""
+    assert qapply(TP(a * BosonFockKet(p), a * BosonFockKet(q))) == TP(
+        sqrt(p) * BosonFockKet(p - 1), sqrt(q) * BosonFockKet(q - 1)
+    )
 
 
 def test_unary_density():
-    d = Density([a*BosonFockKet(p), 0.5], [a*BosonFockKet(q), 0.5])
-    assert qapply(d) == \
-        Density([sqrt(p)*BosonFockKet(p-1), 0.5], [sqrt(q)*BosonFockKet(q-1), 0.5])
-    d = Density([Jz*mo, 0.5], [Jz*po, 0.5])
-    assert qapply(d) == Density([-hbar*mo, 0.5], [hbar*po, 0.5])
+    """Test Density matrix handling"""
+    d = Density([a * BosonFockKet(p), 0.5], [a * BosonFockKet(q), 0.5])
+    assert qapply(d) == Density(
+        [sqrt(p) * BosonFockKet(p - 1), 0.5], [sqrt(q) * BosonFockKet(q - 1), 0.5]
+    )
+    d = Density([Jz * mo, 0.5], [Jz * po, 0.5])
+    assert qapply(d) == Density([-hbar * mo, 0.5], [hbar * po, 0.5])
 
 
-#-----------------------------------------------------------------------------
-# Tests for the main unary dispatcher for qapply_Mul
-#-----------------------------------------------------------------------------
+# =============================================================================
+# Multiplication Processing (qapply_Mul) Unary Handler Tests
+# These test the unary transformations applied to individual factors
+# in multiplication expressions before binary processing
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Factor Expansion and Preprocessing
+# -----------------------------------------------------------------------------
 
 
 def test_mul_unary_pow():
-    assert qapply(a**2*BosonFockKet(p)) == sqrt(p)*sqrt(p-1)*BosonFockKet(p-2)
-    assert qapply(BosonFockBra(q)*a**2*BosonFockKet(p)) == \
-        KroneckerDelta(q, p-2)*sqrt(p)*sqrt(p-1)
+    """Test power expansion in multiplications"""
+    assert qapply(a**2 * BosonFockKet(p)) == sqrt(p) * sqrt(p - 1) * BosonFockKet(p - 2)
+    assert qapply(BosonFockBra(q) * a**2 * BosonFockKet(p)) == KroneckerDelta(
+        q, p - 2
+    ) * sqrt(p) * sqrt(p - 1)
     # Here we are testing the path for a Mul that has a Pow with a non-integer
     # power
-    assert qapply(alpha*sqrt(
-        BosonFockBra(p)*a*BosonFockKet(p+1)*BosonFockBra(p+1)*Dagger(a)*BosonFockKet(p)
-    )) == \
-        simplify(alpha*sqrt(p+1))
+    assert qapply(
+        alpha
+        * sqrt(
+            BosonFockBra(p)
+            * a
+            * BosonFockKet(p + 1)
+            * BosonFockBra(p + 1)
+            * Dagger(a)
+            * BosonFockKet(p)
+        )
+    ) == simplify(alpha * sqrt(p + 1))
 
 
 def test_mul_unary_op():
+    """Test OuterProduct decomposition"""
     assert qapply(
-        OuterProduct(BosonFockKet(p), BosonFockBra(q))*a*BosonFockKet(q+1)
-    ) == \
-        sqrt(q+1)*BosonFockKet(p)
+        OuterProduct(BosonFockKet(p), BosonFockBra(q)) * a * BosonFockKet(q + 1)
+    ) == sqrt(q + 1) * BosonFockKet(p)
 
 
-class Foo(Operator):
-    def _apply_operator_JzKet(self, ket, **options):
-        return ket
+# -----------------------------------------------------------------------------
+# Commutator/Anticommutator Evaluation
+# -----------------------------------------------------------------------------
 
 
 def test_mul_unary_commutator():
-    assert qapply(Commutator(Jx, Jy)*Jz*po) == I*hbar**3*po
-    assert qapply(Commutator(J2, Jz)*Jz*po) == 0
-    assert qapply(Commutator(Jz, Foo('F'))*po) == 0
-    assert qapply(Commutator(Foo('F'), Jz)*po) == 0
+    """Test commutator evaluation in multiplications"""
+    assert qapply(Commutator(Jx, Jy) * Jz * po) == I * hbar**3 * po
+    assert qapply(Commutator(J2, Jz) * Jz * po) == 0
+    assert qapply(Commutator(a, Dagger(a)) * BosonFockKet(1)) == BosonFockKet(1)
+    assert qapply(Commutator(X, PxOp()) * XKet(x)) == I * hbar * XKet(x)
 
 
 def test_mul_unary_anticommutator():
-    assert qapply(AntiCommutator(Jz, Foo('F'))*po) == 2*hbar*po
-    assert qapply(AntiCommutator(Foo('F'), Jz)*po) == 2*hbar*po
+    """Test anticommutator evaluation in multiplications"""
 
 
-#-----------------------------------------------------------------------------
-# Tests for the main binary dispatcher for qapply_Mul
-#-----------------------------------------------------------------------------
+
+# =============================================================================
+# Multiplication Processing (qapply_Mul) Binary Handler Tests
+# These test the binary transformations applied to adjacent pairs
+# of factors in multiplication expressions
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Operator-State Application
+# -----------------------------------------------------------------------------
 
 
 def test_mul_binary_op_ket():
-    assert qapply(a*BosonFockKet(q)) == sqrt(q)*BosonFockKet(q-1)
-    assert qapply(A*BosonFockKet(q)) == A*BosonFockKet(q)
-    assert qapply(Jplus*Jplus*mo) == 2*hbar**2*po
+    """Test operator application to kets"""
+    assert qapply(a * BosonFockKet(q)) == sqrt(q) * BosonFockKet(q - 1)
+    assert qapply(A * BosonFockKet(q)) == A * BosonFockKet(q)
+    assert qapply(Jplus * Jplus * mo) == 2 * hbar**2 * po
 
 
 def test_mul_binary_bra_op():
-    assert qapply(BosonFockBra(q)*a, dagger=True) == \
-        sqrt(q+1)*BosonFockBra(q+1)
+    """Test bra-operator interactions"""
+    assert qapply(BosonFockBra(q) * a, dagger=True) == sqrt(q + 1) * BosonFockBra(q + 1)
+
+
+# -----------------------------------------------------------------------------
+# Distribution Over Linear Combinations
+# -----------------------------------------------------------------------------
 
 
 def test_mul_binary_add():
-    assert qapply((Jplus + Jminus)*z/sqrt(2)).expand() == \
-        (hbar*(po + mo)).expand()
-    assert qapply(Jz*(po + mo)).expand() == (hbar*(po - mo)).expand()
+    """Test distribution over addition"""
+    assert (
+        qapply((Jplus + Jminus) * z / sqrt(2)).expand() == (hbar * (po + mo)).expand()
+    )
+    assert qapply(Jz * (po + mo)).expand() == (hbar * (po - mo)).expand()
+    assert qapply((a + Dagger(a)) * BosonFockKet(1)).expand() == (BosonFockKet(0) + sqrt(2) * BosonFockKet(2)).expand()
 
 
 def test_mul_binary_sum():
-    e = qapply(Jz*Sum(JzKet(j, m), (m, -1, 1)))
-    assert e == Sum(hbar*m*JzKet(j, m), (m, -1, 1))
-    assert e.doit() == hbar*(JzKet(j,1) - JzKet(j,-1))
-    assert qapply(Sum(BosonFockBra(p),(p,0,3))*Sum(BosonFockKet(q),(q,0,3))) == \
-        Sum(KroneckerDelta(p, q), (p,0,3), (q,0,3))
+    """Test sum-expression interactions"""
+    e = qapply(Jz * Sum(JzKet(j, m), (m, -1, 1)))
+    assert e == Sum(hbar * m * JzKet(j, m), (m, -1, 1))
+    assert e.doit() == hbar * (JzKet(j, 1) - JzKet(j, -1))
+    assert qapply(
+        Sum(BosonFockBra(p), (p, 0, 3)) * Sum(BosonFockKet(q), (q, 0, 3))
+    ) == Sum(KroneckerDelta(p, q), (p, 0, 3), (q, 0, 3))
 
 
 def test_mul_binary_integral():
-        e = qapply(XBra(x)*Integral(X*XKet(y), (y,-oo,oo)))
-        assert e == Integral(y*DiracDelta(y-x), (y,-oo,oo))
-        assert e.doit() == x
+    """Test integral-expression interactions"""
+    e = qapply(XBra(x) * Integral(X * XKet(y), (y, -oo, oo)))
+    assert e == Integral(y * DiracDelta(y - x), (y, -oo, oo))
+    assert e.doit() == x
 
-        e = qapply(Integral(XBra(y)*X,(y,-oo,oo))*XKet(x))
-        assert e == Integral(x*DiracDelta(x-y), (y,-oo,oo))
-        assert e.doit() == x
+    e = qapply(Integral(XBra(y) * X, (y, -oo, oo)) * XKet(x))
+    assert e == Integral(x * DiracDelta(x - y), (y, -oo, oo))
+    assert e.doit() == x
 
-        e = qapply(Integral(XBra(x), (x,-oo,oo))*Integral(XKet(y), (y,-oo,oo)))
-        assert e == Integral(DiracDelta(y-x), (x,-oo,oo), (y,-oo,oo))
+    e = qapply(Integral(XBra(x), (x, -oo, oo)) * Integral(XKet(y), (y, -oo, oo)))
+    assert e == Integral(DiracDelta(y - x), (x, -oo, oo), (y, -oo, oo))
 
 
-#-----------------------------------------------------------------------------
-# Additional tests
-#-----------------------------------------------------------------------------
+# =============================================================================
+# Integration and Complex Expression Tests
+# These test combinations of handlers working together and complex scenarios
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Basic Integration Tests
+# -----------------------------------------------------------------------------
 
 
 def test_basic():
-    assert qapply(Jz*po) == hbar*po
-    assert qapply(Jx*z).expand() == (sqrt(2)*hbar*(po + mo)/sympify(2)).expand()
-    assert qapply(Jminus*Jminus*po) == 2*hbar**2*mo
-    assert qapply(Jplus**2*mo) == 2*hbar**2*po
-    assert qapply(Jplus**2*Jminus**2*po) == 4*hbar**4*po
+    """Test basic operator applications"""
+    assert qapply(Jz * po) == hbar * po
+    assert qapply(Jx * z).expand() == (sqrt(2) * hbar * (po + mo) / sympify(2)).expand()
+    assert qapply(Jminus * Jminus * po) == 2 * hbar**2 * mo
+    assert qapply(Jplus**2 * mo) == 2 * hbar**2 * po
+    assert qapply(Jplus**2 * Jminus**2 * po) == 4 * hbar**4 * po
+
+
+# -----------------------------------------------------------------------------
+# Complex Expression Tests
+# -----------------------------------------------------------------------------
 
 
 def test_extra():
-    extra = z.dual*A*z
-    assert qapply(Jz*po*extra) == hbar*po*extra
-    assert qapply(Jx*z*extra).expand() == ((hbar*po/sqrt(2) + hbar*mo/sqrt(2))*extra).expand()
-    assert qapply(
-        (Jplus + Jminus)*z/sqrt(2)*extra).expand() == (hbar*(po + mo)*extra).expand()
-    assert qapply(Jz*(po + mo)*extra).expand() == (hbar*(po - mo)*extra).expand()
-    assert qapply(Jz*po*extra + Jz*mo*extra).expand() == (hbar*(po - mo)*extra).expand()
-    assert qapply(Jminus*Jminus*po*extra) == 2*hbar**2*mo*extra
-    assert qapply(Jplus**2*mo*extra) == 2*hbar**2*po*extra
-    assert qapply(Jplus**2*Jminus**2*po*extra) == 4*hbar**4*po*extra
+    """Test complex expressions with non-quantum factors"""
+    extra = z.dual * A * z
+    assert qapply(Jz * po * extra) == hbar * po * extra
+    assert (
+        qapply(Jx * z * extra).expand()
+        == ((hbar * po / sqrt(2) + hbar * mo / sqrt(2)) * extra).expand()
+    )
+    assert (
+        qapply((Jplus + Jminus) * z / sqrt(2) * extra).expand()
+        == (hbar * (po + mo) * extra).expand()
+    )
+    assert (
+        qapply(Jz * (po + mo) * extra).expand() == (hbar * (po - mo) * extra).expand()
+    )
+    assert (
+        qapply(Jz * po * extra + Jz * mo * extra).expand()
+        == (hbar * (po - mo) * extra).expand()
+    )
+    assert qapply(Jminus * Jminus * po * extra) == 2 * hbar**2 * mo * extra
+    assert qapply(Jplus**2 * mo * extra) == 2 * hbar**2 * po * extra
+    assert qapply(Jplus**2 * Jminus**2 * po * extra) == 4 * hbar**4 * po * extra
+
+
+# -----------------------------------------------------------------------------
+# Quantum Product Types
+# -----------------------------------------------------------------------------
 
 
 def test_innerproduct():
-    assert qapply(po.dual*Jz*po, ip_doit=False) == hbar*(po.dual*po)
-    assert qapply(po.dual*Jz*po) == hbar
+    """Test inner product handling"""
+    assert qapply(po.dual * Jz * po, ip_doit=False) == hbar * (po.dual * po)
+    assert qapply(po.dual * Jz * po) == hbar
 
 
 def test_outerproduct():
-    e = Jz*(mo*po.dual)*Jz*po
-    assert qapply(e) == -hbar**2*mo
-    assert qapply(e, ip_doit=False) == -hbar**2*(po.dual*po)*mo
-    assert qapply(e).doit() == -hbar**2*mo
+    """Test outer product handling"""
+    e = Jz * (mo * po.dual) * Jz * po
+    assert qapply(e) == -(hbar**2) * mo
+    assert qapply(e, ip_doit=False) == -(hbar**2) * (po.dual * po) * mo
+    assert qapply(e).doit() == -(hbar**2) * mo
 
 
 def test_tensorproduct():
+    """Test tensor product applications"""
     a = BosonOp("a")
     b = BosonOp("b")
     ket1 = TensorProduct(BosonFockKet(1), BosonFockKet(2))
@@ -245,53 +348,82 @@ def test_tensorproduct():
     ket3 = TensorProduct(BosonFockKet(0), BosonFockKet(2))
     bra1 = TensorProduct(BosonFockBra(0), BosonFockBra(0))
     bra2 = TensorProduct(BosonFockBra(1), BosonFockBra(2))
-    assert qapply(TensorProduct(a, b ** 2) * ket1) == sqrt(2) * ket2
+    assert qapply(TensorProduct(a, b**2) * ket1) == sqrt(2) * ket2
     assert qapply(TensorProduct(a, Dagger(b) * b) * ket1) == 2 * ket3
-    assert qapply(bra1 * TensorProduct(a, b * b),
-                  dagger=True) == sqrt(2) * bra2
+    assert qapply(bra1 * TensorProduct(a, b * b), dagger=True) == sqrt(2) * bra2
     assert qapply(bra2 * ket1).doit() == S.One
     assert qapply(TensorProduct(a, b * b) * ket1) == sqrt(2) * ket2
-    assert qapply(Dagger(TensorProduct(a, b * b) * ket1),
-                  dagger=True) == sqrt(2) * Dagger(ket2)
+    assert qapply(Dagger(TensorProduct(a, b * b) * ket1), dagger=True) == sqrt(
+        2
+    ) * Dagger(ket2)
 
 
 def test_dagger():
-    lhs = Dagger(Qubit(0))*Dagger(H(0))
-    rhs = Dagger(Qubit(1))/sqrt(2) + Dagger(Qubit(0))/sqrt(2)
+    """Test dagger option handling"""
+    lhs = Dagger(Qubit(0)) * Dagger(H(0))
+    rhs = Dagger(Qubit(1)) / sqrt(2) + Dagger(Qubit(0)) / sqrt(2)
     assert qapply(lhs, dagger=True) == rhs
 
 
+# =============================================================================
+# Bug Fix and Edge Case Tests
+# Tests for specific issues and edge cases that have been reported
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Historical Issues
+# -----------------------------------------------------------------------------
+
+
 def test_issue_6073():
-    x, y = symbols('x y', commutative=False)
+    """Test handling of non-commutative symbols in states"""
+    x, y = symbols("x y", commutative=False)
     A = Ket(x, y)
-    B = Operator('B')
+    B = Operator("B")
     assert qapply(A) == A
-    assert qapply(A.dual*B) == A.dual*B
+    assert qapply(A.dual * B) == A.dual * B
 
 
 def test_issue3044():
-    expr1 = TensorProduct(Jz*JzKet(S(2),S.NegativeOne)/sqrt(2), Jz*JzKet(S.Half,S.Half))
+    """Test tensor product of spin operators"""
+    expr1 = TensorProduct(
+        Jz * JzKet(S(2), S.NegativeOne) / sqrt(2), Jz * JzKet(S.Half, S.Half)
+    )
     result = Mul(S.NegativeOne, Rational(1, 4), 2**S.Half, hbar**2)
-    result *= TensorProduct(JzKet(2,-1), JzKet(S.Half,S.Half))
+    result *= TensorProduct(JzKet(2, -1), JzKet(S.Half, S.Half))
     assert qapply(expr1) == result
 
 
-# Issue 24158: Tests whether qapply incorrectly evaluates some ket*op as op*ket
+# -----------------------------------------------------------------------------
+# Order Sensitivity and Edge Cases
+# -----------------------------------------------------------------------------
+
+
 def test_issue24158_ket_times_op():
-    P = BosonFockKet(0) * BosonOp("a") # undefined term
+    """Test that qapply doesn't incorrectly evaluate ket*op as op*ket"""
+    P = BosonFockKet(0) * BosonOp("a")  # undefined term
     # Does lhs._apply_operator_BosonOp(rhs) still evaluate ket*op as op*ket?
-    assert qapply(P) == P   # qapply(P) -> BosonOp("a")*BosonFockKet(0) = 0 before fix
-    P = Qubit(1) * XGate(0) # undefined term
+    assert qapply(P) == P  # qapply(P) -> BosonOp("a")*BosonFockKet(0) = 0 before fix
+    P = Qubit(1) * XGate(0)  # undefined term
     # Does rhs._apply_operator_Qubit(lhs) still evaluate ket*op as op*ket?
-    assert qapply(P) == P   # qapply(P) -> Qubit(0) before fix
-    P1 = Mul(QubitBra(0), Mul(QubitBra(0), Qubit(0)), XGate(0)) # legal expr <0| * (<1|*|1>) * X
-    assert qapply(P1) == QubitBra(0) * XGate(0)     # qapply(P1) -> 0 before fix
-    P1 = qapply(P1, dagger = True)  # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
-    assert qapply(P1, dagger = True) == QubitBra(1) # qapply(P1, dagger=True) -> 0 before fix
-    P2 = QubitBra(0) * (QubitBra(0) * Qubit(0)) * XGate(0) # 'forgot' to set brackets
-    P2 = qapply(P2, dagger = True) # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
-    assert P2 == QubitBra(1) # qapply(P1) -> 0 before fix
+    assert qapply(P) == P  # qapply(P) -> Qubit(0) before fix
+    P1 = Mul(
+        QubitBra(0), Mul(QubitBra(0), Qubit(0)), XGate(0)
+    )  # legal expr <0| * (<1|*|1>) * X
+    assert qapply(P1) == QubitBra(0) * XGate(0)  # qapply(P1) -> 0 before fix
+    P1 = qapply(
+        P1, dagger=True
+    )  # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
+    assert qapply(P1, dagger=True) == QubitBra(
+        1
+    )  # qapply(P1, dagger=True) -> 0 before fix
+    P2 = QubitBra(0) * (QubitBra(0) * Qubit(0)) * XGate(0)  # 'forgot' to set brackets
+    P2 = qapply(
+        P2, dagger=True
+    )  # unsatisfactorily -> <0|*X(0), expect <1| since dagger=True
+    assert P2 == QubitBra(1)  # qapply(P1) -> 0 before fix
     # Pull Request 24237: IdentityOperator from the right without dagger=True option
     with warns_deprecated_sympy():
-        assert qapply(QubitBra(1)*IdentityOperator()) == QubitBra(1)
-        assert qapply(IdentityGate(0)*(Qubit(0) + Qubit(1))) == Qubit(0) + Qubit(1)
+        assert qapply(QubitBra(1) * IdentityOperator()) == QubitBra(1)
+        assert qapply(IdentityGate(0) * (Qubit(0) + Qubit(1))) == Qubit(0) + Qubit(1)

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -3,7 +3,6 @@ from sympy.core import oo
 from sympy.core.mul import Mul
 from sympy.core.numbers import I, Rational
 from sympy.core.singleton import S
-from sympy.simplify import simplify
 from sympy.core.symbol import symbols, Symbol
 from sympy.core.sympify import sympify
 from sympy.integrals import Integral
@@ -28,7 +27,7 @@ from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.qubit import Qubit, QubitBra
 from sympy.physics.quantum.boson import BosonOp, BosonFockKet, BosonFockBra
-from sympy.physics.quantum.fermion import FermionOp, FermionFockKet, FermionFockBra
+from sympy.physics.quantum.fermion import FermionOp, FermionFockKet
 from sympy.testing.pytest import warns_deprecated_sympy
 
 

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -1,3 +1,5 @@
+# pyright: reportOperatorIssue=false
+
 from sympy.concrete.summations import Sum
 from sympy.core import oo
 from sympy.core.mul import Mul

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -221,7 +221,7 @@ def test_mul_unary_pow():
 # -----------------------------------------------------------------------------
 # qapply_Mul: SlidingTransform binary handler tests
 #
-# The tests in this section cover qapply(Mul) where two of the Mul args are 
+# The tests in this section cover qapply(Mul) where two of the Mul args are
 # handled by the binary SlidingTransform handler for qapply_Mul.
 # -----------------------------------------------------------------------------
 

--- a/sympy/physics/quantum/tests/test_sho1d.py
+++ b/sympy/physics/quantum/tests/test_sho1d.py
@@ -113,7 +113,7 @@ def test_NumberOp():
 
 def test_Hamiltonian():
     assert Commutator(H, N).doit() == Integer(0)
-    assert qapply(H*k) == ((hbar*omega*(k.n + Integer(1)/Integer(2)))*k).expand()
+    assert qapply(H*k) == ((hbar*omega*(k.n + Integer(1)/Integer(2)))*k)
     assert H.rewrite('a').doit() == hbar*omega*(ad*a + Integer(1)/Integer(2))
     assert H.rewrite('xp').doit() == \
         (Integer(1)/(Integer(2)*m))*(Px**2 + (m*omega*X)**2)

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -2,9 +2,7 @@ from sympy.core.mul import Mul
 from sympy.core.symbol import symbols
 from sympy.testing.pytest import raises
 
-from sympy.physics.quantum.slidingtransform import (
-    SlidingTransform, DipatchingSlidingTransform
-)
+from sympy.physics.quantum.slidingtransform import SlidingTransform
 
 a, b, c, d, e, f = symbols('a b c d e f', commutative=False)
 

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -1,0 +1,67 @@
+from sympy.core.mul import Mul
+from sympy.core.symbol import symbols
+from sympy.testing.pytest import raises
+
+from sympy.physics.quantum.slidingtransform import (
+    SlidingTransform, DipatchingSlidingTransform
+)
+
+a, b, c, d, e, f = symbols('a b c d e f', commutative=False)
+
+
+def doubler(x):
+    return (x, x)
+
+def drone(x):
+    return (a,)
+
+
+def test_unary():
+    st = SlidingTransform(unary=doubler)
+    assert st(a*b*c) == Mul._from_args((a, a, b, b, c, c))
+
+    st = SlidingTransform(unary=drone)
+    assert st(a*b*c) == Mul._from_args((a, a, a))
+
+    st = SlidingTransform(unary=lambda x: None)
+    assert st(a*b*c) == Mul._from_args((a, b, c))
+
+
+def mapping(lhs, rhs):
+    if lhs == a and rhs == b:
+        return (c,)
+    elif lhs == b and rhs == c:
+        return (d,)
+    elif lhs == a and rhs == c:
+        return None
+    elif lhs == c and rhs == d:
+        return (e, f)
+    
+
+def test_binary():
+    st = SlidingTransform(binary=mapping)
+
+    assert st(a*b) == Mul._from_args((c,))
+    assert st(b*c) == Mul._from_args((d,))
+    assert st(a*c) == Mul._from_args((a,c))
+    assert st(c*d) == Mul._from_args((e,f))
+
+    assert st(a*b*c) == Mul._from_args((c, c))
+    assert st(b*c*d) == Mul._from_args((d, d))
+    assert st(c*d*e) == Mul._from_args((e, f, e))
+
+    assert st(a*b*d) == Mul._from_args((e, f))
+
+
+def test_reverse():
+    st = SlidingTransform(binary=mapping, reverse=True)
+
+    assert st(a*b) == Mul._from_args((c,))
+    assert st(b*c) == Mul._from_args((d,))
+    assert st(a*c) == Mul._from_args((a,c))
+    assert st(c*d) == Mul._from_args((e,f))
+
+    assert st(a*b*c) == Mul._from_args((a, d))
+    assert st(d*b*c) == Mul._from_args((d, d))
+    assert st(a*c*b*a*b) == Mul._from_args((a, e, f))
+

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -82,7 +82,7 @@ def test_init_all_parameters():
     """Test initialization with all parameters provided."""
     def dummy_unary(x): return None
     def dummy_binary(lhs, rhs): return None
-    
+
     st = SlidingTransform(unary=dummy_unary, binary=dummy_binary, reverse=True, from_args=False)
     assert st.unary is dummy_unary
     assert st.binary is dummy_binary
@@ -94,7 +94,7 @@ def test_property_access():
     """Test that all property getters return the correct values after initialization."""
     def test_unary(x): return (x, x)
     def test_binary(lhs, rhs): return (lhs,)
-    
+
     st = SlidingTransform(unary=test_unary, binary=test_binary, reverse=True, from_args=False)
     assert st.unary is test_unary
     assert st.binary is test_binary
@@ -107,16 +107,16 @@ def test_property_access():
 def test_non_mul_raises_typeerror():
     """Test that calling the transform with non-Mul expressions raises TypeError."""
     st = SlidingTransform()
-    
+
     with raises(TypeError):
         st(a)  # Symbol
-    
+
     with raises(TypeError):
         st(a + b)  # Add
-    
+
     with raises(TypeError):
         st(a**2)  # Pow
-    
+
     with raises(TypeError):
         st(S(5))  # Integer
 
@@ -127,7 +127,7 @@ def test_unary_identity_transform():
     """Test unary function that returns None for all inputs (no transformation)."""
     def identity_unary(x):
         return None
-    
+
     st = SlidingTransform(unary=identity_unary)
     assert st(a*b*c) == Mul._from_args((a, b, c))
     assert st(a*x*b) == Mul._from_args((x, a, b))
@@ -137,10 +137,10 @@ def test_unary_expansion_transform():
     """Test unary function that expands single factors into multiple factors."""
     def tripler(x):
         return (x, x, x)
-    
+
     st = SlidingTransform(unary=tripler)
     assert st(a*b) == Mul._from_args((a, a, a, b, b, b))
-    
+
     # Test with expressions that remain as Mul objects
     # Create a Mul with two different non-commutative factors, then test just one
     result = st(a*c)  # This will triple both a and c
@@ -156,7 +156,7 @@ def test_unary_replacement_transform():
         elif x == b:
             return (d,)
         return None
-    
+
     st = SlidingTransform(unary=replacer)
     assert st(a*b*e) == Mul._from_args((b, c, d, e))
     assert st(a*e*b) == Mul._from_args((b, c, e, d))
@@ -168,7 +168,7 @@ def test_unary_zero_return():
         if x == a:
             return (S.Zero,)
         return None
-    
+
     st = SlidingTransform(unary=zero_maker)
     assert st(a*b*c) == S.Zero
     assert st(b*c*d) == Mul._from_args((b, c, d))
@@ -178,7 +178,7 @@ def test_unary_with_commutative_factors():
     """Test unary transforms with mix of commutative and non-commutative factors."""
     def doubler(x):
         return (x, x)
-    
+
     st = SlidingTransform(unary=doubler, from_args=True)
     assert st(a*x*b*y) == Mul._from_args((x, y, a, a, b, b), is_commutative=False)
     st = SlidingTransform(unary=doubler, from_args=False)
@@ -191,7 +191,7 @@ def test_unary_mixed_output():
         if x == a:
             return (x, y, b)
         return None
-    
+
     st = SlidingTransform(unary=mixed_expander)
     result = st(a*c)
     assert result == Mul._from_args((y, a, b, c), is_commutative=False)
@@ -205,7 +205,7 @@ def test_binary_simple_pairs():
         if lhs == a and rhs == b:
             return (c,)
         return None
-    
+
     st = SlidingTransform(binary=simple_binary)
     assert st(a*b) == Mul._from_args((c,))
     assert st(b*a) == Mul._from_args((b, a))
@@ -216,7 +216,7 @@ def test_binary_no_transformation():
     """Test binary function that returns None (no transformation) for all pairs."""
     def no_transform(lhs, rhs):
         return None
-    
+
     st = SlidingTransform(binary=no_transform)
     assert st(a*b*c*d) == Mul._from_args((a, b, c, d))
 
@@ -229,7 +229,7 @@ def test_binary_cascading_effect():
         elif lhs == d and rhs == e:
             return (f,)
         return None
-    
+
     st = SlidingTransform(binary=expanding_binary)
     # Based on the sliding transform logic:
     # a*b -> (c, d, e), output gets c, d, then e gets fed back
@@ -248,10 +248,10 @@ def test_binary_reverse_direction():
         elif lhs == b and rhs == c:
             return (d,)
         return None
-    
+
     st_forward = SlidingTransform(binary=directional_binary, reverse=False)
     st_reverse = SlidingTransform(binary=directional_binary, reverse=True)
-    
+
     # Forward: a*b -> c, then c*c (no match) -> (c, c)
     # Reverse: b*c -> d, then a*d (no match) -> (a, d)
     assert st_forward(a*b*c) == Mul._from_args((c, c))
@@ -264,7 +264,7 @@ def test_binary_with_commutative_separation():
         if lhs == a and rhs == b:
             return (c,)
         return None
-    
+
     st = SlidingTransform(binary=nc_only_binary)
     # Should skip commutative x, y and only process non-commutative pairs
     result = st(a*x*b*y*d)
@@ -277,7 +277,7 @@ def test_binary_zero_in_transform_output():
         if lhs == a and rhs == b:
             return (S.Zero, c)  # Zero in commutative part
         return None
-    
+
     st = SlidingTransform(binary=zero_producing_binary)
     # When S.Zero appears in commutative parts, it gets multiplied with other factors
     # The result will be S.Zero * c * d, which is still zero but not simplified
@@ -292,12 +292,12 @@ def test_unary_then_binary():
         if x == a:
             return (b, c)
         return None
-    
+
     def binary_combiner(lhs, rhs):
         if lhs == b and rhs == c:
             return (d,)
         return None
-    
+
     st = SlidingTransform(unary=unary_expander, binary=binary_combiner)
     # Test with a*e where e is untransformed by unary
     # a -> (b, c) via unary, then b*c -> d via binary, e remains
@@ -308,12 +308,12 @@ def test_unary_expands_for_binary():
     """Test scenario where unary transform creates more factors that binary processes."""
     def doubler_unary(x):
         return (x, x)
-    
+
     def pair_reducer(lhs, rhs):
         if lhs == rhs:  # Same factor twice
             return (lhs,)  # Reduce to single
         return None
-    
+
     st = SlidingTransform(unary=doubler_unary, binary=pair_reducer)
     # a*b -> (a, a, b, b) via unary, then a*a -> a, b*b -> b via binary
     assert st(a*b) == a*b
@@ -325,14 +325,14 @@ def test_single_factor_expression():
     """Test expressions with single effective factors."""
     def unary_doubler(x):
         return (x, x)
-    
+
     def binary_combiner(lhs, rhs):
         return (lhs,)
-    
+
     st_unary = SlidingTransform(unary=unary_doubler)
     st_binary = SlidingTransform(binary=binary_combiner)
     st_both = SlidingTransform(unary=unary_doubler, binary=binary_combiner)
-    
+
     # Test with expressions that create proper Mul objects
     assert st_unary(a*c) == Mul._from_args((a, a, c, c))  # Both factors doubled
     assert st_binary(a*c) == a  # Binary combines pairs to first element
@@ -343,10 +343,10 @@ def test_all_commutative_factors():
     """Test expressions containing only commutative factors."""
     def unary_transform(x):
         return (x, x)
-    
+
     def binary_transform(lhs, rhs):
         return (lhs,)
-    
+
     st = SlidingTransform(unary=unary_transform, binary=binary_transform)
     # Commutitive factors should not be transformed at all
     assert st(x*y*z) == x*y*z
@@ -358,7 +358,7 @@ def test_alternating_commutative_noncommutative():
         if lhs == a and rhs == b:
             return (c,)
         return None
-    
+
     st = SlidingTransform(binary=simple_binary)
     # Should skip commutative factors and only process a*b pair
     result = st(x*a*y*b*z)
@@ -376,7 +376,7 @@ def test_long_chain_transformations():
         elif lhs == e and rhs == f:
             return (a,)
         return None
-    
+
     st = SlidingTransform(binary=chain_binary)
     # a*b*d*f -> c*d*f -> e*f -> a
     assert st(a*b*d*f) == Mul._from_args((a,))
@@ -390,7 +390,7 @@ def test_complex_cascading():
         elif lhs == e and rhs == f:
             return (a,)
         return None
-    
+
     st = SlidingTransform(binary=complex_binary)
     # a*b -> (c, d, e, f) where f is the last item and goes back to input
     # But with just a*b, there's no more input to process f with
@@ -419,12 +419,12 @@ def test_commutative_collection():
         if x == a:
             return (x, y)  # y is commutative
         return None
-    
+
     def binary_mixed(lhs, rhs):
         if lhs == b and rhs == c:
             return (z, d)  # z is commutative
         return None
-    
+
     st = SlidingTransform(unary=unary_mixed, binary=binary_mixed)
     result = st(a*b*c)
     # Should collect y and z as commutative factors
@@ -435,7 +435,7 @@ def test_split_cnc_functionality():
     """Test the internal _split_cnc function behavior through transform operations."""
     def mixed_output_unary(x):
         return (x, y, z, b)  # Mix of commutative (y, z) and non-commutative (x, b)
-    
+
     st = SlidingTransform(unary=mixed_output_unary)
     result = st(a*c)  # Use proper Mul with two non-commutative factors
     # a -> (a, y, z, b) and c -> (c, y, z, b)
@@ -450,7 +450,7 @@ def test_mixed_result_reconstruction():
     """Test reconstruction of final Mul with both commutative and non-commutative parts."""
     def add_commutative_unary(x):
         return (x, x, y)  # Adds commutative factor
-    
+
     st = SlidingTransform(unary=add_commutative_unary)
     result = st(a*b)
     # Should have both commutative and non-commutative parts properly combined
@@ -466,18 +466,18 @@ def test_transform_function_exceptions():
         if x == a:
             raise ValueError("Test exception")
         return None
-    
+
     def failing_binary(lhs, rhs):
         if lhs == a and rhs == b:
             raise RuntimeError("Test exception")
         return None
-    
+
     st_unary = SlidingTransform(unary=failing_unary)
     st_binary = SlidingTransform(binary=failing_binary)
-    
+
     with raises(ValueError):
         st_unary(a*b)
-    
+
     with raises(RuntimeError):
         st_binary(a*b)
 
@@ -486,16 +486,16 @@ def test_malformed_transform_output():
     """Test behavior when transform functions return invalid output."""
     def bad_unary_string(x):
         return "not a tuple"  # Invalid return type
-    
+
     def bad_binary_int(lhs, rhs):
         return 42  # Invalid return type
-    
+
     st_unary = SlidingTransform(unary=bad_unary_string)
     st_binary = SlidingTransform(binary=bad_binary_int)
-    
+
     # These should raise appropriate errors during processing
     with raises((TypeError, AttributeError)):
         st_unary(a*b)
-    
+
     with raises((TypeError, AttributeError)):
         st_binary(a*b)

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -1,10 +1,14 @@
 from sympy.core.mul import Mul
+from sympy.core.singleton import S
 from sympy.core.symbol import symbols
+from sympy.core.add import Add
+from sympy.core.power import Pow
 from sympy.testing.pytest import raises
 
 from sympy.physics.quantum.slidingtransform import SlidingTransform
 
 a, b, c, d, e, f = symbols('a b c d e f', commutative=False)
+x, y, z = symbols('x y z', commutative=True)
 
 
 def doubler(x):
@@ -12,6 +16,16 @@ def doubler(x):
 
 def drone(x):
     return (a,)
+
+def mapping(lhs, rhs):
+    if lhs == a and rhs == b:
+        return (c,)
+    elif lhs == b and rhs == c:
+        return (d,)
+    elif lhs == a and rhs == c:
+        return None
+    elif lhs == c and rhs == d:
+        return (e, f)
 
 
 def test_unary():
@@ -24,17 +38,6 @@ def test_unary():
     st = SlidingTransform(unary=lambda x: None)
     assert st(a*b*c) == Mul._from_args((a, b, c))
 
-
-def mapping(lhs, rhs):
-    if lhs == a and rhs == b:
-        return (c,)
-    elif lhs == b and rhs == c:
-        return (d,)
-    elif lhs == a and rhs == c:
-        return None
-    elif lhs == c and rhs == d:
-        return (e, f)
-    
 
 def test_binary():
     st = SlidingTransform(binary=mapping)
@@ -63,3 +66,436 @@ def test_reverse():
     assert st(d*b*c) == Mul._from_args((d, d))
     assert st(a*c*b*a*b) == Mul._from_args((a, e, f))
 
+
+# Initialization and Property Tests
+
+def test_init_basic():
+    """Test basic initialization with default parameters."""
+    st = SlidingTransform()
+    assert st.unary is None
+    assert st.binary is None
+    assert st.reverse is False
+    assert st.from_args is True
+
+
+def test_init_all_parameters():
+    """Test initialization with all parameters provided."""
+    def dummy_unary(x): return None
+    def dummy_binary(lhs, rhs): return None
+    
+    st = SlidingTransform(unary=dummy_unary, binary=dummy_binary, reverse=True, from_args=False)
+    assert st.unary is dummy_unary
+    assert st.binary is dummy_binary
+    assert st.reverse is True
+    assert st.from_args is False
+
+
+def test_property_access():
+    """Test that all property getters return the correct values after initialization."""
+    def test_unary(x): return (x, x)
+    def test_binary(lhs, rhs): return (lhs,)
+    
+    st = SlidingTransform(unary=test_unary, binary=test_binary, reverse=True, from_args=False)
+    assert st.unary is test_unary
+    assert st.binary is test_binary
+    assert st.reverse is True
+    assert st.from_args is False
+
+
+# Input Validation Tests
+
+def test_non_mul_raises_typeerror():
+    """Test that calling the transform with non-Mul expressions raises TypeError."""
+    st = SlidingTransform()
+    
+    with raises(TypeError):
+        st(a)  # Symbol
+    
+    with raises(TypeError):
+        st(a + b)  # Add
+    
+    with raises(TypeError):
+        st(a**2)  # Pow
+    
+    with raises(TypeError):
+        st(S(5))  # Integer
+
+
+# Unary Transform Tests
+
+def test_unary_identity_transform():
+    """Test unary function that returns None for all inputs (no transformation)."""
+    def identity_unary(x):
+        return None
+    
+    st = SlidingTransform(unary=identity_unary)
+    assert st(a*b*c) == Mul._from_args((a, b, c))
+    assert st(a*x*b) == Mul._from_args((x, a, b))
+
+
+def test_unary_expansion_transform():
+    """Test unary function that expands single factors into multiple factors."""
+    def tripler(x):
+        return (x, x, x)
+    
+    st = SlidingTransform(unary=tripler)
+    assert st(a*b) == Mul._from_args((a, a, a, b, b, b))
+    
+    # Test with expressions that remain as Mul objects
+    # Create a Mul with two different non-commutative factors, then test just one
+    result = st(a*c)  # This will triple both a and c
+    expected = Mul._from_args((a, a, a, c, c, c))
+    assert result == expected
+
+
+def test_unary_replacement_transform():
+    """Test unary function that replaces factors with different factors."""
+    def replacer(x):
+        if x == a:
+            return (b, c)
+        elif x == b:
+            return (d,)
+        return None
+    
+    st = SlidingTransform(unary=replacer)
+    assert st(a*b*e) == Mul._from_args((b, c, d, e))
+    assert st(a*e*b) == Mul._from_args((b, c, e, d))
+
+
+def test_unary_zero_return():
+    """Test unary function that returns (S.Zero,) for some input, causing entire expression to become zero."""
+    def zero_maker(x):
+        if x == a:
+            return (S.Zero,)
+        return None
+    
+    st = SlidingTransform(unary=zero_maker)
+    assert st(a*b*c) == S.Zero
+    assert st(b*c*d) == Mul._from_args((b, c, d))
+
+
+def test_unary_with_commutative_factors():
+    """Test unary transforms with mix of commutative and non-commutative factors."""
+    def doubler(x):
+        return (x, x)
+    
+    st = SlidingTransform(unary=doubler, from_args=True)
+    assert st(a*x*b*y) == Mul._from_args((x, y, a, a, b, b), is_commutative=False)
+    st = SlidingTransform(unary=doubler, from_args=False)
+    assert st(a*x*b*y) == x*y*a**2*b**2
+
+
+def test_unary_mixed_output():
+    """Test unary function that returns mix of commutative and non-commutative factors."""
+    def mixed_expander(x):
+        if x == a:
+            return (x, y, b)
+        return None
+    
+    st = SlidingTransform(unary=mixed_expander)
+    result = st(a*c)
+    assert result == Mul._from_args((y, a, b, c), is_commutative=False)
+
+
+# Binary Transform Tests
+
+def test_binary_simple_pairs():
+    """Test binary function on simple two-factor expressions."""
+    def simple_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (c,)
+        return None
+    
+    st = SlidingTransform(binary=simple_binary)
+    assert st(a*b) == Mul._from_args((c,))
+    assert st(b*a) == Mul._from_args((b, a))
+    assert st(a*c) == Mul._from_args((a, c))
+
+
+def test_binary_no_transformation():
+    """Test binary function that returns None (no transformation) for all pairs."""
+    def no_transform(lhs, rhs):
+        return None
+    
+    st = SlidingTransform(binary=no_transform)
+    assert st(a*b*c*d) == Mul._from_args((a, b, c, d))
+
+
+def test_binary_cascading_effect():
+    """Test that when binary transform returns multiple factors, the last factor feeds back."""
+    def expanding_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (c, d, e)  # Multiple factors
+        elif lhs == d and rhs == e:
+            return (f,)
+        return None
+    
+    st = SlidingTransform(binary=expanding_binary)
+    # Based on the sliding transform logic:
+    # a*b -> (c, d, e), output gets c, d, then e gets fed back
+    # But there's no more input, so d and e remain as-is
+    # The cascading only happens if there are more factors to process
+    result = st(a*b)
+    # The actual result should be c*d*e (no further cascading happens)
+    assert result == c*d*e
+
+
+def test_binary_reverse_direction():
+    """Test binary processing in reverse direction (right-to-left)."""
+    def directional_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (c,)
+        elif lhs == b and rhs == c:
+            return (d,)
+        return None
+    
+    st_forward = SlidingTransform(binary=directional_binary, reverse=False)
+    st_reverse = SlidingTransform(binary=directional_binary, reverse=True)
+    
+    # Forward: a*b -> c, then c*c (no match) -> (c, c)
+    # Reverse: b*c -> d, then a*d (no match) -> (a, d)
+    assert st_forward(a*b*c) == Mul._from_args((c, c))
+    assert st_reverse(a*b*c) == Mul._from_args((a, d))
+
+
+def test_binary_with_commutative_separation():
+    """Test binary transform correctly skips commutative factors."""
+    def nc_only_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (c,)
+        return None
+    
+    st = SlidingTransform(binary=nc_only_binary)
+    # Should skip commutative x, y and only process non-commutative pairs
+    result = st(a*x*b*y*d)
+    assert result == Mul._from_args((x, y, c, d), is_commutative=False)
+
+
+def test_binary_zero_in_transform_output():
+    """Test binary function that produces zero in commutative parts."""
+    def zero_producing_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (S.Zero, c)  # Zero in commutative part
+        return None
+    
+    st = SlidingTransform(binary=zero_producing_binary)
+    # When S.Zero appears in commutative parts, it gets multiplied with other factors
+    # The result will be S.Zero * c * d, which is still zero but not simplified
+    assert st(a*b*d) == S.Zero
+
+
+# Combined Unary-Binary Tests
+
+def test_unary_then_binary():
+    """Test full pipeline with both unary and binary transforms."""
+    def unary_expander(x):
+        if x == a:
+            return (b, c)
+        return None
+    
+    def binary_combiner(lhs, rhs):
+        if lhs == b and rhs == c:
+            return (d,)
+        return None
+    
+    st = SlidingTransform(unary=unary_expander, binary=binary_combiner)
+    # Test with a*e where e is untransformed by unary
+    # a -> (b, c) via unary, then b*c -> d via binary, e remains
+    assert st(a*e) == d*e
+
+
+def test_unary_expands_for_binary():
+    """Test scenario where unary transform creates more factors that binary processes."""
+    def doubler_unary(x):
+        return (x, x)
+    
+    def pair_reducer(lhs, rhs):
+        if lhs == rhs:  # Same factor twice
+            return (lhs,)  # Reduce to single
+        return None
+    
+    st = SlidingTransform(unary=doubler_unary, binary=pair_reducer)
+    # a*b -> (a, a, b, b) via unary, then a*a -> a, b*b -> b via binary
+    assert st(a*b) == a*b
+
+
+# Edge Cases and Complex Scenarios
+
+def test_single_factor_expression():
+    """Test expressions with single effective factors."""
+    def unary_doubler(x):
+        return (x, x)
+    
+    def binary_combiner(lhs, rhs):
+        return (lhs,)
+    
+    st_unary = SlidingTransform(unary=unary_doubler)
+    st_binary = SlidingTransform(binary=binary_combiner)
+    st_both = SlidingTransform(unary=unary_doubler, binary=binary_combiner)
+    
+    # Test with expressions that create proper Mul objects
+    assert st_unary(a*c) == Mul._from_args((a, a, c, c))  # Both factors doubled
+    assert st_binary(a*c) == a  # Binary combines pairs to first element
+    assert st_both(a*c) == a  # Unary doubles, binary reduces
+
+
+def test_all_commutative_factors():
+    """Test expressions containing only commutative factors."""
+    def unary_transform(x):
+        return (x, x)
+    
+    def binary_transform(lhs, rhs):
+        return (lhs,)
+    
+    st = SlidingTransform(unary=unary_transform, binary=binary_transform)
+    # Commutitive factors should not be transformed at all
+    assert st(x*y*z) == x*y*z
+
+
+def test_alternating_commutative_noncommutative():
+    """Test expressions with alternating commutative and non-commutative factors."""
+    def simple_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (c,)
+        return None
+    
+    st = SlidingTransform(binary=simple_binary)
+    # Should skip commutative factors and only process a*b pair
+    result = st(x*a*y*b*z)
+    assert result == Mul._from_args((x, y, z, c), is_commutative=False)
+
+
+def test_long_chain_transformations():
+    """Test expressions with many factors that undergo multiple rounds of binary transformations."""
+    def chain_binary(lhs, rhs):
+        # Create a chain: a*b -> c, c*d -> e, e*f -> a (cycle)
+        if lhs == a and rhs == b:
+            return (c,)
+        elif lhs == c and rhs == d:
+            return (e,)
+        elif lhs == e and rhs == f:
+            return (a,)
+        return None
+    
+    st = SlidingTransform(binary=chain_binary)
+    # a*b*d*f -> c*d*f -> e*f -> a
+    assert st(a*b*d*f) == Mul._from_args((a,))
+
+
+def test_complex_cascading():
+    """Test scenario where binary transform produces many factors, creating complex cascading."""
+    def complex_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            return (c, d, e, f)  # Produces many factors
+        elif lhs == e and rhs == f:
+            return (a,)
+        return None
+    
+    st = SlidingTransform(binary=complex_binary)
+    # a*b -> (c, d, e, f) where f is the last item and goes back to input
+    # But with just a*b, there's no more input to process f with
+    # So the result is just c*d*e*f without further cascading
+    result = st(a*b)
+    assert result == c*d*e*f
+
+
+# from_args Parameter Tests
+
+def test_from_args():
+    """Test with from_args=True to verify Mul._from_args is used."""
+    st = SlidingTransform(unary=doubler, from_args=True)
+    # Should use _from_args, avoiding post-processors
+    assert st(x*a*b) == Mul._from_args((x, a, a, b, b), is_commutative=False)
+    st = SlidingTransform(unary=doubler, from_args=False)
+    # Should use _from_args, avoiding post-processors
+    assert st(x*a*b) == x*a**2*b**2
+
+
+# Commutative/Non-commutative Handling Tests
+
+def test_commutative_collection():
+    """Test that commutative factors from both unary and binary transforms are properly collected."""
+    def unary_mixed(x):
+        if x == a:
+            return (x, y)  # y is commutative
+        return None
+    
+    def binary_mixed(lhs, rhs):
+        if lhs == b and rhs == c:
+            return (z, d)  # z is commutative
+        return None
+    
+    st = SlidingTransform(unary=unary_mixed, binary=binary_mixed)
+    result = st(a*b*c)
+    # Should collect y and z as commutative factors
+    assert result == Mul._from_args((y, z, a, d), is_commutative=False)
+
+
+def test_split_cnc_functionality():
+    """Test the internal _split_cnc function behavior through transform operations."""
+    def mixed_output_unary(x):
+        return (x, y, z, b)  # Mix of commutative (y, z) and non-commutative (x, b)
+    
+    st = SlidingTransform(unary=mixed_output_unary)
+    result = st(a*c)  # Use proper Mul with two non-commutative factors
+    # a -> (a, y, z, b) and c -> (c, y, z, b)
+    # Commutative parts: y, z, y, z -> combined
+    # Non-commutative parts: a, b, c, b
+    # Final result: y*y*z*z * a*b*c*b
+    expected = y**2*z**2*a*b*c*b
+    assert result == expected
+
+
+def test_mixed_result_reconstruction():
+    """Test reconstruction of final Mul with both commutative and non-commutative parts."""
+    def add_commutative_unary(x):
+        return (x, x, y)  # Adds commutative factor
+    
+    st = SlidingTransform(unary=add_commutative_unary)
+    result = st(a*b)
+    # Should have both commutative and non-commutative parts properly combined
+    expected_commutative = y * y  # y from both a and b
+    assert result == Mul._from_args((expected_commutative, a, a, b, b), is_commutative=False)
+
+
+# Error Handling and Robustness Tests
+
+def test_transform_function_exceptions():
+    """Test behavior when unary or binary functions raise exceptions."""
+    def failing_unary(x):
+        if x == a:
+            raise ValueError("Test exception")
+        return None
+    
+    def failing_binary(lhs, rhs):
+        if lhs == a and rhs == b:
+            raise RuntimeError("Test exception")
+        return None
+    
+    st_unary = SlidingTransform(unary=failing_unary)
+    st_binary = SlidingTransform(binary=failing_binary)
+    
+    with raises(ValueError):
+        st_unary(a*b)
+    
+    with raises(RuntimeError):
+        st_binary(a*b)
+
+
+def test_malformed_transform_output():
+    """Test behavior when transform functions return invalid output."""
+    def bad_unary_string(x):
+        return "not a tuple"  # Invalid return type
+    
+    def bad_binary_int(lhs, rhs):
+        return 42  # Invalid return type
+    
+    st_unary = SlidingTransform(unary=bad_unary_string)
+    st_binary = SlidingTransform(binary=bad_binary_int)
+    
+    # These should raise appropriate errors during processing
+    with raises((TypeError, AttributeError)):
+        st_unary(a*b)
+    
+    with raises((TypeError, AttributeError)):
+        st_binary(a*b)

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -1,8 +1,6 @@
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
-from sympy.core.add import Add
-from sympy.core.power import Pow
 from sympy.testing.pytest import raises
 
 from sympy.physics.quantum.slidingtransform import SlidingTransform

--- a/sympy/physics/quantum/tests/test_slidingtransform.py
+++ b/sympy/physics/quantum/tests/test_slidingtransform.py
@@ -497,3 +497,20 @@ def test_malformed_transform_output():
 
     with raises((TypeError, AttributeError)):
         st_binary(a*b)
+
+
+def test_both_transforms_none():
+    """Test that when both unary and binary transforms are None, the expression is returned unchanged."""
+    st = SlidingTransform(unary=None, binary=None)
+
+    # Test with non-commutative factors only
+    assert st(a*b*c) == a*b*c
+
+    # Test with mixed commutative and non-commutative factors
+    assert st(x*a*y*b*z) == x*a*y*b*z
+
+    # Test with commutative factors only
+    assert st(x*y*z) == x*y*z
+
+    # Test with two factors
+    assert st(a*b) == a*b

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -4010,7 +4010,7 @@ def test_jx():
     assert qapply(Jx*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
         TensorProduct(Sum(hbar*mi*WignerD(j1, mi, m1, 0, 0, pi/2)*Sum(WignerD(j1, mi1, mi, pi*Rational(3, 2), 0, 0)*JyKet(j1, mi1), (mi1, -j1, j1)), (mi, -j1, j1)), JyKet(j2, m2)) + \
         TensorProduct(JyKet(j1, m1), Sum(hbar*mi*WignerD(j2, mi, m2, 0, 0, pi/2)*Sum(WignerD(j2, mi1, mi, pi*Rational(3, 2), 0, 0)*JyKet(j2, mi1), (mi1, -j2, j2)), (mi, -j2, j2)))
-    assert qapply(Jx*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
+    assert qapply(Jx*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))).expand(tensorproduct=True) == \
         hbar*sqrt(j1**2 + j1 - m1**2 - m1)*TensorProduct(JzKet(j1, m1 + 1), JzKet(j2, m2))/2 + \
         hbar*sqrt(j1**2 + j1 - m1**2 + m1)*TensorProduct(JzKet(j1, m1 - 1), JzKet(j2, m2))/2 + \
         hbar*sqrt(j2**2 + j2 - m2**2 - m2)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 + 1))/2 + \
@@ -4103,7 +4103,7 @@ def test_jy():
     assert qapply(Jy*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
         hbar*m1*TensorProduct(JyKet(j1, m1), JyKet(
             j2, m2)) + hbar*m2*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))
-    assert qapply(Jy*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))).expand() == \
+    assert qapply(Jy*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))).expand(tensorproduct=True) == \
         -hbar*I*sqrt(j1**2 + j1 - m1**2 - m1)*TensorProduct(JzKet(j1, m1 + 1), JzKet(j2, m2))/2 + \
         hbar*I*sqrt(j1**2 + j1 - m1**2 + m1)*TensorProduct(JzKet(j1, m1 - 1), JzKet(j2, m2))/2 + \
         -hbar*I*sqrt(j2**2 + j2 - m2**2 - m2)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 + 1))/2 + \

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -3710,44 +3710,44 @@ def test_jplus():
     assert Jplus.rewrite('xyz') == Jx + I*Jy
     # Normal operators, normal states
     # Numerical
-    assert qapply(Jplus*JxKet(1, 1)) == \
+    assert qapply(Jplus*JxKet(1, 1)).expand() == \
         -hbar*sqrt(2)*JxKet(1, 0)/2 + hbar*JxKet(1, 1)
-    assert qapply(Jplus*JyKet(1, 1)) == \
+    assert qapply(Jplus*JyKet(1, 1)).expand() == \
         hbar*sqrt(2)*JyKet(1, 0)/2 + I*hbar*JyKet(1, 1)
     assert qapply(Jplus*JzKet(1, 1)) == 0
     # Symbolic
     assert qapply(Jplus*JxKet(j, m)) == \
-        Sum(hbar * sqrt(-mi**2 - mi + j**2 + j) * WignerD(j, mi, m, 0, pi/2, 0) *
+        Sum(hbar * sqrt(-mi*(mi+1) + j*(j+1)) * WignerD(j, mi, m, 0, pi/2, 0) *
         Sum(WignerD(j, mi1, mi + 1, 0, pi*Rational(3, 2), 0) * JxKet(j, mi1),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jplus*JyKet(j, m)) == \
-        Sum(hbar * sqrt(j**2 + j - mi**2 - mi) * WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
+        Sum(hbar * sqrt(-mi*(mi+1) + j*(j+1)) * WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(WignerD(j, mi1, mi + 1, pi*Rational(3, 2), pi/2, pi/2) * JyKet(j, mi1),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jplus*JzKet(j, m)) == \
-        hbar*sqrt(j**2 + j - m**2 - m)*JzKet(j, m + 1)
+        hbar*sqrt(-m*(m+1) + j*(j+1))*JzKet(j, m + 1)
     # Normal operators, coupled states
     # Numerical
-    assert qapply(Jplus*JxKetCoupled(1, 1, (1, 1))) == -hbar*sqrt(2) * \
+    assert qapply(Jplus*JxKetCoupled(1, 1, (1, 1))).expand() == -hbar*sqrt(2) * \
         JxKetCoupled(1, 0, (1, 1))/2 + hbar*JxKetCoupled(1, 1, (1, 1))
-    assert qapply(Jplus*JyKetCoupled(1, 1, (1, 1))) == hbar*sqrt(2) * \
+    assert qapply(Jplus*JyKetCoupled(1, 1, (1, 1))).expand() == hbar*sqrt(2) * \
         JyKetCoupled(1, 0, (1, 1))/2 + I*hbar*JyKetCoupled(1, 1, (1, 1))
     assert qapply(Jplus*JzKet(1, 1)) == 0
     # Symbolic
     assert qapply(Jplus*JxKetCoupled(j, m, (j1, j2))) == \
-        Sum(hbar * sqrt(-mi**2 - mi + j**2 + j) * WignerD(j, mi, m, 0, pi/2, 0) *
+        Sum(hbar * sqrt(-mi*(mi+1) + j*(j+1)) * WignerD(j, mi, m, 0, pi/2, 0) *
         Sum(
             WignerD(
                 j, mi1, mi + 1, 0, pi*Rational(3, 2), 0) * JxKetCoupled(j, mi1, (j1, j2)),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jplus*JyKetCoupled(j, m, (j1, j2))) == \
-        Sum(hbar * sqrt(j**2 + j - mi**2 - mi) * WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
+        Sum(hbar * sqrt(-mi*(mi+1) + j*(j+1)) * WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(
             WignerD(j, mi1, mi + 1, pi*Rational(3, 2), pi/2, pi/2) *
             JyKetCoupled(j, mi1, (j1, j2)),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jplus*JzKetCoupled(j, m, (j1, j2))) == \
-        hbar*sqrt(j**2 + j - m**2 - m)*JzKetCoupled(j, m + 1, (j1, j2))
+        hbar*sqrt(-m*(m+1) + j*(j+1))*JzKetCoupled(j, m + 1, (j1, j2))
     # Uncoupled operators, uncoupled states
     # Numerical
     e1 = qapply(TensorProduct(Jplus, 1)*TensorProduct(JxKet(1, 1), JxKet(1, -1)))
@@ -3772,27 +3772,27 @@ def test_jplus():
         hbar*sqrt(2)*TensorProduct(JzKet(1, 1), JzKet(1, 0))
     # Symbolic
     assert qapply(TensorProduct(Jplus, 1)*TensorProduct(JxKet(j1, m1), JxKet(j2, m2))) == \
-        TensorProduct(Sum(hbar * sqrt(-mi**2 - mi + j1**2 + j1) * WignerD(j1, mi, m1, 0, pi/2, 0) *
+        TensorProduct(Sum(hbar * sqrt(-mi*(mi+1) + j1*(j1+1)) * WignerD(j1, mi, m1, 0, pi/2, 0) *
         Sum(WignerD(j1, mi1, mi + 1, 0, pi*Rational(3, 2), 0) * JxKet(j1, mi1),
         (mi1, -j1, j1)), (mi, -j1, j1)), JxKet(j2, m2))
     assert qapply(TensorProduct(1, Jplus)*TensorProduct(JxKet(j1, m1), JxKet(j2, m2))) == \
-        TensorProduct(JxKet(j1, m1), Sum(hbar * sqrt(-mi**2 - mi + j2**2 + j2) * WignerD(j2, mi, m2, 0, pi/2, 0) *
+        TensorProduct(JxKet(j1, m1), Sum(hbar * sqrt(-mi*(mi+1) + j2*(j2+1)) * WignerD(j2, mi, m2, 0, pi/2, 0) *
         Sum(WignerD(j2, mi1, mi + 1, 0, pi*Rational(3, 2), 0) * JxKet(j2, mi1),
         (mi1, -j2, j2)), (mi, -j2, j2)))
     assert qapply(TensorProduct(Jplus, 1)*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
-        TensorProduct(Sum(hbar * sqrt(j1**2 + j1 - mi**2 - mi) * WignerD(j1, mi, m1, pi*Rational(3, 2), -pi/2, pi/2) *
+        TensorProduct(Sum(hbar * sqrt(-mi*(mi+1) + j1*(j1+1)) * WignerD(j1, mi, m1, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(WignerD(j1, mi1, mi + 1, pi*Rational(3, 2), pi/2, pi/2) * JyKet(j1, mi1),
         (mi1, -j1, j1)), (mi, -j1, j1)), JyKet(j2, m2))
     assert qapply(TensorProduct(1, Jplus)*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
-        TensorProduct(JyKet(j1, m1), Sum(hbar * sqrt(j2**2 + j2 - mi**2 - mi) * WignerD(j2, mi, m2, pi*Rational(3, 2), -pi/2, pi/2) *
+        TensorProduct(JyKet(j1, m1), Sum(hbar * sqrt(-mi*(mi+1) + j2*(j2+1)) * WignerD(j2, mi, m2, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(WignerD(j2, mi1, mi + 1, pi*Rational(3, 2), pi/2, pi/2) * JyKet(j2, mi1),
         (mi1, -j2, j2)), (mi, -j2, j2)))
     assert qapply(TensorProduct(Jplus, 1)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
         hbar*sqrt(
-            j1**2 + j1 - m1**2 - m1)*TensorProduct(JzKet(j1, m1 + 1), JzKet(j2, m2))
+            -m1*(m1+1) + j1*(j1+1))*TensorProduct(JzKet(j1, m1 + 1), JzKet(j2, m2))
     assert qapply(TensorProduct(1, Jplus)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
         hbar*sqrt(
-            j2**2 + j2 - m2**2 - m2)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 + 1))
+            -m2*(m2+1) + j2*(j2+1))*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 + 1))
 
 
 def test_jminus():
@@ -3801,45 +3801,45 @@ def test_jminus():
     assert Jminus.rewrite('xyz') == Jx - I*Jy
     # Normal operators, normal states
     # Numerical
-    assert qapply(Jminus*JxKet(1, 1)) == \
+    assert qapply(Jminus*JxKet(1, 1)).expand() == \
         hbar*sqrt(2)*JxKet(1, 0)/2 + hbar*JxKet(1, 1)
-    assert qapply(Jminus*JyKet(1, 1)) == \
+    assert qapply(Jminus*JyKet(1, 1)).expand() == \
         hbar*sqrt(2)*JyKet(1, 0)/2 - hbar*I*JyKet(1, 1)
     assert qapply(Jminus*JzKet(1, 1)) == sqrt(2)*hbar*JzKet(1, 0)
     # Symbolic
     assert qapply(Jminus*JxKet(j, m)) == \
-        Sum(hbar*sqrt(j**2 + j - mi**2 + mi)*WignerD(j, mi, m, 0, pi/2, 0) *
+        Sum(hbar*sqrt(j*(j+1) - mi*(mi-1))*WignerD(j, mi, m, 0, pi/2, 0) *
         Sum(WignerD(j, mi1, mi - 1, 0, pi*Rational(3, 2), 0)*JxKet(j, mi1),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jminus*JyKet(j, m)) == \
-        Sum(hbar*sqrt(j**2 + j - mi**2 + mi)*WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
+        Sum(hbar*sqrt(j*(j+1) - mi*(mi-1))*WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(WignerD(j, mi1, mi - 1, pi*Rational(3, 2), pi/2, pi/2)*JyKet(j, mi1),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jminus*JzKet(j, m)) == \
-        hbar*sqrt(j**2 + j - m**2 + m)*JzKet(j, m - 1)
+        hbar*sqrt(j*(j+1) - m*(m-1))*JzKet(j, m - 1)
     # Normal operators, coupled states
     # Numerical
-    assert qapply(Jminus*JxKetCoupled(1, 1, (1, 1))) == \
+    assert qapply(Jminus*JxKetCoupled(1, 1, (1, 1))).expand() == \
         hbar*sqrt(2)*JxKetCoupled(1, 0, (1, 1))/2 + \
         hbar*JxKetCoupled(1, 1, (1, 1))
-    assert qapply(Jminus*JyKetCoupled(1, 1, (1, 1))) == \
+    assert qapply(Jminus*JyKetCoupled(1, 1, (1, 1))).expand() == \
         hbar*sqrt(2)*JyKetCoupled(1, 0, (1, 1))/2 - \
         hbar*I*JyKetCoupled(1, 1, (1, 1))
-    assert qapply(Jminus*JzKetCoupled(1, 1, (1, 1))) == \
+    assert qapply(Jminus*JzKetCoupled(1, 1, (1, 1))).expand() == \
         sqrt(2)*hbar*JzKetCoupled(1, 0, (1, 1))
     # Symbolic
     assert qapply(Jminus*JxKetCoupled(j, m, (j1, j2))) == \
-        Sum(hbar*sqrt(j**2 + j - mi**2 + mi)*WignerD(j, mi, m, 0, pi/2, 0) *
+        Sum(hbar*sqrt(j*(j+1) - mi*(mi-1))*WignerD(j, mi, m, 0, pi/2, 0) *
         Sum(WignerD(j, mi1, mi - 1, 0, pi*Rational(3, 2), 0)*JxKetCoupled(j, mi1, (j1, j2)),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jminus*JyKetCoupled(j, m, (j1, j2))) == \
-        Sum(hbar*sqrt(j**2 + j - mi**2 + mi)*WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
+        Sum(hbar*sqrt(j*(j+1) - mi*(mi-1))*WignerD(j, mi, m, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(
             WignerD(j, mi1, mi - 1, pi*Rational(3, 2), pi/2, pi/2)*
             JyKetCoupled(j, mi1, (j1, j2)),
         (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jminus*JzKetCoupled(j, m, (j1, j2))) == \
-        hbar*sqrt(j**2 + j - m**2 + m)*JzKetCoupled(j, m - 1, (j1, j2))
+        hbar*sqrt(j*(j+1) - m*(m-1))*JzKetCoupled(j, m - 1, (j1, j2))
     # Uncoupled operators, uncoupled states
     # Numerical
     e1 = qapply(TensorProduct(Jminus, 1)*TensorProduct(JxKet(1, 1), JxKet(1, -1)))
@@ -3864,27 +3864,27 @@ def test_jminus():
         1, Jminus)*TensorProduct(JzKet(1, 1), JzKet(1, -1))) == 0
     # Symbolic
     assert qapply(TensorProduct(Jminus, 1)*TensorProduct(JxKet(j1, m1), JxKet(j2, m2))) == \
-        TensorProduct(Sum(hbar*sqrt(j1**2 + j1 - mi**2 + mi)*WignerD(j1, mi, m1, 0, pi/2, 0) *
+        TensorProduct(Sum(hbar*sqrt(j1*(j1+1) - mi*(mi-1))*WignerD(j1, mi, m1, 0, pi/2, 0) *
         Sum(WignerD(j1, mi1, mi - 1, 0, pi*Rational(3, 2), 0)*JxKet(j1, mi1),
         (mi1, -j1, j1)), (mi, -j1, j1)), JxKet(j2, m2))
     assert qapply(TensorProduct(1, Jminus)*TensorProduct(JxKet(j1, m1), JxKet(j2, m2))) == \
-        TensorProduct(JxKet(j1, m1), Sum(hbar*sqrt(j2**2 + j2 - mi**2 + mi)*WignerD(j2, mi, m2, 0, pi/2, 0) *
+        TensorProduct(JxKet(j1, m1), Sum(hbar*sqrt(j2*(j2+1) - mi*(mi-1))*WignerD(j2, mi, m2, 0, pi/2, 0) *
         Sum(WignerD(j2, mi1, mi - 1, 0, pi*Rational(3, 2), 0)*JxKet(j2, mi1),
         (mi1, -j2, j2)), (mi, -j2, j2)))
     assert qapply(TensorProduct(Jminus, 1)*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
-        TensorProduct(Sum(hbar*sqrt(j1**2 + j1 - mi**2 + mi)*WignerD(j1, mi, m1, pi*Rational(3, 2), -pi/2, pi/2) *
+        TensorProduct(Sum(hbar*sqrt(j1*(j1+1) - mi*(mi-1))*WignerD(j1, mi, m1, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(WignerD(j1, mi1, mi - 1, pi*Rational(3, 2), pi/2, pi/2)*JyKet(j1, mi1),
         (mi1, -j1, j1)), (mi, -j1, j1)), JyKet(j2, m2))
     assert qapply(TensorProduct(1, Jminus)*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
-        TensorProduct(JyKet(j1, m1), Sum(hbar*sqrt(j2**2 + j2 - mi**2 + mi)*WignerD(j2, mi, m2, pi*Rational(3, 2), -pi/2, pi/2) *
+        TensorProduct(JyKet(j1, m1), Sum(hbar*sqrt(j2*(j2+1) - mi*(mi-1))*WignerD(j2, mi, m2, pi*Rational(3, 2), -pi/2, pi/2) *
         Sum(WignerD(j2, mi1, mi - 1, pi*Rational(3, 2), pi/2, pi/2)*JyKet(j2, mi1),
         (mi1, -j2, j2)), (mi, -j2, j2)))
     assert qapply(TensorProduct(Jminus, 1)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
         hbar*sqrt(
-            j1**2 + j1 - m1**2 + m1)*TensorProduct(JzKet(j1, m1 - 1), JzKet(j2, m2))
+            j1*(j1+1) - m1*(m1-1))*TensorProduct(JzKet(j1, m1 - 1), JzKet(j2, m2))
     assert qapply(TensorProduct(1, Jminus)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
         hbar*sqrt(
-            j2**2 + j2 - m2**2 + m2)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 - 1))
+            j2*(j2+1) - m2*(m2-1))*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 - 1))
 
 
 def test_j2():
@@ -3897,11 +3897,11 @@ def test_j2():
     assert qapply(J2*JzKet(1, 1)) == 2*hbar**2*JzKet(1, 1)
     # Symbolic
     assert qapply(J2*JxKet(j, m)) == \
-        hbar**2*j**2*JxKet(j, m) + hbar**2*j*JxKet(j, m)
+        hbar**2*j*(j+1)*JxKet(j, m)
     assert qapply(J2*JyKet(j, m)) == \
-        hbar**2*j**2*JyKet(j, m) + hbar**2*j*JyKet(j, m)
+        hbar**2*j*(j+1)*JyKet(j, m)
     assert qapply(J2*JzKet(j, m)) == \
-        hbar**2*j**2*JzKet(j, m) + hbar**2*j*JzKet(j, m)
+        hbar**2*j*(j+1)*JzKet(j, m)
     # Normal operators, coupled states
     # Numerical
     assert qapply(J2*JxKetCoupled(1, 1, (1, 1))) == \
@@ -3912,14 +3912,11 @@ def test_j2():
         2*hbar**2*JzKetCoupled(1, 1, (1, 1))
     # Symbolic
     assert qapply(J2*JxKetCoupled(j, m, (j1, j2))) == \
-        hbar**2*j**2*JxKetCoupled(j, m, (j1, j2)) + \
-        hbar**2*j*JxKetCoupled(j, m, (j1, j2))
+        hbar**2*j*(j+1)*JxKetCoupled(j, m, (j1, j2))
     assert qapply(J2*JyKetCoupled(j, m, (j1, j2))) == \
-        hbar**2*j**2*JyKetCoupled(j, m, (j1, j2)) + \
-        hbar**2*j*JyKetCoupled(j, m, (j1, j2))
+        hbar**2*j*(j+1)*JyKetCoupled(j, m, (j1, j2))
     assert qapply(J2*JzKetCoupled(j, m, (j1, j2))) == \
-        hbar**2*j**2*JzKetCoupled(j, m, (j1, j2)) + \
-        hbar**2*j*JzKetCoupled(j, m, (j1, j2))
+        hbar**2*j*(j+1)*JzKetCoupled(j, m, (j1, j2))
     # Uncoupled operators, uncoupled states
     # Numerical
     assert qapply(TensorProduct(J2, 1)*TensorProduct(JxKet(1, 1), JxKet(1, -1))) == \
@@ -3976,9 +3973,9 @@ def test_jx():
     assert qapply(Jx*JyKet(j, m)) == \
         Sum(hbar*mi*WignerD(j, mi, m, 0, 0, pi/2)*Sum(WignerD(j,
             mi1, mi, pi*Rational(3, 2), 0, 0)*JyKet(j, mi1), (mi1, -j, j)), (mi, -j, j))
-    assert qapply(Jx*JzKet(j, m)) == \
-        hbar*sqrt(j**2 + j - m**2 - m)*JzKet(j, m + 1)/2 + hbar*sqrt(j**2 +
-                  j - m**2 + m)*JzKet(j, m - 1)/2
+    assert qapply(Jx*JzKet(j, m)).expand() == \
+        (hbar*sqrt(j**2 + j - m**2 - m)*JzKet(j, m + 1)/2 + hbar*sqrt(j**2 +
+                  j - m**2 + m)*JzKet(j, m - 1)/2).expand()
     # Normal operators, coupled states
     # Numerical
     assert qapply(Jx*JxKetCoupled(1, 1, (1, 1))) == \
@@ -3992,7 +3989,7 @@ def test_jx():
         hbar*m*JxKetCoupled(j, m, (j1, j2))
     assert qapply(Jx*JyKetCoupled(j, m, (j1, j2))) == \
         Sum(hbar*mi*WignerD(j, mi, m, 0, 0, pi/2)*Sum(WignerD(j, mi1, mi, pi*Rational(3, 2), 0, 0)*JyKetCoupled(j, mi1, (j1, j2)), (mi1, -j, j)), (mi, -j, j))
-    assert qapply(Jx*JzKetCoupled(j, m, (j1, j2))) == \
+    assert qapply(Jx*JzKetCoupled(j, m, (j1, j2))).expand() == \
         hbar*sqrt(j**2 + j - m**2 - m)*JzKetCoupled(j, m + 1, (j1, j2))/2 + \
         hbar*sqrt(j**2 + j - m**2 + m)*JzKetCoupled(j, m - 1, (j1, j2))/2
     # Normal operators, uncoupled states
@@ -4069,7 +4066,7 @@ def test_jy():
         Sum(hbar*mi*WignerD(j, mi, m, pi*Rational(3, 2), 0, 0)*Sum(WignerD(
             j, mi1, mi, 0, 0, pi/2)*JxKet(j, mi1), (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jy*JyKet(j, m)) == hbar*m*JyKet(j, m)
-    assert qapply(Jy*JzKet(j, m)) == \
+    assert qapply(Jy*JzKet(j, m)).expand() == \
         -hbar*I*sqrt(j**2 + j - m**2 - m)*JzKet(
             j, m + 1)/2 + hbar*I*sqrt(j**2 + j - m**2 + m)*JzKet(j, m - 1)/2
     # Normal operators, coupled states
@@ -4085,7 +4082,7 @@ def test_jy():
         Sum(hbar*mi*WignerD(j, mi, m, pi*Rational(3, 2), 0, 0)*Sum(WignerD(j, mi1, mi, 0, 0, pi/2)*JxKetCoupled(j, mi1, (j1, j2)), (mi1, -j, j)), (mi, -j, j))
     assert qapply(Jy*JyKetCoupled(j, m, (j1, j2))) == \
         hbar*m*JyKetCoupled(j, m, (j1, j2))
-    assert qapply(Jy*JzKetCoupled(j, m, (j1, j2))) == \
+    assert qapply(Jy*JzKetCoupled(j, m, (j1, j2))).expand() == \
         -hbar*I*sqrt(j**2 + j - m**2 - m)*JzKetCoupled(j, m + 1, (j1, j2))/2 + \
         hbar*I*sqrt(j**2 + j - m**2 + m)*JzKetCoupled(j, m - 1, (j1, j2))/2
     # Normal operators, uncoupled states
@@ -4106,7 +4103,7 @@ def test_jy():
     assert qapply(Jy*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))) == \
         hbar*m1*TensorProduct(JyKet(j1, m1), JyKet(
             j2, m2)) + hbar*m2*TensorProduct(JyKet(j1, m1), JyKet(j2, m2))
-    assert qapply(Jy*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
+    assert qapply(Jy*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))).expand() == \
         -hbar*I*sqrt(j1**2 + j1 - m1**2 - m1)*TensorProduct(JzKet(j1, m1 + 1), JzKet(j2, m2))/2 + \
         hbar*I*sqrt(j1**2 + j1 - m1**2 + m1)*TensorProduct(JzKet(j1, m1 - 1), JzKet(j2, m2))/2 + \
         -hbar*I*sqrt(j2**2 + j2 - m2**2 - m2)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2 + 1))/2 + \
@@ -4151,8 +4148,8 @@ def test_jz():
     assert Commutator(Jz, Jminus).doit() == -hbar*Jminus
     # Normal operators, normal states
     # Numerical
-    assert qapply(Jz*JxKet(1, 1)) == -sqrt(2)*hbar*JxKet(1, 0)/2
-    assert qapply(Jz*JyKet(1, 1)) == -sqrt(2)*hbar*I*JyKet(1, 0)/2
+    assert qapply(Jz*JxKet(1, 1)).expand() == -sqrt(2)*hbar*JxKet(1, 0)/2
+    assert qapply(Jz*JyKet(1, 1)).expand() == -sqrt(2)*hbar*I*JyKet(1, 0)/2
     assert qapply(Jz*JzKet(2, 1)) == hbar*JzKet(2, 1)
     # Symbolic
     assert qapply(Jz*JxKet(j, m)) == \
@@ -4164,9 +4161,9 @@ def test_jz():
     assert qapply(Jz*JzKet(j, m)) == hbar*m*JzKet(j, m)
     # Normal operators, coupled states
     # Numerical
-    assert qapply(Jz*JxKetCoupled(1, 1, (1, 1))) == \
+    assert qapply(Jz*JxKetCoupled(1, 1, (1, 1))).expand() == \
         -sqrt(2)*hbar*JxKetCoupled(1, 0, (1, 1))/2
-    assert qapply(Jz*JyKetCoupled(1, 1, (1, 1))) == \
+    assert qapply(Jz*JyKetCoupled(1, 1, (1, 1))).expand() == \
         -sqrt(2)*hbar*I*JyKetCoupled(1, 0, (1, 1))/2
     assert qapply(Jz*JzKetCoupled(1, 1, (1, 1))) == \
         hbar*JzKetCoupled(1, 1, (1, 1))
@@ -4200,17 +4197,17 @@ def test_jz():
             j2, m2)) + hbar*m2*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))
     # Uncoupled Operators
     # Numerical
-    assert qapply(TensorProduct(Jz, 1)*TensorProduct(JxKet(1, 1), JxKet(1, -1))) == \
+    assert qapply(TensorProduct(Jz, 1)*TensorProduct(JxKet(1, 1), JxKet(1, -1))).expand() == \
         -sqrt(2)*hbar*TensorProduct(JxKet(1, 0), JxKet(1, -1))/2
-    assert qapply(TensorProduct(1, Jz)*TensorProduct(JxKet(1, 1), JxKet(1, -1))) == \
+    assert qapply(TensorProduct(1, Jz)*TensorProduct(JxKet(1, 1), JxKet(1, -1))).expand() == \
         -sqrt(2)*hbar*TensorProduct(JxKet(1, 1), JxKet(1, 0))/2
-    assert qapply(TensorProduct(Jz, 1)*TensorProduct(JyKet(1, 1), JyKet(1, -1))) == \
+    assert qapply(TensorProduct(Jz, 1)*TensorProduct(JyKet(1, 1), JyKet(1, -1))).expand() == \
         -sqrt(2)*I*hbar*TensorProduct(JyKet(1, 0), JyKet(1, -1))/2
-    assert qapply(TensorProduct(1, Jz)*TensorProduct(JyKet(1, 1), JyKet(1, -1))) == \
+    assert qapply(TensorProduct(1, Jz)*TensorProduct(JyKet(1, 1), JyKet(1, -1))).expand() == \
         sqrt(2)*I*hbar*TensorProduct(JyKet(1, 1), JyKet(1, 0))/2
-    assert qapply(TensorProduct(Jz, 1)*TensorProduct(JzKet(1, 1), JzKet(1, -1))) == \
+    assert qapply(TensorProduct(Jz, 1)*TensorProduct(JzKet(1, 1), JzKet(1, -1))).expand() == \
         hbar*TensorProduct(JzKet(1, 1), JzKet(1, -1))
-    assert qapply(TensorProduct(1, Jz)*TensorProduct(JzKet(1, 1), JzKet(1, -1))) == \
+    assert qapply(TensorProduct(1, Jz)*TensorProduct(JzKet(1, 1), JzKet(1, -1))).expand() == \
         -hbar*TensorProduct(JzKet(1, 1), JzKet(1, -1))
     # Symbolic
     assert qapply(TensorProduct(Jz, 1)*TensorProduct(JxKet(j1, m1), JxKet(j2, m2))) == \
@@ -4241,7 +4238,7 @@ def test_rotation():
         answ.remove(got)
     assert not answ
     arg = Rotation(a, b, g)*fun[0]
-    assert qapply(arg) == (-exp(-I*a)*exp(I*g)*cos(b)*JxKet(1,-1)/2 +
+    assert qapply(arg).expand() == (-exp(-I*a)*exp(I*g)*cos(b)*JxKet(1,-1)/2 +
         exp(-I*a)*exp(I*g)*JxKet(1,-1)/2 - sqrt(2)*exp(-I*a)*sin(b)*JxKet(1,0)/2 +
         exp(-I*a)*exp(-I*g)*cos(b)*JxKet(1,1)/2 + exp(-I*a)*exp(-I*g)*JxKet(1,1)/2)
     #dummy effective
@@ -4261,7 +4258,7 @@ def test_rotation():
         ans.remove(got)
     assert not ans
     arg = Rotation(a, b, g)*fun[0]
-    assert qapply(arg) == (
+    assert qapply(arg).expand() == (
         -exp(-I*a)*exp(I*g)*cos(b)*JxKetCoupled(1,-1,(1,1))/2 +
         exp(-I*a)*exp(I*g)*JxKetCoupled(1,-1,(1,1))/2 -
         sqrt(2)*exp(-I*a)*sin(b)*JxKetCoupled(1,0,(1,1))/2 +

--- a/sympy/physics/quantum/transforms.py
+++ b/sympy/physics/quantum/transforms.py
@@ -12,7 +12,6 @@ THIS IS EXPERIMENTAL.
 """
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
-from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.multipledispatch.dispatcher import (
     Dispatcher, ambiguity_register_error_ignore_dup
@@ -22,7 +21,7 @@ from sympy.utilities.misc import debug
 from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.kind import KetKind, BraKind, OperatorKind
 from sympy.physics.quantum.operator import (
-    OuterProduct, IdentityOperator, Operator
+    OuterProduct, IdentityOperator
 )
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.slidingtransform import SlidingTransform
@@ -59,13 +58,13 @@ register their own transforms to control the canonical form of products
 of quantum expressions.
 """
 
-@_postprocess_qexpr_mul.unary.register(Expr)
-def _remove_identity(a, **options):
-    return None
-
 @_postprocess_qexpr_mul.unary.register(IdentityOperator)
 def _remove_identity(a, **options):
     return ()
+
+@_postprocess_qexpr_mul.unary.register(Expr)
+def _pass_on_expr(a, **options):
+    return None
 
 
 @_postprocess_qexpr_mul.binary.register(Expr, Expr)

--- a/sympy/physics/quantum/transforms.py
+++ b/sympy/physics/quantum/transforms.py
@@ -24,6 +24,7 @@ from sympy.physics.quantum.kind import KetKind, BraKind, OperatorKind
 from sympy.physics.quantum.operator import (
     OuterProduct, IdentityOperator, Operator
 )
+from sympy.physics.quantum.slidingtransform import DipatchingSlidingTransform
 from sympy.physics.quantum.state import BraBase, KetBase, StateBase
 from sympy.physics.quantum.tensorproduct import TensorProduct
 
@@ -32,7 +33,7 @@ from sympy.physics.quantum.tensorproduct import TensorProduct
 # Multipledispatch based transformed for Mul and Pow
 #-----------------------------------------------------------------------------
 
-_transform_state_pair = Dispatcher('_transform_state_pair')
+_postprocess_state_mul = DipatchingSlidingTransform()
 """Transform a pair of expression in a Mul to their canonical form.
 
 All functions that are registered with this dispatcher need to take
@@ -52,40 +53,41 @@ register their own transforms to control the canonical form of products
 of quantum expressions.
 """
 
-@_transform_state_pair.register(Expr, Expr)
+
+@_postprocess_state_mul.binary.register(Expr, Expr)
 def _transform_expr(a, b):
     """Default transformer that does nothing for base types."""
     return None
 
 
 # The identity times anything is the anything.
-_transform_state_pair.add(
+_postprocess_state_mul.binary.add(
     (IdentityOperator, Expr),
     lambda x, y: (y,),
     on_ambiguity=ambiguity_register_error_ignore_dup
 )
-_transform_state_pair.add(
+_postprocess_state_mul.binary.add(
     (Expr, IdentityOperator),
     lambda x, y: (x,),
     on_ambiguity=ambiguity_register_error_ignore_dup
 )
-_transform_state_pair.add(
+_postprocess_state_mul.binary.add(
     (IdentityOperator, IdentityOperator),
     lambda x, y: S.One,
     on_ambiguity=ambiguity_register_error_ignore_dup
 )
 
-@_transform_state_pair.register(BraBase, KetBase)
+@_postprocess_state_mul.binary.register(BraBase, KetBase)
 def _transform_bra_ket(a, b):
     """Transform a bra*ket -> InnerProduct(bra, ket)."""
     return (InnerProduct(a, b),)
 
-@_transform_state_pair.register(KetBase, BraBase)
+@_postprocess_state_mul.binary.register(KetBase, BraBase)
 def _transform_ket_bra(a, b):
     """Transform a keT*bra -> OuterProduct(ket, bra)."""
     return (OuterProduct(a, b),)
 
-@_transform_state_pair.register(KetBase, KetBase)
+@_postprocess_state_mul.binary.register(KetBase, KetBase)
 def _transform_ket_ket(a, b):
     """Raise a TypeError if a user tries to multiply two kets.
 
@@ -95,7 +97,7 @@ def _transform_ket_ket(a, b):
         'Multiplication of two kets is not allowed. Use TensorProduct instead.'
     )
 
-@_transform_state_pair.register(BraBase, BraBase)
+@_postprocess_state_mul.binary.register(BraBase, BraBase)
 def _transform_bra_bra(a, b):
     """Raise a TypeError if a user tries to multiply two bras.
 
@@ -105,15 +107,15 @@ def _transform_bra_bra(a, b):
         'Multiplication of two bras is not allowed. Use TensorProduct instead.'
     )
 
-@_transform_state_pair.register(OuterProduct, KetBase)
+@_postprocess_state_mul.binary.register(OuterProduct, KetBase)
 def _transform_op_ket(a, b):
     return (InnerProduct(a.bra, b), a.ket)
 
-@_transform_state_pair.register(BraBase, OuterProduct)
+@_postprocess_state_mul.binary.register(BraBase, OuterProduct)
 def _transform_bra_op(a, b):
     return (InnerProduct(a, b.ket), b.bra)
 
-@_transform_state_pair.register(TensorProduct, KetBase)
+@_postprocess_state_mul.binary.register(TensorProduct, KetBase)
 def _transform_tp_ket(a, b):
     """Raise a TypeError if a user tries to multiply TensorProduct(*kets)*ket.
 
@@ -124,7 +126,7 @@ def _transform_tp_ket(a, b):
             'Multiplication of TensorProduct(*kets)*ket is invalid.'
         )
 
-@_transform_state_pair.register(KetBase, TensorProduct)
+@_postprocess_state_mul.binary.register(KetBase, TensorProduct)
 def _transform_ket_tp(a, b):
     """Raise a TypeError if a user tries to multiply ket*TensorProduct(*kets).
 
@@ -135,7 +137,7 @@ def _transform_ket_tp(a, b):
             'Multiplication of ket*TensorProduct(*kets) is invalid.'
         )
 
-@_transform_state_pair.register(TensorProduct, BraBase)
+@_postprocess_state_mul.binary.register(TensorProduct, BraBase)
 def _transform_tp_bra(a, b):
     """Raise a TypeError if a user tries to multiply TensorProduct(*bras)*bra.
 
@@ -146,7 +148,7 @@ def _transform_tp_bra(a, b):
             'Multiplication of TensorProduct(*bras)*bra is invalid.'
         )
 
-@_transform_state_pair.register(BraBase, TensorProduct)
+@_postprocess_state_mul.binary.register(BraBase, TensorProduct)
 def _transform_bra_tp(a, b):
     """Raise a TypeError if a user tries to multiply bra*TensorProduct(*bras).
 
@@ -157,7 +159,7 @@ def _transform_bra_tp(a, b):
             'Multiplication of bra*TensorProduct(*bras) is invalid.'
         )
 
-@_transform_state_pair.register(TensorProduct, TensorProduct)
+@_postprocess_state_mul.binary.register(TensorProduct, TensorProduct)
 def _transform_tp_tp(a, b):
     """Combine a product of tensor products if their number of args matches."""
     debug('_transform_tp_tp', a, b)
@@ -167,7 +169,7 @@ def _transform_tp_tp(a, b):
         else:
             return (TensorProduct(*(i*j for (i, j) in zip(a.args, b.args))), )
 
-@_transform_state_pair.register(OuterProduct, OuterProduct)
+@_postprocess_state_mul.binary.register(OuterProduct, OuterProduct)
 def _transform_op_op(a, b):
     """Extract an inner produt from a product of outer products."""
     return (InnerProduct(a.bra, b.ket), OuterProduct(a.ket, b.bra))
@@ -176,69 +178,6 @@ def _transform_op_op(a, b):
 #-----------------------------------------------------------------------------
 # Postprocessing transforms for Mul and Pow
 #-----------------------------------------------------------------------------
-
-
-def _postprocess_state_mul(expr):
-    """Transform a ``Mul`` of quantum expressions into canonical form.
-
-    This function is registered ``_constructor_postprocessor_mapping`` as a
-    transformer for ``Mul``. This means that every time a quantum expression
-    is multiplied, this function will be called to transform it into canonical
-    form as defined by the binary functions registered with
-    ``_transform_state_pair``.
-
-    The algorithm of this function is as follows. It walks the args
-    of the input ``Mul`` from left to right and calls ``_transform_state_pair``
-    on every overlapping pair of args. Each time ``_transform_state_pair``
-    is called it can return a tuple of items or None. If None, the pair isn't
-    transformed. If a tuple, then the last element of the tuple goes back into
-    the args to be transformed again and the others are extended onto the result
-    args list.
-
-    The algorithm can be visualized in the following table:
-
-    step   result                                 args
-    ============================================================================
-    #0     []                                     [a, b, c, d, e, f]
-    #1     []                                     [T(a,b), c, d, e, f]
-    #2     [T(a,b)[:-1]]                          [T(a,b)[-1], c, d, e, f]
-    #3     [T(a,b)[:-1]]                          [T(T(a,b)[-1], c), d, e, f]
-    #4     [T(a,b)[:-1], T(T(a,b)[-1], c)[:-1]]   [T(T(T(a,b)[-1], c)[-1], d), e, f]
-    #5     ...
-
-    One limitation of the current implementation is that we assume that only the
-    last item of the transformed tuple goes back into the args to be transformed
-    again. These seems to handle the cases needed for Mul. However, we may need
-    to extend the algorithm to have the entire tuple go back into the args for
-    further transformation.
-    """
-    args = list(expr.args)
-    result = []
-
-    # Continue as long as we have at least 2 elements
-    while len(args) > 1:
-        # Get first two elements
-        first = args.pop(0)
-        second = args[0]  # Look at second element without popping yet
-
-        transformed = _transform_state_pair(first, second)
-
-        if transformed is None:
-            # If transform returns None, append first element
-            result.append(first)
-        else:
-            # This item was transformed, pop and discard
-            args.pop(0)
-            # The last item goes back to be transformed again
-            args.insert(0, transformed[-1])
-            # All other items go directly into the result
-            result.extend(transformed[:-1])
-
-    # Append any remaining element
-    if args:
-        result.append(args[0])
-
-    return Mul._from_args(result, is_commutative=False)
 
 
 def _postprocess_state_pow(expr):

--- a/sympy/testing/quality_unicode.py
+++ b/sympy/testing/quality_unicode.py
@@ -46,6 +46,9 @@ unicode_whitelist = [
     # joint.py uses some unicode for variable names in the docstrings
     r'*/sympy/physics/mechanics/joint.py',
 
+    # test_qapply.py uses unicode in some of the new tests and comments
+    r'*/sympy/physics/quantum/tests/test_qapply.py',
+
     # lll method has unicode in docstring references and author name
     r'*/sympy/polys/matrices/domainmatrix.py',
     r'*/sympy/matrices/repmatrix.py',


### PR DESCRIPTION
#### References to other Issues or PRs

Related to #28022
Replacement for #24349
Fixes #27526, #27213

#### Brief description of what is fixed or changed

This PR introduces a major refactoring of the quantum physics package's operator application system. The key changes include:

1. New SlidingTransform Algorithm: Extracted and generalized the transformation algorithm used in quantum expression canonicalization into a reusable slidingtransform.py module. This algorithm provides a systematic way to apply transformations to multiplication expressions using a sliding window approach, which is particularly useful for non-commutative quantum operators.
2. Complete qapply Refactoring: Extensively refactored the qapply function to use the new SlidingTransform algorithm, improving its ability to handle complex quantum expressions involving operators, states, tensor products, and other quantum constructs.
3. Sum/Integral handlings: Sums and integrals are now properly handled in qapply.
4. Multiple-dispatch: The refactor uses multipledispatch to provide an extensible and clean way of defining how qapply works on different types of expressions.
5. No expand: qapply no longer calls `.expand()` as it works, resulting in more efficient calculations and results that are more similar to how humans do these types of calculations.
6. Less recursion: While recursion is still used in the algorithms, it is used in fewer places, resulting in a more efficient approach.
7. Enhanced Test Coverage: Added comprehensive tests for both the new SlidingTransform functionality and the refactored qapply system, including edge cases and complex quantum expressions.
8. Bug Fixes and Improvements: Fixed various issues in quantum operator applications, particularly around Grover operators, spin systems, and TensorProduct handling.

The refactoring is mostly backward compatibility while providing a more robust and extensible foundation for quantum symbolic computation.

#### Other comments

The SlidingTransform algorithm operates in two phases:

- Unary Phase: Processes individual factors in multiplications
- Binary Phase: Applies binary transformations to adjacent pairs using a sliding window

This approach allows for better handling of non-commutative quantum operators and provides a foundation for future quantum computation enhancements.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

- physics.quantum
  - Introduced new SlidingTransform algorithm for systematic processing of quantum multiplication expressions
  - Major refactoring of qapply function for improved operator application handling
  - Enhanced support for complex quantum expressions involving tensor products and non-commutative operators
  - Full handling of sums and integrals in qapply
  - The qapply function no longer calls `.expand()` while it works so some of the results may have a slightly different form.
  - Fixed various bugs in Grover operators, spin systems, and quantum state applications
  - Improved test coverage for quantum operator applications and edge cases

<!-- END RELEASE NOTES -->
