### PR TITLE
Sympy.solve now rewrites Max/Min functions as piecewise functions prior to solving.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -383,6 +383,7 @@ Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>
 Avasam <samuel.06@hotmail.com>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>
 Avichal Dayal <avichal.dayal@gmail.com>
+Ayden Alvarez <Aydenalv6282@gmail.com>
 Ayodeji Ige <ayodeji18@outlook.com>
 Ayush Aryan <ayush.aryan71@gmail.com> Ayush aryan <75092320+ayush3781@users.noreply.github.com>
 Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71@gmail.com>

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -994,6 +994,7 @@ def solve(f, *symbols, **flags):
 
     for i, fi in enumerate(f):
         # Abs / Max / Min
+        # Rewrites as piecewise functions prior to solving
         while True:
             was = fi
             fi = fi.replace(Abs, lambda arg:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -31,7 +31,7 @@ from sympy.core.traversal import preorder_traversal
 from sympy.logic.boolalg import And, BooleanAtom
 
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, acos, asin, atan,
-                             Abs, re, im, arg, sqrt, atan2)
+                             Abs, re, im, arg, sqrt, atan2, Max, Min)
 from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
@@ -993,16 +993,30 @@ def solve(f, *symbols, **flags):
         return []
 
     for i, fi in enumerate(f):
-        # Abs
+        # Abs / Max / Min
         while True:
             was = fi
             fi = fi.replace(Abs, lambda arg:
                 separatevars(Abs(arg)).rewrite(Piecewise) if arg.has(*symbols)
                 else Abs(arg))
+            fi = fi.replace(Max, lambda *args:
+                separatevars(Max(*args)).rewrite(Piecewise) if any(arg.has(*symbols) for arg in args)
+                else Max(*args))
+            fi = fi.replace(Min, lambda *args:
+                separatevars(Min(*args)).rewrite(Piecewise) if any(arg.has(*symbols) for arg in args)
+                else Min(*args))
             if was == fi:
                 break
 
         for e in fi.find(Abs):
+            if e.has(*symbols):
+                raise NotImplementedError('solving %s when the argument '
+                    'is not real or imaginary.' % e)
+        for e in fi.find(Max):
+            if e.has(*symbols):
+                raise NotImplementedError('solving %s when the argument '
+                    'is not real or imaginary.' % e)
+        for e in fi.find(Min):
             if e.has(*symbols):
                 raise NotImplementedError('solving %s when the argument '
                     'is not real or imaginary.' % e)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -992,32 +992,19 @@ def solve(f, *symbols, **flags):
             return [], set()
         return []
 
+    repl_funcs = (Abs, Min, Max)
     for i, fi in enumerate(f):
         # Abs / Max / Min
         # Rewrites as piecewise functions prior to solving
         while True:
             was = fi
-            fi = fi.replace(Abs, lambda arg:
-                separatevars(Abs(arg)).rewrite(Piecewise) if arg.has(*symbols)
-                else Abs(arg))
-            fi = fi.replace(Max, lambda *args:
-                separatevars(Max(*args)).rewrite(Piecewise) if any(arg.has(*symbols) for arg in args)
-                else Max(*args))
-            fi = fi.replace(Min, lambda *args:
-                separatevars(Min(*args)).rewrite(Piecewise) if any(arg.has(*symbols) for arg in args)
-                else Min(*args))
+            fi = fi.replace(lambda ex: type(ex) in repl_funcs,
+                       lambda ex: separatevars(ex).rewrite(Piecewise) if any(
+                           arg.has(*symbols) for arg in ex.args) else ex)
             if was == fi:
                 break
 
-        for e in fi.find(Abs):
-            if e.has(*symbols):
-                raise NotImplementedError('solving %s when the argument '
-                    'is not real or imaginary.' % e)
-        for e in fi.find(Max):
-            if e.has(*symbols):
-                raise NotImplementedError('solving %s when the argument '
-                    'is not real or imaginary.' % e)
-        for e in fi.find(Min):
+        for e in fi.find(lambda ex: type(ex) in repl_funcs):
             if e.has(*symbols):
                 raise NotImplementedError('solving %s when the argument '
                     'is not real or imaginary.' % e)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2724,6 +2724,7 @@ def test_solve_Piecewise():
 
 
 def test_solve_maxmin():
+    x, y = symbols('x y', real=True)
     variables = (x, y)
     system = [Eq(y, Max(x, -x)), Eq(y, 1)]
     assert solve(system, variables) == [(-1, 1), (1, 1)]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2691,6 +2691,7 @@ def test_solve_undetermined_coeffs_issue_23927():
         r: (A**2 + A*sqrt(A**2 + B**2) + B**2)/(A + sqrt(A**2 + B**2))/-1
         }]
 
+
 def test_issue_24368():
     # Ideally these would produce a solution, but for now just check that they
     # don't fail with a RuntimeError
@@ -2721,6 +2722,7 @@ def test_solve_Piecewise():
         (0, x < 10),  # this will simplify away
         (S.NaN,True)))
 
