### PR TITLE
docs: replace dead xy-pic links in diagram_drawing.py with archived URLs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1821,3 +1821,7 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>

--- a/.mailmap
+++ b/.mailmap
@@ -673,7 +673,7 @@ Geetika Vadali <geetika.vadali4@gmail.com> Geetika V <geetika047btcsai21@igdtuw.
 Geetika Vadali <geetika.vadali4@gmail.com> Geetika Vadali <123307246+geetHonve@users.noreply.github.com>
 Geoffry Song <goffrie@gmail.com>
 George Frolov <gosha@fro.lv>
-George Korepanov <gkorepanov.gk@gmail.com>
+vGeorge Korepanov <gkorepanov.gk@gmail.com>
 George Pittock <gpittock4@gmail.com>
 George Waksman <waksman@gwax.com>
 Georges Khaznadar <georgesk@debian.org>
@@ -1123,7 +1123,7 @@ Nathan Woods <charlesnwoods@gmail.com>
 Naveen Sai <naveensaisreenivas@gmail.com> Naveen Sai <56525288+naveensaigit@users.noreply.github.com>
 Naveen Sai <naveensaisreenivas@gmail.com> naveensaigit <naveensaisreenivas@gmail.com>
 Neel Gorasiya <mgorasiya1974@gmail.com>
-Neil <mistersheik@gmail.com>
+vNeil <mistersheik@gmail.com>
 Nguyen Truong Duy <truongduy134@yahoo.com>
 Nichita Utiu <nikita.utiu+github@gmail.com> <nichitautiu@nichitautiu-desktop.(none)>
 Nicholas Bollweg <nick.bollweg@gmail.com> <nbollweg@continuum.io>
@@ -1618,7 +1618,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
-Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
+vVarenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
@@ -1797,8 +1797,7 @@ sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
 slacker404 <pchantza@gmail.com>
 soumi7 <soumibardhan10@gmail.com>
 symbolique <symbolique@users.noreply.github.com>
-tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bg>
-tnzl <you@example.com>
+tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bgtnzl <you@example.com>
 tools4origins <tools4origins@gmail.com>
 tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
@@ -1822,4 +1821,6 @@ zzj <29055749+zjzh@users.noreply.github.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
 Sushma Kumari <sushmakg006@gmail.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
 

--- a/.mailmap
+++ b/.mailmap
@@ -493,7 +493,7 @@ Christina Zografou <t8130048@dias.aueb.gr>
 Christoph Gohle <ctg@mpq.mpg.de>
 Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
 Christopher Dembia <cld72@cornell.edu>
-Christopher J. Wright <cjwright4242gh@gmail.com>
+vChristopher J. Wright <cjwright4242gh@gmail.com>
 Clayton Rabideau <claytonrabideau@gmail.com> Zer0Credibility <cmr57@cam.ac.uk>
 Clemens Novak <clemens@familie-novak.net>
 Clément M.T. Robert <cr52@protonmail.com>
@@ -583,7 +583,7 @@ Edward Schembor <eschemb1@jhu.edu>
 Edward Z. Yang <ezyang@mit.edu> Edward Z. Yang <ezyang@meta.com>
 Eh Tan <tan2tan2@gmail.com>
 Ehren Metcalfe <ehren.m@gmail.com>
-Ekansh Purohit <purohit.e15@gmail.com>
+vEkansh Purohit <purohit.e15@gmail.com>
 Elias Basler <e.e.basler@protonmail.com>
 Elisha Hollander <just4now666666@gmail.com> donno2048 <just4now666666@gmail.com>
 Elliot Marshall <Marshall2389@gmail.com> <marshall2389@gmail.com>
@@ -1821,3 +1821,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sushma Kumari <sushmakg006@gmail.com>
+

--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -493,7 +494,6 @@ Christina Zografou <t8130048@dias.aueb.gr>
 Christoph Gohle <ctg@mpq.mpg.de>
 Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
 Christopher Dembia <cld72@cornell.edu>
-vChristopher J. Wright <cjwright4242gh@gmail.com>
 Clayton Rabideau <claytonrabideau@gmail.com> Zer0Credibility <cmr57@cam.ac.uk>
 Clemens Novak <clemens@familie-novak.net>
 Clément M.T. Robert <cr52@protonmail.com>
@@ -583,7 +583,6 @@ Edward Schembor <eschemb1@jhu.edu>
 Edward Z. Yang <ezyang@mit.edu> Edward Z. Yang <ezyang@meta.com>
 Eh Tan <tan2tan2@gmail.com>
 Ehren Metcalfe <ehren.m@gmail.com>
-vEkansh Purohit <purohit.e15@gmail.com>
 Elias Basler <e.e.basler@protonmail.com>
 Elisha Hollander <just4now666666@gmail.com> donno2048 <just4now666666@gmail.com>
 Elliot Marshall <Marshall2389@gmail.com> <marshall2389@gmail.com>
@@ -673,7 +672,6 @@ Geetika Vadali <geetika.vadali4@gmail.com> Geetika V <geetika047btcsai21@igdtuw.
 Geetika Vadali <geetika.vadali4@gmail.com> Geetika Vadali <123307246+geetHonve@users.noreply.github.com>
 Geoffry Song <goffrie@gmail.com>
 George Frolov <gosha@fro.lv>
-vGeorge Korepanov <gkorepanov.gk@gmail.com>
 George Pittock <gpittock4@gmail.com>
 George Waksman <waksman@gwax.com>
 Georges Khaznadar <georgesk@debian.org>
@@ -1123,7 +1121,6 @@ Nathan Woods <charlesnwoods@gmail.com>
 Naveen Sai <naveensaisreenivas@gmail.com> Naveen Sai <56525288+naveensaigit@users.noreply.github.com>
 Naveen Sai <naveensaisreenivas@gmail.com> naveensaigit <naveensaisreenivas@gmail.com>
 Neel Gorasiya <mgorasiya1974@gmail.com>
-vNeil <mistersheik@gmail.com>
 Nguyen Truong Duy <truongduy134@yahoo.com>
 Nichita Utiu <nikita.utiu+github@gmail.com> <nichitautiu@nichitautiu-desktop.(none)>
 Nicholas Bollweg <nick.bollweg@gmail.com> <nbollweg@continuum.io>
@@ -1546,6 +1543,11 @@ Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
+Sushma Kumari <sushmakg006@gmail.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>
@@ -1618,7 +1620,6 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
-vVarenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
@@ -1801,6 +1802,11 @@ tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bgtnzl <you@example.com>
 tools4origins <tools4origins@gmail.com>
 tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
+vChristopher J. Wright <cjwright4242gh@gmail.com>
+vEkansh Purohit <purohit.e15@gmail.com>
+vGeorge Korepanov <gkorepanov.gk@gmail.com>
+vNeil <mistersheik@gmail.com>
+vVarenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
@@ -1820,9 +1826,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sushma Kumari <sushmakg006@gmail.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
-Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
-
 Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
 Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>

--- a/.mailmap
+++ b/.mailmap
@@ -1824,3 +1824,5 @@ Sushma Kumari <sushmakg006@gmail.com>
 Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
 Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
 
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>

--- a/.mailmap
+++ b/.mailmap
@@ -10,181 +10,121 @@
 # correctly record their name and email address so this file is used to be
 # explicit about who has contributed to SymPy and what name and email address
 # they would like to be known by.
-#
-#
 # New contributors quick description
 # ==================================
-#
 # 1. Before committing make sure that git config records your name and email
 # address correctly as you would like it to be recorded in the AUTHORS file.
-#
 # 2. After committing run the bin/mailmap_check.py script. It will check the
 # commits and look for your name and email address in this file. You should see
 # an error message like "This author is not included ...":
-#
 #   $ python bin/mailmap_check.py
 #   This author is not included in the .mailmap file:
 #   Joe Bloggs <joe@bloggs.com>
-#
 #   The .mailmap file needs to be updated because there are commits with
 #   unrecognised author/email metadata.
-#
 #   For instructions on updating the .mailmap file see:
 #   https://docs.sympy.org/dev/contributing/new-contributors-guide/workflow-process.html#add-your-name-and-email-address-to-the-mailmap-file
-#
 #   ...
-#
 # If it fails, you may need to replace `python` by `python3`, here and below, if
 # you're on a system that still uses python2 by default.
-#
 # 3. Add a line to this file with that same name and email address like:
-#
-#   Joe Bloggs <joe@bloggs.com>
-#
 # 4. Run the bin/mailmap_check.py script. This time it will find your name and
 # address and it will also reorder the lines in this file to be in alphabetical
 # order and it will say "the mailmap file was reordered".
-#
-#   $ python bin/mailmap_check.py
 #   The mailmap file was reordered
-#
-#   For instructions on updating the .mailmap file see:
-#   https://docs.sympy.org/dev/contributing/new-contributors-guide/workflow-process.html#add-your-name-and-email-address-to-the-mailmap-file
-#
-#   ...
-#
 # 5. You should be ready now but just to be sure run the bin/mailmap_check.py
 # script one last time and it should say "No changes needed in .mailmap". The
 # output will show that your name and email address is included in the list of
 # names and email addresses that will be added to the AUTHORS file later (make
 # sure that your name only appears once):
-#
-#   $ python bin/mailmap_check.py
 #   No changes needed in .mailmap
-#
 #   The following authors will be added to the AUTHORS file at the time of
 #   the next SymPy release.
-#
-#   Joe Bloggs <joe@bloggs.com>
 #   Other Author <other@author.com>
-#   ...
-#
 # 6. All done. Commit the change to the .mailmap file. When you open a pull
 # request the AUTHORS check will run in CI and it will run the
 # bin/mailmap_check.py script to check that no changes are needed in .mailmap.
 # If the script succeeded locally then it should also succeed in CI.
-#
 # 7. Once you have been added to the .mailmap file it is not necessary to do
 # these steps in any future pull requests unless you change the name and email
 # address you use to make your commits (see Associating different commits
 # below) or want to be recorded under a different name in the AUTHORS file.
-#
-#
 # Configuring git
 # ===============
-#
 # If you are contributing to SymPy for the first time then first make sure that
 # you have configured your name and email address in your local git install.
 # You can check this using the git config command:
-#
 #   $ git config --global user.name
 #   Joe Bloggs
 #   $ git config --global user.email
 #   joe@bloggs.com
-#
 # This name and email address is what will be recorded in any commits that you
 # make with the git commit command. If you want to change the name and or email
 # address that will be used in your commits then you can do also that with the
 # git config command e.g. you can change the name with:
-#
 #   $ git config --global user.name "Jane Doe"
-#   $ git config --global user.name
 #   Jane Doe
-#
 # You can use the git log command to see what name and email address were used
 # in any commits that you have made. Note that changing your name with git
 # config will not change the name that is *already* recorded in any commits
 # that you have made: you have to amend or redo the commits to change that.
-#
-#
 # Associating different names and emails
 # ======================================
-#
 # Entries in this file can also be used to associate commits made under a
 # different name and email address with your own name and email as you would
 # like it to be recorded in the AUTHORS file. This is useful because for
 # example the GitHub web UI will usually record commits under a different name
 # and email address from the one that you use with git locally. To associate
 # that other name and email address with your own add a line like:
-#
 #   Proper Name <Proper@email> commit name <commit@email>
 #   \-----------+------------/ \----------+-------------/
 #               |                         |
 #            replace                     find
-#
 # For example if Joe Bloggs made a commit through the GitHub web UI then it
 # might be recorded with name/email "joeb <12345+joeb@users.noreply.github.com>".
 # In this case Joe should add the following line to .mailmap:
-#
 #   # DO THIS:
 #   Joe Bloggs <joe@bloggs.com> joeb <12345+joeb@users.noreply.github.com>
-#
 # That tells the .mailmap script that any commits with the second name and
 # email are from the same author as the first name and email. This means that
 # only one entry will be added to the AUTHORS file using the first name and
 # email. You can add multiple lines like this all using the same name and email
 # as the first entry but having different second entries e.g.:
-#
-#   # DO THIS:
-#   Joe Bloggs <joe@bloggs.com> joeb <12345+joeb@users.noreply.github.com>
 #   Joe Bloggs <joe@bloggs.com> Joe <joe@gmail.com>
-#
 # It is important to make sure that each author is listed only once in the
 # AUTHORS file so do *NOT* add separate entries that begin with different names
 # or email addresses:
-#
 #   # DO NOT DO THIS (it will be treated as two unrelated authors):
-#   Joe Bloggs <joe@bloggs.com>
 #   joeb <12345+joeb@users.noreply.github.com>
-#
 # If you are unsure what name and email address has been used in your commits
 # then make sure that your local branch is up to date and run git log. It is
 # also possible to see this on GitHub if you click on a commit and then add
 # ".patch" to the end of the page URL.
-#
 # The email (or name and email) in the "find" part of the entry will
 # be used in a case-insensitive way to identify a git author and
 # replace it with whatever is included in the "replace" part:
-#
 #     author                           author
 #     before    .mailmap entry         after
 #     --------- ---------------------- -----------
 #               Foo <Email>
 #     A <Email> ---------------------> Foo <Email>
 #     B <eMAIL> ---------------------> Foo <eMAIL>
-#
 #               <Email> <email>
 #     A <Email> ---------------------> A <Email>
 #     B <eMAIL> ---------------------> B <Email>
-#
 #               Foo <Email> <email>
-#     A <Email> ---------------------> Foo <Email>
 #     B <eMAIL> ---------------------> Foo <Email>
-#
 #               Foo <EMAIL> b <email>
 #     A <Email> ---------------------> same
 #     B <Email> ---------------------> Foo <EMAIL>
 #     b <eMAIL> ---------------------> Foo <EMAIL>
-#
 #               Foo <Email> b <email>
 #               Foo <Email> <liame>
 #     A <Liame> ---------------------> Foo <Email>
 #     B <Email> ---------------------> Foo <Email>
 #     b <eMAIL> ---------------------> Foo <Email>
 #     c <eMAIL> ---------------------> same
-#
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
-#
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -750,7 +690,6 @@ Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelint
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
-Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <ishan9096137017@gmail.com>
 Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>
@@ -888,7 +827,6 @@ Ka Yi <chua.kayi@yahoo.com.sg>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
-Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
 Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>
 Karan Sharma <karan1276@gmail.com>
@@ -1821,7 +1759,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
 Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
 Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>

--- a/.mailmap
+++ b/.mailmap
@@ -1484,6 +1484,9 @@ Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakg006@gmail.com>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>
@@ -1759,6 +1762,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakg006@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1761,3 +1761,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
 Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
 Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
+Sushma Kumari <sushmakg006@gmail.com> <sushmakg006@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,7 +185,6 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
-
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -494,6 +493,7 @@ Christina Zografou <t8130048@dias.aueb.gr>
 Christoph Gohle <ctg@mpq.mpg.de>
 Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
 Christopher Dembia <cld72@cornell.edu>
+Christopher J. Wright <cjwright4242gh@gmail.com>
 Clayton Rabideau <claytonrabideau@gmail.com> Zer0Credibility <cmr57@cam.ac.uk>
 Clemens Novak <clemens@familie-novak.net>
 Clément M.T. Robert <cr52@protonmail.com>
@@ -583,6 +583,7 @@ Edward Schembor <eschemb1@jhu.edu>
 Edward Z. Yang <ezyang@mit.edu> Edward Z. Yang <ezyang@meta.com>
 Eh Tan <tan2tan2@gmail.com>
 Ehren Metcalfe <ehren.m@gmail.com>
+Ekansh Purohit <purohit.e15@gmail.com>
 Elias Basler <e.e.basler@protonmail.com>
 Elisha Hollander <just4now666666@gmail.com> donno2048 <just4now666666@gmail.com>
 Elliot Marshall <Marshall2389@gmail.com> <marshall2389@gmail.com>
@@ -672,6 +673,7 @@ Geetika Vadali <geetika.vadali4@gmail.com> Geetika V <geetika047btcsai21@igdtuw.
 Geetika Vadali <geetika.vadali4@gmail.com> Geetika Vadali <123307246+geetHonve@users.noreply.github.com>
 Geoffry Song <goffrie@gmail.com>
 George Frolov <gosha@fro.lv>
+George Korepanov <gkorepanov.gk@gmail.com>
 George Pittock <gpittock4@gmail.com>
 George Waksman <waksman@gwax.com>
 Georges Khaznadar <georgesk@debian.org>
@@ -1121,6 +1123,7 @@ Nathan Woods <charlesnwoods@gmail.com>
 Naveen Sai <naveensaisreenivas@gmail.com> Naveen Sai <56525288+naveensaigit@users.noreply.github.com>
 Naveen Sai <naveensaisreenivas@gmail.com> naveensaigit <naveensaisreenivas@gmail.com>
 Neel Gorasiya <mgorasiya1974@gmail.com>
+Neil <mistersheik@gmail.com>
 Nguyen Truong Duy <truongduy134@yahoo.com>
 Nichita Utiu <nikita.utiu+github@gmail.com> <nichitautiu@nichitautiu-desktop.(none)>
 Nicholas Bollweg <nick.bollweg@gmail.com> <nbollweg@continuum.io>
@@ -1543,11 +1546,6 @@ Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
-Sushma Kumari <sushmakg006@gmail.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>
@@ -1620,6 +1618,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
@@ -1798,15 +1797,11 @@ sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
 slacker404 <pchantza@gmail.com>
 soumi7 <soumibardhan10@gmail.com>
 symbolique <symbolique@users.noreply.github.com>
-tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bgtnzl <you@example.com>
+tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bg>
+tnzl <you@example.com>
 tools4origins <tools4origins@gmail.com>
 tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
-vChristopher J. Wright <cjwright4242gh@gmail.com>
-vEkansh Purohit <purohit.e15@gmail.com>
-vGeorge Korepanov <gkorepanov.gk@gmail.com>
-vNeil <mistersheik@gmail.com>
-vVarenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
@@ -1826,5 +1821,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushma.kumari@example.com>
-Sushma Kumari <sushmakg006@gmail.com> <sushmakumari@sushmas-MacBook-Air.local>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1377,3 +1377,6 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+Sushma Kumari
+
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1382 +1,1425 @@
-All people who contributed to SymPy by sending at least a patch or
-more (in the order of the date of their first contribution), except
-those who explicitly didn't want to be mentioned. People with a * next
-to their names are not found in the metadata of the git history. This
-file is generated automatically by running `./bin/authors_update.py`.
-
-There are a total of 1371 authors.
-
-Ondřej Čertík <ondrej@certik.cz>
-Fabian Pedregosa <fabian@fseoane.net>
-Jurjen N.E. Bos <jnebos@gmail.com>
-Mateusz Paprocki <mattpap@gmail.com>
-*Marc-Etienne M.Leveille <protonyc@gmail.com>
-Brian Jorgensen <brian.jorgensen@gmail.com>
-Jason Gedge <inferno1386@gmail.com>
-Robert Schwarz <lethargo@googlemail.com>
-Pearu Peterson <pearu.peterson@gmail.com>
-Fredrik Johansson <fredrik.johansson@gmail.com>
-Chris Wu <chris.wu@gmail.com>
-*Ulrich Hecht <ulrich.hecht@gmail.com>
-Goutham Lakshminarayan <dl.goutham@gmail.com>
-David Lawrence <dmlawrence@gmail.com>
-Jaroslaw Tworek <dev.jrx@gmail.com>
-David Marek <h4wk.cz@gmail.com>
-Bernhard R. Link <brlink@debian.org>
-Andrej Tokarčík <androsis@gmail.com>
-Or Dvory <gidesa@gmail.com>
-Saroj Adhikari <adh.saroj@gmail.com>
-Pauli Virtanen <pav@iki.fi>
-Robert Kern <robert.kern@gmail.com>
-James Aspnes <aspnes@cs.yale.edu>
-Nimish Telang <ntelang@gmail.com>
-Abderrahim Kitouni <a.kitouni@gmail.com>
-Pan Peng <pengpanster@gmail.com>
-Friedrich Hagedorn <friedrich_h@gmx.de>
-Elrond der Elbenfuerst <elrond+sympy.org@samba-tng.org>
-Rizgar Mella <rizgar.mella@gmail.com>
-Felix Kaiser <felix.kaiser@fxkr.net>
-Roberto Nobrega <rwnobrega@gmail.com>
-David Roberts <dvdr18@gmail.com>
-Sebastian Krämer <basti.kr@gmail.com>
-Vinzent Steinberg <vinzent.steinberg@gmail.com>
-Riccardo Gori <goriccardo@gmail.com>
-Case Van Horsen <casevh@gmail.com>
-Stepan Roucka <stepan@roucka.eu>
-Ali Raza Syed <arsyed@gmail.com>
-Stefano Maggiolo <s.maggiolo@gmail.com>
-Robert Cimrman <cimrman3@ntc.zcu.cz>
-Bastian Weber <bastian.weber@gmx-topmail.de>
-Sebastian Krause <sebastian.krause@gmx.de>
-Sebastian Kreft <skreft@gmail.com>
-*Dan <coolg49964@gmail.com>
-Alan Bromborsky <abrombo@verizon.net>
-Boris Timokhin <qoqenator@gmail.com>
-Robert <average.programmer@gmail.com>
-Andy R. Terrel <aterrel@uchicago.edu>
-Hubert Tsang <intsangity@gmail.com>
-Konrad Meyer <konrad.meyer@gmail.com>
-Henrik Johansson <henjo2006@gmail.com>
-Priit Laes <plaes@plaes.org>
-Freddie Witherden <freddie@witherden.org>
-Brian E. Granger <ellisonbg@gmail.com>
-Andrew Straw <strawman@astraw.com>
-Kaifeng Zhu <cafeeee@gmail.com>
-Ted Horst <ted.horst@earthlink.net>
-Andrew Docherty <andrewd@maths.usyd.edu.au>
-Akshay Srinivasan <akshaysrinivasan@gmail.com>
-Aaron Meurer <asmeurer@gmail.com>
-Barry Wardell <barry.wardell@gmail.com>
-Tomasz Buchert <thinred@gmail.com>
-Vinay Kumar <gnulinooks@gmail.com>
-Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
-Jochen Voss <voss@seehuhn.de>
-Luke Peterson <hazelnusse@gmail.com>
-Chris Smith <smichr@gmail.com>
-Thomas Sidoti <TSidoti@gmail.com>
-Florian Mickler <florian@mickler.org>
-Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
-Ben Goodrich <goodrich.ben@gmail.com>
-Toon Verstraelen <Toon.Verstraelen@UGent.be>
-Ronan Lamy <ronan.lamy@gmail.com>
-James Abbatiello <abbeyj@gmail.com>
-Ryan Krauss <ryanlists@gmail.com>
-Bill Flynn <wflynny@gmail.com>
-Kevin Goodsell <kevin-opensource@omegacrash.net>
-Jorn Baayen <jorn.baayen@gmail.com>
-Eh Tan <tan2tan2@gmail.com>
-Renato Coutinho <renato.coutinho@gmail.com>
-Oscar Benjamin <oscar.j.benjamin@gmail.com>
-Øyvind Jensen <jensen.oyvind@gmail.com>
-Julio Idichekop Filho <idichekop@yahoo.com.br>
-Łukasz Pankowski <lukpank@o2.pl>
-*Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
-Fernando Perez <Fernando.Perez@berkeley.edu>
-Raffaele De Feo <alberthilbert@gmail.com>
-Christian Muise <christian.muise@gmail.com>
-Matt Curry <mattjcurry@gmail.com>
-Kazuo Thow <kazuo.thow@gmail.com>
-Christian Schubert <chr.schubert@gmx.de>
-Jezreel Ng <jezreel@gmail.com>
-James Pearson <xiong.chiamiov@gmail.com>
-Matthew Brett <matthew.brett@gmail.com>
-Addison Cugini <ajcugini@gmail.com>
-Nicholas J.S. Kinar <n.kinar@usask.ca>
-Harold Erbin <harold.erbin@gmail.com>
-Thomas Dixon <thom@thomdixon.org>
-Cristóvão Sousa <crisjss@gmail.com>
-Andre de Fortier Smit <freevryheid@gmail.com>
-Mark Dewing <markdewing@gmail.com>
-Alexey U. Gudchenko <proga@goodok.ru>
-Gary Kerr <gary.kerr@blueyonder.co.uk>
-Sherjil Ozair <sherjilozair@gmail.com>
-Oleksandr Gituliar <gituliar@gmail.com>
-Sean Vig <sean.v.775@gmail.com>
-Prafullkumar P. Tale <hector1618@gmail.com>
-Vladimir Perić <vlada.peric@gmail.com>
-Tom Bachmann <e_mc_h2@web.de>
-Yuri Karadzhov <yuri.karadzhov@gmail.com>
-Vladimir Lagunov <werehuman@gmail.com>
-Matthew Rocklin <mrocklin@cs.uchicago.edu>
-Saptarshi Mandal <sapta.iitkgp@gmail.com>
-Gilbert Gede <gilbertgede@gmail.com>
-Anatolii Koval <weralwolf@gmail.com>
-Tomo Lazovich <lazovich@gmail.com>
-Pavel Fedotov <fedotovp@gmail.com>
-Jack McCaffery <jpmccaffery@gmail.com>
-Jeremias Yehdegho <j.yehdegho@gmail.com>
-Kibeom Kim <kk1674@nyu.edu>
-Gregory Ksionda <ksiondag846@gmail.com>
-Tomáš Bambas <tomas.bambas@gmail.com>
-Raymond Wong <rayman_407@yahoo.com>
-Luca Weihs <astronomicalcuriosity@gmail.com>
-Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
-Thomas Wiecki <thomas.wiecki@gmail.com>
-Óscar Nájera <najera.oscar@gmail.com>
-Mario Pernici <mario.pernici@gmail.com>
-Benjamin McDonald <mcdonald.ben@gmail.com>
-Sam Magura <samtheman132@gmail.com>
-Stefan Krastanov <krastanov.stefan@gmail.com>
-Bradley Froehle <brad.froehle@gmail.com>
-Min Ragan-Kelley <benjaminrk@gmail.com>
-Emma Hogan <ehogan@gemini.edu>
-Nikhil Sarda <diff.operator@gmail.com>
-Julien Rioux <julien.rioux@gmail.com>
-Roberto Colistete, Jr. <roberto.colistete@gmail.com>
-Raoul Bourquin <raoulb@bluewin.ch>
-Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
-Srinivas Vasudevan <srvasude@gmail.com>
-Jason Moore <moorepants@gmail.com>
-Miha Marolt <tloramus@gmail.com>
-Tim Lahey <tim.lahey@gmail.com>
-Luis Garcia <ppn.online@me.com>
-Matt Rajca <matt.rajca@me.com>
-David Li <l33tnerd.li@gmail.com>
-Alexandr Gudulin <alexandr.gudulin@gmail.com>
-Bilal Akhtar <bilalakhtar@ubuntu.com>
-Grzegorz Świrski <sognat@gmail.com>
-Matt Habel <habelinc@gmail.com>
-David Ju <Sgtmook314@gmail.com>
-Nichita Utiu <nikita.utiu+github@gmail.com>
-Nikolay Lazarov <qwerqwerqwer@abv.bg>
-Steve Anton <anxuiz.nx@gmail.com>
-Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
-Ljubiša Moćić <3rdslasher@gmail.com>
-Piotr Korgul <p.korgul@gmail.com>
-Jim Zhang <Hyriodula@gmail.com>
-Sam Sleight <samuel.sleight@gmail.com>
-tborisova <ts.borisova3@gmail.com>
-Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
-Stepan Simsa <simsa.st@gmail.com>
-Tobias Lenz <t_lenz94@web.de>
-Siddhanathan Shanmugam <siddhanathan@gmail.com>
-Tiffany Zhu <bubble.wubble.303@gmail.com>
-Tristan Hume <tris.hume@gmail.com>
-Alexey Subach <alexey.subach@gmail.com>
-Joan Creus <joan.creus.c@gmail.com>
-Geoffry Song <goffrie@gmail.com>
-Puneeth Chaganti <punchagan@gmail.com>
-Marcin Kostrzewa <>
-Natalia Nawara <fankalemura@gmail.com>
-vishal <vishal.panjwani15@gmail.com>
-Shruti Mangipudi <shruti2395@gmail.com>
-Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
-Swapnil Agarwal <swapnilag29@gmail.com>
-Dhia Kennouche <kendhia@gmail.com>
-jerryma1121 <jerryma1121@gmail.com>
-Joachim Durchholz <jo@durchholz.org>
-Martin Povišer <martin.povik@gmail.com>
-Siddhant Jain <getsiddhant@gmail.com>
-Kevin Hunter <hunteke@earlham.edu>
-Michael Mayorov <marchael@kb.csu.ru>
-Nathan Alison <nathan.f.alison@gmail.com>
-Christian Bühler <christian@cbuehler.de>
-Carsten Knoll <CarstenKnoll@gmx.de>
-Bharath M R <catchmrbharath@gmail.com>
-Matthias Toews <mat.toews@googlemail.com>
-Sergiu Ivanov <unlimitedscolobb@gmail.com>
-Jorge E. Cardona <jorgeecardona@gmail.com>
-Sanket Agarwal <sanket@sanketagarwal.com>
-Manoj Babu K. <manoj.babu2378@gmail.com>
-Sai Nikhil <tsnlegend@gmail.com>
-Aleksandar Makelov <amakelov@college.harvard.edu>
-Sachin Irukula <sachin.irukula@gmail.com>
-Raphael Michel <webmaster@raphaelmichel.de>
-Ashwini Oruganti <ashwini.oruganti@gmail.com>
-Andreas Klöckner <inform@tiker.net>
-Prateek Papriwal <papriwalprateek@gmail.com>
-Arpit Goyal <agmps18@gmail.com>
-Angadh Nanjangud <angadh.n@gmail.com>
-Comer Duncan <comer.duncan@gmail.com>
-Jens H. Nielsen <jenshnielsen@gmail.com>
-Joseph Dougherty <Github@JWDougherty.com>
-Elliot Marshall <Marshall2389@gmail.com>
-Guru Devanla <grdvnl@gmail.com>
-George Waksman <waksman@gwax.com>
-Alexandr Popov <alexandr.s.popov@gmail.com>
-Tarun Gaba <tarun.gaba7@gmail.com>
-Takafumi Arakaki <aka.tkf@gmail.com>
-Saurabh Jha <saurabh.jhaa@gmail.com>
-Rom le Clair <jacen.guardian@gmail.com>
-Angus Griffith <16sn6uv@gmail.com>
-Timothy Reluga <treluga@math.psu.edu>
-Brian Stephanik <xoedusk@gmail.com>
-Alexander Eberspächer <alex.eberspaecher@gmail.com>
-Sachin Joglekar <srjoglekar246@gmail.com>
-Tyler Pirtle <teeler@gmail.com>
-Vasily Povalyaev <vapovalyaev@gmail.com>
-Colleen Lee <colleenclee@gmail.com>
-Matthew Hoff <mhoff14@gmail.com>
-Niklas Thörne <notrupertthorne@gmail.com>
-Huijun Mai <m.maihuijun@gmail.com>
-Marek Šuppa <mr@shu.io>
-Ramana Venkata <idlike2dream@gmail.com>
-Prasoon Shukla <prasoon92.iitr@gmail.com>
-Stefen Yin <zqyin@ucdavis.edu>
-Thomas Hisch <t.hisch@gmail.com>
-Madeleine Ball <mpball@gmail.com>
-Mary Clark <mary.spriteling@gmail.com>
-Rishabh Dixit <rishabhdixit11@gmail.com>
-Manoj Kumar <manojkumarsivaraj334@gmail.com>
-Akshit Agarwal <akshit.jiit@gmail.com>
-CJ Carey <perimosocordiae@gmail.com>
-Patrick Lacasse <patrick.m.lacasse@gmail.com>
-Ananya H <ananyaha93@gmail.com>
-Tarang Patel <tarangrockr@gmail.com>
-Christopher Dembia <cld72@cornell.edu>
-Benjamin Fishbein <fishbeinb@gmail.com>
-Sean Ge <seange727@gmail.com>
-Amit Jamadagni <bitsjamadagni@gmail.com>
-Ankit Agrawal <aaaagrawal@iitb.ac.in>
-Björn Dahlgren <bjodah@gmail.com>
-Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
-Demian Wassermann <demian@bwh.harvard.edu>
-Khagesh Patel <khageshpatel93@gmail.com>
-Stephen Loo <shikil@yahoo.com>
-hm <hacman0@gmail.com>
-Patrick Poitras <acebulf@gmail.com>
-Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
-Varun Joshi <joshi.142@osu.edu>
-Chetna Gupta <cheta.gup@gmail.com>
-Thilina Rathnayake <thilinarmtb@gmail.com>
-Max Hutchinson <maxhutch@gmail.com>
-Shravas K Rao <shravas@gmail.com>
-Matthew Tadd <matt.tadd@gmail.com>
-Alexander Hirzel <alex@hirzel.us>
-Randy Heydon <randy.heydon@clockworklab.net>
-Oliver Lee <oliverzlee@gmail.com>
-Seshagiri Prabhu <seshagiriprabhu@gmail.com>
-Pradyumna <pradyu1993@gmail.com>
-Erik Welch <erik.n.welch@gmail.com>
-Eric Nelson <eric.the.red.XLII@gmail.com>
-Roland Puntaier <roland.puntaier@chello.at>
-Chris Conley <chrisconley15@gmail.com>
-Tim Swast <tswast@gmail.com>
-Dmitry Batkovich <batya239@gmail.com>
-Francesco Bonazzi <franz.bonazzi@gmail.com>
-Yuriy Demidov <iurii.demidov@gmail.com>
-Rick Muller <rpmuller@gmail.com>
-Manish Gill <gill.manish90@gmail.com>
-Markus Müller <markus.mueller.1.g@googlemail.com>
-Amit Saha <amitsaha.in@gmail.com>
-Jeremy <twobitlogic@gmail.com>
-QuaBoo <kisonchristian@gmail.com>
-Stefan van der Walt <stefan@sun.ac.za>
-David Joyner <wdjoyner@gmail.com>
-Lars Buitinck <larsmans@gmail.com>
-Alkiviadis G. Akritas <akritas@uth.gr>
-Vinit Ravishankar <vinit.ravishankar@gmail.com>
-Michael Boyle <michael.oliver.boyle@gmail.com>
-Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
-Pablo Puente <ppuedom@gmail.com>
-James Fiedler <jrfiedler@gmail.com>
-Harsh Gupta <mail@hargup.in>
-Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
-Paul Strickland <p.e.strickland@gmail.com>
-James Goppert <james.goppert@gmail.com>
-rathmann <rathmann.os@gmail.com>
-Avichal Dayal <avichal.dayal@gmail.com>
-Paul Scott <paul.scott@nicta.com.au>
-Shipra Banga <bangashipra@gmail.com>
-Pramod Ch <pramodch14@gmail.com>
-Akshay <akshaynukala95@gmail.com>
-Buck Shlegeris <buck2@bruceh15.anu.edu.au>
-Jonathan Miller <jdmiller93@gmail.com>
-Edward Schembor <eschemb1@jhu.edu>
-Rajath Shashidhara <rajaths.rajaths@gmail.com>
-Zamrath Nizam <zamiguy_ni@yahoo.com>
-Aditya Shah <adityashah30@gmail.com>
-Rajat Aggarwal <rajataggarwal1975@gmail.com>
-Sambuddha Basu <sammygamer@live.com>
-Zeel Shah <kshah215@gmail.com>
-Abhinav Chanda <abhinavchanda01@gmail.com>
-Jim Crist <crist042@umn.edu>
-Sudhanshu Mishra <mrsud94@gmail.com>
-Anurag Sharma <anurags92@gmail.com>
-Soumya Dipta Biswas <sdb1323@gmail.com>
-Sushant Hiray <hiraysushant@gmail.com>
-Ben Lucato <ben.lucato@gmail.com>
-Kunal Arora <kunalarora.135@gmail.com>
-Henry Gebhardt <hsggebhardt@gmail.com>
-Dammina Sahabandu <dmsahabandu@gmail.com>
-Manish Shukla <manish.shukla393@gmail>
-Ralph Bean <rbean@redhat.com>
-richierichrawr <richierichrawr@users.noreply.github.com>
-John Connor <john.theman.connor@gmail.com>
-Juan Luis Cano Rodríguez <juanlu001@gmail.com>
-Sahil Shekhawat <sahilshekhawat01@gmail.com>
-Kundan Kumar <kundankumar18581@gmail.com>
-Stas Kelvich <stanconn@gmail.com>
-sevaader <sevaader@gmail.com>
-Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
-Venkatesh Halli <venkatesh.fatality@gmail.com>
-Lennart Fricke <lennart@die-frickes.eu>
-Vlad Seghete <vlad.seghete@gmail.com>
-Shashank Agarwal <shashank.agarwal94@gmail.com>
-carstimon <carstimon@gmail.com>
-Pierre Haessig <pierre.haessig@crans.org>
-Maciej Baranski <getrox.sc@gmail.com>
-Benjamin Gudehus <hastebrot@gmail.com>
-Faisal Anees <faisal.iiit@gmail.com>
-Mark Shoulson <mark@kli.org>
-Robert Johansson <jrjohansson@gmail.com>
-Kalevi Suominen <jksuom@gmail.com>
-Kaushik Varanasi <kaushik.varanasi1@gmail.com>
-Fawaz Alazemi <Mba7eth@gmail.com>
-Ambar Mehrotra <mehrotraambar@gmail.com>
-David P. Sanders <dpsanders@gmail.com>
-Peter Brady <petertbrady@gmail.com>
-John V. Siratt <jvsiratt@gmail.com>
-Sarwar Chahal <chahal.sarwar98@gmail.com>
-Nathan Woods <charlesnwoods@gmail.com>
-Colin B. Macdonald <cbm@m.fsf.org>
-Marcus Näslund <naslundx@gmail.com>
-Clemens Novak <clemens@familie-novak.net>
-Mridul Seth <seth.mridul@gmail.com>
-Craig A. Stoudt <craig.stoudt@gmail.com>
-Raj <raj454raj@gmail.com>
-Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
-immerrr <immerrr@gmail.com>
-Chai Wah Wu <cwwuieee@gmail.com>
-Leonid Blouvshtein <leonidbl91@gmail.com>
-Peleg Michaeli <freepeleg@gmail.com>
-ck Lux <lux.r.ck@gmail.com>
-zsc347 <zsc347@gmail.com>
-Hamish Dickson <hamish.dickson@gmail.com>
-Michael Gallaspy <gallaspy.michael@gmail.com>
-Roman Inflianskas <infroma@gmail.com>
-Duane Nykamp <nykamp@umn.edu>
-Ted Dokos <tdokos@gmail.com>
-Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
-Victor Brebenar <v.brebenar@gmail.com>
-Akshat Jain <akshat.jain@students.iiit.ac.in>
-Shivam Vats <shivamvats.iitkgp@gmail.com>
-Longqi Wang <iqgnol@gmail.com>
-Juan Felipe Osorio <jfosorio@gmail.com>
-Ray Cathcart <github@cathcart.us>
-Lukas Zorich <lukas.zorich@gmail.com>
-Eric Miller <emiller42@gmail.com>
-Cody Herbst <cyherbst@gmail.com>
-Nishith Shah <nishithshah.2211@gmail.com>
-Amit Kumar <dtu.amit@gmail.com>
-Yury G. Kudryashov <urkud.urkud@gmail.com>
-Guillaume Gay <contact@damcb.com>
-Mihir Wadwekar <m.mihirw@gmail.com>
-Tuan Manh Lai <laituan245@gmail.com>
-Asish Panda <asishrocks95@gmail.com>
-Darshan Chaudhary <deathbullet@gmail.com>
-Alec Kalinin <alec.kalinin@gmail.com>
-Ralf Stephan <ralf@ark.in-berlin.de>
-Aaditya Nair <aadityanair6494@gmail.com>
-Jayesh Lahori <jlahori92@gmail.com>
-Harshil Goel <harshil158@gmail.com>
-Luv Agarwal <agarwal.iiit@gmail.com>
-Jason Ly <jason.ly@gmail.com>
-Lokesh Sharma <lokeshhsharma@gmail.com>
-Sartaj Singh <singhsartaj94@gmail.com>
-Chris Swierczewski <cswiercz@gmail.com>
-Konstantin Togoi <konstantin.togoi@gmail.com>
-Param Singh <paramsingh258@gmail.com>
-Sumith Kulal <sumith1896@gmail.com>
-Juha Remes <jremes@outlook.com>
-Philippe Bouafia <philippe.bouafia@ensea.fr>
-Peter Schmidt <peter@peterjs.com>
-Jiaxing Liang <liangjiaxing57@gmail.com>
-Lucas Jones <lucas@lucasjones.co.uk>
-Gregory Ashton <gash789@gmail.com>
-Jennifer White <jcrw122@googlemail.com>
-Renato Orsino <renato.orsino@gmail.com>
-Alistair Lynn <arplynn@gmail.com>
-Govind Sahai <gsiitbhu@gmail.com>
-Adam Bloomston <adam@glitterfram.es>
-Kyle McDaniel <mcdanie5@illinois.edu>
-Nguyen Truong Duy <truongduy134@yahoo.com>
-Alex Lindsay <adlinds3@ncsu.edu>
-Mathew Chong <mathewchong.dev@gmail.com>
-Jason Siefken <siefkenj@gmail.com>
-Gaurav Dhingra <gauravdhingra.gxyd@gmail.com>
-Gao, Xiang <qasdfgtyuiop@gmail.com>
-Kevin Ventullo <kevin.ventullo@gmail.com>
-mao8 <thisisma08@gmail.com>
-Isuru Fernando <isuruf@gmail.com>
-Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
-Richard Otis <richard.otis@outlook.com>
-Rich LaSota <rjlasota@gmail.com>
-dustyrockpyle <dustyrockpyle@gmail.com>
-Anton Akhmerov <anton.akhmerov@gmail.com>
-Michael Zingale <michael.zingale@stonybrook.edu>
-Chak-Pong Chung <chakpongchung@gmail.com>
-David T <derDavidT@users.noreply.github.com>
-Phil Ruffwind <rf@rufflewind.com>
-Sebastian Koslowski <koslowski@kit.edu>
-Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
-Dustin Gadal <Dustin.Gadal@gmail.com>
-João Moura <operte@gmail.com>
-Yu Kobayashi <yukoba@accelart.jp>
-Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
-Timothy Cyrus <tcyrus@users.noreply.github.com>
-Devyani Kota <devyanikota@gmail.com>
-Keval Shah <kevalshah_96@yahoo.co.in>
-Dzhelil Rufat <drufat@caltech.edu>
-Pastafarianist <mr.pastafarianist@gmail.com>
-Sourav Singh <souravsingh@users.noreply.github.com>
-Jacob Garber <jgarber1@ualberta.ca>
-Vinay Singh <csvinay.d@gmail.com>
-GolimarOurHero <metalera94@hotmail.com>
-Prashant Tyagi <prashanttyagi221295@gmail.com>
-Matthew Davis <davisml.md@gmail.com>
-Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
-Alexander Bentkamp <bentkamp@gmail.com>
-Jack Kemp <metaknightdrake-git@yahoo.co.uk>
-Kshitij Saraogi <KshitijSaraogi@gmail.com>
-Thomas Baruchel <baruchel@gmx.com>
-Nicolás Guarín-Zapata <nicoguarin@gmail.com>
-Jens Jørgen Mortensen <jj@smoerhul.dk>
-Sampad Kumar Saha <sampadsaha5@gmail.com>
-Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
-Laura Domine <temigo@gmx.com>
-Justin Blythe <jblythe29@gmail.com>
-Meghana Madhyastha <meghana.madhyastha@gmail.com>
-Tanu Hari Dixit <tokencolour@gmail.com>
-Shekhar Prasad Rajak <shekharrajak@live.com>
-Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
-Arafat Dad Khan <arafat.da.khan@gmail.com>
-Boris Atamanovskiy <shaomoron@gmail.com>
-Sam Tygier <sam.tygier@hep.manchester.ac.uk>
-Jai Luthra <me@jailuthra.in>
-Guo Xingjian <Seeker1995@gmail.com>
-Sandeep Veethu <sandeep.veethu@gmail.com>
-Archit Verma <architv07@gmail.com>
-Shubham Tibra <shubh.tibra@gmail.com>
-Ashutosh Saboo <ashutosh.saboo96@gmail.com>
-Michael S. Hansen <michael.hansen@nih.gov>
-Anish Shah <shah.anish07@gmail.com>
-Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
-Bhautik Mavani <mavanibhautik@gmail.com>
-Michał Radwański <enedil.isildur@gmail.com>
-Jerry Li <jerry@jerryli.ca>
-Pablo Zubieta <pabloferz@yahoo.com.mx>
-Shivam Agarwal <knowthyself2503@gmail.com>
-Chaitanya Sai Alaparthi <achaitanyasai@gmail.com>
-Arihant Parsoya <parsoyaarihant@gmail.com>
-Ruslan Pisarev <rpisarev@cloudlinux.com>
-Akash Trehan <akash.trehan123@gmail.com>
-Nishant Nikhil <nishantiam@gmail.com>
-Vladimir Poluhsin <vovapolu@gmail.com>
-Akshay Nagar <awesomeay13@yahoo.com>
-James Brandon Milam <jmilam343@gmail.com>
-Abhinav Agarwal <abhinavagarwal1996@gmail.com>
-Rishabh Daal <rishabhdaal@gmail.com>
-Sanya Khurana <sanya@monica.in>
-Aman Deep <amandeep1024@gmail.com>
-Aravind Reddy <aravindreddy255@gmail.com>
-Abhishek Verma <iamvermaabhishek@gmail.com>
-Matthew Parnell <matt@parnmatt.co.uk>
-Thomas Hickman <Thomas.Hickman42@gmail.com>
-Akshay Siramdas <akshaysiramdas@gmail.com>
-YiDing Jiang <yidinggjiangg@gmail.com>
-Jatin Yadav <jatinyadav25@gmail.com>
-Matthew Thomas <mnmt@users.noreply.github.com>
-Rehas Sachdeva <aquannie@gmail.com>
-Michael Mueller <michaeldmueller7@gmail.com>
-Srajan Garg <srajan.garg@gmail.com>
-Prabhjot Singh <prabhjot.nith@gmail.com>
-Haruki Moriguchi <harukimoriguchi@gmail.com>
-Tom Gijselinck <tomgijselinck@gmail.com>
-Nitin Chaudhary <nitinmax1000@gmail.com>
-Alex Argunov <sajkoooo@gmail.com>
-Nathan Musoke <nathan.musoke@gmail.com>
-Abhishek Garg <abhishekgarg119@gmail.com>
-Dana Jacobsen <dana@acm.org>
-Vasiliy Dommes <vasdommes@gmail.com>
-Phillip Berndt <phillip.berndt@googlemail.com>
-Haimo Zhang <zh.hammer.dev@gmail.com>
-Anthony Scopatz <scopatz@gmail.com>
-bluebrook <perl4logic@gmail.com>
-Leonid Kovalev <leonidvkovalev@gmail.com>
-Josh Burkart <jburkart@gmail.com>
-Dimitra Konomi <t8130064@dias.aueb.gr>
-Christina Zografou <t8130048@dias.aueb.gr>
-Fiach Antaw <fiach.antaw+github@gmail.com>
-Langston Barrett <langston.barrett@gmail.com>
-Krit Karan <kritkaran.b13@iiits.in>
-G. D. McBain <gdmcbain@protonmail.com>
-Prempal Singh <prempal.42@gmail.com>
-Gabriel Orisaka <orisaka@gmail.com>
-Matthias Bussonnier <bussonniermatthias@gmail.com>
-rahuldan <rahul02013@gmail.com>
-Colin Marquardt <github@marquardt-home.de>
-Andrew Taber <andrew.e.taber@gmail.com>
-Yash Reddy <write2yashreddy@gmail.com>
-Peter Stangl <peter.stangl@ph.tum.de>
-elvis-sik <e.sikora@grad.ufsc.br>
-Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
-Jainul Vaghasia <jainulvaghasia@gmail.com>
-Dennis Meckel <meckel@datenschuppen.de>
-Harshil Meena <harshil.7535@gmail.com>
-Micky <mickydroch@gmail.com>
-Nick Curtis <nicholas.curtis@uconn.edu>
-Michele Zaffalon <michele.zaffalon@gmail.com>
-Martha Giannoudovardi <maapxa@gmail.com>
-Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
-Steph Papanik <spapanik21@gmail.com>
-Mohammad Sadeq Dousti <msdousti@gmail.com>
-Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
-Abdullah Javed Nesar <abduljaved1994@gmail.com>
-Lakshya Agrawal <zeeshan.lakshya@gmail.com>
-shruti <shrutishrm512@gmail.com>
-Rohit Rango <rohit.rango@gmail.com>
-Hong Xu <hong@topbug.net>
-Ivan Petuhov <ivan@ostrovok.ru>
-Alsheh <alsheh@rpi.edu>
-Marcel Stimberg <marcel.stimberg@ens.fr>
-Alexey Pakhocmhik <cool.Bakov@yandex.ru>
-Tommy Olofsson <tommy.olofsson.90@gmail.com>
-Zulfikar <zulfikar97@gmail.com>
-Blair Azzopardi <blairuk@gmail.com>
-Danny Hermes <daniel.j.hermes@gmail.com>
-Sergey Pestov <pestov-sa@yandex.ru>
-Mohit Chandra <mohit.chandra@research.iiit.ac.in>
-Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in>
-Marcin Briański <marcin.brianski@student.uj.edu.pl>
-andreo <andrey.torba@gmail.com>
-Flamy Owl <flamyowl@protonmail.ch>
-Yicong Guo <guoyicong100@gmail.com>
-Varun Garg <varun.garg03@gmail.com>
-Rishabh Madan <rishabhmadan96@gmail.com>
-Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
-Karan Sharma <karan1276@gmail.com>
-Vedant Rathore <vedantr1998@gmail.com>
-Johan Blåbäck <johan_bluecreek@riseup.net>
-Pranjal Tale <pranjaltale16@gmail.com>
-Jason Tokayer <jason.tokayer@gmail.com>
-Raghav Jajodia <jajodia.raghav@gmail.com>
-Rajat Thakur <rajatthakur1997@gmail.com>
-Dhruv Bhanushali <dhruv_b@live.com>
-Anjul Kumar Tyagi <anjul.ten@gmail.com>
-Barun Parruck <barun.parruck@gmail.com>
-Bao Chau <chauquocbao0907@gmail.com>
-Tanay Agrawal <tanay_agrawal@hotmail.com>
-Ranjith Kumar <ranjith.dakshana2015@gmail.com>
-Shikhar Makhija <shikharmakhija2@gmail.com>
-Yathartha Joshi <yathartha32@gmail.com>
-Valeriia Gladkova <valeriia.gladkova@gmail.com>
-Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
-Daniel Mahler <dmahler@gmail.com>
-Ka Yi <chua.kayi@yahoo.com.sg>
-Rishat Iskhakov <iskhakov@frtk.ru>
-Szymon Mieszczak <szymon.mieszczak@gmail.com>
-Sachin Agarwal <sachinagarwal0499@gmail.com>
-Priyank Patel <pspbot7@gmail.com>
-Satya Prakash Dwibedi <akash581050@gmail.com>
-tools4origins <tools4origins@gmail.com>
-Nico Schlömer <nico.schloemer@gmail.com>
-Fermi Paradox <FermiParadox@users.noreply.github.com>
-Ekansh Purohit <purohit.e15@gmail.com>
-Vedarth Sharma <vedarth.sharma@gmail.com>
-Peeyush Kushwaha <peeyush.p97@gmail.com>
-Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
-Christopher J. Wright <cjwright4242gh@gmail.com>
-Jakub Wilk <jwilk@jwilk.net>
-Mauro Garavello <mauro.garavello@unimib.it>
-Chris Tefer <ctefer@gmail.com>
-Shikhar Jaiswal <jaiswalshikhar87@gmail.com>
-Chiu-Hsiang Hsu <wdv4758h@gmail.com>
-Carlos Cordoba <ccordoba12@gmail.com>
-Fabian Ball <fabian.ball@kit.edu>
-Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
-Christiano Anderson <canderson@riseup.net>
-Robin Neatherway <robin.neatherway@gmail.com>
-Thomas Hunt <thomashunt13@gmail.com>
-Theodore Han <theodorehan@hotmail.com>
-Duc-Minh Phan <alephvn@gmail.com>
-Lejla Metohajrova <l.metohajrova@gmail.com>
-Samyak Jain <samyak.jain2016a@vitstudent.ac.in>
-Aditya Rohan <riyuzakiiitk@gmail.com>
-Vincent Delecroix <vincent.delecroix@labri.fr>
-Michael Sparapany <msparapa@purdue.edu>
-Harsh Jain <harshjniitr@gmail.com>
-Nathan Goldbaum <ngoldbau@illinois.edu>
-latot <felipematas@yahoo.com>
-Kenneth Lyons <ixjlyons@gmail.com>
-Stan Schymanski <stan.schymanski@env.ethz.ch>
-David Daly <david.daly12@kzoo.edu>
-Ayush Shridhar <ayush.shridhar1999@gmail.com>
-Javed Nissar <javednissar@gmail.com>
-Jiri Kuncar <jiri.kuncar@gmail.com>
-vedantc98 <vedantc98@gmail.com>
-Rupesh Harode <rupeshharode@gmail.com>
-Rob Zinkov <rob@zinkov.com>
-James Harrop <ebc121@gmail.com>
-James Taylor <user234683@tutanota.com>
-Ishan Joshi <ishanaj98@gmail.com>
-Marco Mancini <marco.mancini@obspm.fr>
-Boris Ettinger <ettinger.boris@gmail.com>
-Micah Fitch <micahscopes@gmail.com>
-Daniel Wennberg <daniel.wennberg@gmail.com>
-ylemkimon <ylemkimon@naver.com>
-Akash Vaish <akash.9712@gmail.com>
-Peter Enenkel <peter.enenkel+git@gmail.com>
-Waldir Pimenta <waldyrious@gmail.com>
-Jithin D. George <jithindgeorge93@gmail.com>
-Lev Chelyadinov <leva181777@gmail.com>
-Lucas Wiman <lucas.wiman@gmail.com>
-Rhea Parekh <rheaparekh12@gmail.com>
-James Cotton <peabody124@gmail.com>
-Robert Pollak <robert.pollak@posteo.net>
-anca-mc <anca-mc@users.noreply.github.com>
-Sourav Ghosh <souravghosh2197@gmail.com>
-Jonathan Allan <jjallan@users.noreply.github.com>
-Nikhil Pappu <nkhlpappu@gmail.com>
-Ethan Ward <etkewa@gmail.com>
-Cezary Marczak <zeddq1@gmail.com>
-dps7ud <dps7ud@virginia.edu>
-Nilabja Bhattacharya <nilabja10201992@gmail.com>
-Itay4 <31018228+Itay4@users.noreply.github.com>
-Poom Chiarawongse <eight1911@gmail.com>
-Yang Yang <wdscxsj@gmail.com>
-Cavendish McKay <cmckay@tachycline.com>
-Bradley Gannon <bradley.m.gannon@gmail.com>
-B McG <bmcg0890@gmail.com>
-Rob Drynkin <rob.drynkin@gmail.com>
-Seth Ebner <murgrehk@gmail.com>
-Akash Kundu <sk.sayakkundu1997@gmail.com>
-Mark Jeromin <mark.jeromin@sysfrog.net>
-Roberto Díaz Pérez <r.r.1994a@gmail.com>
-Gleb Siroki <g.shiroki@gmail.com>
-Segev Finer <segev208@gmail.com>
-Alex Lubbock <code@alexlubbock.com>
-Ayodeji Ige <ayodeji18@outlook.com>
-Matthew Wardrop <matthew.wardrop@airbnb.com>
-Hugo van Kemenade <hugovk@users.noreply.github.com>
-Austin Palmer <ap4000@nyu.edu>
-der-blaue-elefant <github@kklein.de>
-Filip Gokstorp <filip@gokstorp.se>
-Yuki Matsuda <yuki.matsuda.w@gmail.com>
-Aaron Miller <acmiller273@gmail.com>
-Salil Vishnu Kapur <salilvishnukapur@gmail.com>
-Atharva Khare <khareatharva@gmail.com>
-Shubham Maheshwari <rmaheshwari05@gmail.com>
-Pavel Tkachenko <paveltkachenko@email.com>
-Ashish Kumar Gaurav <ashishkg0022@gmail.com>
-Rajeev Singh <rajs2010@gmail.com>
-Keno Goertz <keno@goertz-berlin.com>
-Lucas Gallindo <lgallindo@gmail.com>
-Himanshu <hs80941@gmail.com>
-David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
-Amit Manchanda <amitdelhi1995@gmail.com>
-Rohit Jain <rohitjain3241@gmail.com>
-Jonathan A. Gross <jarthurgross@gmail.com>
-Unknown <kunda@scribus.net>
-Sayan Goswami <Sayan98@users.noreply.github.com>
-Subhash Saurabh <subhashsaurabh419@gmail.com>
-Rastislav Rabatin <rastislav.rabatin@gmail.com>
-Vishal <vishalg2235@gmail.com>
-Jeremey Gluck <jeremygluck@yahoo.com>
-Akshat Maheshwari <akshat14714@gmail.com>
-symbolique <symbolique@users.noreply.github.com>
-Saloni Jain <tosalonijain@gmail.com>
-Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
-Abhigyan Khaund <mail@abhigyan.xyz>
-Jashanpreet Singh <jashansingh.4398@gmail.com>
-Saurabh Agarwal <shourabh.agarwal@gmail.com>
-luzpaz <luzpaz@users.noreply.github.com>
-P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
-Nirmal Sarswat <nirmalsarswat400@gmail.com>
-Cristian Di Pietrantonio <cristiandipietrantonio@gmail.com>
-Ravi charan <ravicharan.vsp@gmail.com>
-Nityananda Gohain <nityanandagohain@gmail.com>
-Cédric Travelletti <cedrictravelletti@gmail.com>
-Nicholas Bollweg <nick.bollweg@gmail.com>
-Himanshu Ladia <hladia199811@gmail.com>
-Adwait Baokar <adwaitbaokar18@gmail.com>
-Mihail Tarigradschi <m.tarigradschi@gmail.com>
-Saketh <alurusaisaketh@gmail.com>
-rushyam <rushyamsonu@gmail.com>
-sfoo <sfoohei@gmail.com>
-Rahil Hastu <rahilhastu@gmail.com>
-Zach Raines <raineszm@gmail.com>
-Sidhant Nagpal <sidhantnagpal97@gmail.com>
-Gagandeep Singh <singh.23@iitj.ac.in>
-Rishav Chakraborty <annonymousxyz@outlook.com>
-Malkhan Singh <malkhansinghrathaur@gmail.com>
-Joaquim Monserrat <qmonserrat@mailoo.org>
-Mayank Singh <mayank.singh081997@gmail.com>
-Rémy Léone <rleone@online.net>
-Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
-Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk>
-helo9 <helo9@users.noreply.github.com>
-Ken Wakita <wakita@is.titech.ac.jp>
-Carl Sandrock <carl.sandrock@up.ac.za>
-Fredrik Eriksson <freeriks@student.chalmers.se>
-Ian Swire <oversizedpenguin@gmail.com>
-Bulat <daianovich@mail.ru>
-Ehren Metcalfe <ehren.m@gmail.com>
-Dmitry Savransky <dsavransky@gmail.com>
-Kiyohito Yamazaki <kyamaz@openql.org>
-Caley Finn <caleyreuben@gmail.com>
-Zhi-Qiang Zhou <zzq_890709@hotmail.com>
-Alexander Pozdneev <pozdneev@users.noreply.github.com>
-Wes Turner <50891+westurner@users.noreply.github.com>
-JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
-Arshdeep Singh <singh.arshdeep1999@gmail.com>
-cym1 <16437732+cym1@users.noreply.github.com>
-Stewart Wadsworth <stewart.wadsworth@gmail.com>
-Jared Lumpe <mjlumpe@gmail.com>
-Avi Shrivastava <shrivastavaavi123@gmail.com>
-ramvenkat98 <ramvenkat98@gmail.com>
-Bilal Ahmed <b.ahmed0918@gmail.com>
-Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
-Yatna Verma <yatnavermaa@gmail.com>
-S.Y. Lee <sylee957@gmail.com>
-Miro Hrončok <miro@hroncok.cz>
-Sudarshan Kamath <sudarshan.kamath97@gmail.com>
-Ayushman Koul <ayushmankoul4570@gmail.com>
-Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
-Andrey Grozin <A.G.Grozin@inp.nsk.su>
-Bavish Kulur <bavishkulur@gmail.com>
-Arun Singh <arunsin997@gmail.com>
-sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
-Zachariah Etienne <zachetie@gmail.com>
-Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
+袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+彭于斌 <1931127624@qq.com>
 2torus <boris.ettinger@gmail.com>
-Faisal Riyaz <faisalriyaz011@gmail.com>
-Martin Roelfs <u0114255@kuleuven.be>
-SirJohnFranklin <sirjfu@googlemail.com>
-Anthony Sottile <asottile@umich.edu>
-ViacheslavP <public.viacheslav@gmail.com>
-Safiya03 <safiyanesar@gmail.com>
-Alexander Dunlap <alexander.dunlap@gmail.com>
-Rohit Sharma <31184621+rohitx007@users.noreply.github.com>
-Jonathan Warner <warnerjon12@gmail.com>
-Mohit Balwani <mohitbalwani.ict17@gmail.com>
-Marduk Bolaños <mardukbp@mac.com>
-amsuhane <ayushsuhane99@iitkgp.ac.in>
-Matthias Geier <Matthias.Geier@gmail.com>
-klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
-Shubham Kumar Jha <skjha832@gmail.com>
-rationa-kunal <kunalgk1999@gmail.com>
-Animesh Sinha <animeshsinha1309@gmail.com>
-Gaurang Tandon <1gaurangtandon@gmail.com>
-Matthew Craven <clyring@users.noreply.github.com>
-Daniel Ingram <ingramds@appstate.edu>
-Jogi Miglani <jmig5776@gmail.com>
-Takumasa Nakamura <n.takumasa@gmail.com>
-Ritu Raj Singh <RituRajSingh878@gmail.com>
-Rajiv Ranjan Singh <rajivperfect007@gmail.com>
-Vera Lozhkina <veralozhkina@gmail.com>
-adhoc-king <46354827+adhoc-king@users.noreply.github.com>
-Mikel Rouco <mikel.mrm@gmail.com>
-Oscar Gustafsson <oscar.gustafsson@gmail.com>
-damianos <damianos@semmle.com>
-Supreet Agrawal <supreet11agrawal@gmail.com>
-shiksha11 <shiksharawat01@gmail.com>
-Martin Ueding <dev@martin-ueding.de>
-sharma-kunal <kunalsharma6914@gmail.com>
-Divyanshu Thakur <divyanshu@iiitmanipur.ac.in>
-Susumu Ishizuka <susumu.ishizuka@kii.com>
-Samnan Rahee <namanush.rsr.16@gmail.com>
-Fredrik Andersson <fredrik.andersson@fcc.chalmers.se>
-Bhavya Srivastava <bhavya17037@iiitd.ac.in>
-Alpesh Jamgade <alpeshjamgade21@gmail.com>
-Shubham Abhang <shubhamabhang77@gmail.com>
-Vishesh Mangla <manglavishesh64@gmail.com>
-Nicko van Someren <nicko@nicko.org>
-dandiez <47832466+dandiez@users.noreply.github.com>
-Frédéric Chapoton <fchapoton2@gmail.com>
-jhanwar <f2015463@pilani.bits-pilani.ac.in>
-Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
-Salmista-94 <alejandrogroso@hotmail.com>
-Shivani Kohli <shivanikohli.09@gmail.com>
-Parker Berry <parkereberry@gmail.com>
-Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
-Nabanita Dash <dashnabanita@gmail.com>
-Gaetano Guerriero <x.guerriero@tin.it>
-Ankit Raj Pandey <pandeyan@grinnell.edu>
-Ritesh Kumar <ritesh99rakesh@gmail.com>
-kangzhiq <709563092@qq.com>
-Jun Lin <junlin0604@gmail.com>
-Petr Kungurtsev <corwinat@gmail.com>
-Anway De <anway1756@gmail.com>
-znxftw <vishnu2101@gmail.com>
-Denis Ivanenko <ivanenko@ucu.edu.ua>
-Orestis Vaggelis <orestisvaggelis@mail.com>
-Nikhil Maan <nikhilmaan22@gmail.com>
-Abhinav Anand <abhinav.anand2807@gmail.com>
-Qingsha Shi <googol.sqs@gmail.com>
-Juan Barbosa <js.barbosa10@uniandes.edu.co>
-Prionti Nasir <pdn3628@rit.edu>
-Bharat Raghunathan <bharatraghunthan9767@gmail.com>
-arooshiverma <av22@iitbbs.ac.in>
-Christoph Gohle <ctg@mpq.mpg.de>
-Charalampos Tsiagkalis <ctsiagkalis@uth.gr>
-Daniel Sears <highpost@users.noreply.github.com>
-Megan Ly <megan.ly@learnosity.com>
-Sean P. Cornelius <spcornelius@gmail.com>
-Erik R. Gomez <gomez@kth.se>
-Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
-Henry Metlov <genrih.metlov@gmail.com>
-pekochun <hamburg_hamburger2000@yahoo.co.jp>
-Bendik Samseth <b.samseth@gmail.com>
-Vighnesh Shenoy <vighneshq@gmail.com>
-Versus Void <versusvoid@gmail.com>
-Denys Rybalka <rybalka.denis@gmail.com>
-Mark Dickinson <dickinsm@gmail.com>
-Rimi <rimibis@umich.edu>
-rimibis <33387803+rimibis@users.noreply.github.com>
-Steven Lee <stevenlee123@protonmail.com>
-Gilles Schintgen <gschintgen@hambier.lu>
-Abhi58 <abhijithbharadwaj58@gmail.com>
-Tomasz Pytel <tompytel@gmail.com>
 Aadit Kamat <aadit.k12@gmail.com>
-Samesh <samesh.lakhotia@gmail.com>
-Velibor Zeli <velibor@mech.kth.se>
-Gabriel Bernardino <gabriel.bernardino@upf.edu>
-Joseph Redfern <joseph@redfern.me>
-Evelyn King <evelyn.cameron.king@gmail.com>
-Miguel Marco <mmarco@unizar.es>
-David Hagen <david@drhagen.com>
-Hannah Kari <hannah.kari@marquette.edu>
-Soniya Nayak <soniyanayak51@gmail.com>
-Harsh Agarwal <hagarwal9200@gmail.com>
-Enric Florit <efz1005@gmail.com>
-Yogesh Mishra <ymishra013@gmail.com>
-Denis Rykov <rykovd@gmail.com>
-Ivan Tkachenko <me@ratijas.tk>
-Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
-Stephan Seitz <stephan.seitz@fau.de>
-Yeshwanth N <yeshsurya@gmail.com>
-Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk>
-Srinivasa Arun Yeragudipati <ysarun1999@gmail.com>
-Kirtan Mali <kirtanmali555@gmail.com>
-TitanSnow <sweeto@live.cn>
-Pengning Chao <8857165+PengningChao@users.noreply.github.com>
-Louis Abraham <louis.abraham@yahoo.fr>
-Morten Olsen Lysgaard <morten@lysgaard.no>
+Aaditya Nair <aadityanair6494@gmail.com>
+Aaron Gokaslan <aaronGokaslan@gmail.com>
+Aaron Meurer <asmeurer@gmail.com>
+Aaron Miller <acmiller273@gmail.com>
+Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
+Aaryan Dewan <aaryandewan@yahoo.com>
+Aasim Ali <aasim250205@gmail.com>
+Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com>
+Abby Ng <abigailjng@gmail.com>
+Abderrahim Kitouni <a.kitouni@gmail.com>
+Abdullah Javed Nesar <abduljaved1994@gmail.com>
+Abhay_Dhiman <abhaysdhimans@gmail.com>
+Abhi58 <abhijithbharadwaj58@gmail.com>
+Abhigyan Khaund <mail@abhigyan.xyz>
+Abhinav Agarwal <abhinavagarwal1996@gmail.com>
+Abhinav Anand <abhinav.anand2807@gmail.com>
+Abhinav Chanda <abhinavchanda01@gmail.com>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in>
+abhinav28071999 <41710346+abhinav28071999@users.noreply.github.com>
+Abhishek <uchiha@pop-os.localdomain>
+Abhishek Chaudhary <ac5003@columbia.edu>
+Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com>
+Abhishek kumar <kumar325571@gmail.com>
+Abhishek Patidar <1e9abhi1e10@gmail.com>
+Abhishek Verma <iamvermaabhishek@gmail.com>
+Achal Jain <2achaljain@gmail.com>
+Adam Bloomston <adam@glitterfram.es>
+Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
+Addison Cugini <ajcugini@gmail.com>
+adhoc-king <46354827+adhoc-king@users.noreply.github.com>
+aditisingh2362 <aditisingh2362@gmail.com>
+Aditya Jindal <jaditya8889@gmail.com>
+Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
+Aditya Kumar Sinha <adityakumar113141@gmail.com>
+Aditya Ravuri <infprobscix@gmail.com>
+Aditya Rohan <riyuzakiiitk@gmail.com>
+Aditya Shah <adityashah30@gmail.com>
+Advait Pote <apote2050@gmail.com>
+Adwait Baokar <adwaitbaokar18@gmail.com>
+Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Akash Agrawall <akash.wanted@gmail.com>
+Akash Kundu <sk.sayakkundu1997@gmail.com>
 Akash Nagaraj (akasnaga) <akasnaga@cisco.com>
 Akash Nagaraj <grassknoted@gmail.com>
-Lauren Glattly <laurenglattly@gmail.com>
-Hou-Rui <houruinus@gmail.com>
-George Korepanov <gkorepanov.gk@gmail.com>
-dranknight09 <cbhaavan@gmail.com>
-aditisingh2362 <aditisingh2362@gmail.com>
-Gina <Dr-G@users.noreply.github.com>
-gregmedlock <gmedlo@gmail.com>
-Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
-Eric Wieser <wieser.eric@gmail.com>
-Bradley Dowling <34559056+btdow@users.noreply.github.com>
-Maria Marginean <33810762+mmargin@users.noreply.github.com>
-Akash Agrawall <akash.wanted@gmail.com>
-jgulian <josephdgulian@gmail.com>
-Sourav Goyal <souravgl0@gmail.com>
-Zlatan Vasović <zlatanvasovic@gmail.com>
-Alex Meiburg <timeroot.alex@gmail.com>
-Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in>
-Naman Gera <namangera15@gmail.com>
-Julien Palard <julien@palard.fr>
-Dhruv Mendiratta <dhruvmendiratta6@gmail.com>
-erdOne <36414270+erdOne@users.noreply.github.com>
-risubaba <risubhjain1010@gmail.com>
-abhinav28071999 <41710346+abhinav28071999@users.noreply.github.com>
-Jisoo Song <jeesoo9595@snu.ac.kr>
-Jaime R <38530589+Jaime02@users.noreply.github.com>
-Vikrant Malik <vikrantmalik051@gmail.com>
-Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
-Abhishek <uchiha@pop-os.localdomain>
-Johannes Hartung <joha2@gmx.net>
-Milan Jolly <milan.cs16@iitp.ac.in>
-faizan2700 <syedfaizan824@gmail.com>
-mohit <39158356+mohitacecode@users.noreply.github.com>
-Mohit Gupta <mohitgupta@gmail.com>
-Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in>
-Chanakya-Ekbote <ca10@iitbbs.ac.in>
-Rashmi Shehana <rashmi.watagedara@syscolabs.com>
-Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
-Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
-Michal Grňo <m93a.cz@gmail.com>
-vezeli <37907135+vezeli@users.noreply.github.com>
-Tim Gates <tim.gates@iress.com>
-Sandeep Murthy <smurthy@protonmail.ch>
-Neil <mistersheik@gmail.com>
-V1krant <46847915+V1krant@users.noreply.github.com>
-alejandro <amartinhernan@gmail.com>
-Riyan Dhiman <Riyandhiman14@gmail.com>
-sbt4104 <sthorat661@gmail.com>
-Seth Troisi <sethtroisi@google.com>
-Bhaskar Gupta <guptabhanu1999@gmail.com>
-Smit Gajjar <smitgajjar.gs@gmail.com>
-rbl <rlee@grove.co>
-Ilya Pchelintsev <ilya.pchelintsev@outlook.com>
-Omar Wagih <o.wagih.ow@gmail.com>
-prshnt19 <prashant.rawat216@gmail.com>
-Johan Guzman <jguzm022@ucr.edu>
-Vasileios Kalos <kalosbasileios@gmail.com>
-BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
-Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
-Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in>
-Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
-Moses Paul R <iammosespaulr@gmail.com>
-Saanidhya vats <saanidhyavats@gmail.com>
-tnzl <you@example.com>
-Vatsal Srivastava <alstav.trivas.sava@gmail.com>
-Jean-Luc Herren <jlh@gmx.ch>
-Dhruv Kothari <dhruvkothari22@gmail.com>
-seadavis <45022599+seadavis@users.noreply.github.com>
-kamimura <kamimura@live.jp>
-slacker404 <pchantza@gmail.com>
-Jaime Resano <gemailpersonal02@gmail.com>
-Ebrahim Byagowi <ebrahim@gnu.org>
-wuyudi <wuyudi119@163.com>
-Akira Kyle <ak@akirakyle.com>
-Calvin Jay Ross <calvinjayross@gmail.com>
-Martin Thoma <info@martin-thoma.de>
-Thomas A Caswell <tcaswell@gmail.com>
-Lagaras Stelios <stel.lag@hotmail.com>
-Jerry James <loganjerry@gmail.com>
-Jan Kruse <janckruse@t-online.de>
-Nathan Taylor <pecan.pine@gmail.com>
-Vaishnav Damani <vaishnavdamani3496@gmail.com>
-Mohit Shah <mohitshah3111999@gmail.com>
-Mathias Louboutin <mathias.louboutin@gmail.com>
-Marijan Smetko <marijansmetko123@gmail.com>
-Dave Witte Morris <Dave.Morris@uleth.ca>
-soumi7 <soumibardhan10@gmail.com>
-Zhongshi <zj495@nyu.edu>
-Wes Galbraith <galbwe92@gmail.com>
-KaustubhDamania <kaustubh.damania@gmail.com>
-w495 <w495@yandex-team.ru>
+Akash Trehan <akash.trehan123@gmail.com>
+Akash Vaish <akash.9712@gmail.com>
 Akhil Rajput <akh1lrjput@gmail.com>
-Markus Mohrhard <markus.mohrhard@googlemail.com>
-Benjamin Wolba <mail@benjaminwolba.com>
-彭于斌 <1931127624@qq.com>
-Rudr Tiwari <rudrtiwari@gmail.com>
-Aaryan Dewan <aaryandewan@yahoo.com>
-Benedikt Placke <benedikt.placke@outlook.com>
-Sneha Goddu <s.goddu@wustl.edu>
-goddus <39923708+goddus@users.noreply.github.com>
-Shivang Dubey <shivangdubey8@gmail.com>
-Michael Greminger <michael.greminger@gmail.com>
-Peter Cock <p.j.a.cock@googlemail.com>
-Willem Melching <willem.melching@gmail.com>
-Elias Basler <e.e.basler@protonmail.com>
-Brandon David <brandon.david@zoho.com>
-Abhay_Dhiman <abhaysdhimans@gmail.com>
-Tasha Kim <jae_young_kim@brown.edu>
-Ayush Malik <ayushmalik779@gmail.com>
-Devesh Sawant <devesh47cool@gmail.com>
-Wolfgang Stöcher <wolfgang@stoecher.com>
-Sudeep Sidhu <sudeepmanilsidhu@gmail.com>
-foice <foice.news@gmail.com>
-Ben Payne <ben.is.located@gmail.com>
-Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
-noam simcha finkelstein <noam.finkelstein@protonmail.com>
-Garrett Folbe <gmfolbe@yahoo.com>
-Islam Mansour <is3mansour@gmail.com>
-Sayandip Halder <sayandiph4@gmail.com>
-Shubham Agrawal <shubham.ag6845@gmail.com>
-numbermaniac <5206120+numbermaniac@users.noreply.github.com>
-Sakirul Alam <binarysakir@gmail.com>
-Mohammed Bilal <r.mohammedbilal@gmail.com>
-Chris du Plessis <christopherjonduplessis@gmail.com>
-Coder-RG <rgoel1999@gmail.com>
-Ansh Mishra <anshmishra471@gmail.com>
-Alex Malins <github@alexmalins.com>
-Lorenzo Contento <lorenzo.contento@gmail.com>
-Naveen Sai <naveensaisreenivas@gmail.com>
-Shital Mule <shitalmule04@gmail.com>
-Amanda Dsouza <meezamanda@yahoo.com>
-Nijso Beishuizen <nijso@koolmees.numerically-related.com>
-Harry Zheng <harry@harryzheng.com>
-Felix Yan <felixonmars@archlinux.org>
-Constantin Mateescu <costica1234@me.com>
-Eva Tiwari <eva.tiwari@gmail.com>
-Aditya Kumar Sinha <adityakumar113141@gmail.com>
-Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
-Kaustubh Chaudhari <ckaustubhm06@gmail.com>
-Kristian Brünn <hello@kristianbrunn.com>
-Neel Gorasiya <mgorasiya1974@gmail.com>
-Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
-Jose M. Gomez <chemoki@gmail.com>
-Stefan Petrea <stefan@garage-coding.com>
-Praveen Sahu <povinsahu@gmail.com>
-Mark Bell <mark00bell@googlemail.com>
-AlexCQY <alex_chua@u.nus.edu>
-Fabian Froehlich <fabian@schaluck.com>
-Nikhil Gopalam <gopalamn@umich.edu>
-Kartik Sethi <kartiks31416@gmail.com>
-Muhammed Abdul Quadir Owais <quadirowais200@gmail.com>
-Harshit Yadav <harshityadav2k@gmail.com>
-Sidharth Mundhra <sidharthmundhra16@gmail.com>
-Suryam Arnav Kalra <suryamkalra35@gmail.com>
-Prince Gupta <codemastercpp@gmail.com>
-Kunal Singh <ksingh19136@gmail.com>
-Mayank Raj <mayank_1901cs35@iitp.ac.in>
-Achal Jain <2achaljain@gmail.com>
-Mario Maio <mario.maio@aruba.it>
-Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
-Wyatt Peak <wyattpeak@gmail.com>
-Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in>
-Aditya Jindal <jaditya8889@gmail.com>
-Vaibhav Bhat <vaibhav.bhat2097@gmail.com>
-Priyansh Rathi <techiepriyansh@gmail.com>
-Saket Kumar Singh <saketkumar1202@gmail.com>
-Yukai Chou <muzimuzhi@gmail.com>
-Qijia Liu <liumeo@pku.edu.cn>
-Paul Mandel <paulmandel@google.com>
-Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
-Dominik Stańczak <stanczakdominik@gmail.com>
-Rodrigo Luger <rodluger@gmail.com>
-Marco Antônio Habitzreuter <mahabitzreuter@gmail.com>
-Ayush Bisht <bisht.ayush2001@gmail.com>
+Akira Kyle <ak@akirakyle.com>
 Akshansh Bhatt <akshansh@tuta.io>
-Brandon T. Willard <brandonwillard@users.noreply.github.com>
-Thomas Aarholt <thomasaarholt@gmail.com>
-Hiren Chalodiya <hirenchalodiya99@gmail.com>
-Roland Dixon <rols121@gmail.com>
-dimasvq <dimas.vq.2020@bristol.ac.uk>
-Sagar231 <sagarfeb298@gmail.com>
-Michael Chu <michael02chu@gmail.com>
-Abby Ng <abigailjng@gmail.com>
-Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
-Alexander Cockburn <alexander_cockburn12@hotmail.com>
-Yaser AlOsh <yaseralosh@outlook.com>
-Davide Sandonà <sandona.davide@gmail.com>
-Jonathan Gutow <gutow@uwosh.edu>
-Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
-Lee Johnston <lee.johnston.100@gmail.com>
-Zach Carmichael <20629897+craymichael@users.noreply.github.com>
-Vijairam Ganesh Moorthy <vijairamg@gmail.com>
-Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
-Ben Oostendorp <oostben@umich.edu>
-Nikita <nikita.student.cse19@itbhu.ac.in>
-Aman <amanmourya295@gmail.com>
-Shashank KS <shashankks0987@gmail.com>
-Aman Sharma <amansharma110603@gmail.com>
-Anup Parikh <parikhanupk@gmail.com>
-Lucy Mountain <lucymountain1@icloud.com>
-Miguel Torres Costa <miguelptcosta1995@gmail.com>
-Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
-Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
-Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
-Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
-Huangduirong <huangduirong@huawei.com>
-Nils Schulte <47043622+Schnilz@users.noreply.github.com>
-Matt Bogosian <matt@bogosian.net>
-Elisha Hollander <just4now666666@gmail.com>
-Aditya Ravuri <infprobscix@gmail.com>
-Mamidi Ratna Praneeth <praneethratna@gmail.com>
-Jeffrey Ryan <jeffaryan7@gmail.com>
-Jonathan Daniel <36337649+jond01@users.noreply.github.com>
-Robin Richard <raisin@ecomail.fr>
-Gautam Menghani <gum3ng@protonmail.com>
-Remco de Boer <29308176+redeboer@users.noreply.github.com>
-Sebastian East <sebastianeast@ymail.com>
-Evani Balasubramanyam <balasubramanyam.evani@gmail.com>
-Rahil Parikh <r.parikh@somaiya.edu>
-Jason Ross <jasonross1024@gmail.com>
-Joannah Nanjekye <joannah.nanjekye@ibm.com>
-Ayush Kumar <ayushk7102@gmail.com>
-Kshitij <kshitijparwani.mat18@itbhu.ac.in>
-Daniel Hyams <dhyams@gmail.com>
-alijosephine <alijosephine@gmail.com>
-Matthias Köppe <mkoeppe@math.ucdavis.edu>
-mohajain <mohajain99@gmail.com>
-Anibal M. Medina-Mardones <ammedmar@gmail.com>
-Travis Ens <ens.travis@gmail.com>
-Evgenia Karunus <lakesare@gmail.com>
-Risiraj Dey <risirajdey@gmail.com>
-lastcodestanding <rohang71604@gmail.com>
-Andrey Lekar <andrey_lekar@adoriasoft.com>
-Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com>
-Anutosh Bhat <andersonbhat491@gmail.com>
-Steve Kieffer <sk@skieffer.info>
-Paul Spiering <paul@spiering.org>
-Pieter Gijsbers <p.gijsbers@tue.nl>
-Wang Ran (汪然) <wangr@smail.nju.edu.cn>
-naelsondouglas <naelson17@gmail.com>
-Aman Thakur <thakuraman22july@gmail.com>
-S. Hanko <suzy.hanko@gmail.com>
-Dennis Sweeney <sweeney.427@osu.edu>
-Gurpartap Singh <dhaliwal.gurpartap@gmail.com>
-Hampus Malmberg <hampus.malmberg88@gmail.com>
-scimax <max.kellermeier@hotmail.de>
-Nikhil Date <nikhil.s.date@gmail.com>
-Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com>
+Akshat Jain <akshat.jain@students.iiit.ac.in>
+Akshat Maheshwari <akshat14714@gmail.com>
+Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
+Akshay <akshaynukala95@gmail.com>
+Akshay Nagar <awesomeay13@yahoo.com>
+Akshay Siramdas <akshaysiramdas@gmail.com>
+Akshay Srinivasan <akshaysrinivasan@gmail.com>
+Akshit Agarwal <akshit.jiit@gmail.com>
 AkuBrain <76952313+Franck2111@users.noreply.github.com>
-Leo Battle <leowbattle@gmail.com>
-Advait Pote <apote2050@gmail.com>
-Anurag Bhat <bhat.1@iitj.ac.in>
-Jeremy Monat <jemonat@calalum.org>
-Diane Tchuindjo <dtchuindjo@gmail.com>
-Tom Fryers <61272761+TomFryers@users.noreply.github.com>
-Zouhair <zouhair.mahboubi@gmail.com>
-zzj <29055749+zjzh@users.noreply.github.com>
-shubhayu09 <guptashubhayu601@gmail.com>
-Siddhant Jain <siddhantashoknagar@gmail.com>
-Tirthankar Mazumder <63574588+wermos@users.noreply.github.com>
-Sumit Kumar <mr.sumitkrr@gmail.com>
-Shivam Sagar <technoshivam12@gmail.com>
-Gaurav Jain <gjain369@gmail.com>
-Andrii Oriekhov <andriyorehov@gmail.com>
-Luis Talavera <luisfertalavera15@gmail.com>
-Arie Bovenberg <a.c.bovenberg@gmail.com>
-Carson McManus <carson.mcmanus1@gmail.com>
-Jack Schmidt <1107865+jackschmidt@users.noreply.github.com>
-Riley Britten <nrb1324@hotmail.com>
-Georges Khaznadar <georgesk@debian.org>
-Donald Wilson <donwilson1029@gmail.com>
-Timo Stienstra <timostienstra00@gmail.com>
-dispasha <dispasha@users.noreply.github.com>
-Saksham Alok <sakshamalok13@gmail.com>
-Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
-oittaa <8972248+oittaa@users.noreply.github.com>
-Omkaar <79257339+Pysics@users.noreply.github.com>
-Islem BOUZENIA <fi_bouzenia@esi.dz>
-extraymond <extraymond@gmail.com>
+Alan Bromborsky <abrombo@verizon.net>
+Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
+Alec Kalinin <alec.kalinin@gmail.com>
+alejandro <amartinhernan@gmail.com>
+Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com>
+Aleksandar Makelov <amakelov@college.harvard.edu>
+Alex Argunov <sajkoooo@gmail.com>
+Alex Lindsay <adlinds3@ncsu.edu>
+Alex Lubbock <code@alexlubbock.com>
+Alex Malins <github@alexmalins.com>
+Alex Meiburg <timeroot.alex@gmail.com>
 Alexander Behrens <alex.git@gmx.net>
-user202729 <25191436+user202729@users.noreply.github.com>
-Pieter Eendebak <pieter.eendebak@gmail.com>
-Zaz Brown <zazbrown@zazbrown.com>
-ritikBhandari <ritikbhandari68@gmail.com>
-viocha <66580331+viocha@users.noreply.github.com>
-Arthur Ryman <arthur.ryman@gmail.com>
-Xiang Wu <hsiangwu@fb.com>
-tttc3 <T.Coxon2@lboro.ac.uk>
-Seth Poulsen <poulsenseth@yahoo.com>
-cocolato <haiizhu@outlook.com>
-Anton Golovanov <agolovanov256@gmail.com>
-Gareth Ma <grhkm21@gmail.com>
-Clément M.T. Robert <cr52@protonmail.com>
-Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
-Karan <grgkaran03@gmail.com>
-Stefan Behnle <84378403+behnle@users.noreply.github.com>
-Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
-Arthur Milchior <arthur@milchior.fr>
-NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
-Ishan Pandhare <ishan9096137017@gmail.com>
-Carlos García Montoro <TrilceAC@gmail.com>
-Parcly Taxel <reddeloostw@gmail.com>
-Saicharan <saicharanhahaha@gmail.com>
-Kunal Sheth <kunal@kunalsheth.info>
-Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
-Jyn Spring 琴春 <me@vx.st>
-Phil LeMaitre <phil_lemaitre@live.ca>
-Chris Kerr <chris.kerr@mykolab.ch>
-José Senart <jose.senart@gmail.com>
-Uwe L. Korn <uwelk@xhochy.com>
-ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>
-Yves Tumushimire <yvestumushimire@gmail.com>
-wookie184 <wookie1840@gmail.com>
-Costor <pcs2009@web.de>
-Klaus Rettinghaus <klaus.rettinghaus@enote.com>
-Sam Brockie <sambrockie@icloud.com>
-Abhishek Patidar <1e9abhi1e10@gmail.com>
-Eric Demer <demer@mailbox.org>
-Pontus von Brömssen <pontus.vonbromssen+github@gmail.com>
-Victor Immanuel <chrollolucilfer1402@gmail.com>
-Evandro Bernardes <evbernardes@gmail.com>
-Michele Ceccacci <michelececcacci1@gmail.com>
-Ayush Aryan <ayush.aryan71@gmail.com>
-Kishore Gopalakrishnan <kishore96@gmail.com>
-Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com>
-Daiki Takahashi <haru.td@gmail.com>
-Sayan Mitra <ee18b156@smail.iitm.ac.in>
-Aman Kumar Shukla <theprofessionalaman@gmail.com>
-Zoufiné Lauer-Baré <raszoufine@gmail.com>
-Charles Harris <erdos4d@gmail.com>
-Tejaswini Sanapathi <sastejaswini2002@gmail.com>
-Devansh <be19b002@smail.iitm.ac.in>
-Aaron Gokaslan <aaronGokaslan@gmail.com>
-Daan Koning (he/him) <daanolivierkoning@gmail.com>
-Steven Burns <royalstream@hotmail.com>
-Jay Patankar <patankarjays@gmail.com>
-Vivek Soni <sonisheela1977@gmail.com>
-Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
-Sam Ritchie <sam@mentat.org>
-Maciej Skórski <maciej.skorski@gmail.com>
-Tilo Reneau-Cardoso <tiloreneau@gmail.com>
-Laurence Warne <laurencewarne@gmail.com>
-Lukas Molleman <Lukas.Molleman@gmail.com>
-Konstantinos Riganas <kostasriganas24@gmail.com>
-Grace Su <grace.duansu@gmail.com>
-Pedro Rosa <pedro_sxbr@usp.br>
-Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in>
-Baiyuan Qiu <1061688677@qq.com>
-Liwei Cai <cai.lw123@gmail.com>
-Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
-Isidora Araya <iarayaday@gmail.com>
-Seb Tiburzio <sebtiburzio@gmail.com>
-Victory Omole <vtomole2@gmail.com>
-Abhishek Chaudhary <ac5003@columbia.edu>
+Alexander Bentkamp <bentkamp@gmail.com>
+Alexander Cockburn <alexander_cockburn12@hotmail.com>
+Alexander Dunlap <alexander.dunlap@gmail.com>
+Alexander Eberspächer <alex.eberspaecher@gmail.com>
+Alexander Grund <alexander.grund@tu-dresden.de>
+Alexander Hirzel <alex@hirzel.us>
+Alexander Pozdneev <pozdneev@users.noreply.github.com>
+Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
 Alexander Zhura <nice.zhura@list.ru>
-Shuai Zhou <shuaivzhou@berkeley.edu>
-Martin Manns <mmanns@gmx.net>
-John Möller <john.moller@outlook.com>
-zzc <1378113190@qq.com>
-Pablo Galindo Salgado <pablogsal@gmail.com>
-Johannes Kasimir <johannes.kasimir@math.lu.se>
-Theodore Dias <theodore.dias@hotmail.co.uk>
-Kaustubh <90597818+kaustubh-765@users.noreply.github.com>
-Idan Pazi <idan.kp@gmail.com>
-Bobby Palmer <bobbyp@umich.edu>
-Saikat Das <saikatdchhe@gmail.com>
-Suman mondal <smondal.qwerty@gmail.com>
-Taylan Sahin <info@taylansahin.net>
-Fabio Luporini <fabio@devitocodes.com>
-Oriel Malihi <orielmalihi1@gmail.com>
-Geetika Vadali <geetika.vadali4@gmail.com>
-Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
-Mikhail Remnev <maremnev@gmail.com>
-philwillnyc <56197213+philwillnyc@users.noreply.github.com>
-Raphael Lehner <raphael.lehner@gmail.com>
-Harry Mountain <harrymountain1@icloud.com>
-Bhavik Sachdev <b.sachdev1904@gmail.com>
-袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-fazledyn-or <ataf@openrefactory.com>
-mohammedouahman <simofun85@gmail.com>
-K. Kraus <laqueray@googlemail.com>
-Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
-platypus <platypus.computerchip@gmail.com>
-codecruisader <nnisarg55@gmail.com>
-James Whitehead <whiteheadj@gmail.com>
-atharvParlikar <atharvparlikar@gmail.com>
-Ivan Petukhov <satels@gmail.com>
-Augusto Borges <borges.augustoar@gmail.com>
-Han Wei Ang <ang.h.w@u.nus.edu>
-Congxu Yang <u7189828@anu.edu.au>
-Saicharan <62512681+saicharan2804@users.noreply.github.com>
-Arnab Nandi <arnabnandi2002@gmail.com>
-Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
-Corey Cerovsek <corey@cerovsek.com>
-Harsh Kasat <hkasat@waymore.io>
-omahs <73983677+omahs@users.noreply.github.com>
-Pascal Gitz <pascal.gitz@hotmail.ch>
-Ravindu-Hirimuthugoda <ravindu.18@cse.mrt.ac.lk>
-Sophia Pustova <tripplezzed@gmail.com>
-George Pittock <gpittock4@gmail.com>
-Warren Jacinto <warrenjacinto@gmail.com>
-Sachin Singh <sachinishu02@gmail.com>
-Zedmat <104870914+harshkasat@users.noreply.github.com>
-Soumendra Ganguly <soumendraganguly@gmail.com>
-Samith Karunathilake <55777141+samithkavishke@users.noreply.github.com>
-Viraj Vekaria <virajv5593@gmail.com>
-Shishir Kushwaha <kushwahashishir1112@gmail.com>
-Ankit Kumar Singh <ankitdiswar10@gmail.com>
-Abhishek Kumar <abhishek.nitdelhi@gmail.com>
-Mohak Malviya <mohakmalviya2000@gmail.com>
-Matthias Liesenfeld <116307294+maliesen@users.noreply.github.com>
-dodo <palumbododo@gmail.com>
-Mohamed Rezk <mohrizq895@gmail.com>
-Tommaso Vaccari <05-gesto-follemente@icloud.com>
+Alexandr Gudulin <alexandr.gudulin@gmail.com>
+Alexandr Popov <alexandr.s.popov@gmail.com>
+AlexCQY <alex_chua@u.nus.edu>
+Alexey Pakhocmhik <cool.Bakov@yandex.ru>
+Alexey Subach <alexey.subach@gmail.com>
+Alexey U. Gudchenko <proga@goodok.ru>
 Alexis Schotte <alexis.schotte@gmail.com>
-Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
-Prey Patel <patel.prey@iitgn.ac.in>
-Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
-Abhishek kumar <kumar325571@gmail.com>
-Sam Lubelsky <sammy56lt@gmail.com>
-Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
-Vladimir Sereda <voffch@gmail.com>
-Hwayeon Kang <hwayeonniii@gmail.com>
-Raj Sapale <raj4sapale4@gmail.com>
-Gerald Teschl <gerald.teschl@univie.ac.at>
-Richard Samuel <98638849+samuelard7@users.noreply.github.com>
-HeeJae Chang <hechang@microsoft.com>
-Nick Harder <nharder@umich.edu>
+Alhussein Ashraf <alhusseinashraf55@gmail.com>
+Ali Raza Syed <arsyed@gmail.com>
+alijosephine <alijosephine@gmail.com>
+Alistair Lynn <arplynn@gmail.com>
+Alkiviadis G. Akritas <akritas@uth.gr>
+Alpesh Jamgade <alpeshjamgade21@gmail.com>
+Alsheh <alsheh@rpi.edu>
+Aman <amanmourya295@gmail.com>
+Aman Deep <amandeep1024@gmail.com>
+Aman Kumar Shukla <theprofessionalaman@gmail.com>
+Aman Sharma <amansharma110603@gmail.com>
+Aman Thakur <thakuraman22july@gmail.com>
+Amanda Dsouza <meezamanda@yahoo.com>
+Ambar Mehrotra <mehrotraambar@gmail.com>
+Amir Ebrahimi <github@aebrahimi.com>
+Amit Jamadagni <bitsjamadagni@gmail.com>
+Amit Kumar <dtu.amit@gmail.com>
+Amit Manchanda <amitdelhi1995@gmail.com>
+Amit Saha <amitsaha.in@gmail.com>
+amsuhane <ayushsuhane99@iitkgp.ac.in>
+Ananya H <ananyaha93@gmail.com>
+Anatolii Koval <weralwolf@gmail.com>
+anca-mc <anca-mc@users.noreply.github.com>
+Andre de Fortier Smit <freevryheid@gmail.com>
+Andreas Klöckner <inform@tiker.net>
+Andrej Tokarčík <androsis@gmail.com>
+andreo <andrey.torba@gmail.com>
+Andrew Docherty <andrewd@maths.usyd.edu.au>
+Andrew Mosson <amosson@yahoo.com>
+Andrew Straw <strawman@astraw.com>
+Andrew Taber <andrew.e.taber@gmail.com>
+Andrey Grozin <A.G.Grozin@inp.nsk.su>
+Andrey Lekar <andrey_lekar@adoriasoft.com>
+Andrii Oriekhov <andriyorehov@gmail.com>
+Andy R. Terrel <aterrel@uchicago.edu>
+Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
+Angadh Nanjangud <angadh.n@gmail.com>
+Angus Griffith <16sn6uv@gmail.com>
+Anibal M. Medina-Mardones <ammedmar@gmail.com>
+Animesh Sinha <animeshsinha1309@gmail.com>
+Anish Shah <shah.anish07@gmail.com>
+Anjul Kumar Tyagi <anjul.ten@gmail.com>
+Ankit Agrawal <aaaagrawal@iitb.ac.in>
+Ankit Kumar Singh <ankitdiswar10@gmail.com>
+Ankit Raj Pandey <pandeyan@grinnell.edu>
+Ansh Mishra <anshmishra471@gmail.com>
+Anthony Scopatz <scopatz@gmail.com>
+Anthony Sottile <asottile@umich.edu>
+Anton Akhmerov <anton.akhmerov@gmail.com>
+Anton Golovanov <agolovanov256@gmail.com>
+Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
+Anup Parikh <parikhanupk@gmail.com>
+Anurag Bhat <bhat.1@iitj.ac.in>
+Anurag Sharma <anurags92@gmail.com>
+Anutosh Bhat <andersonbhat491@gmail.com>
+Anway De <anway1756@gmail.com>
+Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
+Arafat Dad Khan <arafat.da.khan@gmail.com>
+Aravind Reddy <aravindreddy255@gmail.com>
+Archit Verma <architv07@gmail.com>
+Arie Bovenberg <a.c.bovenberg@gmail.com>
+Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
+Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
+Arihant Parsoya <parsoyaarihant@gmail.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com>
+Arnab Nandi <arnabnandi2002@gmail.com>
+Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
+arooshiverma <av22@iitbbs.ac.in>
+Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in>
+Arpit Goyal <agmps18@gmail.com>
+Arshdeep Singh <singh.arshdeep1999@gmail.com>
+Arthur Milchior <arthur@milchior.fr>
+Arthur Ryman <arthur.ryman@gmail.com>
+Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
+Arun Singh <arunsin997@gmail.com>
+Ashish Kumar Gaurav <ashishkg0022@gmail.com>
+Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
+Ashutosh Saboo <ashutosh.saboo96@gmail.com>
+Ashwini Oruganti <ashwini.oruganti@gmail.com>
+Asish Panda <asishrocks95@gmail.com>
+Atharva Khare <khareatharva@gmail.com>
+atharvParlikar <atharvparlikar@gmail.com>
+Atul Bisht <me.atulbisht@gmail.com>
+Au Huishan <huishan_au@outlook.com>
+Augusto Borges <borges.augustoar@gmail.com>
+Austin Palmer <ap4000@nyu.edu>
+Avasam <samuel.06@hotmail.com>
+Avi Shrivastava <shrivastavaavi123@gmail.com>
+Avichal Dayal <avichal.dayal@gmail.com>
+Ayden Alvarez <Aydenalv6282@gmail.com>
+Ayodeji Ige <ayodeji18@outlook.com>
+Ayush Aryan <ayush.aryan71@gmail.com>
+Ayush Bisht <bisht.ayush2001@gmail.com>
+Ayush Kumar <ayushk7102@gmail.com>
+Ayush Kumar Jha <jha44481@gmail.com>
+Ayush Malik <ayushmalik779@gmail.com>
+Ayush Shridhar <ayush.shridhar1999@gmail.com>
+Ayushman Koul <ayushmankoul4570@gmail.com>
+azure-pipelines[bot] <azure-pipelines[bot]@users.noreply.github.com>
+B McG <bmcg0890@gmail.com>
+Baiyuan Qiu <1061688677@qq.com>
+Bao Chau <chauquocbao0907@gmail.com>
+Barry Wardell <barry.wardell@gmail.com>
+Barun Parruck <barun.parruck@gmail.com>
+BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
+Bastian Weber <bastian.weber@gmx-topmail.de>
+Bavish Kulur <bavishkulur@gmail.com>
+Ben Goodrich <goodrich.ben@gmail.com>
+Ben Lucato <ben.lucato@gmail.com>
+Ben Oostendorp <oostben@umich.edu>
+Ben Payne <ben.is.located@gmail.com>
+Bendik Samseth <b.samseth@gmail.com>
+Benedikt Placke <benedikt.placke@outlook.com>
+Benjamin Fishbein <fishbeinb@gmail.com>
+Benjamin Gudehus <hastebrot@gmail.com>
+Benjamin McDonald <mcdonald.ben@gmail.com>
+Benjamin Wolba <mail@benjaminwolba.com>
+Bernhard R. Link <brlink@debian.org>
+Bharat Raghunathan <bharatraghunthan9767@gmail.com>
+bharatAmeria <21001019007@jcboseust.ac.in>
+Bharath M R <catchmrbharath@gmail.com>
+Bhaskar Gupta <guptabhanu1999@gmail.com>
+Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in>
+Bhautik Mavani <mavanibhautik@gmail.com>
+Bhavik Sachdev <b.sachdev1904@gmail.com>
+Bhavya Srivastava <bhavya17037@iiitd.ac.in>
+Bilal Ahmed <b.ahmed0918@gmail.com>
+Bilal Akhtar <bilalakhtar@ubuntu.com>
+Bill Flynn <wflynny@gmail.com>
+Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
+Björn Dahlgren <bjodah@gmail.com>
+Blair Azzopardi <blairuk@gmail.com>
+bluebrook <perl4logic@gmail.com>
+Bobby Palmer <bobbyp@umich.edu>
+Borek Saheli <boreksaheli@gmail.com>
+Boris Atamanovskiy <shaomoron@gmail.com>
+Boris Ettinger <ettinger.boris@gmail.com>
+Boris Timokhin <qoqenator@gmail.com>
+Bradley Dowling <34559056+btdow@users.noreply.github.com>
+Bradley Froehle <brad.froehle@gmail.com>
+Bradley Gannon <bradley.m.gannon@gmail.com>
+Brandon David <brandon.david@zoho.com>
+Brandon T. Willard <brandonwillard@users.noreply.github.com>
+Brian E. Granger <ellisonbg@gmail.com>
+Brian Jorgensen <brian.jorgensen@gmail.com>
+Brian Stephanik <xoedusk@gmail.com>
+Buck Shlegeris <buck2@bruceh15.anu.edu.au>
+Bulat <daianovich@mail.ru>
+Caley Finn <caleyreuben@gmail.com>
+Calvin Jay Ross <calvinjayross@gmail.com>
+Carl Sandrock <carl.sandrock@up.ac.za>
+Carlos Cordoba <ccordoba12@gmail.com>
+Carlos García Montoro <TrilceAC@gmail.com>
+Carson McManus <carson.mcmanus1@gmail.com>
+Carsten Knoll <CarstenKnoll@gmx.de>
+carstimon <carstimon@gmail.com>
+Case Van Horsen <casevh@gmail.com>
+Cavendish McKay <cmckay@tachycline.com>
+Cédric Travelletti <cedrictravelletti@gmail.com>
+Cezary Marczak <zeddq1@gmail.com>
+Chai Wah Wu <cwwuieee@gmail.com>
+Chaitanya Jain <chaitanya.jain.dev@gmail.com>
+Chaitanya Sai Alaparthi <achaitanyasai@gmail.com>
+Chak-Pong Chung <chakpongchung@gmail.com>
+Chanakya-Ekbote <ca10@iitbbs.ac.in>
+Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
+Charalampos Tsiagkalis <ctsiagkalis@uth.gr>
+Charles Harris <erdos4d@gmail.com>
+Charles Weiss <charles.weiss@augie.edu>
+Chetan Choudhary <cc393653@gmail.com>
+Chetna Gupta <cheta.gup@gmail.com>
+Chiu-Hsiang Hsu <wdv4758h@gmail.com>
+Chris Cameron <chrisjamescameron1@gmail.com>
+Chris Conley <chrisconley15@gmail.com>
+Chris du Plessis <christopherjonduplessis@gmail.com>
+Chris Kerr <chris.kerr@mykolab.ch>
+Chris Paul <chrispaul68002@gmail.com>
+Chris Smith <smichr@gmail.com>
+Chris Swierczewski <cswiercz@gmail.com>
+Chris Tefer <ctefer@gmail.com>
+Chris Wu <chris.wu@gmail.com>
+Christian Bühler <christian@cbuehler.de>
+Christian Muise <christian.muise@gmail.com>
+Christian Schubert <chr.schubert@gmx.de>
+Christiano Anderson <canderson@riseup.net>
+Christina Zografou <t8130048@dias.aueb.gr>
+Christoph Gohle <ctg@mpq.mpg.de>
+Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
+Christopher Dembia <cld72@cornell.edu>
+Christopher J. Wright <cjwright4242gh@gmail.com>
+CJ Carey <perimosocordiae@gmail.com>
+ck Lux <lux.r.ck@gmail.com>
+Clayton Rabideau <claytonrabideau@gmail.com>
+Clemens Novak <clemens@familie-novak.net>
+Clément M.T. Robert <cr52@protonmail.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>
+cocolato <haiizhu@outlook.com>
+codecruisader <nnisarg55@gmail.com>
+Coder-RG <rgoel1999@gmail.com>
+Cody Herbst <cyherbst@gmail.com>
+Colin B. Macdonald <cbm@m.fsf.org>
+Colin Marquardt <github@marquardt-home.de>
+Colleen Lee <colleenclee@gmail.com>
+Comer Duncan <comer.duncan@gmail.com>
+Congxu Yang <u7189828@anu.edu.au>
+Constantin Mateescu <costica1234@me.com>
+Corbet Elkins <corbet286@gmail.com>
+Corey Cerovsek <corey@cerovsek.com>
+Costor <pcs2009@web.de>
+Craig A. Stoudt <craig.stoudt@gmail.com>
+Cristian Di Pietrantonio <cristiandipietrantonio@gmail.com>
+Cristóvão Sousa <crisjss@gmail.com>
+cym1 <16437732+cym1@users.noreply.github.com>
+Daan Koning (he/him) <daanolivierkoning@gmail.com>
+Daiki Takahashi <haru.td@gmail.com>
+damianos <damianos@semmle.com>
+Dammina Sahabandu <dmsahabandu@gmail.com>
+Dana Jacobsen <dana@acm.org>
+dandiez <47832466+dandiez@users.noreply.github.com>
+Daniel Hyams <dhyams@gmail.com>
+Daniel Ingram <ingramds@appstate.edu>
+Daniel Mahler <dmahler@gmail.com>
+Daniel Sears <highpost@users.noreply.github.com>
+Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
+Daniel Wennberg <daniel.wennberg@gmail.com>
+Danny Hermes <daniel.j.hermes@gmail.com>
+Darshan Chaudhary <deathbullet@gmail.com>
+Dave Witte Morris <Dave.Morris@uleth.ca>
+Davi Laerte <davilae011@gmail.com>
+David Brooks <dave@bcs.co.nz>
+David Daly <david.daly12@kzoo.edu>
+David Hagen <david@drhagen.com>
+David Joyner <wdjoyner@gmail.com>
+David Ju <Sgtmook314@gmail.com>
+David Lawrence <dmlawrence@gmail.com>
+David Li <l33tnerd.li@gmail.com>
+David Marek <h4wk.cz@gmail.com>
+David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
+David P. Sanders <dpsanders@gmail.com>
+David Roberts <dvdr18@gmail.com>
+David T <derDavidT@users.noreply.github.com>
+Davide Sandonà <sandona.davide@gmail.com>
+Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
+Dean Price <dean1357price1357@gmail.com>
+Demian Wassermann <demian@bwh.harvard.edu>
+Denis Ivanenko <ivanenko@ucu.edu.ua>
+Denis Rykov <rykovd@gmail.com>
+Dennis Meckel <meckel@datenschuppen.de>
+Dennis Sweeney <sweeney.427@osu.edu>
+Denys Rybalka <rybalka.denis@gmail.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+der-blaue-elefant <github@kklein.de>
+Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
+Devansh <be19b002@smail.iitm.ac.in>
+Devesh Sawant <devesh47cool@gmail.com>
+Devyani Kota <devyanikota@gmail.com>
+Dhia Kennouche <kendhia@gmail.com>
+Dhruv Bhanushali <dhruv_b@live.com>
+Dhruv Kothari <dhruvkothari22@gmail.com>
+Dhruv Mendiratta <dhruvmendiratta6@gmail.com>
+Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
+Diane Tchuindjo <dtchuindjo@gmail.com>
+Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
+dimasvq <dimas.vq.2020@bristol.ac.uk>
+Dimitra Konomi <t8130064@dias.aueb.gr>
+dispasha <dispasha@users.noreply.github.com>
+Divyanshu Thakur <divyanshu@iiitmanipur.ac.in>
+Dmitry Batkovich <batya239@gmail.com>
+Dmitry Savransky <dsavransky@gmail.com>
+dodo <palumbododo@gmail.com>
+Dominik Stańczak <stanczakdominik@gmail.com>
+Donald Wilson <donwilson1029@gmail.com>
+dps7ud <dps7ud@virginia.edu>
+dranknight09 <cbhaavan@gmail.com>
+Duane Nykamp <nykamp@umn.edu>
+Duc-Minh Phan <alephvn@gmail.com>
+Dustin Gadal <Dustin.Gadal@gmail.com>
+dustyrockpyle <dustyrockpyle@gmail.com>
+Dzhelil Rufat <drufat@caltech.edu>
+Ebrahim Byagowi <ebrahim@gnu.org>
+Edward Schembor <eschemb1@jhu.edu>
+Edward Z. Yang <ezyang@mit.edu>
+Eh Tan <tan2tan2@gmail.com>
+Ehren Metcalfe <ehren.m@gmail.com>
+Ekansh Purohit <purohit.e15@gmail.com>
+Elias Basler <e.e.basler@protonmail.com>
+Élie Goudout <eliegoudout@hotmail.com>
+Elisha Hollander <just4now666666@gmail.com>
+Elliot Marshall <Marshall2389@gmail.com>
+Elrond der Elbenfuerst <elrond+sympy.org@samba-tng.org>
+elvis-sik <e.sikora@grad.ufsc.br>
+Emile Fourcini <emile.fourcin1@gmail.com>
+Emma Hogan <ehogan@gemini.edu>
+Enric Florit <efz1005@gmail.com>
+erdOne <36414270+erdOne@users.noreply.github.com>
+Eric Demer <demer@mailbox.org>
+Eric Miller <emiller42@gmail.com>
+Eric Nelson <eric.the.red.XLII@gmail.com>
+Eric Wieser <wieser.eric@gmail.com>
+Erik R. Gomez <gomez@kth.se>
+Erik Welch <erik.n.welch@gmail.com>
 Ethan DeGuire <ethandeguire@gmail.com>
+Ethan Ward <etkewa@gmail.com>
+Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
+Eva Tiwari <eva.tiwari@gmail.com>
+Evandro Bernardes <evbernardes@gmail.com>
+Evani Balasubramanyam <balasubramanyam.evani@gmail.com>
+Evelyn King <evelyn.cameron.king@gmail.com>
+Evgenia Karunus <lakesare@gmail.com>
+extraymond <extraymond@gmail.com>
+Fabian Ball <fabian.ball@kit.edu>
+Fabian Froehlich <fabian@schaluck.com>
+Fabian Pedregosa <fabian@fseoane.net>
+Fabio Luporini <fabio@devitocodes.com>
+Faisal Anees <faisal.iiit@gmail.com>
+Faisal Riyaz <faisalriyaz011@gmail.com>
+faizan2700 <syedfaizan824@gmail.com>
+Fawaz Alazemi <Mba7eth@gmail.com>
+fazledyn-or <ataf@openrefactory.com>
+Felix Kaiser <felix.kaiser@fxkr.net>
+Felix Yan <felixonmars@archlinux.org>
+Fermi Paradox <FermiParadox@users.noreply.github.com>
+Fernando Perez <Fernando.Perez@berkeley.edu>
+Fiach Antaw <fiach.antaw+github@gmail.com>
+Filip Gokstorp <filip@gokstorp.se>
+Flamy Owl <flamyowl@protonmail.ch>
+Florian Mickler <florian@mickler.org>
+foice <foice.news@gmail.com>
+ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>
+Francesco Bonazzi <franz.bonazzi@gmail.com>
+Freddie Witherden <freddie@witherden.org>
+Frédéric Chapoton <fchapoton2@gmail.com>
+Fredrik Andersson <fredrik.andersson@fcc.chalmers.se>
+Fredrik Eriksson <freeriks@student.chalmers.se>
+Fredrik Johansson <fredrik.johansson@gmail.com>
+Friedrich Hagedorn <friedrich_h@gmx.de>
+G. D. McBain <gdmcbain@protonmail.com>
+Gabriel Bernardino <gabriel.bernardino@upf.edu>
+Gabriel Orisaka <orisaka@gmail.com>
+Gaetano Guerriero <x.guerriero@tin.it>
+Gagan Mishra <simonsimple305@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in>
+Gao, Xiang <qasdfgtyuiop@gmail.com>
+Gareth Ma <grhkm21@gmail.com>
+Garrett Folbe <gmfolbe@yahoo.com>
+Gary Kerr <gary.kerr@blueyonder.co.uk>
+Gaurang Tandon <1gaurangtandon@gmail.com>
+Gaurav Dhingra <gauravdhingra.gxyd@gmail.com>
+Gaurav Jain <gjain369@gmail.com>
+Gautam Menghani <gum3ng@protonmail.com>
+Geetika Vadali <geetika.vadali4@gmail.com>
+Geoffry Song <goffrie@gmail.com>
+George Frolov <gosha@fro.lv>
+George Korepanov <gkorepanov.gk@gmail.com>
+George Pittock <gpittock4@gmail.com>
+George Waksman <waksman@gwax.com>
+Georges Khaznadar <georgesk@debian.org>
+Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
+Gerald Teschl <gerald.teschl@univie.ac.at>
+Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
+Gilbert Gede <gilbertgede@gmail.com>
+Gilles Schintgen <gschintgen@hambier.lu>
+Gina <Dr-G@users.noreply.github.com>
+Gleb Siroki <g.shiroki@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
+goddus <39923708+goddus@users.noreply.github.com>
+GolimarOurHero <metalera94@hotmail.com>
+Gonzalo Tornaría <tornaria@cmat.edu.uy>
+Goran Jelic-Cizmek <jcgoran@protonmail.com>
+Goutham Lakshminarayan <dl.goutham@gmail.com>
+Govind Sahai <gsiitbhu@gmail.com>
+Grace Su <grace.duansu@gmail.com>
+gregmedlock <gmedlo@gmail.com>
+Gregory Ashton <gash789@gmail.com>
+Gregory Ksionda <ksiondag846@gmail.com>
+Grzegorz Świrski <sognat@gmail.com>
+Guido Roncarolo <guido.roncarolo@gmail.com>
+Guillaume Gay <contact@damcb.com>
+Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
+Guo Xingjian <Seeker1995@gmail.com>
+Gurpartap Singh <dhaliwal.gurpartap@gmail.com>
+Guru Devanla <grdvnl@gmail.com>
+Haimo Zhang <zh.hammer.dev@gmail.com>
+Håkon Kvernmoen <haakon.kvernmoen@gmail.com>
+Hamish Dickson <hamish.dickson@gmail.com>
+Hampus Malmberg <hampus.malmberg88@gmail.com>
+Han Wei Ang <ang.h.w@u.nus.edu>
+Hannah Kari <hannah.kari@marquette.edu>
+Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
+Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Harikrishna Srinivasan <harikrishnasri3@gmail.com>
+Harold Erbin <harold.erbin@gmail.com>
+Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
+Harry Mountain <harrymountain1@icloud.com>
+Harry Zheng <harry@harryzheng.com>
+Harsh Agarwal <hagarwal9200@gmail.com>
+Harsh Gupta <mail@hargup.in>
+Harsh Jain <harshjniitr@gmail.com>
+Harsh Kasat <hkasat@waymore.io>
+Harshil Goel <harshil158@gmail.com>
+Harshil Meena <harshil.7535@gmail.com>
+Harshit Gupta <harshithigh2001@gmail.com>
+Harshit Yadav <harshityadav2k@gmail.com>
+Haruki Moriguchi <harukimoriguchi@gmail.com>
+HeeJae Chang <hechang@microsoft.com>
+Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
+helo9 <helo9@users.noreply.github.com>
+Henrik Johansson <henjo2006@gmail.com>
+Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
+Henry Gebhardt <hsggebhardt@gmail.com>
+Henry Metlov <genrih.metlov@gmail.com>
+Himanshu <hs80941@gmail.com>
+Himanshu Ladia <hladia199811@gmail.com>
+Hiren Chalodiya <hirenchalodiya99@gmail.com>
+hm <hacman0@gmail.com>
+Hong Xu <hong@topbug.net>
+Hou-Rui <houruinus@gmail.com>
+Huangduirong <huangduirong@huawei.com>
+Hubert Tsang <intsangity@gmail.com>
+Hugo Kerstens <hugo@kerstens.me>
+Hugo van Kemenade <hugovk@users.noreply.github.com>
+Huijun Mai <m.maihuijun@gmail.com>
+Hwayeon Kang <hwayeonniii@gmail.com>
+Ian Swire <oversizedpenguin@gmail.com>
+Idan Pazi <idan.kp@gmail.com>
+Ilya Pchelintsev <ilya.pchelintsev@outlook.com>
+immerrr <immerrr@gmail.com>
+Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
+Ishan Joshi <ishanaj98@gmail.com>
+Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
+Ishan Pandhare <ishan9096137017@gmail.com>
+Isidora Araya <iarayaday@gmail.com>
+Islam Mansour <is3mansour@gmail.com>
+Islem BOUZENIA <fi_bouzenia@esi.dz>
+Isuru Fernando <isuruf@gmail.com>
+Itay4 <31018228+Itay4@users.noreply.github.com>
+Ivan A. Melnikov <iv@altlinux.org>
+Ivan Petuhov <ivan@ostrovok.ru>
+Ivan Petukhov <satels@gmail.com>
+Ivan Tkachenko <me@ratijas.tk>
+Jack Kemp <metaknightdrake-git@yahoo.co.uk>
+Jack McCaffery <jpmccaffery@gmail.com>
+Jack Schmidt <1107865+jackschmidt@users.noreply.github.com>
+Jacob Garber <jgarber1@ualberta.ca>
+Jai Luthra <me@jailuthra.in>
+Jaime R <38530589+Jaime02@users.noreply.github.com>
+Jaime Resano <gemailpersonal02@gmail.com>
+Jainul Vaghasia <jainulvaghasia@gmail.com>
+Jakub Wilk <jwilk@jwilk.net>
+James A. Preiss <jamesalanpreiss@gmail.com>
+James Abbatiello <abbeyj@gmail.com>
+James Aspnes <aspnes@cs.yale.edu>
+James Brandon Milam <jmilam343@gmail.com>
+James Cotton <peabody124@gmail.com>
+James Fiedler <jrfiedler@gmail.com>
+James Goppert <james.goppert@gmail.com>
+James Harrop <ebc121@gmail.com>
+James Pearson <xiong.chiamiov@gmail.com>
+James Taylor <user234683@tutanota.com>
+James Titus <titusjames299@gmail.com>
+James Whitehead <whiteheadj@gmail.com>
+Jan Jancar <johny@neuromancer.sk>
+Jan Kruse <janckruse@t-online.de>
+Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com>
+Jared Lumpe <mjlumpe@gmail.com>
+Jaroslaw Tworek <dev.jrx@gmail.com>
+Jashanpreet Singh <jashansingh.4398@gmail.com>
+Jason Gedge <inferno1386@gmail.com>
+Jason Gross <jasongross9@gmail.com>
+Jason Ly <jason.ly@gmail.com>
+Jason Moore <moorepants@gmail.com>
+Jason Ross <jasonross1024@gmail.com>
+Jason Siefken <siefkenj@gmail.com>
+Jason Tokayer <jason.tokayer@gmail.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com>
+Jatin Gaur <jatingaurchess@gmail.com>
+Jatin Yadav <jatinyadav25@gmail.com>
+Javed Nissar <javednissar@gmail.com>
+Jay Patankar <patankarjays@gmail.com>
+Jayesh Lahori <jlahori92@gmail.com>
+Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
+JDBetteridge <jack@devitocodes.com>
+Jean-François B <2589111+jfbu@users.noreply.github.com>
+Jean-Luc Herren <jlh@gmx.ch>
+Jeffrey Ryan <jeffaryan7@gmail.com>
+Jennifer White <jcrw122@googlemail.com>
+Jens H. Nielsen <jenshnielsen@gmail.com>
+Jens Jørgen Mortensen <jj@smoerhul.dk>
+Jeremey Gluck <jeremygluck@yahoo.com>
+Jeremias Yehdegho <j.yehdegho@gmail.com>
+Jeremy <twobitlogic@gmail.com>
+Jeremy Monat <jemonat@calalum.org>
+Jerry James <loganjerry@gmail.com>
+Jerry Li <jerry@jerryli.ca>
+jerryma1121 <jerryma1121@gmail.com>
+Jezreel Ng <jezreel@gmail.com>
+jgulian <josephdgulian@gmail.com>
+jhanwar <f2015463@pilani.bits-pilani.ac.in>
+Jiaxing Liang <liangjiaxing57@gmail.com>
+Jim Crist <crist042@umn.edu>
+Jim Zhang <Hyriodula@gmail.com>
+Jiri Kuncar <jiri.kuncar@gmail.com>
+Jisoo Song <jeesoo9595@snu.ac.kr>
+Jithin D. George <jithindgeorge93@gmail.com>
+JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
+Jo Liss <joliss42@gmail.com>
+Joachim Durchholz <jo@durchholz.org>
+Joan Creus <joan.creus.c@gmail.com>
+Joannah Nanjekye <joannah.nanjekye@ibm.com>
+João Bravo <joaocgbravo@tecnico.ulisboa.pt>
+João Moura <operte@gmail.com>
+João Rodrigues <abcjoao@hotmail.com>
+Joaquim Monserrat <qmonserrat@mailoo.org>
+Jochen Voss <voss@seehuhn.de>
+Jogi Miglani <jmig5776@gmail.com>
+Johan Blåbäck <johan_bluecreek@riseup.net>
+Johan Guzman <jguzm022@ucr.edu>
+Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
+Johannes Hartung <joha2@gmx.net>
+Johannes Kasimir <johannes.kasimir@math.lu.se>
+John Connor <john.theman.connor@gmail.com>
+John Möller <john.moller@outlook.com>
+John V. Siratt <jvsiratt@gmail.com>
+Jonathan A. Gross <jarthurgross@gmail.com>
+Jonathan Allan <jjallan@users.noreply.github.com>
+Jonathan Daniel <36337649+jond01@users.noreply.github.com>
+Jonathan Gutow <gutow@uwosh.edu>
+Jonathan Miller <jdmiller93@gmail.com>
+Jonathan Warner <warnerjon12@gmail.com>
+Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
+Jorge E. Cardona <jorgeecardona@gmail.com>
+Jorn Baayen <jorn.baayen@gmail.com>
+Jose M. Gomez <chemoki@gmail.com>
+José Senart <jose.senart@gmail.com>
+Joseph Dougherty <Github@JWDougherty.com>
+Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
+Joseph Redfern <joseph@redfern.me>
+Josh Burkart <jburkart@gmail.com>
+Juan Barbosa <js.barbosa10@uniandes.edu.co>
+Juan Felipe Osorio <jfosorio@gmail.com>
+Juan Luis Cano Rodríguez <juanlu001@gmail.com>
+Juha Remes <jremes@outlook.com>
+Julien Palard <julien@palard.fr>
+Julien Rioux <julien.rioux@gmail.com>
+Julio Idichekop Filho <idichekop@yahoo.com.br>
+Jun Lin <junlin0604@gmail.com>
+Jurjen N.E. Bos <jnebos@gmail.com>
+Justin Blythe <jblythe29@gmail.com>
+Jyn Spring 琴春 <me@vx.st>
+K. Kraus <laqueray@googlemail.com>
+Ka Yi <chua.kayi@yahoo.com.sg>
+Kaifeng Zhu <cafeeee@gmail.com>
+Kalevi Suominen <jksuom@gmail.com>
+kamimura <kamimura@live.jp>
+Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
+kangzhiq <709563092@qq.com>
+Karan <grgkaran03@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com>
+Karan Sharma <karan1276@gmail.com>
+Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in>
+Kartik Sethi <kartiks31416@gmail.com>
+Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
+Kaushik Varanasi <kaushik.varanasi1@gmail.com>
+Kaustubh <90597818+kaustubh-765@users.noreply.github.com>
+Kaustubh Chaudhari <ckaustubhm06@gmail.com>
+KaustubhDamania <kaustubh.damania@gmail.com>
+Kazuo Thow <kazuo.thow@gmail.com>
+Ken Wakita <wakita@is.titech.ac.jp>
+Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
+Kenneth Lyons <ixjlyons@gmail.com>
+Keno Goertz <keno@goertz-berlin.com>
+Keval Shah <kevalshah_96@yahoo.co.in>
+Kevin Goodsell <kevin-opensource@omegacrash.net>
+Kevin Hunter <hunteke@earlham.edu>
+Kevin McWhirter <klmcw@yahoo.com>
+Kevin Ventullo <kevin.ventullo@gmail.com>
+Keyron Linerez <keyronlinarez@gmail.com>
+Khagesh Patel <khageshpatel93@gmail.com>
+Kibeom Kim <kk1674@nyu.edu>
+Kirill Smelkov <kirr@landau.phys.spbu.ru>
+Kirtan Mali <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
+Kiyohito Yamazaki <kyamaz@openql.org>
+KJaybhaye <krushnajaybhaye01@gmail.com>
+klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+Klaus Rettinghaus <klaus.rettinghaus@enote.com>
+Konrad Meyer <konrad.meyer@gmail.com>
+Konstantin Togoi <konstantin.togoi@gmail.com>
+Konstantinos Riganas <kostasriganas24@gmail.com>
+Kris Katterjohn <katterjohn@gmail.com>
+Krishnav Bajoria <bajoriakrishnav@gmail.com>
+Kristian Brünn <hello@kristianbrunn.com>
+Krit Karan <kritkaran.b13@iiits.in>
+Kshitij <kshitijparwani.mat18@itbhu.ac.in>
+Kshitij Saraogi <KshitijSaraogi@gmail.com>
+Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com>
+Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+Kunal Arora <kunalarora.135@gmail.com>
+Kunal Sheth <kunal@kunalsheth.info>
+Kunal Singh <ksingh19136@gmail.com>
+Kundan Kumar <kundankumar18581@gmail.com>
+Kyle McDaniel <mcdanie5@illinois.edu>
+Lagaras Stelios <stel.lag@hotmail.com>
+Lakshya Agrawal <zeeshan.lakshya@gmail.com>
+Langston Barrett <langston.barrett@gmail.com>
+Lars Buitinck <larsmans@gmail.com>
+lastcodestanding <rohang71604@gmail.com>
+latot <felipematas@yahoo.com>
+Laura Domine <temigo@gmx.com>
+Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
+Lauren Glattly <laurenglattly@gmail.com>
+Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
+Laurence Warne <laurencewarne@gmail.com>
+Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
+Lee Johnston <lee.johnston.100@gmail.com>
+Lejla Metohajrova <l.metohajrova@gmail.com>
+Lennart Fricke <lennart@die-frickes.eu>
+Leo Battle <leowbattle@gmail.com>
+Leonardo Mangani <leomangani4@gmail.com>
+Leonid Blouvshtein <leonidbl91@gmail.com>
+Leonid Kovalev <leonidvkovalev@gmail.com>
+Lev Chelyadinov <leva181777@gmail.com>
+Liwei Cai <cai.lw123@gmail.com>
+Ljubiša Moćić <3rdslasher@gmail.com>
+Lokesh Sharma <lokeshhsharma@gmail.com>
+Longqi Wang <iqgnol@gmail.com>
 Lorenz Winkler <lorenz.winkler@tuwien.ac.at>
-Richard Rodenbusch <rrodenbusch@gmail.com>
-Zhenxu Zhu <xzdlj@outlook.com>
+Lorenzo Contento <lorenzo.contento@gmail.com>
+Louis Abraham <louis.abraham@yahoo.fr>
+Luca Bertoni <lucabertoni@gmail.com>
+Luca Weihs <astronomicalcuriosity@gmail.com>
+Lucas Gallindo <lgallindo@gmail.com>
+Lucas Jones <lucas@lucasjones.co.uk>
+Lucas Kletzander <lucas.kletzander@gmail.com>
+Lucas Verlaan <lucas.verlaan@gmail.com>
+Lucas Wiman <lucas.wiman@gmail.com>
+Lucy Mountain <lucymountain1@icloud.com>
+Luis Garcia <ppn.online@me.com>
+Luis Talavera <luisfertalavera15@gmail.com>
+Lukas Molleman <Lukas.Molleman@gmail.com>
+Lukas Zorich <lukas.zorich@gmail.com>
+Łukasz Pankowski <lukpank@o2.pl>
+Luke Peterson <hazelnusse@gmail.com>
+Luv Agarwal <agarwal.iiit@gmail.com>
+luzpaz <luzpaz@users.noreply.github.com>
+Lyle Poley <poleylyle@gmail.com>
+Maciej Baranski <getrox.sc@gmail.com>
+Maciej Skórski <maciej.skorski@gmail.com>
+Madeleine Ball <mpball@gmail.com>
+Malkhan Singh <malkhansinghrathaur@gmail.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com>
+Manish Gill <gill.manish90@gmail.com>
+Manish Shukla <manish.shukla393@gmail>
+Manoj Babu K. <manoj.babu2378@gmail.com>
+Manoj Kumar <manojkumarsivaraj334@gmail.com>
+mao8 <thisisma08@gmail.com>
+Marcel Stimberg <marcel.stimberg@ens.fr>
+Marcin Briański <marcin.brianski@student.uj.edu.pl>
+Marcin Kostrzewa <>
+Marco Antônio Habitzreuter <mahabitzreuter@gmail.com>
+Marco Mancini <marco.mancini@obspm.fr>
+Marcus Näslund <naslundx@gmail.com>
+Marduk Bolaños <mardukbp@mac.com>
+Marek Madejski <marekmadejski@yandex.com>
+Marek Šuppa <mr@shu.io>
+Maria Marginean <33810762+mmargin@users.noreply.github.com>
+Marijan Smetko <marijansmetko123@gmail.com>
+Mario Maio <mario.maio@aruba.it>
+Mario Pernici <mario.pernici@gmail.com>
+Mark Bell <mark00bell@googlemail.com>
+Mark Dewing <markdewing@gmail.com>
+Mark Dickinson <dickinsm@gmail.com>
+Mark Jeromin <mark.jeromin@sysfrog.net>
+Mark Shoulson <mark@kli.org>
 Mark van Gelder <m.j.vangelder@student.tudelft.nl>
 Mark van Gelder <mvgmvgmvg@live.com>
-Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
-James A. Preiss <jamesalanpreiss@gmail.com>
-Emile Fourcini <emile.fourcin1@gmail.com>
-Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
-João Bravo <joaocgbravo@tecnico.ulisboa.pt>
-Dean Price <dean1357price1357@gmail.com>
-Edward Z. Yang <ezyang@mit.edu>
-James Titus <titusjames299@gmail.com>
-Zhuoyuan Li <zy.li@stu.pku.edu.cn>
-Hugo Kerstens <hugo@kerstens.me>
-Jan Jancar <johny@neuromancer.sk>
-Andrew Mosson <amosson@yahoo.com>
-Marek Madejski <marekmadejski@yandex.com>
-Gonzalo Tornaría <tornaria@cmat.edu.uy>
-Peter Stahlecker <peter.stahlecker@gmail.com>
-Jean-François B <2589111+jfbu@users.noreply.github.com>
-Zexuan Zhou (Bruce) <zzx498636727@gmail.com>
-George Frolov <gosha@fro.lv>
-Corbet Elkins <corbet286@gmail.com>
-Håkon Kvernmoen <haakon.kvernmoen@gmail.com>
-Muhammad Maaz <mmaaz6004@gmail.com>
-Shishir Kushwaha <138311586+shishir-11@users.noreply.github.com>
-Matt Wang <mattwang44@gmail.com>
-bharatAmeria <21001019007@jcboseust.ac.in>
-Amir Ebrahimi <github@aebrahimi.com>
-Steven Esquea <steven.esquea@irreverente.net>
-Rishabh Kamboj <111004091+VectorNd@users.noreply.github.com>
-Aasim Ali <aasim250205@gmail.com>
-Ivan A. Melnikov <iv@altlinux.org>
-Borek Saheli <boreksaheli@gmail.com>
-Guido Roncarolo <guido.roncarolo@gmail.com>
-Quek Zi Yao <ziyaoqzy2001@gmail.com>
-Roelof Rietbroek <r.rietbroek@utwente.nl>
-MostafaGalal1 <mostafag649.mg@gmail.com>
-Au Huishan <huishan_au@outlook.com>
-Kris Katterjohn <katterjohn@gmail.com>
-Shiyao Guo <mivikq@gmail.com>
-Rushabh Mehta <mehtarushabh2005@gmail.com>
-Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
-Davi Laerte <davilae011@gmail.com>
-Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
-Harshit Gupta <harshithigh2001@gmail.com>
-Praveen Perumal <ppraveen98841@gmail.com>
-Kevin McWhirter <klmcw@yahoo.com>
-Prayag V <v.prayag2005@gmail.com>
-Lucas Kletzander <lucas.kletzander@gmail.com>
-Pratyksh Gupta <pratykshgupta9999@gmail.com>
-Leonardo Mangani <leomangani4@gmail.com>
-Karan Anand <anandkarancompsci@gmail.com>
-Gagan Mishra <simonsimple305@gmail.com>
-Krishnav Bajoria <bajoriakrishnav@gmail.com>
-Matt Ord <matthew.ord1@gmail.com>
-Jatin Bhardwaj <bhardwajjatin093@gmail.com>
-Prashant Tandon <tandonprashant101@gmail.com>
-Paramjit Singh <paramjit1071@gmail.com>
-João Rodrigues <abcjoao@hotmail.com>
-Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com>
-Matthew Treinish <mtreinish@kortar.org>
-Clayton Rabideau <claytonrabideau@gmail.com>
-Victoria Koval <bictoriakoval16@gmail.com>
-Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com>
-Ovsk Mendov <bbb23exposed@gmail.com>
-David Brooks <dave@bcs.co.nz>
-Nicholas Laustrup <124007393+nicklaustrup@users.noreply.github.com>
-Harikrishna Srinivasan <harikrishnasri3@gmail.com>
+Markus Mohrhard <markus.mohrhard@googlemail.com>
+Markus Müller <markus.mueller.1.g@googlemail.com>
+Martha Giannoudovardi <maapxa@gmail.com>
+Martin Manns <mmanns@gmx.net>
+Martin Povišer <martin.povik@gmail.com>
+Martin Roelfs <u0114255@kuleuven.be>
+Martin Thoma <info@martin-thoma.de>
+Martin Ueding <dev@martin-ueding.de>
+Mary Clark <mary.spriteling@gmail.com>
+Mateusz Paprocki <mattpap@gmail.com>
+Mathew Chong <mathewchong.dev@gmail.com>
+Mathias Louboutin <mathias.louboutin@gmail.com>
 Mathis Cros <mathis.cros@telecom-paris.fr>
-Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
+Matt Bogosian <matt@bogosian.net>
+Matt Curry <mattjcurry@gmail.com>
+Matt Habel <habelinc@gmail.com>
+Matt Ord <matthew.ord1@gmail.com>
+Matt Rajca <matt.rajca@me.com>
+Matt Wang <mattwang44@gmail.com>
+Matthew Brett <matthew.brett@gmail.com>
+Matthew Craven <clyring@users.noreply.github.com>
+Matthew Davis <davisml.md@gmail.com>
+Matthew Hoff <mhoff14@gmail.com>
+Matthew Parnell <matt@parnmatt.co.uk>
+Matthew Rocklin <mrocklin@cs.uchicago.edu>
+Matthew Tadd <matt.tadd@gmail.com>
+Matthew Thomas <mnmt@users.noreply.github.com>
+Matthew Treinish <mtreinish@kortar.org>
+Matthew Wardrop <matthew.wardrop@airbnb.com>
+Matthias Bussonnier <bussonniermatthias@gmail.com>
+Matthias Geier <Matthias.Geier@gmail.com>
+Matthias Köppe <mkoeppe@math.ucdavis.edu>
+Matthias Liesenfeld <116307294+maliesen@users.noreply.github.com>
+Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
+Matthias Toews <mat.toews@googlemail.com>
+Mauro Garavello <mauro.garavello@unimib.it>
+Max Hutchinson <maxhutch@gmail.com>
+Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
+Mayank Raj <mayank_1901cs35@iitp.ac.in>
+Mayank Singh <mayank.singh081997@gmail.com>
+Megan Ly <megan.ly@learnosity.com>
+Meghana Madhyastha <meghana.madhyastha@gmail.com>
+Merin Theres Jose <merintheresjose@gmail.com>
+Micah Fitch <micahscopes@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com>
+Michael Chu <michael02chu@gmail.com>
+Michael Gallaspy <gallaspy.michael@gmail.com>
+Michael Greminger <michael.greminger@gmail.com>
+Michael Mayorov <marchael@kb.csu.ru>
+Michael Mueller <michaeldmueller7@gmail.com>
+Michael S. Hansen <michael.hansen@nih.gov>
+Michael Sparapany <msparapa@purdue.edu>
+Michael Zingale <michael.zingale@stonybrook.edu>
+Michal Grňo <m93a.cz@gmail.com>
+Michał Radwański <enedil.isildur@gmail.com>
+Michele Ceccacci <michelececcacci1@gmail.com>
+Michele Zaffalon <michele.zaffalon@gmail.com>
+Micky <mickydroch@gmail.com>
+Miguel Marco <mmarco@unizar.es>
+Miguel Torres Costa <miguelptcosta1995@gmail.com>
+Miha Marolt <tloramus@gmail.com>
+Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
+Mihail Tarigradschi <m.tarigradschi@gmail.com>
+Mihir Wadwekar <m.mihirw@gmail.com>
+Mikel Rouco <mikel.mrm@gmail.com>
+Mikhail Remnev <maremnev@gmail.com>
+Milan Jolly <milan.cs16@iitp.ac.in>
+Min Ragan-Kelley <benjaminrk@gmail.com>
+Miro Hrončok <miro@hroncok.cz>
+mohajain <mohajain99@gmail.com>
+Mohak Malviya <mohakmalviya2000@gmail.com>
+Mohamed Rezk <mohrizq895@gmail.com>
+Mohammad Sadeq Dousti <msdousti@gmail.com>
+Mohammed Bilal <r.mohammedbilal@gmail.com>
+mohammedouahman <simofun85@gmail.com>
+mohit <39158356+mohitacecode@users.noreply.github.com>
+Mohit Balwani <mohitbalwani.ict17@gmail.com>
+Mohit Chandra <mohit.chandra@research.iiit.ac.in>
+Mohit Gupta <mohitgupta@gmail.com>
+Mohit Shah <mohitshah3111999@gmail.com>
+Morten Olsen Lysgaard <morten@lysgaard.no>
+Moses Paul R <iammosespaulr@gmail.com>
+MostafaGalal1 <mostafag649.mg@gmail.com>
+Mridul Seth <seth.mridul@gmail.com>
+Muhammad Maaz <mmaaz6004@gmail.com>
+Muhammed Abdul Quadir Owais <quadirowais200@gmail.com>
+Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
+Nabanita Dash <dashnabanita@gmail.com>
+naelsondouglas <naelson17@gmail.com>
+Naman Gera <namangera15@gmail.com>
+Natalia Nawara <fankalemura@gmail.com>
+Nathan Alison <nathan.f.alison@gmail.com>
+Nathan Goldbaum <ngoldbau@illinois.edu>
+Nathan Musoke <nathan.musoke@gmail.com>
+Nathan Taylor <pecan.pine@gmail.com>
+Nathan Woods <charlesnwoods@gmail.com>
+Naveen Sai <naveensaisreenivas@gmail.com>
+Neel Gorasiya <mgorasiya1974@gmail.com>
+Neil <mistersheik@gmail.com>
+Nguyen Truong Duy <truongduy134@yahoo.com>
+Nichita Utiu <nikita.utiu+github@gmail.com>
+Nicholas Bollweg <nick.bollweg@gmail.com>
+Nicholas J.S. Kinar <n.kinar@usask.ca>
+Nicholas Laustrup <124007393+nicklaustrup@users.noreply.github.com>
+Nick Curtis <nicholas.curtis@uconn.edu>
+Nick Harder <nharder@umich.edu>
+Nicko van Someren <nicko@nicko.org>
+Nico Santamaria <nicoasantamaria@gmail.com>
+Nico Schlömer <nico.schloemer@gmail.com>
+Nicolás Guarín-Zapata <nicoguarin@gmail.com>
+Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
+Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
+Nijso Beishuizen <nijso@koolmees.numerically-related.com>
+Nikhil Date <nikhil.s.date@gmail.com>
+Nikhil Gopalam <gopalamn@umich.edu>
+Nikhil Maan <nikhilmaan22@gmail.com>
+Nikhil Pappu <nkhlpappu@gmail.com>
+Nikhil Sarda <diff.operator@gmail.com>
+Nikita <nikita.student.cse19@itbhu.ac.in>
+Niklas Thörne <notrupertthorne@gmail.com>
+Nikolay Lazarov <qwerqwerqwer@abv.bg>
+Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk>
+Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
+Nilabja Bhattacharya <nilabja10201992@gmail.com>
+Nils Schulte <47043622+Schnilz@users.noreply.github.com>
+Nimish Telang <ntelang@gmail.com>
+Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
+Nirmal Sarswat <nirmalsarswat400@gmail.com>
+Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
+Nishant Nikhil <nishantiam@gmail.com>
+Nishith Shah <nishithshah.2211@gmail.com>
+Nitin Chaudhary <nitinmax1000@gmail.com>
+Nityananda Gohain <nityanandagohain@gmail.com>
+noam simcha finkelstein <noam.finkelstein@protonmail.com>
+NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
+Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+numbermaniac <5206120+numbermaniac@users.noreply.github.com>
+oittaa <8972248+oittaa@users.noreply.github.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com>
+Oleksandr Gituliar <gituliar@gmail.com>
+Oliver Lee <oliverzlee@gmail.com>
+omahs <73983677+omahs@users.noreply.github.com>
+Omar Wagih <o.wagih.ow@gmail.com>
+Omkaar <79257339+Pysics@users.noreply.github.com>
+Ondřej Čertík <ondrej@certik.cz>
+Or Dvory <gidesa@gmail.com>
+Orestis Vaggelis <orestisvaggelis@mail.com>
+Oriel Malihi <orielmalihi1@gmail.com>
+Oscar Benjamin <oscar.j.benjamin@gmail.com>
+Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk>
+Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Óscar Nájera <najera.oscar@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com>
+Øyvind Jensen <jensen.oyvind@gmail.com>
+P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
+Pablo Galindo Salgado <pablogsal@gmail.com>
+Pablo Puente <ppuedom@gmail.com>
+Pablo Zubieta <pabloferz@yahoo.com.mx>
+Pan Peng <pengpanster@gmail.com>
+Param Singh <paramsingh258@gmail.com>
+Paramjit Singh <paramjit1071@gmail.com>
+Parcly Taxel <reddeloostw@gmail.com>
+Parker Berry <parkereberry@gmail.com>
+Pascal Gitz <pascal.gitz@hotmail.ch>
+Pasquale Cocchini <pasquale.cocchini@gmail.com>
+Pastafarianist <mr.pastafarianist@gmail.com>
+Patrick Lacasse <patrick.m.lacasse@gmail.com>
+Patrick Poitras <acebulf@gmail.com>
+Paul Mandel <paulmandel@google.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
+Paul Scott <paul.scott@nicta.com.au>
+Paul Spiering <paul@spiering.org>
+Paul Strickland <p.e.strickland@gmail.com>
+Pauli Virtanen <pav@iki.fi>
+Pavel Fedotov <fedotovp@gmail.com>
+Pavel Tkachenko <paveltkachenko@email.com>
+Pearu Peterson <pearu.peterson@gmail.com>
+Pedro H. S. Prestes <pedrohsprestes@gmail.com>
+Pedro Rosa <pedro_sxbr@usp.br>
+Peeyush Kushwaha <peeyush.p97@gmail.com>
+pekochun <hamburg_hamburger2000@yahoo.co.jp>
+Peleg Michaeli <freepeleg@gmail.com>
+Pengning Chao <8857165+PengningChao@users.noreply.github.com>
+Peter Brady <petertbrady@gmail.com>
+Peter Cock <p.j.a.cock@googlemail.com>
+Peter Enenkel <peter.enenkel+git@gmail.com>
+Peter Schmidt <peter@peterjs.com>
+Peter Stahlecker <peter.stahlecker@gmail.com>
+Peter Stangl <peter.stangl@ph.tum.de>
+Petr Kungurtsev <corwinat@gmail.com>
+Phil LeMaitre <phil_lemaitre@live.ca>
+Phil Ruffwind <rf@rufflewind.com>
+Philippe Bouafia <philippe.bouafia@ensea.fr>
+Phillip Berndt <phillip.berndt@googlemail.com>
+philwillnyc <56197213+philwillnyc@users.noreply.github.com>
+phipf <phipf@online.de>
+Pierre Haessig <pierre.haessig@crans.org>
+Pieter Eendebak <pieter.eendebak@gmail.com>
+Pieter Gijsbers <p.gijsbers@tue.nl>
+Piotr Korgul <p.korgul@gmail.com>
+platypus <platypus.computerchip@gmail.com>
+Pontus von Brömssen <pontus.vonbromssen+github@gmail.com>
+Poom Chiarawongse <eight1911@gmail.com>
+Prabhjot Singh <prabhjot.nith@gmail.com>
+Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
+Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
+Pradyumna <pradyu1993@gmail.com>
+Prafullkumar P. Tale <hector1618@gmail.com>
+Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
+Pramod Ch <pramodch14@gmail.com>
+Pranjal Tale <pranjaltale16@gmail.com>
+Prashant Tandon <tandonprashant101@gmail.com>
+Prashant Tyagi <prashanttyagi221295@gmail.com>
+Prasoon Shukla <prasoon92.iitr@gmail.com>
+Prateek Papriwal <papriwalprateek@gmail.com>
+Pratyksh Gupta <pratykshgupta9999@gmail.com>
+Praveen Perumal <ppraveen98841@gmail.com>
+Praveen Sahu <povinsahu@gmail.com>
+Prayag V <v.prayag2005@gmail.com>
+Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
+Prempal Singh <prempal.42@gmail.com>
+Prey Patel <patel.prey@iitgn.ac.in>
+Priit Laes <plaes@plaes.org>
+Prince Gupta <codemastercpp@gmail.com>
+Prionti Nasir <pdn3628@rit.edu>
+Priyank Patel <pspbot7@gmail.com>
+Priyansh Rathi <techiepriyansh@gmail.com>
+prshnt19 <prashant.rawat216@gmail.com>
+Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in>
+Puneeth Chaganti <punchagan@gmail.com>
+Qijia Liu <liumeo@pku.edu.cn>
+Qingsha Shi <googol.sqs@gmail.com>
+QuaBoo <kisonchristian@gmail.com>
+Quek Zi Yao <ziyaoqzy2001@gmail.com>
+Raffaele De Feo <alberthilbert@gmail.com>
+Raghav Jajodia <jajodia.raghav@gmail.com>
+Rahil Hastu <rahilhastu@gmail.com>
+Rahil Parikh <r.parikh@somaiya.edu>
+rahuldan <rahul02013@gmail.com>
+Raj <raj454raj@gmail.com>
+Raj Sapale <raj4sapale4@gmail.com>
+Rajat Aggarwal <rajataggarwal1975@gmail.com>
+Rajat Thakur <rajatthakur1997@gmail.com>
+Rajath Shashidhara <rajaths.rajaths@gmail.com>
+Rajeev Singh <rajs2010@gmail.com>
+Rajiv Ranjan Singh <rajivperfect007@gmail.com>
+Ralf Stephan <ralf@ark.in-berlin.de>
+Ralph Bean <rbean@redhat.com>
+Ramana Venkata <idlike2dream@gmail.com>
+ramvenkat98 <ramvenkat98@gmail.com>
+Randy Heydon <randy.heydon@clockworklab.net>
+Ranjith Kumar <ranjith.dakshana2015@gmail.com>
+Raoul Bourquin <raoulb@bluewin.ch>
+Raphael Lehner <raphael.lehner@gmail.com>
+Raphael Michel <webmaster@raphaelmichel.de>
+Rashmi Shehana <rashmi.watagedara@syscolabs.com>
+Rastislav Rabatin <rastislav.rabatin@gmail.com>
+rathmann <rathmann.os@gmail.com>
+rationa-kunal <kunalgk1999@gmail.com>
+Ravi charan <ravicharan.vsp@gmail.com>
+Ravindu-Hirimuthugoda <ravindu.18@cse.mrt.ac.lk>
+Ray Cathcart <github@cathcart.us>
+Raymond Wong <rayman_407@yahoo.com>
+rbl <rlee@grove.co>
+Rehas Sachdeva <aquannie@gmail.com>
+Remco de Boer <29308176+redeboer@users.noreply.github.com>
+Rémy Léone <rleone@online.net>
+Renato Coutinho <renato.coutinho@gmail.com>
+Renato Orsino <renato.orsino@gmail.com>
+Rhea Parekh <rheaparekh12@gmail.com>
+Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
+Riccardo Gori <goriccardo@gmail.com>
+Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
+Rich LaSota <rjlasota@gmail.com>
+Richard Osborn <richardosborn@mac.com>
+Richard Otis <richard.otis@outlook.com>
+Richard Rodenbusch <rrodenbusch@gmail.com>
+Richard Samuel <98638849+samuelard7@users.noreply.github.com>
+richierichrawr <richierichrawr@users.noreply.github.com>
+Rick Muller <rpmuller@gmail.com>
+Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
+Riley Britten <nrb1324@hotmail.com>
+Rimi <rimibis@umich.edu>
+rimibis <33387803+rimibis@users.noreply.github.com>
+Rishabh Daal <rishabhdaal@gmail.com>
+Rishabh Dixit <rishabhdixit11@gmail.com>
+Rishabh Kamboj <111004091+VectorNd@users.noreply.github.com>
+Rishabh Madan <rishabhmadan96@gmail.com>
+Rishat Iskhakov <iskhakov@frtk.ru>
+Rishav Chakraborty <annonymousxyz@outlook.com>
+Risiraj Dey <risirajdey@gmail.com>
+risubaba <risubhjain1010@gmail.com>
+Ritesh Kumar <ritesh99rakesh@gmail.com>
+ritikBhandari <ritikbhandari68@gmail.com>
+Ritu Raj Singh <RituRajSingh878@gmail.com>
+Riyan Dhiman <Riyandhiman14@gmail.com>
+Rizgar Mella <rizgar.mella@gmail.com>
+Rob Drynkin <rob.drynkin@gmail.com>
+Rob Zinkov <rob@zinkov.com>
+Robert <average.programmer@gmail.com>
+Robert Brijder <rbrijder@gmail.com>
+Robert Cimrman <cimrman3@ntc.zcu.cz>
+Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
+Robert Johansson <jrjohansson@gmail.com>
+Robert Kern <robert.kern@gmail.com>
+Robert Pollak <robert.pollak@posteo.net>
+Robert Schwarz <lethargo@googlemail.com>
+Roberto Colistete, Jr. <roberto.colistete@gmail.com>
+Roberto Díaz Pérez <r.r.1994a@gmail.com>
+Roberto Nobrega <rwnobrega@gmail.com>
+Robin Neatherway <robin.neatherway@gmail.com>
+Robin Richard <raisin@ecomail.fr>
+Rodrigo Luger <rodluger@gmail.com>
+Roelof Rietbroek <r.rietbroek@utwente.nl>
+Rohit Jain <rohitjain3241@gmail.com>
+Rohit Rango <rohit.rango@gmail.com>
+Rohit Sharma <31184621+rohitx007@users.noreply.github.com>
+Roland Dixon <rols121@gmail.com>
+Roland Puntaier <roland.puntaier@chello.at>
+Rom le Clair <jacen.guardian@gmail.com>
+Roman Inflianskas <infroma@gmail.com>
+Ronan Lamy <ronan.lamy@gmail.com>
+Rudr Tiwari <rudrtiwari@gmail.com>
+Rupesh Harode <rupeshharode@gmail.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com>
+rushyam <rushyamsonu@gmail.com>
+Ruslan Pisarev <rpisarev@cloudlinux.com>
+Russell Fordyce <rfordyce@expressive-py.org>
+Ryan Krauss <ryanlists@gmail.com>
+S. Hanko <suzy.hanko@gmail.com>
+S.Y. Lee <sylee957@gmail.com>
+Saanidhya vats <saanidhyavats@gmail.com>
+Sachin Agarwal <sachinagarwal0499@gmail.com>
+Sachin Irukula <sachin.irukula@gmail.com>
+Sachin Joglekar <srjoglekar246@gmail.com>
+Sachin Singh <sachinishu02@gmail.com>
+Safiya03 <safiyanesar@gmail.com>
+Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
+Sagar231 <sagarfeb298@gmail.com>
+Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Sai Nikhil <tsnlegend@gmail.com>
+Sai Udayagiri <saibabu.udayagiri@gmail.com>
+Saicharan <62512681+saicharan2804@users.noreply.github.com>
+Saicharan <saicharanhahaha@gmail.com>
+Saikat Das <saikatdchhe@gmail.com>
+Saket Kumar Singh <saketkumar1202@gmail.com>
+Saketh <alurusaisaketh@gmail.com>
+Sakirul Alam <binarysakir@gmail.com>
+Saksham Alok <sakshamalok13@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg>
+Salil Vishnu Kapur <salilvishnukapur@gmail.com>
+Salmista-94 <alejandrogroso@hotmail.com>
+Saloni Jain <tosalonijain@gmail.com>
+Sam Brockie <sambrockie@icloud.com>
+Sam Lubelsky <sammy56lt@gmail.com>
+Sam Magura <samtheman132@gmail.com>
+Sam Ritchie <sam@mentat.org>
+Sam Sleight <samuel.sleight@gmail.com>
+Sam Tygier <sam.tygier@hep.manchester.ac.uk>
+Sambuddha Basu <sammygamer@live.com>
+Samesh <samesh.lakhotia@gmail.com>
+Samith Karunathilake <55777141+samithkavishke@users.noreply.github.com>
+Samnan Rahee <namanush.rsr.16@gmail.com>
+Sampad Kumar Saha <sampadsaha5@gmail.com>
+Samyak Jain <samyak.jain2016a@vitstudent.ac.in>
+Sandeep Murthy <smurthy@protonmail.ch>
+Sandeep Veethu <sandeep.veethu@gmail.com>
+Sanket Agarwal <sanket@sanketagarwal.com>
+Sanya Khurana <sanya@monica.in>
+Saptarshi Mandal <sapta.iitkgp@gmail.com>
+Saroj Adhikari <adh.saroj@gmail.com>
+Sartaj Singh <singhsartaj94@gmail.com>
+Sarwar Chahal <chahal.sarwar98@gmail.com>
+Satya Prakash Dwibedi <akash581050@gmail.com>
+Saurabh Agarwal <shourabh.agarwal@gmail.com>
+Saurabh Jha <saurabh.jhaa@gmail.com>
+Sayan Goswami <Sayan98@users.noreply.github.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>
+Sayandip Halder <sayandiph4@gmail.com>
+sbt4104 <sthorat661@gmail.com>
+scimax <max.kellermeier@hotmail.de>
+seadavis <45022599+seadavis@users.noreply.github.com>
+Sean Ge <seange727@gmail.com>
+Sean P. Cornelius <spcornelius@gmail.com>
+Sean Vig <sean.v.775@gmail.com>
+Seb Tiburzio <sebtiburzio@gmail.com>
+Sebastian East <sebastianeast@ymail.com>
+Sebastian Koslowski <koslowski@kit.edu>
+Sebastian Krämer <basti.kr@gmail.com>
+Sebastian Krause <sebastian.krause@gmx.de>
+Sebastian Kreft <skreft@gmail.com>
+Segev Finer <segev208@gmail.com>
+Ser Kim <serk.kmh@gmail.com>
+Sergey B Kirpichev <skirpichev@gmail.com>
+Sergey Pestov <pestov-sa@yandex.ru>
+Sergiu Ivanov <unlimitedscolobb@gmail.com>
+Seshagiri Prabhu <seshagiriprabhu@gmail.com>
+Seth Ebner <murgrehk@gmail.com>
+Seth Poulsen <poulsenseth@yahoo.com>
+Seth Troisi <sethtroisi@google.com>
+sevaader <sevaader@gmail.com>
+sfoo <sfoohei@gmail.com>
+Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
+Shaoliang Jin <18322825326@163.com>
+sharma-kunal <kunalsharma6914@gmail.com>
+Shashank Agarwal <shashank.agarwal94@gmail.com>
+Shashank KS <shashankks0987@gmail.com>
+Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
+Shekhar Prasad Rajak <shekharrajak@live.com>
+Sherjil Ozair <sherjilozair@gmail.com>
+Shikhar Jaiswal <jaiswalshikhar87@gmail.com>
+Shikhar Makhija <shikharmakhija2@gmail.com>
+shiksha11 <shiksharawat01@gmail.com>
+Shipra Banga <bangashipra@gmail.com>
+Shishir Kushwaha <138311586+shishir-11@users.noreply.github.com>
+Shishir Kushwaha <kushwahashishir1112@gmail.com>
+Shital Mule <shitalmule04@gmail.com>
+Shivam Agarwal <knowthyself2503@gmail.com>
+Shivam Sagar <technoshivam12@gmail.com>
+Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
+Shivam Vats <shivamvats.iitkgp@gmail.com>
+Shivang Dubey <shivangdubey8@gmail.com>
+Shivani Kohli <shivanikohli.09@gmail.com>
+Shiyao Guo <mivikq@gmail.com>
+Shravas K Rao <shravas@gmail.com>
+Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
+shruti <shrutishrm512@gmail.com>
+Shruti Mangipudi <shruti2395@gmail.com>
+Shuai Zhou <shuaivzhou@berkeley.edu>
+Shubham Abhang <shubhamabhang77@gmail.com>
+Shubham Agrawal <shubham.ag6845@gmail.com>
+Shubham Kumar Jha <skjha832@gmail.com>
+Shubham Maheshwari <rmaheshwari05@gmail.com>
+Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
+Shubham Tibra <shubh.tibra@gmail.com>
+shubhayu09 <guptashubhayu601@gmail.com>
+Siddhanathan Shanmugam <siddhanathan@gmail.com>
+Siddhant Jain <getsiddhant@gmail.com>
+Siddhant Jain <siddhantashoknagar@gmail.com>
+Sidhant Nagpal <sidhantnagpal97@gmail.com>
+Sidharth Mundhra <sidharthmundhra16@gmail.com>
+Simon Sørensen <simonblsoerensen@gmail.com>
+SirJohnFranklin <sirjfu@googlemail.com>
+sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
+slacker404 <pchantza@gmail.com>
+Smit Gajjar <smitgajjar.gs@gmail.com>
+Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in>
+Sneha Goddu <s.goddu@wustl.edu>
+Soniya Nayak <soniyanayak51@gmail.com>
+Sophia Pustova <tripplezzed@gmail.com>
+Soumendra Ganguly <soumendraganguly@gmail.com>
+Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
+soumi7 <soumibardhan10@gmail.com>
+Soumya Dipta Biswas <sdb1323@gmail.com>
+Sourav Ghosh <souravghosh2197@gmail.com>
+Sourav Goyal <souravgl0@gmail.com>
+Sourav Singh <souravsingh@users.noreply.github.com>
+Srajan Garg <srajan.garg@gmail.com>
+Srinivas Vasudevan <srvasude@gmail.com>
+Srinivasa Arun Yeragudipati <ysarun1999@gmail.com>
+Stan Schymanski <stan.schymanski@env.ethz.ch>
+Stas Kelvich <stanconn@gmail.com>
+Stefan Behnle <84378403+behnle@users.noreply.github.com>
+Stefan Krastanov <krastanov.stefan@gmail.com>
+Stefan Petrea <stefan@garage-coding.com>
+Stefan van der Walt <stefan@sun.ac.za>
+Stefano Maggiolo <s.maggiolo@gmail.com>
+Stefen Yin <zqyin@ucdavis.edu>
+Stepan Roucka <stepan@roucka.eu>
+Stepan Simsa <simsa.st@gmail.com>
+Steph Papanik <spapanik21@gmail.com>
+Stephan Seitz <stephan.seitz@fau.de>
+Stephen Loo <shikil@yahoo.com>
+Steve Anton <anxuiz.nx@gmail.com>
+Steve Kieffer <sk@skieffer.info>
+Steven Burns <royalstream@hotmail.com>
+Steven Esquea <steven.esquea@irreverente.net>
+Steven Lee <stevenlee123@protonmail.com>
+Stewart Wadsworth <stewart.wadsworth@gmail.com>
+Subhash Saurabh <subhashsaurabh419@gmail.com>
+Sudarshan Kamath <sudarshan.kamath97@gmail.com>
+Sudeep Sidhu <sudeepmanilsidhu@gmail.com>
+Sudhanshu Mishra <mrsud94@gmail.com>
+Sujal Kumar <sujaljayantkumar06@gmail.com>
+Suman mondal <smondal.qwerty@gmail.com>
+Sumit Kumar <mr.sumitkrr@gmail.com>
+Sumith Kulal <sumith1896@gmail.com>
+Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
+Supreet Agrawal <supreet11agrawal@gmail.com>
+Suryam Arnav Kalra <suryamkalra35@gmail.com>
+Sushant Hiray <hiraysushant@gmail.com>
+Sushma Kumari <sushma.kumari@example.com>
+Sushma-stack-hub <sushmakumari@sushmas-MacBook-Air.local>
+Susumu Ishizuka <susumu.ishizuka@kii.com>
+Swapnil Agarwal <swapnilag29@gmail.com>
+symbolique <symbolique@users.noreply.github.com>
+Szymon Mieszczak <szymon.mieszczak@gmail.com>
+Takafumi Arakaki <aka.tkf@gmail.com>
+Takumasa Nakamura <n.takumasa@gmail.com>
+Tanay Agrawal <tanay_agrawal@hotmail.com>
+Tanu Hari Dixit <tokencolour@gmail.com>
+Tarang Patel <tarangrockr@gmail.com>
+Tarun Gaba <tarun.gaba7@gmail.com>
+Tasha Kim <jae_young_kim@brown.edu>
+Taylan Sahin <info@taylansahin.net>
+tborisova <ts.borisova3@gmail.com>
+Ted Dokos <tdokos@gmail.com>
+Ted Horst <ted.horst@earthlink.net>
+Tejaswini Sanapathi <sastejaswini2002@gmail.com>
+Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
-KJaybhaye <krushnajaybhaye01@gmail.com>
-Sushma Kumari
-
-
+Theodore Dias <theodore.dias@hotmail.co.uk>
+Theodore Han <theodorehan@hotmail.com>
+Thilina Rathnayake <thilinarmtb@gmail.com>
+Thomas A Caswell <tcaswell@gmail.com>
+Thomas Aarholt <thomasaarholt@gmail.com>
+Thomas Baruchel <baruchel@gmx.com>
+Thomas Dixon <thom@thomdixon.org>
+Thomas Hickman <Thomas.Hickman42@gmail.com>
+Thomas Hisch <t.hisch@gmail.com>
+Thomas Hunt <thomashunt13@gmail.com>
+Thomas Sidoti <TSidoti@gmail.com>
+Thomas Wiecki <thomas.wiecki@gmail.com>
+Tiffany Zhu <bubble.wubble.303@gmail.com>
+Tilo Reneau-Cardoso <tiloreneau@gmail.com>
+Tim Gates <tim.gates@iress.com>
+Tim Lahey <tim.lahey@gmail.com>
+Tim Swast <tswast@gmail.com>
+Timo Stienstra <timostienstra00@gmail.com>
+Timothy Cyrus <tcyrus@users.noreply.github.com>
+Timothy Reluga <treluga@math.psu.edu>
+Tirthankar Mazumder <63574588+wermos@users.noreply.github.com>
+TitanSnow <sweeto@live.cn>
+tnzl <you@example.com>
+Tobias Lenz <t_lenz94@web.de>
+Tom Bachmann <e_mc_h2@web.de>
+Tom Fryers <61272761+TomFryers@users.noreply.github.com>
+Tom Gijselinck <tomgijselinck@gmail.com>
+Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
+Tomáš Bambas <tomas.bambas@gmail.com>
+Tomasz Buchert <thinred@gmail.com>
+Tomasz Pytel <tompytel@gmail.com>
+Tommaso Vaccari <05-gesto-follemente@icloud.com>
+Tommy Olofsson <tommy.olofsson.90@gmail.com>
+Tomo Lazovich <lazovich@gmail.com>
+tools4origins <tools4origins@gmail.com>
+Toon Verstraelen <Toon.Verstraelen@UGent.be>
+Travis Ens <ens.travis@gmail.com>
+Tristan Hume <tris.hume@gmail.com>
+TrungPQ <trungpqhe171493@gmail.com>
+Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
+tttc3 <T.Coxon2@lboro.ac.uk>
+Tuan Manh Lai <laituan245@gmail.com>
+Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
+Tyler Pirtle <teeler@gmail.com>
+Unknown <kunda@scribus.net>
+user202729 <25191436+user202729@users.noreply.github.com>
+Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
+Uwe L. Korn <uwelk@xhochy.com>
+V1krant <46847915+V1krant@users.noreply.github.com>
+Vaibhav Bhat <vaibhav.bhat2097@gmail.com>
+Vaishnav Damani <vaishnavdamani3496@gmail.com>
+Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
+Varun Garg <varun.garg03@gmail.com>
+Varun Joshi <joshi.142@osu.edu>
+Vasileios Kalos <kalosbasileios@gmail.com>
+Vasiliy Dommes <vasdommes@gmail.com>
+Vasily Povalyaev <vapovalyaev@gmail.com>
+Vatsal Srivastava <alstav.trivas.sava@gmail.com>
+Vedant Rathore <vedantr1998@gmail.com>
+vedantc98 <vedantc98@gmail.com>
+Vedarth Sharma <vedarth.sharma@gmail.com>
+Velibor Zeli <velibor@mech.kth.se>
+Venkatesh Halli <venkatesh.fatality@gmail.com>
+Vera Lozhkina <veralozhkina@gmail.com>
+Versus Void <versusvoid@gmail.com>
+vezeli <37907135+vezeli@users.noreply.github.com>
+ViacheslavP <public.viacheslav@gmail.com>
+Victor Brebenar <v.brebenar@gmail.com>
+Victor Immanuel <chrollolucilfer1402@gmail.com>
+Victoria Koval <bictoriakoval16@gmail.com>
+Victory Omole <vtomole2@gmail.com>
+Vighnesh Shenoy <vighneshq@gmail.com>
+Vijairam Ganesh Moorthy <vijairamg@gmail.com>
+Vikrant Malik <vikrantmalik051@gmail.com>
+Vinay Kumar <gnulinooks@gmail.com>
+Vinay Singh <csvinay.d@gmail.com>
+Vincent Delecroix <vincent.delecroix@labri.fr>
+Vinit Ravishankar <vinit.ravishankar@gmail.com>
+Vinzent Steinberg <vinzent.steinberg@gmail.com>
+viocha <66580331+viocha@users.noreply.github.com>
+Viraj Vekaria <virajv5593@gmail.com>
+vishal <vishal.panjwani15@gmail.com>
+Vishal <vishalg2235@gmail.com>
+Vishesh Mangla <manglavishesh64@gmail.com>
+Vivek Soni <sonisheela1977@gmail.com>
+Vlad Seghete <vlad.seghete@gmail.com>
+Vladimir Lagunov <werehuman@gmail.com>
+Vladimir Perić <vlada.peric@gmail.com>
+Vladimir Poluhsin <vovapolu@gmail.com>
+Vladimir Sereda <voffch@gmail.com>
+Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com>
+w495 <w495@yandex-team.ru>
+Waldir Pimenta <waldyrious@gmail.com>
+Wang Ran (汪然) <wangr@smail.nju.edu.cn>
+Warren Jacinto <warrenjacinto@gmail.com>
+Wes Galbraith <galbwe92@gmail.com>
+Wes Turner <50891+westurner@users.noreply.github.com>
+whitesource-bolt-for-github[bot] <whitesource-bolt-for-github[bot]@users.noreply.github.com>
+Willem Melching <willem.melching@gmail.com>
+Wolfgang Stöcher <wolfgang@stoecher.com>
+wookie184 <wookie1840@gmail.com>
+wuyudi <wuyudi119@163.com>
+Wyatt Peak <wyattpeak@gmail.com>
+Xiang Wu <hsiangwu@fb.com>
+Xiao <muzumayao@126.com>
+xndcn <xndchn@gmail.com>
+Yang Yang <wdscxsj@gmail.com>
+Yaser AlOsh <yaseralosh@outlook.com>
+Yash Reddy <write2yashreddy@gmail.com>
+Yathartha Joshi <yathartha32@gmail.com>
+Yatna Verma <yatnavermaa@gmail.com>
+Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
+Yeshwanth N <yeshsurya@gmail.com>
+Yicong Guo <guoyicong100@gmail.com>
+YiDing Jiang <yidinggjiangg@gmail.com>
+ylemkimon <ylemkimon@naver.com>
+Yogesh Mishra <ymishra013@gmail.com>
+Yu Kobayashi <yukoba@accelart.jp>
+Yukai Chou <muzimuzhi@gmail.com>
+Yuki Matsuda <yuki.matsuda.w@gmail.com>
+Yuri Karadzhov <yuri.karadzhov@gmail.com>
+Yuriy Demidov <iurii.demidov@gmail.com>
+Yury G. Kudryashov <urkud.urkud@gmail.com>
+Yves Tumushimire <yvestumushimire@gmail.com>
+Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com>
+Zach Raines <raineszm@gmail.com>
+Zachariah Etienne <zachetie@gmail.com>
+Zamrath Nizam <zamiguy_ni@yahoo.com>
+Zaz Brown <zazbrown@zazbrown.com>
+Zedmat <104870914+harshkasat@users.noreply.github.com>
+Zeel Shah <kshah215@gmail.com>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>
+Zhenxu Zhu <xzdlj@outlook.com>
+Zhi-Qiang Zhou <zzq_890709@hotmail.com>
+Zhongshi <zj495@nyu.edu>
+Zhuoyuan Li <zy.li@stu.pku.edu.cn>
+Zlatan Vasović <zlatanvasovic@gmail.com>
+znxftw <vishnu2101@gmail.com>
+Zoufiné Lauer-Baré <raszoufine@gmail.com>
+Zouhair <zouhair.mahboubi@gmail.com>
+zsc347 <zsc347@gmail.com>
+Zulfikar <zulfikar97@gmail.com>
+zzc <1378113190@qq.com>
+zzj <29055749+zjzh@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1425 +1,1379 @@
-袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-彭于斌 <1931127624@qq.com>
-2torus <boris.ettinger@gmail.com>
-Aadit Kamat <aadit.k12@gmail.com>
-Aaditya Nair <aadityanair6494@gmail.com>
-Aaron Gokaslan <aaronGokaslan@gmail.com>
-Aaron Meurer <asmeurer@gmail.com>
-Aaron Miller <acmiller273@gmail.com>
-Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
-Aaryan Dewan <aaryandewan@yahoo.com>
-Aasim Ali <aasim250205@gmail.com>
-Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com>
-Abby Ng <abigailjng@gmail.com>
-Abderrahim Kitouni <a.kitouni@gmail.com>
-Abdullah Javed Nesar <abduljaved1994@gmail.com>
-Abhay_Dhiman <abhaysdhimans@gmail.com>
-Abhi58 <abhijithbharadwaj58@gmail.com>
-Abhigyan Khaund <mail@abhigyan.xyz>
-Abhinav Agarwal <abhinavagarwal1996@gmail.com>
-Abhinav Anand <abhinav.anand2807@gmail.com>
-Abhinav Chanda <abhinavchanda01@gmail.com>
-Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in>
-abhinav28071999 <41710346+abhinav28071999@users.noreply.github.com>
-Abhishek <uchiha@pop-os.localdomain>
-Abhishek Chaudhary <ac5003@columbia.edu>
-Abhishek Garg <abhishekgarg119@gmail.com>
-Abhishek Kumar <abhishek.nitdelhi@gmail.com>
-Abhishek kumar <kumar325571@gmail.com>
-Abhishek Patidar <1e9abhi1e10@gmail.com>
-Abhishek Verma <iamvermaabhishek@gmail.com>
-Achal Jain <2achaljain@gmail.com>
-Adam Bloomston <adam@glitterfram.es>
-Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
-Addison Cugini <ajcugini@gmail.com>
-adhoc-king <46354827+adhoc-king@users.noreply.github.com>
-aditisingh2362 <aditisingh2362@gmail.com>
-Aditya Jindal <jaditya8889@gmail.com>
-Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
-Aditya Kumar Sinha <adityakumar113141@gmail.com>
-Aditya Ravuri <infprobscix@gmail.com>
-Aditya Rohan <riyuzakiiitk@gmail.com>
-Aditya Shah <adityashah30@gmail.com>
-Advait Pote <apote2050@gmail.com>
-Adwait Baokar <adwaitbaokar18@gmail.com>
-Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
-Akash Agrawall <akash.wanted@gmail.com>
-Akash Kundu <sk.sayakkundu1997@gmail.com>
-Akash Nagaraj (akasnaga) <akasnaga@cisco.com>
-Akash Nagaraj <grassknoted@gmail.com>
-Akash Trehan <akash.trehan123@gmail.com>
-Akash Vaish <akash.9712@gmail.com>
-Akhil Rajput <akh1lrjput@gmail.com>
-Akira Kyle <ak@akirakyle.com>
-Akshansh Bhatt <akshansh@tuta.io>
-Akshat Jain <akshat.jain@students.iiit.ac.in>
-Akshat Maheshwari <akshat14714@gmail.com>
-Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
-Akshay <akshaynukala95@gmail.com>
-Akshay Nagar <awesomeay13@yahoo.com>
-Akshay Siramdas <akshaysiramdas@gmail.com>
-Akshay Srinivasan <akshaysrinivasan@gmail.com>
-Akshit Agarwal <akshit.jiit@gmail.com>
-AkuBrain <76952313+Franck2111@users.noreply.github.com>
-Alan Bromborsky <abrombo@verizon.net>
-Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
-Alec Kalinin <alec.kalinin@gmail.com>
-alejandro <amartinhernan@gmail.com>
-Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com>
-Aleksandar Makelov <amakelov@college.harvard.edu>
-Alex Argunov <sajkoooo@gmail.com>
-Alex Lindsay <adlinds3@ncsu.edu>
-Alex Lubbock <code@alexlubbock.com>
-Alex Malins <github@alexmalins.com>
-Alex Meiburg <timeroot.alex@gmail.com>
-Alexander Behrens <alex.git@gmx.net>
-Alexander Bentkamp <bentkamp@gmail.com>
-Alexander Cockburn <alexander_cockburn12@hotmail.com>
-Alexander Dunlap <alexander.dunlap@gmail.com>
-Alexander Eberspächer <alex.eberspaecher@gmail.com>
-Alexander Grund <alexander.grund@tu-dresden.de>
-Alexander Hirzel <alex@hirzel.us>
-Alexander Pozdneev <pozdneev@users.noreply.github.com>
-Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
-Alexander Zhura <nice.zhura@list.ru>
-Alexandr Gudulin <alexandr.gudulin@gmail.com>
-Alexandr Popov <alexandr.s.popov@gmail.com>
-AlexCQY <alex_chua@u.nus.edu>
-Alexey Pakhocmhik <cool.Bakov@yandex.ru>
-Alexey Subach <alexey.subach@gmail.com>
-Alexey U. Gudchenko <proga@goodok.ru>
-Alexis Schotte <alexis.schotte@gmail.com>
-Alhussein Ashraf <alhusseinashraf55@gmail.com>
-Ali Raza Syed <arsyed@gmail.com>
-alijosephine <alijosephine@gmail.com>
-Alistair Lynn <arplynn@gmail.com>
-Alkiviadis G. Akritas <akritas@uth.gr>
-Alpesh Jamgade <alpeshjamgade21@gmail.com>
-Alsheh <alsheh@rpi.edu>
-Aman <amanmourya295@gmail.com>
-Aman Deep <amandeep1024@gmail.com>
-Aman Kumar Shukla <theprofessionalaman@gmail.com>
-Aman Sharma <amansharma110603@gmail.com>
-Aman Thakur <thakuraman22july@gmail.com>
-Amanda Dsouza <meezamanda@yahoo.com>
-Ambar Mehrotra <mehrotraambar@gmail.com>
-Amir Ebrahimi <github@aebrahimi.com>
-Amit Jamadagni <bitsjamadagni@gmail.com>
-Amit Kumar <dtu.amit@gmail.com>
-Amit Manchanda <amitdelhi1995@gmail.com>
-Amit Saha <amitsaha.in@gmail.com>
-amsuhane <ayushsuhane99@iitkgp.ac.in>
-Ananya H <ananyaha93@gmail.com>
-Anatolii Koval <weralwolf@gmail.com>
-anca-mc <anca-mc@users.noreply.github.com>
-Andre de Fortier Smit <freevryheid@gmail.com>
-Andreas Klöckner <inform@tiker.net>
-Andrej Tokarčík <androsis@gmail.com>
-andreo <andrey.torba@gmail.com>
-Andrew Docherty <andrewd@maths.usyd.edu.au>
-Andrew Mosson <amosson@yahoo.com>
-Andrew Straw <strawman@astraw.com>
-Andrew Taber <andrew.e.taber@gmail.com>
-Andrey Grozin <A.G.Grozin@inp.nsk.su>
-Andrey Lekar <andrey_lekar@adoriasoft.com>
-Andrii Oriekhov <andriyorehov@gmail.com>
-Andy R. Terrel <aterrel@uchicago.edu>
-Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
-Angadh Nanjangud <angadh.n@gmail.com>
-Angus Griffith <16sn6uv@gmail.com>
-Anibal M. Medina-Mardones <ammedmar@gmail.com>
-Animesh Sinha <animeshsinha1309@gmail.com>
-Anish Shah <shah.anish07@gmail.com>
-Anjul Kumar Tyagi <anjul.ten@gmail.com>
-Ankit Agrawal <aaaagrawal@iitb.ac.in>
-Ankit Kumar Singh <ankitdiswar10@gmail.com>
-Ankit Raj Pandey <pandeyan@grinnell.edu>
-Ansh Mishra <anshmishra471@gmail.com>
-Anthony Scopatz <scopatz@gmail.com>
-Anthony Sottile <asottile@umich.edu>
-Anton Akhmerov <anton.akhmerov@gmail.com>
-Anton Golovanov <agolovanov256@gmail.com>
-Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
-Anup Parikh <parikhanupk@gmail.com>
-Anurag Bhat <bhat.1@iitj.ac.in>
-Anurag Sharma <anurags92@gmail.com>
-Anutosh Bhat <andersonbhat491@gmail.com>
-Anway De <anway1756@gmail.com>
-Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
-Arafat Dad Khan <arafat.da.khan@gmail.com>
-Aravind Reddy <aravindreddy255@gmail.com>
-Archit Verma <architv07@gmail.com>
-Arie Bovenberg <a.c.bovenberg@gmail.com>
-Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
-Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
-Arihant Parsoya <parsoyaarihant@gmail.com>
-Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com>
-Arnab Nandi <arnabnandi2002@gmail.com>
-Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
-arooshiverma <av22@iitbbs.ac.in>
-Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in>
-Arpit Goyal <agmps18@gmail.com>
-Arshdeep Singh <singh.arshdeep1999@gmail.com>
-Arthur Milchior <arthur@milchior.fr>
-Arthur Ryman <arthur.ryman@gmail.com>
-Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
-Arun Singh <arunsin997@gmail.com>
-Ashish Kumar Gaurav <ashishkg0022@gmail.com>
-Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
-Ashutosh Saboo <ashutosh.saboo96@gmail.com>
-Ashwini Oruganti <ashwini.oruganti@gmail.com>
-Asish Panda <asishrocks95@gmail.com>
-Atharva Khare <khareatharva@gmail.com>
-atharvParlikar <atharvparlikar@gmail.com>
-Atul Bisht <me.atulbisht@gmail.com>
-Au Huishan <huishan_au@outlook.com>
-Augusto Borges <borges.augustoar@gmail.com>
-Austin Palmer <ap4000@nyu.edu>
-Avasam <samuel.06@hotmail.com>
-Avi Shrivastava <shrivastavaavi123@gmail.com>
-Avichal Dayal <avichal.dayal@gmail.com>
-Ayden Alvarez <Aydenalv6282@gmail.com>
-Ayodeji Ige <ayodeji18@outlook.com>
-Ayush Aryan <ayush.aryan71@gmail.com>
-Ayush Bisht <bisht.ayush2001@gmail.com>
-Ayush Kumar <ayushk7102@gmail.com>
-Ayush Kumar Jha <jha44481@gmail.com>
-Ayush Malik <ayushmalik779@gmail.com>
-Ayush Shridhar <ayush.shridhar1999@gmail.com>
-Ayushman Koul <ayushmankoul4570@gmail.com>
-azure-pipelines[bot] <azure-pipelines[bot]@users.noreply.github.com>
-B McG <bmcg0890@gmail.com>
-Baiyuan Qiu <1061688677@qq.com>
-Bao Chau <chauquocbao0907@gmail.com>
-Barry Wardell <barry.wardell@gmail.com>
-Barun Parruck <barun.parruck@gmail.com>
-BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
-Bastian Weber <bastian.weber@gmx-topmail.de>
-Bavish Kulur <bavishkulur@gmail.com>
-Ben Goodrich <goodrich.ben@gmail.com>
-Ben Lucato <ben.lucato@gmail.com>
-Ben Oostendorp <oostben@umich.edu>
-Ben Payne <ben.is.located@gmail.com>
-Bendik Samseth <b.samseth@gmail.com>
-Benedikt Placke <benedikt.placke@outlook.com>
-Benjamin Fishbein <fishbeinb@gmail.com>
-Benjamin Gudehus <hastebrot@gmail.com>
-Benjamin McDonald <mcdonald.ben@gmail.com>
-Benjamin Wolba <mail@benjaminwolba.com>
-Bernhard R. Link <brlink@debian.org>
-Bharat Raghunathan <bharatraghunthan9767@gmail.com>
-bharatAmeria <21001019007@jcboseust.ac.in>
-Bharath M R <catchmrbharath@gmail.com>
-Bhaskar Gupta <guptabhanu1999@gmail.com>
-Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in>
-Bhautik Mavani <mavanibhautik@gmail.com>
-Bhavik Sachdev <b.sachdev1904@gmail.com>
-Bhavya Srivastava <bhavya17037@iiitd.ac.in>
-Bilal Ahmed <b.ahmed0918@gmail.com>
-Bilal Akhtar <bilalakhtar@ubuntu.com>
-Bill Flynn <wflynny@gmail.com>
-Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
-Björn Dahlgren <bjodah@gmail.com>
-Blair Azzopardi <blairuk@gmail.com>
-bluebrook <perl4logic@gmail.com>
-Bobby Palmer <bobbyp@umich.edu>
-Borek Saheli <boreksaheli@gmail.com>
-Boris Atamanovskiy <shaomoron@gmail.com>
-Boris Ettinger <ettinger.boris@gmail.com>
-Boris Timokhin <qoqenator@gmail.com>
-Bradley Dowling <34559056+btdow@users.noreply.github.com>
-Bradley Froehle <brad.froehle@gmail.com>
-Bradley Gannon <bradley.m.gannon@gmail.com>
-Brandon David <brandon.david@zoho.com>
-Brandon T. Willard <brandonwillard@users.noreply.github.com>
-Brian E. Granger <ellisonbg@gmail.com>
-Brian Jorgensen <brian.jorgensen@gmail.com>
-Brian Stephanik <xoedusk@gmail.com>
-Buck Shlegeris <buck2@bruceh15.anu.edu.au>
-Bulat <daianovich@mail.ru>
-Caley Finn <caleyreuben@gmail.com>
-Calvin Jay Ross <calvinjayross@gmail.com>
-Carl Sandrock <carl.sandrock@up.ac.za>
-Carlos Cordoba <ccordoba12@gmail.com>
-Carlos García Montoro <TrilceAC@gmail.com>
-Carson McManus <carson.mcmanus1@gmail.com>
-Carsten Knoll <CarstenKnoll@gmx.de>
-carstimon <carstimon@gmail.com>
-Case Van Horsen <casevh@gmail.com>
-Cavendish McKay <cmckay@tachycline.com>
-Cédric Travelletti <cedrictravelletti@gmail.com>
-Cezary Marczak <zeddq1@gmail.com>
-Chai Wah Wu <cwwuieee@gmail.com>
-Chaitanya Jain <chaitanya.jain.dev@gmail.com>
-Chaitanya Sai Alaparthi <achaitanyasai@gmail.com>
-Chak-Pong Chung <chakpongchung@gmail.com>
-Chanakya-Ekbote <ca10@iitbbs.ac.in>
-Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
-Charalampos Tsiagkalis <ctsiagkalis@uth.gr>
-Charles Harris <erdos4d@gmail.com>
-Charles Weiss <charles.weiss@augie.edu>
-Chetan Choudhary <cc393653@gmail.com>
-Chetna Gupta <cheta.gup@gmail.com>
-Chiu-Hsiang Hsu <wdv4758h@gmail.com>
-Chris Cameron <chrisjamescameron1@gmail.com>
-Chris Conley <chrisconley15@gmail.com>
-Chris du Plessis <christopherjonduplessis@gmail.com>
-Chris Kerr <chris.kerr@mykolab.ch>
-Chris Paul <chrispaul68002@gmail.com>
-Chris Smith <smichr@gmail.com>
-Chris Swierczewski <cswiercz@gmail.com>
-Chris Tefer <ctefer@gmail.com>
-Chris Wu <chris.wu@gmail.com>
-Christian Bühler <christian@cbuehler.de>
-Christian Muise <christian.muise@gmail.com>
-Christian Schubert <chr.schubert@gmx.de>
-Christiano Anderson <canderson@riseup.net>
-Christina Zografou <t8130048@dias.aueb.gr>
-Christoph Gohle <ctg@mpq.mpg.de>
-Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
-Christopher Dembia <cld72@cornell.edu>
-Christopher J. Wright <cjwright4242gh@gmail.com>
-CJ Carey <perimosocordiae@gmail.com>
-ck Lux <lux.r.ck@gmail.com>
-Clayton Rabideau <claytonrabideau@gmail.com>
-Clemens Novak <clemens@familie-novak.net>
-Clément M.T. Robert <cr52@protonmail.com>
-Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>
-cocolato <haiizhu@outlook.com>
-codecruisader <nnisarg55@gmail.com>
-Coder-RG <rgoel1999@gmail.com>
-Cody Herbst <cyherbst@gmail.com>
-Colin B. Macdonald <cbm@m.fsf.org>
-Colin Marquardt <github@marquardt-home.de>
-Colleen Lee <colleenclee@gmail.com>
-Comer Duncan <comer.duncan@gmail.com>
-Congxu Yang <u7189828@anu.edu.au>
-Constantin Mateescu <costica1234@me.com>
-Corbet Elkins <corbet286@gmail.com>
-Corey Cerovsek <corey@cerovsek.com>
-Costor <pcs2009@web.de>
-Craig A. Stoudt <craig.stoudt@gmail.com>
-Cristian Di Pietrantonio <cristiandipietrantonio@gmail.com>
-Cristóvão Sousa <crisjss@gmail.com>
-cym1 <16437732+cym1@users.noreply.github.com>
-Daan Koning (he/him) <daanolivierkoning@gmail.com>
-Daiki Takahashi <haru.td@gmail.com>
-damianos <damianos@semmle.com>
-Dammina Sahabandu <dmsahabandu@gmail.com>
-Dana Jacobsen <dana@acm.org>
-dandiez <47832466+dandiez@users.noreply.github.com>
-Daniel Hyams <dhyams@gmail.com>
-Daniel Ingram <ingramds@appstate.edu>
-Daniel Mahler <dmahler@gmail.com>
-Daniel Sears <highpost@users.noreply.github.com>
-Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
-Daniel Wennberg <daniel.wennberg@gmail.com>
-Danny Hermes <daniel.j.hermes@gmail.com>
-Darshan Chaudhary <deathbullet@gmail.com>
-Dave Witte Morris <Dave.Morris@uleth.ca>
-Davi Laerte <davilae011@gmail.com>
-David Brooks <dave@bcs.co.nz>
-David Daly <david.daly12@kzoo.edu>
-David Hagen <david@drhagen.com>
-David Joyner <wdjoyner@gmail.com>
-David Ju <Sgtmook314@gmail.com>
-David Lawrence <dmlawrence@gmail.com>
-David Li <l33tnerd.li@gmail.com>
-David Marek <h4wk.cz@gmail.com>
-David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
-David P. Sanders <dpsanders@gmail.com>
-David Roberts <dvdr18@gmail.com>
-David T <derDavidT@users.noreply.github.com>
-Davide Sandonà <sandona.davide@gmail.com>
-Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
-Dean Price <dean1357price1357@gmail.com>
-Demian Wassermann <demian@bwh.harvard.edu>
-Denis Ivanenko <ivanenko@ucu.edu.ua>
-Denis Rykov <rykovd@gmail.com>
-Dennis Meckel <meckel@datenschuppen.de>
-Dennis Sweeney <sweeney.427@osu.edu>
-Denys Rybalka <rybalka.denis@gmail.com>
-dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
-der-blaue-elefant <github@kklein.de>
-Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
-Devansh <be19b002@smail.iitm.ac.in>
-Devesh Sawant <devesh47cool@gmail.com>
-Devyani Kota <devyanikota@gmail.com>
-Dhia Kennouche <kendhia@gmail.com>
-Dhruv Bhanushali <dhruv_b@live.com>
-Dhruv Kothari <dhruvkothari22@gmail.com>
-Dhruv Mendiratta <dhruvmendiratta6@gmail.com>
-Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
-Diane Tchuindjo <dtchuindjo@gmail.com>
-Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
-dimasvq <dimas.vq.2020@bristol.ac.uk>
-Dimitra Konomi <t8130064@dias.aueb.gr>
-dispasha <dispasha@users.noreply.github.com>
-Divyanshu Thakur <divyanshu@iiitmanipur.ac.in>
-Dmitry Batkovich <batya239@gmail.com>
-Dmitry Savransky <dsavransky@gmail.com>
-dodo <palumbododo@gmail.com>
-Dominik Stańczak <stanczakdominik@gmail.com>
-Donald Wilson <donwilson1029@gmail.com>
-dps7ud <dps7ud@virginia.edu>
-dranknight09 <cbhaavan@gmail.com>
-Duane Nykamp <nykamp@umn.edu>
-Duc-Minh Phan <alephvn@gmail.com>
-Dustin Gadal <Dustin.Gadal@gmail.com>
-dustyrockpyle <dustyrockpyle@gmail.com>
-Dzhelil Rufat <drufat@caltech.edu>
-Ebrahim Byagowi <ebrahim@gnu.org>
-Edward Schembor <eschemb1@jhu.edu>
-Edward Z. Yang <ezyang@mit.edu>
-Eh Tan <tan2tan2@gmail.com>
-Ehren Metcalfe <ehren.m@gmail.com>
-Ekansh Purohit <purohit.e15@gmail.com>
-Elias Basler <e.e.basler@protonmail.com>
-Élie Goudout <eliegoudout@hotmail.com>
-Elisha Hollander <just4now666666@gmail.com>
-Elliot Marshall <Marshall2389@gmail.com>
-Elrond der Elbenfuerst <elrond+sympy.org@samba-tng.org>
-elvis-sik <e.sikora@grad.ufsc.br>
-Emile Fourcini <emile.fourcin1@gmail.com>
-Emma Hogan <ehogan@gemini.edu>
-Enric Florit <efz1005@gmail.com>
-erdOne <36414270+erdOne@users.noreply.github.com>
-Eric Demer <demer@mailbox.org>
-Eric Miller <emiller42@gmail.com>
-Eric Nelson <eric.the.red.XLII@gmail.com>
-Eric Wieser <wieser.eric@gmail.com>
-Erik R. Gomez <gomez@kth.se>
-Erik Welch <erik.n.welch@gmail.com>
-Ethan DeGuire <ethandeguire@gmail.com>
-Ethan Ward <etkewa@gmail.com>
-Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
-Eva Tiwari <eva.tiwari@gmail.com>
-Evandro Bernardes <evbernardes@gmail.com>
-Evani Balasubramanyam <balasubramanyam.evani@gmail.com>
-Evelyn King <evelyn.cameron.king@gmail.com>
-Evgenia Karunus <lakesare@gmail.com>
-extraymond <extraymond@gmail.com>
-Fabian Ball <fabian.ball@kit.edu>
-Fabian Froehlich <fabian@schaluck.com>
-Fabian Pedregosa <fabian@fseoane.net>
-Fabio Luporini <fabio@devitocodes.com>
-Faisal Anees <faisal.iiit@gmail.com>
-Faisal Riyaz <faisalriyaz011@gmail.com>
-faizan2700 <syedfaizan824@gmail.com>
-Fawaz Alazemi <Mba7eth@gmail.com>
-fazledyn-or <ataf@openrefactory.com>
-Felix Kaiser <felix.kaiser@fxkr.net>
-Felix Yan <felixonmars@archlinux.org>
-Fermi Paradox <FermiParadox@users.noreply.github.com>
-Fernando Perez <Fernando.Perez@berkeley.edu>
-Fiach Antaw <fiach.antaw+github@gmail.com>
-Filip Gokstorp <filip@gokstorp.se>
-Flamy Owl <flamyowl@protonmail.ch>
-Florian Mickler <florian@mickler.org>
-foice <foice.news@gmail.com>
-ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>
-Francesco Bonazzi <franz.bonazzi@gmail.com>
-Freddie Witherden <freddie@witherden.org>
-Frédéric Chapoton <fchapoton2@gmail.com>
-Fredrik Andersson <fredrik.andersson@fcc.chalmers.se>
-Fredrik Eriksson <freeriks@student.chalmers.se>
-Fredrik Johansson <fredrik.johansson@gmail.com>
-Friedrich Hagedorn <friedrich_h@gmx.de>
-G. D. McBain <gdmcbain@protonmail.com>
-Gabriel Bernardino <gabriel.bernardino@upf.edu>
-Gabriel Orisaka <orisaka@gmail.com>
-Gaetano Guerriero <x.guerriero@tin.it>
-Gagan Mishra <simonsimple305@gmail.com>
-Gagandeep Singh <singh.23@iitj.ac.in>
-Gao, Xiang <qasdfgtyuiop@gmail.com>
-Gareth Ma <grhkm21@gmail.com>
-Garrett Folbe <gmfolbe@yahoo.com>
-Gary Kerr <gary.kerr@blueyonder.co.uk>
-Gaurang Tandon <1gaurangtandon@gmail.com>
-Gaurav Dhingra <gauravdhingra.gxyd@gmail.com>
-Gaurav Jain <gjain369@gmail.com>
-Gautam Menghani <gum3ng@protonmail.com>
-Geetika Vadali <geetika.vadali4@gmail.com>
-Geoffry Song <goffrie@gmail.com>
-George Frolov <gosha@fro.lv>
-George Korepanov <gkorepanov.gk@gmail.com>
-George Pittock <gpittock4@gmail.com>
-George Waksman <waksman@gwax.com>
-Georges Khaznadar <georgesk@debian.org>
-Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
-Gerald Teschl <gerald.teschl@univie.ac.at>
-Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
-Gilbert Gede <gilbertgede@gmail.com>
-Gilles Schintgen <gschintgen@hambier.lu>
-Gina <Dr-G@users.noreply.github.com>
-Gleb Siroki <g.shiroki@gmail.com>
-Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
-goddus <39923708+goddus@users.noreply.github.com>
-GolimarOurHero <metalera94@hotmail.com>
-Gonzalo Tornaría <tornaria@cmat.edu.uy>
-Goran Jelic-Cizmek <jcgoran@protonmail.com>
-Goutham Lakshminarayan <dl.goutham@gmail.com>
-Govind Sahai <gsiitbhu@gmail.com>
-Grace Su <grace.duansu@gmail.com>
-gregmedlock <gmedlo@gmail.com>
-Gregory Ashton <gash789@gmail.com>
-Gregory Ksionda <ksiondag846@gmail.com>
-Grzegorz Świrski <sognat@gmail.com>
-Guido Roncarolo <guido.roncarolo@gmail.com>
-Guillaume Gay <contact@damcb.com>
-Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
-Guo Xingjian <Seeker1995@gmail.com>
-Gurpartap Singh <dhaliwal.gurpartap@gmail.com>
-Guru Devanla <grdvnl@gmail.com>
-Haimo Zhang <zh.hammer.dev@gmail.com>
-Håkon Kvernmoen <haakon.kvernmoen@gmail.com>
-Hamish Dickson <hamish.dickson@gmail.com>
-Hampus Malmberg <hampus.malmberg88@gmail.com>
-Han Wei Ang <ang.h.w@u.nus.edu>
-Hannah Kari <hannah.kari@marquette.edu>
-Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
-Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
-Harikrishna Srinivasan <harikrishnasri3@gmail.com>
-Harold Erbin <harold.erbin@gmail.com>
-Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
-Harry Mountain <harrymountain1@icloud.com>
-Harry Zheng <harry@harryzheng.com>
-Harsh Agarwal <hagarwal9200@gmail.com>
-Harsh Gupta <mail@hargup.in>
-Harsh Jain <harshjniitr@gmail.com>
-Harsh Kasat <hkasat@waymore.io>
-Harshil Goel <harshil158@gmail.com>
-Harshil Meena <harshil.7535@gmail.com>
-Harshit Gupta <harshithigh2001@gmail.com>
-Harshit Yadav <harshityadav2k@gmail.com>
-Haruki Moriguchi <harukimoriguchi@gmail.com>
-HeeJae Chang <hechang@microsoft.com>
-Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
-helo9 <helo9@users.noreply.github.com>
-Henrik Johansson <henjo2006@gmail.com>
-Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
-Henry Gebhardt <hsggebhardt@gmail.com>
-Henry Metlov <genrih.metlov@gmail.com>
-Himanshu <hs80941@gmail.com>
-Himanshu Ladia <hladia199811@gmail.com>
-Hiren Chalodiya <hirenchalodiya99@gmail.com>
-hm <hacman0@gmail.com>
-Hong Xu <hong@topbug.net>
-Hou-Rui <houruinus@gmail.com>
-Huangduirong <huangduirong@huawei.com>
-Hubert Tsang <intsangity@gmail.com>
-Hugo Kerstens <hugo@kerstens.me>
-Hugo van Kemenade <hugovk@users.noreply.github.com>
-Huijun Mai <m.maihuijun@gmail.com>
-Hwayeon Kang <hwayeonniii@gmail.com>
-Ian Swire <oversizedpenguin@gmail.com>
-Idan Pazi <idan.kp@gmail.com>
-Ilya Pchelintsev <ilya.pchelintsev@outlook.com>
-immerrr <immerrr@gmail.com>
-Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
-Ishan Joshi <ishanaj98@gmail.com>
-Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
-Ishan Pandhare <ishan9096137017@gmail.com>
-Isidora Araya <iarayaday@gmail.com>
-Islam Mansour <is3mansour@gmail.com>
-Islem BOUZENIA <fi_bouzenia@esi.dz>
-Isuru Fernando <isuruf@gmail.com>
-Itay4 <31018228+Itay4@users.noreply.github.com>
-Ivan A. Melnikov <iv@altlinux.org>
-Ivan Petuhov <ivan@ostrovok.ru>
-Ivan Petukhov <satels@gmail.com>
-Ivan Tkachenko <me@ratijas.tk>
-Jack Kemp <metaknightdrake-git@yahoo.co.uk>
-Jack McCaffery <jpmccaffery@gmail.com>
-Jack Schmidt <1107865+jackschmidt@users.noreply.github.com>
-Jacob Garber <jgarber1@ualberta.ca>
-Jai Luthra <me@jailuthra.in>
-Jaime R <38530589+Jaime02@users.noreply.github.com>
-Jaime Resano <gemailpersonal02@gmail.com>
-Jainul Vaghasia <jainulvaghasia@gmail.com>
-Jakub Wilk <jwilk@jwilk.net>
-James A. Preiss <jamesalanpreiss@gmail.com>
-James Abbatiello <abbeyj@gmail.com>
-James Aspnes <aspnes@cs.yale.edu>
-James Brandon Milam <jmilam343@gmail.com>
-James Cotton <peabody124@gmail.com>
-James Fiedler <jrfiedler@gmail.com>
-James Goppert <james.goppert@gmail.com>
-James Harrop <ebc121@gmail.com>
-James Pearson <xiong.chiamiov@gmail.com>
-James Taylor <user234683@tutanota.com>
-James Titus <titusjames299@gmail.com>
-James Whitehead <whiteheadj@gmail.com>
-Jan Jancar <johny@neuromancer.sk>
-Jan Kruse <janckruse@t-online.de>
-Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com>
-Jared Lumpe <mjlumpe@gmail.com>
-Jaroslaw Tworek <dev.jrx@gmail.com>
-Jashanpreet Singh <jashansingh.4398@gmail.com>
-Jason Gedge <inferno1386@gmail.com>
-Jason Gross <jasongross9@gmail.com>
-Jason Ly <jason.ly@gmail.com>
-Jason Moore <moorepants@gmail.com>
-Jason Ross <jasonross1024@gmail.com>
-Jason Siefken <siefkenj@gmail.com>
-Jason Tokayer <jason.tokayer@gmail.com>
-Jatin Bhardwaj <bhardwajjatin093@gmail.com>
-Jatin Gaur <jatingaurchess@gmail.com>
-Jatin Yadav <jatinyadav25@gmail.com>
-Javed Nissar <javednissar@gmail.com>
-Jay Patankar <patankarjays@gmail.com>
-Jayesh Lahori <jlahori92@gmail.com>
-Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
-JDBetteridge <jack@devitocodes.com>
-Jean-François B <2589111+jfbu@users.noreply.github.com>
-Jean-Luc Herren <jlh@gmx.ch>
-Jeffrey Ryan <jeffaryan7@gmail.com>
-Jennifer White <jcrw122@googlemail.com>
-Jens H. Nielsen <jenshnielsen@gmail.com>
-Jens Jørgen Mortensen <jj@smoerhul.dk>
-Jeremey Gluck <jeremygluck@yahoo.com>
-Jeremias Yehdegho <j.yehdegho@gmail.com>
-Jeremy <twobitlogic@gmail.com>
-Jeremy Monat <jemonat@calalum.org>
-Jerry James <loganjerry@gmail.com>
-Jerry Li <jerry@jerryli.ca>
-jerryma1121 <jerryma1121@gmail.com>
-Jezreel Ng <jezreel@gmail.com>
-jgulian <josephdgulian@gmail.com>
-jhanwar <f2015463@pilani.bits-pilani.ac.in>
-Jiaxing Liang <liangjiaxing57@gmail.com>
-Jim Crist <crist042@umn.edu>
-Jim Zhang <Hyriodula@gmail.com>
-Jiri Kuncar <jiri.kuncar@gmail.com>
-Jisoo Song <jeesoo9595@snu.ac.kr>
-Jithin D. George <jithindgeorge93@gmail.com>
-JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
-Jo Liss <joliss42@gmail.com>
-Joachim Durchholz <jo@durchholz.org>
-Joan Creus <joan.creus.c@gmail.com>
-Joannah Nanjekye <joannah.nanjekye@ibm.com>
-João Bravo <joaocgbravo@tecnico.ulisboa.pt>
-João Moura <operte@gmail.com>
-João Rodrigues <abcjoao@hotmail.com>
-Joaquim Monserrat <qmonserrat@mailoo.org>
-Jochen Voss <voss@seehuhn.de>
-Jogi Miglani <jmig5776@gmail.com>
-Johan Blåbäck <johan_bluecreek@riseup.net>
-Johan Guzman <jguzm022@ucr.edu>
-Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
-Johannes Hartung <joha2@gmx.net>
-Johannes Kasimir <johannes.kasimir@math.lu.se>
-John Connor <john.theman.connor@gmail.com>
-John Möller <john.moller@outlook.com>
-John V. Siratt <jvsiratt@gmail.com>
-Jonathan A. Gross <jarthurgross@gmail.com>
-Jonathan Allan <jjallan@users.noreply.github.com>
-Jonathan Daniel <36337649+jond01@users.noreply.github.com>
-Jonathan Gutow <gutow@uwosh.edu>
-Jonathan Miller <jdmiller93@gmail.com>
-Jonathan Warner <warnerjon12@gmail.com>
-Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
-Jorge E. Cardona <jorgeecardona@gmail.com>
-Jorn Baayen <jorn.baayen@gmail.com>
-Jose M. Gomez <chemoki@gmail.com>
-José Senart <jose.senart@gmail.com>
-Joseph Dougherty <Github@JWDougherty.com>
-Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
-Joseph Redfern <joseph@redfern.me>
-Josh Burkart <jburkart@gmail.com>
-Juan Barbosa <js.barbosa10@uniandes.edu.co>
-Juan Felipe Osorio <jfosorio@gmail.com>
-Juan Luis Cano Rodríguez <juanlu001@gmail.com>
-Juha Remes <jremes@outlook.com>
-Julien Palard <julien@palard.fr>
-Julien Rioux <julien.rioux@gmail.com>
-Julio Idichekop Filho <idichekop@yahoo.com.br>
-Jun Lin <junlin0604@gmail.com>
-Jurjen N.E. Bos <jnebos@gmail.com>
-Justin Blythe <jblythe29@gmail.com>
-Jyn Spring 琴春 <me@vx.st>
-K. Kraus <laqueray@googlemail.com>
-Ka Yi <chua.kayi@yahoo.com.sg>
-Kaifeng Zhu <cafeeee@gmail.com>
-Kalevi Suominen <jksuom@gmail.com>
-kamimura <kamimura@live.jp>
-Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
-kangzhiq <709563092@qq.com>
-Karan <grgkaran03@gmail.com>
-Karan Anand <anandkarancompsci@gmail.com>
-Karan Sharma <karan1276@gmail.com>
-Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in>
-Kartik Sethi <kartiks31416@gmail.com>
-Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
-Kaushik Varanasi <kaushik.varanasi1@gmail.com>
-Kaustubh <90597818+kaustubh-765@users.noreply.github.com>
-Kaustubh Chaudhari <ckaustubhm06@gmail.com>
-KaustubhDamania <kaustubh.damania@gmail.com>
-Kazuo Thow <kazuo.thow@gmail.com>
-Ken Wakita <wakita@is.titech.ac.jp>
-Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
-Kenneth Lyons <ixjlyons@gmail.com>
-Keno Goertz <keno@goertz-berlin.com>
-Keval Shah <kevalshah_96@yahoo.co.in>
-Kevin Goodsell <kevin-opensource@omegacrash.net>
-Kevin Hunter <hunteke@earlham.edu>
-Kevin McWhirter <klmcw@yahoo.com>
-Kevin Ventullo <kevin.ventullo@gmail.com>
-Keyron Linerez <keyronlinarez@gmail.com>
-Khagesh Patel <khageshpatel93@gmail.com>
-Kibeom Kim <kk1674@nyu.edu>
-Kirill Smelkov <kirr@landau.phys.spbu.ru>
-Kirtan Mali <kirtanmali555@gmail.com>
-Kishore Gopalakrishnan <kishore96@gmail.com>
-Kiyohito Yamazaki <kyamaz@openql.org>
-KJaybhaye <krushnajaybhaye01@gmail.com>
-klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
-Klaus Rettinghaus <klaus.rettinghaus@enote.com>
-Konrad Meyer <konrad.meyer@gmail.com>
-Konstantin Togoi <konstantin.togoi@gmail.com>
-Konstantinos Riganas <kostasriganas24@gmail.com>
-Kris Katterjohn <katterjohn@gmail.com>
-Krishnav Bajoria <bajoriakrishnav@gmail.com>
-Kristian Brünn <hello@kristianbrunn.com>
-Krit Karan <kritkaran.b13@iiits.in>
-Kshitij <kshitijparwani.mat18@itbhu.ac.in>
-Kshitij Saraogi <KshitijSaraogi@gmail.com>
-Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com>
-Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
-Kunal Arora <kunalarora.135@gmail.com>
-Kunal Sheth <kunal@kunalsheth.info>
-Kunal Singh <ksingh19136@gmail.com>
-Kundan Kumar <kundankumar18581@gmail.com>
-Kyle McDaniel <mcdanie5@illinois.edu>
-Lagaras Stelios <stel.lag@hotmail.com>
-Lakshya Agrawal <zeeshan.lakshya@gmail.com>
-Langston Barrett <langston.barrett@gmail.com>
-Lars Buitinck <larsmans@gmail.com>
-lastcodestanding <rohang71604@gmail.com>
-latot <felipematas@yahoo.com>
-Laura Domine <temigo@gmx.com>
-Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
-Lauren Glattly <laurenglattly@gmail.com>
-Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
-Laurence Warne <laurencewarne@gmail.com>
-Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
-Lee Johnston <lee.johnston.100@gmail.com>
-Lejla Metohajrova <l.metohajrova@gmail.com>
-Lennart Fricke <lennart@die-frickes.eu>
-Leo Battle <leowbattle@gmail.com>
-Leonardo Mangani <leomangani4@gmail.com>
-Leonid Blouvshtein <leonidbl91@gmail.com>
-Leonid Kovalev <leonidvkovalev@gmail.com>
-Lev Chelyadinov <leva181777@gmail.com>
-Liwei Cai <cai.lw123@gmail.com>
-Ljubiša Moćić <3rdslasher@gmail.com>
-Lokesh Sharma <lokeshhsharma@gmail.com>
-Longqi Wang <iqgnol@gmail.com>
-Lorenz Winkler <lorenz.winkler@tuwien.ac.at>
-Lorenzo Contento <lorenzo.contento@gmail.com>
-Louis Abraham <louis.abraham@yahoo.fr>
-Luca Bertoni <lucabertoni@gmail.com>
-Luca Weihs <astronomicalcuriosity@gmail.com>
-Lucas Gallindo <lgallindo@gmail.com>
-Lucas Jones <lucas@lucasjones.co.uk>
-Lucas Kletzander <lucas.kletzander@gmail.com>
-Lucas Verlaan <lucas.verlaan@gmail.com>
-Lucas Wiman <lucas.wiman@gmail.com>
-Lucy Mountain <lucymountain1@icloud.com>
-Luis Garcia <ppn.online@me.com>
-Luis Talavera <luisfertalavera15@gmail.com>
-Lukas Molleman <Lukas.Molleman@gmail.com>
-Lukas Zorich <lukas.zorich@gmail.com>
-Łukasz Pankowski <lukpank@o2.pl>
-Luke Peterson <hazelnusse@gmail.com>
-Luv Agarwal <agarwal.iiit@gmail.com>
-luzpaz <luzpaz@users.noreply.github.com>
-Lyle Poley <poleylyle@gmail.com>
-Maciej Baranski <getrox.sc@gmail.com>
-Maciej Skórski <maciej.skorski@gmail.com>
-Madeleine Ball <mpball@gmail.com>
-Malkhan Singh <malkhansinghrathaur@gmail.com>
-Mamidi Ratna Praneeth <praneethratna@gmail.com>
-Manav Sharma <maanav.vashist@gmail.com>
-Manish Gill <gill.manish90@gmail.com>
-Manish Shukla <manish.shukla393@gmail>
-Manoj Babu K. <manoj.babu2378@gmail.com>
-Manoj Kumar <manojkumarsivaraj334@gmail.com>
-mao8 <thisisma08@gmail.com>
-Marcel Stimberg <marcel.stimberg@ens.fr>
-Marcin Briański <marcin.brianski@student.uj.edu.pl>
-Marcin Kostrzewa <>
-Marco Antônio Habitzreuter <mahabitzreuter@gmail.com>
-Marco Mancini <marco.mancini@obspm.fr>
-Marcus Näslund <naslundx@gmail.com>
-Marduk Bolaños <mardukbp@mac.com>
-Marek Madejski <marekmadejski@yandex.com>
-Marek Šuppa <mr@shu.io>
-Maria Marginean <33810762+mmargin@users.noreply.github.com>
-Marijan Smetko <marijansmetko123@gmail.com>
-Mario Maio <mario.maio@aruba.it>
-Mario Pernici <mario.pernici@gmail.com>
-Mark Bell <mark00bell@googlemail.com>
-Mark Dewing <markdewing@gmail.com>
-Mark Dickinson <dickinsm@gmail.com>
-Mark Jeromin <mark.jeromin@sysfrog.net>
-Mark Shoulson <mark@kli.org>
-Mark van Gelder <m.j.vangelder@student.tudelft.nl>
-Mark van Gelder <mvgmvgmvg@live.com>
-Markus Mohrhard <markus.mohrhard@googlemail.com>
-Markus Müller <markus.mueller.1.g@googlemail.com>
-Martha Giannoudovardi <maapxa@gmail.com>
-Martin Manns <mmanns@gmx.net>
-Martin Povišer <martin.povik@gmail.com>
-Martin Roelfs <u0114255@kuleuven.be>
-Martin Thoma <info@martin-thoma.de>
-Martin Ueding <dev@martin-ueding.de>
-Mary Clark <mary.spriteling@gmail.com>
-Mateusz Paprocki <mattpap@gmail.com>
-Mathew Chong <mathewchong.dev@gmail.com>
-Mathias Louboutin <mathias.louboutin@gmail.com>
-Mathis Cros <mathis.cros@telecom-paris.fr>
-Matt Bogosian <matt@bogosian.net>
-Matt Curry <mattjcurry@gmail.com>
-Matt Habel <habelinc@gmail.com>
-Matt Ord <matthew.ord1@gmail.com>
-Matt Rajca <matt.rajca@me.com>
-Matt Wang <mattwang44@gmail.com>
-Matthew Brett <matthew.brett@gmail.com>
-Matthew Craven <clyring@users.noreply.github.com>
-Matthew Davis <davisml.md@gmail.com>
-Matthew Hoff <mhoff14@gmail.com>
-Matthew Parnell <matt@parnmatt.co.uk>
-Matthew Rocklin <mrocklin@cs.uchicago.edu>
-Matthew Tadd <matt.tadd@gmail.com>
-Matthew Thomas <mnmt@users.noreply.github.com>
-Matthew Treinish <mtreinish@kortar.org>
-Matthew Wardrop <matthew.wardrop@airbnb.com>
-Matthias Bussonnier <bussonniermatthias@gmail.com>
-Matthias Geier <Matthias.Geier@gmail.com>
-Matthias Köppe <mkoeppe@math.ucdavis.edu>
-Matthias Liesenfeld <116307294+maliesen@users.noreply.github.com>
-Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
-Matthias Toews <mat.toews@googlemail.com>
-Mauro Garavello <mauro.garavello@unimib.it>
-Max Hutchinson <maxhutch@gmail.com>
-Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
-Mayank Raj <mayank_1901cs35@iitp.ac.in>
-Mayank Singh <mayank.singh081997@gmail.com>
-Megan Ly <megan.ly@learnosity.com>
-Meghana Madhyastha <meghana.madhyastha@gmail.com>
-Merin Theres Jose <merintheresjose@gmail.com>
-Micah Fitch <micahscopes@gmail.com>
-Michael Boyle <michael.oliver.boyle@gmail.com>
-Michael Chu <michael02chu@gmail.com>
-Michael Gallaspy <gallaspy.michael@gmail.com>
-Michael Greminger <michael.greminger@gmail.com>
-Michael Mayorov <marchael@kb.csu.ru>
-Michael Mueller <michaeldmueller7@gmail.com>
-Michael S. Hansen <michael.hansen@nih.gov>
-Michael Sparapany <msparapa@purdue.edu>
-Michael Zingale <michael.zingale@stonybrook.edu>
-Michal Grňo <m93a.cz@gmail.com>
-Michał Radwański <enedil.isildur@gmail.com>
-Michele Ceccacci <michelececcacci1@gmail.com>
-Michele Zaffalon <michele.zaffalon@gmail.com>
-Micky <mickydroch@gmail.com>
-Miguel Marco <mmarco@unizar.es>
-Miguel Torres Costa <miguelptcosta1995@gmail.com>
-Miha Marolt <tloramus@gmail.com>
-Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
-Mihail Tarigradschi <m.tarigradschi@gmail.com>
-Mihir Wadwekar <m.mihirw@gmail.com>
-Mikel Rouco <mikel.mrm@gmail.com>
-Mikhail Remnev <maremnev@gmail.com>
-Milan Jolly <milan.cs16@iitp.ac.in>
-Min Ragan-Kelley <benjaminrk@gmail.com>
-Miro Hrončok <miro@hroncok.cz>
-mohajain <mohajain99@gmail.com>
-Mohak Malviya <mohakmalviya2000@gmail.com>
-Mohamed Rezk <mohrizq895@gmail.com>
-Mohammad Sadeq Dousti <msdousti@gmail.com>
-Mohammed Bilal <r.mohammedbilal@gmail.com>
-mohammedouahman <simofun85@gmail.com>
-mohit <39158356+mohitacecode@users.noreply.github.com>
-Mohit Balwani <mohitbalwani.ict17@gmail.com>
-Mohit Chandra <mohit.chandra@research.iiit.ac.in>
-Mohit Gupta <mohitgupta@gmail.com>
-Mohit Shah <mohitshah3111999@gmail.com>
-Morten Olsen Lysgaard <morten@lysgaard.no>
-Moses Paul R <iammosespaulr@gmail.com>
-MostafaGalal1 <mostafag649.mg@gmail.com>
-Mridul Seth <seth.mridul@gmail.com>
-Muhammad Maaz <mmaaz6004@gmail.com>
-Muhammed Abdul Quadir Owais <quadirowais200@gmail.com>
-Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
-Nabanita Dash <dashnabanita@gmail.com>
-naelsondouglas <naelson17@gmail.com>
-Naman Gera <namangera15@gmail.com>
-Natalia Nawara <fankalemura@gmail.com>
-Nathan Alison <nathan.f.alison@gmail.com>
-Nathan Goldbaum <ngoldbau@illinois.edu>
-Nathan Musoke <nathan.musoke@gmail.com>
-Nathan Taylor <pecan.pine@gmail.com>
-Nathan Woods <charlesnwoods@gmail.com>
-Naveen Sai <naveensaisreenivas@gmail.com>
-Neel Gorasiya <mgorasiya1974@gmail.com>
-Neil <mistersheik@gmail.com>
-Nguyen Truong Duy <truongduy134@yahoo.com>
-Nichita Utiu <nikita.utiu+github@gmail.com>
-Nicholas Bollweg <nick.bollweg@gmail.com>
-Nicholas J.S. Kinar <n.kinar@usask.ca>
-Nicholas Laustrup <124007393+nicklaustrup@users.noreply.github.com>
-Nick Curtis <nicholas.curtis@uconn.edu>
-Nick Harder <nharder@umich.edu>
-Nicko van Someren <nicko@nicko.org>
-Nico Santamaria <nicoasantamaria@gmail.com>
-Nico Schlömer <nico.schloemer@gmail.com>
-Nicolás Guarín-Zapata <nicoguarin@gmail.com>
-Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
-Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
-Nijso Beishuizen <nijso@koolmees.numerically-related.com>
-Nikhil Date <nikhil.s.date@gmail.com>
-Nikhil Gopalam <gopalamn@umich.edu>
-Nikhil Maan <nikhilmaan22@gmail.com>
-Nikhil Pappu <nkhlpappu@gmail.com>
-Nikhil Sarda <diff.operator@gmail.com>
-Nikita <nikita.student.cse19@itbhu.ac.in>
-Niklas Thörne <notrupertthorne@gmail.com>
-Nikolay Lazarov <qwerqwerqwer@abv.bg>
-Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk>
-Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
-Nilabja Bhattacharya <nilabja10201992@gmail.com>
-Nils Schulte <47043622+Schnilz@users.noreply.github.com>
-Nimish Telang <ntelang@gmail.com>
-Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
-Nirmal Sarswat <nirmalsarswat400@gmail.com>
-Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
-Nishant Nikhil <nishantiam@gmail.com>
-Nishith Shah <nishithshah.2211@gmail.com>
-Nitin Chaudhary <nitinmax1000@gmail.com>
-Nityananda Gohain <nityanandagohain@gmail.com>
-noam simcha finkelstein <noam.finkelstein@protonmail.com>
-NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
-Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
-numbermaniac <5206120+numbermaniac@users.noreply.github.com>
-oittaa <8972248+oittaa@users.noreply.github.com>
-Oldrich Klimanek <oldrich.klimanek@gmail.com>
-Oleksandr Gituliar <gituliar@gmail.com>
-Oliver Lee <oliverzlee@gmail.com>
-omahs <73983677+omahs@users.noreply.github.com>
-Omar Wagih <o.wagih.ow@gmail.com>
-Omkaar <79257339+Pysics@users.noreply.github.com>
+All people who contributed to SymPy by sending at least a patch or
+more (in the order of the date of their first contribution), except
+those who explicitly didn't want to be mentioned. People with a * next
+to their names are not found in the metadata of the git history. This
+file is generated automatically by running `./bin/authors_update.py`.
+
+There are a total of 1371 authors.
+
 Ondřej Čertík <ondrej@certik.cz>
-Or Dvory <gidesa@gmail.com>
-Orestis Vaggelis <orestisvaggelis@mail.com>
-Oriel Malihi <orielmalihi1@gmail.com>
-Oscar Benjamin <oscar.j.benjamin@gmail.com>
-Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk>
-Oscar Gustafsson <oscar.gustafsson@gmail.com>
-Óscar Nájera <najera.oscar@gmail.com>
-Ovsk Mendov <bbb23exposed@gmail.com>
-Øyvind Jensen <jensen.oyvind@gmail.com>
-P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
-Pablo Galindo Salgado <pablogsal@gmail.com>
-Pablo Puente <ppuedom@gmail.com>
-Pablo Zubieta <pabloferz@yahoo.com.mx>
-Pan Peng <pengpanster@gmail.com>
-Param Singh <paramsingh258@gmail.com>
-Paramjit Singh <paramjit1071@gmail.com>
-Parcly Taxel <reddeloostw@gmail.com>
-Parker Berry <parkereberry@gmail.com>
-Pascal Gitz <pascal.gitz@hotmail.ch>
-Pasquale Cocchini <pasquale.cocchini@gmail.com>
-Pastafarianist <mr.pastafarianist@gmail.com>
-Patrick Lacasse <patrick.m.lacasse@gmail.com>
-Patrick Poitras <acebulf@gmail.com>
-Paul Mandel <paulmandel@google.com>
-Paul Scofield <Cerebral.Paul@gmail.com>
-Paul Scott <paul.scott@nicta.com.au>
-Paul Spiering <paul@spiering.org>
-Paul Strickland <p.e.strickland@gmail.com>
-Pauli Virtanen <pav@iki.fi>
-Pavel Fedotov <fedotovp@gmail.com>
-Pavel Tkachenko <paveltkachenko@email.com>
-Pearu Peterson <pearu.peterson@gmail.com>
-Pedro H. S. Prestes <pedrohsprestes@gmail.com>
-Pedro Rosa <pedro_sxbr@usp.br>
-Peeyush Kushwaha <peeyush.p97@gmail.com>
-pekochun <hamburg_hamburger2000@yahoo.co.jp>
-Peleg Michaeli <freepeleg@gmail.com>
-Pengning Chao <8857165+PengningChao@users.noreply.github.com>
-Peter Brady <petertbrady@gmail.com>
-Peter Cock <p.j.a.cock@googlemail.com>
-Peter Enenkel <peter.enenkel+git@gmail.com>
-Peter Schmidt <peter@peterjs.com>
-Peter Stahlecker <peter.stahlecker@gmail.com>
-Peter Stangl <peter.stangl@ph.tum.de>
-Petr Kungurtsev <corwinat@gmail.com>
-Phil LeMaitre <phil_lemaitre@live.ca>
-Phil Ruffwind <rf@rufflewind.com>
-Philippe Bouafia <philippe.bouafia@ensea.fr>
-Phillip Berndt <phillip.berndt@googlemail.com>
-philwillnyc <56197213+philwillnyc@users.noreply.github.com>
-phipf <phipf@online.de>
-Pierre Haessig <pierre.haessig@crans.org>
-Pieter Eendebak <pieter.eendebak@gmail.com>
-Pieter Gijsbers <p.gijsbers@tue.nl>
-Piotr Korgul <p.korgul@gmail.com>
-platypus <platypus.computerchip@gmail.com>
-Pontus von Brömssen <pontus.vonbromssen+github@gmail.com>
-Poom Chiarawongse <eight1911@gmail.com>
-Prabhjot Singh <prabhjot.nith@gmail.com>
-Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
-Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
-Pradyumna <pradyu1993@gmail.com>
-Prafullkumar P. Tale <hector1618@gmail.com>
-Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
-Pramod Ch <pramodch14@gmail.com>
-Pranjal Tale <pranjaltale16@gmail.com>
-Prashant Tandon <tandonprashant101@gmail.com>
-Prashant Tyagi <prashanttyagi221295@gmail.com>
-Prasoon Shukla <prasoon92.iitr@gmail.com>
-Prateek Papriwal <papriwalprateek@gmail.com>
-Pratyksh Gupta <pratykshgupta9999@gmail.com>
-Praveen Perumal <ppraveen98841@gmail.com>
-Praveen Sahu <povinsahu@gmail.com>
-Prayag V <v.prayag2005@gmail.com>
-Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
-Prempal Singh <prempal.42@gmail.com>
-Prey Patel <patel.prey@iitgn.ac.in>
-Priit Laes <plaes@plaes.org>
-Prince Gupta <codemastercpp@gmail.com>
-Prionti Nasir <pdn3628@rit.edu>
-Priyank Patel <pspbot7@gmail.com>
-Priyansh Rathi <techiepriyansh@gmail.com>
-prshnt19 <prashant.rawat216@gmail.com>
-Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in>
-Puneeth Chaganti <punchagan@gmail.com>
-Qijia Liu <liumeo@pku.edu.cn>
-Qingsha Shi <googol.sqs@gmail.com>
-QuaBoo <kisonchristian@gmail.com>
-Quek Zi Yao <ziyaoqzy2001@gmail.com>
-Raffaele De Feo <alberthilbert@gmail.com>
-Raghav Jajodia <jajodia.raghav@gmail.com>
-Rahil Hastu <rahilhastu@gmail.com>
-Rahil Parikh <r.parikh@somaiya.edu>
-rahuldan <rahul02013@gmail.com>
-Raj <raj454raj@gmail.com>
-Raj Sapale <raj4sapale4@gmail.com>
-Rajat Aggarwal <rajataggarwal1975@gmail.com>
-Rajat Thakur <rajatthakur1997@gmail.com>
-Rajath Shashidhara <rajaths.rajaths@gmail.com>
-Rajeev Singh <rajs2010@gmail.com>
-Rajiv Ranjan Singh <rajivperfect007@gmail.com>
-Ralf Stephan <ralf@ark.in-berlin.de>
-Ralph Bean <rbean@redhat.com>
-Ramana Venkata <idlike2dream@gmail.com>
-ramvenkat98 <ramvenkat98@gmail.com>
-Randy Heydon <randy.heydon@clockworklab.net>
-Ranjith Kumar <ranjith.dakshana2015@gmail.com>
-Raoul Bourquin <raoulb@bluewin.ch>
-Raphael Lehner <raphael.lehner@gmail.com>
-Raphael Michel <webmaster@raphaelmichel.de>
-Rashmi Shehana <rashmi.watagedara@syscolabs.com>
-Rastislav Rabatin <rastislav.rabatin@gmail.com>
-rathmann <rathmann.os@gmail.com>
-rationa-kunal <kunalgk1999@gmail.com>
-Ravi charan <ravicharan.vsp@gmail.com>
-Ravindu-Hirimuthugoda <ravindu.18@cse.mrt.ac.lk>
-Ray Cathcart <github@cathcart.us>
-Raymond Wong <rayman_407@yahoo.com>
-rbl <rlee@grove.co>
-Rehas Sachdeva <aquannie@gmail.com>
-Remco de Boer <29308176+redeboer@users.noreply.github.com>
-Rémy Léone <rleone@online.net>
-Renato Coutinho <renato.coutinho@gmail.com>
-Renato Orsino <renato.orsino@gmail.com>
-Rhea Parekh <rheaparekh12@gmail.com>
-Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
-Riccardo Gori <goriccardo@gmail.com>
-Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
-Rich LaSota <rjlasota@gmail.com>
-Richard Osborn <richardosborn@mac.com>
-Richard Otis <richard.otis@outlook.com>
-Richard Rodenbusch <rrodenbusch@gmail.com>
-Richard Samuel <98638849+samuelard7@users.noreply.github.com>
-richierichrawr <richierichrawr@users.noreply.github.com>
-Rick Muller <rpmuller@gmail.com>
-Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
-Riley Britten <nrb1324@hotmail.com>
-Rimi <rimibis@umich.edu>
-rimibis <33387803+rimibis@users.noreply.github.com>
-Rishabh Daal <rishabhdaal@gmail.com>
-Rishabh Dixit <rishabhdixit11@gmail.com>
-Rishabh Kamboj <111004091+VectorNd@users.noreply.github.com>
-Rishabh Madan <rishabhmadan96@gmail.com>
-Rishat Iskhakov <iskhakov@frtk.ru>
-Rishav Chakraborty <annonymousxyz@outlook.com>
-Risiraj Dey <risirajdey@gmail.com>
-risubaba <risubhjain1010@gmail.com>
-Ritesh Kumar <ritesh99rakesh@gmail.com>
-ritikBhandari <ritikbhandari68@gmail.com>
-Ritu Raj Singh <RituRajSingh878@gmail.com>
-Riyan Dhiman <Riyandhiman14@gmail.com>
-Rizgar Mella <rizgar.mella@gmail.com>
-Rob Drynkin <rob.drynkin@gmail.com>
-Rob Zinkov <rob@zinkov.com>
-Robert <average.programmer@gmail.com>
-Robert Brijder <rbrijder@gmail.com>
-Robert Cimrman <cimrman3@ntc.zcu.cz>
-Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
-Robert Johansson <jrjohansson@gmail.com>
-Robert Kern <robert.kern@gmail.com>
-Robert Pollak <robert.pollak@posteo.net>
+Fabian Pedregosa <fabian@fseoane.net>
+Jurjen N.E. Bos <jnebos@gmail.com>
+Mateusz Paprocki <mattpap@gmail.com>
+*Marc-Etienne M.Leveille <protonyc@gmail.com>
+Brian Jorgensen <brian.jorgensen@gmail.com>
+Jason Gedge <inferno1386@gmail.com>
 Robert Schwarz <lethargo@googlemail.com>
-Roberto Colistete, Jr. <roberto.colistete@gmail.com>
-Roberto Díaz Pérez <r.r.1994a@gmail.com>
-Roberto Nobrega <rwnobrega@gmail.com>
-Robin Neatherway <robin.neatherway@gmail.com>
-Robin Richard <raisin@ecomail.fr>
-Rodrigo Luger <rodluger@gmail.com>
-Roelof Rietbroek <r.rietbroek@utwente.nl>
-Rohit Jain <rohitjain3241@gmail.com>
-Rohit Rango <rohit.rango@gmail.com>
-Rohit Sharma <31184621+rohitx007@users.noreply.github.com>
-Roland Dixon <rols121@gmail.com>
-Roland Puntaier <roland.puntaier@chello.at>
-Rom le Clair <jacen.guardian@gmail.com>
-Roman Inflianskas <infroma@gmail.com>
-Ronan Lamy <ronan.lamy@gmail.com>
-Rudr Tiwari <rudrtiwari@gmail.com>
-Rupesh Harode <rupeshharode@gmail.com>
-Rushabh Mehta <mehtarushabh2005@gmail.com>
-rushyam <rushyamsonu@gmail.com>
-Ruslan Pisarev <rpisarev@cloudlinux.com>
-Russell Fordyce <rfordyce@expressive-py.org>
-Ryan Krauss <ryanlists@gmail.com>
-S. Hanko <suzy.hanko@gmail.com>
-S.Y. Lee <sylee957@gmail.com>
-Saanidhya vats <saanidhyavats@gmail.com>
-Sachin Agarwal <sachinagarwal0499@gmail.com>
-Sachin Irukula <sachin.irukula@gmail.com>
-Sachin Joglekar <srjoglekar246@gmail.com>
-Sachin Singh <sachinishu02@gmail.com>
-Safiya03 <safiyanesar@gmail.com>
-Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
-Sagar231 <sagarfeb298@gmail.com>
-Sahil Shekhawat <sahilshekhawat01@gmail.com>
-Sai Nikhil <tsnlegend@gmail.com>
-Sai Udayagiri <saibabu.udayagiri@gmail.com>
-Saicharan <62512681+saicharan2804@users.noreply.github.com>
-Saicharan <saicharanhahaha@gmail.com>
-Saikat Das <saikatdchhe@gmail.com>
-Saket Kumar Singh <saketkumar1202@gmail.com>
-Saketh <alurusaisaketh@gmail.com>
-Sakirul Alam <binarysakir@gmail.com>
-Saksham Alok <sakshamalok13@gmail.com>
-SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg>
-Salil Vishnu Kapur <salilvishnukapur@gmail.com>
-Salmista-94 <alejandrogroso@hotmail.com>
-Saloni Jain <tosalonijain@gmail.com>
-Sam Brockie <sambrockie@icloud.com>
-Sam Lubelsky <sammy56lt@gmail.com>
-Sam Magura <samtheman132@gmail.com>
-Sam Ritchie <sam@mentat.org>
-Sam Sleight <samuel.sleight@gmail.com>
-Sam Tygier <sam.tygier@hep.manchester.ac.uk>
-Sambuddha Basu <sammygamer@live.com>
-Samesh <samesh.lakhotia@gmail.com>
-Samith Karunathilake <55777141+samithkavishke@users.noreply.github.com>
-Samnan Rahee <namanush.rsr.16@gmail.com>
-Sampad Kumar Saha <sampadsaha5@gmail.com>
-Samyak Jain <samyak.jain2016a@vitstudent.ac.in>
-Sandeep Murthy <smurthy@protonmail.ch>
-Sandeep Veethu <sandeep.veethu@gmail.com>
-Sanket Agarwal <sanket@sanketagarwal.com>
-Sanya Khurana <sanya@monica.in>
-Saptarshi Mandal <sapta.iitkgp@gmail.com>
+Pearu Peterson <pearu.peterson@gmail.com>
+Fredrik Johansson <fredrik.johansson@gmail.com>
+Chris Wu <chris.wu@gmail.com>
+*Ulrich Hecht <ulrich.hecht@gmail.com>
+Goutham Lakshminarayan <dl.goutham@gmail.com>
+David Lawrence <dmlawrence@gmail.com>
+Jaroslaw Tworek <dev.jrx@gmail.com>
+David Marek <h4wk.cz@gmail.com>
+Bernhard R. Link <brlink@debian.org>
+Andrej Tokarčík <androsis@gmail.com>
+Or Dvory <gidesa@gmail.com>
 Saroj Adhikari <adh.saroj@gmail.com>
-Sartaj Singh <singhsartaj94@gmail.com>
-Sarwar Chahal <chahal.sarwar98@gmail.com>
-Satya Prakash Dwibedi <akash581050@gmail.com>
-Saurabh Agarwal <shourabh.agarwal@gmail.com>
-Saurabh Jha <saurabh.jhaa@gmail.com>
-Sayan Goswami <Sayan98@users.noreply.github.com>
-Sayan Mitra <ee18b156@smail.iitm.ac.in>
-Sayandip Halder <sayandiph4@gmail.com>
-sbt4104 <sthorat661@gmail.com>
-scimax <max.kellermeier@hotmail.de>
-seadavis <45022599+seadavis@users.noreply.github.com>
-Sean Ge <seange727@gmail.com>
-Sean P. Cornelius <spcornelius@gmail.com>
-Sean Vig <sean.v.775@gmail.com>
-Seb Tiburzio <sebtiburzio@gmail.com>
-Sebastian East <sebastianeast@ymail.com>
-Sebastian Koslowski <koslowski@kit.edu>
+Pauli Virtanen <pav@iki.fi>
+Robert Kern <robert.kern@gmail.com>
+James Aspnes <aspnes@cs.yale.edu>
+Nimish Telang <ntelang@gmail.com>
+Abderrahim Kitouni <a.kitouni@gmail.com>
+Pan Peng <pengpanster@gmail.com>
+Friedrich Hagedorn <friedrich_h@gmx.de>
+Elrond der Elbenfuerst <elrond+sympy.org@samba-tng.org>
+Rizgar Mella <rizgar.mella@gmail.com>
+Felix Kaiser <felix.kaiser@fxkr.net>
+Roberto Nobrega <rwnobrega@gmail.com>
+David Roberts <dvdr18@gmail.com>
 Sebastian Krämer <basti.kr@gmail.com>
+Vinzent Steinberg <vinzent.steinberg@gmail.com>
+Riccardo Gori <goriccardo@gmail.com>
+Case Van Horsen <casevh@gmail.com>
+Stepan Roucka <stepan@roucka.eu>
+Ali Raza Syed <arsyed@gmail.com>
+Stefano Maggiolo <s.maggiolo@gmail.com>
+Robert Cimrman <cimrman3@ntc.zcu.cz>
+Bastian Weber <bastian.weber@gmx-topmail.de>
 Sebastian Krause <sebastian.krause@gmx.de>
 Sebastian Kreft <skreft@gmail.com>
-Segev Finer <segev208@gmail.com>
-Ser Kim <serk.kmh@gmail.com>
-Sergey B Kirpichev <skirpichev@gmail.com>
-Sergey Pestov <pestov-sa@yandex.ru>
-Sergiu Ivanov <unlimitedscolobb@gmail.com>
-Seshagiri Prabhu <seshagiriprabhu@gmail.com>
-Seth Ebner <murgrehk@gmail.com>
-Seth Poulsen <poulsenseth@yahoo.com>
-Seth Troisi <sethtroisi@google.com>
-sevaader <sevaader@gmail.com>
-sfoo <sfoohei@gmail.com>
-Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
-Shaoliang Jin <18322825326@163.com>
-sharma-kunal <kunalsharma6914@gmail.com>
-Shashank Agarwal <shashank.agarwal94@gmail.com>
-Shashank KS <shashankks0987@gmail.com>
-Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
-Shekhar Prasad Rajak <shekharrajak@live.com>
-Sherjil Ozair <sherjilozair@gmail.com>
-Shikhar Jaiswal <jaiswalshikhar87@gmail.com>
-Shikhar Makhija <shikharmakhija2@gmail.com>
-shiksha11 <shiksharawat01@gmail.com>
-Shipra Banga <bangashipra@gmail.com>
-Shishir Kushwaha <138311586+shishir-11@users.noreply.github.com>
-Shishir Kushwaha <kushwahashishir1112@gmail.com>
-Shital Mule <shitalmule04@gmail.com>
-Shivam Agarwal <knowthyself2503@gmail.com>
-Shivam Sagar <technoshivam12@gmail.com>
-Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
-Shivam Vats <shivamvats.iitkgp@gmail.com>
-Shivang Dubey <shivangdubey8@gmail.com>
-Shivani Kohli <shivanikohli.09@gmail.com>
-Shiyao Guo <mivikq@gmail.com>
-Shravas K Rao <shravas@gmail.com>
-Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
-shruti <shrutishrm512@gmail.com>
-Shruti Mangipudi <shruti2395@gmail.com>
-Shuai Zhou <shuaivzhou@berkeley.edu>
-Shubham Abhang <shubhamabhang77@gmail.com>
-Shubham Agrawal <shubham.ag6845@gmail.com>
-Shubham Kumar Jha <skjha832@gmail.com>
-Shubham Maheshwari <rmaheshwari05@gmail.com>
-Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
-Shubham Tibra <shubh.tibra@gmail.com>
-shubhayu09 <guptashubhayu601@gmail.com>
-Siddhanathan Shanmugam <siddhanathan@gmail.com>
-Siddhant Jain <getsiddhant@gmail.com>
-Siddhant Jain <siddhantashoknagar@gmail.com>
-Sidhant Nagpal <sidhantnagpal97@gmail.com>
-Sidharth Mundhra <sidharthmundhra16@gmail.com>
-Simon Sørensen <simonblsoerensen@gmail.com>
-SirJohnFranklin <sirjfu@googlemail.com>
-sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
-slacker404 <pchantza@gmail.com>
-Smit Gajjar <smitgajjar.gs@gmail.com>
-Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in>
-Sneha Goddu <s.goddu@wustl.edu>
-Soniya Nayak <soniyanayak51@gmail.com>
-Sophia Pustova <tripplezzed@gmail.com>
-Soumendra Ganguly <soumendraganguly@gmail.com>
-Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
-soumi7 <soumibardhan10@gmail.com>
-Soumya Dipta Biswas <sdb1323@gmail.com>
-Sourav Ghosh <souravghosh2197@gmail.com>
-Sourav Goyal <souravgl0@gmail.com>
-Sourav Singh <souravsingh@users.noreply.github.com>
-Srajan Garg <srajan.garg@gmail.com>
-Srinivas Vasudevan <srvasude@gmail.com>
-Srinivasa Arun Yeragudipati <ysarun1999@gmail.com>
-Stan Schymanski <stan.schymanski@env.ethz.ch>
-Stas Kelvich <stanconn@gmail.com>
-Stefan Behnle <84378403+behnle@users.noreply.github.com>
-Stefan Krastanov <krastanov.stefan@gmail.com>
-Stefan Petrea <stefan@garage-coding.com>
-Stefan van der Walt <stefan@sun.ac.za>
-Stefano Maggiolo <s.maggiolo@gmail.com>
-Stefen Yin <zqyin@ucdavis.edu>
-Stepan Roucka <stepan@roucka.eu>
-Stepan Simsa <simsa.st@gmail.com>
-Steph Papanik <spapanik21@gmail.com>
-Stephan Seitz <stephan.seitz@fau.de>
-Stephen Loo <shikil@yahoo.com>
-Steve Anton <anxuiz.nx@gmail.com>
-Steve Kieffer <sk@skieffer.info>
-Steven Burns <royalstream@hotmail.com>
-Steven Esquea <steven.esquea@irreverente.net>
-Steven Lee <stevenlee123@protonmail.com>
-Stewart Wadsworth <stewart.wadsworth@gmail.com>
-Subhash Saurabh <subhashsaurabh419@gmail.com>
-Sudarshan Kamath <sudarshan.kamath97@gmail.com>
-Sudeep Sidhu <sudeepmanilsidhu@gmail.com>
-Sudhanshu Mishra <mrsud94@gmail.com>
-Sujal Kumar <sujaljayantkumar06@gmail.com>
-Suman mondal <smondal.qwerty@gmail.com>
-Sumit Kumar <mr.sumitkrr@gmail.com>
-Sumith Kulal <sumith1896@gmail.com>
-Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
-Supreet Agrawal <supreet11agrawal@gmail.com>
-Suryam Arnav Kalra <suryamkalra35@gmail.com>
-Sushant Hiray <hiraysushant@gmail.com>
-Sushma Kumari <sushma.kumari@example.com>
-Sushma-stack-hub <sushmakumari@sushmas-MacBook-Air.local>
-Susumu Ishizuka <susumu.ishizuka@kii.com>
-Swapnil Agarwal <swapnilag29@gmail.com>
-symbolique <symbolique@users.noreply.github.com>
-Szymon Mieszczak <szymon.mieszczak@gmail.com>
-Takafumi Arakaki <aka.tkf@gmail.com>
-Takumasa Nakamura <n.takumasa@gmail.com>
-Tanay Agrawal <tanay_agrawal@hotmail.com>
-Tanu Hari Dixit <tokencolour@gmail.com>
-Tarang Patel <tarangrockr@gmail.com>
-Tarun Gaba <tarun.gaba7@gmail.com>
-Tasha Kim <jae_young_kim@brown.edu>
-Taylan Sahin <info@taylansahin.net>
-tborisova <ts.borisova3@gmail.com>
-Ted Dokos <tdokos@gmail.com>
+*Dan <coolg49964@gmail.com>
+Alan Bromborsky <abrombo@verizon.net>
+Boris Timokhin <qoqenator@gmail.com>
+Robert <average.programmer@gmail.com>
+Andy R. Terrel <aterrel@uchicago.edu>
+Hubert Tsang <intsangity@gmail.com>
+Konrad Meyer <konrad.meyer@gmail.com>
+Henrik Johansson <henjo2006@gmail.com>
+Priit Laes <plaes@plaes.org>
+Freddie Witherden <freddie@witherden.org>
+Brian E. Granger <ellisonbg@gmail.com>
+Andrew Straw <strawman@astraw.com>
+Kaifeng Zhu <cafeeee@gmail.com>
 Ted Horst <ted.horst@earthlink.net>
-Tejaswini Sanapathi <sastejaswini2002@gmail.com>
-Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
-Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
-Theodore Dias <theodore.dias@hotmail.co.uk>
-Theodore Han <theodorehan@hotmail.com>
-Thilina Rathnayake <thilinarmtb@gmail.com>
-Thomas A Caswell <tcaswell@gmail.com>
-Thomas Aarholt <thomasaarholt@gmail.com>
-Thomas Baruchel <baruchel@gmx.com>
-Thomas Dixon <thom@thomdixon.org>
-Thomas Hickman <Thomas.Hickman42@gmail.com>
-Thomas Hisch <t.hisch@gmail.com>
-Thomas Hunt <thomashunt13@gmail.com>
-Thomas Sidoti <TSidoti@gmail.com>
-Thomas Wiecki <thomas.wiecki@gmail.com>
-Tiffany Zhu <bubble.wubble.303@gmail.com>
-Tilo Reneau-Cardoso <tiloreneau@gmail.com>
-Tim Gates <tim.gates@iress.com>
-Tim Lahey <tim.lahey@gmail.com>
-Tim Swast <tswast@gmail.com>
-Timo Stienstra <timostienstra00@gmail.com>
-Timothy Cyrus <tcyrus@users.noreply.github.com>
-Timothy Reluga <treluga@math.psu.edu>
-Tirthankar Mazumder <63574588+wermos@users.noreply.github.com>
-TitanSnow <sweeto@live.cn>
-tnzl <you@example.com>
-Tobias Lenz <t_lenz94@web.de>
-Tom Bachmann <e_mc_h2@web.de>
-Tom Fryers <61272761+TomFryers@users.noreply.github.com>
-Tom Gijselinck <tomgijselinck@gmail.com>
-Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
-Tomáš Bambas <tomas.bambas@gmail.com>
+Andrew Docherty <andrewd@maths.usyd.edu.au>
+Akshay Srinivasan <akshaysrinivasan@gmail.com>
+Aaron Meurer <asmeurer@gmail.com>
+Barry Wardell <barry.wardell@gmail.com>
 Tomasz Buchert <thinred@gmail.com>
-Tomasz Pytel <tompytel@gmail.com>
-Tommaso Vaccari <05-gesto-follemente@icloud.com>
-Tommy Olofsson <tommy.olofsson.90@gmail.com>
-Tomo Lazovich <lazovich@gmail.com>
-tools4origins <tools4origins@gmail.com>
-Toon Verstraelen <Toon.Verstraelen@UGent.be>
-Travis Ens <ens.travis@gmail.com>
-Tristan Hume <tris.hume@gmail.com>
-TrungPQ <trungpqhe171493@gmail.com>
-Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
-tttc3 <T.Coxon2@lboro.ac.uk>
-Tuan Manh Lai <laituan245@gmail.com>
-Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
-Tyler Pirtle <teeler@gmail.com>
-Unknown <kunda@scribus.net>
-user202729 <25191436+user202729@users.noreply.github.com>
-Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
-Uwe L. Korn <uwelk@xhochy.com>
-V1krant <46847915+V1krant@users.noreply.github.com>
-Vaibhav Bhat <vaibhav.bhat2097@gmail.com>
-Vaishnav Damani <vaishnavdamani3496@gmail.com>
-Valeriia Gladkova <valeriia.gladkova@gmail.com>
-Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
-Varun Garg <varun.garg03@gmail.com>
-Varun Joshi <joshi.142@osu.edu>
-Vasileios Kalos <kalosbasileios@gmail.com>
-Vasiliy Dommes <vasdommes@gmail.com>
-Vasily Povalyaev <vapovalyaev@gmail.com>
-Vatsal Srivastava <alstav.trivas.sava@gmail.com>
-Vedant Rathore <vedantr1998@gmail.com>
-vedantc98 <vedantc98@gmail.com>
-Vedarth Sharma <vedarth.sharma@gmail.com>
-Velibor Zeli <velibor@mech.kth.se>
-Venkatesh Halli <venkatesh.fatality@gmail.com>
-Vera Lozhkina <veralozhkina@gmail.com>
-Versus Void <versusvoid@gmail.com>
-vezeli <37907135+vezeli@users.noreply.github.com>
-ViacheslavP <public.viacheslav@gmail.com>
-Victor Brebenar <v.brebenar@gmail.com>
-Victor Immanuel <chrollolucilfer1402@gmail.com>
-Victoria Koval <bictoriakoval16@gmail.com>
-Victory Omole <vtomole2@gmail.com>
-Vighnesh Shenoy <vighneshq@gmail.com>
-Vijairam Ganesh Moorthy <vijairamg@gmail.com>
-Vikrant Malik <vikrantmalik051@gmail.com>
 Vinay Kumar <gnulinooks@gmail.com>
-Vinay Singh <csvinay.d@gmail.com>
-Vincent Delecroix <vincent.delecroix@labri.fr>
-Vinit Ravishankar <vinit.ravishankar@gmail.com>
-Vinzent Steinberg <vinzent.steinberg@gmail.com>
-viocha <66580331+viocha@users.noreply.github.com>
-Viraj Vekaria <virajv5593@gmail.com>
-vishal <vishal.panjwani15@gmail.com>
-Vishal <vishalg2235@gmail.com>
-Vishesh Mangla <manglavishesh64@gmail.com>
-Vivek Soni <sonisheela1977@gmail.com>
-Vlad Seghete <vlad.seghete@gmail.com>
-Vladimir Lagunov <werehuman@gmail.com>
+Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
+Jochen Voss <voss@seehuhn.de>
+Luke Peterson <hazelnusse@gmail.com>
+Chris Smith <smichr@gmail.com>
+Thomas Sidoti <TSidoti@gmail.com>
+Florian Mickler <florian@mickler.org>
+Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
+Ben Goodrich <goodrich.ben@gmail.com>
+Toon Verstraelen <Toon.Verstraelen@UGent.be>
+Ronan Lamy <ronan.lamy@gmail.com>
+James Abbatiello <abbeyj@gmail.com>
+Ryan Krauss <ryanlists@gmail.com>
+Bill Flynn <wflynny@gmail.com>
+Kevin Goodsell <kevin-opensource@omegacrash.net>
+Jorn Baayen <jorn.baayen@gmail.com>
+Eh Tan <tan2tan2@gmail.com>
+Renato Coutinho <renato.coutinho@gmail.com>
+Oscar Benjamin <oscar.j.benjamin@gmail.com>
+Øyvind Jensen <jensen.oyvind@gmail.com>
+Julio Idichekop Filho <idichekop@yahoo.com.br>
+Łukasz Pankowski <lukpank@o2.pl>
+*Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
+Fernando Perez <Fernando.Perez@berkeley.edu>
+Raffaele De Feo <alberthilbert@gmail.com>
+Christian Muise <christian.muise@gmail.com>
+Matt Curry <mattjcurry@gmail.com>
+Kazuo Thow <kazuo.thow@gmail.com>
+Christian Schubert <chr.schubert@gmx.de>
+Jezreel Ng <jezreel@gmail.com>
+James Pearson <xiong.chiamiov@gmail.com>
+Matthew Brett <matthew.brett@gmail.com>
+Addison Cugini <ajcugini@gmail.com>
+Nicholas J.S. Kinar <n.kinar@usask.ca>
+Harold Erbin <harold.erbin@gmail.com>
+Thomas Dixon <thom@thomdixon.org>
+Cristóvão Sousa <crisjss@gmail.com>
+Andre de Fortier Smit <freevryheid@gmail.com>
+Mark Dewing <markdewing@gmail.com>
+Alexey U. Gudchenko <proga@goodok.ru>
+Gary Kerr <gary.kerr@blueyonder.co.uk>
+Sherjil Ozair <sherjilozair@gmail.com>
+Oleksandr Gituliar <gituliar@gmail.com>
+Sean Vig <sean.v.775@gmail.com>
+Prafullkumar P. Tale <hector1618@gmail.com>
 Vladimir Perić <vlada.peric@gmail.com>
-Vladimir Poluhsin <vovapolu@gmail.com>
-Vladimir Sereda <voffch@gmail.com>
-Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com>
-w495 <w495@yandex-team.ru>
-Waldir Pimenta <waldyrious@gmail.com>
-Wang Ran (汪然) <wangr@smail.nju.edu.cn>
-Warren Jacinto <warrenjacinto@gmail.com>
-Wes Galbraith <galbwe92@gmail.com>
-Wes Turner <50891+westurner@users.noreply.github.com>
-whitesource-bolt-for-github[bot] <whitesource-bolt-for-github[bot]@users.noreply.github.com>
-Willem Melching <willem.melching@gmail.com>
-Wolfgang Stöcher <wolfgang@stoecher.com>
-wookie184 <wookie1840@gmail.com>
-wuyudi <wuyudi119@163.com>
-Wyatt Peak <wyattpeak@gmail.com>
-Xiang Wu <hsiangwu@fb.com>
-Xiao <muzumayao@126.com>
-xndcn <xndchn@gmail.com>
-Yang Yang <wdscxsj@gmail.com>
-Yaser AlOsh <yaseralosh@outlook.com>
-Yash Reddy <write2yashreddy@gmail.com>
-Yathartha Joshi <yathartha32@gmail.com>
-Yatna Verma <yatnavermaa@gmail.com>
-Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
-Yeshwanth N <yeshsurya@gmail.com>
-Yicong Guo <guoyicong100@gmail.com>
-YiDing Jiang <yidinggjiangg@gmail.com>
-ylemkimon <ylemkimon@naver.com>
-Yogesh Mishra <ymishra013@gmail.com>
-Yu Kobayashi <yukoba@accelart.jp>
-Yukai Chou <muzimuzhi@gmail.com>
-Yuki Matsuda <yuki.matsuda.w@gmail.com>
+Tom Bachmann <e_mc_h2@web.de>
 Yuri Karadzhov <yuri.karadzhov@gmail.com>
+Vladimir Lagunov <werehuman@gmail.com>
+Matthew Rocklin <mrocklin@cs.uchicago.edu>
+Saptarshi Mandal <sapta.iitkgp@gmail.com>
+Gilbert Gede <gilbertgede@gmail.com>
+Anatolii Koval <weralwolf@gmail.com>
+Tomo Lazovich <lazovich@gmail.com>
+Pavel Fedotov <fedotovp@gmail.com>
+Jack McCaffery <jpmccaffery@gmail.com>
+Jeremias Yehdegho <j.yehdegho@gmail.com>
+Kibeom Kim <kk1674@nyu.edu>
+Gregory Ksionda <ksiondag846@gmail.com>
+Tomáš Bambas <tomas.bambas@gmail.com>
+Raymond Wong <rayman_407@yahoo.com>
+Luca Weihs <astronomicalcuriosity@gmail.com>
+Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
+Thomas Wiecki <thomas.wiecki@gmail.com>
+Óscar Nájera <najera.oscar@gmail.com>
+Mario Pernici <mario.pernici@gmail.com>
+Benjamin McDonald <mcdonald.ben@gmail.com>
+Sam Magura <samtheman132@gmail.com>
+Stefan Krastanov <krastanov.stefan@gmail.com>
+Bradley Froehle <brad.froehle@gmail.com>
+Min Ragan-Kelley <benjaminrk@gmail.com>
+Emma Hogan <ehogan@gemini.edu>
+Nikhil Sarda <diff.operator@gmail.com>
+Julien Rioux <julien.rioux@gmail.com>
+Roberto Colistete, Jr. <roberto.colistete@gmail.com>
+Raoul Bourquin <raoulb@bluewin.ch>
+Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
+Srinivas Vasudevan <srvasude@gmail.com>
+Jason Moore <moorepants@gmail.com>
+Miha Marolt <tloramus@gmail.com>
+Tim Lahey <tim.lahey@gmail.com>
+Luis Garcia <ppn.online@me.com>
+Matt Rajca <matt.rajca@me.com>
+David Li <l33tnerd.li@gmail.com>
+Alexandr Gudulin <alexandr.gudulin@gmail.com>
+Bilal Akhtar <bilalakhtar@ubuntu.com>
+Grzegorz Świrski <sognat@gmail.com>
+Matt Habel <habelinc@gmail.com>
+David Ju <Sgtmook314@gmail.com>
+Nichita Utiu <nikita.utiu+github@gmail.com>
+Nikolay Lazarov <qwerqwerqwer@abv.bg>
+Steve Anton <anxuiz.nx@gmail.com>
+Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
+Ljubiša Moćić <3rdslasher@gmail.com>
+Piotr Korgul <p.korgul@gmail.com>
+Jim Zhang <Hyriodula@gmail.com>
+Sam Sleight <samuel.sleight@gmail.com>
+tborisova <ts.borisova3@gmail.com>
+Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
+Stepan Simsa <simsa.st@gmail.com>
+Tobias Lenz <t_lenz94@web.de>
+Siddhanathan Shanmugam <siddhanathan@gmail.com>
+Tiffany Zhu <bubble.wubble.303@gmail.com>
+Tristan Hume <tris.hume@gmail.com>
+Alexey Subach <alexey.subach@gmail.com>
+Joan Creus <joan.creus.c@gmail.com>
+Geoffry Song <goffrie@gmail.com>
+Puneeth Chaganti <punchagan@gmail.com>
+Marcin Kostrzewa <>
+Natalia Nawara <fankalemura@gmail.com>
+vishal <vishal.panjwani15@gmail.com>
+Shruti Mangipudi <shruti2395@gmail.com>
+Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
+Swapnil Agarwal <swapnilag29@gmail.com>
+Dhia Kennouche <kendhia@gmail.com>
+jerryma1121 <jerryma1121@gmail.com>
+Joachim Durchholz <jo@durchholz.org>
+Martin Povišer <martin.povik@gmail.com>
+Siddhant Jain <getsiddhant@gmail.com>
+Kevin Hunter <hunteke@earlham.edu>
+Michael Mayorov <marchael@kb.csu.ru>
+Nathan Alison <nathan.f.alison@gmail.com>
+Christian Bühler <christian@cbuehler.de>
+Carsten Knoll <CarstenKnoll@gmx.de>
+Bharath M R <catchmrbharath@gmail.com>
+Matthias Toews <mat.toews@googlemail.com>
+Sergiu Ivanov <unlimitedscolobb@gmail.com>
+Jorge E. Cardona <jorgeecardona@gmail.com>
+Sanket Agarwal <sanket@sanketagarwal.com>
+Manoj Babu K. <manoj.babu2378@gmail.com>
+Sai Nikhil <tsnlegend@gmail.com>
+Aleksandar Makelov <amakelov@college.harvard.edu>
+Sachin Irukula <sachin.irukula@gmail.com>
+Raphael Michel <webmaster@raphaelmichel.de>
+Ashwini Oruganti <ashwini.oruganti@gmail.com>
+Andreas Klöckner <inform@tiker.net>
+Prateek Papriwal <papriwalprateek@gmail.com>
+Arpit Goyal <agmps18@gmail.com>
+Angadh Nanjangud <angadh.n@gmail.com>
+Comer Duncan <comer.duncan@gmail.com>
+Jens H. Nielsen <jenshnielsen@gmail.com>
+Joseph Dougherty <Github@JWDougherty.com>
+Elliot Marshall <Marshall2389@gmail.com>
+Guru Devanla <grdvnl@gmail.com>
+George Waksman <waksman@gwax.com>
+Alexandr Popov <alexandr.s.popov@gmail.com>
+Tarun Gaba <tarun.gaba7@gmail.com>
+Takafumi Arakaki <aka.tkf@gmail.com>
+Saurabh Jha <saurabh.jhaa@gmail.com>
+Rom le Clair <jacen.guardian@gmail.com>
+Angus Griffith <16sn6uv@gmail.com>
+Timothy Reluga <treluga@math.psu.edu>
+Brian Stephanik <xoedusk@gmail.com>
+Alexander Eberspächer <alex.eberspaecher@gmail.com>
+Sachin Joglekar <srjoglekar246@gmail.com>
+Tyler Pirtle <teeler@gmail.com>
+Vasily Povalyaev <vapovalyaev@gmail.com>
+Colleen Lee <colleenclee@gmail.com>
+Matthew Hoff <mhoff14@gmail.com>
+Niklas Thörne <notrupertthorne@gmail.com>
+Huijun Mai <m.maihuijun@gmail.com>
+Marek Šuppa <mr@shu.io>
+Ramana Venkata <idlike2dream@gmail.com>
+Prasoon Shukla <prasoon92.iitr@gmail.com>
+Stefen Yin <zqyin@ucdavis.edu>
+Thomas Hisch <t.hisch@gmail.com>
+Madeleine Ball <mpball@gmail.com>
+Mary Clark <mary.spriteling@gmail.com>
+Rishabh Dixit <rishabhdixit11@gmail.com>
+Manoj Kumar <manojkumarsivaraj334@gmail.com>
+Akshit Agarwal <akshit.jiit@gmail.com>
+CJ Carey <perimosocordiae@gmail.com>
+Patrick Lacasse <patrick.m.lacasse@gmail.com>
+Ananya H <ananyaha93@gmail.com>
+Tarang Patel <tarangrockr@gmail.com>
+Christopher Dembia <cld72@cornell.edu>
+Benjamin Fishbein <fishbeinb@gmail.com>
+Sean Ge <seange727@gmail.com>
+Amit Jamadagni <bitsjamadagni@gmail.com>
+Ankit Agrawal <aaaagrawal@iitb.ac.in>
+Björn Dahlgren <bjodah@gmail.com>
+Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
+Demian Wassermann <demian@bwh.harvard.edu>
+Khagesh Patel <khageshpatel93@gmail.com>
+Stephen Loo <shikil@yahoo.com>
+hm <hacman0@gmail.com>
+Patrick Poitras <acebulf@gmail.com>
+Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
+Varun Joshi <joshi.142@osu.edu>
+Chetna Gupta <cheta.gup@gmail.com>
+Thilina Rathnayake <thilinarmtb@gmail.com>
+Max Hutchinson <maxhutch@gmail.com>
+Shravas K Rao <shravas@gmail.com>
+Matthew Tadd <matt.tadd@gmail.com>
+Alexander Hirzel <alex@hirzel.us>
+Randy Heydon <randy.heydon@clockworklab.net>
+Oliver Lee <oliverzlee@gmail.com>
+Seshagiri Prabhu <seshagiriprabhu@gmail.com>
+Pradyumna <pradyu1993@gmail.com>
+Erik Welch <erik.n.welch@gmail.com>
+Eric Nelson <eric.the.red.XLII@gmail.com>
+Roland Puntaier <roland.puntaier@chello.at>
+Chris Conley <chrisconley15@gmail.com>
+Tim Swast <tswast@gmail.com>
+Dmitry Batkovich <batya239@gmail.com>
+Francesco Bonazzi <franz.bonazzi@gmail.com>
 Yuriy Demidov <iurii.demidov@gmail.com>
-Yury G. Kudryashov <urkud.urkud@gmail.com>
-Yves Tumushimire <yvestumushimire@gmail.com>
-Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
-Zach Carmichael <20629897+craymichael@users.noreply.github.com>
-Zach Raines <raineszm@gmail.com>
-Zachariah Etienne <zachetie@gmail.com>
+Rick Muller <rpmuller@gmail.com>
+Manish Gill <gill.manish90@gmail.com>
+Markus Müller <markus.mueller.1.g@googlemail.com>
+Amit Saha <amitsaha.in@gmail.com>
+Jeremy <twobitlogic@gmail.com>
+QuaBoo <kisonchristian@gmail.com>
+Stefan van der Walt <stefan@sun.ac.za>
+David Joyner <wdjoyner@gmail.com>
+Lars Buitinck <larsmans@gmail.com>
+Alkiviadis G. Akritas <akritas@uth.gr>
+Vinit Ravishankar <vinit.ravishankar@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com>
+Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
+Pablo Puente <ppuedom@gmail.com>
+James Fiedler <jrfiedler@gmail.com>
+Harsh Gupta <mail@hargup.in>
+Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
+Paul Strickland <p.e.strickland@gmail.com>
+James Goppert <james.goppert@gmail.com>
+rathmann <rathmann.os@gmail.com>
+Avichal Dayal <avichal.dayal@gmail.com>
+Paul Scott <paul.scott@nicta.com.au>
+Shipra Banga <bangashipra@gmail.com>
+Pramod Ch <pramodch14@gmail.com>
+Akshay <akshaynukala95@gmail.com>
+Buck Shlegeris <buck2@bruceh15.anu.edu.au>
+Jonathan Miller <jdmiller93@gmail.com>
+Edward Schembor <eschemb1@jhu.edu>
+Rajath Shashidhara <rajaths.rajaths@gmail.com>
 Zamrath Nizam <zamiguy_ni@yahoo.com>
-Zaz Brown <zazbrown@zazbrown.com>
-Zedmat <104870914+harshkasat@users.noreply.github.com>
+Aditya Shah <adityashah30@gmail.com>
+Rajat Aggarwal <rajataggarwal1975@gmail.com>
+Sambuddha Basu <sammygamer@live.com>
 Zeel Shah <kshah215@gmail.com>
-Zexuan Zhou (Bruce) <zzx498636727@gmail.com>
-Zhenxu Zhu <xzdlj@outlook.com>
-Zhi-Qiang Zhou <zzq_890709@hotmail.com>
-Zhongshi <zj495@nyu.edu>
-Zhuoyuan Li <zy.li@stu.pku.edu.cn>
-Zlatan Vasović <zlatanvasovic@gmail.com>
-znxftw <vishnu2101@gmail.com>
-Zoufiné Lauer-Baré <raszoufine@gmail.com>
-Zouhair <zouhair.mahboubi@gmail.com>
+Abhinav Chanda <abhinavchanda01@gmail.com>
+Jim Crist <crist042@umn.edu>
+Sudhanshu Mishra <mrsud94@gmail.com>
+Anurag Sharma <anurags92@gmail.com>
+Soumya Dipta Biswas <sdb1323@gmail.com>
+Sushant Hiray <hiraysushant@gmail.com>
+Ben Lucato <ben.lucato@gmail.com>
+Kunal Arora <kunalarora.135@gmail.com>
+Henry Gebhardt <hsggebhardt@gmail.com>
+Dammina Sahabandu <dmsahabandu@gmail.com>
+Manish Shukla <manish.shukla393@gmail>
+Ralph Bean <rbean@redhat.com>
+richierichrawr <richierichrawr@users.noreply.github.com>
+John Connor <john.theman.connor@gmail.com>
+Juan Luis Cano Rodríguez <juanlu001@gmail.com>
+Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Kundan Kumar <kundankumar18581@gmail.com>
+Stas Kelvich <stanconn@gmail.com>
+sevaader <sevaader@gmail.com>
+Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
+Venkatesh Halli <venkatesh.fatality@gmail.com>
+Lennart Fricke <lennart@die-frickes.eu>
+Vlad Seghete <vlad.seghete@gmail.com>
+Shashank Agarwal <shashank.agarwal94@gmail.com>
+carstimon <carstimon@gmail.com>
+Pierre Haessig <pierre.haessig@crans.org>
+Maciej Baranski <getrox.sc@gmail.com>
+Benjamin Gudehus <hastebrot@gmail.com>
+Faisal Anees <faisal.iiit@gmail.com>
+Mark Shoulson <mark@kli.org>
+Robert Johansson <jrjohansson@gmail.com>
+Kalevi Suominen <jksuom@gmail.com>
+Kaushik Varanasi <kaushik.varanasi1@gmail.com>
+Fawaz Alazemi <Mba7eth@gmail.com>
+Ambar Mehrotra <mehrotraambar@gmail.com>
+David P. Sanders <dpsanders@gmail.com>
+Peter Brady <petertbrady@gmail.com>
+John V. Siratt <jvsiratt@gmail.com>
+Sarwar Chahal <chahal.sarwar98@gmail.com>
+Nathan Woods <charlesnwoods@gmail.com>
+Colin B. Macdonald <cbm@m.fsf.org>
+Marcus Näslund <naslundx@gmail.com>
+Clemens Novak <clemens@familie-novak.net>
+Mridul Seth <seth.mridul@gmail.com>
+Craig A. Stoudt <craig.stoudt@gmail.com>
+Raj <raj454raj@gmail.com>
+Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
+immerrr <immerrr@gmail.com>
+Chai Wah Wu <cwwuieee@gmail.com>
+Leonid Blouvshtein <leonidbl91@gmail.com>
+Peleg Michaeli <freepeleg@gmail.com>
+ck Lux <lux.r.ck@gmail.com>
 zsc347 <zsc347@gmail.com>
+Hamish Dickson <hamish.dickson@gmail.com>
+Michael Gallaspy <gallaspy.michael@gmail.com>
+Roman Inflianskas <infroma@gmail.com>
+Duane Nykamp <nykamp@umn.edu>
+Ted Dokos <tdokos@gmail.com>
+Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
+Victor Brebenar <v.brebenar@gmail.com>
+Akshat Jain <akshat.jain@students.iiit.ac.in>
+Shivam Vats <shivamvats.iitkgp@gmail.com>
+Longqi Wang <iqgnol@gmail.com>
+Juan Felipe Osorio <jfosorio@gmail.com>
+Ray Cathcart <github@cathcart.us>
+Lukas Zorich <lukas.zorich@gmail.com>
+Eric Miller <emiller42@gmail.com>
+Cody Herbst <cyherbst@gmail.com>
+Nishith Shah <nishithshah.2211@gmail.com>
+Amit Kumar <dtu.amit@gmail.com>
+Yury G. Kudryashov <urkud.urkud@gmail.com>
+Guillaume Gay <contact@damcb.com>
+Mihir Wadwekar <m.mihirw@gmail.com>
+Tuan Manh Lai <laituan245@gmail.com>
+Asish Panda <asishrocks95@gmail.com>
+Darshan Chaudhary <deathbullet@gmail.com>
+Alec Kalinin <alec.kalinin@gmail.com>
+Ralf Stephan <ralf@ark.in-berlin.de>
+Aaditya Nair <aadityanair6494@gmail.com>
+Jayesh Lahori <jlahori92@gmail.com>
+Harshil Goel <harshil158@gmail.com>
+Luv Agarwal <agarwal.iiit@gmail.com>
+Jason Ly <jason.ly@gmail.com>
+Lokesh Sharma <lokeshhsharma@gmail.com>
+Sartaj Singh <singhsartaj94@gmail.com>
+Chris Swierczewski <cswiercz@gmail.com>
+Konstantin Togoi <konstantin.togoi@gmail.com>
+Param Singh <paramsingh258@gmail.com>
+Sumith Kulal <sumith1896@gmail.com>
+Juha Remes <jremes@outlook.com>
+Philippe Bouafia <philippe.bouafia@ensea.fr>
+Peter Schmidt <peter@peterjs.com>
+Jiaxing Liang <liangjiaxing57@gmail.com>
+Lucas Jones <lucas@lucasjones.co.uk>
+Gregory Ashton <gash789@gmail.com>
+Jennifer White <jcrw122@googlemail.com>
+Renato Orsino <renato.orsino@gmail.com>
+Alistair Lynn <arplynn@gmail.com>
+Govind Sahai <gsiitbhu@gmail.com>
+Adam Bloomston <adam@glitterfram.es>
+Kyle McDaniel <mcdanie5@illinois.edu>
+Nguyen Truong Duy <truongduy134@yahoo.com>
+Alex Lindsay <adlinds3@ncsu.edu>
+Mathew Chong <mathewchong.dev@gmail.com>
+Jason Siefken <siefkenj@gmail.com>
+Gaurav Dhingra <gauravdhingra.gxyd@gmail.com>
+Gao, Xiang <qasdfgtyuiop@gmail.com>
+Kevin Ventullo <kevin.ventullo@gmail.com>
+mao8 <thisisma08@gmail.com>
+Isuru Fernando <isuruf@gmail.com>
+Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
+Richard Otis <richard.otis@outlook.com>
+Rich LaSota <rjlasota@gmail.com>
+dustyrockpyle <dustyrockpyle@gmail.com>
+Anton Akhmerov <anton.akhmerov@gmail.com>
+Michael Zingale <michael.zingale@stonybrook.edu>
+Chak-Pong Chung <chakpongchung@gmail.com>
+David T <derDavidT@users.noreply.github.com>
+Phil Ruffwind <rf@rufflewind.com>
+Sebastian Koslowski <koslowski@kit.edu>
+Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+Dustin Gadal <Dustin.Gadal@gmail.com>
+João Moura <operte@gmail.com>
+Yu Kobayashi <yukoba@accelart.jp>
+Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
+Timothy Cyrus <tcyrus@users.noreply.github.com>
+Devyani Kota <devyanikota@gmail.com>
+Keval Shah <kevalshah_96@yahoo.co.in>
+Dzhelil Rufat <drufat@caltech.edu>
+Pastafarianist <mr.pastafarianist@gmail.com>
+Sourav Singh <souravsingh@users.noreply.github.com>
+Jacob Garber <jgarber1@ualberta.ca>
+Vinay Singh <csvinay.d@gmail.com>
+GolimarOurHero <metalera94@hotmail.com>
+Prashant Tyagi <prashanttyagi221295@gmail.com>
+Matthew Davis <davisml.md@gmail.com>
+Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
+Alexander Bentkamp <bentkamp@gmail.com>
+Jack Kemp <metaknightdrake-git@yahoo.co.uk>
+Kshitij Saraogi <KshitijSaraogi@gmail.com>
+Thomas Baruchel <baruchel@gmx.com>
+Nicolás Guarín-Zapata <nicoguarin@gmail.com>
+Jens Jørgen Mortensen <jj@smoerhul.dk>
+Sampad Kumar Saha <sampadsaha5@gmail.com>
+Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
+Laura Domine <temigo@gmx.com>
+Justin Blythe <jblythe29@gmail.com>
+Meghana Madhyastha <meghana.madhyastha@gmail.com>
+Tanu Hari Dixit <tokencolour@gmail.com>
+Shekhar Prasad Rajak <shekharrajak@live.com>
+Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
+Arafat Dad Khan <arafat.da.khan@gmail.com>
+Boris Atamanovskiy <shaomoron@gmail.com>
+Sam Tygier <sam.tygier@hep.manchester.ac.uk>
+Jai Luthra <me@jailuthra.in>
+Guo Xingjian <Seeker1995@gmail.com>
+Sandeep Veethu <sandeep.veethu@gmail.com>
+Archit Verma <architv07@gmail.com>
+Shubham Tibra <shubh.tibra@gmail.com>
+Ashutosh Saboo <ashutosh.saboo96@gmail.com>
+Michael S. Hansen <michael.hansen@nih.gov>
+Anish Shah <shah.anish07@gmail.com>
+Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
+Bhautik Mavani <mavanibhautik@gmail.com>
+Michał Radwański <enedil.isildur@gmail.com>
+Jerry Li <jerry@jerryli.ca>
+Pablo Zubieta <pabloferz@yahoo.com.mx>
+Shivam Agarwal <knowthyself2503@gmail.com>
+Chaitanya Sai Alaparthi <achaitanyasai@gmail.com>
+Arihant Parsoya <parsoyaarihant@gmail.com>
+Ruslan Pisarev <rpisarev@cloudlinux.com>
+Akash Trehan <akash.trehan123@gmail.com>
+Nishant Nikhil <nishantiam@gmail.com>
+Vladimir Poluhsin <vovapolu@gmail.com>
+Akshay Nagar <awesomeay13@yahoo.com>
+James Brandon Milam <jmilam343@gmail.com>
+Abhinav Agarwal <abhinavagarwal1996@gmail.com>
+Rishabh Daal <rishabhdaal@gmail.com>
+Sanya Khurana <sanya@monica.in>
+Aman Deep <amandeep1024@gmail.com>
+Aravind Reddy <aravindreddy255@gmail.com>
+Abhishek Verma <iamvermaabhishek@gmail.com>
+Matthew Parnell <matt@parnmatt.co.uk>
+Thomas Hickman <Thomas.Hickman42@gmail.com>
+Akshay Siramdas <akshaysiramdas@gmail.com>
+YiDing Jiang <yidinggjiangg@gmail.com>
+Jatin Yadav <jatinyadav25@gmail.com>
+Matthew Thomas <mnmt@users.noreply.github.com>
+Rehas Sachdeva <aquannie@gmail.com>
+Michael Mueller <michaeldmueller7@gmail.com>
+Srajan Garg <srajan.garg@gmail.com>
+Prabhjot Singh <prabhjot.nith@gmail.com>
+Haruki Moriguchi <harukimoriguchi@gmail.com>
+Tom Gijselinck <tomgijselinck@gmail.com>
+Nitin Chaudhary <nitinmax1000@gmail.com>
+Alex Argunov <sajkoooo@gmail.com>
+Nathan Musoke <nathan.musoke@gmail.com>
+Abhishek Garg <abhishekgarg119@gmail.com>
+Dana Jacobsen <dana@acm.org>
+Vasiliy Dommes <vasdommes@gmail.com>
+Phillip Berndt <phillip.berndt@googlemail.com>
+Haimo Zhang <zh.hammer.dev@gmail.com>
+Anthony Scopatz <scopatz@gmail.com>
+bluebrook <perl4logic@gmail.com>
+Leonid Kovalev <leonidvkovalev@gmail.com>
+Josh Burkart <jburkart@gmail.com>
+Dimitra Konomi <t8130064@dias.aueb.gr>
+Christina Zografou <t8130048@dias.aueb.gr>
+Fiach Antaw <fiach.antaw+github@gmail.com>
+Langston Barrett <langston.barrett@gmail.com>
+Krit Karan <kritkaran.b13@iiits.in>
+G. D. McBain <gdmcbain@protonmail.com>
+Prempal Singh <prempal.42@gmail.com>
+Gabriel Orisaka <orisaka@gmail.com>
+Matthias Bussonnier <bussonniermatthias@gmail.com>
+rahuldan <rahul02013@gmail.com>
+Colin Marquardt <github@marquardt-home.de>
+Andrew Taber <andrew.e.taber@gmail.com>
+Yash Reddy <write2yashreddy@gmail.com>
+Peter Stangl <peter.stangl@ph.tum.de>
+elvis-sik <e.sikora@grad.ufsc.br>
+Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
+Jainul Vaghasia <jainulvaghasia@gmail.com>
+Dennis Meckel <meckel@datenschuppen.de>
+Harshil Meena <harshil.7535@gmail.com>
+Micky <mickydroch@gmail.com>
+Nick Curtis <nicholas.curtis@uconn.edu>
+Michele Zaffalon <michele.zaffalon@gmail.com>
+Martha Giannoudovardi <maapxa@gmail.com>
+Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
+Steph Papanik <spapanik21@gmail.com>
+Mohammad Sadeq Dousti <msdousti@gmail.com>
+Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
+Abdullah Javed Nesar <abduljaved1994@gmail.com>
+Lakshya Agrawal <zeeshan.lakshya@gmail.com>
+shruti <shrutishrm512@gmail.com>
+Rohit Rango <rohit.rango@gmail.com>
+Hong Xu <hong@topbug.net>
+Ivan Petuhov <ivan@ostrovok.ru>
+Alsheh <alsheh@rpi.edu>
+Marcel Stimberg <marcel.stimberg@ens.fr>
+Alexey Pakhocmhik <cool.Bakov@yandex.ru>
+Tommy Olofsson <tommy.olofsson.90@gmail.com>
 Zulfikar <zulfikar97@gmail.com>
-zzc <1378113190@qq.com>
+Blair Azzopardi <blairuk@gmail.com>
+Danny Hermes <daniel.j.hermes@gmail.com>
+Sergey Pestov <pestov-sa@yandex.ru>
+Mohit Chandra <mohit.chandra@research.iiit.ac.in>
+Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in>
+Marcin Briański <marcin.brianski@student.uj.edu.pl>
+andreo <andrey.torba@gmail.com>
+Flamy Owl <flamyowl@protonmail.ch>
+Yicong Guo <guoyicong100@gmail.com>
+Varun Garg <varun.garg03@gmail.com>
+Rishabh Madan <rishabhmadan96@gmail.com>
+Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
+Karan Sharma <karan1276@gmail.com>
+Vedant Rathore <vedantr1998@gmail.com>
+Johan Blåbäck <johan_bluecreek@riseup.net>
+Pranjal Tale <pranjaltale16@gmail.com>
+Jason Tokayer <jason.tokayer@gmail.com>
+Raghav Jajodia <jajodia.raghav@gmail.com>
+Rajat Thakur <rajatthakur1997@gmail.com>
+Dhruv Bhanushali <dhruv_b@live.com>
+Anjul Kumar Tyagi <anjul.ten@gmail.com>
+Barun Parruck <barun.parruck@gmail.com>
+Bao Chau <chauquocbao0907@gmail.com>
+Tanay Agrawal <tanay_agrawal@hotmail.com>
+Ranjith Kumar <ranjith.dakshana2015@gmail.com>
+Shikhar Makhija <shikharmakhija2@gmail.com>
+Yathartha Joshi <yathartha32@gmail.com>
+Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
+Daniel Mahler <dmahler@gmail.com>
+Ka Yi <chua.kayi@yahoo.com.sg>
+Rishat Iskhakov <iskhakov@frtk.ru>
+Szymon Mieszczak <szymon.mieszczak@gmail.com>
+Sachin Agarwal <sachinagarwal0499@gmail.com>
+Priyank Patel <pspbot7@gmail.com>
+Satya Prakash Dwibedi <akash581050@gmail.com>
+tools4origins <tools4origins@gmail.com>
+Nico Schlömer <nico.schloemer@gmail.com>
+Fermi Paradox <FermiParadox@users.noreply.github.com>
+Ekansh Purohit <purohit.e15@gmail.com>
+Vedarth Sharma <vedarth.sharma@gmail.com>
+Peeyush Kushwaha <peeyush.p97@gmail.com>
+Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
+Christopher J. Wright <cjwright4242gh@gmail.com>
+Jakub Wilk <jwilk@jwilk.net>
+Mauro Garavello <mauro.garavello@unimib.it>
+Chris Tefer <ctefer@gmail.com>
+Shikhar Jaiswal <jaiswalshikhar87@gmail.com>
+Chiu-Hsiang Hsu <wdv4758h@gmail.com>
+Carlos Cordoba <ccordoba12@gmail.com>
+Fabian Ball <fabian.ball@kit.edu>
+Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
+Christiano Anderson <canderson@riseup.net>
+Robin Neatherway <robin.neatherway@gmail.com>
+Thomas Hunt <thomashunt13@gmail.com>
+Theodore Han <theodorehan@hotmail.com>
+Duc-Minh Phan <alephvn@gmail.com>
+Lejla Metohajrova <l.metohajrova@gmail.com>
+Samyak Jain <samyak.jain2016a@vitstudent.ac.in>
+Aditya Rohan <riyuzakiiitk@gmail.com>
+Vincent Delecroix <vincent.delecroix@labri.fr>
+Michael Sparapany <msparapa@purdue.edu>
+Harsh Jain <harshjniitr@gmail.com>
+Nathan Goldbaum <ngoldbau@illinois.edu>
+latot <felipematas@yahoo.com>
+Kenneth Lyons <ixjlyons@gmail.com>
+Stan Schymanski <stan.schymanski@env.ethz.ch>
+David Daly <david.daly12@kzoo.edu>
+Ayush Shridhar <ayush.shridhar1999@gmail.com>
+Javed Nissar <javednissar@gmail.com>
+Jiri Kuncar <jiri.kuncar@gmail.com>
+vedantc98 <vedantc98@gmail.com>
+Rupesh Harode <rupeshharode@gmail.com>
+Rob Zinkov <rob@zinkov.com>
+James Harrop <ebc121@gmail.com>
+James Taylor <user234683@tutanota.com>
+Ishan Joshi <ishanaj98@gmail.com>
+Marco Mancini <marco.mancini@obspm.fr>
+Boris Ettinger <ettinger.boris@gmail.com>
+Micah Fitch <micahscopes@gmail.com>
+Daniel Wennberg <daniel.wennberg@gmail.com>
+ylemkimon <ylemkimon@naver.com>
+Akash Vaish <akash.9712@gmail.com>
+Peter Enenkel <peter.enenkel+git@gmail.com>
+Waldir Pimenta <waldyrious@gmail.com>
+Jithin D. George <jithindgeorge93@gmail.com>
+Lev Chelyadinov <leva181777@gmail.com>
+Lucas Wiman <lucas.wiman@gmail.com>
+Rhea Parekh <rheaparekh12@gmail.com>
+James Cotton <peabody124@gmail.com>
+Robert Pollak <robert.pollak@posteo.net>
+anca-mc <anca-mc@users.noreply.github.com>
+Sourav Ghosh <souravghosh2197@gmail.com>
+Jonathan Allan <jjallan@users.noreply.github.com>
+Nikhil Pappu <nkhlpappu@gmail.com>
+Ethan Ward <etkewa@gmail.com>
+Cezary Marczak <zeddq1@gmail.com>
+dps7ud <dps7ud@virginia.edu>
+Nilabja Bhattacharya <nilabja10201992@gmail.com>
+Itay4 <31018228+Itay4@users.noreply.github.com>
+Poom Chiarawongse <eight1911@gmail.com>
+Yang Yang <wdscxsj@gmail.com>
+Cavendish McKay <cmckay@tachycline.com>
+Bradley Gannon <bradley.m.gannon@gmail.com>
+B McG <bmcg0890@gmail.com>
+Rob Drynkin <rob.drynkin@gmail.com>
+Seth Ebner <murgrehk@gmail.com>
+Akash Kundu <sk.sayakkundu1997@gmail.com>
+Mark Jeromin <mark.jeromin@sysfrog.net>
+Roberto Díaz Pérez <r.r.1994a@gmail.com>
+Gleb Siroki <g.shiroki@gmail.com>
+Segev Finer <segev208@gmail.com>
+Alex Lubbock <code@alexlubbock.com>
+Ayodeji Ige <ayodeji18@outlook.com>
+Matthew Wardrop <matthew.wardrop@airbnb.com>
+Hugo van Kemenade <hugovk@users.noreply.github.com>
+Austin Palmer <ap4000@nyu.edu>
+der-blaue-elefant <github@kklein.de>
+Filip Gokstorp <filip@gokstorp.se>
+Yuki Matsuda <yuki.matsuda.w@gmail.com>
+Aaron Miller <acmiller273@gmail.com>
+Salil Vishnu Kapur <salilvishnukapur@gmail.com>
+Atharva Khare <khareatharva@gmail.com>
+Shubham Maheshwari <rmaheshwari05@gmail.com>
+Pavel Tkachenko <paveltkachenko@email.com>
+Ashish Kumar Gaurav <ashishkg0022@gmail.com>
+Rajeev Singh <rajs2010@gmail.com>
+Keno Goertz <keno@goertz-berlin.com>
+Lucas Gallindo <lgallindo@gmail.com>
+Himanshu <hs80941@gmail.com>
+David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
+Amit Manchanda <amitdelhi1995@gmail.com>
+Rohit Jain <rohitjain3241@gmail.com>
+Jonathan A. Gross <jarthurgross@gmail.com>
+Unknown <kunda@scribus.net>
+Sayan Goswami <Sayan98@users.noreply.github.com>
+Subhash Saurabh <subhashsaurabh419@gmail.com>
+Rastislav Rabatin <rastislav.rabatin@gmail.com>
+Vishal <vishalg2235@gmail.com>
+Jeremey Gluck <jeremygluck@yahoo.com>
+Akshat Maheshwari <akshat14714@gmail.com>
+symbolique <symbolique@users.noreply.github.com>
+Saloni Jain <tosalonijain@gmail.com>
+Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
+Abhigyan Khaund <mail@abhigyan.xyz>
+Jashanpreet Singh <jashansingh.4398@gmail.com>
+Saurabh Agarwal <shourabh.agarwal@gmail.com>
+luzpaz <luzpaz@users.noreply.github.com>
+P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
+Nirmal Sarswat <nirmalsarswat400@gmail.com>
+Cristian Di Pietrantonio <cristiandipietrantonio@gmail.com>
+Ravi charan <ravicharan.vsp@gmail.com>
+Nityananda Gohain <nityanandagohain@gmail.com>
+Cédric Travelletti <cedrictravelletti@gmail.com>
+Nicholas Bollweg <nick.bollweg@gmail.com>
+Himanshu Ladia <hladia199811@gmail.com>
+Adwait Baokar <adwaitbaokar18@gmail.com>
+Mihail Tarigradschi <m.tarigradschi@gmail.com>
+Saketh <alurusaisaketh@gmail.com>
+rushyam <rushyamsonu@gmail.com>
+sfoo <sfoohei@gmail.com>
+Rahil Hastu <rahilhastu@gmail.com>
+Zach Raines <raineszm@gmail.com>
+Sidhant Nagpal <sidhantnagpal97@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in>
+Rishav Chakraborty <annonymousxyz@outlook.com>
+Malkhan Singh <malkhansinghrathaur@gmail.com>
+Joaquim Monserrat <qmonserrat@mailoo.org>
+Mayank Singh <mayank.singh081997@gmail.com>
+Rémy Léone <rleone@online.net>
+Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
+Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk>
+helo9 <helo9@users.noreply.github.com>
+Ken Wakita <wakita@is.titech.ac.jp>
+Carl Sandrock <carl.sandrock@up.ac.za>
+Fredrik Eriksson <freeriks@student.chalmers.se>
+Ian Swire <oversizedpenguin@gmail.com>
+Bulat <daianovich@mail.ru>
+Ehren Metcalfe <ehren.m@gmail.com>
+Dmitry Savransky <dsavransky@gmail.com>
+Kiyohito Yamazaki <kyamaz@openql.org>
+Caley Finn <caleyreuben@gmail.com>
+Zhi-Qiang Zhou <zzq_890709@hotmail.com>
+Alexander Pozdneev <pozdneev@users.noreply.github.com>
+Wes Turner <50891+westurner@users.noreply.github.com>
+JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
+Arshdeep Singh <singh.arshdeep1999@gmail.com>
+cym1 <16437732+cym1@users.noreply.github.com>
+Stewart Wadsworth <stewart.wadsworth@gmail.com>
+Jared Lumpe <mjlumpe@gmail.com>
+Avi Shrivastava <shrivastavaavi123@gmail.com>
+ramvenkat98 <ramvenkat98@gmail.com>
+Bilal Ahmed <b.ahmed0918@gmail.com>
+Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
+Yatna Verma <yatnavermaa@gmail.com>
+S.Y. Lee <sylee957@gmail.com>
+Miro Hrončok <miro@hroncok.cz>
+Sudarshan Kamath <sudarshan.kamath97@gmail.com>
+Ayushman Koul <ayushmankoul4570@gmail.com>
+Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
+Andrey Grozin <A.G.Grozin@inp.nsk.su>
+Bavish Kulur <bavishkulur@gmail.com>
+Arun Singh <arunsin997@gmail.com>
+sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
+Zachariah Etienne <zachetie@gmail.com>
+Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
+2torus <boris.ettinger@gmail.com>
+Faisal Riyaz <faisalriyaz011@gmail.com>
+Martin Roelfs <u0114255@kuleuven.be>
+SirJohnFranklin <sirjfu@googlemail.com>
+Anthony Sottile <asottile@umich.edu>
+ViacheslavP <public.viacheslav@gmail.com>
+Safiya03 <safiyanesar@gmail.com>
+Alexander Dunlap <alexander.dunlap@gmail.com>
+Rohit Sharma <31184621+rohitx007@users.noreply.github.com>
+Jonathan Warner <warnerjon12@gmail.com>
+Mohit Balwani <mohitbalwani.ict17@gmail.com>
+Marduk Bolaños <mardukbp@mac.com>
+amsuhane <ayushsuhane99@iitkgp.ac.in>
+Matthias Geier <Matthias.Geier@gmail.com>
+klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+Shubham Kumar Jha <skjha832@gmail.com>
+rationa-kunal <kunalgk1999@gmail.com>
+Animesh Sinha <animeshsinha1309@gmail.com>
+Gaurang Tandon <1gaurangtandon@gmail.com>
+Matthew Craven <clyring@users.noreply.github.com>
+Daniel Ingram <ingramds@appstate.edu>
+Jogi Miglani <jmig5776@gmail.com>
+Takumasa Nakamura <n.takumasa@gmail.com>
+Ritu Raj Singh <RituRajSingh878@gmail.com>
+Rajiv Ranjan Singh <rajivperfect007@gmail.com>
+Vera Lozhkina <veralozhkina@gmail.com>
+adhoc-king <46354827+adhoc-king@users.noreply.github.com>
+Mikel Rouco <mikel.mrm@gmail.com>
+Oscar Gustafsson <oscar.gustafsson@gmail.com>
+damianos <damianos@semmle.com>
+Supreet Agrawal <supreet11agrawal@gmail.com>
+shiksha11 <shiksharawat01@gmail.com>
+Martin Ueding <dev@martin-ueding.de>
+sharma-kunal <kunalsharma6914@gmail.com>
+Divyanshu Thakur <divyanshu@iiitmanipur.ac.in>
+Susumu Ishizuka <susumu.ishizuka@kii.com>
+Samnan Rahee <namanush.rsr.16@gmail.com>
+Fredrik Andersson <fredrik.andersson@fcc.chalmers.se>
+Bhavya Srivastava <bhavya17037@iiitd.ac.in>
+Alpesh Jamgade <alpeshjamgade21@gmail.com>
+Shubham Abhang <shubhamabhang77@gmail.com>
+Vishesh Mangla <manglavishesh64@gmail.com>
+Nicko van Someren <nicko@nicko.org>
+dandiez <47832466+dandiez@users.noreply.github.com>
+Frédéric Chapoton <fchapoton2@gmail.com>
+jhanwar <f2015463@pilani.bits-pilani.ac.in>
+Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+Salmista-94 <alejandrogroso@hotmail.com>
+Shivani Kohli <shivanikohli.09@gmail.com>
+Parker Berry <parkereberry@gmail.com>
+Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
+Nabanita Dash <dashnabanita@gmail.com>
+Gaetano Guerriero <x.guerriero@tin.it>
+Ankit Raj Pandey <pandeyan@grinnell.edu>
+Ritesh Kumar <ritesh99rakesh@gmail.com>
+kangzhiq <709563092@qq.com>
+Jun Lin <junlin0604@gmail.com>
+Petr Kungurtsev <corwinat@gmail.com>
+Anway De <anway1756@gmail.com>
+znxftw <vishnu2101@gmail.com>
+Denis Ivanenko <ivanenko@ucu.edu.ua>
+Orestis Vaggelis <orestisvaggelis@mail.com>
+Nikhil Maan <nikhilmaan22@gmail.com>
+Abhinav Anand <abhinav.anand2807@gmail.com>
+Qingsha Shi <googol.sqs@gmail.com>
+Juan Barbosa <js.barbosa10@uniandes.edu.co>
+Prionti Nasir <pdn3628@rit.edu>
+Bharat Raghunathan <bharatraghunthan9767@gmail.com>
+arooshiverma <av22@iitbbs.ac.in>
+Christoph Gohle <ctg@mpq.mpg.de>
+Charalampos Tsiagkalis <ctsiagkalis@uth.gr>
+Daniel Sears <highpost@users.noreply.github.com>
+Megan Ly <megan.ly@learnosity.com>
+Sean P. Cornelius <spcornelius@gmail.com>
+Erik R. Gomez <gomez@kth.se>
+Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
+Henry Metlov <genrih.metlov@gmail.com>
+pekochun <hamburg_hamburger2000@yahoo.co.jp>
+Bendik Samseth <b.samseth@gmail.com>
+Vighnesh Shenoy <vighneshq@gmail.com>
+Versus Void <versusvoid@gmail.com>
+Denys Rybalka <rybalka.denis@gmail.com>
+Mark Dickinson <dickinsm@gmail.com>
+Rimi <rimibis@umich.edu>
+rimibis <33387803+rimibis@users.noreply.github.com>
+Steven Lee <stevenlee123@protonmail.com>
+Gilles Schintgen <gschintgen@hambier.lu>
+Abhi58 <abhijithbharadwaj58@gmail.com>
+Tomasz Pytel <tompytel@gmail.com>
+Aadit Kamat <aadit.k12@gmail.com>
+Samesh <samesh.lakhotia@gmail.com>
+Velibor Zeli <velibor@mech.kth.se>
+Gabriel Bernardino <gabriel.bernardino@upf.edu>
+Joseph Redfern <joseph@redfern.me>
+Evelyn King <evelyn.cameron.king@gmail.com>
+Miguel Marco <mmarco@unizar.es>
+David Hagen <david@drhagen.com>
+Hannah Kari <hannah.kari@marquette.edu>
+Soniya Nayak <soniyanayak51@gmail.com>
+Harsh Agarwal <hagarwal9200@gmail.com>
+Enric Florit <efz1005@gmail.com>
+Yogesh Mishra <ymishra013@gmail.com>
+Denis Rykov <rykovd@gmail.com>
+Ivan Tkachenko <me@ratijas.tk>
+Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
+Stephan Seitz <stephan.seitz@fau.de>
+Yeshwanth N <yeshsurya@gmail.com>
+Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk>
+Srinivasa Arun Yeragudipati <ysarun1999@gmail.com>
+Kirtan Mali <kirtanmali555@gmail.com>
+TitanSnow <sweeto@live.cn>
+Pengning Chao <8857165+PengningChao@users.noreply.github.com>
+Louis Abraham <louis.abraham@yahoo.fr>
+Morten Olsen Lysgaard <morten@lysgaard.no>
+Akash Nagaraj (akasnaga) <akasnaga@cisco.com>
+Akash Nagaraj <grassknoted@gmail.com>
+Lauren Glattly <laurenglattly@gmail.com>
+Hou-Rui <houruinus@gmail.com>
+George Korepanov <gkorepanov.gk@gmail.com>
+dranknight09 <cbhaavan@gmail.com>
+aditisingh2362 <aditisingh2362@gmail.com>
+Gina <Dr-G@users.noreply.github.com>
+gregmedlock <gmedlo@gmail.com>
+Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
+Eric Wieser <wieser.eric@gmail.com>
+Bradley Dowling <34559056+btdow@users.noreply.github.com>
+Maria Marginean <33810762+mmargin@users.noreply.github.com>
+Akash Agrawall <akash.wanted@gmail.com>
+jgulian <josephdgulian@gmail.com>
+Sourav Goyal <souravgl0@gmail.com>
+Zlatan Vasović <zlatanvasovic@gmail.com>
+Alex Meiburg <timeroot.alex@gmail.com>
+Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in>
+Naman Gera <namangera15@gmail.com>
+Julien Palard <julien@palard.fr>
+Dhruv Mendiratta <dhruvmendiratta6@gmail.com>
+erdOne <36414270+erdOne@users.noreply.github.com>
+risubaba <risubhjain1010@gmail.com>
+abhinav28071999 <41710346+abhinav28071999@users.noreply.github.com>
+Jisoo Song <jeesoo9595@snu.ac.kr>
+Jaime R <38530589+Jaime02@users.noreply.github.com>
+Vikrant Malik <vikrantmalik051@gmail.com>
+Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Abhishek <uchiha@pop-os.localdomain>
+Johannes Hartung <joha2@gmx.net>
+Milan Jolly <milan.cs16@iitp.ac.in>
+faizan2700 <syedfaizan824@gmail.com>
+mohit <39158356+mohitacecode@users.noreply.github.com>
+Mohit Gupta <mohitgupta@gmail.com>
+Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in>
+Chanakya-Ekbote <ca10@iitbbs.ac.in>
+Rashmi Shehana <rashmi.watagedara@syscolabs.com>
+Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
+Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
+Michal Grňo <m93a.cz@gmail.com>
+vezeli <37907135+vezeli@users.noreply.github.com>
+Tim Gates <tim.gates@iress.com>
+Sandeep Murthy <smurthy@protonmail.ch>
+Neil <mistersheik@gmail.com>
+V1krant <46847915+V1krant@users.noreply.github.com>
+alejandro <amartinhernan@gmail.com>
+Riyan Dhiman <Riyandhiman14@gmail.com>
+sbt4104 <sthorat661@gmail.com>
+Seth Troisi <sethtroisi@google.com>
+Bhaskar Gupta <guptabhanu1999@gmail.com>
+Smit Gajjar <smitgajjar.gs@gmail.com>
+rbl <rlee@grove.co>
+Ilya Pchelintsev <ilya.pchelintsev@outlook.com>
+Omar Wagih <o.wagih.ow@gmail.com>
+prshnt19 <prashant.rawat216@gmail.com>
+Johan Guzman <jguzm022@ucr.edu>
+Vasileios Kalos <kalosbasileios@gmail.com>
+BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
+Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
+Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in>
+Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
+Moses Paul R <iammosespaulr@gmail.com>
+Saanidhya vats <saanidhyavats@gmail.com>
+tnzl <you@example.com>
+Vatsal Srivastava <alstav.trivas.sava@gmail.com>
+Jean-Luc Herren <jlh@gmx.ch>
+Dhruv Kothari <dhruvkothari22@gmail.com>
+seadavis <45022599+seadavis@users.noreply.github.com>
+kamimura <kamimura@live.jp>
+slacker404 <pchantza@gmail.com>
+Jaime Resano <gemailpersonal02@gmail.com>
+Ebrahim Byagowi <ebrahim@gnu.org>
+wuyudi <wuyudi119@163.com>
+Akira Kyle <ak@akirakyle.com>
+Calvin Jay Ross <calvinjayross@gmail.com>
+Martin Thoma <info@martin-thoma.de>
+Thomas A Caswell <tcaswell@gmail.com>
+Lagaras Stelios <stel.lag@hotmail.com>
+Jerry James <loganjerry@gmail.com>
+Jan Kruse <janckruse@t-online.de>
+Nathan Taylor <pecan.pine@gmail.com>
+Vaishnav Damani <vaishnavdamani3496@gmail.com>
+Mohit Shah <mohitshah3111999@gmail.com>
+Mathias Louboutin <mathias.louboutin@gmail.com>
+Marijan Smetko <marijansmetko123@gmail.com>
+Dave Witte Morris <Dave.Morris@uleth.ca>
+soumi7 <soumibardhan10@gmail.com>
+Zhongshi <zj495@nyu.edu>
+Wes Galbraith <galbwe92@gmail.com>
+KaustubhDamania <kaustubh.damania@gmail.com>
+w495 <w495@yandex-team.ru>
+Akhil Rajput <akh1lrjput@gmail.com>
+Markus Mohrhard <markus.mohrhard@googlemail.com>
+Benjamin Wolba <mail@benjaminwolba.com>
+彭于斌 <1931127624@qq.com>
+Rudr Tiwari <rudrtiwari@gmail.com>
+Aaryan Dewan <aaryandewan@yahoo.com>
+Benedikt Placke <benedikt.placke@outlook.com>
+Sneha Goddu <s.goddu@wustl.edu>
+goddus <39923708+goddus@users.noreply.github.com>
+Shivang Dubey <shivangdubey8@gmail.com>
+Michael Greminger <michael.greminger@gmail.com>
+Peter Cock <p.j.a.cock@googlemail.com>
+Willem Melching <willem.melching@gmail.com>
+Elias Basler <e.e.basler@protonmail.com>
+Brandon David <brandon.david@zoho.com>
+Abhay_Dhiman <abhaysdhimans@gmail.com>
+Tasha Kim <jae_young_kim@brown.edu>
+Ayush Malik <ayushmalik779@gmail.com>
+Devesh Sawant <devesh47cool@gmail.com>
+Wolfgang Stöcher <wolfgang@stoecher.com>
+Sudeep Sidhu <sudeepmanilsidhu@gmail.com>
+foice <foice.news@gmail.com>
+Ben Payne <ben.is.located@gmail.com>
+Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
+noam simcha finkelstein <noam.finkelstein@protonmail.com>
+Garrett Folbe <gmfolbe@yahoo.com>
+Islam Mansour <is3mansour@gmail.com>
+Sayandip Halder <sayandiph4@gmail.com>
+Shubham Agrawal <shubham.ag6845@gmail.com>
+numbermaniac <5206120+numbermaniac@users.noreply.github.com>
+Sakirul Alam <binarysakir@gmail.com>
+Mohammed Bilal <r.mohammedbilal@gmail.com>
+Chris du Plessis <christopherjonduplessis@gmail.com>
+Coder-RG <rgoel1999@gmail.com>
+Ansh Mishra <anshmishra471@gmail.com>
+Alex Malins <github@alexmalins.com>
+Lorenzo Contento <lorenzo.contento@gmail.com>
+Naveen Sai <naveensaisreenivas@gmail.com>
+Shital Mule <shitalmule04@gmail.com>
+Amanda Dsouza <meezamanda@yahoo.com>
+Nijso Beishuizen <nijso@koolmees.numerically-related.com>
+Harry Zheng <harry@harryzheng.com>
+Felix Yan <felixonmars@archlinux.org>
+Constantin Mateescu <costica1234@me.com>
+Eva Tiwari <eva.tiwari@gmail.com>
+Aditya Kumar Sinha <adityakumar113141@gmail.com>
+Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
+Kaustubh Chaudhari <ckaustubhm06@gmail.com>
+Kristian Brünn <hello@kristianbrunn.com>
+Neel Gorasiya <mgorasiya1974@gmail.com>
+Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
+Jose M. Gomez <chemoki@gmail.com>
+Stefan Petrea <stefan@garage-coding.com>
+Praveen Sahu <povinsahu@gmail.com>
+Mark Bell <mark00bell@googlemail.com>
+AlexCQY <alex_chua@u.nus.edu>
+Fabian Froehlich <fabian@schaluck.com>
+Nikhil Gopalam <gopalamn@umich.edu>
+Kartik Sethi <kartiks31416@gmail.com>
+Muhammed Abdul Quadir Owais <quadirowais200@gmail.com>
+Harshit Yadav <harshityadav2k@gmail.com>
+Sidharth Mundhra <sidharthmundhra16@gmail.com>
+Suryam Arnav Kalra <suryamkalra35@gmail.com>
+Prince Gupta <codemastercpp@gmail.com>
+Kunal Singh <ksingh19136@gmail.com>
+Mayank Raj <mayank_1901cs35@iitp.ac.in>
+Achal Jain <2achaljain@gmail.com>
+Mario Maio <mario.maio@aruba.it>
+Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
+Wyatt Peak <wyattpeak@gmail.com>
+Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in>
+Aditya Jindal <jaditya8889@gmail.com>
+Vaibhav Bhat <vaibhav.bhat2097@gmail.com>
+Priyansh Rathi <techiepriyansh@gmail.com>
+Saket Kumar Singh <saketkumar1202@gmail.com>
+Yukai Chou <muzimuzhi@gmail.com>
+Qijia Liu <liumeo@pku.edu.cn>
+Paul Mandel <paulmandel@google.com>
+Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
+Dominik Stańczak <stanczakdominik@gmail.com>
+Rodrigo Luger <rodluger@gmail.com>
+Marco Antônio Habitzreuter <mahabitzreuter@gmail.com>
+Ayush Bisht <bisht.ayush2001@gmail.com>
+Akshansh Bhatt <akshansh@tuta.io>
+Brandon T. Willard <brandonwillard@users.noreply.github.com>
+Thomas Aarholt <thomasaarholt@gmail.com>
+Hiren Chalodiya <hirenchalodiya99@gmail.com>
+Roland Dixon <rols121@gmail.com>
+dimasvq <dimas.vq.2020@bristol.ac.uk>
+Sagar231 <sagarfeb298@gmail.com>
+Michael Chu <michael02chu@gmail.com>
+Abby Ng <abigailjng@gmail.com>
+Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
+Alexander Cockburn <alexander_cockburn12@hotmail.com>
+Yaser AlOsh <yaseralosh@outlook.com>
+Davide Sandonà <sandona.davide@gmail.com>
+Jonathan Gutow <gutow@uwosh.edu>
+Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
+Lee Johnston <lee.johnston.100@gmail.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com>
+Vijairam Ganesh Moorthy <vijairamg@gmail.com>
+Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
+Ben Oostendorp <oostben@umich.edu>
+Nikita <nikita.student.cse19@itbhu.ac.in>
+Aman <amanmourya295@gmail.com>
+Shashank KS <shashankks0987@gmail.com>
+Aman Sharma <amansharma110603@gmail.com>
+Anup Parikh <parikhanupk@gmail.com>
+Lucy Mountain <lucymountain1@icloud.com>
+Miguel Torres Costa <miguelptcosta1995@gmail.com>
+Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
+Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
+Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
+Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
+Huangduirong <huangduirong@huawei.com>
+Nils Schulte <47043622+Schnilz@users.noreply.github.com>
+Matt Bogosian <matt@bogosian.net>
+Elisha Hollander <just4now666666@gmail.com>
+Aditya Ravuri <infprobscix@gmail.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com>
+Jeffrey Ryan <jeffaryan7@gmail.com>
+Jonathan Daniel <36337649+jond01@users.noreply.github.com>
+Robin Richard <raisin@ecomail.fr>
+Gautam Menghani <gum3ng@protonmail.com>
+Remco de Boer <29308176+redeboer@users.noreply.github.com>
+Sebastian East <sebastianeast@ymail.com>
+Evani Balasubramanyam <balasubramanyam.evani@gmail.com>
+Rahil Parikh <r.parikh@somaiya.edu>
+Jason Ross <jasonross1024@gmail.com>
+Joannah Nanjekye <joannah.nanjekye@ibm.com>
+Ayush Kumar <ayushk7102@gmail.com>
+Kshitij <kshitijparwani.mat18@itbhu.ac.in>
+Daniel Hyams <dhyams@gmail.com>
+alijosephine <alijosephine@gmail.com>
+Matthias Köppe <mkoeppe@math.ucdavis.edu>
+mohajain <mohajain99@gmail.com>
+Anibal M. Medina-Mardones <ammedmar@gmail.com>
+Travis Ens <ens.travis@gmail.com>
+Evgenia Karunus <lakesare@gmail.com>
+Risiraj Dey <risirajdey@gmail.com>
+lastcodestanding <rohang71604@gmail.com>
+Andrey Lekar <andrey_lekar@adoriasoft.com>
+Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com>
+Anutosh Bhat <andersonbhat491@gmail.com>
+Steve Kieffer <sk@skieffer.info>
+Paul Spiering <paul@spiering.org>
+Pieter Gijsbers <p.gijsbers@tue.nl>
+Wang Ran (汪然) <wangr@smail.nju.edu.cn>
+naelsondouglas <naelson17@gmail.com>
+Aman Thakur <thakuraman22july@gmail.com>
+S. Hanko <suzy.hanko@gmail.com>
+Dennis Sweeney <sweeney.427@osu.edu>
+Gurpartap Singh <dhaliwal.gurpartap@gmail.com>
+Hampus Malmberg <hampus.malmberg88@gmail.com>
+scimax <max.kellermeier@hotmail.de>
+Nikhil Date <nikhil.s.date@gmail.com>
+Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com>
+AkuBrain <76952313+Franck2111@users.noreply.github.com>
+Leo Battle <leowbattle@gmail.com>
+Advait Pote <apote2050@gmail.com>
+Anurag Bhat <bhat.1@iitj.ac.in>
+Jeremy Monat <jemonat@calalum.org>
+Diane Tchuindjo <dtchuindjo@gmail.com>
+Tom Fryers <61272761+TomFryers@users.noreply.github.com>
+Zouhair <zouhair.mahboubi@gmail.com>
 zzj <29055749+zjzh@users.noreply.github.com>
+shubhayu09 <guptashubhayu601@gmail.com>
+Siddhant Jain <siddhantashoknagar@gmail.com>
+Tirthankar Mazumder <63574588+wermos@users.noreply.github.com>
+Sumit Kumar <mr.sumitkrr@gmail.com>
+Shivam Sagar <technoshivam12@gmail.com>
+Gaurav Jain <gjain369@gmail.com>
+Andrii Oriekhov <andriyorehov@gmail.com>
+Luis Talavera <luisfertalavera15@gmail.com>
+Arie Bovenberg <a.c.bovenberg@gmail.com>
+Carson McManus <carson.mcmanus1@gmail.com>
+Jack Schmidt <1107865+jackschmidt@users.noreply.github.com>
+Riley Britten <nrb1324@hotmail.com>
+Georges Khaznadar <georgesk@debian.org>
+Donald Wilson <donwilson1029@gmail.com>
+Timo Stienstra <timostienstra00@gmail.com>
+dispasha <dispasha@users.noreply.github.com>
+Saksham Alok <sakshamalok13@gmail.com>
+Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
+oittaa <8972248+oittaa@users.noreply.github.com>
+Omkaar <79257339+Pysics@users.noreply.github.com>
+Islem BOUZENIA <fi_bouzenia@esi.dz>
+extraymond <extraymond@gmail.com>
+Alexander Behrens <alex.git@gmx.net>
+user202729 <25191436+user202729@users.noreply.github.com>
+Pieter Eendebak <pieter.eendebak@gmail.com>
+Zaz Brown <zazbrown@zazbrown.com>
+ritikBhandari <ritikbhandari68@gmail.com>
+viocha <66580331+viocha@users.noreply.github.com>
+Arthur Ryman <arthur.ryman@gmail.com>
+Xiang Wu <hsiangwu@fb.com>
+tttc3 <T.Coxon2@lboro.ac.uk>
+Seth Poulsen <poulsenseth@yahoo.com>
+cocolato <haiizhu@outlook.com>
+Anton Golovanov <agolovanov256@gmail.com>
+Gareth Ma <grhkm21@gmail.com>
+Clément M.T. Robert <cr52@protonmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
+Karan <grgkaran03@gmail.com>
+Stefan Behnle <84378403+behnle@users.noreply.github.com>
+Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
+Arthur Milchior <arthur@milchior.fr>
+NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
+Ishan Pandhare <ishan9096137017@gmail.com>
+Carlos García Montoro <TrilceAC@gmail.com>
+Parcly Taxel <reddeloostw@gmail.com>
+Saicharan <saicharanhahaha@gmail.com>
+Kunal Sheth <kunal@kunalsheth.info>
+Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
+Jyn Spring 琴春 <me@vx.st>
+Phil LeMaitre <phil_lemaitre@live.ca>
+Chris Kerr <chris.kerr@mykolab.ch>
+José Senart <jose.senart@gmail.com>
+Uwe L. Korn <uwelk@xhochy.com>
+ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>
+Yves Tumushimire <yvestumushimire@gmail.com>
+wookie184 <wookie1840@gmail.com>
+Costor <pcs2009@web.de>
+Klaus Rettinghaus <klaus.rettinghaus@enote.com>
+Sam Brockie <sambrockie@icloud.com>
+Abhishek Patidar <1e9abhi1e10@gmail.com>
+Eric Demer <demer@mailbox.org>
+Pontus von Brömssen <pontus.vonbromssen+github@gmail.com>
+Victor Immanuel <chrollolucilfer1402@gmail.com>
+Evandro Bernardes <evbernardes@gmail.com>
+Michele Ceccacci <michelececcacci1@gmail.com>
+Ayush Aryan <ayush.aryan71@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
+Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com>
+Daiki Takahashi <haru.td@gmail.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>
+Aman Kumar Shukla <theprofessionalaman@gmail.com>
+Zoufiné Lauer-Baré <raszoufine@gmail.com>
+Charles Harris <erdos4d@gmail.com>
+Tejaswini Sanapathi <sastejaswini2002@gmail.com>
+Devansh <be19b002@smail.iitm.ac.in>
+Aaron Gokaslan <aaronGokaslan@gmail.com>
+Daan Koning (he/him) <daanolivierkoning@gmail.com>
+Steven Burns <royalstream@hotmail.com>
+Jay Patankar <patankarjays@gmail.com>
+Vivek Soni <sonisheela1977@gmail.com>
+Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
+Sam Ritchie <sam@mentat.org>
+Maciej Skórski <maciej.skorski@gmail.com>
+Tilo Reneau-Cardoso <tiloreneau@gmail.com>
+Laurence Warne <laurencewarne@gmail.com>
+Lukas Molleman <Lukas.Molleman@gmail.com>
+Konstantinos Riganas <kostasriganas24@gmail.com>
+Grace Su <grace.duansu@gmail.com>
+Pedro Rosa <pedro_sxbr@usp.br>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in>
+Baiyuan Qiu <1061688677@qq.com>
+Liwei Cai <cai.lw123@gmail.com>
+Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
+Isidora Araya <iarayaday@gmail.com>
+Seb Tiburzio <sebtiburzio@gmail.com>
+Victory Omole <vtomole2@gmail.com>
+Abhishek Chaudhary <ac5003@columbia.edu>
+Alexander Zhura <nice.zhura@list.ru>
+Shuai Zhou <shuaivzhou@berkeley.edu>
+Martin Manns <mmanns@gmx.net>
+John Möller <john.moller@outlook.com>
+zzc <1378113190@qq.com>
+Pablo Galindo Salgado <pablogsal@gmail.com>
+Johannes Kasimir <johannes.kasimir@math.lu.se>
+Theodore Dias <theodore.dias@hotmail.co.uk>
+Kaustubh <90597818+kaustubh-765@users.noreply.github.com>
+Idan Pazi <idan.kp@gmail.com>
+Bobby Palmer <bobbyp@umich.edu>
+Saikat Das <saikatdchhe@gmail.com>
+Suman mondal <smondal.qwerty@gmail.com>
+Taylan Sahin <info@taylansahin.net>
+Fabio Luporini <fabio@devitocodes.com>
+Oriel Malihi <orielmalihi1@gmail.com>
+Geetika Vadali <geetika.vadali4@gmail.com>
+Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
+Mikhail Remnev <maremnev@gmail.com>
+philwillnyc <56197213+philwillnyc@users.noreply.github.com>
+Raphael Lehner <raphael.lehner@gmail.com>
+Harry Mountain <harrymountain1@icloud.com>
+Bhavik Sachdev <b.sachdev1904@gmail.com>
+袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+fazledyn-or <ataf@openrefactory.com>
+mohammedouahman <simofun85@gmail.com>
+K. Kraus <laqueray@googlemail.com>
+Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
+platypus <platypus.computerchip@gmail.com>
+codecruisader <nnisarg55@gmail.com>
+James Whitehead <whiteheadj@gmail.com>
+atharvParlikar <atharvparlikar@gmail.com>
+Ivan Petukhov <satels@gmail.com>
+Augusto Borges <borges.augustoar@gmail.com>
+Han Wei Ang <ang.h.w@u.nus.edu>
+Congxu Yang <u7189828@anu.edu.au>
+Saicharan <62512681+saicharan2804@users.noreply.github.com>
+Arnab Nandi <arnabnandi2002@gmail.com>
+Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
+Corey Cerovsek <corey@cerovsek.com>
+Harsh Kasat <hkasat@waymore.io>
+omahs <73983677+omahs@users.noreply.github.com>
+Pascal Gitz <pascal.gitz@hotmail.ch>
+Ravindu-Hirimuthugoda <ravindu.18@cse.mrt.ac.lk>
+Sophia Pustova <tripplezzed@gmail.com>
+George Pittock <gpittock4@gmail.com>
+Warren Jacinto <warrenjacinto@gmail.com>
+Sachin Singh <sachinishu02@gmail.com>
+Zedmat <104870914+harshkasat@users.noreply.github.com>
+Soumendra Ganguly <soumendraganguly@gmail.com>
+Samith Karunathilake <55777141+samithkavishke@users.noreply.github.com>
+Viraj Vekaria <virajv5593@gmail.com>
+Shishir Kushwaha <kushwahashishir1112@gmail.com>
+Ankit Kumar Singh <ankitdiswar10@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com>
+Mohak Malviya <mohakmalviya2000@gmail.com>
+Matthias Liesenfeld <116307294+maliesen@users.noreply.github.com>
+dodo <palumbododo@gmail.com>
+Mohamed Rezk <mohrizq895@gmail.com>
+Tommaso Vaccari <05-gesto-follemente@icloud.com>
+Alexis Schotte <alexis.schotte@gmail.com>
+Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
+Prey Patel <patel.prey@iitgn.ac.in>
+Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
+Abhishek kumar <kumar325571@gmail.com>
+Sam Lubelsky <sammy56lt@gmail.com>
+Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
+Vladimir Sereda <voffch@gmail.com>
+Hwayeon Kang <hwayeonniii@gmail.com>
+Raj Sapale <raj4sapale4@gmail.com>
+Gerald Teschl <gerald.teschl@univie.ac.at>
+Richard Samuel <98638849+samuelard7@users.noreply.github.com>
+HeeJae Chang <hechang@microsoft.com>
+Nick Harder <nharder@umich.edu>
+Ethan DeGuire <ethandeguire@gmail.com>
+Lorenz Winkler <lorenz.winkler@tuwien.ac.at>
+Richard Rodenbusch <rrodenbusch@gmail.com>
+Zhenxu Zhu <xzdlj@outlook.com>
+Mark van Gelder <m.j.vangelder@student.tudelft.nl>
+Mark van Gelder <mvgmvgmvg@live.com>
+Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
+James A. Preiss <jamesalanpreiss@gmail.com>
+Emile Fourcini <emile.fourcin1@gmail.com>
+Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
+João Bravo <joaocgbravo@tecnico.ulisboa.pt>
+Dean Price <dean1357price1357@gmail.com>
+Edward Z. Yang <ezyang@mit.edu>
+James Titus <titusjames299@gmail.com>
+Zhuoyuan Li <zy.li@stu.pku.edu.cn>
+Hugo Kerstens <hugo@kerstens.me>
+Jan Jancar <johny@neuromancer.sk>
+Andrew Mosson <amosson@yahoo.com>
+Marek Madejski <marekmadejski@yandex.com>
+Gonzalo Tornaría <tornaria@cmat.edu.uy>
+Peter Stahlecker <peter.stahlecker@gmail.com>
+Jean-François B <2589111+jfbu@users.noreply.github.com>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>
+George Frolov <gosha@fro.lv>
+Corbet Elkins <corbet286@gmail.com>
+Håkon Kvernmoen <haakon.kvernmoen@gmail.com>
+Muhammad Maaz <mmaaz6004@gmail.com>
+Shishir Kushwaha <138311586+shishir-11@users.noreply.github.com>
+Matt Wang <mattwang44@gmail.com>
+bharatAmeria <21001019007@jcboseust.ac.in>
+Amir Ebrahimi <github@aebrahimi.com>
+Steven Esquea <steven.esquea@irreverente.net>
+Rishabh Kamboj <111004091+VectorNd@users.noreply.github.com>
+Aasim Ali <aasim250205@gmail.com>
+Ivan A. Melnikov <iv@altlinux.org>
+Borek Saheli <boreksaheli@gmail.com>
+Guido Roncarolo <guido.roncarolo@gmail.com>
+Quek Zi Yao <ziyaoqzy2001@gmail.com>
+Roelof Rietbroek <r.rietbroek@utwente.nl>
+MostafaGalal1 <mostafag649.mg@gmail.com>
+Au Huishan <huishan_au@outlook.com>
+Kris Katterjohn <katterjohn@gmail.com>
+Shiyao Guo <mivikq@gmail.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com>
+Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
+Davi Laerte <davilae011@gmail.com>
+Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Harshit Gupta <harshithigh2001@gmail.com>
+Praveen Perumal <ppraveen98841@gmail.com>
+Kevin McWhirter <klmcw@yahoo.com>
+Prayag V <v.prayag2005@gmail.com>
+Lucas Kletzander <lucas.kletzander@gmail.com>
+Pratyksh Gupta <pratykshgupta9999@gmail.com>
+Leonardo Mangani <leomangani4@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com>
+Gagan Mishra <simonsimple305@gmail.com>
+Krishnav Bajoria <bajoriakrishnav@gmail.com>
+Matt Ord <matthew.ord1@gmail.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com>
+Prashant Tandon <tandonprashant101@gmail.com>
+Paramjit Singh <paramjit1071@gmail.com>
+João Rodrigues <abcjoao@hotmail.com>
+Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com>
+Matthew Treinish <mtreinish@kortar.org>
+Clayton Rabideau <claytonrabideau@gmail.com>
+Victoria Koval <bictoriakoval16@gmail.com>
+Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com>
+David Brooks <dave@bcs.co.nz>
+Nicholas Laustrup <124007393+nicklaustrup@users.noreply.github.com>
+Harikrishna Srinivasan <harikrishnasri3@gmail.com>
+Mathis Cros <mathis.cros@telecom-paris.fr>
+Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
+Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
+KJaybhaye <krushnajaybhaye01@gmail.com>

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -79,7 +79,8 @@ therefore attempt to lay the objects out along a line.
 References
 ==========
 
-.. [Xypic] https://xy-pic.sourceforge.net/
+[Xypic] https://web.archive.org/web/20190201000000/http://xy-pic.sourceforge.net/
+
 
 """
 from sympy.categories import (CompositeMorphism, IdentityMorphism,
@@ -1445,7 +1446,8 @@ class ArrowStringDescription:
     References
     ==========
 
-    .. [Xypic] https://xy-pic.sourceforge.net/
+    .. [Xypic] https://web.archive.org/web/20190201000000/http://xy-pic.sourceforge.net/
+
     """
     def __init__(self, unit, curving, curving_amount, looping_start,
                  looping_end, horizontal_direction, vertical_direction,


### PR DESCRIPTION
This PR fixes several dead external links related to Xy-pic in `sympy/categories/diagram_drawing.py`.

### What was changed
- Replaced `https://xy-pic.sourceforge.net/` (returns 403 Forbidden)  
- Updated both occurrences (line ~82 and line ~1448)  
- Used a stable archived snapshot from Web Archive:

  https://web.archive.org/web/20190201000000/http://xy-pic.sourceforge.net/

### Why this is needed
The old SourceForge link is no longer accessible (403 error), which causes warnings in linkcheck and breaks the documentation.

### Additional notes
Let me know if you prefer a different archived snapshot or want the link moved into a reference section. Happy to update!
<!-- BEGIN RELEASE NOTES -->
* other
    * replaced dead xy-pic links in diagram_drawing.py with archived URLs
<!-- END RELEASE NOTES -->
