### PR TITLE
Added flag mode for increasing the speed of `Xor` incase of `to_dnf` …

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1805,3 +1805,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Raman Bansal <bansalraman339@gmail.com> Raman <69149285+ramanbansal1@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1275,6 +1275,7 @@ Rajeev Singh <rajs2010@gmail.com>
 Rajiv Ranjan Singh <rajivperfect007@gmail.com> Rajiv Ranjan Singh <42106787+iamrajiv@users.noreply.github.com>
 Ralf Stephan <ralf@ark.in-berlin.de>
 Ralph Bean <rbean@redhat.com>
+Raman Bansal <bansalraman339@gmail.com> Raman <69149285+ramanbansal1@users.noreply.github.com>
 Ramana Venkata <idlike2dream@gmail.com>
 Ramana Venkata <idlike2dream@gmail.com> <vramana@users.noreply.github.com>
 Randy Heydon <randy.heydon@clockworklab.net>
@@ -1805,4 +1806,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Raman Bansal <bansalraman339@gmail.com> Raman <69149285+ramanbansal1@users.noreply.github.com>

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1078,7 +1078,11 @@ class Xor(BooleanFunction):
                     for s in self.args:
                         clause.append(s if s in subset else Not(s))
                     args.append(And(*clause))
-            return Or(*args)
+            # Simplify the resulting expression if requested
+            if simplify:
+                return Or(*args).simplify()
+            else:
+                return Or(*args)
 
         else:  # CNF (default) expansion
             args = []
@@ -1088,7 +1092,12 @@ class Xor(BooleanFunction):
                     for s in self.args:
                         clause.append(s if s in subset else Not(s))
                     args.append(Or(*clause))
-            return And(*args)
+            # Simplify the resulting expression if requested
+            if simplify:
+                return And(*args).simplify()
+            else:
+                return And(*args)
+
 
 
     def _eval_rewrite_as_Or(self, *args, **kwargs):
@@ -1708,7 +1717,6 @@ def to_nnf(expr, simplify=True, mode="default"):
     """
     if is_nnf(expr, simplify):
         return expr
-    
     if isinstance(expr, Xor):
         return expr.to_nnf(simplify=simplify, mode=mode)
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1706,7 +1706,6 @@ def to_nnf(expr, simplify=True, mode="default"):
     (A | B) & (~C | ~D)
     >>> to_nnf(Equivalent(A >> B, B >> A))
     (A | ~B | (A & ~B)) & (B | ~A | (B & ~A))
-    
     """
     if is_nnf(expr, simplified=simplify):
         return expr

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1689,7 +1689,7 @@ def to_anf(expr, deep=True):
     return expr.to_anf(deep=deep)
 
 
-def to_nnf(expr, simplify=True, mode="default"):
+def to_nnf(expr, simplified=True, mode="default"):
     """
     Converts ``expr`` to Negation Normal Form (NNF).
 
@@ -1711,13 +1711,13 @@ def to_nnf(expr, simplify=True, mode="default"):
     >>> to_nnf(Equivalent(A >> B, B >> A))
     (A | ~B | (A & ~B)) & (B | ~A | (B & ~A))
     """
-    if is_nnf(expr, simplify=simplify):
+    if is_nnf(expr, simplified=simplified):
         return expr
 
     if isinstance(expr, Xor):
-        return expr.to_nnf(simplify=simplify, mode=mode)
+        return expr.to_nnf(simplify=simplified, mode=mode)
 
-    return expr.to_nnf(simplify=simplify)
+    return expr.to_nnf(simplify=simplified)
 
 
 
@@ -1992,7 +1992,7 @@ def eliminate_implications(expr, mode='default'):
     (A | ~C) & (B | ~A) & (C | ~B)
 
     """
-    return to_nnf(expr, simplify=False, mode=mode)
+    return to_nnf(expr, simplified=False, mode=mode)
 
 
 def is_literal(expr):


### PR DESCRIPTION
Fix evaluation of symbolic integrals with piecewise functions

#### References to other Issues or PRs
Fixes #28393

#### Brief description of what is fixed or changed
Added a `mode` flag for `to_cnf` and `to_dnf` conversions. Previously, converting any `Xor` expression to DNF took a very long time because `to_nnf` of `Xor` returned the CNF expression by default. 

The new `mode` flag allows explicit conversion: when `mode='dnf'` is specified, the function returns the DNF form, and when `mode='cnf'` is specified, it returns CNF. This improves performance significantly for large `Xor` expressions.

#### Other comments
NA

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
