### PR TITLE
Fix empty intersection in Plane. projection for extreme normal vectors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -222,6 +222,7 @@ Abhishek Verma <iamvermaabhishek@gmail.com>
 Abhishek kumar <kumar325571@gmail.com>
 Achal Jain <2achaljain@gmail.com>
 Adam Bloomston <adam@glitterfram.es> <mail@adambloomston>
+Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
 Addison Cugini <ajcugini@gmail.com>
 Addison Cugini <ajcugini@gmail.com> <addisonc@csmpm4z6d1ax.local>
 Addison Cugini <ajcugini@gmail.com> <addisonc@pcp065368pcs.dhcp.calpoly.edu>

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -781,7 +781,9 @@ class Plane(GeometryEntity):
         rv = Point(pt, dim=3)
         if rv in self:
             return rv
-        return self.intersection(Line3D(rv, rv + Point3D(self.normal_vector)))[0]
+        n = Point3D(self.normal_vector)
+        d = (rv - self.p1).dot(n) / n.dot(n)
+        return rv - d * n
 
     def random_point(self, seed=None):
         """ Returns a random point on the Plane.

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -255,8 +255,8 @@ def test_dimension_normalization():
     assert Plane((1, 2, 1), (2, 1, 0), (3, 1, 2)
         ).intersection((2, 1)) == [Point(2, 1, 0)]
 
-    p = Plane(Point3D(0, 0, 0), normal_vector=(1, 10**10, 1))
-    pt = Point3D(1, 1, 1)
+    p = Plane(Point3D(0, 0, 0), normal_vector=(10**-7, 0, 1))
+    pt = Point3D(1, 0, 0)
     proj = p.projection(pt)
     assert proj in p
     assert isinstance(proj, Point3D)

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -255,6 +255,12 @@ def test_dimension_normalization():
     assert Plane((1, 2, 1), (2, 1, 0), (3, 1, 2)
         ).intersection((2, 1)) == [Point(2, 1, 0)]
 
+    p = Plane(Point3D(0, 0, 0), normal_vector=(1, 10**10, 1))
+    pt = Point3D(1, 1, 1)
+    proj = p.projection(pt)
+    assert proj in p
+    assert isinstance(proj, Point3D)
+
 
 def test_parameter_value():
     t, u, v = symbols("t, u v")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

motivated by #28612

#### Brief description of what is fixed or changed

Fixed `IndexError` in `Plane.projection()` when normal vector has zero components. Replaced intersection-based approach with direct projection formula.

#### Other comments

Added test cases for edge cases.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* geometry
  * Fixed `IndexError` in `Plane.projection()` for planes with zero normal vector components.

<!-- END RELEASE NOTES -->