### PR TITLE
Fix: ask(Q.real(Pow(0, -1, evaluate=False))) returns False (#28150)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1803,3 +1804,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Aryan Bajpai <aryanbajpai499@gmail.com> <aryan.bajpai.cd.ece23@itbhu.ac.in>
+Aryan Bajpai <aryanbajpai499@gmail.com> <117530164+aryan98795@users.noreply.github.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -230,6 +230,13 @@ def _(expr, assumptions):
 # RealPredicate
 
 def _RealPredicate_number(expr, assumptions):
+    # Special case: 0**negative -> undefined (not real)
+    from sympy import Pow
+    if isinstance(expr, Pow):
+        b, e = expr.args
+        if b.is_zero and e.is_negative:
+            return False
+
     # let as_real_imag() work first since the expression may
     # be simpler to evaluate
     i = expr.as_real_imag()[1].evalf(2)
@@ -237,6 +244,7 @@ def _RealPredicate_number(expr, assumptions):
         return not i
     # allow None to be returned if we couldn't show for sure
     # that i was 0
+
 
 @RealPredicate.register_many(Abs, Exp1, Float, GoldenRatio, im, Pi, Rational,
     re, TribonacciConstant)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2569,3 +2569,7 @@ def test_issue_25221():
 def test_issue_27440():
     nan = S.NaN
     assert ask(Q.negative(nan)) is None
+
+def test_issue_28150():
+    from sympy import Pow, Q, ask
+    assert ask(Q.real(Pow(0, -1, evaluate=False))) is False


### PR DESCRIPTION
Fix ask(Q.real(Pow(0, -1, evaluate=False))) returning True

Fixes #28150

The issue where ask(Q.real(Pow(0, -1, evaluate=False))) incorrectly returned True has been fixed. 
A special case was added in _RealPredicate_number to handle zero to a negative power. 
A new test was added in assumptions/tests/test_query.py to ensure the correct behavior.

  * Fixed bug where ask(Q.real(Pow(0, -1, evaluate=False))) returned True. Now returns False.

<img width="981" height="576" alt="image" src="https://github.com/user-attachments/assets/b72636c1-cc84-4b1d-b98f-e87095b41026" />

<img width="965" height="408" alt="image" src="https://github.com/user-attachments/assets/9f065957-9447-4194-ac15-0fa578407404" />
<img width="1226" height="526" alt="image" src="https://github.com/user-attachments/assets/81d01050-b8c2-4820-9ea4-7e01c2504178" />

updated function

<img width="686" height="379" alt="image" src="https://github.com/user-attachments/assets/e7547eca-bf35-4c6e-9d1e-2c477a76fea0" />

old function 
<img width="635" height="202" alt="image" src="https://github.com/user-attachments/assets/4b20b7bc-84b1-4f4f-80e7-1903e610c99e" />

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed bug where ask(Q.real(Pow(0, -1, evaluate=False))) returned True. Now returns False.
<!-- END RELEASE NOTES -->

