### PR TITLE
NT: Implemented Chinese Remainder Theorem for Vectors (#18428)

### DIFF
--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -22,6 +22,24 @@ def symmetric_residue(a, m):
 
 
 def crt(m, v, symmetric=False, check=True):
+    # Check if we are given vectors (lists) instead of numbers
+    if isinstance(v[0], (list, tuple)):
+        results = []
+        mm = None
+        
+        # Loop through each dimension of the vector (Column 0, Column 1...)
+        for i in range(len(v[0])):
+            # Extract the i-th number from each remainder list
+            column_v = [row[i] for row in v]
+            
+            # recursive call: Solve CRT for this specific column
+            res, modulus = crt(m, column_v, symmetric, check)
+            
+            results.append(res)
+            mm = modulus
+            
+        return results, mm
+    
     r"""Chinese Remainder Theorem.
 
     The moduli in m are assumed to be pairwise coprime.  The output


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18428

#### Brief description of what is fixed or changed
I have extended the `crt` function in `sympy.ntheory.modular` to support lists and tuples as input. Previously, passing a list would raise a TypeError. Now, the function iterates over the list elements and applies the Chinese Remainder Theorem element-wise.

#### Other comments
I have verified this locally using a reproduction script. The implementation correctly handles recursion for vectors/lists.

#### Release Notes

* ntheory
  * Extended `crt` (Chinese Remainder Theorem) to accept lists and tuples, allowing element-wise calculation for vectors.