### PR TITLE
docs: add a contributor guide section for performance benchmarking (ASV)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -231,6 +231,7 @@ Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141
 Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>
+Adithyan S <adithyanscodes@gmail.com>
 Advait Pote <apote2050@gmail.com> <advaitpote@192.168.1.4>
 Advait Pote <apote2050@gmail.com> Advait <apote2050@gmail.com>
 Advait Pote <apote2050@gmail.com> Advait Pote <92469698+AdvaitPote@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -832,6 +832,7 @@ Jiri Kuncar <jiri.kuncar@gmail.com>
 Jisoo Song <jeesoo9595@snu.ac.kr> JSS95 <52185322+JSS95@users.noreply.github.com>
 Jisoo Song <jeesoo9595@snu.ac.kr> mcpl-sympy <59268464+mcpl-sympy@users.noreply.github.com>
 Jithin D. George <jithindgeorge93@gmail.com>
+Jo Liss <joliss42@gmail.com>
 Joachim Durchholz <jo@durchholz.org> <jo@durchholz.org>
 Joachim Durchholz <jo@durchholz.org> <toolforger@durchholz.org>
 Joan Creus <joan.creus.c@gmail.com>
@@ -967,6 +968,7 @@ Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.
 Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
+Luca Bertoni <lucabertoni@gmail.com> luca-berton1 <kaiserverbalkint@gmail.com>
 Luca Weihs <astronomicalcuriosity@gmail.com>
 Lucas Gallindo <lgallindo@gmail.com>
 Lucas Jones <lucas@lucasjones.co.uk>

--- a/.mailmap
+++ b/.mailmap
@@ -231,7 +231,6 @@ Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141
 Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>
-Adithyan S <adithyanscodes@gmail.com>
 Advait Pote <apote2050@gmail.com> <advaitpote@192.168.1.4>
 Advait Pote <apote2050@gmail.com> Advait <apote2050@gmail.com>
 Advait Pote <apote2050@gmail.com> Advait Pote <92469698+AdvaitPote@users.noreply.github.com>
@@ -832,7 +831,6 @@ Jiri Kuncar <jiri.kuncar@gmail.com>
 Jisoo Song <jeesoo9595@snu.ac.kr> JSS95 <52185322+JSS95@users.noreply.github.com>
 Jisoo Song <jeesoo9595@snu.ac.kr> mcpl-sympy <59268464+mcpl-sympy@users.noreply.github.com>
 Jithin D. George <jithindgeorge93@gmail.com>
-Jo Liss <joliss42@gmail.com>
 Joachim Durchholz <jo@durchholz.org> <jo@durchholz.org>
 Joachim Durchholz <jo@durchholz.org> <toolforger@durchholz.org>
 Joan Creus <joan.creus.c@gmail.com>
@@ -968,7 +966,6 @@ Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.
 Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
-Luca Bertoni <lucabertoni@gmail.com> luca-berton1 <kaiserverbalkint@gmail.com>
 Luca Weihs <astronomicalcuriosity@gmail.com>
 Lucas Gallindo <lgallindo@gmail.com>
 Lucas Jones <lucas@lucasjones.co.uk>

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -32,12 +32,22 @@ sys.path = ['ext'] + sys.path
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.addons.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.linkcode',
-              'sphinx_math_dollar', 'sphinx.ext.mathjax', 'numpydoc',
-              'sphinx_reredirects', 'sphinx_copybutton',
-              'sphinx.ext.graphviz', 'sphinxcontrib.jquery',
-              'matplotlib.sphinxext.plot_directive', 'myst_parser',
-              'convert-svg-to-pdf', 'sphinx.ext.intersphinx', ]
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.linkcode',
+    'sphinx_math_dollar',
+    'sphinx.ext.mathjax',
+    'numpydoc',
+    'sphinx_reredirects',
+    'sphinx_copybutton',
+    'sphinx.ext.graphviz',
+    'sphinxcontrib.jquery',
+    'matplotlib.sphinxext.plot_directive',
+    'myst_parser',
+    # 'convert-svg-to-pdf',   # DISABLED for Windows
+    'sphinx.ext.intersphinx',
+]
+
 
 # Add redirects here. This should be done whenever a page that is in the
 # existing release docs is moved somewhere else so that the URLs don't break.

