### PR TITLE
Improve performance of `free_symbols`

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -719,8 +719,10 @@ class Basic(Printable):
         >>> Derivative(x, y).has_free(y)
         True
         """
-        empty: set[Basic] = set()
-        return empty.union(*(a.free_symbols for a in self.args))
+        result: set[Basic] = set()
+        for a in self.args:
+            result.update(a.free_symbols)
+        return result
 
     @property
     def expr_free_symbols(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

N/A

#### Brief description of what is fixed or changed

The previous implementation spawns a bunch of sets and then performs a union. Using a set directly with `update` eliminates some of the needless work.

#### Other comments

To see the performance difference, I tested it with:

```python
# perf.py
from statistics import mean, stdev
import timeit

import sympy as sp

result = sp.sympify('+'.join(f'n{i}' for i in range(3_000)))

def to_measure():
    return result.free_symbols

timing = timeit.repeat(to_measure, number=1_000, repeat=20)
print(f"{mean(timing):.4f} +- {stdev(timing):.4f}")
```

The results on my machine (Linux x86_64) are:

- `0.4395 +- 0.0008` on master
- `0.4035 +- 0.0003` on this PR

which works out to about an 8% increase in performance for this particular case.

One can also use `cProfile`:

```python
# perf2.py
import cProfile

import sympy as sp

result = sp.sympify('+'.join(f'n{i}' for i in range(3_000)))

def to_measure():
    for _ in range(10_000):
        result.free_symbols

timing = cProfile.runctx("to_measure()", globals=globals(), locals=locals())
```

Which outputs:

```plaintext
90040004 function calls in 16.963 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   16.963   16.963 <string>:1(<module>)
 30000000    6.839    0.000    6.839    0.000 basic.py:313(__hash__)
    10000    2.198    0.000   16.689    0.002 basic.py:675(free_symbols)
 30010000    2.720    0.000   13.282    0.000 basic.py:723(<genexpr>)
    10000    0.001    0.000    0.001    0.000 basic.py:904(args)
        1    0.275    0.275   16.963   16.963 perf2.py:7(to_measure)
 30000000    3.723    0.000   10.562    0.000 symbol.py:464(free_symbols)
        1    0.000    0.000   16.963   16.963 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
    10000    1.208    0.000    1.208    0.000 {method 'union' of 'set' objects}
```

on master, and:

```plaintext
90020004 function calls in 14.250 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   14.250   14.250 <string>:1(<module>)
 30000000    1.373    0.000    1.373    0.000 basic.py:313(__hash__)
    10000    5.139    0.001   13.985    0.001 basic.py:675(free_symbols)
    10000    0.001    0.000    0.001    0.000 basic.py:906(args)
        1    0.265    0.265   14.250   14.250 perf2.py:7(to_measure)
 30000000    3.934    0.000    5.308    0.000 symbol.py:464(free_symbols)
        1    0.000    0.000   14.250   14.250 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
 30000000    3.537    0.000    3.537    0.000 {method 'update' of 'set' objects}
```

with this PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Improve performance of `free_symbols` by replacing genexpr and `union` calls with `update`
<!-- END RELEASE NOTES -->
