### PR TITLE
Fix nonlinsolve KeyError with trivially true equations

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -4100,7 +4100,7 @@ def nonlinsolve(system, *symbols):
 
     # to_tuple converts a solution dictionary to a tuple containing the
     # value for each symbol
-    to_tuple = lambda sol: tuple(sol[s] for s in symbols)
+    to_tuple = lambda sol: tuple(sol.get(s, s) for s in symbols)
 
     if not remaining:
         # If there is nothing left to solve then return the solution from

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1852,6 +1852,10 @@ def test_nonlinsolve_basic():
     assert nonlinsolve([x**2 -1], sin(x)) == FiniteSet((S.EmptySet,))
     assert nonlinsolve([x**2 -1], 1) == FiniteSet((x**2,))
     assert nonlinsolve([x**2 -1], x + y) == FiniteSet((S.EmptySet,))
+    assert nonlinsolve([0], [x, y]) == FiniteSet((x, y))
+    assert nonlinsolve([0, 0], [x, y]) == FiniteSet((x, y))
+    assert nonlinsolve([S.Zero], [x, y]) == FiniteSet((x, y))
+    assert nonlinsolve([0], [x, y, z]) == FiniteSet((x, y, z))
     assert nonlinsolve([Eq(1, x + y), Eq(1, -x + y - 1), Eq(1, -x + y - 1)], x, y) == FiniteSet(
         (-S.Half, 3*S.Half))
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes https://github.com/sympy/sympy/issues/28706

#### Brief description of what is fixed or changed

Fixed a `KeyError` in [nonlinsolve()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4130:27) when given trivially true equations (like `0 = 0`) with multiple variables.

**Problem:** When all equations are trivially true, [_separate_poly_nonpoly()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3770:0-3803:67) skips them (line 3797-3798), leaving `poly_sol = [{}]`. The `to_tuple` lambda at line 4103 tried `{}[x]`, causing `KeyError`.

**Testing:**
- Before: [nonlinsolve([0], [x, y])](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4130:27) → `KeyError: x`
- After: [nonlinsolve([0], [x, y])](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4130:27) → `{(x, y)}`

Added test cases for trivially true equations with 2+ variables. Behavior now consistent with [linsolve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:2895:0-3167:14).


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed `KeyError` in [nonlinsolve()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4130:27) when given trivially true equations with multiple variables. Now returns correct solution set.
<!-- END RELEASE NOTES -->