### PR TITLE
Remove Aesara from  CI checks

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -168,11 +168,6 @@ jobs:
       - run: sudo apt-get install antlr4 clang
       - run: python -m pip install --upgrade pip wheel setuptools
 
-      # XXX: Deprecate and remove support for aesara.
-      # For now it pins the numpy version and so doesn't work on 3.13.
-      - if: ${{ ! contains(matrix.python-version, '3.13') }}
-        run: pip install aesara
-
       # dependencies to install in all Python versions:
       - run: pip install numpy numexpr matplotlib bpython ipython cython  \
                          wurlitzer autowrap lxml lark z3-solver pycosat   \

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -35,9 +35,6 @@ test_list = [
     # llvmlite
     '*llvm*',
 
-    # aesara
-    '*aesara*',
-
     # jax
     '*jax*',
 
@@ -96,9 +93,6 @@ doctest_list = [
 
     # llvmlite
     '*llvm*',
-
-    # aesara
-    '*aesara*',
 
     # gmpy
     'sympy/ntheory',


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
closes #28413
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Removed Aesara  from the optional dependency CI checks because they are unmaintained and cause test failures.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
