### PR TITLE
Fix CoordSys3D simplification returning 0 for derivatives

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -257,6 +257,9 @@ class CoordSys3D(Basic):
     def __iter__(self):
         return iter(self.base_vectors())
 
+    def _eval_simplify(self, **kwargs):
+        return self
+
     @staticmethod
     def _check_orthogonality(equations):
         """

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -1,5 +1,6 @@
 from sympy.testing.pytest import raises
 from sympy.vector.coordsysrect import CoordSys3D
+from sympy.vector.operators import gradient
 from sympy.vector.scalar import BaseScalar
 from sympy.core.function import expand
 from sympy.core.numbers import pi
@@ -465,28 +466,16 @@ def test_rotation_trans_equations():
 
 
 def test_issue_28559():
-    # https://github.com/sympy/sympy/issues/28559
-    # Test that simplify() doesn't incorrectly return 0 for derivatives
-    # when using CoordSys3D with transformation
-    from sympy import Function, var
-    from sympy.vector import CoordSys3D, gradient
-
-    var('x y z')
-    f = Function('f')
-    S = CoordSys3D('S', transformation=((x, y, z), (x, y, z)),
-                   variable_names=('a', 'b', 'c'))
+    R = CoordSys3D('S', transformation=((x, y, z), (x, y, z)),
+        variable_names=('a', 'b', 'c'))
 
     # Test gradient simplification
-    eq = gradient(f(S.a, S.b, S.c))
+    eq = gradient(f(R.a, R.b, R.c))
     result = eq.simplify()
     # Should not be 0
     assert result != 0
 
     # Test simple derivative simplification
-    simple_eq = f(S.a).diff(S.a)
+    simple_eq = f(R.a).diff(R.a)
     simple_result = simple_eq.simplify()
-    # Should not be 0
-    assert simple_result != 0
-
-    # Test that CoordSys3D._eval_simplify returns self
-    assert S.simplify() == S
+    assert simple_result == simple_eq

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -462,3 +462,31 @@ def test_rotation_trans_equations():
            (-sin(q0) * c.y + cos(q0) * c.x, sin(q0) * c.x + cos(q0) * c.y, c.z)
     assert c._rotation_trans_equations(c._inverse_rotation_matrix(), c.base_scalars()) == \
            (sin(q0) * c.y + cos(q0) * c.x, -sin(q0) * c.x + cos(q0) * c.y, c.z)
+
+
+def test_issue_28559():
+    # https://github.com/sympy/sympy/issues/28559
+    # Test that simplify() doesn't incorrectly return 0 for derivatives
+    # when using CoordSys3D with transformation
+    from sympy import Function, var
+    from sympy.vector import CoordSys3D, gradient
+
+    var('x y z')
+    f = Function('f')
+    S = CoordSys3D('S', transformation=((x, y, z), (x, y, z)),
+                   variable_names=('a', 'b', 'c'))
+
+    # Test gradient simplification
+    eq = gradient(f(S.a, S.b, S.c))
+    result = eq.simplify()
+    # Should not be 0
+    assert result != 0
+
+    # Test simple derivative simplification
+    simple_eq = f(S.a).diff(S.a)
+    simple_result = simple_eq.simplify()
+    # Should not be 0
+    assert simple_result != 0
+
+    # Test that CoordSys3D._eval_simplify returns self
+    assert S.simplify() == S

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -469,6 +469,8 @@ def test_issue_28559():
     R = CoordSys3D('S', transformation=((x, y, z), (x, y, z)),
         variable_names=('a', 'b', 'c'))
 
+    f = Function('f')
+
     # Test gradient simplification
     eq = gradient(f(R.a, R.b, R.c))
     result = eq.simplify()

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -2,7 +2,7 @@ from sympy.testing.pytest import raises
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.operators import gradient
 from sympy.vector.scalar import BaseScalar
-from sympy.core.function import expand
+from sympy.core.function import expand, Function
 from sympy.core.numbers import pi
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.hyperbolic import (cosh, sinh)


### PR DESCRIPTION
Fixes #28559

The issue was that [simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:93:8-94:15) on derivatives involving CoordSys3D coordinates would incorrectly return 0. This happened because the default simplification recreates the object from its args, but [CoordSys3D.__new__](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/coordsysrect.py:29:4-251:18) only uses name and transformation from args, dropping other important parameters like `variable_names`.

**Solution:**
Added [_eval_simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/coordsysrect.py:259:4-260:19) method to [CoordSys3D](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/coordsysrect.py:24:0-1020:45) class that returns `self`, preventing the object from being recreated during simplification.

**Testing:**
- Added regression test [test_issue_28559()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/tests/test_coordsysrect.py:466:0-491:28) in [test_coordsysrect.py](cci:7://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/tests/test_coordsysrect.py:0:0-0:0)
- All vector tests pass
- Code quality checks pass

<!-- BEGIN RELEASE NOTES -->
* vector
  * Fixed a bug where [simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/core/expr.py:93:8-94:15) on derivatives involving [CoordSys3D](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/coordsysrect.py:24:0-1020:45) coordinates with transformations would incorrectly return 0.
<!-- END RELEASE NOTES -->