### PR TITLE
fix(printing/rust): Correct precedence for implicit TypeCast

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1204,6 +1204,7 @@ Pauli Virtanen <pav@iki.fi>
 Pavel Fedotov <fedotovp@gmail.com>
 Pavel Tkachenko <paveltkachenko@email.com>
 Pearu Peterson <pearu.peterson@gmail.com> pearu.peterson <devnull@localhost>
+Pedro H. S. Prestes <pedrohsprestes@gmail.com>
 Pedro Rosa <pedro_sxbr@usp.br>
 Peeyush Kushwaha <peeyush.p97@gmail.com>
 Peleg Michaeli <freepeleg@gmail.com> <peleg@palgo-at.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1204,7 +1204,7 @@ Pauli Virtanen <pav@iki.fi>
 Pavel Fedotov <fedotovp@gmail.com>
 Pavel Tkachenko <paveltkachenko@email.com>
 Pearu Peterson <pearu.peterson@gmail.com> pearu.peterson <devnull@localhost>
-Pedro H. S. Prestes <pedrohsprestes@gmail.com>
+Pedro H. S. Prestes <pedrohsprestes@gmail.com> Pedro H. Prestes <146496459+phprestes@users.noreply.github.com>
 Pedro Rosa <pedro_sxbr@usp.br>
 Peeyush Kushwaha <peeyush.p97@gmail.com>
 Peleg Michaeli <freepeleg@gmail.com> <peleg@palgo-at.com>

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -45,7 +45,7 @@ from sympy.core.expr import Expr
 from sympy.core.numbers import equal_valued
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.printing.codeprinter import CodePrinter
-from sympy.printing.precedence import PRECEDENCE
+from sympy.printing.precedence import PRECEDENCE, precedence
 
 # Rust's methods for integer and float can be found at here :
 #
@@ -256,6 +256,8 @@ class TypeCast(Expr):
         self._assumptions = expr._assumptions
         if self.explicit:
             setattr(self, 'precedence', PRECEDENCE["Func"] + 10)
+        else:
+            setattr(self, 'precedence', precedence(self.expr))
 
     @property
     def expr(self):
@@ -267,7 +269,6 @@ class TypeCast(Expr):
 
     def sort_key(self, order=None):
         return self.args[0].sort_key(order=order)
-
 
 class RustCodePrinter(CodePrinter):
     """A printer to convert SymPy expressions to strings of Rust code"""

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -1,8 +1,8 @@
-from sympy.core import (S, pi, oo, symbols, Rational, Integer,
+from sympy.core import (S, pi, oo, symbols, Rational, Integer, Symbol,
                         GoldenRatio, EulerGamma, Catalan, Lambda, Dummy,
                         Eq, Ne, Le, Lt, Gt, Ge, Mod)
 from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
-                             sign, floor)
+                             sign, floor, log)
 from sympy.logic import ITE
 from sympy.testing.pytest import raises
 from sympy.utilities.lambdify import implemented_function
@@ -361,3 +361,20 @@ def test_sparse_matrix():
     # gh-15791
     with raises(NotImplementedError):
         rust_code(SparseMatrix([[1, 2, 3]]))
+
+def test_parenthesize_typecast():
+    modulus = Symbol("modulus")
+    lwe_dimension = Symbol("lwe_dimension")
+
+    exp = (
+        2
+        ** (
+            2
+            * ceiling(
+                -0.025167785 * lwe_dimension + log(modulus) / log(2) + 4.10067100000001
+            )
+        )
+        + 0.5
+    ) / (3 * modulus**2)
+
+    assert(rust_code(exp) == '(1_f64/3.0)*(0.5 + (2*(-0.025167785*lwe_dimension + modulus.ln()/2_i32.ln() + 4.10067100000001).ceil()).exp2())*modulus.powi(-2)')

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -364,17 +364,7 @@ def test_sparse_matrix():
 
 def test_parenthesize_typecast():
     modulus = Symbol("modulus")
-    lwe_dimension = Symbol("lwe_dimension")
 
-    exp = (
-        2
-        ** (
-            2
-            * ceiling(
-                -0.025167785 * lwe_dimension + log(modulus) / log(2) + 4.10067100000001
-            )
-        )
-        + 0.5
-    ) / (3 * modulus**2)
-
-    assert(rust_code(exp) == '(1_f64/3.0)*(0.5 + (2*(-0.025167785*lwe_dimension + modulus.ln()/2_i32.ln() + 4.10067100000001).ceil()).exp2())*modulus.powi(-2)')
+    exp = (2 ** (2.0 * ceiling(-y + log(x) / log(2.0) + 4)) + 0.5) / (3 * modulus**2)
+    
+    assert(rust_code(exp) == '(1_f64/3.0)*(0.5 + (2.0*(-y + 1.44269504088896*x.ln()).ceil() + 8.0).exp2())*modulus.powi(-2)')

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -364,7 +364,5 @@ def test_sparse_matrix():
 
 def test_parenthesize_typecast():
     modulus = Symbol("modulus")
-
     exp = (2 ** (2.0 * ceiling(-y + log(x) / log(2.0) + 4)) + 0.5) / (3 * modulus**2)
-    
     assert(rust_code(exp) == '(1_f64/3.0)*(0.5 + (2.0*(-y + 1.44269504088896*x.ln()).ceil() + 8.0).exp2())*modulus.powi(-2)')


### PR DESCRIPTION
Fixes #28418 

This PR fixes a bug in the rust_code printer that caused it to generate syntactically incorrect code for certain expressions. The issue occurred when an expression contained an addition inside a multiplication that also involved floating-point numbers.

The root cause was the internal TypeCast object, used by the printer when floats are present, not having a defined precedence level for implicit casts. This led the printer to misjudge operator precedence and omit necessary parentheses around the addition..

A regression test, test_parenthesize_typecast, has been added to sympy/printing/tests/test_rust.py to prevent this issue from recurring.

```python
from sympy import symbols, rust_code, ceiling, log
x, y = symbols('x y')

# A simplified version of the problematic expression
expr = (2**ceiling(x) + 0.5) / (3*y**2)
print(rust_code(expr))
```
Output from master (incorrect):
```rust 
(1_f64/3.0)*0.5 + x.ceil().exp2()*y.powi(-2)
```

Output from this PR (correct):
```rust 
(1_f64/3.0)*(0.5 + x.ceil().exp2())*y.powi(-2)
```

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug in `rust_code` that generated syntactically incorrect code for expressions involving mixed arithmetic with floats, due to incorrect parenthesization.
<!-- END RELEASE NOTES -->
