### PR TITLE
[RingSeries]: Support higher-precision series elements beyond ring precision

### DIFF
--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -89,6 +89,10 @@ class PowerSeriesRingProto(Protocol[TSeries, Er]):
         """Create a power series from a list of coefficients."""
         ...
 
+    def from_element(self, s: TSeries, /) -> TSeries:
+        """Convert a power series element into the corresponding element of this ring."""
+        ...
+
     def to_list(self, s: TSeries, /) -> list[Er]:
         """Return the coefficients of a power series as a list."""
         ...

--- a/sympy/polys/series/ring.py
+++ b/sympy/polys/series/ring.py
@@ -241,6 +241,21 @@ class PowerSeriesRingRing(Generic[Er]):
         """Convert a lower power series element to a PowerSeriesElement."""
         return PowerSeriesElement(self, element)
 
+    def from_powerserieselement(
+        self, element: PowerSeriesElement[Er]
+    ) -> PowerSeriesElement[Er]:
+        """Convert a power series element to a power series element."""
+        R = self.ring
+        sprec = element.prec
+
+        if sprec is None:
+            s = R(R.to_list(element.series))
+        else:
+            prec = min(self.prec, sprec)
+            s = R(R.to_list(element.series), prec)
+
+        return self.from_element(s)
+
     def from_int(self, arg: int) -> PowerSeriesElement[Er]:
         """Convert an integer to a power series element."""
         g = self.domain_new(arg)
@@ -290,19 +305,7 @@ class PowerSeriesRingRing(Generic[Er]):
     ) -> PowerSeriesElement[Er]:
         """Create a power series element from various types."""
         if isinstance(arg, PowerSeriesElement):
-            R = self.ring
-            if R == arg.ring:
-                return arg
-
-            sprec = arg.prec
-            if sprec is None:
-                prec = self.prec
-            else:
-                prec = min(self.prec, sprec)
-
-            s = R(R.to_list(arg.series), prec)
-            return self.from_element(s)
-
+            return self.from_powerserieselement(arg)
         elif isinstance(arg, Expr):
             return self.from_expr(arg)
         elif isinstance(arg, int):

--- a/sympy/polys/series/ring.py
+++ b/sympy/polys/series/ring.py
@@ -244,16 +244,9 @@ class PowerSeriesRingRing(Generic[Er]):
     def from_powerserieselement(
         self, element: PowerSeriesElement[Er]
     ) -> PowerSeriesElement[Er]:
-        """Convert a power series element to a power series element."""
+        """Convert a power series element into the corresponding element of this ring."""
         R = self.ring
-        sprec = element.prec
-
-        if sprec is None:
-            s = R(R.to_list(element.series))
-        else:
-            prec = min(self.prec, sprec)
-            s = R(R.to_list(element.series), prec)
-
+        s = R.from_element(element.series)
         return self.from_element(s)
 
     def from_int(self, arg: int) -> PowerSeriesElement[Er]:

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -11,6 +11,7 @@ from sympy.external.gmpy import GROUND_TYPES, MPZ, MPQ
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.polys.polyerrors import NotReversible
 
+_require_flint_version = False
 
 if TYPE_CHECKING:
     from flint import fmpq_poly, fmpq_series, fmpz_poly, fmpz_series, ctx  # type: ignore
@@ -18,6 +19,15 @@ if TYPE_CHECKING:
 elif GROUND_TYPES == "flint":
     from flint import fmpq_poly, fmpq_series, fmpz_poly, fmpz_series, ctx
     from flint.utils.flint_exceptions import DomainError
+
+    # Required in specific cases where the 0.8 implementation provides faster
+    # performance for working with Flint series methods.
+    # This can be removed when python-flint 0.8 becomes the minimum supported version.
+    import flint
+
+    _major, _minor, *_ = flint.__version__.split(".")
+    if (int(_major), int(_minor)) >= (0, 8):
+        _require_flint_version = True
 else:
     fmpq_poly = fmpq_series = fmpz_poly = fmpz_series = ctx = None
 
@@ -207,6 +217,20 @@ class FlintPowerSeriesRingZZ:
             prec = self._prec
 
         return fmpz_series(coeffs, prec=prec)
+
+    def from_element(self, s: ZZSeries) -> ZZSeries:
+        """Convert a power series element into the corresponding element of this ring."""
+        ring_prec = self._prec
+        if isinstance(s, fmpz_poly):
+            if s.degree() >= ring_prec:
+                return fmpz_series(s, prec=ring_prec)
+            return s
+
+        prec = min(_get_series_precision(s), ring_prec)
+        if _require_flint_version:
+            return fmpz_series(s, prec=prec)
+        else:
+            return fmpz_series(s.coeffs(), prec=prec)
 
     def to_list(self, s: ZZSeries) -> list[MPZ]:
         """Returns the list of series coefficients."""
@@ -652,6 +676,20 @@ class FlintPowerSeriesRingQQ:
             prec = self._prec
 
         return fmpq_series(coeffs, prec=prec)
