### PR TITLE
Export array expressions into Graphviz dot files

### DIFF
--- a/sympy/tensor/array/expressions/contraction_graphviz.py
+++ b/sympy/tensor/array/expressions/contraction_graphviz.py
@@ -1,0 +1,151 @@
+from dataclasses import dataclass, field
+from functools import singledispatchmethod
+
+from sympy import MatrixSymbol, Expr
+from sympy.tensor.array.expressions import ArraySymbol, ArrayContraction, ArrayDiagonal, PermuteDims, ArrayTensorProduct
+
+
+@dataclass
+class _GraphUnit:
+    name_unique: str
+    name: str | None
+    indices: list[int | None]
+    shape: tuple[Expr | int]
+
+@dataclass
+class _GraphUnits:
+    units: list[_GraphUnit]
+    contractions: list[tuple[str, int]] = field(default_factory=list)
+    diagonals: list[tuple[str, int]] = field(default_factory=list)
+
+
+class ArrayDotGraphPrinter:
+
+    def __init__(self):
+        self._counting: int = 0
+
+    @singledispatchmethod
+    def _s(self, expr) -> _GraphUnits:
+        raise NotImplementedError
+
+    @_s.register
+    def _(self, expr: ArrayContraction) -> _GraphUnits:
+        sup_graph_units = self._s(expr.expr)
+        new_contractions = []
+        for contr in expr.contraction_indices:
+            new_contraction = []
+            counter = 0
+            for graph_unit in sup_graph_units.units:
+                for i, e in enumerate(graph_unit.indices):
+                    if e is None:
+                        continue
+                    if counter in contr:
+                        graph_unit.indices[i] = -1
+                        new_contraction.append((graph_unit.name_unique, i))
+                    counter += 1
+            new_contractions.append(tuple(new_contraction))
+        counter = 0
+        for graph_unit in sup_graph_units.units:
+            for i, e in enumerate(graph_unit.indices):
+                if e is None:
+                    continue
+                elif e == -1:
+                    graph_unit.indices[i] = None
+                    counter += 1
+                else:
+                    graph_unit.indices[i] -= counter
+        sup_graph_units.contractions.extend(new_contractions)
+        return sup_graph_units
+
+    @_s.register
+    def _(self, expr: ArrayDiagonal) -> _GraphUnits:
+        graph_units = self._s(expr.expr)
+        dim_non_diag = len(expr.shape) - len(expr.diagonal_indices)
+        for j, diag_ind in enumerate(expr.diagonal_indices):
+            for graph_unit in graph_units.units:
+                for i, e in enumerate(graph_unit.indices):
+                    if e is None:
+                        continue
+                    if e in diag_ind:
+                        graph_unit.indices[i] = dim_non_diag + j
+        return graph_units
+
+    @_s.register
+    def _(self, expr: PermuteDims) -> _GraphUnits:
+        graph_units = self._s(expr.expr)
+        inverse_perm = expr.permutation**(-1)
+        for graph_unit in graph_units.units:
+            for i, e in enumerate(graph_unit.indices):
+                if e is None:
+                    continue
+                graph_unit.indices[i] = inverse_perm(e)  # expr.permutation(e)
+        return graph_units
+
+    @_s.register
+    def _(self, expr: ArrayTensorProduct) -> _GraphUnits:
+        graph_units: list[_GraphUnit] = [i for arg in expr.args for i in self._s(arg).units]
+        counter = 0
+        for unit in graph_units:
+            local_count = 0
+            for i, e in enumerate(unit.indices):
+                if e is None:
+                    continue
+                unit.indices[i] = counter + e
+                local_count += 1
+            counter += local_count
+        return _GraphUnits(graph_units)
+
+    @_s.register
+    def _(self, expr: ArraySymbol) -> _GraphUnits:
+        return _GraphUnits([
+            _GraphUnit(
+                self._get_name(expr.name),
+                expr.name,
+                [i for i, e in enumerate(expr.shape)], expr.shape)
+        ])
+
+    @_s.register
+    def _(self, expr: MatrixSymbol) -> _GraphUnits:
+        return _GraphUnits([
+            _GraphUnit(
+                self._get_name(expr.name),
+                expr.name,
+                [i for i, e in enumerate(expr.shape)], expr.shape)
+        ])
+
+    def _get_name(self, base_name: str | None) -> str:
+        if base_name is None:
+            base_name = "X"
+        self._counting += 1
+        return f"{base_name}{self._counting}"
+
+    def _graph_units_to_dot(self, graph_units: _GraphUnits, graph_name="ArrayExpr") -> str:
+
+        lines = [
+            f"graph {graph_name} {{",
+            "    rankdir = LR;",
+            "    splines = true;",
+            "",
+            "    node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];",
+            "",
+        ]
+
+        for unit in graph_units.units:
+            labels = " | ".join([f"<p{i}> {'' if idx is None else str(idx) + ' '}[{shape}]" for i, (shape, idx) in enumerate(zip(unit.shape, unit.indices))])
+            line = f"""    {unit.name_unique} [label="{{ {labels} }}", xlabel="{unit.name}"];"""
+            lines.append(line)
+
+        lines.append("")
+
+        for contraction in graph_units.contractions:
+            line = " "*4 + " -- ".join([f"{name}:p{pindex}" for name, pindex in contraction]) + ";"
+            lines.append(line)
+
+        lines.append("}")
+
+        return "\n".join(lines)
+
+    def doprint(self, expr):
+        self._counting = 0
+        gu = self._s(expr)
+        return self._graph_units_to_dot(gu)

