### PR TITLE
Add support checking to discrete distribution evaluation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -644,6 +644,8 @@ Fabio Luporini <fabio@devitocodes.com>
 Faisal Anees <faisal.iiit@gmail.com>
 Faisal Riyaz <faisalriyaz011@gmail.com>
 Fawaz Alazemi <Mba7eth@gmail.com>
+Fazeel Usmani <fazeelusmani18@gmail.com> Fazeel Usmani <fazeel.u@turing.com>
+Fazeel Usmani <fazeelusmani18@gmail.com> FazeelUsmani <fazeelusmani18@gmail.com>
 Felix Kaiser <felix.kaiser@fxkr.net> <felix.kaiser@fxkr.net>
 Felix Kaiser <felix.kaiser@fxkr.net> <kaiser.fx@gmail.com>
 Felix Kaiser <felix.kaiser@fxkr.net> <whatfxkr@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1450 authors.
+There are a total of 1371 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1343,7 +1343,6 @@ Quek Zi Yao <ziyaoqzy2001@gmail.com>
 Roelof Rietbroek <r.rietbroek@utwente.nl>
 MostafaGalal1 <mostafag649.mg@gmail.com>
 Au Huishan <huishan_au@outlook.com>
-Avasam <samuel.06@hotmail.com>
 Kris Katterjohn <katterjohn@gmail.com>
 Shiyao Guo <mivikq@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com>
@@ -1378,82 +1377,3 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
-Pasquale Cocchini <pasquale.cocchini@gmail.com>
-Sai Udayagiri <saibabu.udayagiri@gmail.com>
-Lucas Verlaan <lucas.verlaan@gmail.com>
-Shaoliang Jin <18322825326@163.com>
-Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
-Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
-Nico Santamaria <nicoasantamaria@gmail.com>
-Atul Bisht <me.atulbisht@gmail.com>
-Élie Goudout <eliegoudout@hotmail.com>
-Lyle Poley <poleylyle@gmail.com>
-Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
-Richard Osborn <richardosborn@mac.com>
-Jatin Gaur <jatingaurchess@gmail.com>
-Manav Sharma <maanav.vashist@gmail.com>
-Charles Weiss <charles.weiss@augie.edu>
-Chetan Choudhary <cc393653@gmail.com>
-Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
-Jason Gross <jasongross9@gmail.com>
-JDBetteridge <jack@devitocodes.com>
-Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>
-Chaitanya Jain <chaitanya.jain.dev@gmail.com>
-TrungPQ <trungpqhe171493@gmail.com>
-Ser Kim <serk.kmh@gmail.com>
-SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg>
-Robert Brijder <rbrijder@gmail.com>
-Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com>
-Sujal Kumar <sujaljayantkumar06@gmail.com>
-Goran Jelic-Cizmek <jcgoran@protonmail.com>
-Merin Theres Jose <merintheresjose@gmail.com>
-Chris Cameron <chrisjamescameron1@gmail.com>
-Chris Paul <chrispaul68002@gmail.com>
-xndcn <xndchn@gmail.com>
-Paul Scofield <Cerebral.Paul@gmail.com>
-Keyron Linerez <keyronlinarez@gmail.com>
-Oldrich Klimanek <oldrich.klimanek@gmail.com>
-Alexander Grund <alexander.grund@tu-dresden.de>
-phipf <phipf@online.de>
-Russell Fordyce <rfordyce@expressive-py.org>
-Ayden Alvarez <Aydenalv6282@gmail.com>
-Alhussein Ashraf <alhusseinashraf55@gmail.com>
-Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
-Pedro H. S. Prestes <pedrohsprestes@gmail.com>
-Simon Sørensen <simonblsoerensen@gmail.com>
-Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
-Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
-Jo Liss <joliss42@gmail.com>
-Luca Bertoni <lucabertoni@gmail.com>
-Ayush Kumar Jha <jha44481@gmail.com>
-Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
-Xiao <muzumayao@126.com>
-Rishabh Chordiya <rishabh.arceus@gmail.com>
-Mayank Balyan <78949282+MayankBalyan@users.noreply.github.com>
-leastloris <ivedants05@gmail.com>
-Prajwal Pathade <prajwalpathade7@gmail.com>
-Viraj Palnitkar <virajpalnitkar@gmail.com>
-Liubov Kryzhalka <kryshalkaliub@gmail.com>
-Harsh Menon <harsh.menon@amd.com>
-Disha Holmukhe <dishaholmukh521@gmail.com>
-Baibhav Singh <baibhavsfs@gmail.com>
-Anas <anas23khan083@gmail.com>
-Sai Kiran P <parnandi.saikiran@gmail.com>
-M-Israr-Ul-Haq <israrulhaq590@gmail.com>
-oxygen dioxide <54425948+oxygen-dioxide@users.noreply.github.com>
-Tanmay Rath <rathjyotshna@gmail.com>
-Suneet Mishra <suee.suneet@gmail.com>
-Gagandeep Singh <Gmadaan450@gmail.com>
-Vivek Gaddam <vivek.gaddam2005@gmail.com>
-Vedant Dusane <dusanev4@gmail.com>
-Ishan Khan <ishan372or@gmail.com>
-Abhijith Shaji <abhijithshajikp@gmail.com>
-Alex Sun <alexsun.srand.nums@gmail.com>
-Ayush Bothra <ayush9bothra@gmail.com>
-Anshul Sharma <anshulsharma4605@gmail.com>
-Tien Nguyen <viettien23102006@gmail.com>
-Avanish Salunke <avanishsalunke16@gmail.com>
-Harsh Gupta <harsh2125gupta@gmail.com>
-Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
-Mayank Singh <mayanksingh020607@gmail.com>
-Mohammed Umar <mdumr4@gmail.com>

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -168,6 +168,20 @@ class SingleContinuousDistribution(ContinuousDistribution, NamedArgsMixin):
 
     Provides methods for pdf, cdf, and sampling.
 
+    The distribution object can be called in two ways to evaluate the
+    probability density:
+
+    1. ``distribution(x)``:
+       Returns the probability density at x, with support checking enforced
+       via Piecewise. For symbolic arguments where support membership cannot
+       be determined, this returns a Piecewise expression that evaluates to
+       the pdf formula when x is in the support, and 0 otherwise.
+
+    2. ``distribution.pdf(x)``:
+       Returns the raw probability density formula without support checking.
+       This is useful for symbolic manipulation and integration where the
+       Piecewise wrapper would be cumbersome.
+
     See Also
     ========
 
@@ -301,6 +315,15 @@ class SingleContinuousDistribution(ContinuousDistribution, NamedArgsMixin):
             if quantile is not None:
                 return quantile
         return self.compute_quantile(**kwargs)(x)
+
+    def __call__(self, arg):
+        in_domain = self.set.contains(arg)
+        if in_domain == False:
+            return S.Zero
+        elif in_domain == True:
+            return self.pdf(arg)
+        else:
+            return Piecewise((self.pdf(arg), self.set.as_relational(arg)), (S.Zero, True))
 
 
 class ContinuousPSpace(PSpace):
@@ -478,6 +501,10 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         return self.distribution.set
 
     @property
+    def pdf(self):
+        return self.distribution.pdf(self.symbol)
+
+    @property
     def domain(self):
         return SingleContinuousDomain(sympify(self.symbol), self.set)
 
@@ -527,7 +554,8 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
     def compute_density(self, expr, **kwargs):
         # https://en.wikipedia.org/wiki/Random_variable#Functions_of_random_variables
         if expr == self.value:
-            return self.density
+            # Return a Lambda that uses the pdf method to get the raw formula
+            return Lambda(expr.symbol, self.density.pdf(expr.symbol))
         y = Dummy('y', real=True)
 
         gs = solveset(expr - y, self.value, S.Reals)

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -185,7 +185,7 @@ class SingleContinuousDistribution(ContinuousDistribution, NamedArgsMixin):
     See Also
     ========
 
