### PR TITLE
plotting: Add Plot return type annotation to plot functions

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -205,7 +205,7 @@ plot_backends = {
 # TODO: Add more plotting options for 3d plots.
 # TODO: Adaptive sampling for 3D plots.
 
-def plot(*args, show=True, **kwargs):
+def plot(*args, show=True, **kwargs) -> Plot:
     """Plots a function of a single variable as a curve.
 
     Parameters
@@ -420,7 +420,7 @@ def plot(*args, show=True, **kwargs):
     return plots
 
 
-def plot_parametric(*args, show=True, **kwargs):
+def plot_parametric(*args, show=True, **kwargs) -> Plot:
     """
     Plots a 2D parametric curve.
 
@@ -615,7 +615,7 @@ def plot_parametric(*args, show=True, **kwargs):
     return plots
 
 
-def plot3d_parametric_line(*args, show=True, **kwargs):
+def plot3d_parametric_line(*args, show=True, **kwargs) -> Plot:
     """
     Plots a 3D parametric line plot.
 
@@ -787,7 +787,7 @@ def _plot3d_plot_contour_helper(Series, *args, **kwargs):
     return plots
 
 
-def plot3d(*args, show=True, **kwargs):
+def plot3d(*args, show=True, **kwargs) -> Plot:
     """
     Plots a 3D surface plot.
 
@@ -923,7 +923,7 @@ def plot3d(*args, show=True, **kwargs):
         SurfaceOver2DRangeSeries, *args, **kwargs)
 
 
-def plot3d_parametric_surface(*args, show=True, **kwargs):
+def plot3d_parametric_surface(*args, show=True, **kwargs) -> Plot:
     """
     Plots a 3D parametric surface plot.
 
@@ -1044,7 +1044,7 @@ def plot3d_parametric_surface(*args, show=True, **kwargs):
         plots.show()
     return plots
 
-def plot_contour(*args, show=True, **kwargs):
+def plot_contour(*args, show=True, **kwargs) -> Plot:
     """
     Draws contour plot of a function
 


### PR DESCRIPTION
This PR adds `Plot` return type annotations to all the `plot` functions.

Without this annotation, the inferred return type for `plot` is `MatplotlibBackend | TextBackend | Unknown | Plot` (according to Pyright), which due to the `Unknown` member is much less useful.

#### Other comments

I'm not sure if this kind of incremental PR is useful. Perhaps you'd rather leave it unchanged until someone wants to make a full pass over the plotting code to add types everywhere, in which case please feel free to close this.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
  * Added `Plot` return type annotation to `plot` functions

<!-- END RELEASE NOTES -->