+
+    def from_element(self, s: QQSeries) -> QQSeries:
+        """Convert a power series element into the corresponding element of this ring."""
+        ring_prec = self._prec
+        if isinstance(s, fmpq_poly):
+            if s.degree() >= ring_prec:
+                return fmpq_series(s, prec=ring_prec)
+            return s
+
+        prec = min(_get_series_precision(s), ring_prec)
+        if _require_flint_version:
+            return fmpq_series(s, prec=prec)
+        else:
+            return fmpq_series(s.coeffs(), prec=prec)
 
     def to_list(self, s: QQSeries) -> list[MPQ]:
         """Returns the list of series coefficients."""

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -205,8 +205,6 @@ class FlintPowerSeriesRingZZ:
             if len(coeffs) <= self._prec:
                 return fmpz_poly(coeffs)
             prec = self._prec
-        else:
-            prec = min(prec, self._prec)
 
         return fmpz_series(coeffs, prec=prec)
 
@@ -652,8 +650,6 @@ class FlintPowerSeriesRingQQ:
             if len(coeffs) <= self._prec:
                 return fmpq_poly(coeffs)
             prec = self._prec
-        else:
-            prec = min(prec, self._prec)
 
         return fmpq_series(coeffs, prec=prec)
 

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -54,7 +54,7 @@ def _useries(
 
     prec = min(series_prec, ring_prec)
     if deg < prec:
-        return coeffs, series_prec
+        return coeffs, prec
 
     coeffs = dup_truncate(coeffs, prec, dom)
     return coeffs, prec

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -1194,8 +1194,6 @@ class PythonPowerSeriesRingZZ:
                 return coeffs, None
             else:
                 prec = self._prec
-        else:
-            prec = min(prec, self._prec)
 
         if len(coeffs) > prec:
             coeffs = dup_truncate(coeffs, prec, self._domain)
@@ -1462,8 +1460,6 @@ class PythonPowerSeriesRingQQ:
                 return coeffs, None
             else:
                 prec = self._prec
-        else:
-            prec = min(prec, self._prec)
 
         if len(coeffs) > prec:
             coeffs = dup_truncate(coeffs, prec, self._domain)

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -1200,6 +1200,11 @@ class PythonPowerSeriesRingZZ:
 
         return coeffs, prec
 
+    def from_element(self, s: USeries[MPZ]) -> USeries[MPZ]:
+        """Convert a power series element into the corresponding element of this ring."""
+        coeffs, prec = s
+        return _useries(coeffs, prec, self._domain, self._prec)
+
     def to_list(self, s: USeries[MPZ]) -> list[MPZ]:
         """Returns the list of series coefficients."""
         coeffs, _ = s
@@ -1465,6 +1470,11 @@ class PythonPowerSeriesRingQQ:
             coeffs = dup_truncate(coeffs, prec, self._domain)
 
         return coeffs, prec
+
+    def from_element(self, s: USeries[MPQ]) -> USeries[MPQ]:
+        """Convert a power series element into the corresponding element of this ring."""
+        coeffs, prec = s
+        return _useries(coeffs, prec, self._domain, self._prec)
 
     def to_list(self, s: USeries[MPQ]) -> list[MPQ]:
         """Return the list of series coefficients."""

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -1324,6 +1324,10 @@ def test_PowerSeriesRing_ring_new():
 
     assert R.ring_new(y + y**2 + y**3).ring == R.ring
     assert R.ring_new(y + y**2 + y**3) == R.from_list([QQ(0), QQ(1), QQ(1)], 3)
+    assert (
+        R3.ring_new(R3.from_list([QQ(0), QQ(1), QQ(1), QQ(1)], 4))
+        == y + y**2 + R3.order_term()
+    )
     assert R3.ring_new(x + x**4 + x**5) == y + R3.order_term()
 
 

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -1315,9 +1315,16 @@ def test_PowerSeriesRing_from_expr():
 
 def test_PowerSeriesRing_ring_new():
     R = PowerSeriesRingRing(QQ, "x", 5)
+    R3 = PowerSeriesRingRing(QQ, "y", 3)
+    x = R.gen
+    y = R3.gen
 
     assert R.ring_new(QQ(7)) == R.from_ground(QQ(7))
     assert R.ring_new(3) == R.from_int(3)
+
+    assert R.ring_new(y + y**2 + y**3).ring == R.ring
+    assert R.ring_new(y + y**2 + y**3) == R.from_list([QQ(0), QQ(1), QQ(1)], 3)
+    assert R3.ring_new(x + x**4 + x**5) == y + R3.order_term()
 
 
 def test_PowerSeriesRing_arith(groundring_int):

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -115,7 +115,7 @@ def test_basics(ring_int):
     assert R.series_prec(R([1, 2, 3])) == None
     assert R.series_prec(R([1, 2, 3], None)) == None
     assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7])) == 6
-    assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 6
+    assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 10
 
 
 def test_positive(ring_int):


### PR DESCRIPTION
#### References to other Issues or PRs
PR #28325

#### Brief description of what is changed
This change enables the creation of series elements with precision higher than the ring’s default. However, all operations on these elements continue to respect the ring’s working precision.


#### Other comments
https://github.com/sympy/sympy/pull/28325#issuecomment-3228641402

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
