### PR TITLE
DOC : Fix typo in basic docstring (Add, Mul, Pow -> Add, Mul, and Pow), (return -> Return) and a comma.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1757,6 +1757,7 @@ kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
+leastloris <ivedants05@gmail.com>
 luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
 luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@users.noreply.github.com>
 mao8 <thisisma08@gmail.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -86,10 +86,10 @@ ordering_of_classes = [
 ]
 
 def _cmp_name(x: type, y: type) -> int:
-    """return -1, 0, 1 if the name of x is before that of y.
+    """Return -1, 0, 1 if the name of x is before that of y.
     A string comparison is done if either name does not appear
     in `ordering_of_classes`. This is the helper for
-    ``Basic.compare``
+    ``Basic.compare``.
 
     Examples
     ========
@@ -134,7 +134,7 @@ def _cmp_name(x: type, y: type) -> int:
 
 @cacheit
 def _get_postprocessors(clsname, arg_type):
-    # Since only Add, Mul, Pow can be clsname, this cache
+    # Since only Add, Mul, and Pow can be clsname, this cache
     # is not quadratic.
     postprocessors = set()
     mappings = _get_postprocessors_for_type(arg_type)
@@ -184,7 +184,7 @@ class Basic(Printable):
     (x,)
 
 
-    3)  By "SymPy object" we mean something that can be returned by
+    3)  By "SymPy object", we mean something that can be returned by
         ``sympify``.  But not all objects one encounters using SymPy are
         subclasses of Basic.  For example, mutable objects are not:
 
@@ -212,7 +212,7 @@ class Basic(Printable):
     def __init_subclass__(cls):
         # Initialize the default_assumptions FactKB and also any assumptions
         # property methods. This method will only be called for subclasses of
-        # Basic but not for Basic itself so we call
+        # Basic but not for Basic itself, so we call
         # _prepare_class_assumptions(Basic) below the class definition.
         super().__init_subclass__()
         _prepare_class_assumptions(cls)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

