### PR TITLE
Fix issue #28721: Ensure Sum of Matrix over empty range returns ZeroM…

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -343,7 +343,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         return Sum(f, (k, upper + 1, new_upper)).doit()
 
     def _eval_simplify(self, **kwargs):
-        
+
         if (self.has_empty_sequence and self.function.is_Matrix):
             from sympy.matrices.expressions import ZeroMatrix
             return ZeroMatrix(*self.function.shape)

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -189,7 +189,12 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # cancel out. This only answers whether the summand is zero; if
         # not then None is returned since we don't analyze whether all
         # terms cancel out.
-        if self.function.is_zero or self.has_empty_sequence:
+        if self.function.is_zero:
+            return True
+        # Seperated the checks due to it being skipping simplify function.
+        if self.has_empty_sequence:
+            if self.function.is_Matrix:
+                return None
             return True
 
     def _eval_is_extended_real(self):
@@ -338,6 +343,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         return Sum(f, (k, upper + 1, new_upper)).doit()
 
     def _eval_simplify(self, **kwargs):
+        
+        if (self.has_empty_sequence and self.function.is_Matrix):
+            from sympy.matrices.expressions import ZeroMatrix
+            return ZeroMatrix(*self.function.shape)
 
         function = self.function
 
@@ -1667,6 +1676,10 @@ def _eval_matrix_sum(expression):
         i, a, b = limit
         dif = b - a
         if dif.is_Integer:
+            if (dif == -1):
+                from sympy.matrices.expressions import ZeroMatrix
+                return ZeroMatrix(*f.shape)
+
             if (dif < 0) == True:
                 a, b = b + 1, a - 1
                 f = -f

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1693,3 +1693,16 @@ def test_issue_23952():
     expr = Sum(abs(k1 - k2)*p**k1 *(1 - q)**(n - k2),
         (k1, 0, n), (k2, 0, n))
     assert expr.subs(p,0).subs(q,1).subs(n, 3).doit() == 3
+
+def test_issue_28721():
+    from sympy import MatrixSymbol, Sum, ZeroMatrix
+    from sympy.abc import i
+    
+    M = MatrixSymbol("M", 3, 3)
+    expr = Sum(M, (i, 0, -1))
+    
+    # Test doit()
+    assert expr.doit() == ZeroMatrix(3, 3)
+    
+    # Test simplify()
+    assert expr.simplify() == ZeroMatrix(3, 3)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1697,7 +1697,7 @@ def test_issue_23952():
 def test_issue_28721():
     from sympy import MatrixSymbol, Sum, ZeroMatrix
     from sympy.abc import i
-    
+
     M = MatrixSymbol("M", 3, 3)
     expr = Sum(M, (i, 0, -1))
     


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28721

#### Brief description of what is fixed or changed
Previously, summing a MatrixSymbol over an empty range (e.g., `Sum(M, (i, 0, -1))`) returned a scalar `0` (`S.Zero`). This PR ensures it returns a `ZeroMatrix` of the correct shape.

The fix involves:
1. Updating `_eval_matrix_sum` in `summations.py` to handle the `dif == -1` case explicitly.
2. Updating `_eval_is_zero` to return `None` (instead of `True`) for Matrices with empty sequences, ensuring `simplify()` delegates to `doit()` rather than returning a scalar zero.

#### Other comments
Added a regression test in `sympy/concrete/tests/test_sums_products.py` verifying that both `doit()` and `simplify()` now return `ZeroMatrix`.

<!-- BEGIN RELEASE NOTES -->

#### Release Notes

* concrete
  * Fixed a bug where summation of a matrix over an empty range returned scalar `0` instead of `ZeroMatrix`.
