### PR TITLE
Fix: Added 'setuptools' in requirement-dev.txt which was missing and causing ImportError

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 mpmath
 pytest
+setuptools
 pytest-xdist
 pytest-timeout
 pytest-split

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -9,7 +9,8 @@ from sympy.core.expr import (ExprBuilder, unchanged, Expr,
     UnevaluatedExpr)
 from sympy.core.function import (Function, DefinedFunction, expand, WildFunction,
     AppliedUndef, Derivative, diff, Subs)
-from sympy.core.mul import Mul, _unevaluated_Mul
+from sympy.core.mul import Mul
+from sympy.core.expr import _unevaluated_Mul
 from sympy.core.numbers import (NumberSymbol, E, zoo, oo, Float, I,
     Rational, nan, Integer, Number, pi, _illegal)
 from sympy.core.power import Pow


### PR DESCRIPTION
Added setuptools to requirements-dev.txt (fixing an ImportError).

Fixed import style by splitting:

from sympy.core.mul import Mul
from sympy.core.expr import _unevaluated_Mul

✨ PR Description Template for SymPy

Title:
Fix ImportError by adding setuptools in requirements-dev.txt and correcting import syntax for Mul / _unevaluated_Mul

Summary

Added setuptools to requirements-dev.txt to resolve ImportError during environment setup.

Corrected import statements to comply with updated module structure:

from sympy.core.mul import Mul
from sympy.core.expr import _unevaluated_Mul


Detailed Explanation

Without setuptools, running tests or installing dev dependencies resulted in ImportError.

The old combined import line

from sympy.core.mul import Mul, _unevaluated_Mul


is no longer valid because _unevaluated_Mul now resides in sympy.core.expr.

The imports were split accordingly to restore functionality.

Tests Added / Updated

Verified environment builds correctly with updated requirements-dev.txt.

Verified imports work in relevant modules/tests.

Release Notes

<!-- SymPy requires adding release notes for user-visible changes -->
* requirements
  * Added ``setuptools`` to ``requirements-dev.txt`` to fix ImportError during setup.
* core
  * Fixed incorrect import of ``_unevaluated_Mul`` (now imported from ``sympy.core.expr``).
  * 
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->