### PR TITLE
Add support for derivative and transpose of `FuncMatrix`

### DIFF
--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -116,3 +116,9 @@ class FunctionMatrix(MatrixExpr):
 
     def _eval_as_real_imag(self):
         return (re(Matrix(self)), im(Matrix(self)))
+
+    def _eval_transpose(self):
+        return FunctionMatrix(self.cols, self.rows, Lambda(self.lamda.variables[::-1], self.lamda.expr))
+
+    def _eval_derivative(self, x):
+        return FunctionMatrix(self.rows, self.cols, Lambda(self.lamda.variables, self.lamda.expr.diff(x)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR adds the tests and functionality for finding the transpose and derivative of a `FuncMatrix`. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Implemented lazy evaluation for transpose and derivative of FunctionMatrix.
<!-- END RELEASE NOTES -->
