### PR TITLE
[WIP] Adding is_imaginary and is_real properties for inverse trigonometric functions 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -585,7 +585,7 @@ Dhruv Bhanushali <dhruv_b@live.com>
 Dhruv Kothari <dhruvkothari22@gmail.com>
 Dhruv Mendiratta <dhruvmendiratta6@gmail.com> Dhruv Mendiratta <42745880+dhruvmendiratta6@users.noreply.github.com>
 Dhruv Mendiratta <dhruvmendiratta6@gmail.com> dhruvmendiratta6 <dhruvmendiratta6@gmail.com>
-Dhruv Rambhia <dhruv_rambhia@outlook.com>
+Dhruv Rambhia <dhruv_rambhia@outlook.com> ButteryPaws <87355356+ButteryPaws@users.noreply.github.com>
 Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
 Diane Tchuindjo <dtchuindjo@gmail.com>
 Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>

--- a/.mailmap
+++ b/.mailmap
@@ -585,6 +585,7 @@ Dhruv Bhanushali <dhruv_b@live.com>
 Dhruv Kothari <dhruvkothari22@gmail.com>
 Dhruv Mendiratta <dhruvmendiratta6@gmail.com> Dhruv Mendiratta <42745880+dhruvmendiratta6@users.noreply.github.com>
 Dhruv Mendiratta <dhruvmendiratta6@gmail.com> dhruvmendiratta6 <dhruvmendiratta6@gmail.com>
+Dhruv Rambhia <dhruv_rambhia@outlook.com>
 Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
 Diane Tchuindjo <dtchuindjo@gmail.com>
 Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1042,6 +1042,15 @@ def test_acos():
     assert acos(p + n*I).conjugate() == acos(p - n*I)
     assert acos(z).conjugate() != acos(conjugate(z))
 
+    assert acos(2).is_imaginary is True
+    assert acos(-2).is_imaginary is False
+    assert acos(0.5).is_imaginary is False
+    assert acos(1).is_imaginary is False
+    assert acos(p).is_imaginary is None
+    assert acos(n).is_imaginary is False
+    assert acos(x).is_imaginary is None
+    assert acos((1 + p)).is_imaginary is True
+
 
 def test_acos_leading_term():
     assert acos(x).as_leading_term(x) == pi/2

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2611,6 +2611,10 @@ class acos(InverseTrigonometricFunction):
         x = self.args[0]
         return x.is_extended_real and (1 - abs(x)).is_nonnegative
 
+    def _eval_is_imaginary(self):
+        x = self.args[0]
+        return (x - 1).is_positive
+
     def _eval_is_nonnegative(self):
         return self._eval_is_extended_real()
 


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28541 


#### Brief description of what is fixed or changed
I have added the `_eval_is_imaginary` method in the `acos` class. This simply checks whether we can precisely determine if the argument (`arg`) satisfies `arg > 1`. This simple check automatically handles all cases and even returns `None` when we cannot determine this. I have added ample regression tests to verify the correctness of these claims. 


#### Other comments
A rigorous mathematical proof of necessity and sufficiency can be arrived at by following the definition of inverse cosine for the entire complex domain given [on DLMF](https://dlmf.nist.gov/4.23). This is a reliable [referenced by SymPy for its implementations](https://docs.sympy.org/latest/modules/functions/elementary.html#id28). Here are the proofs of correctness:
###### Proving that the condition is sufficient
```math
\text{To prove that } (x > 1) \implies \arccos{(x)} \in \Im \\
```
```math
\forall (x > 1), \arccos{(x)} = \mp i \ln{\left( (x^2 - 1)^{1/2} + x \right)}
```
```math
\forall (x > 1), \left( (x^2 - 1)^{1/2} + x \right) > 0 \implies \ln{\left( (x^2 - 1)^{1/2} + x \right)} \in \Re, \therefore \arccos{(x)} \in \Im
```
###### Proving that the condition is necessary
This part is slightly involved. Let us prove the contrapositive
```math
\arccos({z}) \in \Im \implies \left(z > 1\right)
```
Case 1: $z \in \left[1, \infty\right)$. Here, the condition is hypothesis is True as we saw and the implication is also True. 

Case 2 $z \in \left( -\infty, -1\right]$. Here, $\arccos{(z}) = \pi \mp i\ln{((x^2 - 1)^{1/2} - x)}$. We can trivially see that $\Re{(\arccos{(z)})} = \pi$, thus the hypothesis is False.

Case 3: $z \in \mathbb{C} - \left(-\infty, -1\right) \cup \left(1, \infty\right)$
```math
\text{Let }\arccos{(z)} = \frac{1}{2}\pi + i \ln{\left((1 - z^2)^{1/2} + iz\right)} = ki \text{ where } k \in \Re - \{ 0 \}
```
```math
\therefore i \ln{\left((1 - z^2)^{1/2} + iz\right)} = ki - \frac{1}{2}\pi
```
```math
\therefore \ln{\left((1 - z^2)^{1/2} + iz\right)} = k +\frac{i}{2}\pi
```
```math
\therefore \left((1 - z^2)^{1/2} + iz\right) = e^{k +\frac{i}{2}\pi} = ie^k
```
```math
\therefore (1 - z^2)^{1/2} = ie^k - iz
```
```math
\implies (1 - z^2)= \left(ie^k - iz\right)^2 = 2e^kz - z^2 - e^{2k}
```
```math
\implies z = \frac{e^k + e^{-k}}{2}
```
```math
\because \left(k \in \Re - \{ 0 \} \right), \text{ by a number of different inequalities, we can see that } \implies z > 1
```
But this contradicts our assumption on the domain of $z$ we made when we started this case, thus the hypothesis is False here as well. Hence, in all 3 cases, the implication holds. This means a simple check on `arg > 1` suffices. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added a check to compute the `is_imaginary` property for the `acos` class. 
<!-- END RELEASE NOTES -->

#### Further work
Currently, this function is not implemented for the other inverse trigonometric function classes as well. Since I am a first time contributor, I just want to get some feedback on this PR before I compute the similar conditions to establish real/imaginary nature and add the `is_real` and `is_imaginary` properties for the other classes as well. In case I get validation for the same, I will add commits which implement the same for other classes and push it here. 