### PR TITLE
docs(printing/LLVM): add documentation for llvmjitcode module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -942,6 +942,7 @@ Lakshya Agrawal <zeeshan.lakshya@gmail.com>
 Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
 Laura Domine <temigo@gmx.com>
+Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
 Lauren Glattly <laurenglattly@gmail.com>
 Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
 Laurence Warne <laurencewarne@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -942,7 +942,7 @@ Lakshya Agrawal <zeeshan.lakshya@gmail.com>
 Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
 Laura Domine <temigo@gmx.com>
-Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
+Laura Pazini Medeiros <laurapazinimedeiros@gmail.com> Laura Pazini Medeiros <162479440+LauraPaziniMedeiros@users.noreply.github.com>
 Lauren Glattly <laurenglattly@gmail.com>
 Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
 Laurence Warne <laurencewarne@gmail.com>

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -123,7 +123,13 @@ Usage::
 
 .. autofunction:: sympy.printing.codeprinter::cxxcode
 
+.. _printing-llvm:
 
+LLVM JIT Code Printing
+----------------------
+
+.. automodule:: sympy.printing.llvmjitcode
+   :members:
 
 RCodePrinter
 ------------

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -386,9 +386,9 @@ def llvm_callable(args, expr, callback_type=None):
     callback_type : string
         Create function with signature appropriate to use as a callback.
         Currently supported:
-           'scipy.integrate'
-           'scipy.integrate.test'
-           'cubature'
+        'scipy.integrate'
+        'scipy.integrate.test'
+        'cubature'
 
     Returns
     =======

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -1,6 +1,13 @@
 '''
 Use llvmlite to create executable functions from SymPy expressions
 
+The primary goal is to significantly accelerate the numerical evaluation of
+expressions, which is especially useful for functions that need to be called
+repeatedly with different arguments (e.g., in numerical integration,
+optimization, or plotting).
+
+The main entry point for users is the llvm_callable function.
+
 This module requires llvmlite (https://github.com/numba/llvmlite).
 '''
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partially deals with #28470

#### Brief description of what is fixed or changed
The  [llvmjitcode](https://github.com/sympy/sympy/blob/master/sympy/printing/llvmjitcode.py) module was not documented, making it difficult for users to discover the LLVM JIT printing functionality. This PR exposes the module's existing docstrings on the main printing documentation page using Sphinx's automodule directive.
Additionally, a docstring indentation error that caused the documentation build to fail has been corrected.

#### Other comments

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->