### PR TITLE
Make check_dimensions error messages deterministic

### DIFF
--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -191,3 +191,8 @@ def test_check_dimensions():
     raises(ValueError, lambda: check_dimensions(2 * meter + 3 * second))
     raises(ValueError, lambda: check_dimensions(1 / second + 1 / meter))
     raises(ValueError, lambda: check_dimensions(2 * meter*(mile + centimeter) + km))
+
+def test_check_dimensions_error_message():
+    with raises(ValueError) as excinfo:
+        check_dimensions(meter + second)
+    assert str(excinfo.value) == "addends have incompatible dimensions: (((Dimension(length, L), 1),), ((Dimension(time, T), 1),))"

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -251,8 +251,9 @@ def check_dimensions(expr, unit_system="SI"):
             if not skip:
                 deset.add(tuple(sorted(dims, key=default_sort_key)))
                 if len(deset) > 1:
+                    sorted_deps = tuple(ordered(deset)) # make message deterministic
                     raise ValueError(
-                        "addends have incompatible dimensions: {}".format(deset))
+                        "addends have incompatible dimensions: {}".format(sorted_deps))
 
     # clear multiplicative constants on Dimensions which may be
     # left after substitution


### PR DESCRIPTION
#### Brief description of what is fixed or changed

If `check_dimensions` finds an error, the message can change non-deterministically between calls. This PR makes the message deterministic.

#### Other comments

I also added a test case for completeness' sake in a second commit. I don't think we usually test error messages, so you might want to cherry-pick only the first commit, depending on if you want the test case.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
