### PR TITLE
latex: escape leading underscores in Symbol names

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1633,8 +1633,19 @@ class LatexPrinter(Printer):
         name: str = self._settings['symbol_names'].get(expr)
         if name is not None:
             return name
+        
+        new_name = expr.name
+        temp = re.match(r"^_+", new_name)
+        if temp:
+            start = r"\_" * len(temp.group(0))
+            remainder = new_name[len(temp.group(0)):]
 
-        return self._deal_with_super_sub(expr.name, style=style)
+            if remainder:
+                return start + remainder
+            else:
+                return start
+
+        return self._deal_with_super_sub(new_name, style=style)
 
     _print_RandomSymbol = _print_Symbol
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -97,6 +97,9 @@ import sympy as sym
 
 from sympy.abc import mu, tau
 
+from sympy import symbols
+from sympy.printing.latex import latex
+
 
 class lowergamma(sym.lowergamma):
     pass   # testing notation inheritance by a subclass with same name
@@ -3185,3 +3188,25 @@ def test_latex_disable_split_super_sub():
     assert latex(Symbol('u^a_b')) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=False) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=True) == 'u\\^a\\_b'
+
+
+def test_latex_leading_underscore_test():
+    temp = symbols('_x')
+    assert latex(temp) == r"\_x"
+
+def test_latex_leading_multiple_underscore():
+    temp = symbols('__alpha')
+    assert latex(temp) == r"\_\_alpha"
+
+def test_latex_check_middle_underscore():
+    temp = symbols('x_1')
+    assert latex(temp) in ("x_{1}", r"x_{1}")
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14718 

#### Brief description of what is fixed or changed
This PR fixes an issue where symbols beginning with underscores were rendered incorrectly by the LaTeX printer. This fix updates '_print_Symbol' in 'sympy/printing/latex.py' to detect leading underscores, escape them, and then append the remainder of the symbol name so the subscript and superscript handling still works correctly.

#### Other comments
Added three new tests in 'sympy/printing/tests/test_latex.py':
- single leading underscores ( _x goes -> \_x )
- multiple leading underscores ( __alpha -> \_\_alpha )
- unaffected middle underscore ( x_1 -> x_{1} )

<!-- BEGIN RELEASE NOTES -->
* printing
* Fixed LaTeX printer bug where symbols beginning with underscores were misinterpreted as subscripts. Leading underscores are now escaped correctly. 

<!-- END RELEASE NOTES -->
