### PR TITLE
initialized correctly .p_p method of modified coset table

### DIFF
--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -82,7 +82,7 @@ class CosetTable(DefaultPrinting):
         H = self.subgroup
         self._grp = free_group(', ' .join(["a_%d" % i for i in range(len(H))]))[0]
         self.P = [[None]*len(self.A)]
-        self.p_p = {}
+        self.p_p = {0:self._grp.identity}
 
     @property
     def omega(self):

--- a/sympy/combinatorics/tests/test_coset_table.py
+++ b/sympy/combinatorics/tests/test_coset_table.py
@@ -690,6 +690,12 @@ def test_coset_enumeration():
     assert C_r.table == table4
     assert C_c.table == table4
 
+    # regression test for wrong initialization of modified coset enumeration
+    F2, a, b = free_group("a, b")
+    H1 = FpGroup(F2, [a**2, b**2, (a*b)**3])
+    Y = [a*b, b**-1]
+    C = modified_coset_enumeration_r(H1, Y)
+    assert C.table == [[0, 0, 0, 0], [None, 0, 0, None]]
 
 def test_look_ahead():
     # Section 3.2 [Test Example] Example (d) from [2]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28652

#### Brief description of what is fixed or changed
Initializing correctly the .p_p method for the modified coset table

#### Other comments
Before this pr, the .p_p method of the modified coset table was initialized as an empty dictionnary. 
As you can see in this code:
```
def define(self, alpha, x, modified=False):
        r"""
        This routine is used in the relator-based strategy of Todd-Coxeter
        algorithm if some `\alpha^x` is undefined. We check whether there is
        space available for defining a new coset. If there is enough space
        then we remedy this by adjoining a new coset `\beta` to `\Omega`
        (i.e to set of live cosets) and put that equal to `\alpha^x`, then
        make an assignment satisfying Property[1]. If there is not enough space
        then we halt the Coset Table creation. The maximum amount of space that
        can be used by Coset Table can be manipulated using the class variable
        ``CosetTable.coset_table_max_limit``.

        See Also
        ========

        define_c

        """
        A = self.A
        table = self.table
        len_table = len(table)
        if len_table >= self.coset_table_limit:
            # abort the further generation of cosets
            raise ValueError("the coset enumeration has defined more than "
                    "%s cosets. Try with a greater value max number of cosets "
                    % self.coset_table_limit)
        table.append([None]*len(A))
        self.P.append([None]*len(self.A))
        # beta is the new coset generated
        beta = len_table   <--------------------------------
        self.p.append(beta)
        table[alpha][self.A_dict[x]] = beta
        table[beta][self.A_dict_inv[x]] = alpha
        # P[alpha][x] = epsilon, P[beta][x**-1] = epsilon
        if modified:
            self.P[alpha][self.A_dict[x]] = self._grp.identity
            self.P[beta][self.A_dict_inv[x]] = self._grp.identity
            self.p_p[beta] = self._grp.identity  <--------------------------------
```
Each time a new coset is added to the coset table, so each time a row is added basically, the .p_p[current number of cosets] is set equal to the identity. The problem with this is that the table starts of with one row: so we have .p_p[n] for n>0, but p_p[0] is not assigned as the identity as it should.
This causes the key error in the issue, since the .p_p method is called with index zero.
Initializing .p_p[0] as the identity element correctly solves the bug.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Corrected the initialization of the Extended Todd-Coxeter algorithm (useful for the rewriting of a Fp group element in terms of a chosen set of generators) : previously modified_coset_enumeration_r failed with a key error when it handled certain (non trivial) Fp groups, now it correctly returns the extended coset table.

<!-- END RELEASE NOTES -->
