### PR TITLE
Fix Cycle().list(size=0) returning [0] instead of []

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -378,7 +378,7 @@ class Cycle(dict):
         if not self and size is None:
             raise ValueError('must give size for empty Cycle')
         if size is not None:
-            big = max([i for i in self.keys() if self[i] != i] + [0])
+            big = max([i for i in self.keys() if self[i] != i] + [-1])
             size = max(size, big + 1)
         else:
             size = self.size

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -434,6 +434,10 @@ def test_Cycle():
     assert Cycle(1, 2).list() == [0, 2, 1]
     assert Cycle(1, 2).list(4) == [0, 2, 1, 3]
     assert Cycle().size == 0
+    # Issue #28658: Cycle().list(size=0) should return [] not [0]
+    assert Cycle().list(size=0) == []
+    assert Cycle().list(size=0) == Permutation([]).list(size=0)
+
     raises(ValueError, lambda: Cycle((1, 2)))
     raises(ValueError, lambda: Cycle(1, 2, 1))
     raises(TypeError, lambda: Cycle(1, 2)*{})


### PR DESCRIPTION
Changed default value in max() from [0] to [-1] in Cycle.list() method to correctly handle empty cycles with size=0, ensuring consistency with Permutation behavior. Fixes #28658.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28658

**Fix:** Changed the default value from `[0]` to `[-1]`, so for empty cycles [max([...] + [-1]) = -1](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/permutations.py:2128:4-2148:59) and `size = max(0, -1+1) = 0`, correctly returning `[]`.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* combinatorics
  * Fixed [Cycle().list(size=0)](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/permutations.py:243:0-469:26) to return `[]` instead of `[0]`, ensuring consistency with [Permutation](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/permutations.py:472:0-3027:23) behavior.

<!-- END RELEASE NOTES -->