### PR TITLE
ILT(LT(f(t), t, s), s, t) now returns f(t)*Heaviside(t)

### DIFF
--- a/sympy/integrals/laplace.py
+++ b/sympy/integrals/laplace.py
@@ -2031,11 +2031,27 @@ def _inverse_laplace_irrational(fn, s, t, plane):
 
 
 @DEBUG_WRAP
+def _inverse_laplace_laplace(fn, s, t, plane):
+    """
+    Helper function for the class InverseLaplaceTransform.
+    """
+
+    if not fn.func == LaplaceTransform:
+        return None
+    _f, _t, _s = fn.args
+    if _s == s:
+        return _f.subs(_t, t)*Heaviside(t), S.true
+    else:
+        return None
+
+
+@DEBUG_WRAP
 def _inverse_laplace_early_prog_rules(F, s, t, plane):
     """
     Helper function for the class InverseLaplaceTransform.
     """
-    prog_rules = [_inverse_laplace_irrational]
+    prog_rules = [
+        _inverse_laplace_laplace, _inverse_laplace_irrational]
 
     for p_rule in prog_rules:
         if (r := p_rule(F, s, t, plane)) is not None:

--- a/sympy/integrals/tests/test_laplace.py
+++ b/sympy/integrals/tests/test_laplace.py
@@ -512,7 +512,7 @@ def test_laplace_transform_exp_2t2():
 @slow
 def test_inverse_laplace_transform():
     s = symbols('s')
-    k, n, t = symbols('k, n, t', real=True)
+    k, n, t, x = symbols('k, n, t, x', real=True)
     a, b, c, d = symbols('a, b, c, d', positive=True)
     f = Function('f')
     F = Function('F')
@@ -526,6 +526,14 @@ def test_inverse_laplace_transform():
     def ILTF(g):
         return laplace_correspondence(
             inverse_laplace_transform(g, s, t), {f: F})
+
+    # Tests for the inverse Laplace transform of a Laplace transform
+    assert (inverse_laplace_transform(LaplaceTransform(f(t), t, s), s, t) ==
+            f(t)*Heaviside(t))
+    assert (inverse_laplace_transform(LaplaceTransform(f(t), t, s), s, x) ==
+            f(x)*Heaviside(x))
+    assert (inverse_laplace_transform(LaplaceTransform(f(t), t, s), x, t) ==
+            LaplaceTransform(f(t), t, s)*DiracDelta(t))
 
     # Tests for the rules in Bateman54.
 


### PR DESCRIPTION
#### References to other Issues or PRs
Partial fix of #28720

#### Brief description of what is fixed or changed
Added code such that ILT(LT(f(t), t, s), s, t) now returns f(t)*Heaviside(t), as well as three test cases.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
- integrals
  - transforms: LaplaceTransform: ILT(LT(f(t), t, s), s, t) now returns f(t)*Heaviside(t)
<!-- END RELEASE NOTES -->
