### PR TITLE
Refactoring of `ratsimpmodprime`

### DIFF
--- a/sympy/simplify/ratsimp.py
+++ b/sympy/simplify/ratsimp.py
@@ -150,17 +150,16 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
             Cs = symbols("c:%d" % len(M1), cls=Dummy)
             Ds = symbols("d:%d" % len(M2), cls=Dummy)
             ng = Cs + Ds
+            g_ng = opt.gens + ng
 
-            c_hat = Poly(
-                sum(Cs[i] * M1[i] for i in range(len(M1))), opt.gens + ng)
-            d_hat = Poly(
-                sum(Ds[i] * M2[i] for i in range(len(M2))), opt.gens + ng)
+            c_hat = Poly(sum(Cs[i] * M1[i] for i in range(len(M1))), g_ng)
+            d_hat = Poly(sum(Ds[i] * M2[i] for i in range(len(M2))), g_ng)
 
-            r = reduced(a * d_hat - b * c_hat, G, opt.gens + ng,
+            r = reduced(a * d_hat - b * c_hat, G, g_ng,
                         order=opt.order, polys=True)[1]
 
             S = Poly(r, gens=opt.gens).coeffs()
-            sol = solve(S, Cs + Ds, particular=True, quick=True)
+            sol = solve(S, ng, particular=True, quick=True)
 
             if sol and not all(s == 0 for s in sol.values()):
                 c = c_hat.subs(sol)
@@ -169,15 +168,15 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
                 # The "free" variables occurring before as parameters
                 # might still be in the substituted c, d, so set them
                 # to the value chosen before:
-                c = c.subs(dict(list(zip(Cs + Ds, [1] * (len(Cs) + len(Ds))))))
-                d = d.subs(dict(list(zip(Cs + Ds, [1] * (len(Cs) + len(Ds))))))
+                c = c.subs(dict(list(zip(ng, [1] * (len(Cs) + len(Ds))))))
+                d = d.subs(dict(list(zip(ng, [1] * (len(Cs) + len(Ds))))))
 
                 c = Poly(c, opt.gens)
                 d = Poly(d, opt.gens)
                 if d == 0:
                     raise ValueError('Ideal not prime?')
 
-                allsol.append((c_hat, d_hat, S, Cs + Ds))
+                allsol.append((c_hat, d_hat, S, ng))
                 if N + D != maxdeg:
                     allsol = [allsol[-1]]
 

--- a/sympy/simplify/ratsimp.py
+++ b/sympy/simplify/ratsimp.py
@@ -137,9 +137,7 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
             bound = maxdeg - 1
         else:
             bound = maxdeg
-        while N + D <= bound:
-            if (N, D) in tested:
-                break
+        while N + D <= bound and (N, D) not in tested:
             tested.add((N, D))
 
             M1 = staircase(N)

--- a/sympy/simplify/ratsimp.py
+++ b/sympy/simplify/ratsimp.py
@@ -167,8 +167,9 @@ def ratsimpmodprime(expr, G, *gens, quick=True, polynomial=False, **args):
                 # The "free" variables occurring before as parameters
                 # might still be in the substituted c, d, so set them
                 # to the value chosen before:
-                c = c.subs(dict(list(zip(ng, [1] * (len(Cs) + len(Ds))))))
-                d = d.subs(dict(list(zip(ng, [1] * (len(Cs) + len(Ds))))))
+                subs_dic = dict.fromkeys(ng, S.One)
+                c = c.subs(subs_dic)
+                d = d.subs(subs_dic)
 
                 c = Poly(c, opt.gens)
                 d = Poly(d, opt.gens)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Use the variable `ng` instead of the expression `Cs + Ds`
* Use the singleton `S`
* Add memoization to the internal `staircase` function
* Use `dict.fromkeys`
* Change `while` loop condition

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
