### PR TITLE
Fix dsolve for ODEs with symbolic exponents (Bessel-type equations)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1600,6 +1600,7 @@ Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
+Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -81,6 +81,9 @@ the various ODE solving methods. For this reason, they are documented here.
 .. autoclass:: sympy.solvers.ode.single::SecondLinearBessel
    :members:
 
+.. autoclass:: sympy.solvers.ode.single::SecondLinearBesselTransform
+   :members:
+
 .. autoclass:: sympy.solvers.ode.single::Bernoulli
    :members:
 

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -300,6 +300,7 @@ allhints = (
     "Liouville",
     "2nd_linear_airy",
     "2nd_linear_bessel",
+    "2nd_linear_bessel_transform",
     "2nd_hypergeometric",
     "2nd_hypergeometric_Integral",
     "nth_order_reducible",


### PR DESCRIPTION
Fixes a `TypeError` that occurred when trying to solve second-order ODEs with symbolic exponents using `dsolve()`. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28438 

#### Brief description of what is fixed or changed
Implemented a new solver class SecondLinearBesselTransform that:

- Detects ODEs of the form y'' + A*x^k*y = 0 where k contains symbolic parameters.

- Returns solutions in terms of Bessel functions.

Changes made : 

- Added SecondLinearBesselTransform class in sympy/solvers/ode/single.py

- Registered '2nd_linear_bessel_transform' in solver_map

- Added hint to allhints tuple in sympy/solvers/ode/ode.py

- Added tests in sympy/solvers/ode/tests/test_single.py

- Added test in sympy/solvers/ode/tests/test_ode.py 

#### Other comments
The implementation uses the standard transformation for ODEs of the form y'' + A*x^k*y = 0 to Bessel's equation, with solutions:
y(x) = √x · [C₁·J_ν(z) + C₂·Y_ν(z)]
where ν = 1/(k+2) and z = (2/(k+2))·x^((k+2)/2)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:


.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed TypeError for 2nd-order ODEs with symbolic exponents. Added SecondLinearBesselTransform solver for y'' + Ax^ky = 0 (k symbolic), with Bessel function solutions.

<!-- END RELEASE NOTES -->
