### PR TITLE
FIX: Documentation build and link resolution 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -752,6 +752,8 @@ Ishan Joshi <ishanaj98@gmail.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <ishan9096137017@gmail.com>
+Ishita <66ishita@gmail.com> ishita <66ishita@gmail.com>
+Ishita <66ishita@gmail.com> project_1 <66ishita@gmail.com>
 Isidora Araya <iarayaday@gmail.com>
 Islam Mansour <is3mansour@gmail.com>
 Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 from datetime import datetime
 
-from intersphinx_registry import get_intersphinx_mapping
+#from intersphinx_registry import get_intersphinx_mapping
 
 
 # Make sure we import sympy from git
@@ -458,9 +458,11 @@ texinfo_documents = [
 graphviz_output_format = 'svg'
 
 # Enable links to other packages
-intersphinx_mapping = get_intersphinx_mapping(
-    packages={"matplotlib", "mpmath", "scipy", "numpy"},
-)
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None),
+"numpy": ("https://numpy.org/doc/stable/", None),
+"scipy": ("https://docs.scipy.org/doc/scipy/", None),
+"matplotlib": ("https://matplotlib.org/stable/", None),
+"mpmath": ("https://mpmath.org/doc/current/", None) ,}
 # Require :external: to reference intersphinx. Prevents accidentally linking
 # to something from matplotlib.
 intersphinx_disabled_reftypes = ['*']

--- a/doc/src/modules/simplify/fu.rst
+++ b/doc/src/modules/simplify/fu.rst
@@ -247,4 +247,4 @@ References
     https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=718d67a8d1ce0a23808c1cc265612f81977357e4
 
 .. [2] A formula sheet for trigonometric functions.
-    http://www.sosmath.com/trig/Trig5/trig5/pdf/pdf.html
+    https://www.mga.edu/computing/mathematics-statistics/docs/Math_Resources_Trigonometric_Formulas.pdf


### PR DESCRIPTION
<FIX: Correct mpmath intersphinx URL and resolve doc build warnings

#### reference to issue :- 24140

#### Brief description 

This PR resolves recurring documentation build warnings and external link failures related to the `mpmath` documentation. other than that it modified a link to a non working page to a relevent open source working page.


#### Other comments

This submission consists of a clean and focused commit. All extraneous file changes, mechanical link replacements, and temporary build artefacts have been removed to adhere to reviewer feedback .

This is a resubmission with inculcating previous feedback.

Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->


