### PR TITLE
Various fixes to the Risch algorithm

### DIFF
--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -17,7 +17,7 @@ each function for more information.
 import itertools
 from functools import reduce
 
-from sympy.core.intfunc import ilcm
+from sympy.core.intfunc import ilcm, igcd
 from sympy.core import Dummy, Add, Mul, Pow, S
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     bound_degree)
@@ -875,6 +875,31 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
 
     The argument w == Dtheta/theta
     """
+    # Note: ideally the code here should let n = 1 whenever possible, as the
+    # check in special_denom() only succeeds in that case.
+
+    # Special case when f and w are rational numbers (not in the book, but
+    # this fails this heuristic and comes up often enough to add here). In
+    # this case, we can set z = 0.
+    f = fa.as_expr()/fd.as_expr()
+    w = wa.as_expr()/wd.as_expr()
+    if f.is_Rational and w.is_Rational:
+        # solve n*x = m*y in integers, i.e., n=y, m=x (after dividing through
+        # by gcd(x, y))
+        x = f.p*w.q
+        y = w.p*f.q
+        g = igcd(x, y)
+        x //=g
+        y //=g
+        n = y
+        m = x
+        if n == 0:
+            return None
+        if n < 0:
+            n = -n
+            m = -m
+        return (n, m, Poly(1, DE.t))
+
     # TODO: finish writing this and write tests
     c1 = c1 or Dummy('c1')
 

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -917,7 +917,7 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
     ln, ls = splitfactor(l, DE)
     z = ls*ln.gcd(ln.diff(DE.t))
 
-    if not z.has(DE.t):
+    if z.degree(DE.t) < 1:
         # TODO: We treat this as 'no solution', until the structure
         # theorem version of parametric_log_deriv is implemented.
         return None

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1509,7 +1509,13 @@ def integrate_hyperexponential_polynomial(p, DE, z):
             except NonElementaryIntegralException:
                 b = False
             else:
-                qa = qa*vd + va*Poly(t1**i)*qd
+                # q += v*t**i
+                if i > 0:
+                    ti = Poly(t1**i, t1)
+                else:
+                    ti = Poly(z**-i, z)
+
+                qa = qa*vd + va*ti*qd
                 qd *= vd
 
     return (qa, qd, b)
@@ -1534,7 +1540,7 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
     """
     # XXX: a and d must be canceled, or this might return incorrect results
     z = z or Dummy("z")
-    s = list(zip(reversed(DE.T), reversed([f(DE.x) for f in DE.Tfuncs])))
+    s = [(z, DE.t**-1)] + list(zip(reversed(DE.T), reversed([f(DE.x) for f in DE.Tfuncs])))
 
     g1, h, r = hermite_reduce(a, d, DE)
     g2, b = residue_reduce(h[0], h[1], DE, z=z)

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -320,3 +320,12 @@ def test_parametric_log_deriv():
     assert parametric_log_deriv_heu(Poly(5*t**2 + t - 6, t), Poly(2*x*t**2, t),
     Poly(-1, t), Poly(x*t**2, t), DE) == \
         (2, 6, t*x**5)
+
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
+    assert parametric_log_deriv_heu(Poly(-1, x), Poly(1, x), Poly(1, x),
+    Poly(1, x), DE) ==\
+        (1, -1, Poly(1, x))
+
+    assert parametric_log_deriv_heu(Poly(-2, x), Poly(5, x), Poly(2, x),
+    Poly(3, x), DE) ==\
+        (5, -3, Poly(1, x))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -95,6 +95,13 @@ def test_special_denom():
     raises(ValueError, lambda: special_denom(Poly(1, t), Poly(t**2, t), Poly(1, t), Poly(t**2 - 1, t),
     Poly(t, t), DE, case='unrecognized_case'))
 
+    # Example 6.2.1
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    a = Poly(t**2 + 2*x*t + x**2, t)
+    b = Poly((1 + 1/x**2)*t**2 + (2*x - 1 + 2/x)*t + x**2, t)
+    c = Poly(t/x**2 - 1 + 2/x, t)
+    assert special_denom(a, b, Poly(1, t), c, Poly(1, t), DE) == \
+        (a, Poly(t**2/x**2 + (2/x - 1)*t, t), Poly(t**2/x**2 + (2/x - 1)*t, t), Poly(t, t))
 
 def test_bound_degree_fail():
     # Primitive

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -207,3 +207,11 @@ def test_rischDE():
     assert rischDE(Poly(-2*x, x), Poly(1, x), Poly(1 - 2*x - 2*x**2, x),
     Poly(1, x), DE) == \
         (Poly(x + 1, x), Poly(1, x))