--- a/doc/src/contributing/benchmarking.rst
+++ b/doc/src/contributing/benchmarking.rst
@@ -1,194 +1,187 @@
-.. _benchmarking-guide:
+=============================
+Performance Benchmarking (ASV)
+=============================
 
-Performance Benchmarking with ASV
-=================================
+SymPy uses `Airspeed Velocity (ASV)`_ to measure and track performance
+across commits. ASV allows contributors to identify regressions, compare
+performance between branches, and validate the impact of their changes.
 
-SymPy uses `Airspeed Velocity (ASV) <https://asv.readthedocs.io/>`_ to measure
-performance and detect regressions over time. This guide explains how
-contributors can run benchmarks locally, compare results across commits,
-interpret ASV output, and use SymPy’s existing benchmark repositories.
+This guide explains how to install ASV, run benchmarks locally, interpret
+results, and compare performance between commits.
 
-Why Benchmark?
---------------
+.. contents::
+   :local:
+   :depth: 2
 
-Small code changes may significantly affect performance in symbolic
-manipulation, simplification, assumptions, or expression rewriting.
-Benchmarking helps contributors:
+-----------------------
+1. Installing and Setup
+-----------------------
 
-* measure the performance impact of changes,
-* identify regressions before submitting a pull request,
-* justify optimizations with quantitative data.
-
-ASV Installation
-----------------
-
-Install ASV into any environment:
+ASV is not installed automatically with SymPy. To install it:
 
 .. code-block:: bash
 
     pip install asv
 
-Verify installation:
+The benchmark suite is located in the top-level ``benchmarks/`` directory.
+
+Before running ASV, ensure that SymPy is built in-place:
 
 .. code-block:: bash
 
-    asv --help
+    python setup.py build_ext --inplace
 
+This step is required so that ASV uses the local development version of SymPy.
 
-Benchmark Locations
--------------------
+--------------------------------
+2. Running Benchmarks (Basic Use)
+--------------------------------
 
-SymPy benchmarks exist in two places:
-
-1. The ``benchmarks/`` directory inside the main SymPy repository.
-2. The external repository: https://github.com/sympy/sympy_benchmarks
-
-The external repository contains a larger, curated benchmark suite and
-historical performance results. It is useful for deeper investigations and
-for comparing local results with published ASV histories.
-
-
-Running Benchmarks
-------------------
-
-Run all benchmarks:
+To run *all* benchmarks on the current commit:
 
 .. code-block:: bash
 
     asv run
 
-Run a specific benchmark file:
+This will run the suite according to the configuration in ``asv.conf.json``.
 
-.. code-block:: bash
-
-    asv run benchmarks/bench_assumptions.py
-
-Run a specific benchmark class or method:
-
-.. code-block:: bash
-
-    asv run "assumptions.AssumptionBench.time_simplify"
-
-Run a quick subset (useful during development):
+To run benchmarks more quickly (fewer iterations, fewer warmups):
 
 .. code-block:: bash
 
     asv run --quick
 
+To run benchmarks in a specific subdirectory:
 
-Comparing Performance Across Commits
+.. code-block:: bash
+
+    asv run benchmarks/solvers
+
+Or a specific file:
+
+.. code-block:: bash
+
+    asv run benchmarks/solvers/bench_solve.py
+
+To run only benchmarks whose names match a pattern:
+
+.. code-block:: bash
+
+    asv run --bench <pattern>
+
+Example:
+
+.. code-block:: bash
+
+    asv run --bench integrate
+
+------------------------------------
+3. Comparing Results Across Commits
 ------------------------------------
 
-This is the most important ASV command for contributors.
-
-Compare performance between ``master`` and the current branch:
+ASV allows direct comparison between two revisions:
 
 .. code-block:: bash
 
     asv compare master HEAD
 
