### PR TITLE
Avoid test_pretty_no_wrap_line failure on large screens

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -277,6 +277,7 @@ Alexander Bentkamp <bentkamp@gmail.com>
 Alexander Cockburn <alexander_cockburn12@hotmail.com>
 Alexander Dunlap <alexander.dunlap@gmail.com>
 Alexander Eberspächer <alex.eberspaecher@gmail.com>
+Alexander Grund <alexander.grund@tu-dresden.de> Alexander Grund <Flamefire@users.noreply.github.com>
 Alexander Hirzel <alex@hirzel.us>
 Alexander Pozdneev <pozdneev@users.noreply.github.com>
 Alexander Puck Neuwirth <alexander@neuwirth-informatik.de> Alexander Puck Neuwirth <APN-Pucky@users.noreply.github.com>

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5342,7 +5342,7 @@ def test_pretty_class():
 
 def test_pretty_no_wrap_line():
     huge_expr = 0
-    for i in range(20):
+    for i in range(50):
         huge_expr += i*sin(i + x)
     assert xpretty(huge_expr            ).find('\n') != -1
     assert xpretty(huge_expr, wrap_line=False).find('\n') == -1

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5342,10 +5342,10 @@ def test_pretty_class():
 
 def test_pretty_no_wrap_line():
     huge_expr = 0
-    for i in range(50):
+    for i in range(20):
         huge_expr += i*sin(i + x)
-    assert xpretty(huge_expr            ).find('\n') != -1
-    assert xpretty(huge_expr, wrap_line=False).find('\n') == -1
+    assert xpretty(huge_expr, num_columns=80            ).find('\n') != -1
+    assert xpretty(huge_expr, num_columns=80, wrap_line=False).find('\n') == -1
 
 
 def test_settings():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

20 expressions don't seem to be enough to ensure line wrapping happens reliably.

Test fails on an 2560x1440 screen with a full screen console but succeeds when shrinking the console

This disables the screen-width detection in the call done in the test such that the behavior is consistent


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
