### PR TITLE
Fix nonlinsolve TypeError when solve_poly_system returns None

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3871,11 +3871,15 @@ def _handle_poly(polys, symbols):
             poly_sol = no_information
             poly_eqs = list(basis)
         else:
-            # Success! We have a finite solution set and solve_poly_system has
-            # succeeded in finding all solutions. Return the solutions and also
-            # an empty list of remaining equations to be solved.
-            poly_sol = [dict(zip(symbols, res)) for res in result]
-            poly_eqs = no_equations
+            if result is None:
+                poly_sol = no_solutions
+                poly_eqs = no_equations
+            else:
+                # Success! We have a finite solution set and solve_poly_system has
+                # succeeded in finding all solutions. Return the solutions and also
+                # an empty list of remaining equations to be solved.
+                poly_sol = [dict(zip(symbols, res)) for res in result]
+                poly_eqs = no_equations
 
     #
     # Infinite families of solutions (positive-dimensional case)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1950,6 +1950,9 @@ def test_nonlinsolve_polysys():
     system = [-x**2*z**2 + x*y*z + y**4, -2*x*z**2 + y*z, x*z + 4*y**3, -2*x**2*z + x*y]
     assert nonlinsolve(system, [x, y, z]) == FiniteSet((0, 0, z), (x, 0, 0))
 
+    lst = [x**2*(y-0.508793242825092)**2-sin(pi/8)*sqrt(0.508793242825092**2), (x-1)**2*y**2-0.508793242825092**2]
+    assert nonlinsolve(lst, x, y) == S.EmptySet
+
 
 def test_nonlinsolve_using_substitution():
     x, y, z, n = symbols('x, y, z, n', real = True)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28646

#### Brief description of what is fixed or changed
Fixed a `TypeError: 'NoneType' object is not iterable` that occurred in `nonlinsolve` when `solve_poly_system` returned `None`. The function `solve_poly_system` can return `None` when the computed Groebner basis contains only the ground (indicating no solutions), but the code in `_handle_poly` did not handle this case and attempted to iterate over `None`, causing a crash.

The fix adds a null check: when `result` is `None`, the function now correctly returns an empty solution set (`EmptySet`) instead of raising an exception.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed `nonlinsolve` raising `TypeError` when the polynomial system has no solutions and `solve_poly_system` returns `None`
<!-- END RELEASE NOTES -->