### PR TITLE
Fix log1p evalf precision for small numbers

### DIFF
--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -136,9 +136,9 @@ class log1p(Function):
 
     @classmethod
     def eval(cls, arg):
-        if arg.is_Rational:
-            return log(arg + S.One)
-        elif not arg.is_Float:  # not safe to add 1 to Float
+        if arg.is_zero:
+            return S.Zero
+        if not arg.is_Float and not arg.is_number:
             return log.eval(arg + S.One)
 
     def _eval_evalf(self, prec):

--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -140,8 +140,16 @@ class log1p(Function):
             return log(arg + S.One)
         elif not arg.is_Float:  # not safe to add 1 to Float
             return log.eval(arg + S.One)
-        elif arg.is_number:
-            return log(Rational(arg) + S.One)
+
+    def _eval_evalf(self, prec):
+        from mpmath import mp, workprec
+        from sympy.core.expr import Expr
+        arg = self.args[0]
+        if arg.is_number:
+            x = arg._to_mpmath(prec)
+            with workprec(prec):
+                res = mp.log1p(x)
+            return Expr._from_mpmath(res, prec)
 
     def _eval_is_real(self):
         return (self.args[0] + S.One).is_nonnegative

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -36,7 +36,8 @@ def test_log1p():
     # Eval
     assert log1p(0) == 0
     d = S(10)
-    assert expand_log(log1p(d**-1000) - log(d**1000 + 1) + log(d**1000)) == 0
+    # First expand log1p to log, then expand_log to combine terms
+    assert expand_log((log1p(d**-1000) - log(d**1000 + 1) + log(d**1000)).expand(func=True)) == 0
 
     x = Symbol('x', real=True)
 
@@ -50,6 +51,8 @@ def test_log1p():
     assert abs(expand_log(log1p(1e-99)).evalf() - 1e-99) < 1e-100
     # Test direct evalf with very small numbers (gh-28579)
     assert abs(log1p(1.3e-45).evalf(n=3) - 1.3e-45) < 1e-46
+    # Test with Rational inputs (bjodah's counter-example)
+    assert abs(log1p(Rational(1.3e-45)).evalf(n=3) - 1.3e-45) < 1e-46
 
     # Properties
     assert log1p(-2**Rational(-1, 2)).is_real

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -48,6 +48,8 @@ def test_log1p():
     # Precision
     assert not abs(log(1e-99 + 1).evalf() - 1e-99) < 1e-100  # for comparison
     assert abs(expand_log(log1p(1e-99)).evalf() - 1e-99) < 1e-100
+    # Test direct evalf with very small numbers (gh-28579)
+    assert abs(log1p(1.3e-45).evalf(n=3) - 1.3e-45) < 1e-46
 
     # Properties
     assert log1p(-2**Rational(-1, 2)).is_real


### PR DESCRIPTION
Fixes #28579

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixed precision issue in `log1p.evalf()` for very small numbers. Previously, [log1p(1.3e-45).evalf(n=3)](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:85:0-168:42) returned `0` instead of the correct value `1.30e-45`.

The fix adds a [_eval_evalf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/functions/special/bessel.py:1088:4-1090:58) method that uses [mpmath.log1p](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:85:0-168:42) directly to avoid catastrophic cancellation that occurs when adding very small numbers to 1 in floating-point arithmetic.

#### Other comments

The implementation follows the same pattern used in other SymPy functions (like Airy functions in [bessel.py](cci:7://file:///Users/ayushkumarjha/Desktop/sympy/sympy/functions/special/bessel.py:0:0-0:0)) that need high-precision numerical evaluation via mpmath.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* codegen
  * Fixed precision issue in `log1p.evalf()` for very small numbers. Now correctly evaluates [log1p(1.3e-45)](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:85:0-168:42) instead of returning 0.

<!-- END RELEASE NOTES -->