### PR TITLE
Add examples to AntihermitianPredicate documentation

### DIFF
--- a/sympy/assumptions/predicates/sets.py
+++ b/sympy/assumptions/predicates/sets.py
@@ -328,13 +328,26 @@ class AntihermitianPredicate(Predicate):
     antihermitian operators, i.e., operators in the form ``x*I``, where
     ``x`` is Hermitian.
 
+    Examples
+    ========
+
+    >>> from sympy import Q, ask, Matrix, I
+    >>> ask(Q.antihermitian(I))
+    True
+    >>> ask(Q.antihermitian(2))
+    False
+    >>> A = Matrix([[0, -2 - I, 0], [2 - I, 0, -I], [0, -I, 0]])
+    >>> ask(Q.antihermitian(A))
+    True
+    >>> ask(Q.antihermitian(0))
+    True
+
     References
     ==========
 
     .. [1] https://mathworld.wolfram.com/HermitianOperator.html
 
     """
-    # TODO: Add examples
     name = 'antihermitian'
     handler = Dispatcher(
         "AntiHermitianHandler",


### PR DESCRIPTION
- Added Examples section with basic usage patterns
- Includes imaginary numbers, real numbers, antihermitian matrix, and zero
- Resolves TODO comment for adding examples
- All examples tested and working correctly

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
