### PR TITLE
Add eval methods to Cbrt, Sqrt, fma, and hypot for numeric evaluation

### DIFF
--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -325,6 +325,11 @@ class fma(Function):
     def _eval_rewrite_as_tractable(self, arg, limitvar=None, **kwargs):
         return _fma(arg)
 
+    @classmethod
+    def eval(cls, x, y, z):
+        if x.is_number and y.is_number and z.is_number:
+            return _fma(x, y, z)
+
 
 _Ten = S(10)
 
@@ -431,6 +436,11 @@ class Sqrt(Function):  # 'sqrt' already defined in sympy.functions.elementary.mi
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow
 
+    @classmethod
+    def eval(cls, arg):
+        if arg.is_number:
+            return _Sqrt(arg)
+
 
 def _Cbrt(x):
     return Pow(x, Rational(1, 3))
@@ -482,6 +492,11 @@ class Cbrt(Function):  # 'cbrt' already defined in sympy.functions.elementary.mi
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow
 
+    @classmethod
+    def eval(cls, arg):
+        if arg.is_number:
+            return _Cbrt(arg)
+
 
 def _hypot(x, y):
     return sqrt(Pow(x, 2) + Pow(y, 2))
@@ -530,6 +545,11 @@ class hypot(Function):
         return _hypot(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow
+
+    @classmethod
+    def eval(cls, x, y):
+        if x.is_number and y.is_number:
+            return _hypot(x, y)
 
 
 class isnan(BooleanFunction):

--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -327,11 +327,8 @@ class fma(Function):
 
     @classmethod
     def eval(cls, x, y, z):
-        # Only fold when all arguments are atomic and the result is a Number
-        if x.is_Atom and y.is_Atom and z.is_Atom:
-            value = _fma(x, y, z)
-            if value.is_Number:
-                return value
+        if all(arg.is_Number for arg in [x, y, z]):
+            return x*y + z
 
 
 _Ten = S(10)
@@ -441,11 +438,8 @@ class Sqrt(Function):  # 'sqrt' already defined in sympy.functions.elementary.mi
 
     @classmethod
     def eval(cls, arg):
-        # Only fold nonnegative atomic arguments; keep e.g. Sqrt(-2) unevaluated
-        if arg.is_Atom and arg.is_nonnegative:
-            value = _Sqrt(arg)
-            if value.is_Number:
-                return value
+        if arg.is_Number and arg.is_nonnegative:
+            return _Sqrt(arg)
 
 
 def _Cbrt(x):
@@ -500,11 +494,8 @@ class Cbrt(Function):  # 'cbrt' already defined in sympy.functions.elementary.mi
 
     @classmethod
     def eval(cls, arg):
-        # Only fold atomic arguments and when the result is a Number
-        if arg.is_Atom:
-            value = _Cbrt(arg)
-            if value.is_Number:
-                return value
+        if arg.is_Number:
+            return _Cbrt(arg)
 
 
 def _hypot(x, y):
@@ -557,11 +548,8 @@ class hypot(Function):
 
     @classmethod
     def eval(cls, x, y):
-        # Only fold atomic arguments and when the result is a Number
-        if x.is_Atom and y.is_Atom:
-            value = _hypot(x, y)
-            if value.is_Number:
-                return value
+        if x.is_Number and y.is_Number:
+            return _hypot(x, y)
 
 
 class isnan(BooleanFunction):

--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -327,8 +327,11 @@ class fma(Function):
 
     @classmethod
     def eval(cls, x, y, z):
-        if x.is_number and y.is_number and z.is_number:
-            return _fma(x, y, z)
+        # Only fold when all arguments are atomic and the result is a Number
+        if x.is_Atom and y.is_Atom and z.is_Atom:
+            value = _fma(x, y, z)
+            if value.is_Number:
+                return value
 
 
 _Ten = S(10)
@@ -438,8 +441,11 @@ class Sqrt(Function):  # 'sqrt' already defined in sympy.functions.elementary.mi
 
     @classmethod
     def eval(cls, arg):
-        if arg.is_number:
-            return _Sqrt(arg)
+        # Only fold nonnegative atomic arguments; keep e.g. Sqrt(-2) unevaluated
+        if arg.is_Atom and arg.is_nonnegative:
+            value = _Sqrt(arg)
+            if value.is_Number:
+                return value
 
 
 def _Cbrt(x):
@@ -494,8 +500,11 @@ class Cbrt(Function):  # 'cbrt' already defined in sympy.functions.elementary.mi
 
     @classmethod
     def eval(cls, arg):
-        if arg.is_number:
-            return _Cbrt(arg)
+        # Only fold atomic arguments and when the result is a Number
+        if arg.is_Atom:
+            value = _Cbrt(arg)
+            if value.is_Number:
+                return value
 
 
 def _hypot(x, y):
@@ -548,8 +557,11 @@ class hypot(Function):
 
     @classmethod
     def eval(cls, x, y):
-        if x.is_number and y.is_number:
-            return _hypot(x, y)
+        # Only fold atomic arguments and when the result is a Number
+        if x.is_Atom and y.is_Atom:
+            value = _hypot(x, y)
+            if value.is_Number:
+                return value
 
 
 class isnan(BooleanFunction):

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -103,8 +103,10 @@ def test_log2():
 def test_fma():
     x, y, z = symbols('x y z')
 
-    # Eval - numeric evaluation
+    # Eval - numeric evaluation (gh-28582)
     assert fma(2, 3, 4) == 10
+    assert fma(5, 6, 7) == 37
+    assert fma(0, 0, 0) == 0
 
     # Eval - evaluate=False should not auto-simplify
     assert fma(2, 3, 4, evaluate=False) == fma(2, 3, 4, evaluate=False)
@@ -126,19 +128,6 @@ def test_fma():
     assert expr.diff(y) - 17*42*x == 0
     assert expr.diff(z) - 101 == 0
 
-    # Numeric evaluation (gh-28582)
-    assert fma(2, 3, 4) == 10
-    assert fma(5, 6, 7) == 37
-    assert fma(0, 0, 0) == 0
-    # Ensure non-atomic numeric expressions are not folded
-    assert fma(pi, 2, 3) != 2*pi + 3
-
-
-def test_fma_evaluate_false():
-    from sympy import pi
-    assert fma(2, 3, 4, evaluate=False) != 10
-    assert fma(pi, 2, 3, evaluate=False) != 2*pi + 3
-
 
 def test_log10():
     x = Symbol('x')
@@ -154,8 +143,10 @@ def test_log10():
 def test_Cbrt():
     x = Symbol('x')
 
-    # Eval - numeric evaluation
+    # Eval - numeric evaluation (gh-28582)
     assert Cbrt(8) == 2
+    assert Cbrt(27) == 3
+    assert Cbrt(64) == 4
 
     # Eval - evaluate=False should not auto-simplify
     assert Cbrt(8, evaluate=False) == Cbrt(8, evaluate=False)
@@ -170,25 +161,14 @@ def test_Cbrt():
     assert Cbrt(42*x).diff(x) - 42*(42*x)**(Rational(1, 3) - 1)/3 == 0
     assert Cbrt(42*x).diff(x) - Cbrt(42*x).expand(func=True).diff(x) == 0
 
-    # Numeric evaluation (gh-28582)
-    assert Cbrt(8) == 2
-    assert Cbrt(27) == 3
-    assert Cbrt(64) == 4
-    # Ensure non-atomic numeric expressions are not folded
-    assert Cbrt(pi) != pi**Rational(1, 3)
-
-
-def test_Cbrt_evaluate_false():
-    from sympy import pi
-    assert Cbrt(8, evaluate=False) != 2
-    assert Cbrt(pi, evaluate=False) != pi**(1/3)
-
 
 def test_Sqrt():
     x = Symbol('x')
 
-    # Eval - numeric evaluation for nonnegative numbers
+    # Eval - numeric evaluation for nonnegative numbers (gh-28582)
     assert Sqrt(4) == 2
+    assert Sqrt(9) == 3
+    assert Sqrt(16) == 4
 
     # Eval - negative numbers should remain unevaluated
     assert Sqrt(-2) == Sqrt(-2)
@@ -206,27 +186,14 @@ def test_Sqrt():
     assert Sqrt(42*x).diff(x) - 42*(42*x)**(S.Half - 1)/2 == 0
     assert Sqrt(42*x).diff(x) - Sqrt(42*x).expand(func=True).diff(x) == 0
 
-    # Numeric evaluation (gh-28582)
-    assert Sqrt(4) == 2
-    assert Sqrt(9) == 3
-    assert Sqrt(16) == 4
-    # Ensure non-atomic numeric expressions are not folded
-    assert Sqrt(pi) != pi**S.Half
-
-
-def test_Sqrt_evaluate_false():
-    from sympy import pi
-    assert Sqrt(4, evaluate=False) != 2
-    assert Sqrt(pi, evaluate=False) != pi**(1/2)
-    # Negative argument should remain unevaluated
-    assert Sqrt(-2) == Sqrt(-2)
-
 
 def test_hypot():
     x, y = symbols('x y')
 
-    # Eval - numeric evaluation
+    # Eval - numeric evaluation (gh-28582)
     assert hypot(3, 4) == 5
+    assert hypot(5, 12) == 13
+    assert hypot(0, 0) == 0
 
     # Eval - evaluate=False should not auto-simplify
     assert hypot(3, 4, evaluate=False) == hypot(3, 4, evaluate=False)
@@ -241,22 +208,8 @@ def test_hypot():
     assert hypot(17*x, 42*y).diff(x).expand(func=True) - hypot(17*x, 42*y).expand(func=True).diff(x) == 0
     assert hypot(17*x, 42*y).diff(y).expand(func=True) - hypot(17*x, 42*y).expand(func=True).diff(y) == 0
 
-    # Numeric evaluation (gh-28582)
-    assert hypot(3, 4) == 5
-    assert hypot(5, 12) == 13
-    assert hypot(0, 0) == 0
-
     assert hypot(17*x, 42*y).diff(x).expand(func=True) - 2*17*17*x*((17*x)**2 + (42*y)**2)**Rational(-1, 2)/2 == 0
     assert hypot(17*x, 42*y).diff(y).expand(func=True) - 2*42*42*y*((17*x)**2 + (42*y)**2)**Rational(-1, 2)/2 == 0
-
-    # Ensure non-atomic numeric expressions are not folded
-    assert hypot(pi, 4) != (pi**2 + 16)**S.Half
-
-
-def test_hypot_evaluate_false():
-    from sympy import pi
-    assert hypot(3, 4, evaluate=False) != 5
-    assert hypot(pi, 4, evaluate=False) != (pi**2 + 16)**(1/2)
 
 
 def test_isnan_isinf():

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -103,6 +103,15 @@ def test_log2():
 def test_fma():
     x, y, z = symbols('x y z')
 
+    # Eval - numeric evaluation
+    assert fma(2, 3, 4) == 10
+
+    # Eval - evaluate=False should not auto-simplify
+    assert fma(2, 3, 4, evaluate=False) == fma(2, 3, 4, evaluate=False)
+
+    # Eval - symbolic constants should not auto-simplify
+    assert fma(pi, 2, 3) == fma(pi, 2, 3)
+
     # Expand
     assert fma(x, y, z).expand(func=True) - x*y - z == 0
 
@@ -145,6 +154,15 @@ def test_log10():
 def test_Cbrt():
     x = Symbol('x')
 
+    # Eval - numeric evaluation
+    assert Cbrt(8) == 2
+
+    # Eval - evaluate=False should not auto-simplify
+    assert Cbrt(8, evaluate=False) == Cbrt(8, evaluate=False)
+
+    # Eval - symbolic constants should not auto-simplify
+    assert Cbrt(pi) == Cbrt(pi)
+
     # Expand
     assert Cbrt(x).expand(func=True) - x**Rational(1, 3) == 0
 
@@ -168,6 +186,18 @@ def test_Cbrt_evaluate_false():
 
 def test_Sqrt():
     x = Symbol('x')
+
+    # Eval - numeric evaluation for nonnegative numbers
+    assert Sqrt(4) == 2
+
+    # Eval - negative numbers should remain unevaluated
+    assert Sqrt(-2) == Sqrt(-2)
+
+    # Eval - evaluate=False should not auto-simplify
+    assert Sqrt(4, evaluate=False) == Sqrt(4, evaluate=False)
+
+    # Eval - symbolic constants should not auto-simplify
+    assert Sqrt(pi) == Sqrt(pi)
 
     # Expand
     assert Sqrt(x).expand(func=True) - x**S.Half == 0
@@ -194,6 +224,15 @@ def test_Sqrt_evaluate_false():
 
 def test_hypot():
     x, y = symbols('x y')
+
+    # Eval - numeric evaluation
+    assert hypot(3, 4) == 5
+
+    # Eval - evaluate=False should not auto-simplify
+    assert hypot(3, 4, evaluate=False) == hypot(3, 4, evaluate=False)
+
+    # Eval - symbolic constants should not auto-simplify
+    assert hypot(pi, 4) == hypot(pi, 4)
 
     # Expand
     assert hypot(x, y).expand(func=True) - (x**2 + y**2)**S.Half == 0

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -121,6 +121,14 @@ def test_fma():
     assert fma(2, 3, 4) == 10
     assert fma(5, 6, 7) == 37
     assert fma(0, 0, 0) == 0
+    # Ensure non-atomic numeric expressions are not folded
+    assert fma(pi, 2, 3) != 2*pi + 3
+
+
+def test_fma_evaluate_false():
+    from sympy import pi
+    assert fma(2, 3, 4, evaluate=False) != 10
+    assert fma(pi, 2, 3, evaluate=False) != 2*pi + 3
 
 
 def test_log10():
@@ -148,6 +156,14 @@ def test_Cbrt():
     assert Cbrt(8) == 2
     assert Cbrt(27) == 3
     assert Cbrt(64) == 4
+    # Ensure non-atomic numeric expressions are not folded
+    assert Cbrt(pi) != pi**Rational(1, 3)
+
+
+def test_Cbrt_evaluate_false():
+    from sympy import pi
+    assert Cbrt(8, evaluate=False) != 2
+    assert Cbrt(pi, evaluate=False) != pi**(1/3)
 
 
 def test_Sqrt():
@@ -164,6 +180,16 @@ def test_Sqrt():
     assert Sqrt(4) == 2
     assert Sqrt(9) == 3
     assert Sqrt(16) == 4
+    # Ensure non-atomic numeric expressions are not folded
+    assert Sqrt(pi) != pi**S.Half
+
+
+def test_Sqrt_evaluate_false():
+    from sympy import pi
+    assert Sqrt(4, evaluate=False) != 2
+    assert Sqrt(pi, evaluate=False) != pi**(1/2)
+    # Negative argument should remain unevaluated
+    assert Sqrt(-2) == Sqrt(-2)
 
 
 def test_hypot():
@@ -183,6 +209,15 @@ def test_hypot():
 
     assert hypot(17*x, 42*y).diff(x).expand(func=True) - 2*17*17*x*((17*x)**2 + (42*y)**2)**Rational(-1, 2)/2 == 0
     assert hypot(17*x, 42*y).diff(y).expand(func=True) - 2*42*42*y*((17*x)**2 + (42*y)**2)**Rational(-1, 2)/2 == 0
+
+    # Ensure non-atomic numeric expressions are not folded
+    assert hypot(pi, 4) != (pi**2 + 16)**S.Half
+
+
+def test_hypot_evaluate_false():
+    from sympy import pi
+    assert hypot(3, 4, evaluate=False) != 5
+    assert hypot(pi, 4, evaluate=False) != (pi**2 + 16)**(1/2)
 
 
 def test_isnan_isinf():

--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -117,6 +117,11 @@ def test_fma():
     assert expr.diff(y) - 17*42*x == 0
     assert expr.diff(z) - 101 == 0
 
+    # Numeric evaluation (gh-28582)
+    assert fma(2, 3, 4) == 10
+    assert fma(5, 6, 7) == 37
+    assert fma(0, 0, 0) == 0
+
 
 def test_log10():
     x = Symbol('x')
@@ -139,6 +144,11 @@ def test_Cbrt():
     assert Cbrt(42*x).diff(x) - 42*(42*x)**(Rational(1, 3) - 1)/3 == 0
     assert Cbrt(42*x).diff(x) - Cbrt(42*x).expand(func=True).diff(x) == 0
 
+    # Numeric evaluation (gh-28582)
+    assert Cbrt(8) == 2
+    assert Cbrt(27) == 3
+    assert Cbrt(64) == 4
+
 
 def test_Sqrt():
     x = Symbol('x')
@@ -150,6 +160,11 @@ def test_Sqrt():
     assert Sqrt(42*x).diff(x) - 42*(42*x)**(S.Half - 1)/2 == 0
     assert Sqrt(42*x).diff(x) - Sqrt(42*x).expand(func=True).diff(x) == 0
 
+    # Numeric evaluation (gh-28582)
+    assert Sqrt(4) == 2
+    assert Sqrt(9) == 3
+    assert Sqrt(16) == 4
+
 
 def test_hypot():
     x, y = symbols('x y')
@@ -160,6 +175,11 @@ def test_hypot():
     # Diff
     assert hypot(17*x, 42*y).diff(x).expand(func=True) - hypot(17*x, 42*y).expand(func=True).diff(x) == 0
     assert hypot(17*x, 42*y).diff(y).expand(func=True) - hypot(17*x, 42*y).expand(func=True).diff(y) == 0
+
+    # Numeric evaluation (gh-28582)
+    assert hypot(3, 4) == 5
+    assert hypot(5, 12) == 13
+    assert hypot(0, 0) == 0
 
     assert hypot(17*x, 42*y).diff(x).expand(func=True) - 2*17*17*x*((17*x)**2 + (42*y)**2)**Rational(-1, 2)/2 == 0
     assert hypot(17*x, 42*y).diff(y).expand(func=True) - 2*42*42*y*((17*x)**2 + (42*y)**2)**Rational(-1, 2)/2 == 0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #28582

#### Brief description of what is fixed or changed

Added [eval()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/functions/special/bessel.py:997:4-1008:25) classmethod implementations to [Cbrt](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:448:0-497:29), [Sqrt](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:393:0-441:29), [fma](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:295:0-338:32), and [hypot](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:504:0-551:31) classes in `sympy.codegen.cfunctions` to enable numeric evaluation. Previously, these functions would not evaluate when given numeric arguments, unlike other functions in the same module ([exp2](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:175:0-224:29), [log2](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:223:0-280:53), [log10](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:340:0-386:53), [expm1](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:20:0-78:37), [log1p](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:85:0-160:42)).

**Before this fix:**
```python
Cbrt(8)       # Returns: Cbrt(8)
Sqrt(4)       # Returns: Sqrt(4)
fma(2, 3, 4)  # Returns: fma(2, 3, 4)
hypot(3, 4)   # Returns: hypot(3, 4)

```

<!-- BEGIN RELEASE NOTES -->

* codegen
  * Fixed numeric evaluation for [Cbrt](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:448:0-497:29), [Sqrt](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:393:0-441:29), [fma](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:295:0-333:24), and [hypot](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/codegen/cfunctions.py:504:0-551:31) functions. These now correctly evaluate numeric arguments instead of remaining unevaluated.

<!-- END RELEASE NOTES -->
