### PR TITLE
fix(solvers): _solve_inequality does not use solvify

### DIFF
--- a/doc/src/guides/solving/reduce-inequalities-algebraically.md
+++ b/doc/src/guides/solving/reduce-inequalities-algebraically.md
@@ -199,24 +199,6 @@ NotImplementedError: The inequality, -_y + x**2 - 4 < 0, cannot be solved using
 solve_univariate_inequality.
 ```
 
-### Not All Results Are Returned for Periodic Functions
-
-The results returned for trigonometric inequalities are restricted in its
-periodic interval. {func}`~.reduce_inequalities` tries to return just enough
-solutions so that all (infinitely many) solutions can generated from the
-returned solutions by adding integer multiples of the {func}`~.periodicity` of
-the equation, here $2\pi$.
-
-```py
->>> from sympy import reduce_inequalities, cos
->>> from sympy.abc import x, y
->>> from sympy.calculus.util import periodicity
->>> reduce_inequalities([2*cos(x) < 1, x > 0], x)
-(0 < x) & (x < oo) & (pi/3 < x) & (x < 5*pi/3)
->>> periodicity(2*cos(x), x)
-2*pi
-```
-
 ## Not All Systems of Inequalities Can Be Reduced
 
 ### Systems of Inequalities Which Cannot Be Satisfied

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -26,7 +26,7 @@ from sympy.printing import srepr
 from sympy.sets.contains import Contains
 from sympy.sets.sets import Interval
 from sympy.solvers.solvers import solve
-from sympy.testing.pytest import raises, slow
+from sympy.testing.pytest import raises, slow, XFAIL
 from sympy.utilities.lambdify import lambdify
 
 a, b, c, d, x, y = symbols('a:d, x, y')
@@ -1192,8 +1192,7 @@ def test__intervals():
     assert Piecewise((1, Ne(x, I)), (0, True))._intervals(x) == (True,
         [(-oo, oo, 1, 0)])
     assert Piecewise((-cos(x), sin(x) >= 0), (cos(x), True)
-        )._intervals(x) == (True,
-        [(0, pi, -cos(x), 0), (-oo, oo, cos(x), 1)])
+        )._intervals(x) == (False, False)
     # the following tests that duplicates are removed and that non-Eq
     # generated zero-width intervals are removed
     assert Piecewise((1, Abs(x**(-2)) > 1), (0, True)
@@ -1346,6 +1345,7 @@ def test_Piecewise_replace_relational_27538():
     assert p2.subs(y, 1) == 1
 
 
+@XFAIL
 def test_issue_14052():
     assert integrate(abs(sin(x)), (x, 0, 2*pi)) == 4
 

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -134,6 +134,7 @@ def test_issue_15925a():
     assert not integrate(sqrt((1+sin(x))**2+(cos(x))**2), (x, -pi/2, pi/2)).has(Integral)
 
 
+@XFAIL
 def test_issue_15925b():
     f = sqrt((-12*cos(x)**2*sin(x))**2+(12*cos(x)*sin(x)**2)**2)
     assert integrate(f, (x, 0, pi/6)) == Rational(3, 2)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -38,7 +38,7 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns
+from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns, XFAIL
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
@@ -685,8 +685,6 @@ def test_integrate_max_min():
     x = symbols('x', real=True)
     assert integrate(Min(x, 2), (x, 0, 3)) == 4
     assert integrate(Max(x**2, x**3), (x, 0, 2)) == Rational(49, 12)
-    assert integrate(Min(exp(x), exp(-x))**2, x) == Piecewise( \
-        (exp(2*x)/2, x <= 0), (1 - exp(-2*x)/2, True))
     # issue 7907
     c = symbols('c', extended_real=True)
     int1 = integrate(Max(c, x)*exp(-x**2), (x, -oo, oo))
@@ -694,6 +692,24 @@ def test_integrate_max_min():
     int3 = integrate(x*exp(-x**2), (x, c, oo))
     assert int1 == int2 + int3 == sqrt(pi)*c*erf(c)/2 + \
         sqrt(pi)*c/2 + exp(-c**2)/2
+
+
+@XFAIL
+def test_integrate_max_min_xfail():
+    x = symbols('x', real=True)
+    # ans = Piecewise((exp(2*x)/2, x <= 0), (1 - exp(-2*x)/2, True))
+    assert not integrate(Min(exp(x), exp(-x))**2, x).has(Integral)
+
+
+@XFAIL
+def test_abs_sin_xfail():
+    assert integrate(abs(sin(2*x)), (x, 0, 2*pi)) == 4
+
+
+def test_abs_sin():
+    # ideally this would be 4 (see XFAIL test above):
+    F = integrate(abs(sin(2*x)), (x, 0, 2*pi))
+    assert F == Integral(Piecewise((sin(2*x), sin(2*x) >= 0), (-sin(2*x), True)), (x, 0, 2*pi))
 
 
 def test_integrate_Abs_sign():

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -327,7 +327,7 @@ def reduce_abs_inequality(expr, rel, gen):
         elif expr.is_Pow:
             n = expr.exp
             if not n.is_Integer:
-                raise ValueError("Only Integer Powers are allowed on Abs.")
+                raise NotImplementedError("Only Integer Powers are allowed on Abs.")
 
             exprs.extend((expr**n, conds) for expr, conds in _bottom_up_scan(expr.base))
         elif isinstance(expr, Abs):
@@ -817,9 +817,14 @@ def _solve_inequality(ie, s, linear=False):
     except (PolynomialError, NotImplementedError):
         if not linear:
             try:
-                rv = reduce_rational_inequalities([[ie]], s)
+                rv = reduce_abs_inequality(ie.lhs - ie.rhs, ie.rel_op, s)
             except PolynomialError:
-                rv = solve_univariate_inequality(ie, s)
+                # XXX: Previously this would call solve_univariate_inequality
+                # but that leads to buggy results for integration of
+                # periodic piecewise functions. This should not call
+                # solve_univariate_inequality as long as it cannot handle
+                # periodic functions correctly.
+                raise NotImplementedError
             # remove restrictions wrt +/-oo that may have been
             # applied when using sets to simplify the relationship
             okoo = classify(ie, s, oo)

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -390,12 +390,16 @@ def test_issue_10198():
     assert reduce_inequalities(
         -1 + 1/abs(1/x - 1) < 0) == (x > -oo) & (x < S(1)/2) & Ne(x, 0)
 
-    assert reduce_inequalities(abs(1/sqrt(x)) - 1, x) == Eq(x, 1)
     assert reduce_abs_inequality(-3 + 1/abs(1 - 1/x), '<', x) == \
         Or(And(-oo < x, x < 0),
         And(S.Zero < x, x < Rational(3, 4)), And(Rational(3, 2) < x, x < oo))
-    raises(ValueError,lambda: reduce_abs_inequality(-3 + 1/abs(
+    raises(NotImplementedError,lambda: reduce_abs_inequality(-3 + 1/abs(
         1 - 1/sqrt(x)), '<', x))
+
+
+@XFAIL
+def test_issue_10198_xfail():
+    assert reduce_inequalities(abs(1/sqrt(x)) - 1, x) == Eq(x, 1)
 
 
 def test_issue_10047():
@@ -403,12 +407,17 @@ def test_issue_10047():
     # is not real the inequality is invalid
     # assert solve(sin(x) < 2) == (x <= oo)
 
-    # with PR 16956, (x <= oo) autoevaluates when x is extended_real
-    # which is assumed in the current implementation of inequality solvers
-    assert solve(sin(x) < 2) == True
+    # This no longer works when _solve_inequality no longer calls
+    # solve_univariate_inequality. It could be fixed in future if
+    # solve_univariate_inequality is fixed to handle periodic functions
+    # correctly:
+    with raises(NotImplementedError):
+        assert solve(sin(x) < 2)
+
     assert solveset(sin(x) < 2, domain=S.Reals) == S.Reals
 
 
+@XFAIL
 def test_issue_10268():
     assert solve(log(x) < 1000) == And(S.Zero < x, x < exp(1000))
 
@@ -487,6 +496,7 @@ def test__pt():
     raises(ValueError, lambda: _pt(Dummy('i', infinite=True), S.One))
 
 
+@XFAIL
 def test_issue_25697():
     assert _solve_inequality(log(x, 3) <= 2, x) == (x <= 9) & (S.Zero < x)
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -829,7 +829,8 @@ def test_solve_inequalities():
     assert solve((x - 3)/(x - 2) < 0, x) == And(Lt(2, x), Lt(x, 3))
     assert solve(x/(x + 1) > 1, x) == And(Lt(-oo, x), Lt(x, -1))
 
-    assert solve(sin(x) > S.Half) == And(pi/6 < x, x < pi*Rational(5, 6))
+    with raises(NotImplementedError):
+        solve(sin(x) > S.Half, x)
 
     assert solve(Eq(False, x < 1)) == (S.One <= x) & (x < oo)
     assert solve(Eq(True, x < 1)) == (-oo < x) & (x < 1)
@@ -1911,12 +1912,20 @@ def test_issues_6819_6820_6821_6248_8692_25777_25779():
     x = symbols('x')
     assert solve(2**x + 4**x) == [I*pi/log(2)]
 
-def test_issue_17638():
 
+@XFAIL
+def test_issue_17638_xfail1():
     assert solve(((2-exp(2*x))*exp(x))/(exp(2*x)+2)**2 > 0, x) == (-oo < x) & (x < log(2)/2)
-    assert solve(((2-exp(2*x)+2)*exp(x+2))/(exp(x)+2)**2 > 0, x) == (-oo < x) & (x < log(4)/2)
-    assert solve((exp(x)+2+x**2)*exp(2*x+2)/(exp(x)+2)**2 > 0, x) == (-oo < x) & (x < oo)
 
+
+@XFAIL
+def test_issue_17638_xfail2():
+    assert solve(((2-exp(2*x)+2)*exp(x+2))/(exp(x)+2)**2 > 0, x) == (-oo < x) & (x < log(4)/2)
+
+
+@XFAIL
+def test_issue_17638_xfail3():
+    assert solve((exp(x)+2+x**2)*exp(2*x+2)/(exp(x)+2)**2 > 0, x) == (-oo < x) & (x < oo)
 
 
 def test_issue_14607():

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -2,7 +2,7 @@ from sympy.core.numbers import pi
 from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, XFAIL
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.integrals import ParametricIntegral, vector_integrate
 from sympy.vector.parametricregion import ParametricRegion
@@ -30,12 +30,13 @@ def test_parametric_lineintegrals():
     field2 = C.y*C.i + C.z*C.j + C.z*C.k
     assert ParametricIntegral(field2, ParametricRegion((cos(t), sin(t), t**2), (t, 0, pi))) == -5*pi/2 + pi**4/2
 
-def test_parametric_surfaceintegrals():
-
+@XFAIL
+def test_parametric_surfaceintegrals_xfail():
     semisphere = ParametricRegion((2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi)),\
                             (theta, 0, 2*pi), (phi, 0, pi/2))
     assert ParametricIntegral(C.z, semisphere) == 8*pi
 
+def test_parametric_surfaceintegrals():
     cylinder = ParametricRegion((sqrt(3)*cos(theta), sqrt(3)*sin(theta), z), (z, 0, 6), (theta, 0, 2*pi))
     assert ParametricIntegral(C.y, cylinder) == 0
 


### PR DESCRIPTION
Previously _solve_inequality would call solve_univariate_inequality which would call solvify. This is incorrect because solvify (much like solve) does not handle periodic functions correctly. This commit at least makes it so that _solve_inequality does not call these mathematically incorrect codepaths which fixes wrong results otherwise seen for some integrals.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes gh-28400 and gh-27379 and likely many other issues involving integrals and Piecewise/Abs.

#### Brief description of what is fixed or changed

Some tests are changed. In some cases the tests themselves were incorrect. In others they are correct but were only previously computed by depending on the buggy `solve_univariate_inequality` codepath.

#### Other comments

Future PRs can make improvements to `solve_univariate_inequality` so that it no longer calls `solvify` but it is important for now to eliminate this code path altogether so that it prevents mathematically incorrect integrals even if there are some cases where this also prevents the evaluation of correct integrals.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * A bug leading to mathematically incorrect integrals involving periodic Piecewise functions (e.g. `abs(sin(x))`) was fixed. This means that some integrals will remain unevaluated rather than returning (potentially) mathematically incorrect results. In some cases this means that integrals that previously happened to be computed correctly will now remain unevaluated.
<!-- END RELEASE NOTES -->
