### PR TITLE
DOCS : Added docstring for printing/llvmjitcode.py module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1459,6 +1459,7 @@ Shishir Kushwaha <kushwahashishir1112@gmail.com>
 Shishir Kushwaha <kushwahashishir1112@gmail.com> shishir-11 <138311586+shishir-11@users.noreply.github.com>
 Shital Mule <shitalmule04@gmail.com>
 Shivam Agarwal <knowthyself2503@gmail.com>
+Shivam Dave <shivamdave2903@gmail.com>
 Shivam Sagar <technoshivam12@gmail.com> Shivam Sagar <77241314+hey-sagar@users.noreply.github.com>
 Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
 Shivam Vats <shivamvats.iitkgp@gmail.com> <aries@aries-Inspiron-3521.(none)>

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -683,6 +683,79 @@ The following constants/functions are for rendering atoms and symbols.
 .. autoclass:: prettyForm
    :members:
 
+LLVM JIT Compilation
+--------------------
+
+.. module:: sympy.printing.llvmjitcode
+
+SymPy can compile symbolic expressions to native machine code using LLVM through
+the `llvmlite` library. This provides significant performance improvements for
+numerical evaluation of expressions, especially when used as callbacks for
+integration routines.
+
+The main function for LLVM JIT compilation is `llvm_callable()`, which converts
+a SymPy expression into a compiled function that can be called with numerical
+arguments.
+
+Usage::
+
+    >>> from sympy.printing.llvmjitcode import llvm_callable
+    >>> from sympy.abc import x, y
+    >>> expr = x**2 + 2*x + 1
+    >>> f = llvm_callable([x], expr)
+    >>> f(3.0)  # Evaluate the expression at x=3
+    16.0
+
+The function supports various callback types for integration with external
+libraries:
+
+- ``'scipy.integrate'``: For use with SciPy's integration functions
+- ``'scipy.integrate.test'``: For direct testing with ctypes
+- ``'cubature'``: For use with the cubature integration library
+
+Example with SciPy integration::
+
+    >>> from sympy.printing.llvmjitcode import llvm_callable
+    >>> from sympy.abc import x
+    >>> from scipy.integrate import quad
+    >>> expr = x**2
+    >>> f = llvm_callable([x], expr, callback_type='scipy.integrate')
+    >>> quad(f, 0, 2)[0]  # Integrate x^2 from 0 to 2
+    2.6666666666666665
+
+The module also supports Common Subexpression Elimination (CSE) for improved
+performance::
+
+    >>> from sympy import cse
+    >>> from sympy.printing.llvmjitcode import llvm_callable
+    >>> from sympy.abc import x, y
+    >>> expr1 = x**2 + y**2
+    >>> expr2 = 4*(x**2 + y**2) + 8
+    >>> cse_result = cse([expr1, expr2])
+    >>> f = llvm_callable([x, y], cse_result)
+    >>> f(1.0, 2.0)  # Returns tuple: (expr1_value, expr2_value)
+    (5.0, 28.0)
+
+**Note**: This functionality requires the `llvmlite` library to be installed.
+See the :ref:`dependencies` page for installation instructions.
+
+.. autofunction:: llvm_callable
+
+.. autoclass:: LLVMJitPrinter
+   :members:
+
+.. autoclass:: LLVMJitCallbackPrinter
+   :members:
+
+.. autoclass:: LLVMJitCode
+   :members:
+
+.. autoclass:: LLVMJitCodeCallback
+   :members:
+
+.. autoclass:: CodeSignature
+   :members:
+
 dotprint
 --------
 

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -27,7 +27,26 @@ __doctest_requires__ = {('llvm_callable'): ['llvmlite']}
 
 
 class LLVMJitPrinter(Printer):
-    '''Convert expressions to LLVM IR'''
+    '''Convert SymPy expressions to LLVM IR.
+
+    Parameters
+    ==========
+
+    module : llvmlite.ir.Module
+        LLVM module to which generated IR is added.
+    builder : llvmlite.ir.IRBuilder
+        IR builder used to construct instructions.
+    fn : llvmlite.ir.Function
+        LLVM function being constructed.
+    func_arg_map : dict, optional
+        Mapping from Symbols to LLVM function arguments/values.
+
+    Notes
+    =====
+
+    This printer is used internally by :func:`llvm_callable` to lower SymPy
+    expressions to LLVM IR for JIT compilation via llvmlite.
+    '''
     def __init__(self, module, builder, fn, *args, **kwargs):
         self.func_arg_map = kwargs.pop("func_arg_map", {})
         if not llvmlite:


### PR DESCRIPTION
References to other Issues or PRs
This is with reference to the issue #28470


#### Brief description of what is fixed or changed

- Add Sphinx documentation for LLVM JIT printing

- Expose sympy.printing.llvmjitcode in doc/src/modules/printing.rst

- Improve in-code documentation. Add a docstring to sympy.printing.llvmjitcode.LLVMJitPrinter describing parameters, usage context, and relation to llvm_callable

- No functional changes to the JIT implementation; this PR only adds docs and a class docstring so that the LLVM JIT functionality appears in the rendered documentation and is easier to discover.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

