### PR TITLE
Optimize to_dnf for XOR expressions to avoid CNF expansion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1077,8 +1077,8 @@ class Xor(BooleanFunction):
             If True, simplifies the result.
         form : str or None
             Can be 'cnf' or 'dnf'. Default (None) keeps backward-compatible CNF-style output.
-            - 'cnf' → builds CNF (POS, conjunction of even-parity-false clauses)
-            - 'dnf' → builds DNF (SOP, disjunction of odd-parity-true clauses)
+            - 'cnf' -> builds CNF (POS, conjunction of even-parity-false clauses)
+            - 'dnf' -> builds DNF (SOP, disjunction of odd-parity-true clauses)
         """
 
         if form == 'dnf':

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1483,9 +1483,8 @@ class ITE(BooleanFunction):
             return c
         if b == c:
             return b
+
         else:
-            # or maybe the results allow the answer to be expressed
-            # in terms of the condition
             if b is true and c is false:
                 return a
             if b is false and c is true:

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1457,3 +1457,36 @@ def test_evaluate_false():
     expr = Equivalent(x, x, x, evaluate=False)
     assert isinstance(expr, Equivalent)
     assert expr.args == (x, x, x)
+
+
+
+import time
+
+
+def test_xor_dnf_cnf_symmetry():
+    x = symbols('x1:6')
+
+    expr = Xor(*x[:3])
+    assert simplify_logic(to_cnf(expr) ^ expr) == False
+    assert simplify_logic(to_dnf(expr) ^ expr) == False
+
+    # Performance test
+    t1 = time.time()
+    to_cnf(Xor(*x[:6]))
+    t_cnf = time.time() - t1
+
+    t2 = time.time()
+    to_dnf(Xor(*x[:6]))
+    t_dnf = time.time() - t2
+
+    assert t_dnf < t_cnf * 10, "DNF is unreasonably slower than CNF"
+
+def test_dnf_hint_behavior():
+    x = symbols('x1:4')
+    expr = Xor(*x)
+    dnf_expr = to_dnf(expr)
+    
+    # DNF should be an OR of AND terms
+    assert dnf_expr.is_Or, "DNF form should be an OR of AND terms"
+    for term in dnf_expr.args:
+        assert term.is_And or term.is_Atom, "Each term in DNF should be AND or literal"

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1485,7 +1485,7 @@ def test_dnf_hint_behavior():
     x = symbols('x1:4')
     expr = Xor(*x)
     dnf_expr = to_dnf(expr)
-    
+
     # DNF should be an OR of AND terms
     assert dnf_expr.is_Or, "DNF form should be an OR of AND terms"
     for term in dnf_expr.args:


### PR DESCRIPTION
Resolves: #28393

`to_dnf(Xor(...))` was slower than `to_cnf(...)` because XOR was internally converted to CNF.  
This PR introduces a direct DNF conversion for XOR, improving performance significantly.

<!-- BEGIN RELEASE NOTES -->
* logic
  * Optimized `to_dnf` for `Xor` expressions to avoid lowering to CNF, improving performance significantly.
  * Updated `to_dnf` and `BooleanFunction.to_nnf` for `Xor` handling.
  * Added tests in `test_boolalg.py` for correctness and performance.
<!-- END RELEASE NOTES -->


Tests can be run with:
pytest sympy/logic/tests/test_boolalg.py -k "xor"
