### PR TITLE
Fix small issues related to tensors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1747,6 +1747,7 @@ oittaa <8972248+oittaa@users.noreply.github.com>
 omahs <73983677+omahs@users.noreply.github.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
+phipf <phipf@online.de>
 platypus <platypus.computerchip@gmail.com>
 prshnt19 <prashant.rawat216@gmail.com>
 rahuldan <rahul02013@gmail.com>

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1269,7 +1269,7 @@ class PrettyPrinter(Printer):
         return self._print(out_expr)
 
     def _printer_tensor_indices(self, name, indices, index_map={}):
-        center = stringPict(name)
+        center = stringPict(pretty_symbol(name))
         top = stringPict(" "*center.width())
         bot = stringPict(" "*center.width())
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7286,6 +7286,7 @@ def test_pretty_print_tensor_expr():
     i, j, k = tensor_indices("i j k", L)
     i0 = tensor_indices("i_0", L)
     A, B, C, D = tensor_heads("A B C D", [L])
+    A0 = tensor_heads("A_0", [L])
     H = TensorHead("H", [L, L])
 
     expr = -i
@@ -7328,6 +7329,22 @@ A   \n\
  i₀\n\
 A  \n\
    \
+"""
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = A0(i0)
+    ascii_str = \
+"""\
+   i_0\n\
+A_0   \n\
+      \
+"""
+    ucode_str = \
+"""\
+  i₀\n\
+A₀  \n\
+    \
 """
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -46,6 +46,7 @@ from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
 from sympy.core.cache import clear_cache
 from sympy.core.containers import Tuple, Dict
+from sympy.core.decorators import call_highest_priority
 from sympy.core.function import WildFunction
 from sympy.core.sorting import default_sort_key
 from sympy.core.symbol import Symbol, symbols, Wild
@@ -2014,18 +2015,23 @@ class TensExpr(Expr, ABC):
     def __abs__(self):
         raise NotImplementedError
 
+    @call_highest_priority('__radd__')
     def __add__(self, other):
         return TensAdd(self, other).doit(deep=False)
 
+    @call_highest_priority('__add__')
     def __radd__(self, other):
         return TensAdd(other, self).doit(deep=False)
 
+    @call_highest_priority('__rsub__')
     def __sub__(self, other):
         return TensAdd(self, -other).doit(deep=False)
 
+    @call_highest_priority('__sub__')
     def __rsub__(self, other):
         return TensAdd(other, -self).doit(deep=False)
 
+    @call_highest_priority('__rmul__')
     def __mul__(self, other):
         """
         Multiply two tensors using Einstein summation convention.
@@ -2051,9 +2057,11 @@ class TensExpr(Expr, ABC):
         """
         return TensMul(self, other).doit(deep=False)
 
+    @call_highest_priority('__mul__')
     def __rmul__(self, other):
         return TensMul(other, self).doit(deep=False)
 
+    @call_highest_priority('__rtruediv__')
     def __truediv__(self, other):
         other = _sympify(other)
         if isinstance(other, TensExpr):

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1306,6 +1306,14 @@ def test_op_priority():
         def __init__(self, name):
             self.name = name
 
+        # The following definitions are required to satisfy mypy.
+
+        def subs():
+            pass
+
+        def simplify():
+            pass
+
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_name='L')
     a = tensor_indices('a', Lorentz)
     p = tensor_heads('p', [Lorentz])


### PR DESCRIPTION
#### References to other Issues or PRs

None. My searches did not yield any corresponding issues.


#### Brief description of what is fixed or changed

1. The `_op_priority` mechanism was broken for tensors, because binary special methods were not decorated with `call_highest_priority`.
2. Tensor heads are pretty-printed.

#### Other comments

*Regarding 1.*: The decorator is not added to `__rtruediv__`, because it seems desirable to always raise an error for a division by a tensor. It is also not added to `__pow__` and `__rpow__`, because powers of objects with co- and contravariant indices seem somewhat questionable in the first place, which I guess is the reason why these methods are not (fully) implemented.

*Regarding 2.*: I considered possible confusions with tensor indices and Unicode subscripts and superscripts, but since the former are printed in the lines above and below the head and clearly have a different size, I don't see this as a problem.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* tensor
  * Fixed the `_op_priority` mechanism for `TensExpr`.

* printing
  * Enabled pretty-printing for tensor heads.

<!-- END RELEASE NOTES -->
