### PR TITLE
Fix #28393: Optimize to_dnf performance for XOR expressions

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1081,7 +1081,7 @@ class Xor(BooleanFunction):
             for i in range(0, len(self.args)+1, 2):
                 for neg in combinations(self.args, i):
                     clause = [Not(s) if s in neg else s for s in self.args]
-                    args.append(Or(*clause))
+                    args.append(Or(*clause, evaluate=False))
             return And._to_nnf(*args, simplify=simplify)
 
     def _eval_rewrite_as_Or(self, *args, **kwargs):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1074,7 +1074,7 @@ class Xor(BooleanFunction):
             for mask in _get_odd_parity_terms(len(self.args)):
                 conj = [self.args[i] if mask[i] == 1 else Not(self.args[i])
                         for i in range(len(self.args))]
-                terms.append(And(*conj))
+                terms.append(And(*conj, evaluate=False))
             return Or._to_nnf(*terms, simplify=simplify)
         else:
             args = []


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #28393

#### Brief description of what is fixed or changed

This PR fixes the severe performance asymmetry between [to_dnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) and [to_cnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1718:0-1757:14) when converting XOR expressions.

**Problem**: [to_dnf(Xor(...))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) was exponentially slower than [to_cnf(Xor(...))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1718:0-1757:14) because [Xor.to_nnf()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1069:4-1075:52) always generated CNF (Product of Sums), forcing an expensive CNF→DNF distribution step. For XOR with 10 variables, [to_dnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) would hang or take 100+ seconds while [to_cnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1718:0-1757:14) completed in ~0.07s.

**Solution**: Added a `form` parameter to the [to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1681:0-1715:43) pipeline that hints the target normal form:
- When [to_dnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) is called, it passes `form='dnf'` through [eliminate_implications](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1967:0-1997:50) → [to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1681:0-1715:43)
- [Xor.to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1069:4-1075:52) now checks this hint and generates DNF directly (Sum of Products) when `form='dnf'`
- When `form='cnf'` or `None`, the original CNF behavior is preserved

**Changes**:
- Updated [to_nnf(expr, simplify=True, form=None)](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1681:0-1715:43) to accept form parameter
- Updated [eliminate_implications(expr, form=None)](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1967:0-1997:50) to pass form to [to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1681:0-1715:43)
- Updated [to_dnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) to call [eliminate_implications(expr, form='dnf')](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1967:0-1997:50)
- Updated [to_cnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1718:0-1757:14) to call [eliminate_implications(expr, form='cnf')](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1967:0-1997:50)
- Updated [Xor.to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1069:4-1075:52) to generate SOP when `form='dnf'`, POS when `form='cnf'`/`None`
- Updated all Boolean class [to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1681:0-1715:43) methods to accept and propagate the `form` parameter

**Performance improvement**:
- Before: [to_dnf(Xor(*x[:10]))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) hangs or takes 100+ seconds
- After: [to_dnf(Xor(*x[:10]))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) completes in ~0.09 seconds
- Ratio DNF/CNF: 1.3x (symmetric performance achieved)

**Backward compatibility**: The `form` parameter defaults to `None`, preserving original behavior. All existing tests pass.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* logic
  * Fixed performance issue where [to_dnf(Xor(...))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1760:0-1797:39) was exponentially slower than [to_cnf(Xor(...))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1718:0-1757:14). Added `form` parameter to [to_nnf](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/logic/boolalg.py:1681:0-1715:43) pipeline to generate optimal normal form directly, improving performance from 100+ seconds to ~0.09 seconds for XOR with 10 variables.
<!-- END RELEASE NOTES -->