### PR TITLE
fix(polys): use dup_exquo_ground rather than dup_quo_ground

### DIFF
--- a/sympy/polys/appellseqs.py
+++ b/sympy/polys/appellseqs.py
@@ -21,7 +21,7 @@ References
 .. [2] Peter Luschny, "An introduction to the Bernoulli function",
        https://arxiv.org/abs/2009.06743
 """
-from sympy.polys.densearith import dup_mul_ground, dup_sub_ground, dup_quo_ground
+from sympy.polys.densearith import dup_mul_ground, dup_sub_ground, dup_exquo_ground
 from sympy.polys.densetools import dup_eval, dup_integrate
 from sympy.polys.domains import ZZ, QQ
 from sympy.polys.polytools import named_poly
@@ -172,7 +172,7 @@ def genocchi_poly(n, x=None, polys=False):
 
 def dup_euler(n, K):
     """Low-level implementation of Euler polynomials."""
-    return dup_quo_ground(dup_genocchi(n+1, ZZ), K(-n-1), K)
+    return dup_exquo_ground(dup_genocchi(n+1, ZZ), K(-n-1), K)
 
 @public
 def euler_poly(n, x=None, polys=False):

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -323,10 +323,7 @@ def dup_quo_ground(f: dup[Er], c: Er, K: Domain[Er]) -> dup[Er]:
     if not f:
         return f
 
-    if K.is_Field:
-        return [ K.quo(cf, c) for cf in f ]
-    else:
-        return [ cf // c for cf in f ] # type: ignore
+    return [ K.quo(cf, c) for cf in f ]
 
 
 def dmp_quo_ground(

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -15,7 +15,6 @@ from sympy.polys.densearith import (
     dup_series_pow,
     dup_rem, dmp_rem,
     dup_mul_ground, dmp_mul_ground,
-    dup_quo_ground, dmp_quo_ground,
     dup_exquo_ground, dmp_exquo_ground,
 )
 from sympy.polys.densebasic import (
@@ -112,7 +111,7 @@ def dmp_integrate(f: dmp[Ef], m: int, u: int, K: Field[Ef]) -> dmp[Ef]:
         for j in range(1, m):
             n *= i + j + 1
 
-        g.insert(0, dmp_quo_ground(c, K(n), v, K))
+        g.insert(0, dmp_exquo_ground(c, K(n), v, K))
 
     return g
 
@@ -704,7 +703,7 @@ def dup_primitive(f: dup[Er], K: Domain[Er]) -> tuple[Er, dup[Er]]:
     if K.is_one(cont):
         return cont, f
     else:
-        return cont, dup_quo_ground(f, cont, K)
+        return cont, dup_exquo_ground(f, cont, K)
 
 
 def dmp_ground_primitive(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[Er, dmp[Er]]:
@@ -741,7 +740,7 @@ def dmp_ground_primitive(f: dmp[Er], u: int, K: Domain[Er]) -> tuple[Er, dmp[Er]
     if K.is_one(cont):
         return cont, f
     else:
-        return cont, dmp_quo_ground(f, cont, u, K)
+        return cont, dmp_exquo_ground(f, cont, u, K)
 
 
 def dup_extract(f: dup[Er], g: dup[Er], K: Domain[Er]) -> tuple[Er, dup[Er], dup[Er]]:
@@ -764,8 +763,8 @@ def dup_extract(f: dup[Er], g: dup[Er], K: Domain[Er]) -> tuple[Er, dup[Er], dup
     gcd = K.gcd(fc, gc)
 
     if not K.is_one(gcd):
-        f = dup_quo_ground(f, gcd, K)
-        g = dup_quo_ground(g, gcd, K)
+        f = dup_exquo_ground(f, gcd, K)
+        g = dup_exquo_ground(g, gcd, K)
 
     return gcd, f, g
 
@@ -792,8 +791,8 @@ def dmp_ground_extract(
     gcd = K.gcd(fc, gc)
 
     if not K.is_one(gcd):
-        f = dmp_quo_ground(f, gcd, u, K)
-        g = dmp_quo_ground(g, gcd, u, K)
+        f = dmp_exquo_ground(f, gcd, u, K)
+        g = dmp_exquo_ground(g, gcd, u, K)
 
     return gcd, f, g
 

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -75,6 +75,9 @@ def dup_half_gcdex(f: dup[Ef], g: dup[Ef], K: Field[Ef]) -> tuple[dup[Ef], dup[E
     if not K.is_Field:
         raise DomainError("Cannot compute half extended GCD over %s" % K)
 
+    a: dup[Ef]
+    b: dup[Ef]
+
     a, b = [K.one], []
 
     while g:

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import overload, Literal
 
-from sympy.polys.domains.domain import Domain, Er
+from sympy.polys.domains.domain import Domain, Er, Ef
+from sympy.polys.domains.field import Field
 from sympy.polys.densearith import (
     dup_sub_mul,
     dup_neg, dmp_neg,
@@ -18,7 +19,9 @@ from sympy.polys.densearith import (
     dup_prem, dmp_prem,
     dup_mul_ground, dmp_mul_ground,
     dmp_mul_term,
-    dup_quo_ground, dmp_quo_ground,
+    dup_exquo_ground,
+    dmp_quo_ground,
+    dmp_exquo_ground,
     dup_max_norm, dmp_max_norm)
 from sympy.polys.densebasic import (
     dup, dmp, _dup, _dmp,
@@ -50,9 +53,7 @@ from sympy.polys.polyerrors import (
     DomainError)
 
 
-
-
-def dup_half_gcdex(f, g, K):
+def dup_half_gcdex(f: dup[Ef], g: dup[Ef], K: Field[Ef]) -> tuple[dup[Ef], dup[Ef]]:
     """
     Half extended Euclidean algorithm in `F[x]`.
 