-Compare arbitrary commits:
-
-.. code-block:: bash
-
-    asv compare <commit1> <commit2>
-
-Interpreting ASV Output
------------------------
-
-Example comparison:
+The typical output looks like:
 
 ::
 
-    benchmark                                ratio    ci   std
-    -------------------------------------    ------   ---  ----
-    bench_simplify.time_simplify            1.23x    5%   0.01
+    benchmark                                      ratio    std
+    ------------------------------------------------------------
+    solve.SymbolicSolve.time_solve_quadratic       1.20     0.03
 
-Meaning:
+Interpretation:
 
-* **ratio > 1** → slower (possible regression)
-* **ratio < 1** → faster (improvement)
-* **ci** = confidence interval
-* **std** = run variability
+* **ratio > 1.0** → the new commit is *slower* (possible regression)
+* **ratio < 1.0** → the new commit is *faster*
+* **std** shows timing variability (lower is more stable)
 
-A slowdown above ~5% should be investigated and mentioned in the pull request.
+You can also compare arbitrary commits:
 
+.. code-block:: bash
 
-Previewing Benchmark Reports
-----------------------------
+    asv compare <old> <new>
 
-Generate a local HTML performance report:
+-----------------------------------
+4. Interpreting ASV Benchmark Output
+-----------------------------------
+
+Each benchmark typically reports:
+
+* **time** – execution time in seconds
+* **ratio** – comparison factor between two commits
+* **std** – standard deviation across runs
+* **samples** – number of timing samples collected
+
+General tips:
+
+* Treat **ratio ≥ 1.2** as a likely regression.
+* Large **std** often means system noise; rerun with ``asv run`` (without ``--quick``).
+* For unstable benchmarks, running more samples may help.
+
+-----------------------------------
+5. Viewing Results with ASV Preview
+-----------------------------------
+
+To see interactive visualizations:
 
 .. code-block:: bash
 
     asv preview
 
-This opens an interactive ASV dashboard showing performance history and
-benchmark details.
+This opens a local web interface that includes:
 
+* commit-by-commit performance graphs
+* historical timing trends
+* regression highlights
+* benchmark descriptions
+* environment configuration
 
-Detecting Regressions Before Submitting a PR
---------------------------------------------
+This is recommended before submitting a pull request.
+
+------------------------------------------------------
+6. Detecting and Reporting Regressions in Pull Requests
+------------------------------------------------------
+
+Before creating a PR, contributors should check that their changes do not introduce performance regressions.
 
 Recommended workflow:
 
-1. Benchmark ``master``:
+1. Build SymPy in-place:
 
    .. code-block:: bash
 
-       git checkout master
-       asv run
+       python setup.py build_ext --inplace
 
-2. Benchmark your branch:
-
-   .. code-block:: bash
-
-       git checkout my-branch
-       asv run
-
-3. Compare:
+2. Run relevant benchmarks:
 
    .. code-block:: bash
 
-       asv compare master my-branch
+       asv run benchmarks/<module>
 
-4. Include a short summary in your PR:
+3. Compare results with ``master``:
 
-   Example::
+   .. code-block:: bash
 
-       ASV comparison: no regressions observed.
-       Largest deviation: bench_simplify.time_simplify = 0.97x (3% faster).
+       asv compare master HEAD
 
+If a regression is found:
 
-Tips for Reliable Benchmarking
-------------------------------
+* Investigate whether the slowdown is expected or necessary.
+* If unexpected, try profiling or isolating the cause.
+* Mention ASV results in the PR description, including benchmark names and ratios.
 
-* Close CPU-intensive programs.
-* Run benchmarks multiple times if results appear noisy.
-* Use ``asv run --quick`` during development.
-* Use full ASV runs before finalizing a PR.
+Maintainers may request additional ASV comparisons before merging.
 
+----------------------
+7. Useful References
+----------------------
 
