### PR TITLE
Fix eigenvals() slowness when eigenvalues include CRootOf

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -261,7 +261,7 @@ def _eigenvals_list(
         for factor, multiplicity in factors:
             eigs = roots(factor, multiple=True, **flags)
 
-            degree = factor.degree()
+            degree = int(factor.degree())
             if len(eigs) != degree:
                 f = factor.as_expr()
                 x = factor.gen
@@ -309,10 +309,11 @@ def _eigenvals_dict(
             charpoly = block.charpoly()
 
         factors = charpoly.factor_list()[1]
+
         for factor, multiplicity in factors:
             eigs = roots(factor, multiple=False, **flags)
 
-            degree = factor.degree()
+            degree = int(factor.degree())
             if sum(eigs.values()) != degree:
                 degree = int(factor.degree())
                 f = factor.as_expr()

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -256,18 +256,24 @@ def _eigenvals_list(
         else:
             charpoly = block.charpoly()
 
-        eigs = roots(charpoly, multiple=True, **flags)
+        factors = charpoly.factor_list()[1]
 
-        if len(eigs) != block.rows:
-            try:
-                eigs = charpoly.all_roots(multiple=True)
-            except NotImplementedError:
-                if error_when_incomplete:
-                    raise MatrixError(eigenvals_error_message)
-                else:
-                    eigs = []
+        for factor, multiplicity in factors:
+            eigs = roots(factor, multiple=True, **flags)
 
-        all_eigs += eigs
+            degree = factor.degree()
+            if len(eigs) != degree:
+                f = factor.as_expr()
+                x = factor.gen
+                try:
+                    eigs = [CRootOf(f, x, idx) for idx in range(degree)]
+                except NotImplementedError:
+                    if error_when_incomplete:
+                        raise MatrixError(eigenvals_error_message)
+                    else:
+                        eigs = []
+
+            all_eigs += eigs * multiplicity
 
     if not simplify:
         return all_eigs
@@ -302,22 +308,29 @@ def _eigenvals_dict(
         else:
             charpoly = block.charpoly()
 
-        eigs = roots(charpoly, multiple=False, **flags)
+        factors = charpoly.factor_list()[1]
+        for factor, multiplicity in factors:
+            eigs = roots(factor, multiple=False, **flags)
 
-        if sum(eigs.values()) != block.rows:
-            try:
-                eigs = dict(charpoly.all_roots(multiple=False))
-            except NotImplementedError:
-                if error_when_incomplete:
-                    raise MatrixError(eigenvals_error_message)
+            degree = factor.degree()
+            if sum(eigs.values()) != degree:
+                degree = int(factor.degree())
+                f = factor.as_expr()
+                x = factor.gen
+                try:
+                    eigs = {CRootOf(f, x, idx): 1 for idx in range(degree)}
+                except NotImplementedError:
+                    if error_when_incomplete:
+                        raise MatrixError(eigenvals_error_message)
+                    else:
+                        eigs = {}
+
+            for k, v in eigs.items():
+                v_total = v * multiplicity
+                if k in all_eigs:
+                    all_eigs[k] += v_total
                 else:
-                    eigs = {}
-
-        for k, v in eigs.items():
-            if k in all_eigs:
-                all_eigs[k] += v
-            else:
-                all_eigs[k] = v
+                    all_eigs[k] = v_total
 
     if not simplify:
         return all_eigs


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
closes #28425
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously, eigenvals() fell back to charpoly.all_roots() if roots() returned fewer roots than the block size , which was slow. This change loops over irreducible factors from charpoly.factor_list() and uses roots(), falling back to CRootOf only if needed. Restores performance while keeping correctness.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Optimize eigenvals() for CRootOf eigenvalues
<!-- END RELEASE NOTES -->
