### PR TITLE
Add examples to HermitianPredicate documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1148,6 +1148,7 @@ Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
 Nilabja Bhattacharya <nilabja10201992@gmail.com>
 Nils Schulte <47043622+Schnilz@users.noreply.github.com>
 Nimish Telang <ntelang@gmail.com>
+Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
 Nirmal Sarswat <nirmalsarswat400@gmail.com>
 Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
 Nishant Nikhil <nishantiam@gmail.com>

--- a/sympy/assumptions/predicates/sets.py
+++ b/sympy/assumptions/predicates/sets.py
@@ -229,13 +229,27 @@ class HermitianPredicate(Predicate):
     ``ask(Q.hermitian(x))`` is true iff ``x`` belongs to the set of
     Hermitian operators.
 
+    Examples
+    ========
+
+    >>> from sympy import Q, ask, Matrix, I, Symbol
+    >>> ask(Q.hermitian(2))
+    True
+    >>> ask(Q.hermitian(I))
+    False
+    >>> A = Matrix([[1, I], [-I, 1]])
+    >>> ask(Q.hermitian(A))
+    True
+    >>> x = Symbol('x', real=True)
+    >>> ask(Q.hermitian(x))
+    True
+
     References
     ==========
 
     .. [1] https://mathworld.wolfram.com/HermitianOperator.html
 
     """
-    # TODO: Add examples
     name = 'hermitian'
     handler = Dispatcher(
         "HermitianHandler",


### PR DESCRIPTION
- Added Examples section with basic usage patterns
- Includes real numbers, imaginary unit, hermitian matrix, and real symbols
- Resolves TODO comment for adding examples
- All examples tested and working correctly

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
