### PR TITLE
Fix collected_word dropping permutation data (issue #28637)

### DIFF
--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -352,15 +352,18 @@ class Collector(DefaultPrinting):
                 key = free_group.dtype(key)
                 if self.pc_presentation[key]:
                     presentation = self.pc_presentation[key].array_form
-                    sym, exp = presentation[0]
-                    word_ = ((w[0][0], r), (sym, q*exp))
+                    word_list = []
+                    for sym, exp in presentation:
+                        scaled_exp = q * exp
+                        if scaled_exp != 0:
+                            word_list.append((sym, scaled_exp))
+                    if r != 0 or not word_list:
+                        word_list.insert(0, (w[0][0], r))
+                    word_ = tuple(word_list)
                     word_ = free_group.dtype(word_)
                 else:
-                    if r != 0:
-                        word_ = ((w[0][0], r), )
-                        word_ = free_group.dtype(word_)
-                    else:
-                        word_ = None
+                    word_ = ((w[0][0], r), )
+                    word_ = free_group.dtype(word_)
                 word = word.eliminate_word(free_group.dtype(w), word_)
 
             if len(w) == 2 and w[1][1] > 0:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28637

#### Brief description of what is fixed or changed

The [collected_word](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/pc_groups.py:269:4-380:19) method in [Collector](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/combinatorics/pc_groups.py:41:0-706:20) class was dropping permutation size information when processing words with negative exponents that divide evenly by the generator's order (e.g., `x_i^(-k*order)`).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed `Collector.collected_word` dropping permutation size information for negative exponents. The method now preserves size by including zero-exponent terms when necessary.
<!-- END RELEASE NOTES -->