### PR TITLE
Add tests for TransferFunction.dc_gain

### DIFF
--- a/sympy/physics/control/tests/test_dc_gain.py
+++ b/sympy/physics/control/tests/test_dc_gain.py
@@ -1,4 +1,3 @@
-import pytest
 from sympy import symbols, Rational, oo
 from sympy.physics.control.lti import TransferFunction
 

--- a/sympy/physics/control/tests/test_dc_gain.py
+++ b/sympy/physics/control/tests/test_dc_gain.py
@@ -1,0 +1,32 @@
+import pytest
+from sympy import symbols, Rational, oo
+from sympy.physics.control.lti import TransferFunction
+
+def test_dc_gain_constant_num_den():
+    s = symbols('s')
+    G = TransferFunction(5, s + 2, s)
+    assert G.dc_gain() == Rational(5, 2)
+
+
+def test_dc_gain_polynomial_num_den():
+    s = symbols('s')
+    G = TransferFunction(s**2 + 3*s + 2, (s + 1)*(s + 2), s)
+    assert G.dc_gain() == 1
+
+
+def test_dc_gain_zero_numerator():
+    s = symbols('s')
+    G = TransferFunction(0, s + 5, s)
+    assert G.dc_gain() == 0
+
+
+def test_dc_gain_den_zero_at_zero_returns_infinity():
+    s = symbols('s')
+    G = TransferFunction(1, s, s)
+    assert G.dc_gain() == oo
+
+
+def test_dc_gain_negative_power_gives_infinity():
+    s = symbols('s')
+    G = TransferFunction(1/s, 1, s)
+    assert G.dc_gain() == oo

--- a/sympy/physics/control/tests/test_dc_gain.py
+++ b/sympy/physics/control/tests/test_dc_gain.py
@@ -1,3 +1,4 @@
+"""Tests for TransferFunction.dc_gain."""
 from sympy import symbols, Rational, oo
 from sympy.physics.control.lti import TransferFunction
 


### PR DESCRIPTION
### Summary

This PR adds missing unit tests for `TransferFunction.dc_gain()` in the
`sympy.physics.control` module.

### Tests added

- constant numerator / polynomial denominator
- polynomial numerator / polynomial denominator
- zero numerator case
- denominator zero at s = 0 → infinite dc gain
- negative power in numerator → infinite dc gain

### Motivation

`dc_gain()` is a commonly used helper in control engineering, but it previously
had no dedicated tests. These tests ensure correct symbolic behaviour for
standard and edge cases, improving coverage and reliability of the control module.

### Notes

No core logic changes were made; only new tests are added.
All tests pass locally (`74 passed`).
<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Added missing tests for `TransferFunction.dc_gain()`.
<!-- END RELEASE NOTES -->