### PR TITLE
Fix:  FourierSeries printing AttributeError with Dict coefficients

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2393,8 +2393,6 @@ class LatexPrinter(Printer):
         return r"%s \in %s" % tuple(self._print(a) for a in e.args)
 
     def _print_FourierSeries(self, s):
-        if s.an.formula is S.Zero and s.bn.formula is S.Zero:
-            return self._print(s.a0)
         return self._print_Add(s.truncate()) + r' + \ldots'
 
     def _print_FormalPowerSeries(self, s):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2347,8 +2347,6 @@ class PrettyPrinter(Printer):
             return prettyForm(sstr(e))
 
     def _print_FourierSeries(self, s):
-        if s.an.formula is S.Zero and s.bn.formula is S.Zero:
-            return self._print(s.a0)
         if self._use_unicode:
             dots = pretty_atom('Dots')
         else:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4952,6 +4952,7 @@ def test_pretty_FourierSeries():
 
     assert pretty(f) == ascii_str
     assert upretty(f) == ucode_str
+    assert pretty(fourier_series(sin(x), (x, -pi, pi))) == 'sin(x) + ...'
 
 
 def test_pretty_FormalPowerSeries():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1116,6 +1116,7 @@ def test_latex_FourierSeries():
     latex_str = \
         r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
+    assert latex(fourier_series(sin(x), (x, -pi, pi))) == r'\sin{\left(x \right)} + \ldots'
 
 
 def test_latex_FormalPowerSeries():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28724

#### Brief description of what is fixed or changed
Fixed AttributeError when printing FourierSeries of simple trigonometric functions like `sin(x)` and `cos(x)`. The printers now handle both Dict coefficients (from FiniteFourierSeries) and SeqFormula coefficients (from infinite FourierSeries).

#### Other comments
The issue occurred because `_print_FourierSeries` in both LaTeX and pretty printers assumed coefficients always had a `.formula` attribute, but FiniteFourierSeries uses Dict objects for coefficients.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed AttributeError when printing Fourier series of simple trigonometric functions
<!-- END RELEASE NOTES -->