### PR TITLE
Fix collected_word dropping permutation data

### DIFF
--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -352,15 +352,17 @@ class Collector(DefaultPrinting):
                 key = free_group.dtype(key)
                 if self.pc_presentation[key]:
                     presentation = self.pc_presentation[key].array_form
-                    sym, exp = presentation[0]
-                    word_ = ((w[0][0], r), (sym, q*exp))
+                    word_array = []
+                    if r != 0:
+                        word_array.append((w[0][0], r))
+                    for sym, exp in presentation:
+                        if q*exp != 0:
+                            word_array.append((sym, q*exp))
+                    word_ = tuple(word_array) if word_array else ()
                     word_ = free_group.dtype(word_)
                 else:
-                    if r != 0:
-                        word_ = ((w[0][0], r), )
-                        word_ = free_group.dtype(word_)
-                    else:
-                        word_ = None
+                    word_ = ((w[0][0], r), ) if r != 0 else ()
+                    word_ = free_group.dtype(word_)
                 word = word.eliminate_word(free_group.dtype(w), word_)
 
             if len(w) == 2 and w[1][1] > 0:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28637

#### Brief description of what is fixed or changed

The `Collector.collected_word` method in polycyclic group computations was incorrectly handling words with negative exponents in two ways:

1. **Zero-exponent terms**: When normalizing power relations, terms with zero exponents (representing the identity element) were being included in the collected form instead of being filtered out. For example, `x0^-2` would produce [((x0, 0), (x3, -1))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/pc_groups.py:578:4-610:83) instead of [((x3, -1))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/pc_groups.py:578:4-610:83).

2. **Multi-term power relations**: Only the first term of multi-term power relations was being processed. For power relations like `x0^2 = x2*x3`, only `x2` was handled, ignoring `x3`.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed [collected_word](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/pc_groups.py:269:4-385:19) method dropping permutation data for words with negative exponents in polycyclic group presentations
<!-- END RELEASE NOTES -->