### PR TITLE
fixed invert for Fp groups, and added check for perm groups

### DIFF
--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -82,7 +82,7 @@ class CosetTable(DefaultPrinting):
         H = self.subgroup
         self._grp = free_group(', ' .join(["a_%d" % i for i in range(len(H))]))[0]
         self.P = [[None]*len(self.A)]
-        self.p_p = {}
+        self.p_p = {0:self._grp.identity}
 
     @property
     def omega(self):

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -61,7 +61,6 @@ def test_homomorphism():
     T = homomorphism(D3, D3, D3.generators, D3.generators)
     assert T.is_isomorphism()
 
-
 def test_isomorphisms():
 
     F, a, b = free_group("a, b")
@@ -111,9 +110,60 @@ def test_isomorphisms():
     H=PermutationGroup([a, b])
     assert is_isomorphic(SymmetricGroup(3),H)==True
 
-
 def test_check_homomorphism():
     a = Permutation(1,2,3,4)
     b = Permutation(1,3)
     G = PermutationGroup([a, b])
     raises(ValueError, lambda: homomorphism(G, G, [a], [a]))
+
+def test_fpgroup_isomorphism():
+
+    # S3
+    F, r, s = free_group("r, s")
+    G = FpGroup(F, [r**3, s**2, s*r*s*r])
+    F, a, b = free_group("a, b")
+    H = FpGroup(F, [a**2, b**2, (a*b)**3])
+    assert is_isomorphic(G, H)
+
+    # D4
+    n = 4
+    F, r, s = free_group("r, s")
+    G = FpGroup(F, [r**n, s**2, s*r*s*r])
+    F, a, b = free_group("a, b")
+    H = FpGroup(F, [a**2, b**2, (a*b)**n])
+    assert is_isomorphic(G, H)
+
+    # Q8
+    F, i, j = free_group("i, j")
+    G = FpGroup(F, [i**4, i**2 * j**-2, j**-1 * i * j * i])
+    F, x, y = free_group("x, y")
+    H = FpGroup(F, [x**4, x**2 * y**-2, y**-1 * x * y * x])
+    assert is_isomorphic(G, H)
+
+    # S4
+    F, a, b = free_group("a, b")
+    G = FpGroup(F, [a**4, b**2, (a*b)**3])
+    F, s, t, u = free_group("s, t, u")
+    H = FpGroup(F, [s**2, t**2, u**2, (s*t)**3, (t*u)**3, (s*u)**2])
+    assert is_isomorphic(G, H)
+
+    # C2^3 vs C4xC2
+    F, a, b, c = free_group("a, b, c")
+    G = FpGroup(F, [a**2, b**2, c**2, a*b*a**-1*b**-1, a*c*a**-1*c**-1, b*c*b**-1*c**-1])
+    F, x, y = free_group("x, y")
+    H = FpGroup(F, [x**4, y**4, x**2*y**-2, x*y*(y*x)**-1])
+    assert not is_isomorphic(G, H)
+
+    # Q8 vs D4
+    F, i, j = free_group("i, j")
+    G = FpGroup(F, [i**4, i**2 * j**-2, j**-1 * i * j * i])
+    F, r, s = free_group("r, s")
+    H = FpGroup(F, [r**4, s**2, (r*s)**2])
+    assert not is_isomorphic(G, H)
+
+    # A4
+    F, s, t = free_group("s, t")
+    G = FpGroup(F, [s**2, t**3, (s*t)**3])
+    F, x, y = free_group("x, y")
+    H = FpGroup(F, [x**2, y**3, (x*y)**3])
+    assert is_isomorphic(G, H)


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28625 #28593 

#### Brief description of what is fixed or changed
The invert logic is rewritten for Fp groups to prevent it from crashing with key errors. For permutation groups, only an image membership test is added.

#### Other comments
This pr partially overlaps with pr #28653. I added the same modifications of that pr here, because without those the code provided here doesn't work. 

The invert logic was flawed for Fp groups. The problems are described in issue #28593.

