### PR TITLE
Fixed PDF and eval_prob function in stats

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1374,6 +1374,7 @@ S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
+Sachi Jain <jainsachi1202@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> sachin-4099 <sachinagarwal0499@gmail.com>
 Sachin Irukula <sachin.irukula@gmail.com>

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -207,7 +207,11 @@ class GeometricDistribution(SingleDiscreteDistribution):
         _value_check((0 < p, p <= 1), "p must be between 0 and 1")
 
     def pdf(self, k):
-        return (1 - self.p)**(k - 1) * self.p
+        k = sympify(k)
+        p = self.p
+        if k.is_number and (not k.is_integer or k < 1):
+            return S.Zero
+        return p * (1 - p)**(k - 1)
 
     def _characteristic_function(self, t):
         p = self.p


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Fix geometric distribution PDF domain and evaluation inconsistencies

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #20031 " (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20031 

#### Brief description of what is fixed or changed

- I have fixed the PDF and evel_prob_ function in drv to calculate the density and probability more precisely and give 0 as output , instead of float , as it should be.

-  doit() on the full nested sum is returning 0. The issue is that when we have a nested sum with KroneckerDelta that depends on both summation variables, SymPy doesn't evaluate it correctly. Thats why I am using simplify() to evaluate.

- I have added detailed test cases for both of the issues pointed out in #20031 

#### Other comments
I have made changes in 2 existing test cases :
1.  assert x*(x - 1)*2 == (x * ((-x + 1) * 2))  (I have added equals in place of this as these are mathematically same)
2. **Issue**: Test expected `P(X1 + X2 = 3) = 1/12` but correct answer is `7/36`.

  Calculation: For X1 ~ Geometric(1/2) and X2 ~ Geometric(1/3):
- `P(X1=1, X2=2) = (1/2) × (1/3)(2/3) = 1/2 × 2/9 = 1/9`
- `P(X1=2, X2=1) = (1/4) × (1/3) = 1/12`
- **Total: 1/9 + 1/12 = 4/36 + 3/36 = 7/36** 



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY
<!-- END RELEASE NOTES -->
