### PR TITLE
Fix TypeError in Limit.doit() due to missing cdir parameter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1812,5 +1812,6 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
+Ayush Kumar Jha <jha44481@gmail.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>

--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>
@@ -1812,6 +1813,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
-Ayush Kumar Jha <jha44481@gmail.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -523,7 +523,7 @@ def mrv_leadterm(e, x):
         _series = Order(1)
         incr = S.One
         while _series.is_Order:
-            _series = f._eval_nseries(w, n=n0+incr, logx=logw)
+            _series = f._eval_nseries(w, n=n0+incr, logx=logw, cdir=0)
             incr *= 2
         series = _series.expand().removeO()
         try:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1451,3 +1451,20 @@ def test_issue_28130():
     assert limit(3**x, x, -oo) == 0
     assert limit(E**x, x, -oo) == 0
     assert limit((0.3)**x, x, -oo) == oo
+
+
+def test_issue_28558():
+    # https://github.com/sympy/sympy/issues/28558
+    # Test that Limit.doit() doesn't raise TypeError about missing 'cdir' parameter
+    # The original issue was: Limit(log(x)*cos(x), x, oo, dir='-').doit()
+    # raised TypeError: Expr._eval_nseries() missing 1 required positional argument: 'cdir'
+    # This was fixed by adding cdir=0 parameter in gruntz.py
+    
+    # These limits should not raise TypeError about missing 'cdir'
+    assert limit(log(x), x, oo, dir='-') is oo
+    assert limit(exp(x), x, oo, dir='-') is oo
+    assert limit(x**2, x, oo, dir='-') is oo
+    
+    # The original problematic case now raises NotImplementedError instead of TypeError
+    # This confirms the fix - the TypeError about missing 'cdir' is resolved
+    raises(NotImplementedError, lambda: limit(log(x)*cos(x), x, oo, dir='-'))

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1459,12 +1459,12 @@ def test_issue_28558():
     # The original issue was: Limit(log(x)*cos(x), x, oo, dir='-').doit()
     # raised TypeError: Expr._eval_nseries() missing 1 required positional argument: 'cdir'
     # This was fixed by adding cdir=0 parameter in gruntz.py
-    
+
     # These limits should not raise TypeError about missing 'cdir'
     assert limit(log(x), x, oo, dir='-') is oo
     assert limit(exp(x), x, oo, dir='-') is oo
     assert limit(x**2, x, oo, dir='-') is oo
-    
+
     # The original problematic case now raises NotImplementedError instead of TypeError
     # This confirms the fix - the TypeError about missing 'cdir' is resolved
     raises(NotImplementedError, lambda: limit(log(x)*cos(x), x, oo, dir='-'))


### PR DESCRIPTION

Added `cdir=0` parameter to the [_eval_nseries](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:3484:4-3498:22) call in the [mrv_leadterm](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/series/gruntz.py:484:0-536:44) function. This is consistent with the default value used throughout the codebase.

Added regression test in [test_limits.py](cci:7://file:///Users/ayushkumarjha/Desktop/sympy/sympy/series/tests/test_limits.py:0:0-0:0) to verify the fix.

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed a TypeError in [Limit.doit()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:4119:4-4123:31) where [_eval_nseries()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:3484:4-3498:22) was called without the required `cdir` parameter in the gruntz algorithm.
<!-- END RELEASE NOTES -->