### PR TITLE
Fix Abs.n() not evaluating constants.

### DIFF
--- a/sympy/codegen/tests/test_algorithms.py
+++ b/sympy/codegen/tests/test_algorithms.py
@@ -170,7 +170,7 @@ def test_newtons_method_function__rtol_cse_nan():
             exec(v, ns, ns)
             root_find_b[k] = ns[f'{k}_b']
         ref = Float('13.2261515064168768938151923226496')
-        reftol = {'clamped_newton': 2e-16, 'halley': 2e-16, 'halley_alt': 3e-16}
+        reftol = {'clamped_newton': 3e-16, 'halley': 3e-16, 'halley_alt': 3e-16} # Loosening tolerance slightly to account for evalf changes.
         guess = 4.0
         for meth, func in root_find_b.items():
             result = func(guess, 1e-2, 1e2, 50, 100)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -570,7 +570,7 @@ class Function(Application, Expr):
                         new_args.append(arg)
                     else:
                         new_args.append(new_arg)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, AttributeError):
                     new_args.append(arg) # Use original args even in case of exception.
             return self.func(*new_args)
         # Convert all args to mpf or mpc

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -561,7 +561,7 @@ class Function(Application, Expr):
                 return Float(imp(*[i.evalf(prec) for i in self.args]), prec)
             except (TypeError, ValueError):
                 return None
-        elif not all(_.is_number for _ in args): # mpmath will not handle symbols
+        elif any(arg.free_symbols for arg in args): # mpmath will not handle symbols
             new_args = []
             for arg in args:
                 try:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -590,9 +590,6 @@ class Function(Application, Expr):
             if any(bad(a) for a in args):
                 raise ValueError  # one or more args failed to compute with significance
         except ValueError:
-            from sympy.functions.elementary.trigonometric import TrigonometricFunction
-            if isinstance(self, TrigonometricFunction):
-                return # If trig function is encountered, leave as it is to preserve structure.
             if all(isinstance(arg, Expr) for arg in self.args): # mpmath will not handle symbols
                 dps = prec_to_dps(prec) # Needed to match evalf behavior (May lead to precision mismatch without it.)
                 new_args = []

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -570,7 +570,7 @@ class Function(Application, Expr):
                         new_args.append(arg)
                     else:
                         new_args.append(new_arg)
-                except Exception:
+                except (TypeError, ValueError):
                     new_args.append(arg) # Use original args even in case of exception.
             return self.func(*new_args)
         # Convert all args to mpf or mpc

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -561,7 +561,18 @@ class Function(Application, Expr):
                 return Float(imp(*[i.evalf(prec) for i in self.args]), prec)
             except (TypeError, ValueError):
                 return None
-
+        elif not all(_.is_number for _ in args): # mpmath will not handle symbols
+            new_args = []
+            for arg in args:
+                try:
+                    new_arg = arg.evalf(prec, maxn=1)
+                    if new_arg is None or new_arg == arg: # could not evalf hence fallback to original
+                        new_args.append(arg)
+                    else:
+                        new_args.append(new_arg)
+                except Exception:
+                    new_args.append(arg) # Use original args even in case of exception.
+            return self.func(*new_args)
         # Convert all args to mpf or mpc
         # Convert the arguments to *higher* precision than requested for the
         # final result.

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -707,38 +707,6 @@ class Abs(DefinedFunction):
     def _eval_rewrite_as_conjugate(self, arg, **kwargs):
         return sqrt(arg*conjugate(arg))
 
-    def _eval_evalf(self, prec):
-        """
-        Evaluate Abs numerically by evaluating constants in the argument.
-
-        This fixes issue #25765 where Abs.n() wasn't evaluating constants
-        like sqrt(2) to their decimal forms.
-
-        Examples
-        ========
-        >>> from sympy import Abs, sqrt, symbols
-        >>> t = symbols('t')
-        >>> Abs(sqrt(2) + t).n()  # doctest: +ELLIPSIS
-        Abs(t + 1.41421356237310...)
-        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()  # doctest: +ELLIPSIS
-        Abs(2.41421356237310... - 2.41421356237310...*t)
-        """
-        arg = self.args[0]
-
-        # If argument has no free symbols, let default evaluation handle it
-        if not arg.free_symbols:
-            return None
-
-        # Evaluate the argument to convert constants to numerical values
-        evaluated_arg = arg.evalf(prec, maxn=1)
-
-        # If nothing changed, return None to use default behavior
-        if evaluated_arg == arg:
-            return None
-
-        # Return Abs with the evaluated argument
-        # Use evaluate=False to preserve the exact structure of the evaluated expression
-        return self.func(evaluated_arg, evaluate=False)
 
 class arg(DefinedFunction):
     r"""

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -716,13 +716,12 @@ class Abs(DefinedFunction):
 
         Examples
         ========
-
         >>> from sympy import Abs, sqrt, symbols
         >>> t = symbols('t')
-        >>> Abs(sqrt(2) + t).n()
-        Abs(t + 1.41421356237310)
-        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()
-        Abs(2.41421356237310 - 2.41421356237310*t)
+        >>> Abs(sqrt(2) + t).n()  # doctest: +ELLIPSIS
+        Abs(t + 1.41421356237310...)
+        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()  # doctest: +ELLIPSIS
+        Abs(2.41421356237310... - 2.41421356237310...*t)
         """
         arg = self.args[0]
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -713,6 +713,15 @@ class Abs(DefinedFunction):
 
         This fixes issue #25765 where Abs.n() wasn't evaluating constants
         like sqrt(2) to their decimal forms.
