### PR TITLE
Fix Python 3.9 compatibility: Replace bit_count() with bin().count('1')

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2216,7 +2216,7 @@ def _get_odd_parity_terms(n):
     with an odd number of ones.
     """
     return [[1 if (mask >> i) & 1 else 0 for i in range(n)]
-            for mask in range(1 << n) if mask.bit_count() % 2 == 1]
+            for mask in range(1 << n) if bin(mask).count("1") % 2 == 1]
 
 
 def _get_even_parity_terms(n):
@@ -2225,7 +2225,7 @@ def _get_even_parity_terms(n):
     with an even number of ones.
     """
     return [[1 if (mask >> i) & 1 else 0 for i in range(n)]
-            for mask in range(1 << n) if mask.bit_count() % 2 == 0]
+            for mask in range(1 << n) if bin(mask).count("1") % 2 == 0]
 
 
 def _simplified_pairs(terms):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -27,10 +27,10 @@ from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
 
 
-def _bit_count(i):
-    if sys.version_info > (3, 9):
-        return int.bit_count(i)
-    return bin(i).count("1")
+if sys.version_info > (3, 9):
+     _bit_count = int.bit_count
+else:
+    _bit_count = lambda i: bin(i).count("1")
 
 
 def as_Boolean(e):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2,6 +2,8 @@
 Boolean algebra module for SymPy
 """
 
+import sys
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, overload, Any
 from collections.abc import Iterable, Mapping
@@ -23,6 +25,12 @@ from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
+
+
+def _bit_count:
+    if sys.version_info > (3, 9):
+      return int.bit_count
+    return lambda i: bin(i).count("1")
 
 
 def as_Boolean(e):
@@ -2216,7 +2224,7 @@ def _get_odd_parity_terms(n):
     with an odd number of ones.
     """
     return [[1 if (mask >> i) & 1 else 0 for i in range(n)]
-            for mask in range(1 << n) if bin(mask).count("1") % 2 == 1]
+            for mask in range(1 << n) if _bit_count(mask) % 2 == 1]
 
 
 def _get_even_parity_terms(n):
@@ -2225,7 +2233,7 @@ def _get_even_parity_terms(n):
     with an even number of ones.
     """
     return [[1 if (mask >> i) & 1 else 0 for i in range(n)]
-            for mask in range(1 << n) if bin(mask).count("1") % 2 == 0]
+            for mask in range(1 << n) if _bit_count(mask) % 2 == 0]
 
 
 def _simplified_pairs(terms):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -27,10 +27,10 @@ from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
 
 
-def _bit_count:
+def _bit_count(i):
     if sys.version_info > (3, 9):
-      return int.bit_count
-    return lambda i: bin(i).count("1")
+        return int.bit_count(i)
+    return bin(i).count("1")
 
 
 def as_Boolean(e):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2,11 +2,10 @@
 Boolean algebra module for SymPy
 """
 
-import sys
-
 from __future__ import annotations
 from typing import TYPE_CHECKING, overload, Any
 from collections.abc import Iterable, Mapping
+import sys
 
 from collections import defaultdict
 from itertools import chain, combinations, product, permutations
@@ -28,7 +27,7 @@ from sympy.utilities.misc import filldedent
 
 
 if sys.version_info > (3, 9):
-     _bit_count = int.bit_count
+    _bit_count = int.bit_count
 else:
     _bit_count = lambda i: bin(i).count("1")
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes Python 3.9 compatibility issue in #28591
closes #28607

#### Brief description of what is fixed or changed

PR #28591 used `mask.bit_count()` which is only available in Python 3.10+, breaking CI on Python 3.9.

This fix replaces `mask.bit_count()` with `bin(mask).count("1")` which works on Python 3.9+ and provides identical functionality.

#### Other comments

Minimal fix to restore Python 3.9 compatibility while preserving all optimizations from #28591.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* logic
  * Fixed Python 3.9 compatibility in `_get_odd_parity_terms` and `_get_even_parity_terms` by replacing `bit_count()` with version aware `_bit_count`
<!-- END RELEASE NOTES -->