### PR TITLE
Fix eigenvects NotImplementedError for matrices with algebraic coefficients

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1135,6 +1135,7 @@ Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
 Nicolás Guarín-Zapata <nicoguarin@gmail.com>
 Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
 Nijso Beishuizen <nijso@koolmees.numerically-related.com>
+Nikhil Arora <nikhilarora13832@gmail.com>
 Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <47920034+NikhilSDate@users.noreply.github.com>
 Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <nikhil.s.date@gmail.com>
 Nikhil Gopalam <gopalamn@umich.edu> gopalamn <gopalamn@umich.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1135,7 +1135,7 @@ Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
 Nicolás Guarín-Zapata <nicoguarin@gmail.com>
 Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
 Nijso Beishuizen <nijso@koolmees.numerically-related.com>
-Nikhil Arora <nikhilarora13832@gmail.com>
+Nikhil Arora <nikhilarora13832@gmail.com> Nikhil172913832 <nikhilarora13832@gmail.com>
 Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <47920034+NikhilSDate@users.noreply.github.com>
 Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <nikhil.s.date@gmail.com>
 Nikhil Gopalam <gopalamn@umich.edu> gopalamn <gopalamn@umich.edu>

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -225,6 +225,18 @@ def test_eigenvects():
         assert M*vec_list[0] == val*vec_list[0]
 
 
