### PR TITLE
Standardize CRootOf and RootSum with dedicated dummy symbols

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2211,7 +2211,7 @@ def manualintegrate(f, var):
     >>> manualintegrate(exp(x) / (1 + exp(2 * x)), x)
     atan(exp(x))
     >>> integrate(exp(x) / (1 + exp(2 * x)))
-    RootSum(4*_z**2 + 1, Lambda(_i, _i*log(2*_i + exp(x))))
+    RootSum(4*w**2 + 1, Lambda(w, w*log(2*w + exp(x))))
     >>> manualintegrate(cos(x)**4 * sin(x), x)
     -cos(x)**5/5
     >>> integrate(cos(x)**4 * sin(x), x)

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -52,7 +52,7 @@ def apart(f, x=None, full=False, **options):
     You can choose Bronstein's algorithm by setting ``full=True``:
 
     >>> apart(y/(x**2 + x + 1), x, full=True)
-    RootSum(_w**2 + _w + 1, Lambda(_a, (-2*_a*y/3 - y/3)/(-_a + x)))
+    RootSum(w**2 + w + 1, Lambda(w, (-2*w*y/3 - y/3)/(-w + x)))
 
     Calling ``doit()`` yields a human-readable result:
 
@@ -286,7 +286,7 @@ def apart_list(f, x=None, dummies=None, **options):
     1)])
 
     >>> assemble_partfrac_list(pfd)
-    RootSum(_w**2 + _w + t, Lambda(_a, (-2*_a*t/(4*t - 1) - t/(4*t - 1))/(-_a + x)))
+    RootSum(t + w**2 + w, Lambda(w, (-2*t*w/(4*t - 1) - t/(4*t - 1))/(-w + x)))
 
     This example is taken from Bronstein's original paper:
 
@@ -454,7 +454,7 @@ def assemble_partfrac_list(partial_list):
 
     >>> pfda = assemble_partfrac_list(pfd)
     >>> pfda
-    RootSum(_w**2 - 2, Lambda(_a, _a/(-_a + x)))/2
+    RootSum(w**2 - 2, Lambda(w, w/(-w + x)))/2
 
     >>> pfda.doit()
     -sqrt(2)/(2*(x + sqrt(2))) + sqrt(2)/(2*(x - sqrt(2)))

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -51,26 +51,33 @@ class _pure_key_dict:
 
     >>> P = _pure_key_dict()
 
-    2) assignment for a PurePoly or univariate polynomial
+    2) assignment for a Poly or univariate polynomial
 
     >>> P[x] = 1
     >>> P[PurePoly(x - y, x)] = 2
 
-    3) retrieval based on PurePoly key comparison (use this
-       instead of the get method)
+    3) retrieval based on Poly key comparison
 
-    >>> P[y]
+    >>> P[x]
     1
 
-    4) KeyError when trying to retrieve a nonexisting key
+    4) KeyError when trying to retrieve with different symbol or nonexisting key
 
+    >>> P[y]  # Different symbol, not found
+    Traceback (most recent call last):
+    ...
+    KeyError: Poly(y, y, domain='ZZ')
     >>> P[y + 1]
     Traceback (most recent call last):
     ...
-    KeyError: PurePoly(y + 1, y, domain='ZZ')
+    KeyError: Poly(y + 1, y, domain='ZZ')
 
     5) ability to query with ``in``
 
+    >>> x in P
+    True
+    >>> y in P  # Different symbol
+    False
     >>> x + 1 in P
     False
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -19,7 +19,7 @@ from sympy.polys.polyfuncs import symmetrize, viete
 from sympy.polys.polyroots import (
     roots_linear, roots_quadratic, roots_binomial,
     preprocess_roots, roots)
