### PR TITLE
LaTeX printer: parenthesize products under derivatives if mul_symbol is given: d/dx (f*g)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -831,6 +831,7 @@ Jiri Kuncar <jiri.kuncar@gmail.com>
 Jisoo Song <jeesoo9595@snu.ac.kr> JSS95 <52185322+JSS95@users.noreply.github.com>
 Jisoo Song <jeesoo9595@snu.ac.kr> mcpl-sympy <59268464+mcpl-sympy@users.noreply.github.com>
 Jithin D. George <jithindgeorge93@gmail.com>
+Jo Liss <joliss42@gmail.com>
 Joachim Durchholz <jo@durchholz.org> <jo@durchholz.org>
 Joachim Durchholz <jo@durchholz.org> <toolforger@durchholz.org>
 Joan Creus <joan.creus.c@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -824,14 +824,18 @@ class LatexPrinter(Printer):
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, self._print(dim), tex)
 
+        precedence = PRECEDENCE["Mul"]
+        if self._settings['mul_symbol']:
+            # Nudge up the precedence so d/dx (f(x) * g(x)) also gets parenthesized
+            precedence += 1
         if any(i.could_extract_minus_sign() for i in expr.args):
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
-                                                  PRECEDENCE["Mul"],
+                                                  precedence,
                                                   is_neg=True,
                                                   strict=True))
 
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
-                                                  PRECEDENCE["Mul"],
+                                                  precedence,
                                                   is_neg=False,
                                                   strict=True))
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -944,6 +944,18 @@ def test_latex_derivatives():
     assert latex(diff(f(x), (x, Max(n1, n2)))) == \
         r'\frac{d^{\max\left(n_{1}, n_{2}\right)}}{d x^{\max\left(n_{1}, n_{2}\right)}} f{\left(x \right)}'
 
+    # parenthesizing of the argument
+    g = Function("g")
+    # addition always parenthesized
+    for mul_symbol in (None, 'dot'):
+        assert latex(Derivative(f(x) + g(x), x), mul_symbol=mul_symbol) == \
+            r"\frac{d}{d x} \left(f{\left(x \right)} + g{\left(x \right)}\right)"
+    # multiplication parenthesized only if mul_symbol isn't None
+    assert latex(Derivative(f(x) * g(x), x)) == \
+        r"\frac{d}{d x} f{\left(x \right)} g{\left(x \right)}"
+    assert latex(Derivative(f(x) * g(x), x), mul_symbol='dot') == \
+        r"\frac{d}{d x} \left(f{\left(x \right)} \cdot g{\left(x \right)}\right)"
+
     # set diff operator
     assert latex(diff(f(x), x), diff_operator="rd") == r'\frac{\mathrm{d}}{\mathrm{d} x} f{\left(x \right)}'
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The LaTeX printer makes precedence-aware choices when deciding whether to parenthesize derivative expressions:

`Derivative(f(x) + g(x), x)` => $\frac{d}{d x} \left(f{\left(x \right)} + g{\left(x \right)}\right)$

`Derivative(f(x) * g(x), x)` => $\frac{d}{d x} f{\left(x \right)} g{\left(x \right)}$

However, if we pass `mul_symbol="dot"`, the presence of the `\cdot` makes the expression look wrong to me:

`Derivative(f(x) * g(x), x)` => $\frac{d}{d x} f{\left(x \right)} \cdot g{\left(x \right)}$

The issue to me is that the $\frac{d}{d x}$ operator is visually very close to $f(x)$, and there's space around the $\cdot$ operator, and this makes it look like `\cdot` should bind less tightly than the derivative. In other words, the LaTeX above reads to me like it might mean $(\frac{d}{d x} f{\left(x \right)}) \cdot g{\left(x \right)}$.

This PR changes the behavior so that products (`Mul` expressions) are parenthesized when `mul_symbol` is given:

`Derivative(f(x) * g(x), x)` => $\frac{d}{d x} \left(f{\left(x \right)} \cdot g{\left(x \right)}\right)$

#### Other comments

We accomplish this by nudging up the precedence of d/dx from `PRECEDENCE["Mul"]` to `PRECEDENCE["Mul"] + 1` whenever a `mul_symbol` is given. This is slightly hacky, but it should be OK given that precedences are defined like so:

```py
...
    "Add": 40,
    "Mul": 50,
    "Pow": 60,
...
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * In LaTeX output, parenthesize derivatives of products like `d/dx (f(x) * g(x))` when `mul_symbol` is given.

<!-- END RELEASE NOTES -->
