### PR TITLE
fix(core): fix is_integer when dividing by even integer

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1479,11 +1479,13 @@ class Mul(Expr, AssocOp):
             return False
         if len(denominators) == 1:
             d = denominators[0]
-            if d.is_Integer and d.is_even:
+            if d.is_Integer:
+                t = trailing(d.p)
+                is_power_of_two = (d == 2**t)
                 # if minimal power of 2 in num vs den is not
                 # negative then we have an integer
-                if (Add(*[i.as_base_exp()[1] for i in
-                        numerators if i.is_even]) - trailing(d.p)
+                if is_power_of_two and (Add(*[i.as_base_exp()[1] for i in
+                        numerators if i.is_even]) - t
                         ).is_nonnegative:
                     return True
         if len(numerators) == 1:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1480,12 +1480,11 @@ class Mul(Expr, AssocOp):
         if len(denominators) == 1:
             d = denominators[0]
             if d.is_Integer:
-                t = trailing(d.p)
-                is_power_of_two = (d == 2**t)
+                is_power_of_two = d.p & (d.p - 1) == 0
                 # if minimal power of 2 in num vs den is not
                 # negative then we have an integer
                 if is_power_of_two and (Add(*[i.as_base_exp()[1] for i in
-                        numerators if i.is_even]) - t
+                        numerators if i.is_even]) - trailing(d.p)
                         ).is_nonnegative:
                     return True
         if len(numerators) == 1:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1096,6 +1096,10 @@ def test_Pow_is_integer():
     o = Symbol('o', odd=True, prime=True)
     assert (k/o).is_integer is False
 
+    x = Symbol('x', integer=True)
+    assert ((2*x + 2*x**3)*x/10).is_integer is None
+    assert ((2*x + 2*x**3)*x/2).is_integer
+
 
 def test_Pow_is_real():
     x = Symbol('x', real=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes a bug introduced in #21952

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Fix expr.is_integer reporting true for even integer numerators in some cases

<!-- END RELEASE NOTES -->
