### PR TITLE
Doc: enhance Matrix.rref() documentation with examples

### DIFF
--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -369,7 +369,7 @@ def _rref(
         pivots: bool = True,
         normalize_last: bool = True,
     ) -> Tmat | tuple[Tmat, tuple[int]]:
-    """Return reduced row-echelon form of matrix and indices
+        """Return reduced row-echelon form of matrix and indices
     of pivot vars.
 
     Parameters
@@ -401,11 +401,14 @@ def _rref(
 
     >>> from sympy import Matrix
     >>> from sympy.abc import x
+
+    # Basic usage
     >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
     >>> m.rref()
     (Matrix([
     [1, 0],
     [0, 1]]), (0, 1))
+
     >>> rref_matrix, rref_pivots = m.rref()
     >>> rref_matrix
     Matrix([
@@ -414,6 +417,35 @@ def _rref(
     >>> rref_pivots
     (0, 1)
 
+    # Example: simplify=True
+    >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
+    >>> m.rref(simplify=True)
+    (Matrix([
+    [1, 0],
+    [0, 1]]), (0, 1))
+
+    # Example: pivots=False (returns only the matrix)
+    >>> m = Matrix([[1, 2], [3, 4]])
+    >>> m.rref(pivots=False)
+    Matrix([
+    [1, 0],
+    [0, 1]])
+
+    # Example: iszerofunc for float matrices
+    >>> m = Matrix([[1.0, 2.0], [2.0, 4.0]])
+    >>> m.rref(iszerofunc=lambda v: abs(v) < 1e-8)
+    (Matrix([
+    [1.0, 2.0],
+    [0.0, 0.0]]), (0,))
+
+    # Example: normalize_last=False
+    >>> m = Matrix([[1, 2], [3, 4]])
+    >>> m.rref(normalize_last=False)
+    (Matrix([
+    [1, 0],
+    [0, 1]]), (0, 1))
+
+    # Example showing float rounding error correction (existing example)
     ``iszerofunc`` can correct rounding errors in matrices with float
     values. In the following example, calling ``rref()`` leads to
     floating point errors, incorrectly row reducing the matrix.
@@ -426,7 +458,7 @@ def _rref(
     [1, 0, 0, 0],
     [0, 1, 0, 0],
     [0, 0, 1, 0]]), (0, 1, 2))
-    >>> m.rref(iszerofunc=lambda x:abs(x)<1e-9)
+    >>> m.rref(iszerofunc=lambda x: abs(x) < 1e-9)
     (Matrix([
     [1, 0, -0.301369863013699, 0],
     [0, 1, -0.712328767123288, 0],
@@ -438,8 +470,9 @@ def _rref(
     The default value of ``normalize_last=True`` can provide significant
     speedup to row reduction, especially on matrices with symbols.  However,
     if you depend on the form row reduction algorithm leaves entries
-    of the matrix, set ``normalize_last=False``
+    of the matrix, set ``normalize_last=False``.
     """
+
     # Try to use DomainMatrix for ZZ or QQ
     dM = _to_DM_ZZ_QQ(M)
 


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Improved documentation for Matrix.rref() by adding examples for simplify,
    pivots, iszerofunc, and normalize_last.
<!-- END RELEASE NOTES -->
