### PR TITLE
A minor improvement to `_sqrt_mod_tonelli_shanks`.

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -16,7 +16,7 @@ from sympy.utilities.decorator import deprecated
 from sympy.utilities.memoization import recurrence_memo
 from sympy.utilities.misc import as_int
 from sympy.utilities.iterables import iproduct
-from sympy.core.random import _randint, randint
+from sympy.core.random import _randint
 
 from itertools import product
 
@@ -462,17 +462,18 @@ def _sqrt_mod_tonelli_shanks(a, p):
     s = bit_scan1(p - 1)
     t = p >> s
     # find a non-quadratic residue
-    if p % 12 == 5:
-        # Legendre symbol (3/p) == -1 if p % 12 in [5, 7]
+    # Noting that we are assuming p=1 (mod 8), we have (d/p) = (p/d)
+    # for any odd prime d. Here, (d/p) denotes the Legendre symbol.
+    if p % 3 == 2:
         d = 3
     elif p % 5 in [2, 3]:
-        # Legendre symbol (5/p) == -1 if p % 5 in [2, 3]
         d = 5
     else:
-        while 1:
-            d = randint(6, p - 1)
-            if jacobi(d, p) == -1:
+        for d in primerange(7, p):
+            if jacobi(p, d) == -1:
                 break
+        else:
+            assert False
     #assert legendre_symbol(d, p) == -1
     A = pow(a, t, p)
     D = pow(d, t, p)


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously, the condition was checked using `p % 12 == 5`, but we noticed that the same property can be determined with `p % 3 == 2`, so we rewrote it accordingly. In addition, instead of choosing `d` at random and testing it, we now restrict the checks to prime candidates only. This doesn’t make a practical difference, but it avoids testing values that are obviously not quadratic non-residues.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
