### PR TITLE
Fix _eval_interval in Piecewise to handle NaN correctly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -966,6 +966,7 @@ Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.
 Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
+Luca Bertoni <lucabertoni@gmail.com> luca-berton1 <kaiserverbalkint@gmail.com>
 Luca Weihs <astronomicalcuriosity@gmail.com>
 Lucas Gallindo <lgallindo@gmail.com>
 Lucas Jones <lucas@lucasjones.co.uk>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -577,8 +577,12 @@ class Piecewise(DefinedFunction):
                     return Undefined
                 # TODO simplify hi <= upto
                 return Piecewise((sum, hi <= upto), (Undefined, True))
-            sum += abei[i][-2]._eval_interval(x, a, b)
-            upto = b
+            k = abei[i][-2]._eval_interval(x, a, b)
+            if k is Undefined:
+                return Piecewise((sum, hi <= upto), (Undefined, True))
+            else:
+                sum += k
+                upto = b
         return sum
 
     def _intervals(self, sym, err_on_Eq=False):


### PR DESCRIPTION
#### Avoiding incorrect propagation of NaN when integrating piecewise functions with simbolic integration boundaries


<-- Fixes #28469 -->

#### Brief description of what is changed
When integrating piecewise functions, the integration interval is split up into smaller intervals, then the antiderivative is evaluated on every one of those, and the results are summed togheter. If one nan appears, the whole sum is corrupted, even if up to that point it was correct. 

To avoid that, I added a check on the value that is passed to the sum: if it is a NaN, the value of the function integrated up to that point is returned, and after that point it is left undefined.

Under the issue, the last comment I added explains with more detail the nature of the fix.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * Fixed a bug with multiple nested integrals of a piecewise function.
<!-- END RELEASE NOTES -->
