### PR TITLE
Replace `if <inequality> is True` with `if <inequality> == True`

### DIFF
--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -235,7 +235,7 @@ def test_harmonic():
     assert harmonic(oo, 3) == zeta(3)
     assert harmonic(oo, Dummy(negative=True)) is S.NaN
     ip = Dummy(integer=True, positive=True)
-    if (1/ip <= 1) is True:  #---------------------------------+
+    if (1/ip <= 1) == True:  #---------------------------------+
         assert None, 'delete this if-block and the next line' #|
     ip = Dummy(even=True, positive=True)  #--------------------+
     assert harmonic(oo, 1/ip) is oo

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1340,5 +1340,5 @@ class multigamma(DefinedFunction):
             return False
         if intlike(y) and (y <= (p - 1)):
             return False
-        if y > (p - 1) or y.is_noninteger:
+        if (y > (p - 1)) == True or y.is_noninteger:
             return True

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1336,7 +1336,7 @@ class multigamma(DefinedFunction):
     def _eval_is_real(self):
         x, p = self.args
         y = 2*x
-        if y.is_integer and (y <= (p - 1)) is True:
+        if y.is_integer and (y <= (p - 1)) == True:
             return False
         if intlike(y) and (y <= (p - 1)):
             return False

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -734,6 +734,10 @@ def test_multigamma():
     assert multigamma(0.7, 3, evaluate=False).is_real == True
     assert multigamma(3, 3, evaluate=False).is_real == True
 
+    assert multigamma(n, 1, evaluate=False).is_real is None
+    n_neg = Symbol('n', integer=True, negative=True)
+    assert multigamma(n_neg, 1, evaluate=False).is_real == False
+
 def test_gamma_as_leading_term():
     assert gamma(x).as_leading_term(x) == 1/x
     assert gamma(2 + x).as_leading_term(x) == S(1)

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1146,6 +1146,13 @@ class Polygon(GeometrySet):
         if center_dist <= e1_max_radius + e2_max_radius:
             warnings.warn("Polygons may intersect producing erroneous output",
                           stacklevel=3)
