### PR TITLE
Improve which_all_roots and add eigenvects test

### DIFF
--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -238,6 +238,25 @@ def test_eigenvects():
         assert M*vec_list[0] == val*vec_list[0]
 
 
+@slow
+def test_eigenvects_slow():
+    # https://github.com/sympy/sympy/issues/28507
+    # This test is slow because of issues/28486
+    # After the fix, this test should be moved to test_eigenvects
+    M = Matrix([
+        [123, 45, 67, 89, sqrt(13)/2],
+        [45, 234, 56, 78, Rational(19, 43)],
+        [67, 56, 345, 90, 5*sqrt(7)/3],
+        [Rational(17, 3), 12, 34, 456, sqrt(11)/7],
+        [Rational(55, 17), sqrt(11)/5, 12, 34, 56]
+    ])
+    vecs = M.eigenvects()
+    for val, mult, vec_list in vecs:
+        assert len(vec_list) == 1
+        diff = (M*vec_list[0]).n() - (val*vec_list[0]).n()
+        assert all(abs(x) < 1e-10 for x in diff)
+
+
 def test_left_eigenvects():
     M = Matrix([[0, 1, 1],
                 [1, 0, 0],

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3974,19 +3974,23 @@ class Poly(Basic):
         return f._which_roots(candidates, f.degree())
 
     def _which_roots(f, candidates, num_roots):
+        fe = f.as_expr()
+        x = f.gens[0]
         prec = 10
-        # using Counter bc its like an ordered set
-        root_counts = Counter(candidates)
-        while len(root_counts) > num_roots:
-            for r in list(root_counts.keys()):
-                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
-                f_r = f(r).evalf(prec, maxn=2*prec)
-                if abs(f_r)._prec >= 2:
-                    root_counts.pop(r)
+        candidates = list(Counter(candidates).keys())
 
+        while len(candidates) > num_roots:
+            potential_candidates = []
+            for r in candidates:
+                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
+                f_r = fe.xreplace({x: r}).evalf(prec, maxn=2*prec)
+                if abs(f_r)._prec < 2:
+                    potential_candidates.append(r)
+
+            candidates = potential_candidates
             prec *= 2
 
-        return list(root_counts.keys())
+        return candidates
 
     def same_root(f, a, b):
         """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see gh-https://github.com/sympy/sympy/pull/28512#issuecomment-3462785623
closes #28507
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This pr replace  f(r) with xreplace({x: r}) in  _which_roots for better performance and Added a test case for  eigenvects.
The issue(gh-28507) was already fixed in gh-28538 by using all_roots

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * The `all_roots` function was made faster for polynomials with algebraic coefficients.
<!-- END RELEASE NOTES -->
