### PR TITLE
feat(assumptions): extend ask(Q.integer(x ** y), ...) to more cases

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -71,8 +71,14 @@ def _(expr, assumptions):
     if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
-        if ask_any(Q.positive(expr.exp), Q.nonnegative(expr.exp) & ~Q.zero(expr.base), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
+        neg_exp = ask(Q.negative(expr.exp), assumptions)
+        if  neg_exp is False:
             return True
+        base_pm_1 = ask_any( Q.zero(expr.base - 1), Q.zero(expr.base + 1), assumptions=assumptions)
+        if base_pm_1:
+            return True
+        if neg_exp and base_pm_1 is False:
+            return False
 
 @IntegerPredicate.register(Mul)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1694,6 +1694,8 @@ def test_integer():
     assert ask(Q.integer(x**y), Q.zero(x) & Q.integer(y) & Q.positive(y)) is True
     assert ask(Q.integer(pi**x), Q.zero(x)) is True
     assert ask(Q.integer(x**y), Q.imaginary(x) & Q.zero(y)) is True
+    assert ask(Q.integer(x ** y), Q.integer(x) & Q.integer(y) & ~Q.negative(y)) is True
+    assert ask(Q.integer(x ** y), Q.integer(x) & Q.integer(y) & Q.negative(y) & ~Q.zero(x-1) & ~Q.zero(x+1)) is False
 
 
 def test_negative():


### PR DESCRIPTION
The following give True and False instead of None respectively:

- ask(Q.integer(x ** y), Q.integer(x) & Q.integer(y) & ~Q.negative(y))
- ask(Q.integer(x ** y), Q.integer(x) & Q.integer(y) & Q.negative(y))



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * extend ask(Q.integer(x ** y), ...) to more cases 

<!-- END RELEASE NOTES -->
