### PR TITLE
Fix singularities and continues domain

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1150,6 +1150,7 @@ Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Oldrich Klimanek <oldrich.klimanek@gmail.com> Oldrich Klimanek <oldrich.klimanek@gmail.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com> klimanek <oldrich.klimanek@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1149,6 +1149,7 @@ Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com> Oldrich Klimanek <oldrich.klimanek@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Oliver Lee <oliverzlee@gmail.com>
 Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -42,10 +42,11 @@ def singularities(expression, symbol, domain=None):
     Returns
     =======
 
-    Set
+    Set or Interval
         A set of values for ``symbol`` for which ``expression`` has a
         singularity. An ``EmptySet`` is returned if ``expression`` has no
-        singularities for any given value of ``Symbol``.
+        singularities for any given value of ``Symbol``. An ``Interval`` is returned
+        if ``expression`` has uncountably many singularities.
 
     Raises
     ======
@@ -84,9 +85,12 @@ def singularities(expression, symbol, domain=None):
     {-1, 1/2 - sqrt(3)*I/2, 1/2 + sqrt(3)*I/2}
     >>> singularities(log(x), x)
     {0}
+    >>> singularities(0**x, x)
+    Interval.open(-oo, 0)
 
     """
     from sympy.solvers.solveset import solveset
+    from sympy.sets.sets import Interval
 
     if domain is None:
         domain = S.Reals if symbol.is_real else S.Complexes
@@ -95,6 +99,13 @@ def singularities(expression, symbol, domain=None):
         e = expression.rewrite([sec, csc, cot, tan], cos)
         e = e.rewrite([sech, csch, coth, tanh], cosh)
         for i in e.atoms(Pow):
+            if i.base == S.Zero:
+                sing_interval = solveset(i.exp <= 0, symbol, domain)
+                # Since in Sympy we assume that 0**0 = 1,
+                # we can't have a singularity at i.exp == 0 and therefore
+                # we must return an open interval.
+                sing_interval = Interval.open(sing_interval.inf, sing_interval.sup)
+                sings += sing_interval
             if i.exp.is_infinite:
                 raise NotImplementedError
             if i.exp.is_negative:

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -42,7 +42,7 @@ def singularities(expression, symbol, domain=None):
     Returns
     =======
 
-    Set or Interval
+    Set
         A set of values for ``symbol`` for which ``expression`` has a
         singularity. An ``EmptySet`` is returned if ``expression`` has no
         singularities for any given value of ``Symbol``. An ``Interval`` is returned

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -51,6 +51,9 @@ def test_singularities():
         pi/2, 3*pi/2, 5*pi/2)
     assert singularities(csc(x), x, Interval(0, 3*pi)) == FiniteSet(
         0, pi, 2*pi, 3*pi)
+    assert singularities(0**x, x) == Interval.open(-oo, 0)
+    assert singularities(0**(x-1), x) == Interval.open(-oo, 1)
+    assert singularities(0**(x+1)/(x-2), x) == Union({2}, Interval.open(-oo, -1))
 
 
 def test_is_increasing():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -133,6 +133,10 @@ def test_continuous_domain():
     raises(NotImplementedError, lambda : continuous_domain(
         gamma(x), x, Interval(-5,0)))
     assert continuous_domain(x + gamma(pi), x, S.Reals) == S.Reals
+    assert continuous_domain(0**x, x, S.Reals) == Interval(0, oo)
+    assert continuous_domain(0**(x+1), x, S.Reals) == Interval(-1, oo)
+    assert continuous_domain(0**(x+1)/(x-2), x, S.Reals) == Union(
+        Interval.Ropen(-1, 2), Interval.open(2, oo))
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes part of #26949.

#### Brief description of what is fixed or changed
Extends the singularity detection machinery in SymPy. Previously, singularities were only detected at isolated points. With this PR, singularities can also be represented as intervals.

Examples of expressions that were previously mishandled:

* Functions that vanish or blow up identically on entire domains
* e.g. $h(t) := 0^{t+1}/(t - 1)$. 

#### Other comments
Improvements:

- Singularity sets are no longer limited to finite points.
- Fixes errors in `continuous_domain`, which previously ignored functions with infinitely many singularities.

Previously:
```Python
In [1]: from sympy import Symbol, S
   ...: from sympy.calculus.singularities import singularities
   ...: t = Symbol('t', real=True)
   ...: h = -0**(t+1)/(t+1)
   ...: sings = singularities(h, t) # Should be uncountably many in (-oo, -1]
   ...: print(sings)
{-1}
```

Now:
```Python
In [1]: from sympy import Symbol, S
   ...: from sympy.calculus.singularities import singularities
   ...: t = Symbol('t', real=True)
   ...: h = -0**(t+1)/(t+1)
   ...: sings = singularities(h, t)
   ...: print(sings)
Interval(-oo, -1)
```


Previously:
```python
In [2]: from sympy.calculus.util import continuous_domain
   ...: domain = continuous_domain(h, t, S.Reals) # Should be (-1, oo)
   ...: print(domain)
Union(Interval.open(-oo, -1), Interval.open(-1, oo))
```

Now:
```python
In [2]: from sympy.calculus.util import continuous_domain
   ...: domain = continuous_domain(h, t, S.Reals)
   ...: print(domain)
Interval.open(-1, oo)
```


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * Fixes singularity detection in case of $f(t) \propto 0^t$.
    * Fixes therefore domains of continuity.
   
<!-- END RELEASE NOTES -->