-    sympy.stats.crv_types.*
+    sympy.stats.crv_types
     """
 
     set = Interval(-oo, oo)
@@ -554,7 +554,6 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
     def compute_density(self, expr, **kwargs):
         # https://en.wikipedia.org/wiki/Random_variable#Functions_of_random_variables
         if expr == self.value:
-            # Return a Lambda that uses the pdf method to get the raw formula
             return Lambda(expr.symbol, self.density.pdf(expr.symbol))
         y = Dummy('y', real=True)
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -294,7 +294,7 @@ def Arcsin(name, a=0, b=1):
 
     >>> X = Arcsin("x", a, b)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     1/(pi*sqrt((-a + z)*(b - z)))
 
     >>> cdf(X)(z)
@@ -377,7 +377,7 @@ def Benini(name, alpha, beta, sigma):
 
     >>> X = Benini("x", alpha, beta, sigma)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
     /                  /  z  \\             /  z  \            2/  z  \
     |        2*beta*log|-----||  - alpha*log|-----| - beta*log  |-----|
@@ -459,7 +459,7 @@ def Beta(name, alpha, beta):
 
     >>> X = Beta("x", alpha, beta)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
      alpha - 1        beta - 1
     z         *(1 - z)
@@ -540,7 +540,7 @@ def BetaNoncentral(name, alpha, beta, lamda):
 
     >>> X = BetaNoncentral("x", alpha, beta, lamda)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
       oo
     _____
@@ -626,7 +626,7 @@ def BetaPrime(name, alpha, beta):
 
     >>> X = BetaPrime("x", alpha, beta)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
      alpha - 1        -alpha - beta
     z         *(z + 1)
@@ -691,7 +691,7 @@ def BoundedPareto(name, alpha, left, right):
     >>> L, H = symbols('L, H', positive=True)
     >>> X = BoundedPareto('X', 2, L, H)
     >>> x = symbols('x')
-    >>> density(X)(x)
+    >>> density(X).pdf(x)
     2*L**2/(x**3*(1 - L**2/H**2))
     >>> cdf(X)(x)
     Piecewise((-H**2*L**2/(x**2*(H**2 - L**2)) + H**2/(H**2 - L**2), L <= x), (0, True))
@@ -773,7 +773,7 @@ def Cauchy(name, x0, gamma):
 
     >>> X = Cauchy("x", x0, gamma)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     1/(pi*gamma*(1 + (-x0 + z)**2/gamma**2))
 
     References
@@ -851,7 +851,7 @@ def Chi(name, k):
 
     >>> X = Chi("x", k)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     2**(1 - k/2)*z**(k - 1)*exp(-z**2/2)/gamma(k/2)
 
     >>> simplify(E(X))
@@ -927,7 +927,7 @@ def ChiNoncentral(name, k, l):
 
     >>> X = ChiNoncentral("x", k, l)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     l*z**k*exp(-l**2/2 - z**2/2)*besseli(k/2 - 1, l*z)/(l*z)**(k/2)
 
     References
@@ -1007,7 +1007,7 @@ def ChiSquared(name, k):
 
     >>> X = ChiSquared("x", k)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     z**(k/2 - 1)*exp(-z/2)/(2**(k/2)*gamma(k/2))
 
     >>> E(X)
@@ -1095,7 +1095,7 @@ def Dagum(name, p, a, b):
 
     >>> X = Dagum("x", p, a, b)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     a*p*(z/b)**(a*p)*((z/b)**a + 1)**(-p - 1)/z
 
     >>> cdf(X)(z)
@@ -1170,7 +1170,7 @@ def Davis(name, b, n, mu):
     >>> mu = Symbol("mu", positive=True)
     >>> z = Symbol("z")
     >>> X = Davis("x", b, n, mu)
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     b**n*(-mu + z)**(-n - 1)/((exp(b/(-mu + z)) - 1)*gamma(n)*zeta(n))
 
     References
@@ -1224,7 +1224,7 @@ def Erlang(name, k, l):
 
     >>> X = Erlang("x", k, l)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
      k  k - 1  -l*z
     l *z     *e
@@ -1345,7 +1345,7 @@ def ExGaussian(name, mean, std, rate):
     >>> z = Symbol("z")
     >>> X = ExGaussian("x", mean, std, rate)
 
-    >>> pprint(density(X)(z), use_unicode=False)
+    >>> pprint(density(X).pdf(z), use_unicode=False)
                  /           2             \
            lamda*\lamda*sigma  + 2*mu - 2*z/
            ---------------------------------     /  ___ /           2         \\
@@ -1444,7 +1444,7 @@ def Exponential(name, rate):
     >>> p = Symbol("p")
     >>> X = Exponential("x", l)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     lambda*exp(-lambda*z)
 
     >>> cdf(X)(z)
@@ -1464,7 +1464,7 @@ def Exponential(name, rate):
 
     >>> X = Exponential('x', 10)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     10*exp(-10*z)
 
     >>> E(X)
@@ -1552,7 +1552,7 @@ def ExponentialPower(name, mu, alpha, beta):
     >>> alpha = Symbol("alpha", positive=True)
     >>> beta = Symbol("beta", positive=True)
     >>> X = ExponentialPower("x", mu, alpha, beta)
-    >>> pprint(density(X)(z), use_unicode=False)
+    >>> pprint(density(X).pdf(z), use_unicode=False)
                      beta
            /|mu - z|\
           -|--------|
@@ -1639,7 +1639,7 @@ def FDistribution(name, d1, d2):
 
     >>> X = FDistribution("x", d1, d2)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
       d2
       --    ______________________________
@@ -1719,7 +1719,7 @@ def FisherZ(name, d1, d2):
 
     >>> X = FisherZ("x", d1, d2)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                                 d1   d2
         d1   d2               - -- - --
@@ -1807,7 +1807,7 @@ def Frechet(name, a, s=1, m=0):
 
     >>> X = Frechet("x", a, s, m)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     a*((-m + z)/s)**(-a - 1)*exp(-1/((-m + z)/s)**a)/s
 
     >>> cdf(X)(z)
@@ -1890,7 +1890,7 @@ def Gamma(name, k, theta):
 
     >>> X = Gamma("x", k, theta)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                       -z
                     -----
@@ -1997,7 +1997,7 @@ def GammaInverse(name, a, b):
 
     >>> X = GammaInverse("x", a, b)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                 -b
                 ---
@@ -2102,7 +2102,7 @@ def Gumbel(name, beta, mu, minimum=False):
     >>> mu = Symbol("mu")
     >>> beta = Symbol("beta", positive=True)
     >>> X = Gumbel("x", beta, mu)
-    >>> density(X)(x)
+    >>> density(X).pdf(x)
     exp(-exp(-(-mu + x)/beta) - (-mu + x)/beta)/beta
     >>> cdf(X)(x)
     exp(-exp(-(-mu + x)/beta))
@@ -2180,7 +2180,7 @@ def Gompertz(name, b, eta):
 
     >>> X = Gompertz("x", b, eta)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     b*eta*exp(eta)*exp(b*z)*exp(-eta*exp(b*z))
 
     References
@@ -2253,7 +2253,7 @@ def Kumaraswamy(name, a, b):
 
     >>> X = Kumaraswamy("x", a, b)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                        b - 1
          a - 1 /     a\
@@ -2339,7 +2339,7 @@ def Laplace(name, mu, b):
 
     >>> X = Laplace("x", mu, b)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     exp(-Abs(mu - z)/b)/(2*b)
 
     >>> cdf(X)(z)
@@ -2432,7 +2432,7 @@ def Levy(name, mu, c):
 
     >>> X = Levy("x", mu, c)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*sqrt(c)*exp(-c/(-2*mu + 2*z))/(2*sqrt(pi)*(-mu + z)**(3/2))
 
     >>> cdf(X)(z)
@@ -2508,7 +2508,7 @@ def LogCauchy(name, mu, sigma):
 
     >>> X = LogCauchy("x", mu, sigma)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     1/(5*pi*z*((log(z) - 2)**2 + 1/25))
 
     >>> cdf(X)(z)
@@ -2588,7 +2588,7 @@ def Logistic(name, mu, s):
 
     >>> X = Logistic("x", mu, s)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     exp((mu - z)/s)/(s*(exp((mu - z)/s) + 1)**2)
 
     >>> cdf(X)(z)
@@ -2672,7 +2672,7 @@ def LogLogistic(name, alpha, beta):
 
     >>> X = LogLogistic("x", alpha, beta)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                   beta - 1
            /  z  \
@@ -2755,7 +2755,7 @@ def LogitNormal(name, mu, s):
     >>> z = Symbol("z")
     >>> X = LogitNormal("x",mu,s)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                               2
             /         /  z  \\
@@ -2769,7 +2769,7 @@ def LogitNormal(name, mu, s):
             ____
         2*\/ pi *s*z*(1 - z)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*exp(-(-mu + log(z/(1 - z)))**2/(2*s**2))/(2*sqrt(pi)*s*z*(1 - z))
 
     >>> cdf(X)(z)
@@ -2853,7 +2853,7 @@ def LogNormal(name, mean, std):
 
     >>> X = LogNormal("x", mu, sigma)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                           2
            -(-mu + log(z))
@@ -2868,7 +2868,7 @@ def LogNormal(name, mean, std):
 
     >>> X = LogNormal('x', 0, 1) # Mean 0, standard deviation 1
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*exp(-log(z)**2/2)/(2*sqrt(pi)*z)
 
     References
@@ -2927,7 +2927,7 @@ def Lomax(name, alpha, lamda):
     >>> a, l = symbols('a, l', positive=True)
     >>> X = Lomax('X', a, l)
     >>> x = symbols('x')
-    >>> density(X)(x)
+    >>> density(X).pdf(x)
     a*(1 + x/l)**(-a - 1)/l
     >>> cdf(X)(x)
     Piecewise((1 - 1/(1 + x/l)**a, x >= 0), (0, True))
@@ -3007,7 +3007,7 @@ def Maxwell(name, a):
 
     >>> X = Maxwell("x", a)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*z**2*exp(-z**2/(2*a**2))/(sqrt(pi)*a**3)
 
     >>> E(X)
@@ -3091,7 +3091,7 @@ def Moyal(name, mu, sigma):
     >>> sigma = Symbol("sigma", positive=True, real=True)
     >>> z = Symbol("z")
     >>> X = Moyal("x", mu, sigma)
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*exp(-exp((mu - z)/sigma)/2 - (-mu + z)/(2*sigma))/(2*sqrt(pi)*sigma)
     >>> simplify(cdf(X)(z))
     1 - erf(sqrt(2)*exp((mu - z)/(2*sigma))/2)
@@ -3168,7 +3168,7 @@ def Nakagami(name, mu, omega):
 
     >>> X = Nakagami("x", mu, omega)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                                     2
                                -mu*z
@@ -3270,7 +3270,7 @@ def Normal(name, mean, std):
     >>> p = Symbol("p")
     >>> X = Normal("x", mu, sigma)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*exp(-(-mu + z)**2/(2*sigma**2))/(2*sqrt(pi)*sigma)
 
     >>> C = simplify(cdf(X))(z) # it needs a little more help...
@@ -3289,7 +3289,7 @@ def Normal(name, mean, std):
     0
 
     >>> X = Normal("x", 0, 1) # Mean 0, standard deviation 1
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     sqrt(2)*exp(-z**2/2)/(2*sqrt(pi))
 
     >>> E(2*X + 1)
@@ -3403,7 +3403,7 @@ def GaussianInverse(name, mean, shape):
     >>> z = Symbol("z", positive=True)
     >>> X = GaussianInverse("x", mu, lamda)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                                        2
                       -lambda*(-mu + z)
@@ -3509,7 +3509,7 @@ def Pareto(name, xm, alpha):
 
     >>> X = Pareto("x", xm, beta)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     beta*xm**beta*z**(-beta - 1)
 
     References
@@ -3584,7 +3584,7 @@ def PowerFunction(name, alpha, a, b):
 
     >>> X = PowerFunction("X", 2, a, b)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     (-2*a + 2*z)/(-a + b)**2
 
     >>> cdf(X)(z)
@@ -3681,7 +3681,7 @@ def QuadraticU(name, a, b):
 
     >>> X = QuadraticU("x", a, b)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
     /                2
     |   /  a   b    \
@@ -3770,7 +3770,7 @@ def RaisedCosine(name, mu, s):
 
     >>> X = RaisedCosine("x", mu, s)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
     /   /pi*(-mu + z)\
     |cos|------------| + 1
@@ -3854,7 +3854,7 @@ def Rayleigh(name, sigma):
 
     >>> X = Rayleigh("x", sigma)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     z*exp(-z**2/(2*sigma**2))/sigma**2
 
     >>> E(X)
@@ -3917,7 +3917,7 @@ def Reciprocal(name, a, b):
     >>> a, b, x = symbols('a, b, x', positive=True)
     >>> R = Reciprocal('R', a, b)
 
-    >>> density(R)(x)
+    >>> density(R).pdf(x)
     1/(x*(-log(a) + log(b)))
     >>> cdf(R)(x)
     Piecewise((log(a)/(log(a) - log(b)) - log(x)/(log(a) - log(b)), a <= x), (0, True))
@@ -3985,7 +3985,7 @@ def ShiftedGompertz(name, b, eta):
 
     >>> X = ShiftedGompertz("x", b, eta)
 
-    >>> density(X)(x)
+    >>> density(X).pdf(x)
     b*(eta*(1 - exp(-b*x)) + 1)*exp(-b*x)*exp(-eta*exp(-b*x))
 
     References
@@ -4057,7 +4057,7 @@ def StudentT(name, nu):
 
     >>> X = StudentT("x", nu)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
                nu   1
              - -- - -
@@ -4159,7 +4159,7 @@ def Trapezoidal(name, a, b, c, d):
 
     >>> X = Trapezoidal("x", a,b,c,d)
 
-    >>> pprint(density(X)(z), use_unicode=False)
+    >>> pprint(density(X).pdf(z), use_unicode=False)
     /        -2*a + 2*z
     |-------------------------  for And(a <= z, b > z)
     |(-a + b)*(-a - b + c + d)
@@ -4260,7 +4260,7 @@ def Triangular(name, a, b, c):
 
     >>> X = Triangular("x", a,b,c)
 
-    >>> pprint(density(X)(z), use_unicode=False)
+    >>> pprint(density(X).pdf(z), use_unicode=False)
     /    -2*a + 2*z
     |-----------------  for And(a <= z, c > z)
     |(-a + b)*(-a + c)
@@ -4373,7 +4373,7 @@ def Uniform(name, left, right):
 
     >>> X = Uniform("x", a, b)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     Piecewise((1/(-a + b), (b >= z) & (a <= z)), (0, True))
 
     >>> cdf(X)(z)
@@ -4468,7 +4468,7 @@ def UniformSum(name, n):
 
     >>> X = UniformSum("x", n)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
     floor(z)
       ___
@@ -4559,7 +4559,7 @@ def VonMises(name, mu, k):
 
     >>> X = VonMises("x", mu, k)
 
-    >>> D = density(X)(z)
+    >>> D = density(X).pdf(z)
     >>> pprint(D, use_unicode=False)
          k*cos(mu - z)
         e
@@ -4635,7 +4635,7 @@ def Weibull(name, alpha, beta):
 
     >>> X = Weibull("x", l, k)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     k*(z/lambda)**(k - 1)*exp(-(z/lambda)**k)/lambda
 
     >>> simplify(E(X))
@@ -4716,7 +4716,7 @@ def WignerSemicircle(name, R):
 
     >>> X = WignerSemicircle("x", R)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     2*sqrt(R**2 - z**2)/(pi*R**2)
 
     >>> E(X)

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -39,10 +39,61 @@ class SingleDiscreteDistribution(DiscreteDistribution, NamedArgsMixin):
 
     Serves as superclass for PoissonDistribution etc....
 
-    Provides methods for pdf, cdf, and sampling
+    Provides methods for pdf, cdf, and sampling.
 
-    See Also:
-        sympy.stats.crv_types.*
+    Explanation
+    ===========
+
+    The distribution object can be called in two ways to evaluate the
+    probability mass function:
+
+    1. ``distribution(x)``:
+       Returns the probability mass at x, with support checking enforced
+       via Piecewise. For symbolic arguments where support membership cannot
+       be determined, this returns a Piecewise expression that evaluates to
+       the pmf formula when x is in the support, and 0 otherwise.
+
+    2. ``distribution.pdf(x)``:
+       Returns the raw probability mass formula without support checking.
+       This is useful for symbolic manipulation and summation where the
+       Piecewise wrapper would be cumbersome.
+
+    Examples
+    ========
+
+    >>> from sympy.stats import Geometric, density
+    >>> from sympy import Symbol, Rational
+    >>> X = Geometric('X', Rational(1, 5))
+    >>> z = Symbol('z')
+
+    Using distribution call with symbolic argument returns Piecewise:
+
+    >>> density(X)(z)
+    Piecewise(((4/5)**(z - 1)/5, (z >= 1) & (z < oo) & Eq(z, floor(z))), (0, True))
+
+    Using .pdf() returns the raw formula:
+
+    >>> density(X).pdf(z)
+    (4/5)**(z - 1)/5
+
+    For concrete values, both give the same result:
+
+    >>> density(X)(3)
+    16/125
+    >>> density(X).pdf(3)
+    16/125
+
+    Support checking for values outside support:
+
+    >>> density(X)(0)
+    0
+    >>> density(X)(1/2)
+    0
+
+    See Also
+    ========
+
+    sympy.stats.crv_types
     """
 
     set = S.Integers
