### PR TITLE
Add Mul postprocessor for Vector

### DIFF
--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -220,30 +220,14 @@ def test_vector_simplify():
 
 
 def test_vector_mul_postprocessor():
-    """
-    Test that Mul postprocessor correctly handles vector multiplication.
-    
-    Regression test for the bug where Mul(scalar, vector) would return
-    a plain Mul instead of VectorMul, causing TypeError during simplification
-    of vector expressions involving spherical coordinates.
-    """
-    # Test basic Mul postprocessor functionality
     assert isinstance(Mul(2, C.i), VectorMul)
     assert Mul(2, C.i) == 2*C.i
-    
-    # Test the original bug - spherical coordinate simplification
-    # This used to raise: TypeError: location should be a Vector
     C1 = CoordSys3D("C1")
     C2 = C1.locate_new("C2", 2 * C1.i)
     S = C2.create_new("S", transformation="spherical")
     
     expr = S.r**2*sin(S.phi)**2*sin(S.theta)**2 + S.r**2*sin(S.theta)**2*cos(S.phi)**2
-    
-    # This should not raise TypeError
     result = expr.simplify()
-    
-    # Verify the result simplifies correctly
-    # sin²θ·sin²φ + sin²θ·cos²φ = sin²θ·(sin²φ + cos²φ) = sin²θ
     expected = S.r**2 * sin(S.theta)**2
     assert simplify(result - expected) == 0
 

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -225,7 +225,6 @@ def test_vector_mul_postprocessor():
     C1 = CoordSys3D("C1")
     C2 = C1.locate_new("C2", 2 * C1.i)
     S = C2.create_new("S", transformation="spherical")
-    
     expr = S.r**2*sin(S.phi)**2*sin(S.theta)**2 + S.r**2*sin(S.theta)**2*cos(S.phi)**2
     result = expr.simplify()
     expected = S.r**2 * sin(S.theta)**2

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from itertools import product
 
-from sympy.core import Add, Basic
+from sympy.core import Add, Mul, Basic
 from sympy.core.assumptions import StdFactKB
 from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.power import Pow
@@ -418,7 +418,7 @@ class Vector(BasisDependent):
 
 def get_postprocessor(cls):
     def _postprocessor(expr):
-        vec_class = {Add: VectorAdd}[cls]
+        vec_class = {Add: VectorAdd, Mul: VectorMul}[cls]
         vectors = []
         for term in expr.args:
             if isinstance(term.kind, VectorKind):
@@ -426,11 +426,14 @@ def get_postprocessor(cls):
 
         if vec_class == VectorAdd:
             return VectorAdd(*vectors).doit(deep=False)
+        if vec_class == VectorMul:
+            return VectorMul(*expr.args).doit(deep=False)
     return _postprocessor
 
 
 Basic._constructor_postprocessor_mapping[Vector] = {
     "Add": [get_postprocessor(Add)],
+    "Mul": [get_postprocessor(Mul)],
 }
 
 class BaseVector(Vector, AtomicExpr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to gh-26121 and gh-26623.

#### Brief description of what is fixed or changed

When [simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/tests/test_vector.py:193:0-225:60) traverses expression trees using `bottom_up()`, it reconstructs nodes via `.func(*args)`. This caused [VectorMul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) objects to become [Mul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) objects, which then failed type checks in `CoordSys3D.__new__()` with `TypeError: location should be a Vector`.

This PR adds a postprocessor for [Mul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) (similar to the existing [Add](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:498:0-517:27) postprocessor from gh-26623) to ensure [Mul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) operations on vectors return [VectorMul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) objects.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Fixed TypeError when simplifying vector expressions with spherical coordinates and `locate_new()`. VectorMul objects are now preserved during simplification.

<!-- END RELEASE NOTES -->