### PR TITLE
Fix integration error for polynomials

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1375,6 +1375,7 @@ S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
+Sachi Jain <jainsachi1202@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> sachin-4099 <sachinagarwal0499@gmail.com>
 Sachin Irukula <sachin.irukula@gmail.com>

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -631,7 +631,7 @@ class Integral(AddWithLimits):
                             continue
 
             final = hints.get('final', True)
-            # dotit may be iterated but floor terms making atan and acot
+            # doit may be iterated but floor terms making atan and acot
             # continuous should only be added in the final round
             if (final and not isinstance(antideriv, Integral) and
                 antideriv is not None):

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -67,7 +67,7 @@ from sympy.functions.special.hyper import hyper, meijerg
 from sympy.functions.special.singularity_functions import SingularityFunction
 from .integrals import Integral
 from sympy.logic.boolalg import And, Or, BooleanAtom, Not, BooleanFunction
-from sympy.polys import cancel, factor
+from sympy.polys import cancel, factor, Poly
 from sympy.utilities.iterables import multiset_partitions
 from sympy.utilities.misc import debug as _debug
 from sympy.utilities.misc import debugf as _debugf
@@ -418,6 +418,13 @@ def _find_splitting_points(expr, x):
             return
         if expr.is_Atom:
             return
+        if expr.is_Add and expr.is_polynomial(x):
+            poly = Poly(expr, x)
+            if poly.degree() == 2:
+                a_coeff, b_coeff = poly.all_coeffs()[:2]
+                if a_coeff != 0 and b_coeff != 0:
+                    res.add(-b_coeff/(2*a_coeff))
+                    return
         for argument in expr.args:
             compute_innermost(argument, res)
     innermost = set()

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -2,6 +2,7 @@ from sympy.core.function import expand_func
 from sympy.core.numbers import (I, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
+from sympy.core.symbol import symbols
 from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import cosh, acosh, sinh
@@ -772,3 +773,18 @@ def test_issue_25949():
     from sympy.core.symbol import symbols
     y = symbols("y", nonzero=True)
     assert integrate(cosh(y*(x + 1)), (x, -1, -0.25), meijerg=True) == sinh(0.75*y)/y
+
+
+def test_issue_28485():
+    """Test cases for Gaussian integrals with linear terms.
+    """
+    x = symbols('x')
+    a_neg = symbols('a', negative=True)
+    result_neg = integrate(exp(a_neg*(x**2 + 2*x)), (x, -oo, oo))
+    expected_neg = sqrt(pi)*exp(-a_neg)/sqrt(-a_neg)
+    assert result_neg.equals(expected_neg)
+
+    a_pos = symbols('a', positive=True)
+    result_pos = integrate(exp(-a_pos*(x**2 + 2*x)), (x, -oo, oo))
+    expected_pos = sqrt(pi)*exp(a_pos)/sqrt(a_pos)
+    assert result_pos.equals(expected_pos)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fix integration error for polynomails with negative=True

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28485 

#### Brief description of what is fixed or changed

*The Problem:* _find_splitting_points() only looked for linear terms p*x + q and returned -q/p. It didn't handle quadratic expressions properly.

For a*x**2 + 2*a*x, it would find the linear term 2*a*x and return -0/(2*a) = 0, which is incorrect.  

After the fix:
- _find_splitting_points(exp(a*(x**2 + 2*x)), x) now returns {0, -1} (includes the correct splitting point -1)
- I have also tested them out for sin(expr) , this is returning correct fsp.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->


NO ENTRY

<!-- END RELEASE NOTES -->
