### PR TITLE
sympy/assumptions/handlers/sets.py _RealPredicate_number 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1150,6 +1150,7 @@ Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
+Noah Rosenberger <noahrosenberger@ufl.edu>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Oldrich Klimanek <oldrich.klimanek@gmail.com> Oldrich Klimanek <oldrich.klimanek@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1150,6 +1150,7 @@ Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
+Noah Rosenberger <noahjberger@icloud.com> <noahrosenberger@ufl.edu>
 Noah Rosenberger <noahrosenberger@ufl.edu>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -230,7 +230,7 @@ def _(expr, assumptions):
 # RealPredicate
 
 def _RealPredicate_number(expr, assumptions):
-    evaluated = expr.doit()  # force evaluation like 0**-1 → zoo
+    evaluated = expr.doit()  # force evaluation like 0**-1 -> zoo
 
     # let as_real_imag() work first since the expression may
     # be simpler to evaluate

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -230,9 +230,11 @@ def _(expr, assumptions):
 # RealPredicate
 
 def _RealPredicate_number(expr, assumptions):
+    evaluated = expr.doit()  # force evaluation like 0**-1 → zoo
+
     # let as_real_imag() work first since the expression may
     # be simpler to evaluate
-    i = expr.as_real_imag()[1].evalf(2)
+    i = evaluated.as_real_imag()[1].evalf(2)
     if i._prec != 1:
         return not i
     # allow None to be returned if we couldn't show for sure


### PR DESCRIPTION
Fixes #28150 

ask(Q.real(Pow(0, -1, evaluate=False))) # gives True wrongly


I added a line so the passed-in expression is now evaluated before being sent to as_real_imag(). This will fix the error evaluated=False creates in the Pow functions.



<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
