### PR TITLE
Fix CoordSys3D simplification returning 0 for derivatives

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1812,5 +1812,6 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
+Ayush Kumar Jha <jha44481@gmail.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>

--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>
@@ -1812,6 +1813,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Óscar Nájera <najera.oscar@gmail.com>
 Øyvind Jensen <jensen.oyvind@gmail.com>
 Łukasz Pankowski <lukpank@o2.pl>
-Ayush Kumar Jha <jha44481@gmail.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -523,7 +523,7 @@ def mrv_leadterm(e, x):
         _series = Order(1)
         incr = S.One
         while _series.is_Order:
-            _series = f._eval_nseries(w, n=n0+incr, logx=logw)
+            _series = f._eval_nseries(w, n=n0+incr, logx=logw, cdir=0)
             incr *= 2
         series = _series.expand().removeO()
         try:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1451,3 +1451,20 @@ def test_issue_28130():
     assert limit(3**x, x, -oo) == 0
     assert limit(E**x, x, -oo) == 0
     assert limit((0.3)**x, x, -oo) == oo
+
+
+def test_issue_28558():
+    # https://github.com/sympy/sympy/issues/28558
+    # Test that Limit.doit() doesn't raise TypeError about missing 'cdir' parameter
+    # The original issue was: Limit(log(x)*cos(x), x, oo, dir='-').doit()
+    # raised TypeError: Expr._eval_nseries() missing 1 required positional argument: 'cdir'
+    # This was fixed by adding cdir=0 parameter in gruntz.py
+    
+    # These limits should not raise TypeError about missing 'cdir'
+    assert limit(log(x), x, oo, dir='-') is oo
+    assert limit(exp(x), x, oo, dir='-') is oo
+    assert limit(x**2, x, oo, dir='-') is oo
+    
+    # The original problematic case now raises NotImplementedError instead of TypeError
+    # This confirms the fix - the TypeError about missing 'cdir' is resolved
+    raises(NotImplementedError, lambda: limit(log(x)*cos(x), x, oo, dir='-'))

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1459,12 +1459,12 @@ def test_issue_28558():
     # The original issue was: Limit(log(x)*cos(x), x, oo, dir='-').doit()
     # raised TypeError: Expr._eval_nseries() missing 1 required positional argument: 'cdir'
     # This was fixed by adding cdir=0 parameter in gruntz.py
-    
+
     # These limits should not raise TypeError about missing 'cdir'
     assert limit(log(x), x, oo, dir='-') is oo
     assert limit(exp(x), x, oo, dir='-') is oo
     assert limit(x**2, x, oo, dir='-') is oo
-    
+
     # The original problematic case now raises NotImplementedError instead of TypeError
     # This confirms the fix - the TypeError about missing 'cdir' is resolved
     raises(NotImplementedError, lambda: limit(log(x)*cos(x), x, oo, dir='-'))

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -257,6 +257,9 @@ class CoordSys3D(Basic):
     def __iter__(self):
         return iter(self.base_vectors())
 
+    def _eval_simplify(self, **kwargs):
+        return self
+
     @staticmethod
     def _check_orthogonality(equations):
         """

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -462,3 +462,31 @@ def test_rotation_trans_equations():
            (-sin(q0) * c.y + cos(q0) * c.x, sin(q0) * c.x + cos(q0) * c.y, c.z)
     assert c._rotation_trans_equations(c._inverse_rotation_matrix(), c.base_scalars()) == \
            (sin(q0) * c.y + cos(q0) * c.x, -sin(q0) * c.x + cos(q0) * c.y, c.z)
+
+
+def test_issue_28559():
+    # https://github.com/sympy/sympy/issues/28559
+    # Test that simplify() doesn't incorrectly return 0 for derivatives
+    # when using CoordSys3D with transformation
+    from sympy import Function, var
+    from sympy.vector import CoordSys3D, gradient
+
+    var('x y z')
+    f = Function('f')
+    S = CoordSys3D('S', transformation=((x, y, z), (x, y, z)),
+                   variable_names=('a', 'b', 'c'))
+
+    # Test gradient simplification
+    eq = gradient(f(S.a, S.b, S.c))
+    result = eq.simplify()
+    # Should not be 0
+    assert result != 0
+
+    # Test simple derivative simplification
+    simple_eq = f(S.a).diff(S.a)
+    simple_result = simple_eq.simplify()
+    # Should not be 0
+    assert simple_result != 0
+
+    # Test that CoordSys3D._eval_simplify returns self
+    assert S.simplify() == S


### PR DESCRIPTION
Fixes #28559

The issue was that [simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:93:8-94:15) on derivatives involving CoordSys3D coordinates would incorrectly return 0. This happened because the default simplification recreates the object from its args, but CoordSys3D.__new__ only uses name and transformation from args, dropping other important parameters like variable_names.

Added [_eval_simplify](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/coordsysrect.py:259:4-260:19) method to CoordSys3D that returns self, preventing the object from being recreated during simplification.

Added regression test in test_coordsysrect.py to verify the fix.

<!-- BEGIN RELEASE NOTES -->
* vector
  * Fixed a bug where [simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:93:8-94:15) on derivatives involving [CoordSys3D](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/coordsysrect.py:24:0-1020:45) coordinates with transformations would incorrectly return 0.
<!-- END RELEASE NOTES -->