### PR TITLE
Fix: Elliptic curve P + (-P) now correctly returns point at infinity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1623,7 +1623,6 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
-Ved Thorat <vedthorat1029@gmail.com> i3hz <vedthorat1029@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>
 Vedarth Sharma <vedarth.sharma@gmail.com>
 Velibor Zeli <velibor@mech.kth.se>
@@ -1741,6 +1740,8 @@ goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
 helo9 <helo9@users.noreply.github.com>
 hm <hacman0@gmail.com>
+i3hz <144821361+i3hz@users.noreply.github.com>
+i3hz <vedthorat1029@gmail.com>
 immerrr <immerrr@gmail.com>
 jerryma1121 <jerryma1121@gmail.com>
 jgulian <josephdgulian@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1623,6 +1623,7 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Ved Thorat <vedthorat1029@gmail.com> i3hz <vedthorat1029@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>
 Vedarth Sharma <vedarth.sharma@gmail.com>
 Velibor Zeli <velibor@mech.kth.se>

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -322,8 +322,8 @@ class EllipticCurvePoint:
             slope = (y1 - y2) / (x1 - x2)
             yint = (y1 * x2 - y2 * x1) / (x2 - x1)
         else:
-            y_inverse = -y1 - a1*x1 - a3
-            if y2 == y_inverse:
+            # For the general Weierstrass form the inverse of a point (x,y) is (x, -y - a1*x - a3)
+            if y2 == -y1 - a1*x1 - a3:
                 return self.point_at_infinity(self._curve)
             slope = (3 * x1**2 + 2*a2*x1 + a4 - a1*y1) / (a1 * x1 + a3 + 2 * y1)
             yint = (-x1**3 + a4*x1 + 2*a6 - a3*y1) / (a1*x1 + a3 + 2*y1)
@@ -396,6 +396,7 @@ class EllipticCurvePoint:
             if p.z == 0:
                 return i
         return oo
+
     def __eq__(self, other):
         """
         Check if two elliptic curve points are equal.
@@ -411,8 +412,11 @@ class EllipticCurvePoint:
 
         Returns
         =======
-        bool
-            True if the points are equal, False otherwise.
+        bool or NotImplemented
+            True if the points are equal, False if they are different points on
+            the same curve, NotImplemented if other is not an EllipticCurvePoint
+            or is on a different curve.
+
 
         Examples
         ========
@@ -426,11 +430,11 @@ class EllipticCurvePoint:
         True
         """
         if not isinstance(other, EllipticCurvePoint):
-            return False
+            return NotImplemented
 
         # Points must be on the same curve
-        if self._curve != other._curve:
-            return False
+        if self._curve is not other._curve:
+            return NotImplemented
 
         # Both points at infinity are equal
         if self.z == 0 and other.z == 0:
@@ -440,10 +444,13 @@ class EllipticCurvePoint:
         if self.z == 0 or other.z == 0:
             return False
 
-        # If both are finite points  compare in projective coordinates
+        # If both are finite points compare in projective coordinates
         return (self.x * other.z == other.x * self.z and
                 self.y * other.z == other.y * self.z)
 
     def __ne__(self, other):
         """Check if two points are not equal."""
-        return not self.__eq__(other)
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -433,7 +433,6 @@ class EllipticCurvePoint:
             return False
 
         # Both points at infinity are equal
-        # In projective coordinates, any point with z=0 represents infinity
         if self.z == 0 and other.z == 0:
             return True
 
@@ -441,8 +440,7 @@ class EllipticCurvePoint:
         if self.z == 0 or other.z == 0:
             return False
 
-        # Both are finite points - compare in projective coordinates
-        # (x1:y1:z1) == (x2:y2:z2) iff x1*z2 == x2*z1 and y1*z2 == y2*z1
+        # If both are finite points  compare in projective coordinates
         return (self.x * other.z == other.x * self.z and
                 self.y * other.z == other.y * self.z)
 

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -432,7 +432,7 @@ class EllipticCurvePoint:
         if not isinstance(other, EllipticCurvePoint):
             return NotImplemented
 
-        # points must have all values equal 
+        # points must have all values equal
         if (self._curve._a1 != other._curve._a1 or
             self._curve._a2 != other._curve._a2 or
             self._curve._a3 != other._curve._a3 or

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -432,10 +432,14 @@ class EllipticCurvePoint:
         if not isinstance(other, EllipticCurvePoint):
             return NotImplemented
 
-        # Points must be on the same curve
-        if self._curve is not other._curve:
-            return NotImplemented
-
+        # points must have all values equal 
+        if (self._curve._a1 != other._curve._a1 or
+            self._curve._a2 != other._curve._a2 or
+            self._curve._a3 != other._curve._a3 or
+            self._curve._a4 != other._curve._a4 or
+            self._curve._a6 != other._curve._a6 or
+            self._curve.modulus != other._curve.modulus):
+            return False
         # Both points at infinity are equal
         if self.z == 0 and other.z == 0:
             return True

--- a/sympy/ntheory/tests/test_elliptic_curve.py
+++ b/sympy/ntheory/tests/test_elliptic_curve.py
@@ -1,4 +1,4 @@
-from sympy.ntheory.elliptic_curve import EllipticCurve
+from sympy.ntheory.elliptic_curve import EllipticCurve, EllipticCurvePoint
 
 
 def test_elliptic_curve():
@@ -18,3 +18,12 @@ def test_elliptic_curve():
     assert EllipticCurve(-2731, -55146, 1, 0, 1).discriminant == 25088
     # Torsion points
     assert len(EllipticCurve(0, 1).torsion_points()) == 6
+
+def test_point_addition_inverse():
+    """Test that P + (-P) returns the point at infinity."""
+    # Test case from issue #28529
+    curve = EllipticCurve(0, 0, 1, 0, 1, 0)
+    P = curve(0, 0, 1)
+    result = P + (-P)
+    expected = EllipticCurvePoint.point_at_infinity(curve)
+    assert result == expected


### PR DESCRIPTION
Fixes a bug in the EllipticCurvePoint class where adding a point to its inverse (P + (-P)) returned an incorrect finite point instead of the point at infinity (the identity element of the elliptic curve group).

#### References to other Issues or PRs
#28529 


#### Brief description of what is fixed or changed
Fixed the `__add__` method in EllipticCurvePoint class to use the correct general Weierstrass form
```python
y_inverse = -y1 - a1*x1 - a3
if y2 == y_inverse:
    return self.point_at_infinity(self._curve)
```
Also added the `__eq__` method for properly comparing points and treating all points at infinity as equal
Added the `__ne__` method for completeness

#### Other comments
I have written the doc strings using AI so please let me know if there's anything wrong in them .

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed a bug in `EllipticCurvePoint.__add__` where adding a point to its inverse (`P + (-P)`) returned a finite point instead of the point at infinity.
<!-- END RELEASE NOTES -->