The _inverses method for homomorphisms provides us with a ditionary `{im : gen}`, where gen is a generator of the image and im is its image. The chosen approach for finding a preimage for a generic element **g** of the image, is to rewrite g in terms of the generators of the image in the dictionary, so we write  `g=g1*g2*..*gn` , with  `hi=preimage(gi)`  for each i, and then a preimage of g is of course given by `h1*h2*...*hn` .
The most delicate part is the rewriting of g in terms of the set of generators of the image. That is done by computation of the modified coset table.
**Mathematical explanation of the rewriting process:**
![sympy](https://github.com/user-attachments/assets/ba2d2f72-371f-419e-a112-796324b891f4)
I added some reference taken from the handbook of computational group theory above: 
What's really important for this pr, is that as you can see with the equation underlined in red we compute `Ytx` to be te element of `Y` such that we have: `tx*(canonical representative of lcoset tx)^-1=phi(Ytx)` , where t represents a coset, and x is a generator of `G`.
 Why is this interesting for us? Its interesting because suppose we have a word `a*b=1*a*b` in the image: then we would have `1*a*(canonical representative of coset a)^-1=phi(Y1a)`.
 `1*a` is now in a new coset: lets suppose coset with representative k; now we would know that `k*b*(canonical representative of coset kb)^-1=phi(Ykb)`.
 But this means that `phi(Y1a)*phi(Ykb)=1*a*(canonical representative of coset a)^-1*k*b*(canonical representative of coset kb)^-1`=`a*k^-1*k*b*(canonical representative of coset kb)^-1`, but since `a*b` is in the image, the coset we land in after applying `a` and `b` to the identity has to be `H`, and therefore its canonical representative is the identity.
So we translated the word in our chosen set of generators of the image. 
The logic applies for words of any lenght.
The words underlined in blue tell us where to find the stored words.

**Code comments**
In the actual implementation of the translation described above, we start of from coset 0, and from there we apply the generators of the codomain to move to the next cosets. The coset table describes those movements between cosets:
```
t=symbol_to_group_gen[s]
                    if exp<0:
                        j=C.A_dict[t**-1]<---------- C.A_dict associates the generators to integers allowing us to move in the coset table
                    else:
                        j=C.A_dict[t]
```
As we move from one coset to the next, we read from C.P the words `Ytx` (word intermediate in the code)related to each coset switch
```
for _ in range(abs(exp)):
    word_intermediate = C.P[current_coset][j]
    if word_intermediate is not None:
        for s,exp in word_intermediate.array_form:
            total_word = total_word * transl_map[s]**exp
    current_coset = C.table[current_coset][j]
```

These 2 pieces of code are needed because we need to compute with the actual group elements and not with their symbols in certain scenarios
```
temp_symbols = [gen.array_form[0][0] for gen in C._grp.generators]
symbol_to_group_gen = {gen.array_form[0][0]: gen for gen in self.codomain.generators}
```
For any doubts please ask me and I'll try to explain myself better.


**Testing**
I will copy a test file here with various isomorphism checks that failed before due to invert: you can verify that now they all pass.
```
import sys
import traceback
import time

from sympy.combinatorics import free_group
from sympy.combinatorics.fp_groups import FpGroup
from sympy.combinatorics.homomorphisms import is_isomorphic

# Wrapper function with timing
def run_test(test_num, name, G, H, expected_result):
    print(f"\n=== {test_num}. Group {name} ===", flush=True)
    
    start_time = time.time()
    try:
        print(f"   G order: {G.order()} | H order: {H.order()}", flush=True)
        print("   Starting is_isomorphic test...", flush=True)
        
        # The magic happens here: this calls invert() internally to check kernel
        result = is_isomorphic(G, H)
        
        elapsed = time.time() - start_time
        print(f"   Result: {result} (Time: {elapsed:.4f}s)", flush=True)
        
        if result != expected_result:
            print(f"❌ FAILURE: Expected {expected_result}, got {result}", flush=True)
        else:
            print(f"✅ SUCCESS", flush=True)

    except Exception as e:
        print(f"\n--- CRASH IN TEST {test_num} ---", flush=True)
        print(f"ERROR: {e}", flush=True)
        traceback.print_exc(file=sys.stdout)
        print("--------------------------", flush=True)

# ===================================================================
# --- PREVIOUS TESTS (1-5) ---
# ===================================================================

print("--- BASIC TESTS (S3, D4, Q8, S4) ---")

# 1. S3
F, r, s = free_group("r, s")
G1 = FpGroup(F, [r**3, s**2, s*r*s*r])
F2, a, b = free_group("a, b")
H1 = FpGroup(F2, [a**2, b**2, (a*b)**3])
run_test(1, "S3 (Order 6)", G1, H1, True)

# 2. D4
n = 4
F, r, s = free_group("r, s")
G2 = FpGroup(F, [r**n, s**2, s*r*s*r])
F2, a, b = free_group("a, b")
H2 = FpGroup(F2, [a**2, b**2, (a*b)**n])
run_test(2, "D4 (Order 8)", G2, H2, True)

# 3. Q8
F, i, j = free_group("i, j")
G3 = FpGroup(F, [i**4, i**2 * j**-2, j**-1 * i * j * i])
F2, x, y = free_group("x, y")
H3 = FpGroup(F2, [x**4, x**2 * y**-2, y**-1 * x * y * x])
run_test(3, "Q8 (Order 8)", G3, H3, True)

# 4. S4
F, a, b = free_group("a, b")
G4 = FpGroup(F, [a**4, b**2, (a*b)**3])
F2, s, t, u = free_group("s, t, u")
H4 = FpGroup(F2, [s**2, t**2, u**2, (s*t)**3, (t*u)**3, (s*u)**2])
run_test(4, "S4 (Order 24)", G4, H4, True)

# 5. C2^3 vs C4xC2
F, a, b, c = free_group("a, b, c")
G5 = FpGroup(F, [a**2, b**2, c**2, a*b*a**-1*b**-1, a*c*a**-1*c**-1, b*c*b**-1*c**-1])
F2, x, y = free_group("x, y")
H5 = FpGroup(F2, [x**4, y**4, x**2*y**-2, x*y*(y*x)**-1])
run_test(5, "C2^3 vs C4xC2 (Order 8 - Not Iso)", G5, H5, False)

# ===================================================================
# --- NEW EXTENDED TESTS ---
# ===================================================================

print("\n--- EXTENDED STRESS TESTS ---")

# --- 6. Cyclic Group C12 (Rewrite Check) ---
# G: Single generator
# H: Direct product C3 x C4
F, a = free_group("a")
G6 = FpGroup(F, [a**12])

F2, x, y = free_group("x, y")
# C3 x C4 = <x, y | x^3=1, y^4=1, xy=yx>
H6 = FpGroup(F2, [x**3, y**4, x*y*x**-1*y**-1])
run_test(6, "C12 (Cyclic vs Direct Product)", G6, H6, True)


# --- 7. Q8 vs D4 (The Classic Counter-Example) ---
# Same order (8), both non-abelian.
# Invert must NOT crash, but simply fail to find isomorphism.
F, i, j = free_group("i, j")
G7 = FpGroup(F, [i**4, i**2 * j**-2, j**-1 * i * j * i]) # Q8

F2, r, s = free_group("r, s")
H7 = FpGroup(F2, [r**4, s**2, (r*s)**2]) # D4
run_test(7, "Q8 vs D4 (Order 8 - Not Iso)", G7, H7, False)


# --- 8. Alternating Group A4 (Order 12) ---
# Tetrahedral group presentation
F, s, t = free_group("s, t")
G8 = FpGroup(F, [s**2, t**3, (s*t)**3])

F2, x, y = free_group("x, y")
H8 = FpGroup(F2, [x**2, y**3, (x*y)**3])
run_test(8, "A4 (Order 12)", G8, H8, True)


# --- 9. A5 (Order 60) - STRESS TEST ---
# Icosahedral group. This requires a larger coset table.
# If invert logic is slow or memory hungry, this might fail.
F, a, b = free_group("a, b")
# < a, b | a^2, b^3, (ab)^5 >
G9 = FpGroup(F, [a**2, b**3, (a*b)**5])

F2, x, y = free_group("x, y")
H9 = FpGroup(F2, [x**2, y**3, (x*y)**5])
run_test(9, "A5 (Order 60 - Stress Test)", G9, H9, True)


# --- 10. Trivial Group (Edge Case) ---
# < x | x=1 > vs < y | y=1 >
# This tests the "if m=0" fix in coset_unrank and empty tables logic
F, x = free_group("x")
G10 = FpGroup(F, [x])

F2, y = free_group("y")
H10 = FpGroup(F2, [y])
run_test(10, "Trivial Group {1}", G10, H10, True)
```
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Invert method for homomorphisms is rewritten for the case of Fp groups, since it wasn't consistent mathematically and crashed with key errors. In addition, an image membership test is added to invert.
<!-- END RELEASE NOTES -->
