### PR TITLE
Fix induced_pcgs dropping generators at final depth

### DIFF
--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -674,7 +674,7 @@ class Collector(DefaultPrinting):
         >>> gens = [G[0], G[1]]
         >>> ipcgs = collector.induced_pcgs(gens)
         >>> [gen.order() for gen in ipcgs]
-        [3]
+        [3, 3]
 
         """
         z = [1]*len(self.pcgs)
@@ -683,7 +683,7 @@ class Collector(DefaultPrinting):
             g = G.pop(0)
             h = self._sift(z, g)
             d = self.depth(h)
-            if d < len(self.pcgs):
+            if d <= len(self.pcgs) and z[d-1] == 1:
                 for gen in z:
                     if gen != 1:
                         G.append(h**-1*gen**-1*h*gen)
@@ -705,6 +705,6 @@ class Collector(DefaultPrinting):
                 h = gen**(-f)*h
                 e[i] = f
                 d = self.depth(h)
-        if h == 1:
+        if h.is_identity:
             return e
         return False

--- a/sympy/combinatorics/tests/test_pc_groups.py
+++ b/sympy/combinatorics/tests/test_pc_groups.py
@@ -85,3 +85,26 @@ def test_induced_pcgs():
         for i in ipcgs:
             m.append(collector.exponent_vector(i))
         assert Matrix(m).is_upper
+
+
+def test_induced_pcgs_final_depth():
+    G = SymmetricGroup(3)
+    H = G.sylow_subgroup(2)
+    pc_group = H.polycyclic_group()
+    collector = pc_group.collector
+
+    ipcgs = collector.induced_pcgs(H.generators[:])
+    assert len(ipcgs) > 0
+
+    for gen in H.generators:
+        e = collector.constructive_membership_test(ipcgs, gen)
+        assert e != False
+
+        reconstructed = H.identity
+        for i, exp in enumerate(e):
+            reconstructed = reconstructed * ipcgs[i]**exp
+        assert reconstructed == gen
+
+    identity = H.identity
+    e_identity = collector.constructive_membership_test(ipcgs, identity)
+    assert e_identity == [0]


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28642

#### Brief description of what is fixed or changed
Fixed a bug in `collector.induced_pcgs()` where generators at the final depth (depth equal to the length of the PC sequence) were incorrectly excluded from the result. This caused `constructive_membership_test()` to always return `False` for non-identity elements in groups where all generators are at the final depth.

The fix changes the condition from `d < len(self.pcgs)` to `d <= len(self.pcgs) and z[d-1] == 1` to properly include generators at the final depth while avoiding reprocessing already-set positions.

Additionally fixed `constructive_membership_test()` to use `.is_identity` instead of comparing with integer `1`, which was causing incorrect identity checks.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed `collector.induced_pcgs()`dropping generators whose depth equals the length of the PC sequence, which caused `constructive_membership_test()` to incorrectly return `False` for valid group elements.
<!-- END RELEASE NOTES -->