### PR TITLE
beam: raise ValueError on inconsistent reaction systems; add tests & docstring

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -810,6 +810,7 @@ Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
 Jean-François B <2589111+jfbu@users.noreply.github.com>
 Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>
 Jeffrey Ryan <jeffaryan7@gmail.com>
+Jenna Sin <jennasin@ufl.edu>
 Jennifer White <jcrw122@googlemail.com>
 Jens H. Nielsen <jenshnielsen@gmail.com>
 Jens Jørgen Mortensen <jj@smoerhul.dk>

--- a/.mailmap
+++ b/.mailmap
@@ -811,6 +811,7 @@ Jean-François B <2589111+jfbu@users.noreply.github.com>
 Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>
 Jeffrey Ryan <jeffaryan7@gmail.com>
 Jenna Sin <jennasin@ufl.edu>
+Jenna Sin <149205146+jjennasin@users.noreply.github.com>
 Jennifer White <jcrw122@googlemail.com>
 Jens H. Nielsen <jenshnielsen@gmail.com>
 Jens Jørgen Mortensen <jj@smoerhul.dk>

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -932,7 +932,7 @@ class Beam:
             If the system of equations for the reaction loads is inconsistent
         (no solution). This can occur when supports, loads, or boundary
         conditions conflict.
-        
+    
         Parameters
         ==========
         reactions : Symbol

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -13,7 +13,6 @@ from sympy.core.sympify import sympify
 from sympy.solvers import linsolve, solveset
 from sympy.solvers.ode.ode import dsolve
 from sympy.solvers.solvers import solve
-from sympy.solvers.solveset import linsolve
 from sympy.printing import sstr
 from sympy.functions import SingularityFunction, Piecewise, factorial
 from sympy.integrals import integrate
@@ -25,7 +24,6 @@ from sympy.sets.sets import Interval, FiniteSet
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import iterable
-from sympy import EmptySet
 import warnings
 
 

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1052,7 +1052,7 @@ class Beam:
             eqs = deflection_curve.subs(x, position) - value
             deflection_eqs.append(eqs)
         total_supports = tuple(set(applied_supports + reactions))
-        
+
         solution_set = linsolve(
             [shear_curve, moment_curve] + shear_force_eqs + bending_moment_eqs + slope_eqs + deflection_eqs,
             (C3, C4) + total_supports + rotation_jumps + deflection_jumps

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1063,9 +1063,7 @@ class Beam:
             )
 
         # safely unpack the single solution tuple (no brittle .args indexing)
-        sol_tuple = next(iter(solution_set))
-        solution = list(sol_tuple)
-        if not solution or solution == EmptySet:
+        if solution_set is S.EmptySet:
             raise ValueError("Insufficient boundary conditions to solve the beam.")
         sol_tuple = next(iter(solution_set))
         solution = list(sol_tuple)

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -932,7 +932,7 @@ class Beam:
             If the system of equations for the reaction loads is inconsistent
         (no solution). This can occur when supports, loads, or boundary
         conditions conflict.
-    
+
         Parameters
         ==========
         reactions : Symbol

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -10,10 +10,8 @@ from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log, s
 from sympy.testing.pytest import raises
 from sympy.physics.units import meter, newton, kilo, giga, milli
 from sympy.physics.continuum_mechanics.beam import Beam3D
-from sympy.physics.continuum_mechanics.beam import Beam
 from sympy.geometry import Circle, Polygon, Point2D, Triangle
 from sympy.core.sympify import sympify
-from sympy import Symbol
 
 x = Symbol('x')
 y = Symbol('y')

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -1,3 +1,4 @@
+import pytest
 from sympy.core.function import expand
 from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
@@ -9,13 +10,32 @@ from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log, s
 from sympy.testing.pytest import raises
 from sympy.physics.units import meter, newton, kilo, giga, milli
 from sympy.physics.continuum_mechanics.beam import Beam3D
+from sympy.physics.continuum_mechanics.beam import Beam
 from sympy.geometry import Circle, Polygon, Point2D, Triangle
 from sympy.core.sympify import sympify
+from sympy import Symbol
 
 x = Symbol('x')
 y = Symbol('y')
 R1, R2 = symbols('R1, R2')
 
+def test_reaction_inconsistent_symbolic_raises_valueerror():
+    E, I, P = Symbol('E'), Symbol('I'), Symbol('P')
+    b = Beam(10, E, I)
+    r1 = b.apply_support(0, 'pin')
+    r2 = b.apply_support(10, 'roller')
+    b.apply_rotation_hinge(4)
+    b.apply_load(-P, 4, -1)
+    with pytest.raises(ValueError):
+        b.solve_for_reaction_loads(r1, r2)
+
+def test_reaction_inconsistent_numeric_raises_valueerror():
+    E, I = Symbol('E'), Symbol('I')
+    b = Beam(10, E, I)
+    r1 = b.apply_support(0, 'pin')
+    b.apply_load(10, 10, -1)
+    with pytest.raises(ValueError):
+        b.solve_for_reaction_loads(r1)
 
 def test_Beam():
     E = Symbol('E')


### PR DESCRIPTION
Fixes #28346

Problem
- solve_for_reaction_loads assumed linsolve always returns a solution. For inconsistent systems, linsolve returns EmptySet, and the old code indexed it, causing a misleading IndexError.

Change
- Guarded the result of linsolve: if solution_set is S.EmptySet, raise ValueError with a clear, user-facing message.
- Safely unpacked the solution via next(iter(solution_set)) (no brittle .args indexing).
- Added a Raises note to the method docstring.
- Added two regression tests (symbolic and numeric inconsistent cases) that expect ValueError.

Why
- Replaces a cryptic crash with a helpful error message and makes incorrect boundary/support/load configurations easier to diagnose.

Checks
- bin/test quality passes
- bin/test sympy/physics/continuum_mechanics/tests/test_beam.py → all tests pass

<!-- BEGIN RELEASE NOTES -->
- physics.continuum_mechanics
   - Raised a ValueError in Beam.solve_for_reaction_loads when the reaction system was inconsistent, replacing an unhelpful IndexError with a clear message.

<!-- END RELEASE NOTES -->