### PR TITLE
Fix coset_rank/coset_unrank for trivial groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1297,6 +1297,11 @@ class PermutationGroup(Basic):
         coset_factor
 
         """
+        if len(self._base) == 0:
+            if self.contains(g):
+                return 0
+            else:
+                return None
         factors = self.coset_factor(g, True)
         if not factors:
             return None
@@ -1326,11 +1331,10 @@ class PermutationGroup(Basic):
         basic_orbits = self.basic_orbits
         m = len(base)
         if m == 0:
-            h = list(range(self._degree))
             if af:
-                return h
+                return list(range(self._degree))
             else:
-                return _af_new(h)
+                return self.identity
         v = [0]*m
         for i in range(m):
             rank, c = divmod(rank, len(transversals[i]))

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1297,7 +1297,7 @@ class PermutationGroup(Basic):
         coset_factor
 
         """
-        if len(self._base) == 0:
+        if len(self.base) == 0:
             if self.contains(g):
                 return 0
             else:

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -204,6 +204,22 @@ def test_coset_rank():
     assert G.coset_unrank(G.coset_rank(gens[0])) == gens[0]
 
 
+def test_coset_rank_trivial_group():
+    G = PermutationGroup(Permutation([0, 1, 2]))
+    assert G.order() == 1
+    assert G.base == []
+    identity = G.identity
+    assert G.contains(identity)
+    assert G.coset_rank(identity) == 0
+    assert G.coset_unrank(0) == identity
+    assert G.coset_rank(G.coset_unrank(0)) == 0
+    assert G.coset_unrank(-1) is None
+    assert G.coset_unrank(1) is None
+    non_member = Permutation(0, 1, 2)
+    assert not G.contains(non_member)
+    assert G.coset_rank(non_member) is None
+
+
 def test_coset_factor():
     a = Permutation([0, 2, 1])
     G = PermutationGroup([a])


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28677

#### Brief description of what is fixed or changed
Fixed the `coset_rank()` and `coset_unrank()` methods to properly handle trivial groups (groups with empty Schreier-Sims base). Previously, `coset_rank()` returned `None` for the identity element in trivial groups, and `coset_unrank(0)` raised a `ValueError`. Now both methods work correctly:
- `coset_rank(identity)` returns `0` for trivial groups
- `coset_unrank(0)` returns the identity permutation for trivial groups

The fix adds special handling for the case when the base is empty (`len(self._base) == 0`), ensuring that trivial groups are treated as having exactly one element (the identity) at rank 0.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed `coset_rank()` and `coset_unrank()` to properly handle trivial groups with empty Schreier-Sims base. Previously, `coset_rank()` returned `None` for the identity element and `coset_unrank(0)` raised `ValueError`.
<!-- END RELEASE NOTES -->
