### PR TITLE
docs: add simple worked example for sympy.integrals.integrate on rational-function partial fractions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1704,6 +1704,7 @@ cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>
 der-blaue-elefant <github@kklein.de>
+devBitt <adithyanscodes@gmail.com>
 dimasvq <dimas.vq.2020@bristol.ac.uk>
 dispasha <dispasha@users.noreply.github.com>
 dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.com>

--- a/doc/src/tutorials/index.rst
+++ b/doc/src/tutorials/index.rst
@@ -16,6 +16,8 @@ If you are new to SymPy, start here.
    :hidden:
 
    intro-tutorial/index.rst
+   integrals.rst
+
 
 :ref:`Physics Tutorial <physics_tutorials>`
 ===========================================

--- a/doc/src/tutorials/integrals.rst
+++ b/doc/src/tutorials/integrals.rst
@@ -1,0 +1,56 @@
+.. _integrate-partial-fractions:
+
+=========================================================
+Example: Integration of Rational Functions using SymPy
+=========================================================
+
+SymPy can automatically perform integration on rational functions using
+partial fraction decomposition. This is a common operation when dealing
+with symbolic calculus, and SymPy makes it very simple to execute.
+
+This example demonstrates how to integrate a rational function and verify
+the result.
+
+.. code-block:: python
+
+   from sympy import symbols, integrate
+
+   # Define the variable
+   x = symbols('x')
+
+   # Define the rational function
+   expr = (2*x + 3) / (x**2 + 3*x + 2)
+
+   # Perform the integration
+   result = integrate(expr, x)
+   print(result)
+
+The output will be:
+
+.. code-block:: text
+
+   log(x + 1) + log(x + 2)
+
+SymPy automatically decomposes the rational expression into partial fractions
+and integrates them.
+
+You can verify that the result is correct by differentiating the integral:
+
+.. code-block:: python
+
+   from sympy import diff, simplify
+
+   simplify(diff(result, x) - expr)
+
+This returns ``0``, confirming that the integration result is correct.
+
+---
+
+**Explanation**
+
+- ``integrate(expr, x)`` computes the indefinite integral of ``expr`` with respect to ``x``.
+- For rational functions, SymPy internally uses *partial fraction decomposition* when appropriate.
+- You can use ``diff(result, x)`` to differentiate the result and confirm it matches the original expression.
+
+This simple example demonstrates how SymPy’s integration engine handles rational
+functions efficiently while allowing users to symbolically verify results.


### PR DESCRIPTION
docs: add simple worked example for sympy.integrals.integrate on rational-function partial fractions

#### References to other Issues or PRs
None (new contribution)

#### Brief description of what is fixed or changed
Added a clear worked example demonstrating the use of `sympy.integrals.integrate` on a rational function that requires partial fraction decomposition.

The new tutorial file `doc/src/tutorials/integrals.rst` includes:
- A step-by-step example integrating `(2*x + 3)/(x**2 + 3*x + 2)`
- Explanation of how SymPy performs partial fraction decomposition automatically
- Verification via differentiation (`diff(result, x) - expr`)
- Clear documentation-style formatting with code blocks and outputs

This helps beginners understand symbolic integration of rational functions and makes the tutorials more complete.

#### Other comments
None

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added a tutorial example for `sympy.integrals.integrate` showing rational-function integration using partial fractions.
<!-- END RELEASE NOTES -->
