### PR TITLE
Fix integration error for exp(a(x^2+2x)) with negative=True assumption

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1834,31 +1834,30 @@ def meijerint_definite(f, x, a, b):
     elif a is S.NegativeInfinity:
         # Integrating -oo to oo. We need to find a place to split the integral.
         _debug('  Integrating -oo to +oo.')
-        
         # Special case for exp(a*(x^2 + 2*b*x + c)) where a < 0
         # This is a Gaussian integral that can be solved analytically
         from sympy.core.symbol import Wild
-        
+
         # Pattern: exp(a*(x^2 + 2*b*x + c)) where a < 0
         a_coeff = Wild('a_coeff', exclude=[x])
         b_coeff = Wild('b_coeff', exclude=[x])
         c_coeff = Wild('c_coeff', exclude=[x])
         pattern = exp(a_coeff * (x**2 + 2*b_coeff*x + c_coeff))
-        
+
         match = f.match(pattern)
         if match and match[a_coeff].is_negative:
             a_val = match[a_coeff]
             b_val = match[b_coeff]
             c_val = match[c_coeff]
-            
+
             # Complete the square: a*(x^2 + 2*b*x + c) = a*((x+b)^2 + (c-b^2))
             # The integral is: exp(a*(c-b^2)) * integral(exp(a*(x+b)^2)) from -oo to oo
             # = exp(a*(c-b^2)) * sqrt(pi/(-a))
             # = sqrt(pi) * exp(a*(c-b^2)) / sqrt(-a)
-            
+
             result = sqrt(pi) * exp(a_val * (c_val - b_val**2)) / sqrt(-a_val)
             return result, True
-        
+
         innermost = _find_splitting_points(f, x)
         _debug('  Sensible splitting points:', innermost)
         for c in sorted(innermost, key=default_sort_key, reverse=True) + [S.Zero]:

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -237,7 +237,7 @@ def test_meijerint():
     a_neg = symbols('a', negative=True)
     assert integrate(exp(a_neg*(x**2 + 2*x)), (x, -oo, oo)) == \
         sqrt(pi)*exp(-a_neg)/sqrt(-a_neg)
-    
+
     # Test that it matches the positive case
     a_pos = symbols('a', positive=True)
     result_pos = integrate(exp(-a_pos*(x**2 + 2*x)), (x, -oo, oo))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -233,6 +233,18 @@ def test_meijerint():
     assert simplify(integrate(x**s*exp(-a*x**2), (x, -oo, oo))) == \
         a**(-s/2 - S.Half)*((-1)**s + 1)*gamma(s/2 + S.Half)/2
 
+    # Test fix for issue #28485: exp(a*(x^2 + 2*x)) with negative a
+    a_neg = symbols('a', negative=True)
+    assert integrate(exp(a_neg*(x**2 + 2*x)), (x, -oo, oo)) == \
+        sqrt(pi)*exp(-a_neg)/sqrt(-a_neg)
+    
+    # Test that it matches the positive case
+    a_pos = symbols('a', positive=True)
+    result_pos = integrate(exp(-a_pos*(x**2 + 2*x)), (x, -oo, oo))
+    result_neg = integrate(exp(a_neg*(x**2 + 2*x)), (x, -oo, oo))
+    # They should be equal when a_neg = -a_pos
+    assert result_neg.subs(a_neg, -a_pos) == result_pos
+
 
 def test_bessel():
     from sympy.functions.special.bessel import (besseli, besselj)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

Fixed integration error for `exp(a*(x^2+2*x))` with `negative=True` assumption. The meijerg integration method was incorrectly returning expression `I*sqrt(pi)*exp(-a)*erfc(I*sqrt(a))/sqrt(a)` instead of the expected result `sqrt(pi)*exp(-a)/sqrt(-a)`.

Added special case handling in `meijerint_definite` for Gaussian integrals with negative coefficients using analytical solution for `exp(a*(x^2 + 2*b*x + c))` where `a < 0`.

Fixes #28485

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
  * Fixed integration error for `exp(a*(x^2+2*x))` with negative coefficient assumption.

<!-- END RELEASE NOTES -->