### PR TITLE
Shifting rad and deg functions

### DIFF
--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -1,4 +1,5 @@
 import pytest
+from sympy.core import pi
 from sympy.core.numbers import Float
 from sympy.core.function import (Derivative, Function)
 from sympy.core.singleton import S
@@ -7,7 +8,7 @@ from sympy.functions import exp, cos, sin, tan, cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry import Point, Point2D, Line, Polygon, Segment, convex_hull,\
     intersection, centroid, Point3D, Line3D, Ray, Ellipse
-from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar
+from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points, are_coplanar, rad, deg
 from sympy.solvers.solvers import solve
 from sympy.testing.pytest import raises
 
@@ -168,3 +169,15 @@ def test_are_coplanar():
 
     assert are_coplanar(a, b, c) == False
     assert are_coplanar(a, d) == False
+
+def test_rad():
+    assert rad(180) == pi
+    assert rad(30) == pi/6
+    assert rad(60) == pi/3
+    assert rad(900) == 5*pi
+
+def test_deg():
+    assert deg(pi/3) == 60
+    assert deg(pi/2) == 90
+    assert deg(pi) == 180
+    assert deg(3*pi) == 540

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -18,6 +18,7 @@ from sympy import nsimplify
 from .entity import GeometryEntity
 from .exceptions import GeometryError
 from .point import Point, Point2D, Point3D
+from sympy.core import pi
 from sympy.core.containers import OrderedSet
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import Function, expand_mul
@@ -729,3 +730,11 @@ def intersection(*entities, pairwise=False, **kwargs):
         p = prec_to_dps(prec)
         res = [i.n(p) for i in res]
     return res
+
+def rad(d):
+    """Return the radian value for the given degrees (pi = 180 degrees)."""
+    return d*pi/180
+
+def deg(r):
+    """Return the degree value for the given radians (pi = 180 degrees)."""
+    return r/pi*180


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28118

#### Brief description of what is fixed or changed
Shifted rad and deg from a fairly vague place, `sympy.geometry.polygon.py`, to a better place `sympy.geometry.util.py`, updated tests accordingly and updated wherever the function is being used.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Shifted rad and deg functions from `sympy.geometry.polygon.py` to `sympy.geometry.util.py`.
<!-- END RELEASE NOTES -->
