### PR TITLE
Add support for Mathematica Not operator (!) in parse_mathematica.

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -1143,7 +1143,6 @@ class MathematicaParser:
         "Not": Not,
         "Function": _parse_Function,
         "Factorial": factorial,
-        "Factorial2": lambda x: factorial(x) * factorial(x - 1),
     }
 
     _atom_conversions = {

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -9,7 +9,7 @@ from sympy import Mul, Add, Pow, Rational, log, exp, sqrt, cos, sin, tan, asin, 
     acosh, atanh, acoth, asech, acsch, expand, im, flatten, polylog, cancel, expand_trig, sign, simplify, \
     UnevaluatedExpr, S, atan, atan2, Mod, Max, Min, rf, Ei, Si, Ci, airyai, airyaiprime, airybi, primepi, prime, \
     isprime, cot, sec, csc, csch, sech, coth, Function, E, I, pi, Tuple, GreaterThan, StrictGreaterThan, StrictLessThan, \
-    LessThan, Equality, Or, And, Lambda, Integer, Dummy, symbols
+    LessThan, Equality, Or, And, Lambda, Integer, Dummy, symbols, Not, factorial
 from sympy.core.sympify import sympify, _sympify
 from sympy.functions.special.bessel import airybiprime
 from sympy.functions.special.error_functions import li
@@ -912,6 +912,11 @@ class MathematicaParser:
                         if pointer == 0 or pointer == size - 1 or self._is_op(tokens[pointer - 1]) or self._is_op(tokens[pointer + 1]):
                             pointer += 1
                             continue
+                    # Special case: "!" without preceding operand is PREFIX Not, not POSTFIX Factorial
+                    if token == "!" and op_type == self.POSTFIX:
+                        if pointer == 0 or self._is_op(tokens[pointer - 1]):
+                            pointer += 1
+                            continue
                     changed = True
                     tokens[pointer] = node
                     if op_type == self.INFIX:
@@ -1135,8 +1140,10 @@ class MathematicaParser:
         "Equal": Equality,
         "Or": Or,
         "And": And,
-
+        "Not": Not,
         "Function": _parse_Function,
+        "Factorial": factorial,
+        "Factorial2": lambda x: factorial(x) * factorial(x - 1),
     }
 
     _atom_conversions = {

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -1,8 +1,9 @@
-from sympy import sin, Function, symbols, Dummy, Lambda, cos
+from sympy import sin, Function, symbols, Dummy, Lambda, cos, Symbol, factorial, S
 from sympy.parsing.mathematica import parse_mathematica, MathematicaParser
 from sympy.core.sympify import sympify
 from sympy.abc import n, w, x, y, z
 from sympy.testing.pytest import raises
+from sympy.logic.boolalg import And, Or, Not
 
 
 def test_mathematica():
@@ -335,3 +336,22 @@ def test_Mathematica_literal_regex():
                 assert literal_regex.fullmatch(c)
             if f"x{c}".isidentifier():
                 assert literal_regex.fullmatch(f"x{c}")
+
+
+def test_mathematica_not_operator():
+    # Basic tests
+    x = Symbol('x')
+    assert parse_mathematica("!x") == Not(x)
+
+    # And / Or combinations
+    x1, x2 = Symbol('x1'), Symbol('x2')
+    assert parse_mathematica("x1 && !x2") == And(x1, Not(x2))
+    assert parse_mathematica("!x1 || !x2") == Or(Not(x1), Not(x2))
+
+    # Constants
+    assert parse_mathematica("!True") == S.false
+    assert parse_mathematica("!False") == S.true
+
+    # Factorial distinction
+    assert parse_mathematica("x!") == factorial(x)
+

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -354,4 +354,3 @@ def test_mathematica_not_operator():
 
     # Factorial distinction
     assert parse_mathematica("x!") == factorial(x)
-


### PR DESCRIPTION
Fixes a KeyError that occurred when trying to parse boolean string from Mathematica that contains a Not operator : '!'. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #27859 

#### Brief description of what is fixed or changed
- Added "Not": Not to_node_conversions in mathematica.py.

- Added tests for basic Not operator parsing, including combinations with And (&&), Or (||), and boolean constants in test_mathematica.py.

- Added special case to handle '!' operator in _parse_after_braces function inside mathematica.py.

-  Added "Factorial": factorial to _node_conversions to ensure postfix factorial (x!) correctly maps to SymPy’s factorial(x) rather than creating a generic Function("Factorial").

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed `KeyError` when parsing Mathematica `Not` (`!`) operator in `parse_mathematica`.
  * Added proper conversion for postfix factorial (`x!`) to map to SymPy’s `factorial(x)`.
<!-- END RELEASE NOTES -->