@@ -175,8 +226,14 @@ class SingleDiscreteDistribution(DiscreteDistribution, NamedArgsMixin):
             return Sum(expr * self.pdf(var),
                          (var, self.set.inf, self.set.sup), **kwargs)
 
-    def __call__(self, *args):
-        return self.pdf(*args)
+    def __call__(self, arg):
+        in_domain = self.set.contains(arg)
+        if in_domain == False:
+            return S.Zero
+        elif in_domain == True:
+            return self.pdf(arg)
+        else:
+            return Piecewise((self.pdf(arg), self.set.as_relational(arg)), (S.Zero, True))
 
 
 class DiscreteDomain(RandomDomain):
@@ -314,7 +371,7 @@ class SingleDiscretePSpace(DiscretePSpace, SinglePSpace):
             return self.distribution.expectation(expr, x, evaluate=evaluate,
                     **kwargs)
         except NotImplementedError:
-            return Sum(expr * self.pdf, (x, self.set.inf, self.set.sup),
+            return Sum(expr * self.distribution.pdf(x), (x, self.set.inf, self.set.sup),
                     **kwargs)
 
     def compute_cdf(self, expr, **kwargs):

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -56,13 +56,15 @@ class SingleDiscreteDistribution(DiscreteDistribution, NamedArgsMixin):
     2. ``distribution.pdf(x)``:
        Returns the raw probability mass formula without support checking.
        This is useful for symbolic manipulation and summation where the
-       Piecewise wrapper would be cumbersome.
+       Piecewise wrapper would be cumbersome. The method is named
+       ``.pdf()`` for historical reasons, but for discrete distributions
+       it computes the probability mass function (PMF).
 
     Examples
     ========
 
     >>> from sympy.stats import Geometric, density
-    >>> from sympy import Symbol, Rational
+    >>> from sympy import Symbol, S, Rational
     >>> X = Geometric('X', Rational(1, 5))
     >>> z = Symbol('z')
 
@@ -87,13 +89,13 @@ class SingleDiscreteDistribution(DiscreteDistribution, NamedArgsMixin):
 
     >>> density(X)(0)
     0
-    >>> density(X)(1/2)
+    >>> density(X)(S(1)/2)
     0
 
     See Also
     ========
 
-    sympy.stats.crv_types
+    sympy.stats.drv_types
     """
 
     set = S.Integers

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -179,7 +179,7 @@ def FlorySchulz(name, a):
 
     >>> X = FlorySchulz("x", a)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     (4/5)**(z - 1)*z/25
 
     >>> E(X)
@@ -209,6 +209,9 @@ class GeometricDistribution(SingleDiscreteDistribution):
 
     def pdf(self, k):
         return (1 - self.p)**(k - 1) * self.p
+
+    def _cdf(self, x):
+        return Piecewise((1 - (1 - self.p)**floor(x), x >= 1), (0, True))
 
     def _characteristic_function(self, t):
         p = self.p
@@ -252,7 +255,7 @@ def Geometric(name, p):
 
     >>> X = Geometric("x", p)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     (4/5)**(z - 1)/5
 
     >>> E(X)
@@ -417,7 +420,7 @@ def Logarithmic(name, p):
 
     >>> X = Logarithmic("x", p)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     -1/(5**z*z*log(4/5))
 
     >>> E(X)
@@ -499,7 +502,7 @@ def NegativeBinomial(name, r, p):
 
     >>> r = 5
     >>> p = S.One / 3
-    >>> z = Symbol("z")
+    >>> z = Symbol("z", nonnegative=True, integer=True)
 
     >>> X = NegativeBinomial("x", r, p)
 
@@ -585,7 +588,7 @@ def Poisson(name, lamda):
     >>> from sympy import Symbol, simplify
 
     >>> rate = Symbol("lambda", positive=True)
-    >>> z = Symbol("z")
+    >>> z = Symbol("z", nonnegative=True, integer=True)
 
     >>> X = Poisson("x", rate)
 
@@ -759,7 +762,7 @@ def YuleSimon(name, rho):
 
     >>> X = YuleSimon("x", p)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     5*beta(z, 6)
 
     >>> simplify(E(X))
@@ -832,7 +835,7 @@ def Zeta(name, s):
 
     >>> X = Zeta("x", s)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     1/(z**5*zeta(5))
 
     >>> E(X)

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -502,11 +502,11 @@ def NegativeBinomial(name, r, p):
 
     >>> r = 5
     >>> p = S.One / 3
-    >>> z = Symbol("z", nonnegative=True, integer=True)
+    >>> z = Symbol("z")
 
     >>> X = NegativeBinomial("x", r, p)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     (2/3)**z*binomial(z + 4, z)/243
 
     >>> E(X)
@@ -588,11 +588,11 @@ def Poisson(name, lamda):
     >>> from sympy import Symbol, simplify
 
     >>> rate = Symbol("lambda", positive=True)
-    >>> z = Symbol("z", nonnegative=True, integer=True)
+    >>> z = Symbol("z")
 
     >>> X = Poisson("x", rate)
 
-    >>> density(X)(z)
+    >>> density(X).pdf(z)
     lambda**z*exp(-lambda)/factorial(z)
 
     >>> E(X)

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -24,6 +24,7 @@ from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.logic.boolalg import (And, Or)
 from sympy.sets.sets import Intersection
+from sympy.sets.contains import Contains
 from sympy.core.containers import Dict
 from sympy.core.logic import Logic
 from sympy.core.relational import Relational
@@ -192,6 +193,23 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
 
 
 class SingleFiniteDistribution(Distribution, NamedArgsMixin):
+    """Finite distribution of a single variable.
+
+    The distribution object can be called in two ways to evaluate the
+    probability mass:
+
+    1. ``distribution(x)``:
+       Returns the probability mass at x, with support checking enforced
+       via Piecewise. For symbolic arguments where support membership cannot
+       be determined, this returns a Piecewise expression that evaluates to
+       the pmf formula when x is in the support, and 0 otherwise.
+
+    2. ``distribution.pmf(x)``:
+       Returns the raw probability mass formula without support checking.
+       This is useful for symbolic manipulation where the Piecewise wrapper
+       would be cumbersome.
+    """
+
     def __new__(cls, *args):
         args = list(map(sympify, args))
         return Basic.__new__(cls, *args)
@@ -220,8 +238,14 @@ class SingleFiniteDistribution(Distribution, NamedArgsMixin):
     __iter__ = property(lambda self: self.dict.__iter__)
     __getitem__ = property(lambda self: self.dict.__getitem__)
 
-    def __call__(self, *args):
-        return self.pmf(*args)
+    def __call__(self, arg):
+        in_domain = Contains(arg, self.set)
+        if in_domain == False:
+            return S.Zero
+        elif in_domain == True:
+            return self.pmf(arg)
+        else:
+            return Piecewise((self.pmf(arg), in_domain), (S.Zero, True))
 
     def __contains__(self, other):
         return other in self.set

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -205,9 +205,12 @@ class SingleFiniteDistribution(Distribution, NamedArgsMixin):
        the pmf formula when x is in the support, and 0 otherwise.
 
     2. ``distribution.pmf(x)``:
-       Returns the raw probability mass formula without support checking.
-       This is useful for symbolic manipulation where the Piecewise wrapper
-       would be cumbersome.
+       Returns the probability mass formula as defined by the subclass.
+       For distributions with a single closed-form formula (Die, Binomial),
+       this returns the raw formula without support checking. For
+       distributions whose formula is inherently piecewise (Bernoulli,
+       IdealSoliton), the returned Piecewise includes the formula's
+       natural structure.
     """
 
     def __new__(cls, *args):

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -29,7 +29,6 @@ from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.logic.boolalg import Or
-from sympy.sets.contains import Contains
 from sympy.sets.fancysets import Range
 from sympy.sets.sets import (Intersection, Interval)
 from sympy.functions.special.beta_functions import beta as beta_fn
@@ -226,7 +225,7 @@ class DieDistribution(SingleFiniteDistribution):
     @property
     def set(self):
         if self.is_symbolic:
-            return Intersection(S.Naturals0, Interval(0, self.sides))
+            return Intersection(S.Naturals, Interval(1, self.sides))
         return set(map(Integer, range(1, self.sides + 1)))
 
     def pmf(self, x):
@@ -234,8 +233,7 @@ class DieDistribution(SingleFiniteDistribution):
         if not (x.is_number or x.is_Symbol or is_random(x)):
             raise ValueError("'x' expected as an argument of type 'number', 'Symbol', or "
                         "'RandomSymbol' not %s" % (type(x)))
-        cond = Ge(x, 1) & Le(x, self.sides) & Contains(x, S.Integers)
-        return Piecewise((S.One/self.sides, cond), (S.Zero, True))
+        return S.One / self.sides
 
 def Die(name, sides=6):
     r"""
@@ -423,8 +421,7 @@ class BinomialDistribution(SingleFiniteDistribution):
         if not (x.is_number or x.is_Symbol or is_random(x)):
             raise ValueError("'x' expected as an argument of type 'number', 'Symbol', or "
                         "'RandomSymbol' not %s" % (type(x)))
-        cond = Ge(x, 0) & Le(x, n) & Contains(x, S.Integers)
-        return Piecewise((binomial(n, x) * p**x * (1 - p)**(n - x), cond), (S.Zero, True))
+        return binomial(n, x) * p**x * (1 - p)**(n - x)
 
     @property  # type: ignore
     @cacheit

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -935,7 +935,7 @@ def density(expr, condition=None, evaluate=True, numsamples=None, **kwargs):
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
     >>> density(2*D).dict
     {2: 1/6, 4: 1/6, 6: 1/6, 8: 1/6, 10: 1/6, 12: 1/6}
-    >>> density(X)(x)
+    >>> density(X).pdf(x)
     sqrt(2)*exp(-x**2/2)/(2*sqrt(pi))
     """
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -906,9 +906,18 @@ def density(expr, condition=None, evaluate=True, numsamples=None, **kwargs):
     Explanation
     ===========
 
-    This density will take on different forms for different types of
-    probability spaces. Discrete variables produce Dicts. Continuous
-    variables produce Lambdas.
+    For a simple random variable, this returns the distribution object.
+    The returned object supports two ways of evaluating the density:
+
+    - ``density(X)(x)`` evaluates the density with support checking.
+      For concrete values outside the support it returns 0. For symbolic
+      values it returns a Piecewise that is 0 outside the support.
+    - ``density(X).pdf(x)`` (or ``.pmf(x)`` for finite distributions)
+      returns the raw formula without support checking, which is more
+      convenient for symbolic manipulation.
+
+    For transformed expressions the return type varies: finite
+    expressions produce dicts, continuous expressions produce Lambdas.
 
     Parameters
     ==========

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -139,10 +139,18 @@ def entropy(expr, condition=None, **kwargs):
     .. [2] https://www.crmarsh.com/static/pdf/Charles_Marsh_Continuous_Entropy.pdf
     .. [3] https://kconrad.math.uconn.edu/blurbs/analysis/entropypost.pdf
     """
+    from .crv import SingleContinuousDistribution
+    from .drv import SingleDiscreteDistribution
+    from .frv import SingleFiniteDistribution
+
     pdf = density(expr, condition, **kwargs)
     base = kwargs.get('b', exp(1))
     if isinstance(pdf, dict):
-            return sum(-prob*log(prob, base) for prob in pdf.values())
+        return sum(-prob*log(prob, base) for prob in pdf.values())
+    if isinstance(pdf, (SingleContinuousDistribution, SingleDiscreteDistribution)):
+        return expectation(-log(pdf.pdf(expr), base))
+    elif isinstance(pdf, SingleFiniteDistribution):
+        return expectation(-log(pdf.pmf(expr), base))
     return expectation(-log(pdf(expr), base))
 
 def covariance(X, Y, condition=None, **kwargs):

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -139,6 +139,7 @@ def entropy(expr, condition=None, **kwargs):
     .. [2] https://www.crmarsh.com/static/pdf/Charles_Marsh_Continuous_Entropy.pdf
     .. [3] https://kconrad.math.uconn.edu/blurbs/analysis/entropypost.pdf
     """
+    from sympy.core.function import Lambda
     from .crv import SingleContinuousDistribution
     from .drv import SingleDiscreteDistribution
     from .frv import SingleFiniteDistribution
@@ -151,7 +152,10 @@ def entropy(expr, condition=None, **kwargs):
         return expectation(-log(pdf.pdf(expr), base))
     elif isinstance(pdf, SingleFiniteDistribution):
         return expectation(-log(pdf.pmf(expr), base))
-    return expectation(-log(pdf(expr), base))
+    elif isinstance(pdf, Lambda):
+        return expectation(-log(pdf(expr), base))
+    else:
+        raise NotImplementedError("Entropy not implemented for density type %s" % type(pdf))
 
 def covariance(X, Y, condition=None, **kwargs):
     """

--- a/sympy/stats/tests/test_compound_rv.py
+++ b/sympy/stats/tests/test_compound_rv.py
@@ -49,7 +49,7 @@ def test_poisson_CompoundDist():
     k, t, y = symbols('k t y', positive=True, real=True)
     G = Gamma('G', k, t)
     D = Poisson('P', G)
-    assert density(D)(y).simplify() == t**y*(t + 1)**(-k - y)*gamma(k + y)/(gamma(k)*gamma(y + 1))
+    assert density(D).pdf(y).simplify() == t**y*(t + 1)**(-k - y)*gamma(k + y)/(gamma(k)*gamma(y + 1))
     # https://en.wikipedia.org/wiki/Negative_binomial_distribution#Gamma%E2%80%93Poisson_mixture
     assert E(D).simplify() == k*t # mean of NegativeBinomialDistribution
 
@@ -96,7 +96,7 @@ def test_unevaluated_CompoundDist():
     Z = Poisson('Z', Y)
     exprd = Sum(exp(-Y)*Y**x*Sum(exp(-1)*exp(-X)*X**Y/(factorial(X)*factorial(Y)
                 ), (X, 0, oo))/factorial(x), (Y, 0, oo))
-    assert density(Z)(x) == exprd
+    assert density(Z).pdf(x) == exprd
 
     N = Normal('N', 1, 2)
     M = Normal('M', 3, 4)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1604,6 +1604,8 @@ def test_continuous_distribution_call_vs_pdf():
 
     assert density(Y).pdf(x) == 2*exp(-2*x)
 
+    assert density(Y)(-1) is S.Zero
+
     z_pos = Symbol('z', positive=True)
     assert density(Y)(z_pos) == 2*exp(-2*z_pos)
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -83,7 +83,7 @@ def test_conditional_1d():
     Y = given(X, X >= 0)
     z = Symbol('z')
 
-    assert density(Y)(z) == 2 * density(X)(z)
+    assert density(Y)(z) == 2 * density(X).pdf(z)
 
     assert Y.pspace.domain.set == Interval(0, oo)
     assert E(Y) == sqrt(2) / sqrt(pi)
@@ -374,7 +374,7 @@ def test_arcsin():
     b = Symbol("b", real=True)
 
     X = Arcsin('x', a, b)
-    assert density(X)(x) == 1/(pi*sqrt((-x + b)*(x - a)))
+    assert density(X).pdf(x) == 1/(pi*sqrt((-x + b)*(x - a)))
     assert cdf(X)(x) == Piecewise((0, a > x),
                             (2*asin(sqrt((-a + x)/(-a + b)))/pi, b >= x),
                             (1, True))
@@ -386,7 +386,7 @@ def test_benini():
     sigma = Symbol("sigma", positive=True)
     X = Benini('x', alpha, beta, sigma)
 
-    assert density(X)(x) == ((alpha/x + 2*beta*log(x/sigma)/x)
+    assert density(X).pdf(x) == ((alpha/x + 2*beta*log(x/sigma)/x)
                           *exp(-alpha*log(x/sigma) - beta*log(x/sigma)**2))
 
     assert pspace(X).domain.set == Interval(sigma, oo)
@@ -410,7 +410,7 @@ def test_beta():
 
     assert pspace(B).domain.set == Interval(0, 1)
     assert characteristic_function(B)(x) == hyper((a,), (a + b,), I*x)
-    assert density(B)(x) == x**(a - 1)*(1 - x)**(b - 1)/beta(a, b)
+    assert density(B).pdf(x) == x**(a - 1)*(1 - x)**(b - 1)/beta(a, b)
 
     assert simplify(E(B)) == a / (a + b)
     assert simplify(variance(B)) == a*b / (a**3 + 3*a**2*b + a**2 + 3*a*b**2 + 2*a*b + b**3 + b**2)
@@ -436,7 +436,7 @@ def test_beta_noncentral():
 
     res = Sum( z**(_k + a - 1)*(c/2)**_k*(1 - z)**(b - 1)*exp(-c/2)/
                (beta(_k + a, b)*factorial(_k)), (_k, 0, oo))
-    assert dens(z).dummy_eq(res)
+    assert dens.pdf(z).dummy_eq(res)
 
     # BetaCentral should not raise if the assumptions
     # on the symbols can not be determined
@@ -461,7 +461,7 @@ def test_betaprime():
     betap = Symbol("beta", positive=True)
 
     X = BetaPrime('x', alpha, betap)
-    assert density(X)(x) == x**(alpha - 1)*(x + 1)**(-alpha - betap)/beta(alpha, betap)
+    assert density(X).pdf(x) == x**(alpha - 1)*(x + 1)**(-alpha - betap)/beta(alpha, betap)
 
     alpha = Symbol("alpha", nonpositive=True)
     raises(ValueError, lambda: BetaPrime('x', alpha, betap))
@@ -483,7 +483,7 @@ def test_BoundedPareto():
 
     X = BoundedPareto('X', 2, L, H)
     assert X.pspace.domain.set == Interval(L, H)
-    assert density(X)(x) == 2*L**2/(x**3*(1 - L**2/H**2))
+    assert density(X).pdf(x) == 2*L**2/(x**3*(1 - L**2/H**2))
     assert cdf(X)(x) == Piecewise((-H**2*L**2/(x**2*(H**2 - L**2)) \
                             + H**2/(H**2 - L**2), L <= x), (0, True))
     assert E(X).simplify() == 2*H*L/(H + L)
@@ -502,8 +502,8 @@ def test_cauchy():
     # Tests the characteristic function
     assert characteristic_function(X)(x) == exp(-gamma*Abs(x) + I*x*x0)
     raises(NotImplementedError, lambda: moment_generating_function(X))
-    assert density(X)(x) == 1/(pi*gamma*(1 + (x - x0)**2/gamma**2))
-    assert diff(cdf(X)(x), x) == density(X)(x)
+    assert density(X).pdf(x) == 1/(pi*gamma*(1 + (x - x0)**2/gamma**2))
+    assert diff(cdf(X)(x), x) == density(X).pdf(x)
     assert quantile(X)(p) == gamma*tan(pi*(p - S.Half)) + x0
 
     x1 = Symbol("x1", real=False)
@@ -517,7 +517,7 @@ def test_chi():
     k = Symbol("k", integer=True)
 
     X = Chi('x', k)
-    assert density(X)(x) == 2**(-k/2 + 1)*x**(k - 1)*exp(-x**2/2)/gamma(k/2)
+    assert density(X).pdf(x) == 2**(-k/2 + 1)*x**(k - 1)*exp(-x**2/2)/gamma(k/2)
 
     # Tests the characteristic function
     assert characteristic_function(X)(x) == sqrt(2)*I*x*gamma(k/2 + S(1)/2)*hyper((k/2 + S(1)/2,),
@@ -538,7 +538,7 @@ def test_chi_noncentral():
     l = Symbol("l")
 
     X = ChiNoncentral("x", k, l)
-    assert density(X)(x) == (x**k*l*(x*l)**(-k/2)*
+    assert density(X).pdf(x) == (x**k*l*(x*l)**(-k/2)*
                           exp(-x**2/2 - l**2/2)*besseli(k/2 - 1, x*l))
 
     k = Symbol("k", integer=True, positive=False)
@@ -560,7 +560,7 @@ def test_chi_squared():
     # Tests the characteristic function
     assert characteristic_function(X)(x) == ((-2*I*x + 1)**(-k/2))
 
-    assert density(X)(x) == 2**(-k/2)*x**(k/2 - 1)*exp(-x/2)/gamma(k/2)
+    assert density(X).pdf(x) == 2**(-k/2)*x**(k/2 - 1)*exp(-x/2)/gamma(k/2)
     assert cdf(X)(x) == Piecewise((lowergamma(k/2, x/2)/gamma(k/2), x >= 0), (0, True))
     assert E(X) == k
     assert variance(X) == 2*k
@@ -581,7 +581,7 @@ def test_dagum():
     a = Symbol("a", positive=True)
 
     X = Dagum('x', p, a, b)
-    assert density(X)(x) == a*p*(x/b)**(a*p)*((x/b)**a + 1)**(-p - 1)/x
+    assert density(X).pdf(x) == a*p*(x/b)**(a*p)*((x/b)**a + 1)**(-p - 1)/x
     assert cdf(X)(x) == Piecewise(((1 + (x/b)**(-a))**(-p), x >= 0),
                                     (0, True))
 
@@ -606,7 +606,7 @@ def test_davis():
     X = Davis('x', b, n, mu)
     dividend = b**n*(x - mu)**(-1-n)
     divisor = (exp(b/(x-mu))-1)*(gamma(n)*zeta(n))
-    assert density(X)(x) == dividend/divisor
+    assert density(X).pdf(x) == dividend/divisor
 
 
 def test_erlang():
@@ -614,7 +614,7 @@ def test_erlang():
     l = Symbol("l", positive=True)
 
     X = Erlang("x", k, l)
-    assert density(X)(x) == x**(k - 1)*l**k*exp(-x*l)/gamma(k)
+    assert density(X).pdf(x) == x**(k - 1)*l**k*exp(-x*l)/gamma(k)
     assert cdf(X)(x) == Piecewise((lowergamma(k, l*x)/gamma(k), x > 0),
                                (0, True))
 
@@ -624,7 +624,7 @@ def test_exgaussian():
     s, l = symbols("s, l", positive=True)
     X = ExGaussian("x", m, s, l)
 
-    assert density(X)(z) == l*exp(l*(l*s**2 + 2*m - 2*z)/2) *\
+    assert density(X).pdf(z) == l*exp(l*(l*s**2 + 2*m - 2*z)/2) *\
         erfc(sqrt(2)*(l*s**2 + m - z)/(2*s))/2
 
     # Note: actual_output simplifies to expected_output.
@@ -696,7 +696,7 @@ def test_exponential_power():
 
     X = ExponentialPower('x', mu, alpha, beta)
 
-    assert density(X)(z) == beta*exp(-(Abs(mu - z)/alpha)
+    assert density(X).pdf(z) == beta*exp(-(Abs(mu - z)/alpha)
                                      ** beta)/(2*alpha*gamma(1/beta))
     assert cdf(X)(z) == S.Half + lowergamma(1/beta,
                             (Abs(mu - z)/alpha)**beta)*sign(-mu + z)/\
@@ -709,7 +709,7 @@ def test_f_distribution():
 
     X = FDistribution("x", d1, d2)
 
-    assert density(X)(x) == (d2**(d2/2)*sqrt((d1*x)**d1*(d1*x + d2)**(-d1 - d2))
+    assert density(X).pdf(x) == (d2**(d2/2)*sqrt((d1*x)**d1*(d1*x + d2)**(-d1 - d2))
                              /(x*beta(d1/2, d2/2)))
 
     raises(NotImplementedError, lambda: moment_generating_function(X))
@@ -732,7 +732,7 @@ def test_fisher_z():
     d2 = Symbol("d2", positive=True)
 
     X = FisherZ("x", d1, d2)
-    assert density(X)(x) == (2*d1**(d1/2)*d2**(d2/2)*(d1*exp(2*x) + d2)
+    assert density(X).pdf(x) == (2*d1**(d1/2)*d2**(d2/2)*(d1*exp(2*x) + d2)
                              **(-d1/2 - d2/2)*exp(d1*x)/beta(d1/2, d2/2))
 
 def test_frechet():
@@ -741,7 +741,7 @@ def test_frechet():
     m = Symbol("m", real=True)
 
     X = Frechet("x", a, s=s, m=m)
-    assert density(X)(x) == a*((x - m)/s)**(-a - 1)*exp(-((x - m)/s)**(-a))/s
+    assert density(X).pdf(x) == a*((x - m)/s)**(-a - 1)*exp(-((x - m)/s)**(-a))/s
     assert cdf(X)(x) == Piecewise((exp(-((-m + x)/s)**(-a)), m <= x), (0, True))
 
 @slow
@@ -754,7 +754,7 @@ def test_gamma():
     # Tests characteristic function
     assert characteristic_function(X)(x) == ((-I*theta*x + 1)**(-k))
 
-    assert density(X)(x) == x**(k - 1)*theta**(-k)*exp(-x/theta)/gamma(k)
+    assert density(X).pdf(x) == x**(k - 1)*theta**(-k)*exp(-x/theta)/gamma(k)
     assert cdf(X, meijerg=True)(z) == Piecewise(
             (-k*lowergamma(k, 0)/gamma(k + 1) +
                 k*lowergamma(k, z/theta)/gamma(k + 1), z >= 0),
@@ -779,7 +779,7 @@ def test_gamma_inverse():
     a = Symbol("a", positive=True)
     b = Symbol("b", positive=True)
     X = GammaInverse("x", a, b)
-    assert density(X)(x) == x**(-a - 1)*b**a*exp(-b/x)/gamma(a)
+    assert density(X).pdf(x) == x**(-a - 1)*b**a*exp(-b/x)/gamma(a)
     assert cdf(X)(x) == Piecewise((uppergamma(a, b/x)/gamma(a), x > 0), (0, True))
     assert characteristic_function(X)(x) == 2 * (-I*b*x)**(a/2) \
             * besselk(a, 2*sqrt(b)*sqrt(-I*x))/gamma(a)
@@ -791,9 +791,9 @@ def test_gompertz():
 
     X = Gompertz("x", b, eta)
 
-    assert density(X)(x) == b*eta*exp(eta)*exp(b*x)*exp(-eta*exp(b*x))
+    assert density(X).pdf(x) == b*eta*exp(eta)*exp(b*x)*exp(-eta*exp(b*x))
     assert cdf(X)(x) == 1 - exp(eta)*exp(-eta*exp(b*x))
-    assert diff(cdf(X)(x), x) == density(X)(x)
+    assert diff(cdf(X)(x), x) == density(X).pdf(x)
 
 
 def test_gumbel():
@@ -803,9 +803,9 @@ def test_gumbel():
     y = Symbol("y")
     X = Gumbel("x", beta, mu)
     Y = Gumbel("y", beta, mu, minimum=True)
-    assert density(X)(x).expand() == \
+    assert density(X).pdf(x).expand() == \
     exp(mu/beta)*exp(-x/beta)*exp(-exp(mu/beta)*exp(-x/beta))/beta
-    assert density(Y)(y).expand() == \
+    assert density(Y).pdf(y).expand() == \
     exp(-mu/beta)*exp(y/beta)*exp(-exp(-mu/beta)*exp(y/beta))/beta
     assert cdf(X)(x).expand() == \
     exp(-exp(mu/beta)*exp(-x/beta))
@@ -816,7 +816,7 @@ def test_kumaraswamy():
     b = Symbol("b", positive=True)
 
     X = Kumaraswamy("x", a, b)
-    assert density(X)(x) == x**(a - 1)*a*b*(-x**a + 1)**(b - 1)
+    assert density(X).pdf(x) == x**(a - 1)*a*b*(-x**a + 1)**(b - 1)
     assert cdf(X)(x) == Piecewise((0, x < 0),
                                 (-(-x**a + 1)**b + 1, x <= 1),
                                 (1, True))
@@ -831,7 +831,7 @@ def test_laplace():
     #Tests characteristic_function
     assert characteristic_function(X)(x) == (exp(I*mu*x)/(b**2*x**2 + 1))
 
-    assert density(X)(x) == exp(-Abs(x - mu)/b)/(2*b)
+    assert density(X).pdf(x) == exp(-Abs(x - mu)/b)/(2*b)
     assert cdf(X)(x) == Piecewise((exp((-mu + x)/b)/2, mu > x),
                             (-exp((mu - x)/b)/2 + 1, True))
     X = Laplace('x', [1, 2], [[1, 0], [0, 1]])
@@ -843,7 +843,7 @@ def test_levy():
 
     X = Levy('x', mu, c)
     assert X.pspace.domain.set == Interval(mu, oo)
-    assert density(X)(x) == sqrt(c/(2*pi))*exp(-c/(2*(x - mu)))/((x - mu)**(S.One + S.Half))
+    assert density(X).pdf(x) == sqrt(c/(2*pi))*exp(-c/(2*(x - mu)))/((x - mu)**(S.One + S.Half))
     assert cdf(X)(x) == erfc(sqrt(c/(2*(x - mu))))
 
     raises(NotImplementedError, lambda: moment_generating_function(X))
@@ -862,7 +862,7 @@ def test_logcauchy():
 
     X = LogCauchy("x", mu, sigma)
 
-    assert density(X)(x) == sigma/(x*pi*(sigma**2 + (-mu + log(x))**2))
+    assert density(X).pdf(x) == sigma/(x*pi*(sigma**2 + (-mu + log(x))**2))
     assert cdf(X)(x) == atan((log(x) - mu)/sigma)/pi + S.Half
 
 
@@ -877,7 +877,7 @@ def test_logistic():
     assert characteristic_function(X)(x) == \
            (Piecewise((pi*s*x*exp(I*mu*x)/sinh(pi*s*x), Ne(x, 0)), (1, True)))
 
-    assert density(X)(x) == exp((-x + mu)/s)/(s*(exp((-x + mu)/s) + 1)**2)
+    assert density(X).pdf(x) == exp((-x + mu)/s)/(s*(exp((-x + mu)/s) + 1)**2)
     assert cdf(X)(x) == 1/(exp((mu - x)/s) + 1)
     assert quantile(X)(p) == mu - s*log(-S.One + 1/p)
 
@@ -895,7 +895,7 @@ def test_loglogistic():
 
     a, b, z, p = symbols('a b z p', positive=True)
     X = LogLogistic('x', a, b)
-    assert density(X)(z) == b*(z/a)**(b - 1)/(a*((z/a)**b + 1)**2)
+    assert density(X).pdf(z) == b*(z/a)**(b - 1)/(a*((z/a)**b + 1)**2)
     assert cdf(X)(z) == 1/(1 + (z/a)**(-b))
     assert quantile(X)(p) == a*(p/(1 - p))**(1/b)
 
@@ -913,7 +913,7 @@ def test_logitnormal():
     X = LogitNormal('x', mu, s)
     x = Symbol('x')
 
-    assert density(X)(x) == sqrt(2)*exp(-(-mu + log(x/(1 - x)))**2/(2*s**2))/(2*sqrt(pi)*s*x*(1 - x))
+    assert density(X).pdf(x) == sqrt(2)*exp(-(-mu + log(x/(1 - x)))**2/(2*s**2))/(2*sqrt(pi)*s*x*(1 - x))
     assert cdf(X)(x) == erf(sqrt(2)*(-mu + log(x/(1 - x)))/(2*s))/2 + S(1)/2
 
 def test_lognormal():
@@ -931,7 +931,7 @@ def test_lognormal():
     sigma = Symbol("sigma", positive=True)
 
     X = LogNormal('x', mu, sigma)
-    assert density(X)(x) == (sqrt(2)*exp(-(-mu + log(x))**2
+    assert density(X).pdf(x) == (sqrt(2)*exp(-(-mu + log(x))**2
                                     /(2*sigma**2))/(2*x*sqrt(pi)*sigma))
     # Tests cdf
     assert cdf(X)(x) == Piecewise(
@@ -939,7 +939,7 @@ def test_lognormal():
                         + S(1)/2, x > 0), (0, True))
 
     X = LogNormal('x', 0, 1)  # Mean 0, standard deviation 1
-    assert density(X)(x) == sqrt(2)*exp(-log(x)**2/2)/(2*x*sqrt(pi))
+    assert density(X).pdf(x) == sqrt(2)*exp(-log(x)**2/2)/(2*x*sqrt(pi))
 
 
 def test_Lomax():
@@ -951,7 +951,7 @@ def test_Lomax():
     a, l = symbols('a, l', positive=True)
     X = Lomax('X', a, l)
     assert X.pspace.domain.set == Interval(0, oo)
-    assert density(X)(x) == a*(1 + x/l)**(-a - 1)/l
+    assert density(X).pdf(x) == a*(1 + x/l)**(-a - 1)/l
     assert cdf(X)(x) == Piecewise((1 - (1 + x/l)**(-a), x >= 0), (0, True))
     a = 3
     X = Lomax('X', a, l)
@@ -965,12 +965,12 @@ def test_maxwell():
 
     X = Maxwell('x', a)
 
-    assert density(X)(x) == (sqrt(2)*x**2*exp(-x**2/(2*a**2))/
+    assert density(X).pdf(x) == (sqrt(2)*x**2*exp(-x**2/(2*a**2))/
         (sqrt(pi)*a**3))
     assert E(X) == 2*sqrt(2)*a/sqrt(pi)
     assert variance(X) == -8*a**2/pi + 3*a**2
     assert cdf(X)(x) == erf(sqrt(2)*x/(2*a)) - sqrt(2)*x*exp(-x**2/(2*a**2))/(sqrt(pi)*a)
-    assert diff(cdf(X)(x), x) == density(X)(x)
+    assert diff(cdf(X)(x), x) == density(X).pdf(x)
 
 
 @slow
@@ -985,7 +985,7 @@ def test_Moyal():
 
     sigma = Symbol('sigma', positive=True)
     M = Moyal('M', mu, sigma)
-    assert density(M)(z) == sqrt(2)*exp(-exp((mu - z)/sigma)/2
+    assert density(M).pdf(z) == sqrt(2)*exp(-exp((mu - z)/sigma)/2
                         - (-mu + z)/(2*sigma))/(2*sqrt(pi)*sigma)
     assert cdf(M)(z).simplify() == 1 - erf(sqrt(2)*exp((mu - z)/(2*sigma))/2)
     assert characteristic_function(M)(z) == 2**(-I*sigma*z)*exp(I*mu*z) \
@@ -1000,7 +1000,7 @@ def test_nakagami():
     omega = Symbol("omega", positive=True)
 
     X = Nakagami('x', mu, omega)
-    assert density(X)(x) == (2*x**(2*mu - 1)*mu**mu*omega**(-mu)
+    assert density(X).pdf(x) == (2*x**(2*mu - 1)*mu**mu*omega**(-mu)
                                 *exp(-x**2*mu/omega)/gamma(mu))
     assert simplify(E(X)) == (sqrt(mu)*sqrt(omega)
                                             *gamma(mu + S.Half)/gamma(mu + 1))
@@ -1021,13 +1021,13 @@ def test_gaussian_inverse():
     # `GaussianInverse` can also be referred by the name `Wald`
     a, b, z = symbols('a b z')
     X = Wald('x', a, b)
-    assert density(X)(z) == sqrt(2)*sqrt(b/z**3)*exp(-b*(-a + z)**2/(2*a**2*z))/(2*sqrt(pi))
+    assert density(X).pdf(z) == sqrt(2)*sqrt(b/z**3)*exp(-b*(-a + z)**2/(2*a**2*z))/(2*sqrt(pi))
 
     a, b = symbols('a b', positive=True)
     z = Symbol('z', positive=True)
 
     X = GaussianInverse('x', a, b)
-    assert density(X)(z) == sqrt(2)*sqrt(b)*sqrt(z**(-3))*exp(-b*(-a + z)**2/(2*a**2*z))/(2*sqrt(pi))
+    assert density(X).pdf(z) == sqrt(2)*sqrt(b)*sqrt(z**(-3))*exp(-b*(-a + z)**2/(2*a**2*z))/(2*sqrt(pi))
     assert E(X) == a
     assert variance(X).expand() == a**3/b
     assert cdf(X)(z) == (S.Half - erf(sqrt(2)*sqrt(b)*(1 + z/a)/(2*sqrt(z)))/2)*exp(2*b/a) +\
@@ -1055,7 +1055,7 @@ def test_pareto():
     assert characteristic_function(X)(x) == \
            ((-I*x*xm)**(beta + 5)*(beta + 5)*uppergamma(-beta - 5, -I*x*xm))
 
-    assert dens(x) == x**(-(alpha + 1))*xm**(alpha)*(alpha)
+    assert dens.pdf(x) == x**(-(alpha + 1))*xm**(alpha)*(alpha)
 
     assert simplify(E(X)) == alpha*xm/(alpha-1)
 
@@ -1087,12 +1087,12 @@ def test_PowerFunction():
     raises (ValueError, lambda: PowerFunction('x', alpha, 5, 2))
 
     X = PowerFunction('X', 2, a, b)
-    assert density(X)(z) == (-2*a + 2*z)/(-a + b)**2
+    assert density(X).pdf(z) == (-2*a + 2*z)/(-a + b)**2
     assert cdf(X)(z) == Piecewise((a**2/(a**2 - 2*a*b + b**2) -
         2*a*z/(a**2 - 2*a*b + b**2) + z**2/(a**2 - 2*a*b + b**2), a <= z), (0, True))
 
     X = PowerFunction('X', 2, 0, 1)
-    assert density(X)(z) == 2*z
+    assert density(X).pdf(z) == 2*z
     assert cdf(X)(z) == Piecewise((z**2, z >= 0), (0,True))
     assert E(X) == Rational(2,3)
     assert P(X < 0) == 0
@@ -1110,7 +1110,7 @@ def test_raised_cosine():
     assert characteristic_function(X)(x) == \
            Piecewise((exp(-I*pi*mu/s)/2, Eq(x, -pi/s)), (exp(I*pi*mu/s)/2, Eq(x, pi/s)), (pi**2*exp(I*mu*x)*sin(s*x)/(s*x*(-s**2*x**2 + pi**2)), True))
 
-    assert density(X)(x) == (Piecewise(((cos(pi*(x - mu)/s) + 1)/(2*s),
+    assert density(X).pdf(x) == (Piecewise(((cos(pi*(x - mu)/s) + 1)/(2*s),
                           And(x <= mu + s, mu - s <= x)), (0, True)))
 
 
@@ -1122,18 +1122,18 @@ def test_rayleigh():
     #Tests characteristic_function
     assert characteristic_function(X)(x) == (-sqrt(2)*sqrt(pi)*sigma*x*(erfi(sqrt(2)*sigma*x/2) - I)*exp(-sigma**2*x**2/2)/2 + 1)
 
-    assert density(X)(x) ==  x*exp(-x**2/(2*sigma**2))/sigma**2
+    assert density(X).pdf(x) ==  x*exp(-x**2/(2*sigma**2))/sigma**2
     assert E(X) == sqrt(2)*sqrt(pi)*sigma/2
     assert variance(X) == -pi*sigma**2/2 + 2*sigma**2
     assert cdf(X)(x) == 1 - exp(-x**2/(2*sigma**2))
-    assert diff(cdf(X)(x), x) == density(X)(x)
+    assert diff(cdf(X)(x), x) == density(X).pdf(x)
 
 def test_reciprocal():
     a = Symbol("a", real=True)
     b = Symbol("b", real=True)
 
     X = Reciprocal('x', a, b)
-    assert density(X)(x) == 1/(x*(-log(a) + log(b)))
+    assert density(X).pdf(x) == 1/(x*(-log(a) + log(b)))
     assert cdf(X)(x) == Piecewise((log(a)/(log(a) - log(b)) - log(x)/(log(a) - log(b)), a <= x), (0, True))
     X = Reciprocal('x', 5, 30)
 
@@ -1153,14 +1153,14 @@ def test_shiftedgompertz():
     b = Symbol("b", positive=True)
     eta = Symbol("eta", positive=True)
     X = ShiftedGompertz("x", b, eta)
-    assert density(X)(x) == b*(eta*(1 - exp(-b*x)) + 1)*exp(-b*x)*exp(-eta*exp(-b*x))
+    assert density(X).pdf(x) == b*(eta*(1 - exp(-b*x)) + 1)*exp(-b*x)*exp(-eta*exp(-b*x))
 
 
 def test_studentt():
     nu = Symbol("nu", positive=True)
 
     X = StudentT('x', nu)
-    assert density(X)(x) == (1 + x**2/nu)**(-nu/2 - S.Half)/(sqrt(nu)*beta(S.Half, nu/2))
+    assert density(X).pdf(x) == (1 + x**2/nu)**(-nu/2 - S.Half)/(sqrt(nu)*beta(S.Half, nu/2))
     assert cdf(X)(x) == S.Half + x*gamma(nu/2 + S.Half)*hyper((S.Half, nu/2 + S.Half),
                                 (Rational(3, 2),), -x**2/nu)/(sqrt(pi)*sqrt(nu)*gamma(nu/2))
     raises(NotImplementedError, lambda: moment_generating_function(X))
@@ -1172,7 +1172,7 @@ def test_trapezoidal():
     d = Symbol("d", real=True)
 
     X = Trapezoidal('x', a, b, c, d)
-    assert density(X)(x) == Piecewise(((-2*a + 2*x)/((-a + b)*(-a - b + c + d)), (a <= x) & (x < b)),
+    assert density(X).pdf(x) == Piecewise(((-2*a + 2*x)/((-a + b)*(-a - b + c + d)), (a <= x) & (x < b)),
                                       (2/(-a - b + c + d), (b <= x) & (x < c)),
                                       ((2*d - 2*x)/((-c + d)*(-a - b + c + d)), (c <= x) & (x <= d)),
                                       (0, True))
@@ -1190,7 +1190,7 @@ def test_triangular():
 
     X = Triangular('x', a, b, c)
     assert pspace(X).domain.set == Interval(a, b)
-    assert str(density(X)(x)) == ("Piecewise(((-2*a + 2*x)/((-a + b)*(-a + c)), (a <= x) & (c > x)), "
+    assert str(density(X).pdf(x)) == ("Piecewise(((-2*a + 2*x)/((-a + b)*(-a + c)), (a <= x) & (c > x)), "
     "(2/(-a + b), Eq(c, x)), ((2*b - 2*x)/((-a + b)*(b - c)), (b >= x) & (c < x)), (0, True))")
 
     #Tests moment_generating_function
@@ -1212,7 +1212,7 @@ def test_quadratic_u():
     assert moment_generating_function(Y)(2) == -9*exp(4)/2 + 21*exp(2)/2
 
     assert characteristic_function(Y)(1) == 3*I*(-1 + 4*I)*exp(I*exp(2*I))
-    assert density(X)(x) == (Piecewise((12*(x - a/2 - b/2)**2/(-a + b)**3,
+    assert density(X).pdf(x) == (Piecewise((12*(x - a/2 - b/2)**2/(-a + b)**3,
                           And(x <= b, a <= x)), (0, True)))
 
 
@@ -1266,7 +1266,7 @@ def test_uniformsum():
 
     X = UniformSum('x', n)
     res = Sum((-1)**_k*(-_k + x)**(n - 1)*binomial(n, _k), (_k, 0, floor(x)))/factorial(n - 1)
-    assert density(X)(x).dummy_eq(res)
+    assert density(X).pdf(x).dummy_eq(res)
 
     #Tests set functions
     assert X.pspace.domain.set == Interval(0, n)
@@ -1283,7 +1283,7 @@ def test_von_mises():
     k = Symbol("k", positive=True)
 
     X = VonMises("x", mu, k)
-    assert density(X)(x) == exp(k*cos(x - mu))/(2*pi*besseli(0, k))
+    assert density(X).pdf(x) == exp(k*cos(x - mu))/(2*pi*besseli(0, k))
 
 
 def test_weibull():
@@ -1316,7 +1316,7 @@ def test_wignersemicircle():
 
     X = WignerSemicircle('x', R)
     assert pspace(X).domain.set == Interval(-R, R)
-    assert density(X)(x) == 2*sqrt(-x**2 + R**2)/(pi*R**2)
+    assert density(X).pdf(x) == 2*sqrt(-x**2 + R**2)/(pi*R**2)
     assert E(X) == 0
 
 
@@ -1411,7 +1411,7 @@ def test_random_parameters_given():
 def test_conjugate_priors():
     mu = Normal('mu', 2, 3)
     x = Normal('x', mu, 1)
-    assert isinstance(simplify(density(mu, Eq(x, y), evaluate=False)(z)),
+    assert isinstance(simplify(density(mu, Eq(x, y), evaluate=False).pdf(z)),
             Mul)
 
 
@@ -1502,10 +1502,10 @@ def test_long_precomputed_cdf():
             ]
     for distr in distribs:
         for _ in range(5):
-            assert tn(diff(cdf(distr)(x), x), density(distr)(x), x, a=0, b=0, c=1, d=0)
+            assert tn(diff(cdf(distr)(x), x), density(distr).pdf(x), x, a=0, b=0, c=1, d=0)
 
     US = UniformSum("US", 5)
-    pdf01 = density(US)(x).subs(floor(x), 0).doit()   # pdf on (0, 1)
+    pdf01 = density(US).pdf(x).subs(floor(x), 0).doit()   # pdf on (0, 1)
     cdf01 = cdf(US, evaluate=False)(x).subs(floor(x), 0).doit()   # cdf on (0, 1)
     assert tn(diff(cdf01, x), pdf01, x, a=0, b=0, c=1, d=0)
 
@@ -1582,3 +1582,29 @@ def test_issue_16318():
 def test_compute_density():
     X = Normal('X', 0, Symbol("sigma")**2)
     raises(ValueError, lambda: density(X**5 + X))
+
+def test_continuous_distribution_call_vs_pdf():
+    X = Normal('X', 0, 1)
+    z = Symbol('z')
+
+    assert density(X)(z) == Piecewise(
+        (sqrt(2)*exp(-z**2/2)/(2*sqrt(pi)), (z > -oo) & (z < oo)),
+        (0, True)
+    )
+
+    assert density(X).pdf(z) == sqrt(2)*exp(-z**2/2)/(2*sqrt(pi))
+
+    Y = Exponential('Y', 2)
+    x = Symbol('x')
+
+    assert density(Y)(x) == Piecewise(
+        (2*exp(-2*x), (x >= 0) & (x < oo)),
+        (0, True)
+    )
+
+    assert density(Y).pdf(x) == 2*exp(-2*x)
+
+    z_pos = Symbol('z', positive=True)
+    assert density(Y)(z_pos) == 2*exp(-2*z_pos)
+
+    assert density(Y).pdf(z_pos) == 2*exp(-2*z_pos)

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -27,7 +27,7 @@ from sympy.stats.drv_types import (PoissonDistribution, GeometricDistribution,
                                     DiscreteRV)
 from sympy.testing.pytest import slow, nocache_fail, raises, skip
 from sympy.stats.symbolic_probability import Expectation
-from sympy.functions.combinatorial.factorials import FallingFactorial
+from sympy.functions.combinatorial.factorials import FallingFactorial, factorial
 
 x = Symbol('x')
 
@@ -74,7 +74,7 @@ def test_FlorySchulz():
     x = FlorySchulz('x', a)
     assert E(x) == (2 - a)/a
     assert (variance(x) - 2*(1 - a)/a**2).simplify() == S(0)
-    assert density(x)(z) == a**2*z*(1 - a)**(z - 1)
+    assert density(x).pdf(z) == a**2*z*(1 - a)**(z - 1)
 
 
 @slow
@@ -91,6 +91,45 @@ def test_GeometricDistribution():
     X = Geometric('X', Rational(1, 5))
     Y = Geometric('Y', Rational(3, 10))
     assert coskewness(X, X + Y, X + 2*Y).simplify() == sqrt(230)*Rational(81, 1150)
+
+    # Test that density returns 0 for values outside the support (issue #20031)
+    # The support for Geometric is positive integers {1, 2, 3, ...}
+    assert density(X)(0) == 0  # zero is not in support
+    assert density(X)(-1) == 0  # negative integers not in support
+    assert density(X)(-5) == 0  # negative integers not in support
+    assert density(X)(S(1)/2) == 0  # non-integer not in support
+    assert density(X)(S(5)/2) == 0  # non-integer not in support
+    # Test that density is correct for values inside the support
+    assert density(X)(1) == Rational(1, 5)
+    assert density(X)(2) == Rational(4, 25)
+    assert density(X)(3) == Rational(16, 125)
+
+
+def test_discrete_distribution_call_vs_pdf():
+    X = Geometric('X', Rational(1, 5))
+    z = Symbol('z')
+
+    assert density(X)(z) == Piecewise(
+        ((Rational(4, 5))**(z - 1) / 5, (z >= 1) & (z < oo) & Eq(z, floor(z))),
+        (0, True)
+    )
+
+    assert density(X).pdf(z) == (Rational(4, 5))**(z - 1) / 5
+
+    Y = Poisson('Y', 3)
+    k = Symbol('k')
+
+    assert density(Y)(k) == Piecewise(
+        (3**k * exp(-3) / factorial(k), (k >= 0) & (k < oo) & Eq(k, floor(k))),
+        (0, True)
+    )
+
+    assert density(Y).pdf(k) == 3**k * exp(-3) / factorial(k)
+
+    z_pos_int = Symbol('z', positive=True, integer=True)
+    assert density(X)(z_pos_int) == (Rational(4, 5))**(z_pos_int - 1) / 5
+
+    assert density(X).pdf(z_pos_int) == (Rational(4, 5))**(z_pos_int - 1) / 5
 
 
 def test_Hermite():
@@ -145,7 +184,7 @@ def test_skellam():
     z = Symbol('z')
     X = Skellam('x', mu1, mu2)
 
-    assert density(X)(z) == (mu1/mu2)**(z/2) * \
+    assert density(X).pdf(z) == (mu1/mu2)**(z/2) * \
         exp(-mu1 - mu2)*besseli(z, 2*sqrt(mu1*mu2))
     assert skewness(X).expand() == mu1/(mu1*sqrt(mu1 + mu2) + mu2 *
                 sqrt(mu1 + mu2)) - mu2/(mu1*sqrt(mu1 + mu2) + mu2*sqrt(mu1 + mu2))

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -93,13 +93,11 @@ def test_GeometricDistribution():
     assert coskewness(X, X + Y, X + 2*Y).simplify() == sqrt(230)*Rational(81, 1150)
 
     # Test that density returns 0 for values outside the support (issue #20031)
-    # The support for Geometric is positive integers {1, 2, 3, ...}
-    assert density(X)(0) == 0  # zero is not in support
-    assert density(X)(-1) == 0  # negative integers not in support
-    assert density(X)(-5) == 0  # negative integers not in support
-    assert density(X)(S(1)/2) == 0  # non-integer not in support
-    assert density(X)(S(5)/2) == 0  # non-integer not in support
-    # Test that density is correct for values inside the support
+    assert density(X)(0) == 0
+    assert density(X)(-1) == 0
+    assert density(X)(-5) == 0
+    assert density(X)(S(1)/2) == 0
+    assert density(X)(S(5)/2) == 0
     assert density(X)(1) == Rational(1, 5)
     assert density(X)(2) == Rational(4, 25)
     assert density(X)(3) == Rational(16, 125)

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -508,3 +508,23 @@ def test_symbolic_conditions():
     assert Z == \
     Piecewise((Rational(1, 4), n < 1), (0, True)) + Piecewise((S.Half, n < 2), (0, True)) + \
     Piecewise((Rational(3, 4), n < 3), (0, True)) + Piecewise((S.One, n < 4), (0, True))
+
+def test_finite_distribution_call_vs_pmf():
+    from sympy.sets.contains import Contains
+    X = Bernoulli('X', Rational(1, 4))
+    z = Symbol('z')
+
+    result = density(X)(z)
+    assert isinstance(result, Piecewise)
+    assert result == Piecewise(
+        (Piecewise((Rational(1, 4), Eq(z, 1)), (Rational(3, 4), Eq(z, 0)), (0, True)), Contains(z, FiniteSet(0, 1))),
+        (0, True)
+    )
+
+    assert density(X).pmf(z) == Piecewise((Rational(1, 4), Eq(z, 1)), (Rational(3, 4), Eq(z, 0)), (0, True))
+
+    assert density(X)(0) == Rational(3, 4)
+    assert density(X).pmf(0) == Rational(3, 4)
+
+    assert density(X)(1) == Rational(1, 4)
+    assert density(X).pmf(1) == Rational(1, 4)

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -16,7 +16,8 @@ from sympy.functions.elementary.trigonometric import cos
 from sympy.functions.special.beta_functions import beta
 from sympy.logic.boolalg import (And, Or)
 from sympy.polys.polytools import cancel
-from sympy.sets.sets import FiniteSet
+from sympy.sets.contains import Contains
+from sympy.sets.sets import (FiniteSet, Interval, Intersection)
 from sympy.simplify.simplify import simplify
 from sympy.matrices import Matrix
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial, BetaBinomial,
@@ -137,9 +138,7 @@ def test_dice():
     assert dens == Density(DieDistribution(n))
     assert set(dens.subs(n, 4).doit().keys()) == {1, 2, 3, 4}
     assert set(dens.subs(n, 4).doit().values()) == {Rational(1, 4)}
-    k = Dummy('k', integer=True)
-    assert E(D).dummy_eq(
-        Sum(Piecewise((k/n, k <= n), (0, True)), (k, 1, n)))
+    assert simplify(E(D)) == Rational(1, 2) + n/2
     assert variance(D).subs(n, 6).doit() == Rational(35, 12)
 
     ki = Dummy('ki')
@@ -314,8 +313,8 @@ def test_binomial_symbolic():
     {(1 - p)**4, 4*p*(1 - p)**3, 6*p**2*(1 - p)**2, 4*p**3*(1 - p), p**4}
     k = Dummy('k', integer=True)
     assert E(B > 2).dummy_eq(
-        Sum(Piecewise((k*p**k*(1 - p)**(-k + n)*binomial(n, k), (k >= 0)
-        & (k <= n) & (k > 2)), (0, True)), (k, 0, n)))
+        Sum(Piecewise((k*p**k*(1 - p)**(-k + n)*binomial(n, k),
+        k > 2), (0, True)), (k, 0, n)))
 
 def test_beta_binomial():
     # verify parameters
@@ -483,13 +482,21 @@ def test_density_call():
 def test_DieDistribution():
     from sympy.abc import x
     X = DieDistribution(6)
-    assert X.pmf(S.Half) is S.Zero
-    assert X.pmf(x).subs({x: 1}).doit() == Rational(1, 6)
-    assert X.pmf(x).subs({x: 7}).doit() == 0
-    assert X.pmf(x).subs({x: -1}).doit() == 0
-    assert X.pmf(x).subs({x: Rational(1, 3)}).doit() == 0
+    # .pmf() returns the raw formula without support checking
+    assert X.pmf(1) == Rational(1, 6)
+    assert X.pmf(S.Half) == Rational(1, 6)
+    # __call__ performs support checking
+    assert X(S.Half) is S.Zero
+    assert X(1) == Rational(1, 6)
+    assert X(7) is S.Zero
+    assert X(-1) is S.Zero
+    assert X(Rational(1, 3)) is S.Zero
     raises(ValueError, lambda: X.pmf(Matrix([0, 0])))
     raises(ValueError, lambda: X.pmf(x**2 - 1))
+    # symbolic Die must reject 0 (die faces start at 1)
+    n = Symbol('n', positive=True, integer=True)
+    Dn = DieDistribution(n)
+    assert Dn(0) is S.Zero
 
 def test_FinitePSpace():
     X = Die('X', 6)
@@ -510,13 +517,10 @@ def test_symbolic_conditions():
     Piecewise((Rational(3, 4), n < 3), (0, True)) + Piecewise((S.One, n < 4), (0, True))
 
 def test_finite_distribution_call_vs_pmf():
-    from sympy.sets.contains import Contains
     X = Bernoulli('X', Rational(1, 4))
     z = Symbol('z')
 
-    result = density(X)(z)
-    assert isinstance(result, Piecewise)
-    assert result == Piecewise(
+    assert density(X)(z) == Piecewise(
         (Piecewise((Rational(1, 4), Eq(z, 1)), (Rational(3, 4), Eq(z, 0)), (0, True)), Contains(z, FiniteSet(0, 1))),
         (0, True)
     )
@@ -528,3 +532,18 @@ def test_finite_distribution_call_vs_pmf():
 
     assert density(X)(1) == Rational(1, 4)
     assert density(X).pmf(1) == Rational(1, 4)
+
+    # Binomial: .pmf() returns raw formula, __call__ adds support checking
+    n = symbols('n', positive=True, integer=True)
+    p = symbols('p', positive=True)
+    B = Binomial('B', n, p)
+    k = Symbol('k')
+    assert density(B).pmf(k) == p**k*(1 - p)**(-k + n)*binomial(n, k)
+    assert density(B)(k) == Piecewise(
+        (p**k*(1 - p)**(-k + n)*binomial(n, k),
+         Contains(k, Intersection(Interval(0, n), S.Naturals0))),
+        (0, True)
+    )
+    B5 = Binomial('B5', 5, Rational(1, 2))
+    assert density(B5)(3) == Rational(5, 16)
+    assert density(B5)(-1) is S.Zero

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -128,6 +128,7 @@ def test_NormalGamma():
     assert marginal_distribution(ng, 0)(1) == \
         3*sqrt(10)*gamma(Rational(7, 4))/(10*sqrt(pi)*gamma(Rational(5, 4)))
     assert marginal_distribution(ng, y)(1) == exp(Rational(-1, 4))/128
+    # positive=True needed for the Gamma pdf to simplify (removes absolute values)
     z = symbols('z', positive=True)
     assert marginal_distribution(ng,[0,1])(z) == z**2*exp(-z/4)/128
 

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -128,7 +128,8 @@ def test_NormalGamma():
     assert marginal_distribution(ng, 0)(1) == \
         3*sqrt(10)*gamma(Rational(7, 4))/(10*sqrt(pi)*gamma(Rational(5, 4)))
     assert marginal_distribution(ng, y)(1) == exp(Rational(-1, 4))/128
-    assert marginal_distribution(ng,[0,1])(x) == x**2*exp(-x/4)/128
+    z = symbols('z', positive=True)
+    assert marginal_distribution(ng,[0,1])(z) == z**2*exp(-z/4)/128
 
 
 def test_GeneralizedMultivariateLogGammaDistribution():

--- a/sympy/stats/tests/test_mix.py
+++ b/sympy/stats/tests/test_mix.py
@@ -35,7 +35,7 @@ def test_density():
     N1 = Normal('N1', 0, 1)
     N2 = Normal('N2', N1, 2)
     assert density(N2)(0).doit() == sqrt(10)/(10*sqrt(pi))
-    assert simplify(density(N2, Eq(N1, 1))(x)) == \
+    assert simplify(density(N2, Eq(N1, 1)).pdf(x)) == \
         sqrt(2)*exp(-(x - 1)**2/8)/(4*sqrt(pi))
     assert simplify(density(N2)(x)) == sqrt(10)*exp(-x**2/10)/(10*sqrt(pi))
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -3,7 +3,7 @@ from sympy.concrete.summations import Sum
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.function import Lambda
-from sympy.core.numbers import (Rational, nan, oo, pi)
+from sympy.core.numbers import (Rational, oo, pi)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -29,7 +29,6 @@ from sympy.external import import_module
 from sympy.core.numbers import comp
 from sympy.stats.frv_types import BernoulliDistribution
 from sympy.core.symbol import Dummy
-from sympy.functions.elementary.piecewise import Piecewise
 
 def test_where():
     X, Y = Die('X'), Die('Y')
@@ -437,5 +436,5 @@ def test_issue_20286():
     n, p = symbols('n p')
     B = Binomial('B', n, p)
     k = Dummy('k', integer = True)
-    eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
+    eq = Sum(-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k, 0, n))
     assert eq.dummy_eq(H(B))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #20031

#### Brief description of what is fixed or changed

* The Geometric distribution was returning non-zero density values for inputs outside its support (positive integers). For example, `density(X)(0)` returned `1/4` instead of `0`.

* Fixed by overriding `__call__()` to check the support and return 0 using Piecewise when appropriate. Also added a closed-form `_cdf()` method.

#### Other comments

Tests added for values outside support (0, -1, 0.5) and all existing tests pass including coskewness calculations.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* stats
  * discrete distributions - The `__call__` method of discrete distributions now performs automatic support checking. For symbolic arguments where support membership cannot be determined, it returns a Piecewise expression. The `.pdf()` method continues to return the raw formula without support checking. This ensures distributions return 0 for values outside their support while preserving access to raw formulas for symbolic manipulation.
   
<!-- END RELEASE NOTES -->