### PR TITLE
Fix float(0.0) handling in matrix_to_vector (fixes #28627)

### DIFF
--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -424,6 +424,11 @@ def matrix_to_vector(matrix, system):
     outvec = Vector.zero
     vects = system.base_vectors()
     for i, x in enumerate(matrix):
+        # --- FIX for Issue #28627 ---
+        # Float(0.0) may turn into special Zero() object.
+        # Convert any "zero-like" element to Python int 0.
+        if hasattr(x, "is_zero") and x.is_zero:
+            x = 0
         outvec += x * vects[i]
     return outvec
 

--- a/sympy/vector/tests/test_matrix_to_vector_float_zero.py
+++ b/sympy/vector/tests/test_matrix_to_vector_float_zero.py
@@ -1,0 +1,9 @@
+from sympy import ImmutableMatrix as Matrix
+from sympy.vector import CoordSys3D, matrix_to_vector
+
+def test_matrix_to_vector_float_zero():
+    C = CoordSys3D('C')
+    m = Matrix([0.0, 2, 3])
+    v = matrix_to_vector(m, C)
+    assert v.to_matrix(C).equals(m)
+


### PR DESCRIPTION
This PR fixes Issue #28627 where `matrix_to_vector` raised an error:

    AttributeError: 'Zero' object has no attribute '_base_instance'

The regression appeared when the input matrix contained `Float(0.0)`.  
Such entries were converted internally to `Zero`, which lacks attributes expected for scalar operations.
### Fix
Inside `matrix_to_vector`, normalize zero-like elements using:

    if hasattr(x, "is_zero") and x.is_zero:
        x = 0

This ensures consistent scalar behavior for both `0` and `0.0` inputs.
### Tests
Added a regression test:

`sympy/vector/tests/test_matrix_to_vector_float_zero.py`

This ensures matrices containing `Float(0.0)` convert correctly into Vector objects.

### Issue
Fixes #28627

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* vector
  * Fixed AttributeError when converting matrices containing `Float(0.0)` to vectors using `matrix_to_vector`.
<!-- END RELEASE NOTES -->

