### PR TITLE
Add LLVMJitCode module documentation

### DIFF
--- a/docs/src/modules/printing/index.rst
+++ b/docs/src/modules/printing/index.rst
@@ -1,0 +1,8 @@
+Printing Module
+===============
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   llvmjitcode

--- a/docs/src/modules/printing/llvmjitcode.rst
+++ b/docs/src/modules/printing/llvmjitcode.rst
@@ -1,0 +1,47 @@
+LLVMJITCode Module
+==================
+
+This module uses llvmlite to create executable functions from SymPy expressions.
+The primary goal is to significantly accelerate the numerical evaluation of
+expressions, which is especially useful for functions that need to be called
+repeatedly with different arguments (e.g., in numerical integration, optimization, or plotting).
+
+Public API
+----------
+
+- `LLVMJitPrinter` : A printer class that converts SymPy expressions into LLVM code.
+- `llvm_callable` : Compile a SymPy expression into a callable Python function.
+
+Dependencies
+------------
+
+- Requires llvmlite: https://github.com/numba/llvmlite
+
+Example
+-------
+
+.. code-block:: python
+
+    from sympy import symbols
+    from sympy.printing.llvmjitcode import llvm_callable
+
+    x, y = symbols("x y")
+    expr = x**2 + y**2
+
+    f = llvm_callable(expr, [x, y])
+    result = f(2, 3)  # returns 13
+
+API Reference
+-------------
+
+.. autoclass:: sympy.printing.llvmjitcode.LLVMJitCode
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: sympy.printing.llvmjitcode.LLVMJitPrinter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autofunction:: sympy.printing.llvmjitcode.llvm_callable


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #28470

#### Brief description of what is fixed or changed
Added a new documentation file llvmjitcode.rst for the LLVMJitCode, LLVMJitPrinter, and llvm_callable components.

Updated the index.rst in the printing module to include the new documentation page.

Verified that the Sphinx build completes successfully and HTML pages are generated for the new documentation.


#### Other comments
This PR only adds documentation; no code changes are included.

The documentation includes usage examples, public API description, and dependencies.


#### Release Notes


<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added Sphinx documentation for LLVM JIT code generation module, including `LLVMJitCode`, `LLVMJitPrinter`, and `llvm_callable`.

<!-- END RELEASE NOTES -->