--- a/sympy/tensor/array/expressions/tests/test_contraction_graphviz.py
+++ b/sympy/tensor/array/expressions/tests/test_contraction_graphviz.py
@@ -1,0 +1,278 @@
+from textwrap import dedent
+
+from sympy import tensorcontraction, tensorproduct, MatrixSymbol, Trace
+from sympy.tensor.array.expressions import ArraySymbol, ArrayDiagonal, ArrayContraction, ArrayTensorProduct, \
+    PermuteDims, convert_matrix_to_array
+from sympy.tensor.array.expressions.contraction_graphviz import ArrayDotGraphPrinter
+
+
+def _get_graphviz_dot_content(expr):
+    adgp = ArrayDotGraphPrinter()
+    output = adgp.doprint(expr)
+    return output
+
+
+def test_output_contraction_graphviz():
+    A = ArraySymbol('A', (3, 4, 5))
+    B = ArraySymbol('B', (5, 4))
+
+    expr: ArrayContraction = tensorcontraction(tensorproduct(A, B), (1, 4), (2, 3))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            B1 [label="{ <p0> [5] | <p1> [4] }", xlabel="B"];
+            A2 [label="{ <p0> 0 [3] | <p1> [4] | <p2> [5] }", xlabel="A"];
+
+            B1:p0 -- A2:p2;
+            B1:p1 -- A2:p1;
+        }
+    """).strip()
+
+    expr: ArrayContraction = ArrayContraction(ArrayTensorProduct(A, B), (1, 4), (2, 3))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> [4] | <p2> [5] }", xlabel="A"];
+            B2 [label="{ <p0> [5] | <p1> [4] }", xlabel="B"];
+
+            A1:p1 -- B2:p1;
+            A1:p2 -- B2:p0;
+        }
+    """).strip()
+
+    A = ArraySymbol("A", (3, 3))
+
+    expr = ArrayDiagonal(A, (0, 1))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> 0 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    expr = ArrayDiagonal(ArrayTensorProduct(A, A), (0, 1))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 2 [3] | <p1> 2 [3] }", xlabel="A"];
+            A2 [label="{ <p0> 2 [3] | <p1> 3 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    expr = ArrayDiagonal(ArrayTensorProduct(A, A), (0, 1), (2, 3))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> 0 [3] }", xlabel="A"];
+            A2 [label="{ <p0> 1 [3] | <p1> 1 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    expr = ArrayDiagonal(ArrayTensorProduct(A, A), (0, 2), (1, 3))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> 1 [3] }", xlabel="A"];
+            A2 [label="{ <p0> 0 [3] | <p1> 1 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    expr = ArrayTensorProduct(A, A)
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> 1 [3] }", xlabel="A"];
+            A2 [label="{ <p0> 2 [3] | <p1> 3 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    expr = ArrayContraction(ArrayTensorProduct(A, A), (1, 2))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> [3] }", xlabel="A"];
+            A2 [label="{ <p0> [3] | <p1> 1 [3] }", xlabel="A"];
+
+            A1:p1 -- A2:p0;
+        }
+    """).strip()
+
+    expr = ArrayContraction(ArrayTensorProduct(A, A), (1, 2), (0, 3))
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> [3] | <p1> [3] }", xlabel="A"];
+            A2 [label="{ <p0> [3] | <p1> [3] }", xlabel="A"];
+
+            A1:p0 -- A2:p1;
+            A1:p1 -- A2:p0;
+        }
+    """).strip()
+
+    expr = PermuteDims(A, [1, 0])
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 1 [3] | <p1> 0 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    A = ArraySymbol("A", (1, 2, 3))
+    expr = PermuteDims(A, index_order_old="ijk", index_order_new="kij")
+    assert _get_graphviz_dot_content(expr) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 1 [1] | <p1> 2 [2] | <p2> 0 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    M = MatrixSymbol("M", 3, 3)
+    N = MatrixSymbol("N", 3, 3)
+    P = MatrixSymbol("P", 3, 3)
+
+    A = ArraySymbol("A", (3, 3, 3))
+
+    assert _get_graphviz_dot_content(ArrayDiagonal(A, (0, 1, 2))) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            A1 [label="{ <p0> 0 [3] | <p1> 0 [3] | <p2> 0 [3] }", xlabel="A"];
+
+        }
+    """).strip()
+
+    assert _get_graphviz_dot_content(convert_matrix_to_array(M * N)) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            M1 [label="{ <p0> 0 [3] | <p1> [3] }", xlabel="M"];
+            N2 [label="{ <p0> [3] | <p1> 1 [3] }", xlabel="N"];
+
+            M1:p1 -- N2:p0;
+        }""").strip()
+    assert _get_graphviz_dot_content(convert_matrix_to_array(M * N * P)) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            N1 [label="{ <p0> [3] | <p1> [3] }", xlabel="N"];
+            M2 [label="{ <p0> 0 [3] | <p1> [3] }", xlabel="M"];
+            P3 [label="{ <p0> [3] | <p1> 1 [3] }", xlabel="P"];
+
+            N1:p0 -- M2:p1;
+            N1:p1 -- P3:p0;
+        }""").strip()
+    assert _get_graphviz_dot_content(convert_matrix_to_array(M * N.T * P)) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            N1 [label="{ <p0> [3] | <p1> [3] }", xlabel="N"];
+            M2 [label="{ <p0> 0 [3] | <p1> [3] }", xlabel="M"];
+            P3 [label="{ <p0> [3] | <p1> 1 [3] }", xlabel="P"];
+
+            N1:p0 -- P3:p0;
+            N1:p1 -- M2:p1;
+        }""").strip()
+    assert _get_graphviz_dot_content(convert_matrix_to_array(Trace(M.T * N.T * P))) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            M1 [label="{ <p0> [3] | <p1> [3] }", xlabel="M"];
+            N2 [label="{ <p0> [3] | <p1> [3] }", xlabel="N"];
+            P3 [label="{ <p0> [3] | <p1> [3] }", xlabel="P"];
+
+            M1:p0 -- N2:p1;
+            M1:p1 -- P3:p1;
+            N2:p0 -- P3:p0;
+        }""").strip()
+    assert _get_graphviz_dot_content(convert_matrix_to_array(Trace(M.T * N.T * P))) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            M1 [label="{ <p0> [3] | <p1> [3] }", xlabel="M"];
+            N2 [label="{ <p0> [3] | <p1> [3] }", xlabel="N"];
+            P3 [label="{ <p0> [3] | <p1> [3] }", xlabel="P"];
+
+            M1:p0 -- N2:p1;
+            M1:p1 -- P3:p1;
+            N2:p0 -- P3:p0;
+        }""").strip()
+    assert _get_graphviz_dot_content(convert_matrix_to_array(Trace(M))) == dedent("""
+        graph ArrayExpr {
+            rankdir = LR;
+            splines = true;
+
+            node [shape=record, style=rounded, fontsize=12, height=0.4, width=1.2];
+
+            M1 [label="{ <p0> [3] | <p1> [3] }", xlabel="M"];
+
+            M1:p0 -- M1:p1;
+        }""").strip()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Added printer for GraphViz dot files to represent array expression contraction structure visually.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
