### PR TITLE
Fixed simplify not simplifying equations other than linear polynomial equations.

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -433,6 +433,10 @@ class Relational(Boolean, EvalfMixin):
         if r.is_Relational:
             if not isinstance(r.lhs, Expr) or not isinstance(r.rhs, Expr):
                 return r
+            lhs_c, lhs_t = r.lhs.as_coeff_Add()
+            rhs_c, rhs_t = r.rhs.as_coeff_Add()
+            if lhs_c != 0 and lhs_c == rhs_c:
+                r = r.func(r.lhs - lhs_c, r.rhs - rhs_c)
             dif = r.lhs - r.rhs
             # replace dif with a valid Number that will
             # allow a definitive comparison with 0

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -428,15 +428,37 @@ class Relational(Boolean, EvalfMixin):
     def _eval_simplify(self, **kwargs):
         from .add import Add
         from .expr import Expr
+        from sympy.polys.polytools import gcd
         r = self
         r = r.func(*[i.simplify(**kwargs) for i in r.args])
         if r.is_Relational:
             if not isinstance(r.lhs, Expr) or not isinstance(r.rhs, Expr):
                 return r
-            lhs_c, lhs_t = r.lhs.as_coeff_Add()
-            rhs_c, rhs_t = r.rhs.as_coeff_Add()
-            if lhs_c != 0 and lhs_c == rhs_c:
-                r = r.func(r.lhs - lhs_c, r.rhs - rhs_c)
+            # Remove additive common terms first.
+            terms_lhs = set(Add.make_args(r.lhs))
+            terms_rhs = set(Add.make_args(r.rhs))
+            common = terms_lhs.intersection(terms_rhs)
+
+            if common:
+                # Subtract the sum of common terms from both sides
+                common_term = Add(*common)
+                r = r.func(r.lhs - common_term, r.rhs - common_term)
+
+            # Remove multiplicative common terms.
+            c1, p1 = r.lhs.as_content_primitive()
+            c2, p2 = r.rhs.as_content_primitive()
+
+            if c1.is_Number and c2.is_Number and (c1 != 1 or c2 != 1):
+                try:
+                    common_factor = gcd(c1, c2)
+                except (TypeError, ValueError):
+                    common_factor = S.One
+
+                # Divide if we found a valid common factor
+                if common_factor is not S.One and common_factor is not S.Zero:
+                    # For inequalities, only divide by positive factors to preserve direction
+                    if r.is_Equality:
+                        r = r.func(r.lhs / common_factor, r.rhs / common_factor)
             dif = r.lhs - r.rhs
             # replace dif with a valid Number that will
             # allow a definitive comparison with 0

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -27,7 +27,6 @@ from sympy.core.relational import (Relational, Equality, Unequality,
                                    StrictLessThan, Rel, Eq, Lt, Le,
                                    Gt, Ge, Ne, is_le, is_gt, is_ge, is_lt, is_eq, is_neq)
 from sympy.sets.sets import Interval, FiniteSet
-from sympy import Matrix
 from itertools import combinations
 
 x, y, z, t = symbols('x,y,z,t')

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -27,7 +27,7 @@ from sympy.core.relational import (Relational, Equality, Unequality,
                                    StrictLessThan, Rel, Eq, Lt, Le,
                                    Gt, Ge, Ne, is_le, is_gt, is_ge, is_lt, is_eq, is_neq)
 from sympy.sets.sets import Interval, FiniteSet
-
+from sympy import Matrix
 from itertools import combinations
 
 x, y, z, t = symbols('x,y,z,t')
@@ -807,6 +807,10 @@ def test_simplify_relational():
     assert simplify(m*x + 2*m*y > 1) is S.false
     assert simplify(m*x + y > 1 + y) is S.false
 
+    # Test simplification of equations/inequalities involving equations other than linear polynomials.
+    assert simplify(Eq(91*sin(x) + 40, 91*sin(y) + 40)) == Eq(sin(x), sin(y))
+    assert simplify(Lt(-2*sin(x),-2*sin(y))) == Gt(sin(x), sin(y))
+    assert simplify(Eq(x**9 + pi, y**9 + pi)) == Eq(x**9, y**9)
 
 def test_equals():
     w, x, y, z = symbols('w:z')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28666

#### Brief description of what is fixed or changed
Implemented a masking strategy inside `_eval_simplify` present in `relational.py` to use dummy variables in order to utilize the pre-existing simplifying mechanism.

#### Other comments
The changes fixes the issue at hand, while preserving the behavior of `simplify` with linear equations.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Fixed issue pertaining to simplify not evaluating equations other than linear polynomial equations.

<!-- END RELEASE NOTES -->