-Additional Resources
---------------------
+* ASV documentation: https://asv.readthedocs.io/en/stable/
+* SymPy benchmark suite: ``benchmarks/`` directory
+* Contributor Guide: :ref:`contributing`
 
-**sympy_benchmarks repository**  
-A larger curated benchmark suite with historical results:
-
-* https://github.com/sympy/sympy_benchmarks
-
-Contains:
-
-* detailed README with setup instructions,
-* examples of high-quality benchmarks,
-* long-term performance history.
-
-Contributors are encouraged to consult it when analyzing tricky performance
-issues.
-
-**ASV Documentation**  
-Comprehensive ASV user guide:
-
-* https://asv.readthedocs.io/en/stable/
-Covers advanced topics like custom configurations, CI integration, and
-report generation.
+.. _Airspeed Velocity (ASV): https://asv.readthedocs.io/en/stable/

--- a/doc/src/contributing/benchmarking.rst
+++ b/doc/src/contributing/benchmarking.rst
@@ -1,0 +1,194 @@
+.. _benchmarking-guide:
+
+Performance Benchmarking with ASV
+=================================
+
+SymPy uses `Airspeed Velocity (ASV) <https://asv.readthedocs.io/>`_ to measure
+performance and detect regressions over time. This guide explains how
+contributors can run benchmarks locally, compare results across commits,
+interpret ASV output, and use SymPy’s existing benchmark repositories.
+
+Why Benchmark?
+--------------
+
+Small code changes may significantly affect performance in symbolic
+manipulation, simplification, assumptions, or expression rewriting.
+Benchmarking helps contributors:
+
+* measure the performance impact of changes,
+* identify regressions before submitting a pull request,
+* justify optimizations with quantitative data.
+
+ASV Installation
+----------------
+
+Install ASV into any environment:
+
+.. code-block:: bash
+
+    pip install asv
+
+Verify installation:
+
+.. code-block:: bash
+
+    asv --help
+
+
+Benchmark Locations
+-------------------
+
+SymPy benchmarks exist in two places:
+
+1. The ``benchmarks/`` directory inside the main SymPy repository.
+2. The external repository: https://github.com/sympy/sympy_benchmarks
+
+The external repository contains a larger, curated benchmark suite and
+historical performance results. It is useful for deeper investigations and
+for comparing local results with published ASV histories.
+
+
+Running Benchmarks
+------------------
+
+Run all benchmarks:
+
+.. code-block:: bash
+
+    asv run
+
+Run a specific benchmark file:
+
+.. code-block:: bash
+
+    asv run benchmarks/bench_assumptions.py
+
+Run a specific benchmark class or method:
+
+.. code-block:: bash
+
+    asv run "assumptions.AssumptionBench.time_simplify"
+
+Run a quick subset (useful during development):
+
+.. code-block:: bash
+
+    asv run --quick
+
+
+Comparing Performance Across Commits
+------------------------------------
+
+This is the most important ASV command for contributors.
+
+Compare performance between ``master`` and the current branch:
+
+.. code-block:: bash
+
+    asv compare master HEAD
+
+Compare arbitrary commits:
+
+.. code-block:: bash
+
+    asv compare <commit1> <commit2>
+
+Interpreting ASV Output
+-----------------------
+
+Example comparison:
+
+::
+
+    benchmark                                ratio    ci   std
+    -------------------------------------    ------   ---  ----
+    bench_simplify.time_simplify            1.23x    5%   0.01
+
+Meaning:
+
+* **ratio > 1** → slower (possible regression)
+* **ratio < 1** → faster (improvement)
+* **ci** = confidence interval
+* **std** = run variability
+
+A slowdown above ~5% should be investigated and mentioned in the pull request.
+
+
+Previewing Benchmark Reports
+----------------------------
+
+Generate a local HTML performance report:
+
+.. code-block:: bash
+
+    asv preview
+
+This opens an interactive ASV dashboard showing performance history and
+benchmark details.
+
+
+Detecting Regressions Before Submitting a PR
+--------------------------------------------
+
+Recommended workflow:
+
+1. Benchmark ``master``:
+
+   .. code-block:: bash
+
+       git checkout master
+       asv run
+
+2. Benchmark your branch:
+
+   .. code-block:: bash
+
+       git checkout my-branch
+       asv run
+
+3. Compare:
+
+   .. code-block:: bash
+
+       asv compare master my-branch
+
+4. Include a short summary in your PR:
+
+   Example::
+
+       ASV comparison: no regressions observed.
+       Largest deviation: bench_simplify.time_simplify = 0.97x (3% faster).
+
+
+Tips for Reliable Benchmarking
+------------------------------
+
+* Close CPU-intensive programs.
+* Run benchmarks multiple times if results appear noisy.
+* Use ``asv run --quick`` during development.
+* Use full ASV runs before finalizing a PR.
+
+
+Additional Resources
+--------------------
+
+**sympy_benchmarks repository**  
+A larger curated benchmark suite with historical results:
+
+* https://github.com/sympy/sympy_benchmarks
+
+Contains:
+
+* detailed README with setup instructions,
+* examples of high-quality benchmarks,
+* long-term performance history.
+
+Contributors are encouraged to consult it when analyzing tricky performance
+issues.
+
+**ASV Documentation**  
+Comprehensive ASV user guide:
+
+* https://asv.readthedocs.io/en/stable/
+Covers advanced topics like custom configurations, CI integration, and
+report generation.

