### PR TITLE
Fix: Q.real(Pow(0,-1)) is false 

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -230,6 +230,12 @@ def _(expr, assumptions):
 # RealPredicate
 
 def _RealPredicate_number(expr, assumptions):
+    from sympy import oo, zoo, I
+    #Complex inf is not real
+    if expr == zoo:
+        return False
+    if expr == oo or expr == -oo:
+        return True
     # let as_real_imag() work first since the expression may
     # be simpler to evaluate
     i = expr.as_real_imag()[1].evalf(2)
@@ -237,6 +243,13 @@ def _RealPredicate_number(expr, assumptions):
         return not i
     # allow None to be returned if we couldn't show for sure
     # that i was 0
+    if i.prec !=1:
+        return not i
+    return None
+
+def test_pow_zero_neg():
+    from sympy import ask, Q, Pow
+    assert ask(Q.real(Pow(0, -1, evaluate=False))) == False
 
 @RealPredicate.register_many(Abs, Exp1, Float, GoldenRatio, im, Pi, Rational,
     re, TribonacciConstant)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2569,3 +2569,7 @@ def test_issue_25221():
 def test_issue_27440():
     nan = S.NaN
     assert ask(Q.negative(nan)) is None
+
+def test_pow_zero_neg():
+    from sympy import ask, Q, Pow
+    assert ask(Q.real(Pow(0, -1, evaluate=False))) == False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28150

#### Brief description of what is fixed or changed
Fixed the issue of 0 raised to a negative power (Pow(0, {exp<0})) being considered real.
This was fixed by adding a check into ```_RealPredicate_number()```.
#### Other comments
A testcase has been added into sympy/assumptions/tests/test_query.py to ensure intended behavior. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fix the zero division by zero error
<!-- END RELEASE NOTES -->
