### PR TITLE
Evaluate gradient of matrix expression not containing deriving variable to ZeroMatrix

### DIFF
--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -647,3 +647,16 @@ def test_matexpr_derivative_by_matrix_element():
 
     A = MatrixSymbol(a, a, a)
     assert A.diff(Y[a,a]) == ZeroMatrix(a, a)
+
+
+def test_issue_28617():
+    X = MatrixSymbol("X", 3, 3)
+    a = MatrixSymbol("a", 3, 1)
+
+    expr = sqrt(a.T*a)
+    result = expr.diff(X)
+    assert result == ZeroMatrix(3, 3)
+
+    expr = a.T*a
+    result = expr.diff(X)
+    assert result == ZeroMatrix(3, 3)

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -76,6 +76,8 @@ class ArrayDerivative(Derivative):
         if expr.has(v):
             return _matrix_derivative(expr, v)
         else:
+            if isinstance(expr, MatrixExpr) and isinstance(v, MatrixExpr) and expr.shape == (1, 1):
+                return ZeroMatrix(*v.shape)
             return None
 
     @classmethod


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28617

#### Brief description of what is fixed or changed

Matrix derivatives now correctly evaluate to ZeroMatrix when expression doesn't contain the deriving variable.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed matrix derivatives to return ZeroMatrix when expression doesn't contain deriving variable.
<!-- END RELEASE NOTES -->
