### PR TITLE
improve is_imaginary attribute of  to handle extended real value

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1029,6 +1029,15 @@ def test_acos():
     assert acos(p + n*I).conjugate() == acos(p - n*I)
     assert acos(z).conjugate() != acos(conjugate(z))
 
+    assert acos(2).is_imaginary is True
+    assert acos(-2).is_imaginary is True
+    assert acos(Rational(3, 2), evaluate=False).is_imaginary is True
+    assert acos(Rational(2, 3), evaluate=False).is_imaginary is False
+
+    assert acos(p + 2).is_imaginary is True
+    assert acos(1/(p + 1)).is_imaginary is False
+    assert acos(r).is_imaginary is None
+
 
 def test_acos_leading_term():
     assert acos(x).as_leading_term(x) == pi/2

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2578,6 +2578,14 @@ class acos(InverseTrigonometricFunction):
         x = self.args[0]
         return x.is_extended_real and (1 - abs(x)).is_nonnegative
 
+    def _eval_is_imaginary(self):
+        x = self.args[0]
+        if x.is_extended_real:
+            if (x - 1).is_positive or (x + 1).is_negative:
+                return True
+            if (1 - abs(x)).is_nonnegative:
+                return False
+
     def _eval_is_nonnegative(self):
         return self._eval_is_extended_real()
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes https://github.com/sympy/sympy/issues/28541

#### Brief description of what is fixed or changed

Implement `_eval_is_imaginary` method in `acos` class to handle real argument with `abs(x) > 1` value or unknown `abs(x)` value.

#### Other comments

I've used a coding agent to help with the solution, but I've done my part to ensure that improvements were made on it, like introduction of test case(s) with symbolic (real/positive) arguments to `acos`

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* trigonometric
  * fix incorrect evaluation of `is_imaginary` attribute of `acos` for real argument with `abs(x) > 1` value or unknown `abs(x)` value.
<!-- END RELEASE NOTES -->


