### PR TITLE
[WIP] Fixed a bug in sampling discrete finite RVs using SciPy

### DIFF
--- a/sympy/stats/sampling/sample_scipy.py
+++ b/sympy/stats/sampling/sample_scipy.py
@@ -158,10 +158,13 @@ def _(dist: SingleFiniteDistribution, size, seed):
     # scipy can handle with custom distributions
 
     from scipy.stats import rv_discrete
+    import numpy
     density_ = dist.dict
     x, y = [], []
-    for k, v in density_.items():
-        x.append(int(k))
+    sample_space = numpy.empty(shape=(len(density_),), dtype=object)
+    for i, (k, v) in enumerate(density_.items()):
+        x.append(i)
         y.append(float(v))
+        sample_space[i] = k
     scipy_rv = rv_discrete(name='scipy_rv', values=(x, y))
-    return scipy_rv.rvs(size=size, random_state=seed)
+    return sample_space[scipy_rv.rvs(size=size, random_state=seed)]


### PR DESCRIPTION
When one chooses the library as SciPy for sampling a finite, discrete random variable, the current setup forces the elements of the sample set to be integers. In case the elements are not integers, i.e. the __int__ method cannot be applied to them (e.g. SymPy symbols), we run into an exception. This is concerning because the Coin RV by default uses SymPy symbols 'H' and 'T' as default parameters and sampling it without any other changes leads to this exception. It is also an issue when we are sampling from a Uniform Discrete RV where not all the elements in the sample set have the output of __int__ distinct. Some breaking examples fixed by this are:
```python
>>> import sympy.stats as st
>>> from sympy import Rational
>>> coin_rv = st.Coin('C')
>>> coin_samples = st.sample(coin_rv, size=(N,))  # Wouldn't work before
>>> discrete_int_rv = st.DiscreteUniform('DI', [0, 'a', 1, 1.5, 2])
>>> discrete_int_samples = np.empty(10, dtype=object)
>>> for i in range(10):
...     discrete_int_samples[i] = st.sample(discrete_int_rv)
>>> # Here, we get an accurate sampling of both floats and symbols
>>>  pmf = {Rational(1, 2): Rational(1, 3), Rational(4, 3): Rational(1, 6), Rational(9, 4): Rational(1, 4), Rational(16, 5): Rational(1, 4)}
>>> X = st.FiniteRV('X', pmf)
>>> sample(X)  # Returns out of sample-space values
```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28553 partially

#### Brief description of what is fixed or changed
When we use `scipy` to sample **Discrete Finite Random Variables** in SciPy, we are using the [`scipy.stats.rv_discrete`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.html) base class and providing the PMF as we calculated in SymPy to the `values` argument of the constructor. However, this has a fundamental flaw because **`values` demands the elements of the sample space to be integers necessarily**. This is a technical limitation of `scipy` and if we're using it to sample, we cannot get around this. 

The solution to this is to store locally a map of integers to the SymPy objects in our sample space. For example, let's say from the coin example, our sample set contains SymPy symbols 'H' with probability $p$ and 'T' with probability $(1-p)$, then we assign 0 to 'H' and 1 to 'T'. We pass `rv_discrete` a `values` mapping: `((0, p), (1, 1-p))` and sample from it using the `rvs` method. If the method returns 0, then we return to the callee 'H' and if it returns 1, then we return to the callee 'T'. 

This is exactly the logic I've implemented but instead of using explicit dictionaries for mapping, I've leveraged NumPy's array indexing capabilities to save on memory and make the lookup blazing-fast. 

#### Other comments
This approach not only solves existing bug but also provides improvements because now the output of our sampling is **SymPy native objects** instead of Python `int` or `float` objects. This means that we can use it for downstream processing without calling `sympyify` again! It also allows for greater flexibility, because we can sample from RVs with symbolic sample spaces such as discrete uniform distribution as show in the examples. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* stats
  * Fixed a bug with sampling of discrete finite RVs and enhanced the sampling usability. 

<!-- END RELEASE NOTES -->
