### PR TITLE
Fix Geometric distribution density to return 0 outside support

### DIFF
--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -91,6 +91,18 @@ def test_GeometricDistribution():
     Y = Geometric('Y', Rational(3, 10))
     assert coskewness(X, X + Y, X + 2*Y).simplify() == sqrt(230)*Rational(81, 1150)
 
+    # Test that density returns 0 for values outside the support (issue #20031)
+    # The support for Geometric is positive integers {1, 2, 3, ...}
+    assert density(X)(0) == 0  # zero is not in support
+    assert density(X)(-1) == 0  # negative integers not in support
+    assert density(X)(-5) == 0  # negative integers not in support
+    assert density(X)(S(1)/2) == 0  # non-integer not in support
+    assert density(X)(S(5)/2) == 0  # non-integer not in support
+    # Test that density is correct for values inside the support
+    assert density(X)(1) == Rational(1, 5)
+    assert density(X)(2) == Rational(4, 25)
+    assert density(X)(3) == Rational(16, 125)
+
 
 def test_Hermite():
     a1 = Symbol("a1", positive=True)


### PR DESCRIPTION
Fixes #20031

The Geometric distribution's density function was incorrectly returning non-zero values for inputs outside its support (positive integers {1, 2, 3, ...}). For example, density(X)(0) would return a non-zero value instead of 0.

Changes made:
1. Override __call__() method in GeometricDistribution to check if the input is within the support before computing the density
2. When the input contains random symbols (for symbolic computations), return the pdf directly to avoid interference with expectation calculations
3. When the input is a concrete value outside the support, return 0 using Piecewise
4. Add closed-form _cdf() implementation for better performance
5. Add comprehensive tests for values inside and outside the support

The fix ensures that density(X)(k) returns 0 for k <= 0 or non-integer k, while maintaining compatibility with existing symbolic computations like coskewness calculations.

The Geometric distribution's `density()` function now correctly returns 0 for values outside its support (positive integers). Previously, it would evaluate the formula `(1-p)^(k-1) * p` for any input, including invalid values like 0, negative numbers, and non-integers, producing mathematically incorrect non-zero probabilities.

The fix overrides the `__call__()` method to add support checking while preserving backward compatibility with symbolic computations (e.g., expectations, coskewness). A closed-form CDF implementation was also added for better performance.

#### Other comments

All existing tests pass, including the complex coskewness test. The implementation carefully distinguishes between concrete values (where support checking is applied) and symbolic expressions containing random variables (where the raw PDF formula is used for proper integration/summation).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* stats
  * Fixed a bug in Geometric distribution where `density(X)(k)` incorrectly returned non-zero values for k outside the support. Now correctly returns 0 for k ≤ 0 or non-integer k.

<!-- END RELEASE NOTES -->
