### PR TITLE
Add tokenizer tests for Not operator (!).

### DIFF
--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -228,6 +228,21 @@ def test_parser_mathematica_tokenizer():
     assert chain("a//b//c") == [["a", "b"], "c"]
     assert chain("a//b//c//d") == [[["a", "b"], "c"], "d"]
 
+    # Not operator
+    assert chain("!x") == ["Not", "x"]
+    assert chain("!(a + b)") == ["Not", ["Plus", "a", "b"]]
+    assert chain("!True") == ["Not", "True"]
+    assert chain("!False") == ["Not", "False"]
+
+    # Distinguish Not and factorial
+    assert chain("x!") == ["Factorial", "x"]
+    assert chain("(a + b)!") == ["Factorial", ["Plus", "a", "b"]]
+
+    # Combination of Not with And/Or
+    assert chain("!x && y") == ["And", ["Not", "x"], "y"]
+    assert chain("x || !y") == ["Or", "x", ["Not", "y"]]
+    assert chain("!x || !y") == ["Or", ["Not", "x"], ["Not", "y"]]
+
     # Compound expressions
     assert chain("a;b") == ["CompoundExpression", "a", "b"]
     assert chain("a;") == ["CompoundExpression", "a", "Null"]

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -243,6 +243,10 @@ def test_parser_mathematica_tokenizer():
     assert chain("x || !y") == ["Or", "x", ["Not", "y"]]
     assert chain("!x || !y") == ["Or", ["Not", "x"], ["Not", "y"]]
 
+    # Enablement of implicit multiplication with factorial
+    assert chain("x!y") == ["Times", ["Factorial", "x"], "y"]
+    assert chain("x!y!") == ["Times", ["Factorial", "x"], ["Factorial", "y"]]
+
     # Compound expressions
     assert chain("a;b") == ["CompoundExpression", "a", "b"]
     assert chain("a;") == ["CompoundExpression", "a", "Null"]
@@ -369,3 +373,7 @@ def test_mathematica_not_operator():
 
     # Factorial distinction
     assert parse_mathematica("x!") == factorial(x)
+
+    # Factorial with implicit multiplication
+    assert parse_mathematica("x!y") == y*factorial(x)
+    assert parse_mathematica("x!y!") == factorial(x)*factorial(y)


### PR DESCRIPTION
Based on feedback, test cases are added in `test_parser_mathematica_tokenizer`, testing that S-expression equivalent is correctly parsed before converting to a SymPy expression.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Follow-up to #28492 

#### Brief description of what is fixed or changed
Added tests for Not operator(!) inside the aforementioned test block.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