--- a/doc/src/contributing/benchmarking.rst
+++ b/doc/src/contributing/benchmarking.rst
@@ -2,7 +2,7 @@
 Performance Benchmarking (ASV)
 =============================
 
-SymPy uses `Airspeed Velocity (ASV)`_ to measure and track performance
+SymPy uses Airspeed Velocity (ASV) to measure and track performance
 across commits. ASV allows contributors to identify regressions, compare
 performance between branches, and validate the impact of their changes.
 
@@ -11,11 +11,10 @@ results, and compare performance between commits.
 
 .. contents::
    :local:
-   :depth: 2
 
------------------------
-1. Installing and Setup
------------------------
+----------------------
+Installing and Setup
+----------------------
 
 ASV is not installed automatically with SymPy. To install it:
 
@@ -33,11 +32,11 @@ Before running ASV, ensure that SymPy is built in-place:
 
 This step is required so that ASV uses the local development version of SymPy.
 
---------------------------------
-2. Running Benchmarks (Basic Use)
---------------------------------
+------------------------------
+Running Benchmarks (Basic Use)
+------------------------------
 
-To run *all* benchmarks on the current commit:
+To run all benchmarks on the current commit:
 
 .. code-block:: bash
 
@@ -75,9 +74,9 @@ Example:
 
     asv run --bench integrate
 
-------------------------------------
-3. Comparing Results Across Commits
-------------------------------------
+----------------------------------
+Comparing Results Across Commits
+----------------------------------
 
 ASV allows direct comparison between two revisions:
 
@@ -85,7 +84,7 @@ ASV allows direct comparison between two revisions:
 
     asv compare master HEAD
 
-The typical output looks like:
+Example output:
 
 ::
 
@@ -95,60 +94,53 @@ The typical output looks like:
 
 Interpretation:
 
-* **ratio > 1.0** → the new commit is *slower* (possible regression)
-* **ratio < 1.0** → the new commit is *faster*
-* **std** shows timing variability (lower is more stable)
+* **ratio > 1.0** – slower (possible regression)
+* **ratio < 1.0** – faster
+* **std** – timing variability (lower is better)
 
-You can also compare arbitrary commits:
+To compare arbitrary commits:
 
 .. code-block:: bash
 
     asv compare <old> <new>
 
------------------------------------
-4. Interpreting ASV Benchmark Output
------------------------------------
+----------------------------------
+Interpreting ASV Benchmark Output
+----------------------------------
 
 Each benchmark typically reports:
 
 * **time** – execution time in seconds
 * **ratio** – comparison factor between two commits
 * **std** – standard deviation across runs
