### PR TITLE
Tensorfication for Lambdify with method=torch

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1571,6 +1571,7 @@ Tilo Reneau-Cardoso <tiloreneau@gmail.com> Tilo Reneau-Cardoso <67246777+TiloRC@
 Tim Gates <tim.gates@iress.com>
 Tim Lahey <tim.lahey@gmail.com>
 Tim Swast <tswast@gmail.com>
+TimWalter <tim.walter@tum.de>
 Timo Stienstra <timostienstra00@gmail.com> TJStienstra <T.J.Stienstra@student.tudelft.nl>
 Timo Stienstra <timostienstra00@gmail.com> TJStienstra <timostienstra00@gmail.com>
 Timo Stienstra <timostienstra00@gmail.com> Timo Stienstra <97806294+TJStienstra@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1571,6 +1571,7 @@ Tilo Reneau-Cardoso <tiloreneau@gmail.com> Tilo Reneau-Cardoso <67246777+TiloRC@
 Tim Gates <tim.gates@iress.com>
 Tim Lahey <tim.lahey@gmail.com>
 Tim Swast <tswast@gmail.com>
+Tim Walter <tim.michelbach@hotmail.com>
 TimWalter <tim.walter@tum.de>
 Timo Stienstra <timostienstra00@gmail.com> TJStienstra <T.J.Stienstra@student.tudelft.nl>
 Timo Stienstra <timostienstra00@gmail.com> TJStienstra <timostienstra00@gmail.com>

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -16,6 +16,7 @@ llvmlite = import_module('llvmlite')
 if llvmlite:
     ll = import_module('llvmlite.ir').ir
     llvm = import_module('llvmlite.binding').binding
+    llvm.initialize()
     llvm.initialize_native_target()
     llvm.initialize_native_asmprinter()
 

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -16,7 +16,6 @@ llvmlite = import_module('llvmlite')
 if llvmlite:
     ll = import_module('llvmlite.ir').ir
     llvm = import_module('llvmlite.binding').binding
-    llvm.initialize()
     llvm.initialize_native_target()
     llvm.initialize_native_asmprinter()
 

--- a/sympy/printing/pytorch.py
+++ b/sympy/printing/pytorch.py
@@ -1,4 +1,3 @@
-
 from sympy.printing.pycode import AbstractPythonCodePrinter, ArrayPrinter
 from sympy.matrices.expressions import MatrixExpr
 from sympy.core.mul import Mul
@@ -14,7 +13,6 @@ torch = import_module('torch')
 
 
 class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
-
     printmethod = "_torchcode"
 
     mapping = {
@@ -115,6 +113,15 @@ class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
     _print_HadamardProduct = _print_Function
     _print_Trace = _print_Function
     _print_Determinant = _print_Function
+
+    def _print_Float(self, expr):
+        return f"torch.tensor({super()._print_Float(expr)}, dtype={self.dtype})"
+
+    def _print_Integer(self, expr):
+        return f"torch.tensor({super()._print_Integer(expr)}, dtype={torch.int64})"
+
+    def _print_Rational(self, expr):
+        return f"torch.tensor({super()._print_Rational(expr)}, dtype={self.dtype})"
 
     def _print_Inverse(self, expr):
         return '{}({})'.format(self._module_format("torch.linalg.inv"),
@@ -218,7 +225,7 @@ class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
             return self._expand_fold_binary_op("torch.matmul", mat_args)
 
     def _print_MatPow(self, expr):
-        return self._expand_fold_binary_op("torch.mm", [expr.base]*expr.exp)
+        return self._expand_fold_binary_op("torch.mm", [expr.base] * expr.exp)
 
     def _print_MatrixBase(self, expr):
         data = "[" + ", ".join(["[" + ", ".join([self._print(j) for j in i]) + "]" for i in expr.tolist()]) + "]"
@@ -291,6 +298,7 @@ class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
     _transpose = "t"
     _ones = "ones"
     _zeros = "zeros"
+
 
 def torch_code(expr, requires_grad=False, dtype="torch.float64", **settings):
     printer = TorchPrinter(settings={'requires_grad': requires_grad, 'dtype': dtype})


### PR DESCRIPTION
Wrap scalars in torch.tensor(x) when lambdifying
expressions,since torch is pickier than numpy and
expects tensors for a lot of functions, e.g.
torch.min. Previously, lambdifying sp.Max(1.0, x)
would fail as 1.0 was not a torch.tensor, this
behaviour is now more robust. Fixes issue #28457

<!-- BEGIN RELEASE NOTES -->
* printing
  *  Fixed an issue in `lambdify(method="torch")` where scalar constants were not converted to `torch.tensor`, causing functions like `torch.min` or `torch.max` to fail. Scalars are now automatically wrapped in tensors, improving compatibility with PyTorch.

<!-- END RELEASE NOTES -->