### PR TITLE
select correct _bit_count

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -26,9 +26,9 @@ from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
 
 
-if sys.version_info > (3, 9):
+try:  # sys.version_info >= (3, 10)
     _bit_count = int.bit_count
-else:
+except AttributeError:
     _bit_count = lambda i: bin(i).count("1")
 
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -5,7 +5,6 @@ Boolean algebra module for SymPy
 from __future__ import annotations
 from typing import TYPE_CHECKING, overload, Any
 from collections.abc import Iterable, Mapping
-import sys
 
 from collections import defaultdict
 from itertools import chain, combinations, product, permutations

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3,7 +3,7 @@ Boolean algebra module for SymPy
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, overload, Any
+from typing import TYPE_CHECKING, overload, Any, Callable
 from collections.abc import Iterable, Mapping
 
 from collections import defaultdict
@@ -26,7 +26,7 @@ from sympy.utilities.misc import filldedent
 
 
 try:  # sys.version_info >= (3, 10)
-    _bit_count = int.bit_count
+    _bit_count: Callable[[int], int] = int.bit_count
 except AttributeError:
     _bit_count = lambda i: bin(i).count("1")
 


### PR DESCRIPTION
sys.version_info > (3,9) failed to discriminate for version (3,10), perhaps because of a microversion control number? So I am using a try/except AttributeError instead.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
