### PR TITLE
all_roots() : skipping real/complex root computation when only one factor

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -265,10 +265,8 @@ def _eigenvals_list(
 
             degree = int(factor.degree())
             if len(eigs) != degree:
-                f = factor.as_expr()
-                x = factor.gen
                 try:
-                    eigs = [CRootOf(f, x, idx) for idx in range(degree)]
+                    eigs = factor.all_roots(multiple=True)
                 except NotImplementedError:
                     if error_when_incomplete:
                         raise MatrixError(eigenvals_error_message)
@@ -318,10 +316,8 @@ def _eigenvals_dict(
             degree = int(factor.degree())
             if sum(eigs.values()) != degree:
                 degree = int(factor.degree())
-                f = factor.as_expr()
-                x = factor.gen
                 try:
-                    eigs = {CRootOf(f, x, idx): 1 for idx in range(degree)}
+                    eigs = dict(charpoly.all_roots(multiple=False))
                 except NotImplementedError:
                     if error_when_incomplete:
                         raise MatrixError(eigenvals_error_message)
@@ -1404,7 +1400,7 @@ def _jordan_form_rational_matrix(M, calc_transform):
                 roots_found = list(roots(minpoly.as_expr(), l, quartics=False, cubics=False))
                 degree = minpoly.degree()
                 if len(roots_found) != degree:
-                    roots_found = [CRootOf(minpoly, l, idx) for idx in range(degree)]
+                    roots_found = minpoly.all_roots(multiple=True)
                 eigenvals.extend(roots_found)
 
             eigenvals_by_factor[(tuple(base), exp)] = eigenvals

--- a/sympy/polys/matrices/eigen.py
+++ b/sympy/polys/matrices/eigen.py
@@ -9,7 +9,6 @@ from ..agca.extensions import FiniteExtension
 from ..factortools import dup_factor_list
 from ..polyroots import roots
 from ..polytools import Poly
-from ..rootoftools import CRootOf
 
 from .domainmatrix import DomainMatrix
 
@@ -76,11 +75,9 @@ def dom_eigenvects_to_sympy(
         eigenvects = [[field.to_sympy(x) for x in vect] for vect in eigenvects]
 
         degree = minpoly.degree()
-        minpoly = minpoly.as_expr()
-        eigenvals = roots(minpoly, l, **kwargs)
+        eigenvals = roots(minpoly.as_expr(), l, **kwargs)
         if len(eigenvals) != degree:
-            eigenvals = [CRootOf(minpoly, l, idx) for idx in range(degree)]
-
+            eigenvals = minpoly.all_roots(multiple=True)
         for eigenvalue in eigenvals:
             new_eigenvects = [
                 Matrix([x.subs(l, eigenvalue) for x in vect])

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -691,7 +691,9 @@ class ComplexRootOf(RootOf):
         """
         Reset all intervals
         """
-        self._all_roots(self.poly, use_cache=False)
+        factors = _pure_factors(self.poly)
+        self._get_reals(factors, use_cache=False)
+        self._get_complexes(factors, use_cache=False)
 
     @classmethod
     def _all_roots(cls, poly, use_cache=True):

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -698,19 +698,24 @@ class ComplexRootOf(RootOf):
         """Get real and complex roots of a composite polynomial. """
         factors = _pure_factors(poly)
 
-        reals = cls._get_reals(factors, use_cache=use_cache)
-        reals_count = cls._count_roots(reals)
-
         roots = []
 
-        for index in range(0, reals_count):
-            roots.append(cls._reals_index(reals, index))
+        if len(factors) == 1:
+            f, multiplicity = factors[0]
+            deg = f.degree()
+            roots.extend((f, i) for i in range(deg) for _ in range(multiplicity))
+        else:
+            reals = cls._get_reals(factors, use_cache=use_cache)
+            reals_count = cls._count_roots(reals)
 
-        complexes = cls._get_complexes(factors, use_cache=use_cache)
-        complexes_count = cls._count_roots(complexes)
+            for index in range(0, reals_count):
+                roots.append(cls._reals_index(reals, index))
 
-        for index in range(0, complexes_count):
-            roots.append(cls._complexes_index(complexes, index))
+            complexes = cls._get_complexes(factors, use_cache=use_cache)
+            complexes_count = cls._count_roots(complexes)
+
+            for index in range(0, complexes_count):
+                roots.append(cls._complexes_index(complexes, index))
 
         return roots
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see gh-28527
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
In this PR, we skip real/complex root computation when there is only one factor, since it’s unnecessary in that case and takes a lot of time to compute and sort.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
