### PR TITLE
Fix FiniteExtension domain exquo implementation

### DIFF
--- a/sympy/polys/agca/extensions.py
+++ b/sympy/polys/agca/extensions.py
@@ -3,7 +3,7 @@
 from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.polyerrors import (CoercionFailed, NotInvertible,
-        GeneratorsError)
+        GeneratorsError, ExactQuotientFailed)
 from sympy.polys.polytools import Poly
 from sympy.printing.defaults import DefaultPrinting
 
@@ -341,7 +341,14 @@ class MonogenicFiniteExtension(Domain):
         return self.exquo(f, g)
 
     def exquo(self, f, g):
-        rep = self.ring.exquo(f.rep, g.rep)
+        ring = self.ring
+        try:
+            rep = ring.exquo(f.rep, g.rep)
+        except ExactQuotientFailed:
+            if not ring.domain.is_Field:
+                raise
+            ginv = ring.invert(g.rep, self.mod)
+            rep = ring.mul(f.rep, ginv)
         return ExtElem(rep % self.mod, self)
 
     def is_negative(self, a):

--- a/sympy/polys/agca/tests/test_extensions.py
+++ b/sympy/polys/agca/tests/test_extensions.py
@@ -112,6 +112,10 @@ def test_FiniteExtension_exquo():
     xf = K(x)
     assert K.exquo(xf**2 - 1, xf - 1) == xf + 1
 
+    K1 = FiniteExtension(Poly(x**3 - 101*x**2 - 1141*x - 15066, x, domain=QQ))
+    x1 = K1(x)
+    assert K1.exquo(-25*x1**2 - 1797*x1 - 15106, 10 - x1) == x1**2 - 66*x1 - 4
+
 
 def test_FiniteExtension_convert():
     # Test from_MonogenicFiniteExtension
@@ -194,3 +198,12 @@ def test_FiniteExtension_sincos_jacobian():
         J = DomainMatrix(elements_K, (3, 3), K)
         det = J.charpoly()[-1] * (-K.one)**3
         assert det == K.convert(r**2*sin(p))
+
+def test_nullspace_finiteextension():
+    mat = DomainMatrix({0: {0: 10, 1: 12, 2: 44}, 1: {0: 47, 1: 56, 2: 67},
+                        2: {0: 22, 1: 37, 2: 35}}, (3, 3), QQ)
+    field = FiniteExtension(Poly(x**3 - 101*x**2 - 1141*x - 15066, x, domain=QQ))
+    expected_result = DomainMatrix({0: {i: field.convert(e)
+            for i, e in enumerate([44*x - 1660, 67*x + 1398, x**2 - 66*x - 4])}}, (1, 3), field)
+    result = (mat.convert_to(field) - field(x) * mat.eye(mat.shape, field)).nullspace()
+    assert result == expected_result


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see - https://github.com/sympy/sympy/pull/28195#issuecomment-3341703506
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Implemented proper exquo support in FiniteExtension domains to allow exact division of elements. This resolves errors in matrix operations such as nullspace() that previously raised ExactQuotientFailed when working over finite extension fields.

#### Other comments
Before
```
>>> mat = DomainMatrix({0: {0: 10, 1: 12, 2: 44}, 1: {0: 47, 1: 56, 2: 67},
...                         2: {0: 22, 1: 37, 2: 35}}, (3, 3), QQ)
>>> field = FiniteExtension(Poly(x**3 - 101*x**2 - 1141*x - 15066, x, domain=QQ))
>>> (mat.convert_to(field)- field(x) * mat.eye(mat.shape, field)).nullspace()

sympy.polys.polyerrors.ExactQuotientFailed: DMP_Python([-1, 10], QQ) does not divide DMP_Python([-25, -1797, -15106], QQ) in QQ[x]
```

After
```
>>> mat = DomainMatrix({0: {0: 10, 1: 12, 2: 44}, 1: {0: 47, 1: 56, 2: 67},
...                         2: {0: 22, 1: 37, 2: 35}}, (3, 3), QQ)
>>> field = FiniteExtension(Poly(x**3 - 101*x**2 - 1141*x - 15066, x, domain=QQ))
>>>
>>> mat = DomainMatrix({0: {0: 10, 1: 12, 2: 44}, 1: {0: 47, 1: 56, 2: 67},
...                         2: {0: 22, 1: 37, 2: 35}}, (3, 3), QQ)
>>> field = FiniteExtension(Poly(x**3 - 101*x**2 - 1141*x - 15066, x, domain=QQ))
>>> (mat.convert_to(field)- field(x) * mat.eye(mat.shape, field)).nullspace()
DomainMatrix({0: {2: x**2 - 66*x - 4, 0: 44*x - 1660, 1: 67*x + 1398}}, (1, 3), QQ[x]/(x**3 - 101*x**2 - 1141*x - 15066))
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
