### PR TITLE
Fix EllipticCurvePoint.__neg__ to return canonical infinity point

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -393,6 +393,7 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -352,6 +352,8 @@ class EllipticCurvePoint:
         return self * n
 
     def __neg__(self):
+        if self.z == 0:
+            return self
         return EllipticCurvePoint(self.x, -self.y - self._curve._a1*self.x - self._curve._a3, self.z, self._curve)
 
     def __repr__(self):

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -353,7 +353,7 @@ class EllipticCurvePoint:
 
     def __neg__(self):
         if self.z == 0:
-            return self
+            return self.point_at_infinity(self._curve)
         return EllipticCurvePoint(self.x, -self.y - self._curve._a1*self.x - self._curve._a3, self.z, self._curve)
 
     def __repr__(self):

--- a/sympy/ntheory/tests/test_elliptic_curve.py
+++ b/sympy/ntheory/tests/test_elliptic_curve.py
@@ -1,4 +1,4 @@
-from sympy.ntheory.elliptic_curve import EllipticCurve
+from sympy.ntheory.elliptic_curve import EllipticCurve, EllipticCurvePoint
 
 
 def test_elliptic_curve():
@@ -18,3 +18,6 @@ def test_elliptic_curve():
     assert EllipticCurve(-2731, -55146, 1, 0, 1).discriminant == 25088
     # Torsion points
     assert len(EllipticCurve(0, 1).torsion_points()) == 6
+    # Issue 28546: -O should return canonical infinity point
+    O = EllipticCurvePoint.point_at_infinity(e3)
+    assert (-O).x == O.x and (-O).y == O.y and (-O).z == O.z


### PR DESCRIPTION
Fixes #28546

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28546

#### Brief description of what is fixed or changed

[EllipticCurvePoint.__neg__](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/ntheory/elliptic_curve.py:353:4-356:114) was returning a non-canonical infinity point `(0, -1, 0)` instead of the canonical form `(0, 1, 0)` when negating the point at infinity. Added a check to return `self` when `z == 0`, ensuring `-O` returns the canonical infinity point.

#### Other comments

Added minimal regression test in existing [test_elliptic_curve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/ntheory/tests/test_elliptic_curve.py:3:0-22:60) function.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed [EllipticCurvePoint.__neg__](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/ntheory/elliptic_curve.py:353:4-356:114) to return canonical infinity point `(0, 1, 0)` instead of `(0, -1, 0)`.
<!-- END RELEASE NOTES -->