### PR TITLE
lint: replace bin/hex string slicing with f-string formatting

### DIFF
--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -282,7 +282,7 @@ class GrayCode(Basic):
         """
         rv = self._current or '0'
         if not isinstance(rv, str):
-            rv = bin(rv)[2:]
+            rv = f'{rv:b}'
         return rv.rjust(self.n, '0')
 
     @classmethod

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -96,7 +96,7 @@ class Subset():
         """
         bin_list = Subset.bitlist_from_subset(self.subset, self.superset)
         n = (int(''.join(bin_list), 2) + k) % 2**self.superset_size
-        bits = bin(n)[2:].rjust(self.superset_size, '0')
+        bits = f'{n:b}'.rjust(self.superset_size, '0')
         return Subset.subset_from_bitlist(self.superset, bits)
 
     def next_binary(self):
@@ -538,7 +538,7 @@ class Subset():
 
         iterate_binary, rank_binary
         """
-        bits = bin(rank)[2:].rjust(len(superset), '0')
+        bits = f'{rank:b}'.rjust(len(superset), '0')
         return Subset.subset_from_bitlist(superset, bits)
 
     @classmethod

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -934,7 +934,7 @@ class Float(Number):
 
     def __getnewargs_ex__(self):
         sign, man, exp, bc = self._mpf_
-        arg = (sign, hex(man)[2:], exp, bc)
+        arg = (sign, f'{man:x}', exp, bc)
         kwargs = {'precision': self._prec}
         return ((arg,), kwargs)
 

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -556,7 +556,7 @@ class IntegerPowerable:
             except NotImplementedError:
                 return NotImplemented
         else:
-            bits = [int(d) for d in reversed(bin(e)[2:])]
+            bits = [int(d) for d in reversed(f'{e:b}')]
             n = len(bits)
             p = self
             first = True

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -377,14 +377,14 @@ def ibin(n, bits=None, str=False):
 
     if not str:
         if bits >= 0:
-            return [1 if i == "1" else 0 for i in bin(n)[2:].rjust(bits, "0")]
+            return [1 if i == "1" else 0 for i in f'{n:b}'.rjust(bits, "0")]
         else:
             return variations(range(2), n, repetition=True)
     else:
         if bits >= 0:
-            return bin(n)[2:].rjust(bits, "0")
+            return f'{n:b}'.rjust(bits, "0")
         else:
-            return (bin(i)[2:].rjust(n, "0") for i in range(2**n))
+            return (f'{i:b}'.rjust(n, "0") for i in range(2**n))
 
 
 def variations(seq, n, repetition=False):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think yesterday a new version of ruff came out which is causing the code quality checks to fail. For example, the CI is failing is [this pr](https://github.com/sympy/sympy/actions/runs/17633564583/job/50105564981?pr=28356) for reasons unrelated to its contents.  
```python
% ruff check --select=FURB116 --statistics
8       FURB116 f-string-number-format
Found 8 errors.
```
https://docs.astral.sh/ruff/rules/f-string-number-format/


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
