### PR TITLE
Consider the case where the result of `factorint` is not prime

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1536,7 +1536,6 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
                                  verbose=verbose)
                 for k, v in facs.items():
                     factors[k] = factors.get(k, 0) + v
-                factor_cache.add(n, facs)
             if verbose:
                 print(complete_msg)
             return factors

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -266,6 +266,10 @@ def test_factorint():
     assert factorint(28300421052393658575) == {3: 1, 5: 2, 11: 2, 43: 1, 2063: 2, 4127: 1, 4129: 1}
     assert factorint(2063**2 * 4127**1 * 4129**1) == {2063: 2, 4127: 1, 4129: 1}
     assert factorint(2347**2 * 7039**1 * 7043**1) == {2347: 2, 7039: 1, 7043: 1}
+    #issue 28621
+    assert factorint(978188756923448938700236182276357436, limit=2**15,
+                     use_trial=True, use_rho=False, use_pm1=False) ==\
+                          {2: 2, 494517127261244783: 1, 494517127415229473: 1}
 
     assert factorint(0, multiple=True) == [0]
     assert factorint(1, multiple=True) == []


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #28621

#### Brief description of what is fixed or changed
When the `limit` option is specified, `factorint` may return a result that is not fully factored. However, `factor_cache` had been assuming that the result of `factorint` was always a complete factorization. I updated it so that it no longer caches results except in places where a prime result is guaranteed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * We fixed an issue where `factorint` could fail when the `limit` option was specified.
<!-- END RELEASE NOTES -->
