### PR TITLE
Fix AbelianGroup(1).random() crash with trivial group

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1325,6 +1325,12 @@ class PermutationGroup(Basic):
         transversals = self.basic_transversals
         basic_orbits = self.basic_orbits
         m = len(base)
+        if m == 0:
+            h = list(range(self._degree))
+            if af:
+                return h
+            else:
+                return _af_new(h)
         v = [0]*m
         for i in range(m):
             rank, c = divmod(rank, len(transversals[i]))

--- a/sympy/combinatorics/tests/test_named_groups.py
+++ b/sympy/combinatorics/tests/test_named_groups.py
@@ -65,6 +65,12 @@ def test_AbelianGroup():
     assert A.order() == 27
     assert A.is_abelian is True
 
+    B = AbelianGroup(1)
+    assert B.order() == 1
+    assert B.degree == 1
+    r = B.random()
+    assert r == B.identity
+
 
 def test_RubikGroup():
     raises(ValueError, lambda: RubikGroup(1))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28635

#### Brief description of what is fixed or changed

**Before (crashed):**
```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], line 4
      1 from sympy.combinatorics.named_groups import AbelianGroup
      3 G = AbelianGroup(1)
----> 4 G.random()

File /lib/python3.12/site-packages/sympy/combinatorics/perm_groups.py:3424, in PermutationGroup.random(self, af)
   3421 """Return a random group element
   3422 """
   3423 rank = randrange(self.order())
-> 3424 return self.coset_unrank(rank, af)

File /lib/python3.12/site-packages/sympy/combinatorics/perm_groups.py:1333, in PermutationGroup.coset_unrank(self, rank, af)
   1331     v[i] = basic_orbits[i][c]
   1332 a = [transversals[i][v[i]]._array_form for i in range(m)]
-> 1333 h = _af_rmuln(*a)
   1334 if af:
   1335     return h

File /lib/python3.12/site-packages/sympy/combinatorics/permutations.py:109, in _af_rmuln(*abc)
    107     return [a[i] for i in b]
    108 if m == 0:
--> 109     raise ValueError("String must not be empty")
    110 p0 = _af_rmuln(*a[:m//2])
    111 p1 = _af_rmuln(*a[m//2:])

ValueError: String must not be empty

```
**After**
```python
from sympy.combinatorics.named_groups import AbelianGroup
G = AbelianGroup(1)
G.random()  # Returns: (0) - the identity element
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* combinatorics
  * Fixed [AbelianGroup(1).random()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/named_groups.py:7:0-52:12) crash. Trivial groups now correctly return identity element.

<!-- END RELEASE NOTES -->