### PR TITLE
Add StateSpace rewrite methods to TransferFunctionMatrix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1242,6 +1242,7 @@ Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
 Pradyumna <pradyu1993@gmail.com>
 Prafullkumar P. Tale <hector1618@gmail.com> <Hector1618@gmail.com>
 Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
+Prakhar Chhalotre <chhalotreprakhar00@gmail.com> cprakhar <chhalotreprakhar00@gmail.com>
 Pramod Ch <pramodch14@gmail.com>
 Pranjal Tale <pranjaltale16@gmail.com>
 Prashant Tandon <102211549+PT-10@users.noreply.github.com>\

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5367,7 +5367,17 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         # For MIMO systems, convert each transfer function to state space
         # and create a block-diagonal state space representation
         tf_list = self._flat()
-        ss_list = [tf.rewrite(StateSpace) for tf in tf_list]
+        ss_list = []
+        for tf in tf_list:
+            # Normalize Series/Parallel/Feedback to TransferFunction first
+            tf_norm = tf.doit()
+            ss = tf_norm.rewrite(StateSpace)
+            if not isinstance(ss, StateSpace):
+                raise TypeError(
+                    "Each element of TransferFunctionMatrix must rewrite to a "
+                    "SISO StateSpace when converting to StateSpace. "
+                    f"Got {type(ss).__name__} instead.")
+            ss_list.append(ss)
         
         # Calculate dimensions
         total_states = sum(ss.num_states for ss in ss_list)
@@ -5475,7 +5485,17 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         # For MIMO systems, convert each transfer function to state space
         # and create a block-diagonal state space representation
         tf_list = self._flat()
-        ss_list = [tf.rewrite(DiscreteStateSpace) for tf in tf_list]
+        ss_list = []
+        for tf in tf_list:
+            # Normalize Series/Parallel/Feedback to DiscreteTransferFunction first
+            tf_norm = tf.doit()
+            ss = tf_norm.rewrite(DiscreteStateSpace)
+            if not isinstance(ss, DiscreteStateSpace):
+                raise TypeError(
+                    "Each element of TransferFunctionMatrix must rewrite to a "
+                    "SISO DiscreteStateSpace when converting to DiscreteStateSpace. "
+                    f"Got {type(ss).__name__} instead.")
+            ss_list.append(ss)
         
         # Calculate dimensions
         total_states = sum(ss.num_states for ss in ss_list)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5312,7 +5312,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
 
     def _eval_rewrite_as_StateSpace(self, *args):
         """
-        Converts a continuous-time MIMO transfer function matrix to an 
+        Converts a continuous-time MIMO transfer function matrix to an
         equivalent state-space model.
 
         This method converts each transfer function in the matrix to its
@@ -5363,7 +5363,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
             raise TypeError(
                 "Cannot rewrite a discrete-time TransferFunctionMatrix as a "
                 "continuous-time StateSpace model.")
-        
+
         # For MIMO systems, convert each transfer function to state space
         # and create a block-diagonal state space representation
         tf_list = self._flat()
@@ -5378,12 +5378,12 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                     "SISO StateSpace when converting to StateSpace. "
                     f"Got {type(ss).__name__} instead.")
             ss_list.append(ss)
-        
+
         # Calculate dimensions
         total_states = sum(ss.num_states for ss in ss_list)
         num_inputs = self.num_inputs
         num_outputs = self.num_outputs
-        
+
         # Build block diagonal A matrix
         A = zeros(total_states, total_states)
         state_offset = 0
@@ -5391,7 +5391,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
             n = ss.num_states
             A[state_offset:state_offset+n, state_offset:state_offset+n] = ss.A
             state_offset += n
-        
+
         # Build B matrix - each input affects its corresponding transfer functions
         B = zeros(total_states, num_inputs)
         state_offset = 0
@@ -5402,7 +5402,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 n = ss.num_states
                 B[state_offset:state_offset+n, in_idx:in_idx+1] = ss.B
                 state_offset += n
-        
+
         # Build C matrix - each output comes from its corresponding transfer functions
         C = zeros(num_outputs, total_states)
         state_offset = 0
@@ -5413,7 +5413,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 n = ss.num_states
                 C[out_idx:out_idx+1, state_offset:state_offset+n] = ss.C
                 state_offset += n
-        
+
         # Build D matrix - direct feedthrough from inputs to outputs
         D = zeros(num_outputs, num_inputs)
         for out_idx in range(num_outputs):
@@ -5421,12 +5421,12 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 ss_idx = out_idx * num_inputs + in_idx
                 ss = ss_list[ss_idx]
                 D[out_idx, in_idx] = ss.D[0, 0]
-        
+
         return StateSpace(A, B, C, D)
 
     def _eval_rewrite_as_DiscreteStateSpace(self, *args):
         """