+            # If polygons actually intersect (vertex inside other polygon), return 0
+            for vertex in e1.vertices:
+                if e2.encloses_point(vertex):
+                    return S.Zero
+            for vertex in e2.vertices:
+                if e1.encloses_point(vertex):
+                    return S.Zero
 
         '''
         Find the upper rightmost vertex of e1 and the lowest leftmost vertex of e2

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1234,7 +1234,7 @@ class Polygon(GeometrySet):
             e2_angle = pi - support_line.angle_between(Line(
                 e2_current, e2_next))
 
-            if (e1_angle < e2_angle) is True:
+            if (e1_angle < e2_angle) == True:
                 support_line = Line(e1_current, e1_next)
                 e1_segment = Segment(e1_current, e1_next)
                 min_dist_current = e1_segment.distance(e2_current)
@@ -1248,7 +1248,7 @@ class Polygon(GeometrySet):
                 else:
                     e1_current = e1_next
                     e1_next = e1_connections[e1_next][1]
-            elif (e1_angle > e2_angle) is True:
+            elif (e1_angle > e2_angle) == True:
                 support_line = Line(e2_next, e2_current)
                 e2_segment = Segment(e2_current, e2_next)
                 min_dist_current = e2_segment.distance(e1_current)

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -409,7 +409,7 @@ def spde(a, b, c, n, DE):
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
-        if (n < 0) is True:
+        if n < 0:
             raise NonElementaryIntegralException
 
         g = a.gcd(b)

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -9,7 +9,7 @@ from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     no_cancel_equal, cancel_primitive, cancel_exp, rischDE)
 
 from sympy.testing.pytest import raises
-from sympy.abc import x, t, z, n
+from sympy.abc import x, t, z
 
 t0, t1, t2, k = symbols('t:3 k')
 
@@ -146,9 +146,12 @@ def test_spde():
     assert spde(Poly(x**2 + x + 1, x), Poly(-2*x - 1, x), Poly(x**5/2 +
     3*x**4/4 + x**3 - x**2 + 1, x), 4, DE) == \
         (Poly(0, x, domain='QQ'), Poly(x/2 - Rational(1, 4), x), 2, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
-    assert spde(Poly(x**2 + x + 1, x), Poly(-2*x - 1, x), Poly(x**5/2 +
-    3*x**4/4 + x**3 - x**2 + 1, x), n, DE) == \
-        (Poly(0, x, domain='QQ'), Poly(x/2 - Rational(1, 4), x), -2 + n, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
+    # Example 6.4.4. This example uses a symbolic n, so it doesn't work
+    # because it fails the "if n < 0" check.
+    #
+    # assert spde(Poly(x**2 + x + 1, x), Poly(-2*x - 1, x), Poly(x**5/2 +
+    # 3*x**4/4 + x**3 - x**2 + 1, x), n, DE) == \
+    #     (Poly(0, x, domain='QQ'), Poly(x/2 - Rational(1, 4), x), -2 + n, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
     raises(NonElementaryIntegralException, lambda: spde(Poly((t - 1)*(t**2 + 1)**2, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), 0, DE))
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -1086,8 +1086,8 @@ def _getitem_RepMatrix(self, key):
             return self._rep.getitem_sympy(index_(i), index_(j))
         except (TypeError, IndexError):
             if (isinstance(i, Expr) and not i.is_number) or (isinstance(j, Expr) and not j.is_number):
-                if ((j < 0) is True) or ((j >= self.shape[1]) is True) or\
-                   ((i < 0) is True) or ((i >= self.shape[0]) is True):
+                if ((j < 0) == True) or ((j >= self.shape[1]) == True) or\
+                   ((i < 0) == True) or ((i >= self.shape[0]) == True):
                     raise ValueError("index out of boundary")
                 from sympy.matrices.expressions.matexpr import MatrixElement
                 return MatrixElement(self, i, j)

--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -1,7 +1,8 @@
 from sympy.testing.pytest import raises
 from sympy.matrices.exceptions import NonSquareMatrixError, NonInvertibleMatrixError
+from sympy.matrices.expressions.matexpr import MatrixElement
 
-from sympy import Matrix, Rational
+from sympy import Matrix, Rational, Symbol
 
 
 def test_lll():
@@ -60,3 +61,19 @@ def test_matrix_inv_mod():
         [14, 1, 15, 1],
         [25, 23, 3, 12],
     ])
+
+
+def test_symbolic_index_bounds():
+    M = Matrix([[1, 2], [3, 4]])
+
+    n = Symbol('n', integer=True)
+    assert M[n, 0] == MatrixElement(M, n, 0)
+
+    n_neg = Symbol('n', integer=True, negative=True)
+    raises(ValueError, lambda: M[n_neg, 0])
+
+    n_pos = Symbol('n', integer=True, positive=True)
+    raises(ValueError, lambda: M[n_pos + 2, 0])
+
+    n_valid = Symbol('n', integer=True, nonnegative=True)
+    assert M[n_valid, 0] == MatrixElement(M, n_valid, 0)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1709,7 +1709,7 @@ class LatexPrinter(Printer):
             if self._settings['mode'] == 'inline':
                 mat_str = 'smallmatrix'
             else:
-                if (expr.cols <= 10) is True:
+                if (expr.cols <= 10) == True:
                     mat_str = 'matrix'
                 else:
                     mat_str = 'array'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1567,8 +1567,13 @@ def test_latex_Matrix():
     assert latex(M, mat_delim=None, mat_str='bmatrix') == \
         r'\begin{bmatrix}x + 1 & y\\y & x - 1\end{bmatrix}'
 
-    M2 = Matrix(1, 11, range(11))
-    assert latex(M2) == \
+    M_10 = Matrix(1, 10, range(10))
+    assert latex(M_10) == \
+        r'\left[\begin{matrix}' \
+        r'0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9\end{matrix}\right]'
+
+    M_11 = Matrix(1, 11, range(11))
+    assert latex(M_11) == \
         r'\left[\begin{array}{ccccccccccc}' \
         r'0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10\end{array}\right]'
 


### PR DESCRIPTION
The "is True" was added to these at some point to avoid calling bool(<inequality>), which results in an error if the inequality is symbolic. However, in SymPy when an inequality does evaluate, it evaluates to the SymPy true or false objects, not the built-in True or False. So the "is True" check would never succeed, even when it should.

This no doubt fixes several bugs (I know for a fact the one in risch fixes a bug that can prevent infinite looping, which is how I found this). If desired, I can try to find test cases to test these. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
