### PR TITLE
Fix collected_word dropping permutation info for order multiples

### DIFF
--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -346,21 +346,30 @@ class Collector(DefaultPrinting):
             if len(w) == 1:
                 re = self.relative_order[self.index[s1]]
                 q = e1 // re
-                r = e1-q*re
+                r = e1 - q*re
 
                 key = ((w[0][0], re), )
                 key = free_group.dtype(key)
+
                 if self.pc_presentation[key]:
                     presentation = self.pc_presentation[key].array_form
                     sym, exp = presentation[0]
-                    word_ = ((w[0][0], r), (sym, q*exp))
-                    word_ = free_group.dtype(word_)
+
+                    if r != 0:
+                        word_ = ((w[0][0], r), (sym, q*exp))
+                        word_ = free_group.dtype(word_)
+                    elif q != 0:
+                        word_ = ((sym, q*exp), )
+                        word_ = free_group.dtype(word_)
+                    else:
+                        word_ = free_group.identity
                 else:
                     if r != 0:
                         word_ = ((w[0][0], r), )
                         word_ = free_group.dtype(word_)
                     else:
-                        word_ = None
+                        word_ = free_group.identity
+
                 word = word.eliminate_word(free_group.dtype(w), word_)
 
             if len(w) == 2 and w[1][1] > 0:

--- a/sympy/combinatorics/tests/test_pc_groups.py
+++ b/sympy/combinatorics/tests/test_pc_groups.py
@@ -85,3 +85,42 @@ def test_induced_pcgs():
         for i in ipcgs:
             m.append(collector.exponent_vector(i))
         assert Matrix(m).is_upper
+
+
+def test_collected_word_with_order_multiples():
+    from sympy.combinatorics import free_group
+
+    G = SymmetricGroup(4)
+    pc_group = G.polycyclic_group()
+    collector = pc_group.collector
+    pcgs = collector.pcgs
+    F, *gens = free_group(','.join([f'x{i}' for i in range(len(pcgs))]))
+
+    def perm_from_word(w):
+        if len(pcgs) > 0:
+            perm = Permutation(size=pcgs[0].size)
+        else:
+            perm = Permutation()
+        for sym, exp in w.array_form:
+            perm *= pcgs[int(sym.name[1:])] ** exp
+        return perm
+
+
+    test_cases = [
+        (gens[2] ** -2, "x2^-2 where x2 has order 2"),
+        (gens[2] ** 2, "x2^2 where x2 has order 2"),
+        (gens[2] ** -4, "x2^-4 where x2 has order 2"),
+        (gens[2] ** 4, "x2^4 where x2 has order 2"),
+        (gens[0] ** 4, "x0^4 where x0 has order 4"),
+        (gens[0] ** 8, "x0^8 where x0 has order 4"),
+        (gens[1] ** 3, "x1^3 where x1 has order 3"),
+        (gens[1] ** 6, "x1^6 where x1 has order 3"),
+        (gens[1] ** -3, "x1^-3 where x1 has order 3"),
+    ]
+
+    for word, description in test_cases:
+        word_perm = perm_from_word(word)
+        collected = collector.collected_word(word)
+        col_perm = perm_from_word(collected)
+        assert word_perm == col_perm, \
+            f"Failed for {description}: {word_perm} != {col_perm}"


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes https://github.com/sympy/sympy/issues/28637

#### Brief description of what is fixed or changed

Fixed a bug in `Collector.collected_word()` where words with exponents that are exact multiples of generator relative orders (e.g., `x^(k*order)`) were incorrectly returning `None`, causing loss of permutation information when converting back to group elements.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed `Collector.collected_word()` incorrectly dropping permutation information when exponents are multiples of generator relative orders. The method now correctly returns identity elements instead of `None`.
<!-- END RELEASE NOTES -->