+
+    # See issue 28407
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    fa = Poly(-t + 1, t)
+    fd = Poly(1, t)
+    ga = Poly(1, t)
+    gd = Poly(1, t)
+    assert rischDE(fa, fd, ga, gd, DE) == (Poly(-1, t), Poly(t, t))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -703,6 +703,9 @@ def test_risch_integrate():
     assert risch_integrate(log(x**y), x) == x*log(x**y) - x*y
     assert risch_integrate(log(sqrt(x)), x) == x*log(sqrt(x)) - x/2
 
+    # Example 6.2.1
+    expr = (exp(x) - x**2 + 2*x)/((exp(x) + x)**2*x**2)*exp((x**2 - 1)/x + 1/(exp(x) + x))
+    assert risch_integrate(expr, x) == exp(-x)*exp(1/(x + exp(x)) + (x**2 - 1)/x)
 
 def test_risch_integrate_float():
     assert risch_integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) == -2.4*exp(8*x) - 12.0*exp(5*x)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -707,6 +707,23 @@ def test_risch_integrate():
     expr = (exp(x) - x**2 + 2*x)/((exp(x) + x)**2*x**2)*exp((x**2 - 1)/x + 1/(exp(x) + x))
     assert risch_integrate(expr, x) == exp(-x)*exp(1/(x + exp(x)) + (x**2 - 1)/x)
 
+    # issue 28407
+    # TODO: exp(exp(x)) - exp(-exp(x)) would be a simpler return form
+    expr = exp(x + exp(x)) + exp(x - exp(x))
+    assert risch_integrate(expr, x) == \
+        (exp(2*x)*exp(-x + exp(x)) - exp(x - exp(x)))*exp(-x)
+
+    # Ensure the results from integrate_hyperexponential() are in a simple
+    # form, i.e., this doesn't return something like (1 + exp(-2*x))*exp(x)/2
+
+    # sinh(x).rewrite(exp)
+    expr = exp(x)/2 - exp(-x)/2
+    assert risch_integrate(expr, x) == exp(x)/2 + exp(-x)/2
+
+    # sin(x).rewrite(exp)
+    expr = -I*(exp(I*x) - exp(-I*x))/2
+    assert risch_integrate(expr, x) == -exp(I*x)/2 - exp(-I*x)/2
+
 def test_risch_integrate_float():
     assert risch_integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) == -2.4*exp(8*x) - 12.0*exp(5*x)
 


### PR DESCRIPTION
See the commits and the discussion in #28407 for more details. 

Some examples of integrals that now work, which previously did not. 

```py
>>> pprint(integrate(exp(x + exp(x)) + exp(x - exp(x)), x))
⎛            x         x⎞
⎜ 2⋅x  -x + ℯ     x - ℯ ⎟  -x
⎝ℯ   ⋅ℯ        - ℯ      ⎠⋅ℯ
>>> expr = (exp(x) - x**2 + 2*x)/((exp(x) + x)**2*x**2)*exp((x**2 - 1)/x + 1/(exp(x) + x))
>>> pprint(integrate(expr, x))
               2
       1      x  - 1
     ────── + ──────
          x     x
 -x  x + ℯ
ℯ  ⋅ℯ
```

A note: there is one issue discussed in #28407 which is not addressed here, which is that some of the internal routines of the Risch algorithm use heuristic checks (notably `parametric_log_deriv_heu`). When these checks fail, sometimes this triggers code in other functions which assume that the result has no solution, and they return NonElementyIntegral. The result is that sometimes risch_integrate might return a NonElementaryIntegral for integrals that are actually elementary, just not yet implemented. This could be fixed by making these heuristic routines raise NotImplementedError instead of returning None. However, I haven't done that here, as it's possible this would make some integrals that currently work stop working, and it requires more investigation to determine if this is worth it. Alternatively, the code could be modified to better carry through information whether an integral is proved nonelementary or just failed a heuristic, but this would require some refactoring as this is not presently something the code allows for. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28407.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - Some improvements to the Risch algorithm that makes some integrals involving exponentials work now. 
<!-- END RELEASE NOTES -->
