### PR TITLE
Implementation of quotient group method for permutation groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5034,6 +5034,42 @@ class PermutationGroup(Basic):
 
         return PolycyclicGroup(pc_sequence, pc_series, relative_order, collector=None)
 
+    def quotient_group(self,N):
+        """
+        Returns a permutation group isomorphic to the quotient group of G/N .
+
+        Explanation
+        ===========
+
+        The method constructs the quotient group G/N by determining
+        its faithful permutation representation induced by the
+        action of G's generators on the set of N's cosets.
+
+        Example
+        ========
+
+        >>> from sympy.combinatorics.homomorphisms import is_isomorphic
+        >>> from sympy.combinatorics.named_groups import SymmetricGroup, AlternatingGroup, CyclicGroup
+        >>> G = SymmetricGroup(4)
+        >>> N = AlternatingGroup(4)
+        >>> Q = G.quotient_group(N)
+        >>> Q_expected = CyclicGroup(2)
+        >>> is_isomorphic(Q, Q_expected)
+        True
+
+        """
+        if not N.is_normal(self):
+            raise ValueError("N must be a normal subgroup of G")
+        else:
+            t = self.coset_table(N)
+
+        gen = []
+        for j in range(len(t[0])):
+            p = [t[i][j] for i in range(len(t))]
+            gen.append(Permutation(p))
+
+        return PermutationGroup(gen)
+
 
 def _orbit(degree, generators, alpha, action='tuples'):
     r"""Compute the orbit of alpha `\{g(\alpha) | g \in G\}` as a set.

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1240,3 +1240,10 @@ def test_symmetricpermutationgroup():
     assert a.degree == 5
     assert a.order() == 120
     assert a.identity() == Permutation(4)
+
+def test_quotient_group():
+    G = SymmetricGroup(4)
+    N = AlternatingGroup(4)
+    Q = G.quotient_group(N)
+    Q_expected = CyclicGroup(2)
+    assert(is_isomorphic(Q, Q_expected) == True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
A new method for the computation of the quotient group is implemented for permutation groups. 

#### Other comments
The method constructs the quotient group G/N by determining its faithful permutation representation induced by the action of G's generators on the set of N's cosets

Quoting chapter 3.1 of _"handbook_ of computational group theory" : 

> "if_ we need a faithful representation of a proper quotient of an existing permutation or matrix group, then the only default choice is the regular representation." 

This underlines that while there are specific subgroups that support specifically suited approaches, the implementation of this pr is the only approach that works in the general scenario. 

Here is a brief overview of the math underlying the algorithm: 

Since **N** is normal, every generator of **G** induces a well-defined permutation on the set of **N**'s cosets,  (computed via the **coset_table**).
So we can define the homomorphism **f: G---> Sym(G/N)**. 
The permutation group **Q** generated by these coset actions (the image of f) is guaranteed to be isomorphic to the group **G/N**. 
That s because **ker(f)=N**, and therefore the first isomorphism theorem states that **G/N** is isomorphic to **image(f)**.

Further explanations of permutation representations can be found at chapter 2.2 of  "handbook of computational group theory". 

I also already tested the algorithm with various quotients, with positive results.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * implementation of quotient_group method for permutation groups
<!-- END RELEASE NOTES -->
