### PR TITLE
Fix nonlinsolve TypeError when nfloat produces nan

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3828,7 +3828,7 @@ def _handle_poly(polys, symbols):
         # The use of Groebner over RR is likely to result incorrectly in an
         # inconsistent Groebner basis. So, convert any float coefficients to
         # Rational before computing the Groebner basis.
-        polys = [poly(nsimplify(p, rational=True)) for p in polys]
+        polys = [poly(nsimplify(p.as_expr().evalf(), rational=True)) for p in polys]
 
     # Compute a Groebner basis in grevlex order wrt the ordering given. We will
     # try to convert this to lex order later. Usually it seems to be more

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2030,6 +2030,28 @@ def test_nonlinsolve_inexact():
     assert all(abs(res.args[i][j] - sol[i][j]) < 1e-9
                for i in range(5) for j in range(2))
 
+def test_nonlinsolve_issue_28646():
+    # Issue #28646
+    x, y = symbols('x, y')
+    lst = [
+        x**2*(y - 0.508793242825092)**2 - sin(pi/8)*sqrt(0.508793242825092**2),
+        (x - 1)**2*y**2 - 0.508793242825092**2
+    ]
+    sol = [
+        (-1.46090514484456, 0.206750448667629),
+        (-0.523599958428888, -0.333941491669343),
+        (0.343659735308009, -0.775197363617209),
+        (0.593645451108387, 1.25209190893042),
+        (1.65634026469208, 0.77519736361721),
+        (2.52359995842889, 0.333941491669342),
+        (0.433629846868413 - 0.82415098716298*I, 0.28816530685116 - 0.419322453336153*I),
+        (0.433629846868413 + 0.82415098716298*I, 0.28816530685116 + 0.419322453336153*I),
+    ]
+    res = nonlinsolve(lst, x, y)
+    assert len(res) == 8
+    assert all(abs(res.args[i][j] - sol[i][j]) < 1e-9
+               for i in range(8) for j in range(2))
+
 @XFAIL
 def test_solve_nonlinear_trans():
     # After the transcendental equation solver these will work


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28646

#### Brief description of what is fixed or changed

Fixed `TypeError: 'NoneType' object is not iterable` in [nonlinsolve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3920:0-4152:27) when processing equations with float coefficients.

**Root Cause:**
The [_handle_poly](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3806:0-3917:29) function was converting polynomial coefficients back to float using `nfloat()`, which produced `nan` for certain complex expressions. This caused [solve_poly_system](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/polysys.py:38:0-97:51) to return `None`, leading to a crash when attempting to iterate over the result.

**before**
On Running:- 
```python
lst=[x**2*(y-0.508793242825092)**2-sin(pi/8)*sqrt(0.508793242825092**2), 
    (x-1)**2*y**2-0.508793242825092**2]
nonlinsolve(lst, x,y)
  ```

**Output:**
```python
TypeError: 'NoneType' object is not iterable
```
after fix:- 
```python
lst=[x**2*(y-0.508793242825092)**2-sin(pi/8)*sqrt(0.508793242825092**2), 
    (x-1)**2*y**2-0.508793242825092**2]
nonlinsolve(lst, x,y)

FiniteSet(
    (solution_x1, solution_y1),
    (solution_x2, solution_y2),
    ...
    (Total 8 set)
)
```

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, [log(-x)](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:1971:0-2026:13) incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a bug where nonlinsolve would fail with an exception for some systems of polynomial equations that mix floats and surds.

<!-- END RELEASE NOTES -->