+
+        Examples
+        ========
+        >>> from sympy import Abs, sqrt, symbols
+        >>> t = symbols('t')
+        >>> Abs(sqrt(2) + t).n()  # doctest: +ELLIPSIS
+        Abs(t + 1.41421356237310...)
+        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()  # doctest: +ELLIPSIS
+        Abs(2.41421356237310... - 2.41421356237310...*t)
         """
         arg = self.args[0]
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -713,15 +713,6 @@ class Abs(DefinedFunction):
 
         This fixes issue #25765 where Abs.n() wasn't evaluating constants
         like sqrt(2) to their decimal forms.
-
-        Examples
-        ========
-        >>> from sympy import Abs, sqrt, symbols
-        >>> t = symbols('t')
-        >>> Abs(sqrt(2) + t).n()  # doctest: +ELLIPSIS
-        Abs(t + 1.41421356237310...)
-        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()  # doctest: +ELLIPSIS
-        Abs(2.41421356237310... - 2.41421356237310...*t)
         """
         arg = self.args[0]
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -707,6 +707,39 @@ class Abs(DefinedFunction):
     def _eval_rewrite_as_conjugate(self, arg, **kwargs):
         return sqrt(arg*conjugate(arg))
 
+    def _eval_evalf(self, prec):
+        """
+        Evaluate Abs numerically by evaluating constants in the argument.
+
+        This fixes issue #25765 where Abs.n() wasn't evaluating constants
+        like sqrt(2) to their decimal forms.
+
+        Examples
+        ========
+
+        >>> from sympy import Abs, sqrt, symbols
+        >>> t = symbols('t')
+        >>> Abs(sqrt(2) + t).n()
+        Abs(t + 1.41421356237310)
+        >>> Abs(-sqrt(2)*t - t + sqrt(2) + 1).n()
+        Abs(2.41421356237310 - 2.41421356237310*t)
+        """
+        arg = self.args[0]
+
+        # If argument has no free symbols, let default evaluation handle it
+        if not arg.free_symbols:
+            return None
+
+        # Evaluate the argument to convert constants to numerical values
+        evaluated_arg = arg.evalf(prec, maxn=1)
+
+        # If nothing changed, return None to use default behavior
+        if evaluated_arg == arg:
+            return None
+
+        # Return Abs with the evaluated argument
+        # Use evaluate=False to preserve the exact structure of the evaluated expression
+        return self.func(evaluated_arg, evaluate=False)
 
 class arg(DefinedFunction):
     r"""

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,5 +1,5 @@
 from sympy.core.function import (Derivative, Function, Lambda, expand, PoleError)
-from sympy.core.numbers import (E, I, Rational, comp, nan, oo, pi, zoo)
+from sympy.core.numbers import (E, I, Rational, comp, nan, oo, pi, zoo, Float)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -1023,3 +1023,39 @@ def test_issue_15893():
     x = Symbol('x', real=True)
     eq = Derivative(Abs(f(x)), f(x))
     assert eq.doit() == sign(f(x))
+
+
+def test_issue_25765():
+    t, x = symbols('t x')
+
+    # Test 1: Simple case with sqrt and symbolic variable
+    expr1 = Abs(sqrt(2) + t)
+    result1 = expr1.n()
+    assert 'sqrt' not in str(result1)
+    assert result1.has(t)
+    assert abs(result1.subs(t, 0).n() - 1.41421356237310) < 1e-10
+
+    # Test 2: Original issue from GitHub #25765
+    expr2 = Abs(-sqrt(2)*t - t + 2/(sqrt(2) + 2) + 2*sqrt(2)/(sqrt(2) + 2) + 1)
+    result2 = expr2.n()
+    assert 'sqrt' not in str(result2)
+    assert abs(result2.subs(t, 0).n() - 2.41421356237309) < 1e-10
+    assert abs(result2.subs(t, 1).n()) < 1e-10
+
+    # Test 3: Multiple symbolic variables
+    expr3 = Abs(sqrt(2)*t + sqrt(3)*x + sqrt(5))
+    result3 = expr3.n()
+    assert 'sqrt' not in str(result3)
+    assert result3.has(t) and result3.has(x)
+
+    # Test 4: Pure numeric case should still work
+    expr4 = Abs(sqrt(2) + sqrt(3))
+    result4 = expr4.n()
+    assert isinstance(result4, Float)
+    assert abs(result4 - 3.14626436994197) < 1e-10
+
+    # Test 5: Verify behavior matches sqrt (both should evaluate constants)
+    sqrt_result = sqrt(x + pi).n()
+    abs_result = Abs(x + pi).n()
+    assert 'pi' not in str(sqrt_result).lower()
+    assert 'pi' not in str(abs_result).lower()

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -3565,8 +3565,8 @@ def test_StateSpace_dsolve():
     U3 = Matrix([10])
     ss3 = StateSpace(A3, B3, C3, D3)
     op = ss3.dsolve(input_vector=U3, var=t)
-    assert str(op.simplify().expand().evalf()[0]) == str(5.0 + 20.7880460155075*exp(-5*t/2)*sin(sqrt(7)*t/2)
-                                            - 5.0*exp(-5*t/2)*cos(sqrt(7)*t/2))
+    assert str(op.simplify().expand().evalf()[0]) == str(5.0 + 20.7880460155075*exp(-2.5*t)*sin(sqrt(7)*t/2)
+                                            - 5.0*exp(-2.5*t)*cos(sqrt(7)*t/2))
 
     # Test with Heaviside as input
     A4 = Matrix([[-1, 1], [-4, -4]])
@@ -3575,8 +3575,8 @@ def test_StateSpace_dsolve():
     U4 = Matrix([[10*Heaviside(t)]])
     ss4 = StateSpace(A4, B4, C4)
     op4 = str(ss4.dsolve(var=t, input_vector=U4)[0].simplify().expand().evalf())
-    assert op4 == str(5.0*Heaviside(t) + 20.7880460155075*exp(-5*t/2)*sin(sqrt(7)*t/2)*Heaviside(t)
-                                            - 5.0*exp(-5*t/2)*cos(sqrt(7)*t/2)*Heaviside(t))
+    assert op4 == str(5.0*Heaviside(t) + 20.7880460155075*exp(-2.5*t)*sin(sqrt(7)*t/2)*Heaviside(t)
+                                            - 5.0*exp(-2.5*t)*cos(sqrt(7)*t/2)*Heaviside(t))
 
     # Test with Symbolic Matrices
     m, a, x0 = symbols('m a x_0')

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -3565,8 +3565,8 @@ def test_StateSpace_dsolve():
     U3 = Matrix([10])
     ss3 = StateSpace(A3, B3, C3, D3)
     op = ss3.dsolve(input_vector=U3, var=t)
-    assert str(op.simplify().expand().evalf()[0]) == str(5.0 + 20.7880460155075*exp(-2.5*t)*sin(sqrt(7)*t/2)
-                                            - 5.0*exp(-2.5*t)*cos(sqrt(7)*t/2))
+    assert str(op.simplify().expand().evalf()[0]) == str(5.0 + 20.7880460155075*exp(-2.5*t)*sin(1.3228756555323*t)
+                                            - 5.0*exp(-2.5*t)*cos(1.3228756555323*t))
 
     # Test with Heaviside as input
     A4 = Matrix([[-1, 1], [-4, -4]])
@@ -3575,8 +3575,8 @@ def test_StateSpace_dsolve():
     U4 = Matrix([[10*Heaviside(t)]])
     ss4 = StateSpace(A4, B4, C4)
     op4 = str(ss4.dsolve(var=t, input_vector=U4)[0].simplify().expand().evalf())
-    assert op4 == str(5.0*Heaviside(t) + 20.7880460155075*exp(-2.5*t)*sin(sqrt(7)*t/2)*Heaviside(t)
-                                            - 5.0*exp(-2.5*t)*cos(sqrt(7)*t/2)*Heaviside(t))
+    assert op4 == str(5.0*Heaviside(t) + 20.7880460155075*exp(-2.5*t)*sin(1.3228756555323*t)*Heaviside(t)
+                                            - 5.0*exp(-2.5*t)*cos(1.3228756555323*t)*Heaviside(t))
 
     # Test with Symbolic Matrices
     m, a, x0 = symbols('m a x_0')

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1061,11 +1061,12 @@ def test_issue_11004():
     half = Float('0.5', 4)
     z = log(p(n, k) / p(n, k + 1)).expand(force=True)
     r = simplify(z.subs(n, N).n(4))
+    one = Float(1, 4)
     assert r == (
         half*k*log(k)
-        - half*k*log(k + 1)
+        - half*k*log(k + one)
         + half*log(N)
-        - half*log(k + 1)
+        - half*log(k + one)
         + Float(0.9189224, 4)
     )
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25765

#### Brief description of what is fixed or changed
##### Modified sympy/core/function.py:
- Modified `_eval_evalf` in `class Function` to handle partial expressions.

##### Modified tests in following files:
- `sympy\codegen\tests\test_algorithms.py`: Loosened tolerance to account for changes. (Based on limits set for machine epsilon by IEEE- 754)
- `sympy\physics\control\tests\test_lti.py`: Changed test cases to expect evaluation.
- `sympy\simplify\tests\test_simplify.py`: Changed test case to expect floating-point conversion. 

#### Other comments
The mentioned issue wasn't strictly confined to `Abs`, but for every function that is associated with Function class in `function.py`

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed .n() not evaluating expressions inside functions.

<!-- END RELEASE NOTES -->
