### PR TITLE
quadratic denominator integration #28596

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -196,6 +196,7 @@ Aaron Gokaslan <aaronGokaslan@gmail.com>
 Aaron Meurer <asmeurer@gmail.com>
 Aaron Miller <acmiller273@gmail.com> <78561124+aaron-skydio@users.noreply.github.com>
 Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
+Aarushi Verma <aarushiverma203@gmail.com> <167199295+aashvgit@users.noreply.github.com>
 Aaryan Dewan <aaryandewan@yahoo.com> Aaryan Dewan <49852384+aaryandewan@users.noreply.github.com>
 Aasim Ali <aasim250205@gmail.com> Aasim Ali <94692076+aasim-maverick@users.noreply.github.com>
 Aasim Ali <aasim250205@gmail.com> aasim-maverick <aasim250205@gmail.com>

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1489,7 +1489,8 @@ def quadratic_denom_rule(integral):
             r2 = 1/(symbol+constant)
             log_steps = [ReciprocalRule(r1, symbol, symbol-constant),
                          ConstantTimesRule(-r2, symbol, -1, r2, ReciprocalRule(r2, symbol, symbol+constant))]
-            rewritten = sub = r1 - r2
+            sub = r1 +(-r2)
+            rewritten = log(symbol - constant) - log(symbol + constant)
             negative_step = AddRule(sub, symbol, log_steps)
             if coeff != 1:
                 rewritten = Mul(coeff, sub, evaluate=False)
@@ -1539,8 +1540,8 @@ def quadratic_denom_rule(integral):
             return step1
         step2 = integral_steps(numer2/denominator, symbol)
         substeps = AddRule(integrand, symbol, [step1, step2])
-        rewriten = const*numer1/denominator+numer2/denominator
-        return RewriteRule(integrand, symbol, rewriten, substeps)
+        rewritten = const*numer1/denominator+numer2/denominator
+        return RewriteRule(integrand, symbol, rewritten, substeps)
 
     return
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -708,6 +708,14 @@ def test_issue_25093():
         + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a)))
 
 
+def test_issue_28596():
+    a, x = symbols('a x', real=True)
+    expr = 1/(a + x**2)
+    res = integrate(expr, x)
+    assert res != 0
+    assert res.has(x)
+
+
 def test_nested_pow():
     assert_is_integral_of(sqrt(x**2), x*sqrt(x**2)/2)
     assert_is_integral_of(sqrt(x**(S(5)/3)), 6*x*sqrt(x**(S(5)/3))/11)


### PR DESCRIPTION
Fixes #28596

I fixed the negative-discriminant branch in quadratic_denom_rule so that it now produces a logarithmic antiderivative instead of the reciprocal partial-fraction form.

This restores correct behaviour for symbolic parameters in integrate(1/(a + x**2), x) and I also added a regression test in the test_manual.py

**References to other Issues or PRs** #28596 

**Brief description of what is fixed or changed**

**Other comments**

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->