### PR TITLE
Added regression testing for vector printing with fractions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -810,6 +810,7 @@ Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
+Jay Vijan <jvijan@umich.edu> Jay Sun Vijan <145924415+jvijan@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
 Jean-François B <2589111+jfbu@users.noreply.github.com>

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -359,31 +359,73 @@ def test_issue_12157():
     Test for proper pretty printing of vectors with fractions involved.
     """
 
-    d1 = (a/b) * (N.x | N.y)
+    first_test = (a/b) * (N.x | N.y)
 
-    result = ascii_vpretty(d1)
+    expected = '''\
+/a\\          \n\
+|-| (n_x|n_y)\n\
+\\b/          \
+'''    
+    uexpected = '''\
+⎛a⎞          \n\
+|-| (n_x⊗n_y)\n\
+⎝b⎠          \
+    '''
 
-    # a, b, and the basis dyad (n_x|n_y) should appear in the output
-    assert result == "a\n-\nb n_x|n_y"
+    assert ascii_vpretty(first_test) == expected
+    assert unicode_vpretty(first_test) == uexpected
 
-    # More complex case: fraction with sum in numerator
-    d2 = ((a + b)/c) * (N.x | N.y)
+    second_test = ((a + b)/c) * (N.x | N.y)
 
-    result2 = ascii_vpretty(d2)
+    expected = '''\
+/a + b\\          \n\
+|-----| (n_x|n_y)\n\
+\\  c  /           \
+'''
+    uexpected = '''\
+⎛a + b⎞          \n\
+|-----| (n_x⊗n_y)\n\
+⎝  c  ⎠          \
+'''
+    
+    assert ascii_vpretty(second_test) == expected
+    assert unicode_vpretty(second_test) == uexpected
 
-    # Basis dyad should still be present
-    assert result2 == "a + b\n-----\n  c   n_x|n_y"
 
-    # Multiple terms with fractions
-    d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
+    third_test = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
 
-    result3 = ascii_vpretty(d3)
+    expected ='''\
+/a\\             /c\\          \n\
+|-| (n_x|n_y) + |-| (n_y|n_z)\n\
+\\b/             \\b/          \
+'''
+    uexpected ='''\
+⎛a⎞             ⎛c⎞          \n\
+|-| (n_x⊗n_y) + |-| (n_y⊗n_z)\n\
+⎝b⎠             ⎝b⎠          \
+'''
 
-    assert result3 == "a\n-\nb n_x|n_y + c\n-\nb n_y|n_z"
+    assert ascii_vpretty(third_test) == expected
+    assert unicode_vpretty(third_test) == uexpected
 
-    # Test More complex case
     d = symbols('d')
-    vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
+    # This case comes from the correct output example provided by @faze-geek in the issue
+    fourth_test = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
 
-    result_vv = ascii_vpretty(vv)
-    assert result_vv =="d n_x|n_z +  2  2      2        \na *c  + a*b  + b*c*d\n--------------------\n       b + c         n_y|n_y"
+    expected = """\
+                / 2  2      2       \\          \n\
+(d) (n_x|n_z) + |a *c  + a*b + b*c*d| (n_y|n_y)\n\
+                |-------------------|          \n\
+                \\       b + c       /          \
+"""
+    uexpected = """\
+                ⎛ 2  2      2       ⎞          \n\
+(d) (n_x⊗n_z) + |a *c  + a*b + b*c*d| (n_y⊗n_y)\n\
+                |-------------------|          \n\
+                ⎝       b + c       ⎠          \
+"""
+
+    assert ascii_vpretty(fourth_test) == expected
+    assert unicode_vpretty(fourth_test) == uexpected
+    
+    

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -10,6 +10,7 @@ from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint,
 
 
 a, b, c = symbols('a, b, c')
+
 alpha, omega, beta = dynamicsymbols('alpha, omega, beta')
 
 A = ReferenceFrame('A')
@@ -351,3 +352,55 @@ def test_issue_14041():
         r"\left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
     assert vlatex((phid*thetad)**a*A_frame.x) == \
         r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"
+
+        
+def test_issue_12157():
+    
+    d1 = (a/b) * (N.x | N.y)
+    
+    result = ascii_vpretty(d1)
+    print(f"Result for (a/b)*(N.x|N.y):\n{result}")
+    
+    # The basis dyad (n_x|n_y) should appear in the output
+    assert 'n_x|n_y' in result or 'n_x' in result, \
+        f"Basis dyad missing or malformed in output: {result}"
+    
+    # Both 'a' and 'b' should be in the output
+    assert 'a' in result and 'b' in result, \
+        f"Fraction components missing: {result}"
+    
+    # More complex case: fraction with sum in numerator
+    d2 = ((a + b)/c) * (N.x | N.y)
+    
+    result2 = ascii_vpretty(d2)
+    print(f"\nResult for ((a+b)/c)*(N.x|N.y):\n{result2}")
+    
+    # Basis dyad should still be present
+    assert 'n_x|n_y' in result2 or 'n_x' in result2, \
+        f"Basis dyad missing in output: {result2}"
+    
+    # Multiple terms with fractions
+    d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
+    
+    result3 = ascii_vpretty(d3)
+    print(f"\nResult for (a/b)*(N.x|N.y) + (c/b)*(N.y|N.z):\n{result3}")
+    
+    # Both basis dyads should appear
+    lines = result3.split('\n')
+    full_text = ' '.join(lines)
+    
+    assert 'n_x' in full_text and 'n_y' in full_text, \
+        f"Basis vectors missing from output: {result3}"
+    
+    # Test the complex case from vv
+    d = symbols('d')
+    vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
+    
+    result_vv = ascii_vpretty(vv)
+    print(f"\nResult for vv:\n{result_vv}")
+    
+    # Both dyadic products should appear in output
+    assert 'n_x' in result_vv and 'n_z' in result_vv, \
+        f"First dyadic basis missing: {result_vv}"
+    assert 'n_y|n_y' in result_vv or result_vv.count('n_y') >= 2, \
+        f"Second dyadic basis missing or malformed: {result_vv}"

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -355,52 +355,35 @@ def test_issue_14041():
 
         
 def test_issue_12157():
+    """
+    Test for proper pretty printing of vectors with fractions involved.
+    """
     
     d1 = (a/b) * (N.x | N.y)
     
     result = ascii_vpretty(d1)
-    print(f"Result for (a/b)*(N.x|N.y):\n{result}")
     
-    # The basis dyad (n_x|n_y) should appear in the output
-    assert 'n_x|n_y' in result or 'n_x' in result, \
-        f"Basis dyad missing or malformed in output: {result}"
-    
-    # Both 'a' and 'b' should be in the output
-    assert 'a' in result and 'b' in result, \
-        f"Fraction components missing: {result}"
+    # a, b, and the basis dyad (n_x|n_y) should appear in the output
+    assert result == "a\n-\nb n_x|n_y"
     
     # More complex case: fraction with sum in numerator
     d2 = ((a + b)/c) * (N.x | N.y)
     
     result2 = ascii_vpretty(d2)
-    print(f"\nResult for ((a+b)/c)*(N.x|N.y):\n{result2}")
     
     # Basis dyad should still be present
-    assert 'n_x|n_y' in result2 or 'n_x' in result2, \
-        f"Basis dyad missing in output: {result2}"
+    assert result2 == "a + b\n-----\n  c   n_x|n_y"
     
     # Multiple terms with fractions
     d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
     
     result3 = ascii_vpretty(d3)
-    print(f"\nResult for (a/b)*(N.x|N.y) + (c/b)*(N.y|N.z):\n{result3}")
     
-    # Both basis dyads should appear
-    lines = result3.split('\n')
-    full_text = ' '.join(lines)
+    assert result3 == "a\n-\nb n_x|n_y + c\n-\nb n_y|n_z"
     
-    assert 'n_x' in full_text and 'n_y' in full_text, \
-        f"Basis vectors missing from output: {result3}"
-    
-    # Test the complex case from vv
+    # Test More complex case
     d = symbols('d')
     vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
     
     result_vv = ascii_vpretty(vv)
-    print(f"\nResult for vv:\n{result_vv}")
-    
-    # Both dyadic products should appear in output
-    assert 'n_x' in result_vv and 'n_z' in result_vv, \
-        f"First dyadic basis missing: {result_vv}"
-    assert 'n_y|n_y' in result_vv or result_vv.count('n_y') >= 2, \
-        f"Second dyadic basis missing or malformed: {result_vv}"
+    assert result_vv =="d n_x|n_z +  2  2      2        \na *c  + a*b  + b*c*d\n--------------------\n       b + c         n_y|n_y"

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -353,37 +353,37 @@ def test_issue_14041():
     assert vlatex((phid*thetad)**a*A_frame.x) == \
         r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"
 
-        
+
 def test_issue_12157():
     """
     Test for proper pretty printing of vectors with fractions involved.
     """
-    
+
     d1 = (a/b) * (N.x | N.y)
-    
+
     result = ascii_vpretty(d1)
-    
+
     # a, b, and the basis dyad (n_x|n_y) should appear in the output
     assert result == "a\n-\nb n_x|n_y"
-    
+
     # More complex case: fraction with sum in numerator
     d2 = ((a + b)/c) * (N.x | N.y)
-    
+
     result2 = ascii_vpretty(d2)
-    
+
     # Basis dyad should still be present
     assert result2 == "a + b\n-----\n  c   n_x|n_y"
-    
+
     # Multiple terms with fractions
     d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
-    
+
     result3 = ascii_vpretty(d3)
-    
+
     assert result3 == "a\n-\nb n_x|n_y + c\n-\nb n_y|n_z"
-    
+
     # Test More complex case
     d = symbols('d')
     vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
-    
+
     result_vv = ascii_vpretty(vv)
     assert result_vv =="d n_x|n_z +  2  2      2        \na *c  + a*b  + b*c*d\n--------------------\n       b + c         n_y|n_y"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#12157 Regression Testing


#### Brief description of what is fixed or changed

Added regression testing for the above issue, testing different vectors with fractions and how they are pretty printed.

#### Other comments



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * Added regression testing for a previous bug with pretty printing vectors with fractions

<!-- END RELEASE NOTES -->
