### PR TITLE
Add Flight Level (FL) unit for aviation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1814,3 +1814,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+jhaayushkumar <jha44481@gmail.com>
+

--- a/.mailmap
+++ b/.mailmap
@@ -1815,5 +1815,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-jhaayushkumar <jha44481@gmail.com>
-

--- a/sympy/physics/units/aviation_units.py
+++ b/sympy/physics/units/aviation_units.py
@@ -1,0 +1,28 @@
+import re
+from sympy.physics.units import Quantity, foot, meter
+
+# Flight Level unit: 1 FL = 100 ft
+FL = Quantity('flight_level', factor=100 * foot)
+
+MIN_FL = -10
+MAX_FL = 1267
+
+def parse_flight_level(fl_str):
+    """
+    Parse 'FLxxx' string to SymPy Quantity (flight_level)
+    """
+    m = re.match(r"FL(\d{1,4})", fl_str.upper())
+    if not m:
+        raise ValueError(f"Invalid Flight Level string: {fl_str}")
+
+    fl_number = int(m.group(1))
+    if not (MIN_FL <= fl_number <= MAX_FL):
+        raise ValueError(f"Flight Level {fl_number} out of range ({MIN_FL}..{MAX_FL})")
+
+    return FL * fl_number  # Quantity object
+
+def convert_quantity_to_numeric(qty, unit):
+    """
+    Convert Quantity to numeric value in given unit (meter or foot)
+    """
+    return (qty / unit).evalf()

--- a/sympy/physics/units/aviation_units.py
+++ b/sympy/physics/units/aviation_units.py
@@ -1,5 +1,5 @@
 import re
-from sympy.physics.units import Quantity, foot, meter
+from sympy.physics.units import Quantity, foot
 
 # Flight Level unit: 1 FL = 100 ft
 FL = Quantity('flight_level', factor=100 * foot)

--- a/sympy/physics/units/tests/test_flight_level.py
+++ b/sympy/physics/units/tests/test_flight_level.py
@@ -3,7 +3,7 @@ import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
-from aviation_units import parse_flight_level, convert_quantity_to_numeric
+from sympy.physics.units.aviation_units import parse_flight_level, convert_quantity_to_numeric
 from sympy.physics.units import meter, foot
 
 def test_flight_level():

--- a/sympy/physics/units/tests/test_flight_level.py
+++ b/sympy/physics/units/tests/test_flight_level.py
@@ -1,0 +1,22 @@
+# Fix imports to work in both direct run and python -m
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+from aviation_units import parse_flight_level, convert_quantity_to_numeric
+from sympy.physics.units import meter, foot
+
+def test_flight_level():
+    # Test valid FL
+    fl = parse_flight_level("FL290")
+    print("FL290 in meters:", convert_quantity_to_numeric(fl, meter))  # ~8839.2
+    print("FL290 in feet:", convert_quantity_to_numeric(fl, foot))     # 29000
+
+    # Test out-of-range
+    try:
+        parse_flight_level("FL2000")
+    except ValueError as e:
+        print("Error:", e)
+
+if __name__ == "__main__":
+    test_flight_level()


### PR DESCRIPTION
Resolves: #28478

This PR adds support for Flight Level (FL) units in SymPy, which is commonly used in aviation.

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Added support for 'Flight Level (FL)' as a new unit of altitude.
<!-- END RELEASE NOTES -->


### Changes made:
- Added `FL` Quantity in `physics/units/aviation_units.py`:
  - 1 FL = 100 ft
- Added parser function `parse_flight_level`:
  - Converts strings like "FL290" to a SymPy Quantity
  - Validates FL range: -10 to 1267
- Added helper function `convert_quantity_to_numeric`:
  - Converts Quantity to numeric value in meters or feet
- Added tests in `physics/units/tests/test_flight_level.py`:
  - Tests valid FL conversion
  - Tests out-of-range error handling

### Notes for reviewers:
- All new files contain proper docstrings
- Tests can be run directly via:
  ```bash
  cd sympy/physics/units
  python tests/test_flight_level.py
