### PR TITLE
Fix TypeError when replacing matrix addition expressions in MatAdd

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1729,6 +1729,7 @@ dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.co
 dps7ud <dps7ud@virginia.edu>
 dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>
+edson duarte <eduarte.uatach@gmail.com>
 elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -2,9 +2,9 @@ from functools import reduce
 import operator
 
 from sympy.core import Basic, sympify
-from sympy.singleton import S
 from sympy.core.add import add, Add, _could_extract_minus_sign
 from sympy.core.sorting import default_sort_key
+from sympy.core.singleton import S
 from sympy.functions import adjoint
 from sympy.matrices.matrixbase import MatrixBase
 from sympy.matrices.expressions.transpose import transpose

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -2,6 +2,7 @@ from functools import reduce
 import operator
 
 from sympy.core import Basic, sympify
+from sympy.singleton import S
 from sympy.core.add import add, Add, _could_extract_minus_sign
 from sympy.core.sorting import default_sort_key
 from sympy.functions import adjoint

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -106,51 +106,43 @@ class MatAdd(MatrixExpr, Add):
         return [j for i in add_lines for j in i]
 
     def _eval_subs(self, old, new):
+        substitution = None
+
         if not old.is_Add:
             if old is S.Infinity and -old in self.args:
-                # foo - oo is foo + (-oo) internally
-                return self.xreplace({-old: -new})
-            return None
+                substitution = self.xreplace({-old: -new})
 
         coeff_self, terms_self = self.as_coeff_Add()
         coeff_old, terms_old = old.as_coeff_Add()
 
         if coeff_self.is_Rational and coeff_old.is_Rational:
-            if terms_self == terms_old:   # (2 + a).subs( 3 + a, y) -> -1 + y
-                return self.func(new, coeff_self, -coeff_old)
-            if terms_self == -terms_old:  # (2 + a).subs(-3 - a, y) -> -1 - y
-                return self.func(-new, coeff_self, coeff_old)
+            if terms_self == terms_old:
+                substitution = self.func(new, coeff_self, -coeff_old)
+            elif terms_self == -terms_old:
+                substitution = self.func(-new, coeff_self, coeff_old)
+        elif coeff_self == coeff_old:
+            args_old = self.func.make_args(terms_old)
+            args_self = self.func.make_args(terms_self)
 
-        if coeff_self.is_Rational and coeff_old.is_Rational \
-                or coeff_self == coeff_old:
-            args_old, args_self = self.func.make_args(
-                terms_old), self.func.make_args(terms_self)
-            if len(args_old) < len(args_self):  # (a+b+c).subs(b+c,x) -> a+x
+            if len(args_old) < len(args_self):
                 self_set = set(args_self)
                 old_set = set(args_old)
 
+                if old_set >= self_set:
+                    args_old = self.func.make_args(-terms_old)
+                    old_set = set(args_old)
+
                 if old_set < self_set:
                     ret_set = self_set - old_set
                     if isinstance(coeff_old, MatrixExpr) \
                             and isinstance(coeff_self, MatrixExpr):
-                        return self.func(new, coeff_self, -coeff_old,
+                        substitution = self.func(new, coeff_self, -coeff_old,
                                    *[s._subs(old, new) for s in ret_set])
                     else:
-                        return self.func(new,
+                        substitution = self.func(new,
                                    *[s._subs(old, new) for s in ret_set])
 
-                args_old = self.func.make_args(
-                    -terms_old)     # (a+b+c+d).subs(-b-c,x) -> a-x+d
-                old_set = set(args_old)
-                if old_set < self_set:
-                    ret_set = self_set - old_set
-                    if isinstance(coeff_old, MatrixExpr) \
-                            and isinstance(coeff_self, MatrixExpr):
-                        return self.func(new, coeff_self, -coeff_old,
-                                   *[s._subs(old, new) for s in ret_set])
-                    else:
-                        return self.func(new,
-                                   *[s._subs(old, new) for s in ret_set])
+        return substitution
 
 add.register_handlerclass((Add, MatAdd), MatAdd)
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28264

#### Brief description of what is fixed or changed
`MatAdd` inherits `_eval_subs` from parent `Add` but it does not work when replacing expressions that contain matrix additions

#### Other comments
None

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed `TypeError` in _eval_subs when replacing expressions containing matrix addition
<!-- END RELEASE NOTES -->
