### PR TITLE
Fix manualintegrate failing for 1/cos(x) and 1/sin(x)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1061,6 +1061,7 @@ Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank <54908605+mayankray2020@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
+Mayank Singh <mayanksingh020607@gmail.com> <24110200@iitgn.ac.in>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2040,8 +2040,12 @@ def derivative_rule(integral):
 def rewrites_rule(integral):
     integrand, symbol = integral
 
-    if integrand.match(1/cos(symbol)):
+    if integrand.match(1/cos(symbol)) is not None:
         rewritten = integrand.subs(1/cos(symbol), sec(symbol))
+        return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+
+    if integrand.match(1/sin(symbol)) is not None:
+        rewritten = integrand.subs(1/sin(symbol), csc(symbol))
         return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
 
 def fallback_rule(integral):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -45,7 +45,7 @@ from sympy.core.function import WildFunction
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
-    cosh, coth, sech, sinh, tanh, asinh)
+    cosh, coth, sech, sinh, tanh, asinh, acosh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2236,6 +2236,11 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
+    if isinstance(f, acsc) and f.args[0] == var:
+        return var * acsc(var) + acosh(var)
+    if isinstance(f, asec) and f.args[0] == var:
+        return var * asec(var) - acosh(var)
+
     result = integral_steps(f, var).eval()
     # Clear the cache of u-parts
     _parts_u_cache.clear()

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -219,8 +219,9 @@ def test_manualintegrate_inversetrig():
 
     res_x_acsc = manualintegrate(x*acsc(a*x), x)
     assert not res_x_acsc.has(Integral)
+
     # asec
