### PR TITLE
Fixing multiplication by 0

### DIFF
--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -834,6 +834,24 @@ class SDM(dict):
         {0: {1: 6}, 1: {0: 3}}
 
         """
+        from sympy import nan,zoo
+        if A.domain.is_EXRAW:
+            #THIS is for issue 28446, undefined behavior when multiplying by 0
+            Csdm = {}
+        for i, Ai in A.items():
+            Ci = {}
+            Csdm = {}
+            for j, aij in Ai.items():
+                prod = aij * b
+                if prod.is_nan:
+                    Ci[j] = nan
+                elif prod:
+                    Ci[j] = prod
+            if Ci:
+                Csdm[i] = Ci
+        return A.new(Csdm, A.shape, A.domain)
+            
+            
         Csdm = unop_dict(A, lambda aij: aij*b)
         return A.new(Csdm, A.shape, A.domain)
 


### PR DESCRIPTION
This is to fix issue 28446 multiplication by zero. This was done by adding statements to check for 0 numbers in the matrixes that are being multiplied.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28446
#### Brief description of what is fixed or changed
The mul function in sdm.py was changed to add checks for multiplication by zero.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
