### PR TITLE
Fix nonlinsolve returning wrong results for non-zero constants

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3731,6 +3731,8 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
 
 def _solveset_work(system, symbols):
     soln = solveset(system[0], symbols[0])
+    if soln == S.EmptySet:
+        return S.EmptySet
     if isinstance(soln, FiniteSet):
         _soln = FiniteSet(*[(s,) for s in soln])
         return _soln
@@ -3794,7 +3796,7 @@ def _separate_poly_nonpoly(system, symbols):
         if isinstance(eq, Expr):
             eq = eq.as_numer_denom()[0]
             poly = eq.as_poly(*symbols, extension=True)
-        elif simplify(eq).is_number:
+        elif eq == 0:
             continue
         if poly is not None:
             polys.append(poly)
@@ -4068,6 +4070,7 @@ def nonlinsolve(system, *symbols):
         raise IndexError(filldedent(msg))
 
     symbols = list(map(_sympify, symbols))
+    system = [_sympify(eq) for eq in system]
     system, symbols, swap = recast_to_symbols(system, symbols)
     if swap:
         soln = nonlinsolve(system, symbols)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1848,10 +1848,15 @@ def test_nonlinsolve_basic():
     assert nonlinsolve([f(x), 0], f(x), f(y)) == FiniteSet((0, f(y)))
     A = Indexed('A', x)
     assert nonlinsolve([A, 0], A, y) == FiniteSet((0, y))
-    assert nonlinsolve([x**2 -1], [sin(x)]) == FiniteSet((S.EmptySet,))
-    assert nonlinsolve([x**2 -1], sin(x)) == FiniteSet((S.EmptySet,))
+    assert nonlinsolve([x**2 -1], [sin(x)]) == S.EmptySet
+    assert nonlinsolve([x**2 -1], sin(x)) == S.EmptySet
     assert nonlinsolve([x**2 -1], 1) == FiniteSet((x**2,))
-    assert nonlinsolve([x**2 -1], x + y) == FiniteSet((S.EmptySet,))
+    assert nonlinsolve([x**2 -1], x + y) == S.EmptySet
+    assert nonlinsolve([1], [x]) == S.EmptySet
+    assert nonlinsolve([5], [x, y]) == S.EmptySet
+    assert nonlinsolve([-1], [x, y]) == S.EmptySet
+    assert nonlinsolve([Rational(1, 2)], [x]) == S.EmptySet
+    assert nonlinsolve([sqrt(2)], [x]) == S.EmptySet
     assert nonlinsolve([0], [x, y]) == FiniteSet((x, y))
     assert nonlinsolve([0, 0], [x, y]) == FiniteSet((x, y))
     assert nonlinsolve([S.Zero], [x, y]) == FiniteSet((x, y))
@@ -3498,7 +3503,7 @@ def test_issue_19144():
     soln_eq2 = nonlinsolve(eq2, [x, y])
     assert soln_eq2 == soln_expr2 == soln2
     # denominators that cancel in expression
-    assert nonlinsolve([Eq(x + 1/x, 1/x)], [x]) == FiniteSet((S.EmptySet,))
+    assert nonlinsolve([Eq(x + 1/x, 1/x)], [x]) == S.EmptySet
 
 
 def test_issue_22413():


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/28713

#### Brief description of what is fixed or changed

Fixed [nonlinsolve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4142:27) to correctly return `EmptySet` for non-zero constant equations (e.g., `1 = 0`, `5 = 0`) which are always false.

Previously:
- [nonlinsolve([1], [x])](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4142:27) returned `{(EmptySet,)}`
- [nonlinsolve([5], [x, y])](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4142:27) returned `{(x, y)}`

Now both correctly return `EmptySet`, consistent with [linsolve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:2895:0-3167:14) behavior.

Added checks in two code paths (single and multi-variable) and 5 test cases covering integers, rationals, and irrationals.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed [nonlinsolve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3898:0-4142:27) returning incorrect results for non-zero constant equations. Now correctly returns `EmptySet` for equations like `5 = 0`.
<!-- END RELEASE NOTES -->