### PR TITLE
Add typechecking and linting packages to requirements-dev.txt

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -80,7 +80,7 @@ jobs:
           pip install .
 
           # Install dependencies and optional test dependencies
-          pip install pytest pytest-split hypothesis
+          pip install -r requirements-dev.txt
           pip install matplotlib numpy scipy
 
           # Trigger test suite (slow and tooslow tests are skipped by default)

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -24,8 +24,6 @@ jobs:
       - run: python -m pip install --upgrade pip setuptools
 
       - run: pip install -r requirements-dev.txt
-      - run: pip install ruff
-
       - name: Basic code quality tests
         run: bin/test quality
 
@@ -41,7 +39,7 @@ jobs:
       - name: Test all modules are listed in setup.py
         run: bin/test_setup.py
 
-      - run: pip install slotscheck .
+      - run: pip install .
 
       - name: Check for incorrect use of ``__slots__`` using slotscheck
         run: python -m slotscheck --no-strict-imports --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra|sympy.plotting.pygletplot.*)" sympy
@@ -69,7 +67,7 @@ jobs:
         with:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath mypy hypothesis
+      - run: pip install -r requirements-dev.txt
 
       - name: Run mypy on the sympy package
         run: mypy sympy
@@ -101,7 +99,7 @@ jobs:
         with:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
-      - run: pip install sphinx-lint
+      - run: pip install -r requirements-dev.txt
 
       - name: Run sphinx-lint on the sympy documentation
         run: sphinx-lint doc/
@@ -120,7 +118,7 @@ jobs:
         with:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install -r requirements-dev.txt
       - run: bin/mailmap_check.py
 
   # -------------------- Doctests latest Python -------------------- #
@@ -135,7 +133,7 @@ jobs:
         with:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
-      - run: pip install mpmath
+      - run: pip install -r requirements-dev.txt
       - run: bin/doctest --force-colors
 
   # ------------------------- Test latest Python ------------------- #

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 mpmath
-mypy
+mypy; platform_python_implementation != "PyPy"  # Mypy's librt dependency isn't available on PyPy
 sphinx-lint
 pytest
 pytest-xdist
@@ -9,5 +9,5 @@ pytest-doctestplus
 hypothesis
 flake8
 flake8-comprehensions
-ruff
+ruff; sys_platform != "emscripten"  # exclude Pyodide
 slotscheck

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 mpmath
+mypy
+sphinx-lint
 pytest
 pytest-xdist
 pytest-timeout
@@ -8,3 +10,4 @@ hypothesis
 flake8
 flake8-comprehensions
 ruff
+slotscheck


### PR DESCRIPTION
Add typechecking and linting packages to requirements-dev.txt.

In the GitHub Actions workflows, reference requirements-dev.txt rather than installing specific packages.

#### Other comments

It took me a moment to figure that I needed to manually install `mypy` in order to run type checking from the command line.

This PR collects `mypy` as well as linting packages from the GitHub Actions workflows and adds them to `requirements-dev.txt`.

In a second commit (in case you only want to cherry pick the first), this runs `pip install -r requirements-dev.txt` in the GitHub Actions workflows instead of installing individual packages, in order to improve maintainability.

I'm sending this PR in the hopes of making other contributors' lives easier, but I'm not super familiar with how Python tooling works, so if you don't think this is a good idea, feel free to close it.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
