### PR TITLE
safer implementation for group_isomorphisms that avoids invert

### DIFF
--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -516,17 +516,26 @@ def group_isomorphism(G, H, isomorphism=True):
         _images = dict(zip(gens,images))
         if _check_homomorphism(G, _H, _images):
             if isinstance(H, FpGroup):
-                images = h_isomorphism.invert(images)
-            T =  homomorphism(G, H, G.generators, images, check=False)
-            if T.is_isomorphism():
-                # It is a valid isomorphism
-                if not isomorphism:
-                    return True
-                return (True, T)
+                image=PermutationGroup(images)
+                if image.order()== h_order:
+                # thats enough to say that we have a bijective function
+                    if not isomorphism:
+                        return True
+                    images = h_isomorphism.invert(images)
+                    T =  homomorphism(G, H, G.generators, images, check=False)
+                    return (True, T)
+            else:
+                T =  homomorphism(G, H, G.generators, images, check=False)
+                if T.is_isomorphism():
+                    # It is a valid isomorphism
+                    if not isomorphism:
+                        return True
+                    return (True, T)
 
     if not isomorphism:
         return False
     return (False, None)
+
 
 def is_isomorphic(G, H):
     '''


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28625 

#### Brief description of what is fixed or changed
This pr is aimed at making the function group_isomorphism more robust, by choosing an alternative way to determine wether an homomorphism is a bijection

#### Other comments
Basically, how it is implemented now, the function group_homomorphism checks wether a mapping from the generators of a group G to the elements of a group H is a homomorphism, and if the answer is affirmative, it calls the function **is_isomorphism** to determine wether the homomorphism is injective and biective. The problem is that this function then calls the kernel function, that calls the invert function, and at the moment the implementation of the invert function in sympy is very problematic for fp groups.
This is described in issue #28593

This pr, avoids the problems of invert by not calling **is_isomorphism**. Instead, the implemented approach is to find the order of the image and to check if it is the same as the order of the codomain. If thats true, we have a bijection and therefore an isomorphism.

I think this approach is better not only because it avoids the problems of **invert** , but also because the approach becomes much more straightforward: instead of calculating the kernel and so on of an homomorphism that has an fp group as a codomain, we simply use the fact that group_isomorphism previously transformed H into a perm group, and so calculating its order means calculating the order of a perm group.
Basically we avoid computing with fp groups and rather use the already calculated perm group isomorphic to H and do our calculations there. (Its easier to compute with perm groups)
I also run some tests, and this approach also was faster in those tests.

I will also copy here a test generated by gemini: you can check that many of the isomorphisms tested fail due to the call of **is_isomorphism**. With this pr they all work, and you can also check that they run faster. (The isomorphisms that cause a crash here are the same reported in the issue related to this pr.)
```
import sys
import time
import traceback

from sympy.combinatorics import free_group, Permutation
from sympy.combinatorics.fp_groups import FpGroup
from sympy.combinatorics.homomorphisms import is_isomorphic
from sympy.combinatorics.named_groups import SymmetricGroup



def run_test(test_num, name, G, H, expected_result):
    """
    Helper function to run a single isomorphism test
    and measure its time.
    """
    print(f"\n##############################################", flush=True)
    print(f"=== {test_num}. Group {name} ===", flush=True)
    print(f"Expected: {expected_result}", flush=True)
    
    try:
        # 1. Calculate orders (first check)
        start_order_g = time.perf_counter()
        order_g = G.order()
        time_order_g = (time.perf_counter() - start_order_g) * 1000
        
        start_order_h = time.perf_counter()
        order_h = H.order()
        time_order_h = (time.perf_counter() - start_order_h) * 1000

        print(f"Order G = {order_g} (calculated in {time_order_g:.2f} ms)", flush=True)
        print(f"Order H = {order_h} (calculated in {time_order_h:.2f} ms)", flush=True)

        if order_g != order_h:
            print("Result: False (Orders do not match)", flush=True)
            if expected_result is False:
                print("✅ Success (As expected)", flush=True)
            else:
                print("❌ FAILURE: Different orders, expected isomorphism", flush=True)
            return

        # 2. Isomorphism Test
        print("Starting is_isomorphic test (can be SLOW)...", flush=True)
        start_iso = time.perf_counter()
        
        result = is_isomorphic(G, H)
        
        time_iso = (time.perf_counter() - start_iso) * 1000
        
        print(f"Test Time: {time_iso:.2f} ms", flush=True)
        print(f"Result: {result}", flush=True)
        
        if result == expected_result:
            print("✅ Success (As expected)", flush=True)
        else:
            print(f"❌ FAILURE: Result {result}, expected {expected_result}", flush=True)

    except Exception as e:
        print(f"\n--- 💥 CRASH IN TEST {test_num} ---", flush=True)
        print(f"ERROR: {e}", flush=True)
        import traceback
        traceback.print_exc()
        print("--------------------------", flush=True)

# ===================================================================
# --- START OF MAIN SCRIPT ---
# ===================================================================

print("##############################################")
print("# Verification of isomorphic presentation pairs  #")
print("# Translation from GAP to SymPy                  #")
print("##############################################")

# --- 1. Group C6 (order 6) ---
# G1 = C6, H1 = C2 x C3 (which is C6)
F, a = free_group("a")
G1 = FpGroup(F, [a**6])

F2, x, y = free_group("x, y")
# H1 = <x, y | x^2, y^3, xy(yx)^-1> 
# The last relator is xyx^-1y^-1 = [x,y], so it is abelian C2 x C3
H1 = FpGroup(F2, [x**2, y**3, x*y*(y*x)**-1])
run_test(1, "C6 (order 6)", G1, H1, expected_result=True)

# --- 2. Group V4 (order 4) ---
# G2 = C2 x C2 (V4), H2 = C2 x C2
F, a, b = free_group("a, b")
# G2 = <a, b | a^2, b^2, (ab)^2> (V4)
G2 = FpGroup(F, [a**2, b**2, (a*b)**2])

F2, x, y, z = free_group("x, y, z")
# H2 = <x, y, z | x^2, y^2, z^2, xyz> 
# xyz=id -> z=(xy)^-1 = y^-1x^-1 = yx. 
# Substituting z^2 = (yx)^2 = 1 (which is = (xy)^2)
# H2 is <x, y | x^2, y^2, (xy)^2>, so V4
H2 = FpGroup(F2, [x**2, y**2, z**2, x*y*z])
run_test(2, "V4 (order 4)", G2, H2, expected_result=True)

# --- 3. Group S3 (order 6) ---
# G3 = D3 (S3), H3 = S3
F, r, s = free_group("r, s")
# G3 = <r, s | r^3, s^2, (sr)^2> (S3)
G3 = FpGroup(F, [r**3, s**2, s*r*s*r])

F2, a, b = free_group("a, b")
# H3 = <a, b | a^2, b^2, (ab)^3> (S3)
H3 = FpGroup(F2, [a**2, b**2, (a*b)**3])
run_test(3, "S3 (order 6)", G3, H3, expected_result=True)

# --- 4. Group D4 (order 8) ---
# G4 = D4, H4 = D4
n = 4
F, r, s = free_group("r, s")
# G4 = <r, s | r^4, s^2, (sr)^2> (D4)
G4 = FpGroup(F, [r**n, s**2, s*r*s*r])

F2, a, b = free_group("a, b")
# H4 = <a, b | a^2, b^2, (ab)^4> (D4)
H4 = FpGroup(F2, [a**2, b**2, (a*b)**n])
run_test(4, "D4 (order 8)", G4, H4, expected_result=True)

# --- 5. Group Q8 (order 8) ---
# G5 = Q8, H5 = Q8 (same presentation)
F, i, j = free_group("i, j")
# G5 = <i, j | i^4, i^2=j^2, j^-1 i j = i^-1>
G5 = FpGroup(F, [i**4, i**2 * j**-2, j**-1 * i * j * i])

F2, x, y = free_group("x, y")
H5 = FpGroup(F2, [x**4, x**2 * y**-2, y**-1 * x * y * x])
run_test(5, "Q8 (order 8)", G5, H5, expected_result=True)

# --- 6. Group S4 (order 24) ---
# G6 = S4, H6 = S4 (Coxeter presentation)
# THIS IS THE TEST THAT REVEALED THE BUG
F, a, b = free_group("a, b")
# G6 = <a, b | a^4, b^2, (ab)^3> (S4)
G6 = FpGroup(F, [a**4, b**2, (a*b)**3])

F2, s, t, u = free_group("s, t, u")
# H6 = Coxeter presentation of S4
H6 = FpGroup(F2, [s**2, t**2, u**2, (s*t)**3, (t*u)**3, (s*u)**2])
run_test(6, "S4 (order 24)", G6, H6, expected_result=True)

# --- 7. Group A5 (order 60) ---
# G7 = A5 (pres. 2,3,5), H7 = A5 (pres. 5,2,3)
F, x, y = free_group("x, y")
# G7 = <x, y | x^2, y^3, (xy)^5> (A5)
G7 = FpGroup(F, [x**2, y**3, (x*y)**5])

F2, r, s = free_group("r, s")
# H7 = <r, s | r^5, s^2, (rs)^3> (A5)
H7 = FpGroup(F2, [r**5, s**2, (r*s)**3])
run_test(7, "A5 (order 60)", G7, H7, expected_result=True)

# --- 8. Group C2xC2xC2 vs C4xC2 (order 8) ---
# G8 = C2 x C2 x C2, H8 = C4 x C2
F, a, b, c = free_group("a, b, c")
# G8 = C2^3 (abelian, all ord 2)
G8 = FpGroup(F, [a**2, b**2, c**2, a*b*a**-1*b**-1, a*c*a**-1*c**-1, b*c*b**-1*c**-1])

F2, x, y = free_group("x, y")
# H8 = <x, y | x^4, y^4, x^2=y^2, [x,y]> (Abelian C4 x C2)
H8 = FpGroup(F2, [x**4, y**4, x**2*y**-2, x*y*(y*x)**-1])
run_test(8, "C2xC2xC2 vs C4xC2 (order 8)", G8, H8, expected_result=False)

print("\n##############################################")
print("=== END OF VERIFICATIONS ===")
print("##############################################")

```



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * switching to a safer implementation of group_isomorphism
<!-- END RELEASE NOTES -->
