### PR TITLE
Fix Abs.n() not evaluating constants.

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -401,25 +401,4 @@ def is_monotonic(expression, interval=S.Reals, symbol=None):
     True
 
     """
-    from sympy.solvers.solveset import solveset
-
-    expression = sympify(expression)
-
-    free = expression.free_symbols
-    if symbol is None and len(free) > 1:
-        raise NotImplementedError(
-            'is_monotonic has not yet been implemented'
-            ' for all multivariate expressions.'
-        )
-
-    variable = symbol or (free.pop() if free else Symbol('x'))
-    derivative = expression.diff(variable)
-
-    # Check if function is non-decreasing (derivative >= 0) throughout interval
-    increasing_interval = solveset(derivative >= 0, variable, interval)
-
-    # Check if function is non-increasing (derivative <= 0) throughout interval
-    decreasing_interval = solveset(derivative <= 0, variable, interval)
-
-    # Monotonic if either condition holds for the entire interval
-    return interval.is_subset(increasing_interval) or interval.is_subset(decreasing_interval)
+    return is_increasing(expression, interval, symbol) or is_decreasing(expression, interval, symbol)

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -413,5 +413,13 @@ def is_monotonic(expression, interval=S.Reals, symbol=None):
         )
 
     variable = symbol or (free.pop() if free else Symbol('x'))
-    turning_points = solveset(expression.diff(variable), variable, interval)
-    return interval.intersection(turning_points) is S.EmptySet
+    derivative = expression.diff(variable)
+
+    # Check if function is non-decreasing (derivative >= 0) throughout interval
+    increasing_interval = solveset(derivative >= 0, variable, interval)
+
+    # Check if function is non-increasing (derivative <= 0) throughout interval
+    decreasing_interval = solveset(derivative <= 0, variable, interval)
+
+    # Monotonic if either condition holds for the entire interval
+    return interval.is_subset(increasing_interval) or interval.is_subset(decreasing_interval)

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -118,82 +118,33 @@ def test_is_monotonic():
     assert is_monotonic(x**2 + y + 1, Interval(1, 2), x)
     raises(NotImplementedError, lambda: is_monotonic(x**2 + y + 1))
 
-    # Test cases for functions with derivative = 0 at isolated points.
-    # x**3: derivative is 3*x**2, which is >= 0 everywhere (zero at x=0)
-    assert is_monotonic(x**3, Interval(-10, 10))
+    # Functions with isolated stationary points
     assert is_monotonic(x**3, S.Reals)
-
-    # -x**3: derivative is -3*x**2, which is <= 0 everywhere (zero at x=0)
-    assert is_monotonic(-x**3, Interval(-10, 10))
     assert is_monotonic(-x**3, S.Reals)
-
-    # x**5: derivative is 5*x**4, which is >= 0 everywhere (zero at x=0)
     assert is_monotonic(x**5, S.Reals)
 
-    # x**7: another odd power
-    assert is_monotonic(x**7, S.Reals)
-    assert is_monotonic(-x**7, S.Reals)
-
-    # Test strictly increasing linear and polynomial functions
+    # Basic monotonic functions
     assert is_monotonic(x, S.Reals)
     assert is_monotonic(2*x + 3, S.Reals)
-    assert is_monotonic(x**3 + x, S.Reals)
-    assert is_monotonic(x**3 + 2*x, S.Reals)
-
-    # Test strictly decreasing functions
     assert is_monotonic(-x, S.Reals)
-    assert is_monotonic(-2*x + 5, S.Reals)
 
-    # Test non-monotonic polynomial functions
-    assert not is_monotonic(x**2, S.Reals)  # Has minimum at x=0
-    assert not is_monotonic(x**3 - 3*x, S.Reals)  # Has local max and min
-    assert not is_monotonic(x**4 - x**2, S.Reals)
-    assert not is_monotonic(x**4, S.Reals)  # Has minimum at x=0
+    # Non-monotonic functions
+    assert not is_monotonic(x**2, S.Reals)
+    assert not is_monotonic(x**3 - 3*x, S.Reals)
 
-    # Test monotonic on restricted intervals
-    assert is_monotonic(x**2, Interval(0, oo))  # Increasing on [0, oo)
-    assert is_monotonic(x**2, Interval.Lopen(0, oo))
-    assert is_monotonic(x**2, Interval(1, 10))
-    assert is_monotonic(-x**2, Interval(-oo, 0))  # Increasing on (-oo, 0]
-    assert not is_monotonic(x**2, Interval(-1, 1))  # Not monotonic on [-1, 1]
+    # Monotonic on restricted intervals
+    assert is_monotonic(x**2, Interval(0, oo))
+    assert is_monotonic(-x**2, Interval(-oo, 0))
+    assert not is_monotonic(x**2, Interval(-1, 1))
 
-    # Test constant functions (monotonic both ways)
-    assert is_monotonic(5, S.Reals)
-    assert is_monotonic(pi, Interval(-10, 10))
-    assert is_monotonic(0, S.Reals)
+    # Rational functions
+    assert is_monotonic(1/x, Interval.open(0, oo))
+    assert is_monotonic(1/x, Interval.open(-oo, 0))
 
-    # Test rational functions on appropriate intervals
-    assert is_monotonic(1/x, Interval.open(0, oo))  # Decreasing on (0, oo)
-    assert is_monotonic(1/x, Interval.open(-oo, 0))  # Decreasing on (-oo, 0)
-    assert is_monotonic(1/x, Interval(1, 10))
-    assert is_monotonic(1/x, Interval(-10, -1))
-
-    # Test polynomial with all stationary points
-    assert is_monotonic(x**3 + 3*x**2 + 3*x + 1, S.Reals)  # (x+1)**3, always increasing
-    assert is_monotonic((x + 2)**3, S.Reals)
-    assert is_monotonic((x - 1)**5, S.Reals)
-
-    # Test with specified symbol (multivariate)
-    assert is_monotonic(x**2 + y, Interval(-oo, 0), x)  # Decreasing in x on (-oo, 0]
-    assert is_monotonic(x**2 + y, Interval(0, oo), x)  # Increasing in x on [0, oo)
-    assert is_monotonic(x + y**2, Interval(0, oo), y)  # Increasing in y on [0, oo)
-
-    # Edge cases with single point intervals
+    # Edge cases
+    assert is_monotonic(5, S.Reals)  # Constant
     assert is_monotonic(x**2, Interval(5, 5))  # Single point
-    assert is_monotonic(x**3 - x, Interval(0, 0))  # Single point
-
-    # Test x**4 on restricted intervals where they're monotonic
-    assert is_monotonic(x**4, Interval(0, oo))
-    assert is_monotonic(x**4, Interval.Lopen(0, oo))
-    assert is_monotonic(-x**4, Interval(-oo, 0))
-
-    # Test more complex polynomials with all odd powers
-    assert is_monotonic(x**7 + x**5 + x**3 + x, S.Reals)
-    assert is_monotonic(-(x**7 + x**5 + x**3 + x), S.Reals)
-
-    # Test polynomials with derivative that has zeros but maintains sign
-    assert is_monotonic(x**5 + x**3, S.Reals)  # f'(x) = 5x**4 + 3x**2 >= 0
-    assert is_monotonic(x**9 + x**7 + x**5 + x**3 + x, S.Reals)
+    assert is_monotonic(x**2 + y, Interval(-oo, 0), x)  # Multivariate
 
 def test_issue_23401():
     x = Symbol('x')

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -118,7 +118,7 @@ def test_is_monotonic():
     assert is_monotonic(x**2 + y + 1, Interval(1, 2), x)
     raises(NotImplementedError, lambda: is_monotonic(x**2 + y + 1))
 
-    # Test cases for functions with derivative = 0 at isolated points (THE MAIN FIX)
+    # Test cases for functions with derivative = 0 at isolated points.
     # x**3: derivative is 3*x**2, which is >= 0 everywhere (zero at x=0)
     assert is_monotonic(x**3, Interval(-10, 10))
     assert is_monotonic(x**3, S.Reals)
@@ -151,10 +151,10 @@ def test_is_monotonic():
     assert not is_monotonic(x**4, S.Reals)  # Has minimum at x=0
 
     # Test monotonic on restricted intervals
-    assert is_monotonic(x**2, Interval(0, oo))  # Increasing on [0, ∞)
+    assert is_monotonic(x**2, Interval(0, oo))  # Increasing on [0, oo)
     assert is_monotonic(x**2, Interval.Lopen(0, oo))
     assert is_monotonic(x**2, Interval(1, 10))
-    assert is_monotonic(-x**2, Interval(-oo, 0))  # Increasing on (-∞, 0]
+    assert is_monotonic(-x**2, Interval(-oo, 0))  # Increasing on (-oo, 0]
     assert not is_monotonic(x**2, Interval(-1, 1))  # Not monotonic on [-1, 1]
 
     # Test constant functions (monotonic both ways)
@@ -163,8 +163,8 @@ def test_is_monotonic():
     assert is_monotonic(0, S.Reals)
 
     # Test rational functions on appropriate intervals
-    assert is_monotonic(1/x, Interval.open(0, oo))  # Decreasing on (0, ∞)
-    assert is_monotonic(1/x, Interval.open(-oo, 0))  # Decreasing on (-∞, 0)
+    assert is_monotonic(1/x, Interval.open(0, oo))  # Decreasing on (0, oo)
+    assert is_monotonic(1/x, Interval.open(-oo, 0))  # Decreasing on (-oo, 0)
     assert is_monotonic(1/x, Interval(1, 10))
     assert is_monotonic(1/x, Interval(-10, -1))
 
@@ -174,9 +174,9 @@ def test_is_monotonic():
     assert is_monotonic((x - 1)**5, S.Reals)
 
     # Test with specified symbol (multivariate)
-    assert is_monotonic(x**2 + y, Interval(-oo, 0), x)  # Decreasing in x on (-∞, 0]
-    assert is_monotonic(x**2 + y, Interval(0, oo), x)  # Increasing in x on [0, ∞)
-    assert is_monotonic(x + y**2, Interval(0, oo), y)  # Increasing in y on [0, ∞)
+    assert is_monotonic(x**2 + y, Interval(-oo, 0), x)  # Decreasing in x on (-oo, 0]
+    assert is_monotonic(x**2 + y, Interval(0, oo), x)  # Increasing in x on [0, oo)
+    assert is_monotonic(x + y**2, Interval(0, oo), y)  # Increasing in y on [0, oo)
 
     # Edge cases with single point intervals
     assert is_monotonic(x**2, Interval(5, 5))  # Single point

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -3,7 +3,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.function import Lambda
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.trigonometric import sec, csc
+from sympy.functions.elementary.trigonometric import sec, csc, sin, cos
 from sympy.functions.elementary.hyperbolic import (coth, sech,
                                                    atanh, asech, acoth, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -118,6 +118,82 @@ def test_is_monotonic():
     assert is_monotonic(x**2 + y + 1, Interval(1, 2), x)
     raises(NotImplementedError, lambda: is_monotonic(x**2 + y + 1))
 
+    # Test cases for functions with derivative = 0 at isolated points (THE MAIN FIX)
+    # x**3: derivative is 3*x**2, which is >= 0 everywhere (zero at x=0)
+    assert is_monotonic(x**3, Interval(-10, 10))
+    assert is_monotonic(x**3, S.Reals)
+
+    # -x**3: derivative is -3*x**2, which is <= 0 everywhere (zero at x=0)
+    assert is_monotonic(-x**3, Interval(-10, 10))
+    assert is_monotonic(-x**3, S.Reals)
+
+    # x**5: derivative is 5*x**4, which is >= 0 everywhere (zero at x=0)
+    assert is_monotonic(x**5, S.Reals)
+
+    # x**7: another odd power
+    assert is_monotonic(x**7, S.Reals)
+    assert is_monotonic(-x**7, S.Reals)
+
+    # Test strictly increasing linear and polynomial functions
+    assert is_monotonic(x, S.Reals)
+    assert is_monotonic(2*x + 3, S.Reals)
+    assert is_monotonic(x**3 + x, S.Reals)
+    assert is_monotonic(x**3 + 2*x, S.Reals)
+
+    # Test strictly decreasing functions
+    assert is_monotonic(-x, S.Reals)
+    assert is_monotonic(-2*x + 5, S.Reals)
+
+    # Test non-monotonic polynomial functions
+    assert not is_monotonic(x**2, S.Reals)  # Has minimum at x=0
+    assert not is_monotonic(x**3 - 3*x, S.Reals)  # Has local max and min
+    assert not is_monotonic(x**4 - x**2, S.Reals)
+    assert not is_monotonic(x**4, S.Reals)  # Has minimum at x=0
+
+    # Test monotonic on restricted intervals
+    assert is_monotonic(x**2, Interval(0, oo))  # Increasing on [0, ∞)
+    assert is_monotonic(x**2, Interval.Lopen(0, oo))
+    assert is_monotonic(x**2, Interval(1, 10))
+    assert is_monotonic(-x**2, Interval(-oo, 0))  # Increasing on (-∞, 0]
+    assert not is_monotonic(x**2, Interval(-1, 1))  # Not monotonic on [-1, 1]
+
+    # Test constant functions (monotonic both ways)
+    assert is_monotonic(5, S.Reals)
+    assert is_monotonic(pi, Interval(-10, 10))
+    assert is_monotonic(0, S.Reals)
+
+    # Test rational functions on appropriate intervals
+    assert is_monotonic(1/x, Interval.open(0, oo))  # Decreasing on (0, ∞)
+    assert is_monotonic(1/x, Interval.open(-oo, 0))  # Decreasing on (-∞, 0)
+    assert is_monotonic(1/x, Interval(1, 10))
+    assert is_monotonic(1/x, Interval(-10, -1))
+
+    # Test polynomial with all stationary points
+    assert is_monotonic(x**3 + 3*x**2 + 3*x + 1, S.Reals)  # (x+1)**3, always increasing
+    assert is_monotonic((x + 2)**3, S.Reals)
+    assert is_monotonic((x - 1)**5, S.Reals)
+
+    # Test with specified symbol (multivariate)
+    assert is_monotonic(x**2 + y, Interval(-oo, 0), x)  # Decreasing in x on (-∞, 0]
+    assert is_monotonic(x**2 + y, Interval(0, oo), x)  # Increasing in x on [0, ∞)
+    assert is_monotonic(x + y**2, Interval(0, oo), y)  # Increasing in y on [0, ∞)
+
+    # Edge cases with single point intervals
+    assert is_monotonic(x**2, Interval(5, 5))  # Single point
+    assert is_monotonic(x**3 - x, Interval(0, 0))  # Single point
+
+    # Test x**4 on restricted intervals where they're monotonic
+    assert is_monotonic(x**4, Interval(0, oo))
+    assert is_monotonic(x**4, Interval.Lopen(0, oo))
+    assert is_monotonic(-x**4, Interval(-oo, 0))
+
+    # Test more complex polynomials with all odd powers
+    assert is_monotonic(x**7 + x**5 + x**3 + x, S.Reals)
+    assert is_monotonic(-(x**7 + x**5 + x**3 + x), S.Reals)
+
+    # Test polynomials with derivative that has zeros but maintains sign
+    assert is_monotonic(x**5 + x**3, S.Reals)  # f'(x) = 5x**4 + 3x**2 >= 0
+    assert is_monotonic(x**9 + x**7 + x**5 + x**3 + x, S.Reals)
 
 def test_issue_23401():
     x = Symbol('x')

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -3,7 +3,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.function import Lambda
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.trigonometric import sec, csc, sin, cos
+from sympy.functions.elementary.trigonometric import sec, csc
 from sympy.functions.elementary.hyperbolic import (coth, sech,
                                                    atanh, asech, acoth, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -707,6 +707,39 @@ class Abs(DefinedFunction):
     def _eval_rewrite_as_conjugate(self, arg, **kwargs):
         return sqrt(arg*conjugate(arg))
 
+    def _eval_evalf(self, prec):
+        """
+        Evaluate Abs numerically by evaluating constants in the argument.
+
+        This fixes issue #25765 where Abs.n() wasn't evaluating constants
+        like sqrt(2) to their decimal forms.
+
+        Examples
+        ========
+
+        >>> from sympy import Abs, sqrt, symbols
+        >>> t = symbols('t')
+        >>> Abs(sqrt(2) + t).n()
+        Abs(t + 1.41421356237310)
+        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()
+        Abs(2.41421356237310 - 2.41421356237310*t)
+        """
+        arg = self.args[0]
+
+        # If argument has no free symbols, let default evaluation handle it
+        if not arg.free_symbols:
+            return None
+
+        # Evaluate the argument to convert constants to numerical values
+        evaluated_arg = arg.evalf(prec, maxn=1)
+
+        # If nothing changed, return None to use default behavior
+        if evaluated_arg == arg:
+            return None
+
+        # Return Abs with the evaluated argument
+        # Use evaluate=False to preserve the exact structure of the evaluated expression
+        return self.func(evaluated_arg, evaluate=False)
 
 class arg(DefinedFunction):
     r"""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25765

#### Brief description of what is fixed or changed
##### Modified sympy/functions/elementary/complexes.py:

- Added _eval_evalf(self, prec) method to the class Abs(DefinedFunction). 
- The method evaluates constants in the argument using arg.evalf(prec, maxn=1).
- Returns Abs(evaluated_arg, evaluate=False) to preserve the exact structure of the evaluated expression.

##### Added tests in sympy/functions/elementary/tests/test_complexes.py.

#### Other comments
Based on my understanding, I found that the presence of symbols in expression raised `NotImplementedError` in `get_abs` method, which results in a fallback mechanism where `evalf` calls `Abs._eval_evalf(prec)`. Since `Abs` class just inherited this method from `EvalfMixin`, it resulted in the expression being returned as it is without modifications. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `Abs.n()` not evaluating constants.

<!-- END RELEASE NOTES -->
