### PR TITLE
Fix is_monotonic to check continuity before checking monotonicity

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -172,6 +172,16 @@ def monotonicity_helper(expression, predicate, interval=S.Reals, symbol=None):
             )
 
     variable = symbol or (free.pop() if free else Symbol('x'))
+
+    try:
+        sings = singularities(expression, variable, interval)
+        if interval.is_subset(S.Reals):
+            interior_sings = interval.interior.intersection(sings)
+            if interior_sings != S.EmptySet:
+                return False
+    except (NotImplementedError, AttributeError):
+        pass
+
     derivative = expression.diff(variable)
     predicate_interval = solveset(predicate(derivative), variable, S.Reals)
     return interval.is_subset(predicate_interval)
@@ -381,24 +391,80 @@ def is_monotonic(expression, interval=S.Reals, symbol=None):
     NotImplementedError
         Monotonicity check has not been implemented for the queried function.
 
+    Explanation
+    ===========
+
+    A real-valued function f is monotonic on an interval I if it is either
+    monotonically increasing or monotonically decreasing throughout I:
+
+    - **Monotonically increasing**: For all x1, x2 in I where x1 < x2,
+      we have f(x1) <= f(x2)
+    - **Monotonically decreasing**: For all x1, x2 in I where x1 < x2,
+      we have f(x1) >= f(x2)
+
+    According to Rudin (Theorem 4.30), monotonic functions can have jump
+    discontinuities (first kind) but NOT poles (second kind). Poles violate
+    the ordering property. Example: tan(x) on [0,5] has poles at pi/2, 3*pi/2
+    causing transitions between +-infinity, which breaks monotonicity.
+
     Examples
     ========
 
-    >>> from sympy import is_monotonic
+    Basic monotonicity tests:
+
+    >>> from sympy import is_monotonic, tan, Interval, pi, oo
     >>> from sympy.abc import x, y
-    >>> from sympy import S, Interval, oo
-    >>> is_monotonic(1/(x**2 - 3*x), Interval.open(S(3)/2, 3))
-    True
-    >>> is_monotonic(1/(x**2 - 3*x), Interval.open(1.5, 3))
-    True
-    >>> is_monotonic(1/(x**2 - 3*x), Interval.Lopen(3, oo))
-    True
+    >>> from sympy import S
     >>> is_monotonic(x**3 - 3*x**2 + 4*x, S.Reals)
     True
     >>> is_monotonic(-x**2, S.Reals)
     False
+
+    Functions with poles (interior singularities) are not monotonic:
+
+    >>> is_monotonic(tan(x), Interval(0, 5), x)
+    False
+    >>> is_monotonic(1/x, Interval(-1, 1), x)
+    False
+
+    But the same functions are monotonic on intervals that exclude the poles:
+
+    >>> is_monotonic(tan(x), Interval.open(-pi/2, pi/2), x)
+    True
+    >>> is_monotonic(1/x, Interval.open(0, 1), x)
+    True
+
+    Piecewise constant intervals:
+
+    >>> is_monotonic(1/(x**2 - 3*x), Interval.open(S(3)/2, 3), x)
+    True
+    >>> is_monotonic(1/(x**2 - 3*x), Interval.Lopen(3, oo), x)
+    True
+
+    Multivariate expressions:
+
     >>> is_monotonic(x**2 + y + 1, Interval(1, 2), x)
     True
