### PR TITLE
Fix Geometric distribution density for invalid inputs

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -207,6 +207,13 @@ class GeometricDistribution(SingleDiscreteDistribution):
         _value_check((0 < p, p <= 1), "p must be between 0 and 1")
 
     def pdf(self, k):
+        # For symbolic k, return the formula directly
+        # For concrete k, check if it's a positive integer
+        k = sympify(k)
+        if k.is_number:
+            # Concrete value: check domain
+            if not (k.is_Integer and k >= 1):
+                return S.Zero
         return (1 - self.p)**(k - 1) * self.p
 
     def _characteristic_function(self, t):

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -91,6 +91,21 @@ def test_GeometricDistribution():
     Y = Geometric('Y', Rational(3, 10))
     assert coskewness(X, X + Y, X + 2*Y).simplify() == sqrt(230)*Rational(81, 1150)
 
+    # Test for issue #20031: density should be 0 for non-positive integers
+    g = Geometric("G", p=S(1)/4)
+    # Test negative integers
+    assert density(g)(-1) == 0
+    assert density(g)(-2) == 0
+    # Test zero
+    assert density(g)(0) == 0
+    # Test non-integer values
+    assert density(g)(S(1)/2) == 0
+    assert density(g)(S(3)/2) == 0
+    assert density(g)(0.5) == 0
+    # Verify that valid positive integers still work
+    assert density(g)(1) == S(1)/4
+    assert density(g)(2) == S(3)/16
+
 
 def test_Hermite():
     a1 = Symbol("a1", positive=True)


### PR DESCRIPTION
Fixes #20031

#### Brief description of what is fixed or changed

Fixed the Geometric distribution's probability density function to correctly return 0 for invalid inputs (negative integers, zero, and non-integer values). 

Previously, the `pdf()` method would evaluate the formula `(1-p)^(k-1) * p` for any input without checking if k was a positive integer. This resulted in incorrect non-zero probabilities:
- `density(g)(-1)` returned `4/9` instead of `0`
- `density(g)(0)` returned `1/3` instead of `0`
- `density(g)(0.5)` returned `0.288...` instead of `0`

The fix adds domain validation that:
- Checks if the input is a concrete number (not a symbol)
- Returns 0 for inputs that are not positive integers
- Preserves symbolic computation by returning the formula directly for symbolic inputs

#### Other comments

The solution avoids using `Piecewise` for domain validation because that would add extra conditions to symbolic expressions, breaking tests like `test_product_spaces`. Instead, the fix only validates concrete numeric inputs while allowing symbolic expressions to remain clean for algebraic manipulation.

Added comprehensive test cases to verify the fix handles negative integers, zero, fractional values, and valid positive integers correctly.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

solvers
  * Added a new solver for logarithmic equations.

functions
  * Fixed a bug with log of integers. Formerly, log(-x) incorrectly gave -log(x).

physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

stats
  * Fixed Geometric distribution density function to correctly return 0 for invalid inputs (negative integers, zero, and non-integer values). Previously it incorrectly returned non-zero probabilities for these values.

<!-- END RELEASE NOTES -->