### PR TITLE
docs: fix broken links the docs

### DIFF
--- a/doc/src/modules/physics/units/philosophy.rst
+++ b/doc/src/modules/physics/units/philosophy.rst
@@ -275,7 +275,7 @@ Literature
 ==========
 
 .. [Page52] C. H. Page, `Classes of units in the SI
-    <https://doi.org/10.1119/1.1927482>`_,
+    <https://pubs.aip.org/aapt/ajp/article-abstract/20/1/1/1034555/Units-and-Dimensions-in-Physics?redirectedFrom=fulltext>`_,
     Am. J. of Phys. 20, 1 (1952): 1.
 
 .. [Page78] C. H. Page, `Units and Dimensions in Physics
@@ -283,7 +283,7 @@ Literature
     Am. J. of Phys. 46, 1 (1978): 78.
 
 .. [deBoer79] J. de Boer, `Group properties of quantities and units
-    <https://aapt.scitation.org/doi/10.1119/1.11703>`_,
+    <https://pubs.aip.org/aapt/ajp/article-abstract/47/9/818/1051258/Group-properties-of-quantities-and-units?redirectedFrom=fulltext>`_,
     Am. J. of Phys. 47, 9 (1979): 818.
 
 .. [LevyLeblond77] J.-M. Lévy-Leblond, `On the Conceptual Nature of the

--- a/doc/src/modules/simplify/fu.rst
+++ b/doc/src/modules/simplify/fu.rst
@@ -247,4 +247,4 @@ References
     https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=718d67a8d1ce0a23808c1cc265612f81977357e4
 
 .. [2] A formula sheet for trigonometric functions.
-    http://www.sosmath.com/trig/Trig5/trig5/pdf/pdf.html
+    https://www.drkhamsi.com/sosmath/trig/Trig2/trig2/trig2.html 

--- a/doc/src/tutorials/physics/mechanics/bicycle_example.rst
+++ b/doc/src/tutorials/physics/mechanics/bicycle_example.rst
@@ -370,4 +370,4 @@ References
    L. (2007). Linearized dynamics equations for the balance and steer of a
    bicycle: A benchmark and review. Proceedings of the Royal Society A:
    Mathematical, Physical and Engineering Sciences, 463(2084), 1955–1982.
-   https://doi.org/10.1098/rspa.2007.1857
+   https://royalsocietypublishing.org/doi/10.1098/rspa.2007.1857

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -3443,7 +3443,7 @@ class DomainMatrix:
 
         .. [1]  Nakos, G. C., Turner, P. R., & Williams, R. M. (1997). Fraction-free
                 algorithms for linear and polynomial equations. ACM SIGSAM Bulletin,
-                31(3), 11-19. https://doi.org/10.1145/271130.271133
+                31(3), 11-19. https://dl.acm.org/doi/10.1145/271130.271133
         .. [2]  Middeke, J.; Jeffrey, D.J.; Koutschan, C. (2020), "Common Factors
                 in Fraction-Free Matrix Decompositions", Mathematics in Computer Science,
                 15 (4): 589–608, arXiv:2005.12380, doi:10.1007/s11786-020-00495-9


### PR DESCRIPTION
Fixed several broken documentation links that were returning 404 errors.
made sure that all the links are working and correct.

Following the reference to the files in which changes are made:
- Updated links in fu.rst (lines 247, 250)
- Updated link in philosophy.rst (line 278)
- Updated link in bicycle_example.rst (line 373)
- Updated link in domainmatrix.py (line 3446)

Fixes #24140

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->