-        Converts a discrete-time MIMO transfer function matrix to an 
+        Converts a discrete-time MIMO transfer function matrix to an
         equivalent discrete state-space model.
 
         This method converts each transfer function in the matrix to its
@@ -5481,7 +5481,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
             raise TypeError(
                 "Cannot rewrite a continuous-time TransferFunctionMatrix as a "
                 "discrete-time DiscreteStateSpace model.")
-        
+
         # For MIMO systems, convert each transfer function to state space
         # and create a block-diagonal state space representation
         tf_list = self._flat()
@@ -5496,12 +5496,12 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                     "SISO DiscreteStateSpace when converting to DiscreteStateSpace. "
                     f"Got {type(ss).__name__} instead.")
             ss_list.append(ss)
-        
+
         # Calculate dimensions
         total_states = sum(ss.num_states for ss in ss_list)
         num_inputs = self.num_inputs
         num_outputs = self.num_outputs
-        
+
         # Build block diagonal A matrix
         A = zeros(total_states, total_states)
         state_offset = 0
@@ -5509,7 +5509,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
             n = ss.num_states
             A[state_offset:state_offset+n, state_offset:state_offset+n] = ss.A
             state_offset += n
-        
+
         # Build B matrix - each input affects its corresponding transfer functions
         B = zeros(total_states, num_inputs)
         state_offset = 0
@@ -5520,7 +5520,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 n = ss.num_states
                 B[state_offset:state_offset+n, in_idx:in_idx+1] = ss.B
                 state_offset += n
-        
+
         # Build C matrix - each output comes from its corresponding transfer functions
         C = zeros(num_outputs, total_states)
         state_offset = 0
@@ -5531,7 +5531,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 n = ss.num_states
                 C[out_idx:out_idx+1, state_offset:state_offset+n] = ss.C
                 state_offset += n
-        
+
         # Build D matrix - direct feedthrough from inputs to outputs
         D = zeros(num_outputs, num_inputs)
         for out_idx in range(num_outputs):
@@ -5539,7 +5539,7 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
                 ss_idx = out_idx * num_inputs + in_idx
                 ss = ss_list[ss_idx]
                 D[out_idx, in_idx] = ss.D[0, 0]
-        
+
         return DiscreteStateSpace(A, B, C, D, self.sampling_time)
 
     @property

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -4909,3 +4909,50 @@ def test_DiscreteStateSpace_stability():
     ss2 = DiscreteStateSpace(A2, B, C, D)
     ineq = ss2.get_asymptotic_stability_conditions()
     assert ineq == [False]