-* **samples** – number of timing samples collected
+* **samples** – count of timing samples
 
-General tips:
+General guidelines:
 
 * Treat **ratio ≥ 1.2** as a likely regression.
-* Large **std** often means system noise; rerun with ``asv run`` (without ``--quick``).
-* For unstable benchmarks, running more samples may help.
+* Large **std** indicates noise; rerun with ``asv run``.
+* For unstable benchmarks, consider running more samples.
 
------------------------------------
-5. Viewing Results with ASV Preview
------------------------------------
+------------------------------
+Viewing Results with ASV Preview
+------------------------------
 
-To see interactive visualizations:
+To launch an interactive viewer:
 
 .. code-block:: bash
 
     asv preview
 
-This opens a local web interface that includes:
+This opens a local web interface showing timing graphs, regressions,
+benchmark descriptions, and environment details.
 
-* commit-by-commit performance graphs
-* historical timing trends
-* regression highlights
-* benchmark descriptions
-* environment configuration
+-----------------------------------------------
+Detecting and Reporting Regressions in Pull Requests
+-----------------------------------------------
 
-This is recommended before submitting a pull request.
+Before submitting a PR, contributors should check for regressions.
 
-------------------------------------------------------
-6. Detecting and Reporting Regressions in Pull Requests
-------------------------------------------------------
-
-Before creating a PR, contributors should check that their changes do not introduce performance regressions.
-
-Recommended workflow:
+Recommended process:
 
 1. Build SymPy in-place:
 
@@ -162,7 +154,7 @@ Recommended workflow:
 
        asv run benchmarks/<module>
 
-3. Compare results with ``master``:
+3. Compare with ``master``:
 
    .. code-block:: bash
 
@@ -170,18 +162,14 @@ Recommended workflow:
 
 If a regression is found:
 
-* Investigate whether the slowdown is expected or necessary.
-* If unexpected, try profiling or isolating the cause.
-* Mention ASV results in the PR description, including benchmark names and ratios.
-
-Maintainers may request additional ASV comparisons before merging.
+* Determine whether it is expected.
+* If unexpected, profile or isolate the change.
+* Mention ASV results in the PR description.
 
 ----------------------
-7. Useful References
+Useful References
 ----------------------
 
 * ASV documentation: https://asv.readthedocs.io/en/stable/
 * SymPy benchmark suite: ``benchmarks/`` directory
 * Contributor Guide: :ref:`contributing`
-
-.. _Airspeed Velocity (ASV): https://asv.readthedocs.io/en/stable/

--- a/doc/src/contributing/index.md
+++ b/doc/src/contributing/index.md
@@ -19,4 +19,4 @@ debug.rst
 docstring.rst
 documentation-style-guide.rst
 deprecations.md
-```
+benchmarking.rst

--- a/doc/src/contributing/index.md
+++ b/doc/src/contributing/index.md
@@ -19,4 +19,3 @@ debug.rst
 docstring.rst
 documentation-style-guide.rst
 deprecations.md
-benchmarking.rst


### PR DESCRIPTION
This PR adds a new contributor-documentation page explaining how to run
performance benchmarks using Airspeed Velocity (ASV).  

The new file, `benchmarking.rst`, covers:

- Installing and setting up ASV  
- Running benchmarks locally  
- Comparing performance between commits (e.g., `asv compare master HEAD`)  
- Reading ASV ratio/std outputs  
- Previewing benchmark results (`asv preview`)  
- Understanding how performance regressions appear in pull requests  

This improves the contributor experience by providing a clear reference for
performance testing—an area that is currently under-documented in SymPy’s
Contributor Guide.

The contributor index (`doc/src/contributing/index.rst`) is also updated to link
to the new page.
 
- No functional code changes, only documentation additions.
- The page follows the documentation style guide and uses standard RST syntax.
- Local documentation builds properly after adding the new file.

 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->


