### PR TITLE
fix alternating group

### DIFF
--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -91,25 +91,28 @@ def AlternatingGroup(n):
 
     """
     # small cases are special
-    if n in (1, 2):
-        return PermutationGroup([Permutation([0])])
+    if n == 1:
+        G = PermutationGroup([Permutation([0])])
+    elif n == 2:
+        G = PermutationGroup([Permutation([0,1])])
 
-    a = list(range(n))
-    a[0], a[1], a[2] = a[1], a[2], a[0]
-    gen1 = a
-    if n % 2:
-        a = list(range(1, n))
-        a.append(0)
-        gen2 = a
     else:
-        a = list(range(2, n))
-        a.append(1)
-        a.insert(0, 0)
-        gen2 = a
-    gens = [gen1, gen2]
-    if gen1 == gen2:
-        gens = gens[:1]
-    G = PermutationGroup([_af_new(a) for a in gens], dups=False)
+        a = list(range(n))
+        a[0], a[1], a[2] = a[1], a[2], a[0]
+        gen1 = a
+        if n % 2:
+            a = list(range(1, n))
+            a.append(0)
+            gen2 = a
+        else:
+            a = list(range(2, n))
+            a.append(1)
+            a.insert(0, 0)
+            gen2 = a
+        gens = [gen1, gen2]
+        if gen1 == gen2:
+            gens = gens[:1]
+        G = PermutationGroup([_af_new(a) for a in gens], dups=False)
 
     set_alternating_group_properties(G, n, n)
     G._is_alt = True
@@ -118,6 +121,8 @@ def AlternatingGroup(n):
 
 def set_alternating_group_properties(G, n, degree):
     """Set known properties of an alternating group. """
+    if n < 3:
+        G._order = 1
     if n < 4:
         G._is_abelian = True
         G._is_nilpotent = True
@@ -129,7 +134,10 @@ def set_alternating_group_properties(G, n, degree):
     else:
         G._is_solvable = False
     G._degree = degree
-    G._is_transitive = True
+    if n == 2:
+        G._is_transitive = False
+    else:
+        G._is_transitive = True
     G._is_dihedral = False
 
 

--- a/sympy/combinatorics/tests/test_named_groups.py
+++ b/sympy/combinatorics/tests/test_named_groups.py
@@ -58,6 +58,8 @@ def test_AlternatingGroup():
     assert H.order() == 1
     L = AlternatingGroup(2)
     assert L.order() == 1
+    assert L.degree == 2
+    assert SymmetricGroup(2).index(L) == 2
 
 
 def test_AbelianGroup():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28636 

#### Brief description of what is fixed or changed
Alternating group on 2 elements was incorrectly generated on the identical permutation on one element

#### Other comments
Now the cases on 1 or 2 elements are handled separately.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Alternating group of order 2 was instantiated as the identity permutation on one element, now it is instantiated as the identity permutation on 2 elements as it should. 
<!-- END RELEASE NOTES -->