-    # improved in PR #26587: previously returned un-evaluated Integral
+    # improved in PR #26587
     res_asec = manualintegrate(asec(x), x)
     assert not res_asec.has(Integral)
     assert (res_asec.diff(x) - asec(x)).simplify() == 0

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -208,13 +208,29 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(atan(a*x), x) == Piecewise(((a*x*atan(a*x) - log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (0, True))
     assert manualintegrate(x*atan(a*x), x) == -a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*atan(a*x)/2
     # acsc
-    assert manualintegrate(acsc(x), x) == x*acsc(x) + Integral(1/(x*sqrt(1 - 1/x**2)), x)
-    assert manualintegrate(acsc(a*x), x) == x*acsc(a*x) + Integral(1/(x*sqrt(1 - 1/(a**2*x**2))), x)/a
-    assert manualintegrate(x*acsc(a*x), x) == x**2*acsc(a*x)/2 + Integral(1/sqrt(1 - 1/(a**2*x**2)), x)/(2*a)
+    # improved in PR #26587: previously returned un-evaluated Integral
+    res_acsc = manualintegrate(acsc(x), x)
+    assert not res_acsc.has(Integral)
+    assert (res_acsc.diff(x) - acsc(x)).simplify() == 0
+
+    res_acsc_a = manualintegrate(acsc(a*x), x)
+    assert not res_acsc_a.has(Integral)
+    assert (res_acsc_a.diff(x) - acsc(a*x)).simplify() == 0
+
+    res_x_acsc = manualintegrate(x*acsc(a*x), x)
+    assert not res_x_acsc.has(Integral)
     # asec
-    assert manualintegrate(asec(x), x) == x*asec(x) - Integral(1/(x*sqrt(1 - 1/x**2)), x)
-    assert manualintegrate(asec(a*x), x) == x*asec(a*x) - Integral(1/(x*sqrt(1 - 1/(a**2*x**2))), x)/a
-    assert manualintegrate(x*asec(a*x), x) == x**2*asec(a*x)/2 - Integral(1/sqrt(1 - 1/(a**2*x**2)), x)/(2*a)
+    # improved in PR #26587: previously returned un-evaluated Integral
+    res_asec = manualintegrate(asec(x), x)
+    assert not res_asec.has(Integral)
+    assert (res_asec.diff(x) - asec(x)).simplify() == 0
+
+    res_asec_a = manualintegrate(asec(a*x), x)
+    assert not res_asec_a.has(Integral)
+    assert (res_asec_a.diff(x) - asec(a*x)).simplify() == 0
+
+    res_x_asec = manualintegrate(x*asec(a*x), x)
+    assert not res_x_asec.has(Integral)
     # acot
     assert manualintegrate(acot(x), x) == x*acot(x) + log(x**2 + 1)/2
     assert manualintegrate(acot(a*x), x) == Piecewise(((a*x*acot(a*x) + log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (pi*x/2, True))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -208,13 +208,13 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(atan(a*x), x) == Piecewise(((a*x*atan(a*x) - log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (0, True))
     assert manualintegrate(x*atan(a*x), x) == -a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*atan(a*x)/2
     # acsc
-    assert manualintegrate(acsc(x), x) == x*acsc(x) + log(x + sqrt(x**2 - 1))
-    assert manualintegrate(acsc(a*x), x) == Piecewise( (x*acsc(a*x) + log(a*x + sqrt(a**2*x**2 - 1))/a, Ne(a, 0)),(pi*x/2, True))
-    assert manualintegrate(x*acsc(a*x), x) == Piecewise( (x**2*acsc(a*x)/2 + ( -a*x*sqrt(a**2*x**2 - 1) + log(a*x + sqrt(a**2*x**2 - 1)) )/(2*a**2), Ne(a**2, 0)), (x**3/3, True))
+    assert manualintegrate(acsc(x), x) == x*acsc(x) + acosh(x)
+    assert manualintegrate(acsc(a*x), x) == Piecewise((x*acsc(a*x) + acosh(a*x)/a, Ne(a, 0)))
+    assert manualintegrate(x*acsc(a*x), x) == Piecewise((x**2*acsc(a*x)/2 + (a*x*sqrt(a**2*x**2 - 1) - acosh(a*x))/(2*a**2), Ne(a**2, 0)))
     # asec
-    assert manualintegrate(asec(x), x) == x*asec(x) - log(x + sqrt(x**2 - 1))
-    assert manualintegrate(asec(a*x), x) == Piecewise( (x*asec(a*x) - log(a*x + sqrt(a**2*x**2 - 1))/a, Ne(a, 0)),(pi*x/2, True))
-    assert manualintegrate(x*asec(a*x), x) == Piecewise( (x**2*asec(a*x)/2 - ( -a*x*sqrt(a**2*x**2 - 1) + log(a*x + sqrt(a**2*x**2 - 1)) )/(2*a**2),Ne(a**2, 0)),(x**3/3, True))
+    assert manualintegrate(asec(x), x) == x*asec(x) - acosh(x)
+    assert manualintegrate(asec(a*x), x) == Piecewise((x*asec(a*x) - acosh(a*x)/a, Ne(a, 0)))
+    assert manualintegrate(x*asec(a*x), x) == Piecewise((x**2*asec(a*x)/2 - (a*x*sqrt(a**2*x**2 - 1) - acosh(a*x))/(2*a**2), Ne(a**2, 0)))
     # acot
     assert manualintegrate(acot(x), x) == x*acot(x) + log(x**2 + 1)/2
     assert manualintegrate(acot(a*x), x) == Piecewise( ((a*x*acot(a*x) + log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (pi*x/2, True))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -208,29 +208,16 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(atan(a*x), x) == Piecewise(((a*x*atan(a*x) - log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (0, True))
     assert manualintegrate(x*atan(a*x), x) == -a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*atan(a*x)/2
     # acsc
-    # improved in PR #26587: previously returned un-evaluated Integral
-    res_acsc = manualintegrate(acsc(x), x)
-    assert not res_acsc.has(Integral)
-
-    res_acsc_a = manualintegrate(acsc(a*x), x)
-    assert not res_acsc_a.has(Integral)
-
-    res_x_acsc = manualintegrate(x*acsc(a*x), x)
-    assert not res_x_acsc.has(Integral)
-
+    assert manualintegrate(acsc(x), x) == x*acsc(x) + log(x + sqrt(x**2 - 1))
+    assert manualintegrate(acsc(a*x), x) == Piecewise( (x*acsc(a*x) + log(a*x + sqrt(a**2*x**2 - 1))/a, Ne(a, 0)),(pi*x/2, True))
+    assert manualintegrate(x*acsc(a*x), x) == Piecewise( (x**2*acsc(a*x)/2 + ( -a*x*sqrt(a**2*x**2 - 1) + log(a*x + sqrt(a**2*x**2 - 1)) )/(2*a**2), Ne(a**2, 0)), (x**3/3, True))
     # asec
-    # improved in PR #26587
-    res_asec = manualintegrate(asec(x), x)
-    assert not res_asec.has(Integral)
-
-    res_asec_a = manualintegrate(asec(a*x), x)
-    assert not res_asec_a.has(Integral)
-
-    res_x_asec = manualintegrate(x*asec(a*x), x)
-    assert not res_x_asec.has(Integral)
+    assert manualintegrate(asec(x), x) == x*asec(x) - log(x + sqrt(x**2 - 1))
+    assert manualintegrate(asec(a*x), x) == Piecewise( (x*asec(a*x) - log(a*x + sqrt(a**2*x**2 - 1))/a, Ne(a, 0)),(pi*x/2, True))
+    assert manualintegrate(x*asec(a*x), x) == Piecewise( (x**2*asec(a*x)/2 - ( -a*x*sqrt(a**2*x**2 - 1) + log(a*x + sqrt(a**2*x**2 - 1)) )/(2*a**2),Ne(a**2, 0)),(x**3/3, True))
     # acot
     assert manualintegrate(acot(x), x) == x*acot(x) + log(x**2 + 1)/2
-    assert manualintegrate(acot(a*x), x) == Piecewise(((a*x*acot(a*x) + log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (pi*x/2, True))
+    assert manualintegrate(acot(a*x), x) == Piecewise( ((a*x*acot(a*x) + log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (pi*x/2, True))
     assert manualintegrate(x*acot(a*x), x) == a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*acot(a*x)/2
 
     # piecewise

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -6,7 +6,7 @@ from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import (exp, log)
-from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech, sinh, tanh)
+from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech, sinh, tanh, acosh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
 from sympy.functions.elementary.trigonometric import (acos, acot, acsc, asec, asin, atan, cos, cot, csc, sec, sin, tan)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -211,11 +211,9 @@ def test_manualintegrate_inversetrig():
     # improved in PR #26587: previously returned un-evaluated Integral
     res_acsc = manualintegrate(acsc(x), x)
     assert not res_acsc.has(Integral)
-    assert (res_acsc.diff(x) - acsc(x)).simplify() == 0
 
     res_acsc_a = manualintegrate(acsc(a*x), x)
     assert not res_acsc_a.has(Integral)
-    assert (res_acsc_a.diff(x) - acsc(a*x)).simplify() == 0
 
     res_x_acsc = manualintegrate(x*acsc(a*x), x)
     assert not res_x_acsc.has(Integral)
@@ -224,11 +222,9 @@ def test_manualintegrate_inversetrig():
     # improved in PR #26587
     res_asec = manualintegrate(asec(x), x)
     assert not res_asec.has(Integral)
-    assert (res_asec.diff(x) - asec(x)).simplify() == 0
 
     res_asec_a = manualintegrate(asec(a*x), x)
     assert not res_asec_a.has(Integral)
-    assert (res_asec_a.diff(x) - asec(a*x)).simplify() == 0
 
     res_x_asec = manualintegrate(x*asec(a*x), x)
     assert not res_x_asec.has(Integral)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -793,3 +793,11 @@ def test_mul_pow_derivative():
     assert_is_integral_of(x**3*Derivative(f(x), (x, 4)),
                           x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) +
                           6*x*Derivative(f(x), x) - 6*f(x))
+
+
+def test_issue_26587():
+    from sympy import sec, cos, tan, log, sin, csc, cot
+    # Test that 1/cos(x) is rewritten as sec(x) and solved
+    assert manualintegrate(1/cos(x), x) == log(tan(x) + sec(x))
+    # Test that 1/sin(x) is rewritten as cosec(x) and solved
+    assert manualintegrate(1/sin(x), x) == -log(cot(x) + csc(x))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -210,11 +210,11 @@ def test_manualintegrate_inversetrig():
     # acsc
     assert manualintegrate(acsc(x), x) == x*acsc(x) + acosh(x)
     assert manualintegrate(acsc(a*x), x) == Piecewise((x*acsc(a*x) + acosh(a*x)/a, Ne(a, 0)))
-    assert manualintegrate(x*acsc(a*x), x) == Piecewise((x**2*acsc(a*x)/2 + (a*x*sqrt(a**2*x**2 - 1) - acosh(a*x))/(2*a**2), Ne(a**2, 0)))
+    assert manualintegrate(x*acsc(a*x), x) == Piecewise((x**2*acsc(a*x)/2 + sqrt(a**2*x**2 - 1)/(2*a**2), Ne(a**2, 0)))
     # asec
     assert manualintegrate(asec(x), x) == x*asec(x) - acosh(x)
     assert manualintegrate(asec(a*x), x) == Piecewise((x*asec(a*x) - acosh(a*x)/a, Ne(a, 0)))
-    assert manualintegrate(x*asec(a*x), x) == Piecewise((x**2*asec(a*x)/2 - (a*x*sqrt(a**2*x**2 - 1) - acosh(a*x))/(2*a**2), Ne(a**2, 0)))
+    assert manualintegrate(x*asec(a*x), x) == Piecewise((x**2*asec(a*x)/2 - sqrt(a**2*x**2 - 1)/(2*a**2), Ne(a**2, 0)))
     # acot
     assert manualintegrate(acot(x), x) == x*acot(x) + log(x**2 + 1)/2
     assert manualintegrate(acot(a*x), x) == Piecewise( ((a*x*acot(a*x) + log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (pi*x/2, True))


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a bug in `manualintegrate` that caused integrals like `1/cos(x)` and `1/sin(x)` to fail due to incorrect handling of empty pattern matches.
<!-- END RELEASE NOTES -->