+
 def test_issue_28331():
     # Prior to pull#28435, solve does not automatically rewrite
     # Min and Max functions to piecewise, as it does with Abs.
@@ -2729,7 +2731,7 @@ def test_issue_28331():
     # Min/Max in the system can prevent some solutions from being found.
     x, y = symbols('x y', real=True)
     variables = (x, y)
-    # Prior to PR: [(1, 1)]
+    # Prior to PR: "[(1, 1)]" (Missing (-1, 1))
     system = [Eq(y, Max(x, -x)), Eq(y, 1)]
     assert solve(system, variables) == [(-1, 1), (1, 1)]
     # Prior to PR: "NotImplementedError: could not solve y - Min(3/2 - y/2, y/2 - 3/2)"
@@ -2738,6 +2740,6 @@ def test_issue_28331():
     # Prior to PR: "NotImplementedError: could not solve y - Max(y/10 - 17/10, (y/10 - 17/10)**2)"
     system = [Eq(y, Max(x ** 2, x)), Eq(y, 10 * x + 17)]
     assert solve(system, variables) == [(5 - sqrt(42), 67 - 10*sqrt(42)), (5 + sqrt(42), 10*sqrt(42) + 67)]
-    system = [Eq(y, Max(3*x, -(S(1)/3)*x)), Eq(y, -(x**2)+10)]
     # Prior to PR: "NotImplementedError: could not solve y - Max(-sqrt(10 - y)/3, 3*sqrt(10 - y))"
+    system = [Eq(y, Max(3*x, -(S(1)/3)*x)), Eq(y, -(x**2)+10)]
     assert solve(system, variables) == [(-3, 1), (2, 6)]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2724,7 +2724,6 @@ def test_solve_Piecewise():
 
 
 def test_solve_maxmin():
-    x, y = symbols('x y', real=True)
     variables = (x, y)
     system = [Eq(y, Max(x, -x)), Eq(y, 1)]
     assert solve(system, variables) == [(-1, 1), (1, 1)]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2723,23 +2723,13 @@ def test_solve_Piecewise():
         (S.NaN,True)))
 
 
-def test_issue_28331():
-    # Prior to pull#28435, solve does not automatically rewrite
-    # Min and Max functions to piecewise, as it does with Abs.
-    # A "NotImplementedError" may be raised even if the system is
-    # solvable after being rewritten as piecewise. Also, leaving
-    # Min/Max in the system can prevent some solutions from being found.
-    x, y = symbols('x y', real=True)
+def test_solve_maxmin():
     variables = (x, y)
-    # Prior to PR: "[(1, 1)]" (Missing (-1, 1))
     system = [Eq(y, Max(x, -x)), Eq(y, 1)]
     assert solve(system, variables) == [(-1, 1), (1, 1)]
-    # Prior to PR: "NotImplementedError: could not solve y - Min(3/2 - y/2, y/2 - 3/2)"
     system = [Eq(y, Min(x, -x)), Eq(y, 2*x+3)]
     assert solve(system, variables) == [(-3, -3)]
-    # Prior to PR: "NotImplementedError: could not solve y - Max(y/10 - 17/10, (y/10 - 17/10)**2)"
     system = [Eq(y, Max(x ** 2, x)), Eq(y, 10 * x + 17)]
     assert solve(system, variables) == [(5 - sqrt(42), 67 - 10*sqrt(42)), (5 + sqrt(42), 10*sqrt(42) + 67)]
-    # Prior to PR: "NotImplementedError: could not solve y - Max(-sqrt(10 - y)/3, 3*sqrt(10 - y))"
     system = [Eq(y, Max(3*x, -(S(1)/3)*x)), Eq(y, -(x**2)+10)]
     assert solve(system, variables) == [(-3, 1), (2, 6)]


### PR DESCRIPTION
#### References to other Issues or PRs
This PR implements a feature discussed in https://github.com/sympy/sympy/issues/28331, though the other mentioned issue is unchanged. The issue and feature are discussed in detail here https://groups.google.com/g/sympy/c/ghwniVSFyY8?pli=1.

#### Brief description of what is fixed or changed
Solving a system of equations involving Min/Max using Sympy.solve would raise a NotImplementedError. This shouldn't be the case all the time, since Sympy.solve is capable of solving certain systems of piecewise equations equivalent to a system involving Min/Max. Abs was already automatically rewritten to piecewise, so the same was done for Min/Max.

#### Other comments
Sometimes, when there is no non piecewise equation in a system, a NaN error is raised (prior to the changes made in this PR) as discussed in the issue above. Rewriting Min/Max to piecewise functions will allow more systems to be solvable, but some instances of a "NotImplentedError" will be replaced with a "NaN" error due to the issue discussed in #28331. To fix this, some systems of piecewise equations should raise a "NotImplementedError" prior to raising a NaN exception.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Sympy.solve now rewrites Max/Min functions as piecewise functions prior to solving.
<!-- END RELEASE NOTES -->
