### PR TITLE
Fix AttributeError for vector conversion with float 0.0

### DIFF
--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -204,6 +204,8 @@ class BasisDependentAdd(BasisDependent, Add):
                 continue
             # Else, update components accordingly
             for x in arg.components:
+                if not hasattr(x, '_base_instance'):
+                    continue
                 components[x] = components.get(x, 0) + arg.components[x]
 
         temp = list(components.keys())

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -260,7 +260,7 @@ class BasisDependentMul(BasisDependent, Mul):
             if isinstance(arg, cls._zero_func):
                 count += 1
                 zeroflag = True
-            elif arg == S.Zero or arg == 0.0:
+            elif arg == S.Zero or arg == 0.0 or (hasattr(arg, 'is_zero') and arg.is_zero):
                 zeroflag = True
             elif isinstance(arg, (cls._base_func, cls._mul_func)):
                 count += 1

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -163,6 +163,10 @@ def test_matrix_to_vector():
            Vector.zero
     m = Matrix([[q1], [q2], [q3]])
     assert matrix_to_vector(m, N) == q1*N.i + q2*N.j + q3*N.k
+    m = Matrix([[0.0], [2], [3]])
+    v = matrix_to_vector(m, C)
+    assert v == 2*C.j + 3*C.k
+    assert v.to_matrix(C) == Matrix([[0], [2], [3]])
 
 
 def test_orthogonalize():

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -167,6 +167,8 @@ def test_matrix_to_vector():
     v = matrix_to_vector(m, C)
     assert v == 2*C.j + 3*C.k
     assert v.to_matrix(C) == Matrix([[0], [2], [3]])
+    assert C.i * 0.0 == Vector.zero
+    assert 0.0 * C.i == Vector.zero
 
 
 def test_orthogonalize():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28627

#### Brief description of what is fixed or changed

Fixed `AttributeError: 'Zero' object has no attribute '_base_instance'` when converting matrices containing `Float(0.0)` to vectors. Added defensive check in `BasisDependentAdd.__new__()` to skip components without `_base_instance` attribute.

#### Other comments

Added test case for `matrix_to_vector()` with `Float(0.0)`.

#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
  * Fixed `AttributeError` when converting matrices with `Float(0.0)` to vectors using `matrix_to_vector()`
<!-- END RELEASE NOTES -->