+
+def test_TransferFunctionMatrix_to_StateSpace():
+    # Test continuous-time TFM to StateSpace conversion
+    tf1 = TransferFunction(2, s + 1, s)
+    tf2 = TransferFunction(1, 2*s + 1, s)
+    G_tf = TransferFunctionMatrix([[tf1], [tf2]])
+    
+    # Should not raise AttributeError anymore
+    ss = G_tf.rewrite(StateSpace)
+    
+    # Verify it returns a StateSpace object
+    assert isinstance(ss, StateSpace)
+    
+    # Check dimensions
+    assert ss.num_inputs == 1
+    assert ss.num_outputs == 2
+    assert ss.num_states == 2  # One state per transfer function
+    
+    # Test with multiple inputs and outputs
+    tf3 = TransferFunction(3, s + 2, s)
+    tf4 = TransferFunction(1, s + 3, s)
+    G_tf2 = TransferFunctionMatrix([[tf1, tf3], [tf2, tf4]])
+    
+    ss2 = G_tf2.rewrite(StateSpace)
+    assert isinstance(ss2, StateSpace)
+    assert ss2.num_inputs == 2
+    assert ss2.num_outputs == 2
+    assert ss2.num_states == 4  # Four transfer functions, each with one state
+    
+    # Test discrete-time TFM to DiscreteStateSpace conversion
+    dtf1 = DiscreteTransferFunction(2, z + 1, z, 0.1)
+    dtf2 = DiscreteTransferFunction(1, 2*z + 1, z, 0.1)
+    G_dtf = TransferFunctionMatrix([[dtf1], [dtf2]])
+    
+    dss = G_dtf.rewrite(DiscreteStateSpace)
+    assert isinstance(dss, DiscreteStateSpace)
+    assert dss.num_inputs == 1
+    assert dss.num_outputs == 2
+    assert dss.num_states == 2
+    assert dss.sampling_time == 0.1
+    
+    # Test error when trying to convert continuous TFM to DiscreteStateSpace
+    raises(TypeError, lambda: G_tf.rewrite(DiscreteStateSpace))
+    
+    # Test error when trying to convert discrete TFM to continuous StateSpace
+    raises(TypeError, lambda: G_dtf.rewrite(StateSpace))
+


### PR DESCRIPTION
Add StateSpace rewrite methods for TransferFunctionMatrix

#### References to other Issues or PRs
Fixes #28678

#### Brief description of what is fixed or changed

This PR adds `_eval_rewrite_as_StateSpace` and `_eval_rewrite_as_DiscreteStateSpace` methods to the `TransferFunctionMatrix` class, enabling conversion from MIMO transfer function matrices to equivalent state-space representations.

**What was broken:**
Calling `TransferFunctionMatrix.rewrite(StateSpace)` raised an `AttributeError` because the required rewrite methods were not implemented.

**What was fixed:**
- Added `_eval_rewrite_as_StateSpace` for continuous-time systems
- Added `_eval_rewrite_as_DiscreteStateSpace` for discrete-time systems
- Both methods use a block-diagonal approach to combine individual transfer function state-space representations into a single MIMO system
- Added type checking to prevent invalid conversions (discrete→continuous and continuous→discrete)
- Added comprehensive doctests showing usage examples, properties, and error handling
- Added unit tests in `test_lti.py` covering SIMO, MIMO, continuous, discrete, and error cases

**Example usage:**
```python
>>> from sympy.abc import s
>>> from sympy.physics.control import TransferFunction, TransferFunctionMatrix, StateSpace
>>> tf1 = TransferFunction(2, s + 1, s)
>>> tf2 = TransferFunction(1, 2*s + 1, s)
>>> G_tf = TransferFunctionMatrix([[tf1], [tf2]])
>>> ss = G_tf.rewrite(StateSpace)
>>> ss.num_states
2
```
#### Other comments
The implementation preserves the input-output relationships of the original transfer function matrix while providing an alternative representation useful for control system analysis and design.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
- physics.control
    - Fixed 
        - `TransferFunctionMatrix.rewrite(StateSpace)` and `TransferFunctionMatrix.rewrite(DiscreteStateSpace)` which previously raised `AttributeError`. These methods now correctly convert MIMO transfer function matrices to equivalent state-space representations using a block-diagonal approach.
<!-- END RELEASE NOTES -->