### PR TITLE
Fix `AccumBounds.intersection` to obey the commutativity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1667,6 +1667,8 @@ Willem Melching <willem.melching@gmail.com>
 Wolfgang Stöcher <wolfgang@stoecher.com> coproc <wolfgang@stoecher.com>
 Wyatt Peak <wyattpeak@gmail.com>
 Xiang Wu <hsiangwu@fb.com>
+Xiao <muzumayao@126.com> Xiao <88570037+T90REAL@users.noreply.github.com>
+Xiao <muzumayao@126.com> Xiao <muzumayao@126.com>
 Yang Yang <wdscxsj@gmail.com>
 Yaser AlOsh <yaseralosh@outlook.com> Yaser <yaseralosh@outlook.com>
 Yash Reddy <write2yashreddy@gmail.com>

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -679,7 +679,7 @@ class AccumulationBounds(Expr):
                 return other
 
         if other.min <= self.min:
-            if other.max < self.max:
+            if other.max <= self.max:
                 return AccumBounds(self.min, other.max)
             if other.max > self.max:
                 return self

--- a/sympy/calculus/tests/test_accumulationbounds.py
+++ b/sympy/calculus/tests/test_accumulationbounds.py
@@ -325,6 +325,8 @@ def test_intersection_AccumBounds():
     assert B(0, 3).intersection(B(-1, 2)) == B(0, 2)
     assert B(0, 3).intersection(B(-1, 4)) == B(0, 3)
     assert B(0, 1).intersection(B(2, 3)) == S.EmptySet
+    assert B(0.5, 1.0).intersection(B(0.0, 1.0)) == B(0.5, 1.0)
+    assert B(0.5, 1.0).intersection(B(0.0, 1.0)) == B(0.0, 1.0).intersection(B(0.5, 1.0))
     raises(TypeError, lambda: B(0, 3).intersection(1))
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28576 


#### Brief description of what is fixed or changed
`AccumBounds.intersection` fails when the two intervals share the same upper bound but differ on the lower bound. Change '<' to '<=' in the comparing logic.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:



* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fix `AccumBounds.intersection`, it obeys commutativity when the two intervals share the same upper bound but differ on the lower bound now.
<!-- END RELEASE NOTES -->
