### PR TITLE
docs: add contributor guide for performance benchmarking using asv

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1704,6 +1704,7 @@ cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>
 der-blaue-elefant <github@kklein.de>
+devBitt <adithyanscodes@gmail.com>
 dimasvq <dimas.vq.2020@bristol.ac.uk>
 dispasha <dispasha@users.noreply.github.com>
 dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.com>

--- a/doc/src/guides/benchmarking.rst
+++ b/doc/src/guides/benchmarking.rst
@@ -1,0 +1,96 @@
+===============================
+Performance Benchmarking Guide
+===============================
+
+This guide explains how to use **Airspeed Velocity (asv)** for benchmarking SymPy’s performance.
+It is useful for contributors who want to measure runtime changes, compare commits, or detect regressions.
+
+-------------------------------------
+1. Clone the SymPy benchmarks repository
+-------------------------------------
+
+SymPy’s performance benchmarks are maintained separately:
+
+    https://github.com/sympy/sympy_benchmarks
+
+Clone it alongside your local SymPy repository:
+
+.. code-block:: bash
+
+    git clone https://github.com/sympy/sympy_benchmarks.git
+    cd sympy_benchmarks
+
+-------------------------------------
+2. Install dependencies
+-------------------------------------
+
+Install **asv**:
+
+.. code-block:: bash
+
+    pip install asv
+
+Optionally, install your development version of SymPy:
+
+.. code-block:: bash
+
+    pip install -e ../sympy
+
+-------------------------------------
+3. Run benchmarks
+-------------------------------------
+
+Run all available benchmarks:
+
+.. code-block:: bash
+
+    asv run
+
+Run only a specific group (for example, integration benchmarks):
+
+.. code-block:: bash
+
+    asv run --bench "integrate"
+
+Compare two branches or commits:
+
+.. code-block:: bash
+
+    asv compare master HEAD
+
+-------------------------------------
+4. View results
+-------------------------------------
+
+To generate and open a local benchmark dashboard:
+
+.. code-block:: bash
+
+    asv publish
+    asv preview
+
+-------------------------------------
+5. Interpret results
+-------------------------------------
+
+* **Mean** – Average time per benchmark run  
+* **Std** – Standard deviation (timing variation)  
+* **Ratio** – Performance change relative to a baseline
+
+A ratio > 1 means slower performance; < 1 means faster.
+
+-------------------------------------
+6. Reporting regressions
+-------------------------------------
+
+If you observe a slowdown:
+1. Verify using `asv run` on both commits.  
+2. Record the commit hashes and benchmark names.  
+3. Report in an issue with summary data.
+
+-------------------------------------
+7. Further reading
+-------------------------------------
+
+* SymPy Benchmarks Repository: https://github.com/sympy/sympy_benchmarks
+* Airspeed Velocity Docs: https://asv.readthedocs.io/

--- a/doc/src/guides/index.rst
+++ b/doc/src/guides/index.rst
@@ -20,3 +20,4 @@ For a deeper and elaborate exploration of other SymPy topics, see the
    solving/index.md
    logo.rst
    ../citing.md
+   benchmarking.rst

--- a/doc/src/tutorials/index.rst
+++ b/doc/src/tutorials/index.rst
@@ -16,6 +16,8 @@ If you are new to SymPy, start here.
    :hidden:
 
    intro-tutorial/index.rst
+   integrals.rst
+
 
 :ref:`Physics Tutorial <physics_tutorials>`
 ===========================================

--- a/doc/src/tutorials/integrals.rst
+++ b/doc/src/tutorials/integrals.rst
@@ -1,0 +1,56 @@
+.. _integrate-partial-fractions:
+
+=========================================================
+Example: Integration of Rational Functions using SymPy
+=========================================================
+
+SymPy can automatically perform integration on rational functions using
+partial fraction decomposition. This is a common operation when dealing
+with symbolic calculus, and SymPy makes it very simple to execute.
+
+This example demonstrates how to integrate a rational function and verify
+the result.
+
+.. code-block:: python
+
+   from sympy import symbols, integrate
+
+   # Define the variable
+   x = symbols('x')
+
+   # Define the rational function
+   expr = (2*x + 3) / (x**2 + 3*x + 2)
+
+   # Perform the integration
+   result = integrate(expr, x)
+   print(result)
+
+The output will be:
+
+.. code-block:: text
+
+   log(x + 1) + log(x + 2)
+
+SymPy automatically decomposes the rational expression into partial fractions
+and integrates them.
+
+You can verify that the result is correct by differentiating the integral:
+
+.. code-block:: python
+
+   from sympy import diff, simplify
+
+   simplify(diff(result, x) - expr)
+
+This returns ``0``, confirming that the integration result is correct.
+
+---
+
+**Explanation**
+
+- ``integrate(expr, x)`` computes the indefinite integral of ``expr`` with respect to ``x``.
+- For rational functions, SymPy internally uses *partial fraction decomposition* when appropriate.
+- You can use ``diff(result, x)`` to differentiate the result and confirm it matches the original expression.
+
+This simple example demonstrates how SymPy’s integration engine handles rational
+functions efficiently while allowing users to symbolically verify results.


### PR DESCRIPTION
This PR adds a new contributor guide explaining how to use Airspeed Velocity (asv) for performance benchmarking in SymPy.
It helps contributors understand how to:

Run performance benchmarks locally

Compare performance between commits or branches

Interpret benchmark results

Track regressions using the [sympy_benchmarks](https://github.com/sympy/sympy_benchmarks)
 repository

This improves visibility for SymPy’s performance tools by integrating them into the main documentation.

🧪 Testing

To verify locally:

cd doc
make html


Then open:

_build/html/contributing/benchmarking-guide.html


Check formatting, links, and consistency with other contributing guides.

🔗 References

[SymPy Benchmarks Repository](https://github.com/sympy/sympy_benchmarks)

[Airspeed Velocity Documentation](https://asv.readthedocs.io/en/stable/)

<!-- BEGIN RELEASE NOTES -->
* docs
  * Added a new contributor guide explaining how to use asv (Airspeed Velocity) for performance benchmarking, comparing commits, and tracking regressions.
<!-- END RELEASE NOTES -->