### PR TITLE
making path checks cross platform

### DIFF
--- a/sympy/testing/tests/test_runtests_pytest.py
+++ b/sympy/testing/tests/test_runtests_pytest.py
@@ -1,6 +1,6 @@
 import pathlib
 from typing import List
-
+from pathlib import Path
 import pytest
 
 from sympy.testing.runtests_pytest import (
@@ -101,7 +101,7 @@ class TestUpdateArgsWithPaths:
         args = update_args_with_paths(paths=paths, keywords=None, args=[])
         assert len(args) == len(expected_paths)
         for arg, expected in zip(sorted(args), expected_paths):
-            assert expected in arg
+            assert Path(expected).as_posix() in Path(arg).as_posix()
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -122,7 +122,7 @@ class TestUpdateArgsWithPaths:
         expected_args = ['sympy/physics/mechanics/tests/test_kane3.py::test_bicycle']
         assert len(args) == len(expected_args)
         for arg, expected in zip(sorted(args), expected_args):
-            assert expected in arg
+            assert Path(expected).as_posix() in Path(arg).as_posix()
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -142,7 +142,7 @@ class TestUpdateArgsWithPaths:
         expected_args = ['sympy/core/tests/test_sympify.py::test_issue_3538']
         assert len(args) == len(expected_args)
         for arg, expected in zip(sorted(args), expected_args):
-            assert expected in arg
+            assert Path(expected).as_posix() in Path(arg).as_posix()
 
     @staticmethod
     def test_multiple_keywords():
@@ -155,7 +155,7 @@ class TestUpdateArgsWithPaths:
         ]
         assert len(args) == len(expected_args)
         for arg, expected in zip(sorted(args), expected_args):
-            assert expected in arg
+            assert Path(expected).as_posix() in Path(arg).as_posix()
 
     @staticmethod
     def test_keyword_match_in_multiple_files():
@@ -168,4 +168,4 @@ class TestUpdateArgsWithPaths:
         ]
         assert len(args) == len(expected_args)
         for arg, expected in zip(sorted(args), expected_args):
-            assert expected in arg
+            assert Path(expected).as_posix() in Path(arg).as_posix()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #28535


#### Brief description of what is fixed or changed
converting paths to unix style so that assert with path names can be cross platform

#### Other comments
Some tests automatically failed on windows environment, and that was because of tests not designed to be cross platform. Now every path is converted to the same path type (path with **/**) so that these tests don't fail anymore.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* testing
  * Fixed a bug of tests not working on windows environment
<!-- END RELEASE NOTES -->