+def test_eigenvects_algebraic_field():
+    M = Matrix([
+        [45, 15, 20, 18, sqrt(5)/2],
+        [15, 85, 35, 22, Rational(11, 37)],
+        [20, 35, 15, 40, 3*sqrt(3)/7],
+        [Rational(9, 2), 2, 4, 12, sqrt(7)/5],
+        [Rational(25, 13), sqrt(7)/4, 2, 1, 1]
+    ])
+    vecs = M.eigenvects()
+    assert len(vecs) > 0
+
+
 def test_left_eigenvects():
     M = Matrix([[0, 1, 1],
                 [1, 0, 0],
@@ -710,28 +722,3 @@ def test_issue_25282():
         mat.append(rotate(ds, i) + rotate(dd, i))
 
     assert sum(Matrix(mat).eigenvals().values()) == 24
-
-
-def test_eigenvects_algebraic_field():
-    # Test that eigenvects works with matrices having algebraic coefficients
-    # where symbolic root solving fails and CRootOf is needed.
-    # Regression test for issue #28507: NotImplementedError: CRootOf is not supported over EX
-    # Matrix from the original issue with multiple algebraic coefficients
-    # The characteristic polynomial has domain over QQ<sqrt(3) + sqrt(5) + sqrt(7)>
-    M = Matrix([
-        [45, 15, 20, 18, sqrt(5)/2],
-        [15, 85, 35, 22, Rational(11, 37)],
-        [20, 35, 15, 40, 3*sqrt(3)/7],
-        [Rational(9, 2), 2, 4, 12, sqrt(7)/5],
-        [Rational(25, 13), sqrt(7)/4, 2, 1, 1]
-    ])
-
-    # Before the fix, this would raise:
-    # NotImplementedError: CRootOf is not supported over EX
-    # because the minimal polynomial has algebraic coefficients and
-    # converting to expression lost the AlgebraicField domain
-    vecs = M.eigenvects()
-
-    # Just verify it completes without error and returns results
-    assert len(vecs) > 0
-    assert all(mult > 0 for _, mult, _ in vecs)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -710,3 +710,32 @@ def test_issue_25282():
         mat.append(rotate(ds, i) + rotate(dd, i))
 
     assert sum(Matrix(mat).eigenvals().values()) == 24
+
+
+def test_issue_28507():
+    # Test that eigenvects works with matrices containing algebraic coefficients
+    # Previously raised: NotImplementedError: CRootOf is not supported over EX
+    M = Matrix([
+        [1, sqrt(2)],
+        [sqrt(2), 3]
+    ])
+
+    vecs = M.eigenvects()
+    assert len(vecs) == 2
+    # Verify eigenvector equation: M*v = lambda*v
+    for val, mult, vec_list in vecs:
+        assert len(vec_list) == mult
+        for v in vec_list:
+            assert simplify(M*v - val*v) == Matrix([0, 0])
+
+    # Test with multiple algebraic coefficients (sqrt(2) and sqrt(3))
+    M2 = Matrix([
+        [sqrt(2), 1],
+        [1, sqrt(3)]
+    ])
+
+    vecs2 = M2.eigenvects()
+    assert len(vecs2) == 2
+    for val, mult, vec_list in vecs2:
+        for v in vec_list:
+            assert simplify(M2*v - val*v) == Matrix([0, 0])

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -713,29 +713,26 @@ def test_issue_25282():
 
 
 def test_eigenvects_algebraic_field():
-    # Test that eigenvects works with matrices containing algebraic coefficients
-    # Regression test for issue #28507
+    # Test that eigenvects works with matrices having algebraic coefficients
+    # where symbolic root solving fails and CRootOf is needed.
+    # Regression test for issue #28507: NotImplementedError: CRootOf is not supported over EX
+    
+    # Matrix from the original issue with multiple algebraic coefficients
+    # The characteristic polynomial has domain over QQ<sqrt(3) + sqrt(5) + sqrt(7)>
     M = Matrix([
-        [1, sqrt(2)],
-        [sqrt(2), 3]
+        [45, 15, 20, 18, sqrt(5)/2],
+        [15, 85, 35, 22, Rational(11, 37)],
+        [20, 35, 15, 40, 3*sqrt(3)/7],
+        [Rational(9, 2), 2, 4, 12, sqrt(7)/5],
+        [Rational(25, 13), sqrt(7)/4, 2, 1, 1]
     ])
-
+    
+    # Before the fix, this would raise:
+    # NotImplementedError: CRootOf is not supported over EX
+    # because the minimal polynomial has algebraic coefficients and
+    # converting to expression lost the AlgebraicField domain
     vecs = M.eigenvects()
-    assert len(vecs) == 2
-    # Verify eigenvector equation: M*v = lambda*v
-    for val, mult, vec_list in vecs:
-        assert len(vec_list) == mult
-        for v in vec_list:
-            assert simplify(M*v - val*v) == Matrix([0, 0])
-
-    # Test with multiple algebraic coefficients (sqrt(2) and sqrt(3))
-    M2 = Matrix([
-        [sqrt(2), 1],
-        [1, sqrt(3)]
-    ])
-
-    vecs2 = M2.eigenvects()
-    assert len(vecs2) == 2
-    for val, mult, vec_list in vecs2:
-        for v in vec_list:
-            assert simplify(M2*v - val*v) == Matrix([0, 0])
+    
+    # Just verify it completes without error and returns results
+    assert len(vecs) > 0
+    assert all(mult > 0 for _, mult, _ in vecs)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -716,7 +716,6 @@ def test_eigenvects_algebraic_field():
     # Test that eigenvects works with matrices having algebraic coefficients
     # where symbolic root solving fails and CRootOf is needed.
     # Regression test for issue #28507: NotImplementedError: CRootOf is not supported over EX
-    
     # Matrix from the original issue with multiple algebraic coefficients
     # The characteristic polynomial has domain over QQ<sqrt(3) + sqrt(5) + sqrt(7)>
     M = Matrix([
@@ -726,13 +725,13 @@ def test_eigenvects_algebraic_field():
         [Rational(9, 2), 2, 4, 12, sqrt(7)/5],
         [Rational(25, 13), sqrt(7)/4, 2, 1, 1]
     ])
-    
+
     # Before the fix, this would raise:
     # NotImplementedError: CRootOf is not supported over EX
     # because the minimal polynomial has algebraic coefficients and
     # converting to expression lost the AlgebraicField domain
     vecs = M.eigenvects()
-    
+
     # Just verify it completes without error and returns results
     assert len(vecs) > 0
     assert all(mult > 0 for _, mult, _ in vecs)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -225,6 +225,7 @@ def test_eigenvects():
         assert M*vec_list[0] == val*vec_list[0]
 
 
+@slow
 def test_eigenvects_algebraic_field():
     M = Matrix([
         [45, 15, 20, 18, sqrt(5)/2],
@@ -234,7 +235,12 @@ def test_eigenvects_algebraic_field():
         [Rational(25, 13), sqrt(7)/4, 2, 1, 1]
     ])
     vecs = M.eigenvects()
-    assert len(vecs) > 0
+    assert len(vecs) == 5
+    for val, mult, vec_list in vecs:
+        assert len(vec_list) == 1
+        v = vec_list[0]
+        diff = M*v - val*v
+        assert all(abs(x) < 1e-10 for x in diff.evalf().values())
 
 
 def test_left_eigenvects():

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -712,9 +712,9 @@ def test_issue_25282():
     assert sum(Matrix(mat).eigenvals().values()) == 24
 
 
-def test_issue_28507():
+def test_eigenvects_algebraic_field():
     # Test that eigenvects works with matrices containing algebraic coefficients
-    # Previously raised: NotImplementedError: CRootOf is not supported over EX
+    # Regression test for issue #28507
     M = Matrix([
         [1, sqrt(2)],
         [sqrt(2), 3]

--- a/sympy/polys/matrices/eigen.py
+++ b/sympy/polys/matrices/eigen.py
@@ -76,10 +76,12 @@ def dom_eigenvects_to_sympy(
         eigenvects = [[field.to_sympy(x) for x in vect] for vect in eigenvects]
 
         degree = minpoly.degree()
-        minpoly = minpoly.as_expr()
-        eigenvals = roots(minpoly, l, **kwargs)
+        # Try to get symbolic roots first
+        eigenvals = roots(minpoly.as_expr(), l, **kwargs)
         if len(eigenvals) != degree:
-            eigenvals = [CRootOf(minpoly, l, idx) for idx in range(degree)]
+            # Use CRootOf.all_roots which handles algebraic fields properly
+            # by passing the Poly object directly instead of converting to expression
+            eigenvals = CRootOf.all_roots(minpoly, radicals=kwargs.get('radicals', True))
 
         for eigenvalue in eigenvals:
             new_eigenvects = [


### PR DESCRIPTION
Fixes #28507

Replace CRootOf(expr, var, idx) with CRootOf.all_roots(poly) to preserve AlgebraicField domain and avoid conversion to unsupported EX domain.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28507

#### Brief description of what is fixed or changed

The `eigenvects()` method was raising `NotImplementedError: CRootOf is not supported over EX` when computing eigenvectors for matrices with algebraic coefficients (e.g., sqrt(2), sqrt(3), sqrt(5), sqrt(7)).

**Root cause:** Converting the minimal polynomial to an expression via `minpoly.as_expr()` before passing to `CRootOf` caused the domain to convert from `AlgebraicField` to `EX` domain during `PurePoly` construction and subsequent `retract()` call.

**Solution:** Use `CRootOf.all_roots(poly)` with the `Poly` object directly instead of creating individual `CRootOf` objects from an expression. This preserves the `AlgebraicField` domain and ensures the correct code path (`_get_roots_alg`) is used for handling algebraic coefficients.

#### Other comments

The slow performance (~20 minutes for large matrices) mentioned in the issue is tracked separately in #28486 and requires root refinement algorithm improvements, which is beyond the scope of this fix.

All existing tests pass without regression.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Fixed `NotImplementedError` in `eigenvects()` for matrices with algebraic coefficients. The method now correctly handles polynomials over algebraic fields by preserving domain information.

<!-- END RELEASE NOTES -->