@@ -81,7 +82,7 @@ def dup_half_gcdex(f, g, K):
         f, g = g, r
         a, b = b, dup_sub_mul(a, q, b, K)
 
-    a = dup_quo_ground(a, dup_LC(f, K), K)
+    a = dup_exquo_ground(a, dup_LC(f, K), K)
     f = dup_monic(f, K)
 
     return a, f
@@ -310,7 +311,7 @@ def dmp_primitive_prs(f, g, u, K):
         raise MultivariatePolynomialError(f, g)
 
 
-def dup_inner_subresultants(f, g, K):
+def dup_inner_subresultants(f: dup[Er], g: dup[Er], K: Domain[Er]):
     """
     Subresultant PRS algorithm in `K[x]`.
 
@@ -375,7 +376,7 @@ def dup_inner_subresultants(f, g, K):
         b = -lc * c**d
 
         h = dup_prem(f, g, K)
-        h = dup_quo_ground(h, b, K)
+        h = dup_exquo_ground(h, b, K)
 
         lc = dup_LC(g, K)
 
@@ -769,7 +770,7 @@ def dmp_qq_collins_resultant(f, g, u, K0):
 
     c = K0.convert(cf**m * cg**n, K1)
 
-    return dmp_quo_ground(r, c, u - 1, K0)
+    return dmp_exquo_ground(r, c, u - 1, K0)
 
 
 @overload

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -45,7 +45,7 @@ from sympy.polys.densearith import (
     dup_max_norm, dmp_max_norm,
     dup_l1_norm,
     dup_mul_ground, dmp_mul_ground,
-    dup_quo_ground, dmp_quo_ground)
+    dup_exquo_ground, dmp_quo_ground, dmp_exquo_ground)
 
 from sympy.polys.densetools import (
     dup_clear_denoms, dmp_clear_denoms,
@@ -1506,7 +1506,7 @@ def dup_factor_list(f, K0):
             if K0_inexact:
                 for i, (f, k) in enumerate(factors):
                     max_norm = dup_max_norm(f, K0)
-                    f = dup_quo_ground(f, max_norm, K0)
+                    f = dup_exquo_ground(f, max_norm, K0)
                     f = dup_convert(f, K0, K0_inexact)
                     factors[i] = (f, k)
                     coeff = K0.mul(coeff, K0.pow(max_norm, k))
@@ -1590,7 +1590,7 @@ def dmp_factor_list(f, u, K0):
             if K0_inexact:
                 for i, (f, k) in enumerate(factors):
                     max_norm = dmp_max_norm(f, u, K0)
-                    f = dmp_quo_ground(f, max_norm, u, K0)
+                    f = dmp_exquo_ground(f, max_norm, u, K0)
                     f = dmp_convert(f, u, K0, K0_inexact)
                     factors[i] = (f, k)
                     coeff = K0.mul(coeff, K0.pow(max_norm, k))

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -39,11 +39,10 @@ from .domainscalar import DomainScalar
 
 from sympy.polys.domains import ZZ, EXRAW, QQ
 
-from sympy.polys.densearith import dup_mul
+from sympy.polys.densearith import dup_mul, dup_exquo_ground
 from sympy.polys.densebasic import dup_convert
 from sympy.polys.densetools import (
     dup_mul_ground,
-    dup_quo_ground,
     dup_content,
     dup_clear_denoms,
     dup_primitive,
@@ -2014,7 +2013,7 @@ class DomainMatrix:
             common = K.gcd(content, denom)
 
             if not K.is_one(common):
-                elements = dup_quo_ground(elements, common, K)
+                elements = dup_exquo_ground(elements, common, K)
                 denom = K.quo(denom, common)
 
         if not K.is_one(u):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1629,7 +1629,7 @@ class DMP_Python(DMP[Er]):
 
     def _half_gcdex(f, g: Self) -> tuple[Self, Self]:
         """Half extended Euclidean algorithm, if univariate. """
-        s, h = dup_half_gcdex(f._rep, g._rep, f.dom)
+        s, h = dup_half_gcdex(f._rep, g._rep, f.dom) # type: ignore
         return f.per(s), f.per(h)
 
     def _gcdex(f, g: Self) -> tuple[Self, Self, Self]:


### PR DESCRIPTION
Many places used quo when it should be exquo. The difference is that quo discards a nonzero remainder whereas exquo asserts that the remainder is zero so that the quotient is exact. I don't know when it really makes sense to want to have the quotient without the remainder or without asserting that the remainder is zero. There don't seem to be any good examples of this in the codebase.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Spin off from gh-27360

#### Brief description of what is fixed or changed

- The `dup_quo_ground` function is simplified
- All code that calls it is changed to use `dup_exquo_ground` instead apart from `dmp_quo_ground`.
- The `dmp_quo_ground` function is replaced by `dmp_exquo_ground` in the places where it is obvious from the code that it can be replaced.

The advantage of using exquo rather than quo:

- It raises an error if the division is not exact showing a bug in a situation where the division should be exact.
- It communicates to the reader of the code that the division should be exact.

There are three remaining places where `dmp_quo_ground` is called directly:

https://github.com/sympy/sympy/blob/61b0a0a1fa332982c7eff7aed6f6ecc4b3746560/sympy/polys/euclidtools.py#L1285
https://github.com/sympy/sympy/blob/61b0a0a1fa332982c7eff7aed6f6ecc4b3746560/sympy/polys/factortools.py#L920
https://github.com/sympy/sympy/blob/61b0a0a1fa332982c7eff7aed6f6ecc4b3746560/sympy/polys/factortools.py#L975

It is possible that these could use `dmp_exquo_ground` as well but someone would need to look closer to verify that. Changing to `dmp_exquo_ground` there causes no test failures but I don't know if there are cases not covered by the tests. Note that in all three of those examples the code is only valid for `ZZ` domain so it potentially makes sense to have a ZZ-specific function rather than using `dmp_quo_ground` as a generic function. For now I left those three cases unchanged.

The fourth place that uses `dmp_quo_ground` is the `Poly.quo_ground` method. That is used in some other places:
```console
$ git grep '\.quo_ground('
sympy/integrals/risch.py:        z_part = z_part.replace(t, z).to_field().quo_ground(pd.LC())
sympy/polys/heuristicgcd.py:            h = (h - g).quo_ground(x)
sympy/polys/modulargcd.py:        h = hm.quo_ground(hm.content())
sympy/polys/modulargcd.py:        h = hm.quo_ground(hm.content())
sympy/polys/modulargcd.py:    h = h.quo_ground(h.LC)
sympy/polys/polyclasses.py:                return f.quo_ground(g)
sympy/polys/polyclasses.py:        return f.per(f._rep.quo_ground(c))
sympy/polys/polyclasses.py:            return f.quo_ground(g)
sympy/polys/polytools.py:        >>> Poly(2*x + 4).quo_ground(2)
sympy/polys/polytools.py:        >>> Poly(2*x + 3).quo_ground(2)
sympy/polys/polytools.py:            result = f.rep.quo_ground(coeff)
sympy/polys/rings.py:            return self.quo_ground(self.LC)
sympy/polys/rings.py:        f = f.quo_ground(gcd)
sympy/polys/rings.py:        g = g.quo_ground(gcd)
sympy/polys/rings.py:            return self.quo_ground(coeff)
sympy/polys/rings.py:        return self.quo_ground(x), self.rem_ground(x)
sympy/polys/rings.py:        return self.quo_ground(p2)
sympy/polys/rings.py:        return cont, self.quo_ground(cont)
sympy/polys/tests/test_polyclasses.py:    assert f.quo_ground(2) == DMP([[ZZ(1)], [ZZ(1), ZZ(0)]], ZZ)
sympy/polys/tests/test_polytools.py:    assert Poly(2*x + 4).quo_ground(2) == Poly(x + 2)
sympy/polys/tests/test_polytools.py:    assert Poly(2*x + 3).quo_ground(2) == Poly(x + 1)
sympy/polys/tests/test_rings.py:    assert r == (x**2 + 2*x + 1).quo_ground(2)
sympy/polys/tests/test_rings.py:    raises(ZeroDivisionError, lambda: x.quo_ground(0))
sympy/polys/tests/test_rings.py:    assert R.zero.quo_ground(5) == R.zero
sympy/polys/tests/test_rings.py:    assert (x**2 + 2*x + 3).quo_ground(1) == x**2 + 2*x + 3
sympy/polys/tests/test_rings.py:    assert (x**2 + 2*x + 4).quo_ground(2) == (x**2)/2 + x + 2
sympy/polys/tests/test_rings.py:    assert (x**2 + 3*x + 6).quo_ground(3) == (x**2)/3 + x + 2
```
I suspect that similar considerations apply there and it would be better to use `exquo_ground` rather than `quo_ground`.

#### Other comments

I think that `quo` vs `exquo` is a hangover from Python 2 where `a / b` for integers did Euclidean division so the general idea of division was a bit ambiguous.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * Some internal polys code now uses `dup_exquo_ground` or `dmp_exquo_ground` instead of `dup_quo_ground` or `dmp_quo_ground` meaning that it checks for errors if a division is inexaxct. 
<!-- END RELEASE NOTES -->