+
+    See Also
+    ========
+
+    is_increasing : Test if function is non-decreasing
+    is_decreasing : Test if function is non-increasing
+    is_strictly_increasing : Test if function is strictly increasing
+    is_strictly_decreasing : Test if function is strictly decreasing
+    singularities : Find singularities of a function
+    continuous_domain : Find the domain where function is continuous
+
+    References
+    ==========
+
+    .. [1] Rudin, W. (1976). "Principles of Mathematical Analysis" (3rd ed.),
+           McGraw-Hill. Theorem 4.30: A monotonic function has at most
+           countably many discontinuities, and all are of the first kind
+           (jump discontinuities).
+
+    .. [2] https://en.wikipedia.org/wiki/Monotonic_function
 
     """
     from sympy.solvers.solveset import solveset
@@ -413,5 +479,15 @@ def is_monotonic(expression, interval=S.Reals, symbol=None):
         )
 
     variable = symbol or (free.pop() if free else Symbol('x'))
+
+    try:
+        sings = singularities(expression, variable, interval)
+        if interval.is_subset(S.Reals):
+            interior_sings = interval.interior.intersection(sings)
+            if interior_sings != S.EmptySet:
+                return False
+    except (NotImplementedError, AttributeError):
+        pass
+
     turning_points = solveset(expression.diff(variable), variable, interval)
     return interval.intersection(turning_points) is S.EmptySet

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -3,7 +3,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.function import Lambda
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.trigonometric import sec, csc
+from sympy.functions.elementary.trigonometric import sec, csc, tan
 from sympy.functions.elementary.hyperbolic import (coth, sech,
                                                    atanh, asech, acoth, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -123,3 +123,20 @@ def test_issue_23401():
     x = Symbol('x')
     expr = (x + 1)/(-1.0e-3*x**2 + 0.1*x + 0.1)
     assert is_increasing(expr, Interval(1,2), x)
+
+
+def test_monotonicity_with_interior_singularities():
+    assert is_monotonic(tan(x), Interval(0, 5), x) is False
+    assert is_increasing(tan(x), Interval(0, 5), x) is False
+
+    assert is_monotonic(1/x, Interval(-1, 1), x) is False
+    assert is_increasing(1/x, Interval(-1, 1), x) is False
+    assert is_decreasing(1/x, Interval(-1, 1), x) is False
+
+    assert is_increasing(tan(x), Interval(0, 1), x) is True
+    assert is_increasing(tan(x), Interval.open(-pi/2, pi/2), x) is True
+
+    assert is_decreasing(1/x, Interval.open(0, 1), x) is True
+    assert is_decreasing(1/x, Interval(-1, Rational(-1, 10)), x) is True
+    assert not is_decreasing(1/x, Interval(-1, 1), x)
+    assert not is_increasing(1/x, Interval(-1, 1), x)

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sympy.calculus.singularities import is_decreasing
+from sympy.calculus.util import continuous_domain
 from sympy.calculus.accumulationbounds import AccumulationBounds
 from .expr_with_intlimits import ExprWithIntLimits
 from .expr_with_limits import AddWithLimits
@@ -579,8 +580,13 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         ### ------------- alternating series test ----------- ###
         dict_val = sequence_term.match(S.NegativeOne**(sym + p)*q)
-        if not dict_val[p].has(sym) and is_decreasing(dict_val[q], interval):
-            return S.true
+        if not dict_val[p].has(sym):
+            try:
+                cont_dom = continuous_domain(dict_val[q], sym, interval)
+                if interval.is_subset(cont_dom) and is_decreasing(dict_val[q], interval):
+                    return S.true
+            except NotImplementedError:
+                pass
 
         ### ------------- integral test -------------- ###
         check_interval = None
@@ -590,17 +596,22 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             check_interval = interval
         elif isinstance(maxima, FiniteSet) and maxima.sup.is_number:
             check_interval = Interval(maxima.sup, interval.sup)
-        if (check_interval is not None and
-            (is_decreasing(sequence_term, check_interval) or
-            is_decreasing(-sequence_term, check_interval))):
-                integral_val = Integral(
-                    sequence_term, (sym, lower_limit, upper_limit))
-                try:
-                    integral_val_evaluated = integral_val.doit()
-                    if integral_val_evaluated.is_number:
-                        return S(integral_val_evaluated.is_finite)
-                except NotImplementedError:
-                    pass
+        if check_interval is not None:
+            try:
+                cont_dom = continuous_domain(sequence_term, sym, check_interval)
+                if (check_interval.is_subset(cont_dom) and
+                    (is_decreasing(sequence_term, check_interval) or
+                    is_decreasing(-sequence_term, check_interval))):
+                        integral_val = Integral(
+                            sequence_term, (sym, lower_limit, upper_limit))
+                        try:
+                            integral_val_evaluated = integral_val.doit()
+                            if integral_val_evaluated.is_number:
+                                return S(integral_val_evaluated.is_finite)
+                        except NotImplementedError:
+                            pass
+            except NotImplementedError:
+                pass
 
         ### ----- Dirichlet and bounded times convergent tests ----- ###
         # TODO
@@ -654,10 +665,15 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                     a_n = Mul(*a_tuple)
                     b_n = Mul(*b_set)
 
-                    if is_decreasing(a_n, interval):
-                        dirich = _dirichlet_test(b_n)
-                        if dirich is not None:
-                            return dirich
+                    try:
+                        cont_dom = continuous_domain(a_n, sym, interval)
+                        if interval.is_subset(cont_dom): # Defensive: ensure continuity even though is_decreasing now checks singularities
+                            if is_decreasing(a_n, interval):
+                                dirich = _dirichlet_test(b_n)
+                                if dirich is not None:
+                                    return dirich
+                    except NotImplementedError:
+                        pass
 
                     bc_test = _bounded_convergent_test(a_n, b_n)
                     if bc_test is not None:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28578

#### Brief description of what is fixed or changed
Added continuity checks to [monotonicity_helper()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/calculus/singularities.py:130:0-183:49) and [is_monotonic()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/calculus/singularities.py:362:0-430:62) functions. Previously, these functions only verified that the derivative had no roots in the interval, without checking if the function was continuous throughout. This caused functions with poles to be incorrectly classified as monotonic.

**Before this fix:**
```python
from sympy import Symbol, Interval, tan
from sympy.calculus.singularities import is_monotonic, is_increasing

x = Symbol('x')
is_monotonic(tan(x), Interval(0, 5), x)   # Returns: True (incorrect)
is_increasing(tan(x), Interval(0, 5), x)  # Returns: True (incorrect)
# tan(x) has poles at pi/2 ≈ 1.57 and 3*pi/2 ≈ 4.71, both within [0, 5]
```

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixed [is_monotonic](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/calculus/singularities.py:362:0-430:62) and related functions to verify continuity before checking monotonicity. Functions with poles or discontinuities now correctly return `False`.
<!-- END RELEASE NOTES -->