-from sympy.polys.polytools import Poly, PurePoly, factor
+from sympy.polys.polytools import Poly, factor
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import (
     dup_isolate_complex_roots_sqf,

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1150,11 +1150,7 @@ class RootSum(Expr):
             is_func = getattr(func, 'is_Function', False)
 
             if is_func and 1 in func.nargs:
-                if not isinstance(func, Lambda):
-                    func = Lambda(poly.gen, func(poly.gen))
-                else:
-                    old_var = func.variables[0]
-                    func = Lambda(poly.gen, func.expr.subs(old_var, poly.gen))
+                func = Lambda(poly.gen, func(poly.gen))
             else:
                 raise ValueError(
                     "expected a univariate function, got %s" % func)

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -106,6 +106,7 @@ class _pure_key_dict:
 
 _reals_cache = _pure_key_dict()
 _complexes_cache = _pure_key_dict()
+_rootof_dummy = Dummy('x')
 
 
 def _pure_factors(poly):
@@ -366,6 +367,7 @@ class ComplexRootOf(RootOf):
         """Construct new ``CRootOf`` object from raw data. """
         obj = Expr.__new__(cls)
 
+        poly = poly.replace(poly.gen, _rootof_dummy)
         obj.poly = PurePoly(poly)
         obj.index = index
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -115,6 +115,7 @@ class _pure_key_dict:
 _reals_cache = _pure_key_dict()
 _complexes_cache = _pure_key_dict()
 _rootof_dummy = Dummy('x')
+_rootsum_dummy = Dummy('w')
 
 
 def _pure_factors(poly):
@@ -1139,18 +1140,19 @@ class RootSum(Expr):
         """Construct a new ``RootSum`` instance of roots of a polynomial."""
         coeff, poly = cls._transform(expr, x)
 
-        poly = Poly(poly.replace(poly.gen, _rootof_dummy))
         if not poly.is_univariate:
             raise MultivariatePolynomialError(
                 "only univariate polynomials are allowed")
 
+        poly = Poly(poly.replace(poly.gen, _rootsum_dummy))
+
         if func is None:
-            func = Lambda(poly.gen, poly.gen)
+            func = Lambda(_rootsum_dummy, _rootsum_dummy)
         else:
             is_func = getattr(func, 'is_Function', False)
 
             if is_func and 1 in func.nargs:
-                func = Lambda(poly.gen, func(poly.gen))
+                func = Lambda(_rootsum_dummy, func(_rootsum_dummy))
             else:
                 raise ValueError(
                     "expected a univariate function, got %s" % func)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -185,6 +185,11 @@ def test_CRootOf_subs():
     assert rootof(x**3 + x + 1, 0).subs(x, y) == rootof(y**3 + y + 1, 0)
 
 
+def test_CRootOf_xreplace():
+    r = CRootOf(x**2 + 2*x - 1, 0)
+    assert (x - r).xreplace({x: r}) == 0
+
+
 def test_CRootOf_diff():
     assert rootof(x**3 + x + 1, 0).diff(x) == 0
     assert rootof(x**3 + x + 1, 0).diff(y) == 0
@@ -695,3 +700,9 @@ def test_issue_19113():
         ) == '[CRootOf(x**3 - x + 1, 0)]'
     assert str(Poly(eq.subs(y, tan(x))).real_roots()
         ) == '[CRootOf(x**3 - x + 1, 0)]'
+
+
+def test_Poly_with_CRootOf():
+    r = RootOf(x**3 + x + 1, 0)
+    p = Poly(r, x)
+    assert p.as_expr() == CRootOf(x**3 + x + 1, 0)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -286,7 +286,7 @@ def test_issue_24978():
     # (factor of -1 is extracted), before being stored as CRootOf.poly.
     f = -x**2 + 2
     r = CRootOf(f, 0)
-    assert r.poly.as_expr() == x**2 - 2
+    assert r.poly(x) == x**2 - 2
     # An action that prompts calculation of an interval puts r.poly in
     # the cache.
     r.n()

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -625,8 +625,6 @@ def test_pure_key_dict():
     assert (1 in p) is False
     p[x] = 1
     assert x in p
