### PR TITLE
fix(polys): Do not duplicate roots in ratint

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -340,16 +340,20 @@ def _roots_real_complex(poly):
     reals = {}
     complexes = {}
 
-    for r, m in list(rs.items()):
+    remaining = list(rs)
+
+    while remaining:
+        r = remaining.pop()
         r_c = r.conjugate()
         if r != r_c and r_c in rs:
-            assert rs.pop(r_c) == m
+            assert rs[r_c] == rs[r]
+            remaining.remove(r_c)
             r_re, r_im = r.as_real_imag()
             _, r_im = ordered([r_im, -r_im])
-            complexes[(r_re, r_im)] = m
+            complexes[(r_re, r_im)] = rs[r]
         else:
             # If we didn't find a conjugate just treat as real
-            reals[r] = m
+            reals[r] = rs[r]
 
     return reals, complexes
 

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -1,4 +1,4 @@
-from sympy.core.numbers import (I, Rational)
+from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions.elementary.exponential import log
@@ -201,3 +201,9 @@ def test_issue_28186():
     )
     assert integrate(f, x) == F
     assert (F.diff(x) - f).ratsimp() == 0
+
+    # https://github.com/sympy/sympy/issues/28657
+    p = 400*pi**2*x**2/(1600*pi**4*x**4 - 796*pi**2*x**2 + 100)
+    P = ratint(p, x)
+    res = P.evalf(subs={x:1e100}) - P.evalf(subs={x:0})
+    assert abs(res - 2.5) < 1e-10


### PR DESCRIPTION
Fixes gh-28657 which arises from a bug introduced in gh-28189.

The log_to_real function needs to distinguish which roots are real and which are complex conjugate pairs. The code to do this was counting each complex conjugate pair as two roots.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

No release note as this is fixing a new bug that did not exist in the previous release.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
