### PR TITLE
eigenvals_dict: replace charpoly with factor; drop duplicate degree

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -315,9 +315,8 @@ def _eigenvals_dict(
 
             degree = int(factor.degree())
             if sum(eigs.values()) != degree:
-                degree = int(factor.degree())
                 try:
-                    eigs = dict(charpoly.all_roots(multiple=False))
+                    eigs = dict(factor.all_roots(multiple=False))
                 except NotImplementedError:
                     if error_when_incomplete:
                         raise MatrixError(eigenvals_error_message)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -214,6 +214,19 @@ def test_eigenvals():
     # CRootOf may not be unique.
     assert m.eigenvals()
 
+    A = Matrix([
+        [1, 1, 0, 1, -1, 0, 1],
+        [0, 2, 1, 0, 1, -1, 0],
+        [1, 0, 1, 1, 0, 1, -1],
+        [1, -1, 0, 0, 1, 0, 1],
+        [0, 1, 1, -1, 1, 1, 0],
+        [1, 0, -1, 1, 0, 1, 1],
+        [0, 1, 0, 1, -1, 0, 2]
+    ])
+    eigs = A.eigenvals()
+    diff = (A.trace() - sum(eig * mult for eig, mult in eigs.items())).evalf()
+    assert abs(diff) < 1e-10
+
 
 def test_eigenvects():
     M = Matrix([[0, 1, 1],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR corrects a mistake I introduced in the previous PR(https://github.com/sympy/sympy/pull/28538)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