-    assert y in p
-    assert p[y] == 1
     raises(KeyError, lambda: p[1])
     def dont(k):
         p[k] = 2

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5168,12 +5168,12 @@ def test_pretty_RootSum():
     ascii_str = \
 """\
        / 5           \\\n\
-RootSum\\x  + 11*x - 2/\
+RootSum\\w  + 11*w - 2/\
 """
     ucode_str = \
 """\
        ⎛ 5           ⎞\n\
-RootSum⎝x  + 11⋅x - 2⎠\
+RootSum⎝w  + 11⋅w - 2⎠\
 """
 
     assert pretty(expr) == ascii_str
@@ -5181,15 +5181,11 @@ RootSum⎝x  + 11⋅x - 2⎠\
 
     expr = RootSum(x**5 + 11*x - 2, Lambda(z, exp(z)))
     ascii_str = \
-"""\
-       / 5                   z\\\n\
-RootSum\\x  + 11*x - 2, z -> e /\
-"""
+"""       / 5                   w\\
+RootSum\\w  + 11*w - 2, w -> e /"""
     ucode_str = \
-"""\
-       ⎛ 5                  z⎞\n\
-RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠\
-"""
+"""       ⎛ 5                  w⎞
+RootSum⎝w  + 11⋅w - 2, w ↦ ℯ ⎠"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from sympy.core import S, Rational, Pow, Basic, Mul, Number
+from sympy.core.function import Lambda
 from sympy.core.mul import _keep_coeff
 from sympy.core.numbers import Integer
 from sympy.core.relational import Relational
@@ -785,10 +786,11 @@ class StrPrinter(Printer):
         return "CRootOf(%s, %d)" % (self._print_Add(poly_expr, order='lex'), expr.index)
 
     def _print_RootSum(self, expr):
-        args = [self._print_Add(expr.expr, order='lex')]
+        args = [self._print_Add(expr.poly(_rootof_x), order='lex')]
 
         if expr.fun is not S.IdentityFunction:
-            args.append(self._print(expr.fun))
+            func = Lambda(_rootof_x, expr.fun(_rootof_x))
+            args.append(self._print(func))
 
         return "RootSum(%s)" % ", ".join(args)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -10,10 +10,14 @@ from sympy.core.mul import _keep_coeff
 from sympy.core.numbers import Integer
 from sympy.core.relational import Relational
 from sympy.core.sorting import default_sort_key
+from sympy.core.symbol import Symbol
 from sympy.external.mpmath import prec_to_dps, to_str as mlib_to_str
 from sympy.utilities.iterables import sift
 from .precedence import precedence, PRECEDENCE
 from .printer import Printer, print_function
+
+
+_rootof_x = Symbol('x')
 
 
 class StrPrinter(Printer):
@@ -777,8 +781,8 @@ class StrPrinter(Printer):
                            self.parenthesize(expr.rhs, precedence(expr)))
 
     def _print_ComplexRootOf(self, expr):
-        return "CRootOf(%s, %d)" % (self._print_Add(expr.expr,  order='lex'),
-                                    expr.index)
+        poly_expr = expr.poly(_rootof_x)
+        return "CRootOf(%s, %d)" % (self._print_Add(poly_expr, order='lex'), expr.index)
 
     def _print_RootSum(self, expr):
         args = [self._print_Add(expr.expr, order='lex')]

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -19,6 +19,7 @@ from .printer import Printer, print_function
 
 
 _rootof_x = Symbol('x')
+_rootsum_w = Symbol('w')
 
 
 class StrPrinter(Printer):
@@ -786,10 +787,10 @@ class StrPrinter(Printer):
         return "CRootOf(%s, %d)" % (self._print_Add(poly_expr, order='lex'), expr.index)
 
     def _print_RootSum(self, expr):
-        args = [self._print_Add(expr.poly(_rootof_x), order='lex')]
+        args = [self._print_Add(expr.poly(_rootsum_w), order='lex')]
 
         if expr.fun is not S.IdentityFunction:
-            func = Lambda(_rootof_x, expr.fun(_rootof_x))
+            func = Lambda(_rootsum_w, expr.fun(_rootsum_w))
             args.append(self._print(func))
 
         return "RootSum(%s)" % ", ".join(args)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1803,8 +1803,8 @@ def test_latex_ComplexRootOf():
 
 
 def test_latex_RootSum():
-    assert latex(RootSum(x**5 + x + 3, sin)) == \
-        r"\operatorname{RootSum} {\left(x^{5} + x + 3, \left( x \mapsto \sin{\left(x \right)} \right)\right)}"
+    assert latex(RootSum(w**5 + w + 3, sin)) == \
+        r"\operatorname{RootSum} {\left(w^{5} + w + 3, \left( w \mapsto \sin{\left(w \right)} \right)\right)}"
 
 
 def test_settings():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -647,9 +647,9 @@ def test_RootSum():
     f = x**5 + 2*x - 1
 
     assert str(
-        RootSum(f, Lambda(z, z), auto=False)) == "RootSum(x**5 + 2*x - 1)"
+        RootSum(f, Lambda(z, z), auto=False)) == "RootSum(w**5 + 2*w - 1)"
     assert str(RootSum(f, Lambda(
-        z, z**2), auto=False)) == "RootSum(x**5 + 2*x - 1, Lambda(z, z**2))"
+        z, z**2), auto=False)) == "RootSum(w**5 + 2*w - 1, Lambda(w, w**2))"
 
 
 def test_GroebnerBasis():

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -2112,11 +2112,11 @@ class NthLinearConstantCoeffHomogeneous(SingleODESolver):
     >>> dsolve(f(x).diff(x, 5) + 10*f(x).diff(x) - 2*f(x), f(x),
     ... hint='nth_linear_constant_coeff_homogeneous')
     ... # doctest: +NORMALIZE_WHITESPACE
-    Eq(f(x), C5*exp(x*CRootOf(_x**5 + 10*_x - 2, 0))
-    + (C1*sin(x*im(CRootOf(_x**5 + 10*_x - 2, 1)))
-    + C2*cos(x*im(CRootOf(_x**5 + 10*_x - 2, 1))))*exp(x*re(CRootOf(_x**5 + 10*_x - 2, 1)))
-    + (C3*sin(x*im(CRootOf(_x**5 + 10*_x - 2, 3)))
-    + C4*cos(x*im(CRootOf(_x**5 + 10*_x - 2, 3))))*exp(x*re(CRootOf(_x**5 + 10*_x - 2, 3))))
+    Eq(f(x), C5*exp(x*CRootOf(x**5 + 10*x - 2, 0))
+    + (C1*sin(x*im(CRootOf(x**5 + 10*x - 2, 1)))
+    + C2*cos(x*im(CRootOf(x**5 + 10*x - 2, 1))))*exp(x*re(CRootOf(x**5 + 10*x - 2, 1)))
+    + (C3*sin(x*im(CRootOf(x**5 + 10*x - 2, 3)))
+    + C4*cos(x*im(CRootOf(x**5 + 10*x - 2, 3))))*exp(x*re(CRootOf(x**5 + 10*x - 2, 3))))
 
     Note that because this method does not involve integration, there is no
     ``nth_linear_constant_coeff_homogeneous_Integral`` hint.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
see https://github.com/sympy/sympy/issues/26808
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR replaces the symbol inside CRootOf with a dummy symbol "_x". The problem is that xreplace gets confused by the symbol used inside CRootOf, as discussed in #28645.
In the printing code, the dummy symbol is replaced with the normal symbol "x" so that users can easily copy and paste the output.

This PR also applies the same approach to RootSum, using a dummy symbol "_w" internally and printing it as "w".

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * RootOf now uses an internal dummy symbol so that all instances will display using the symbol "x". This fixes some bugs where code involving RootOf would get confused if mixed with the symbol that was used to create the RootOf.
<!-- END RELEASE NOTES -->
