### PR TITLE
Fix physics dyadic.py and implement test cases

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -810,6 +810,7 @@ Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
+Jay Vijan <jvijan@umich.edu> Jay Sun Vijan <145924415+jvijan@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
 Jean-François B <2589111+jfbu@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1667,6 +1667,7 @@ Wes Galbraith <galbwe92@gmail.com>
 Wes Turner <50891+westurner@users.noreply.github.com>
 Willem Melching <willem.melching@gmail.com>
 Wolfgang Stöcher <wolfgang@stoecher.com> coproc <wolfgang@stoecher.com>
+Wonsik Jung <algrthm@umich.edu> wonsik99 <algrthm@umich.edu>
 Wyatt Peak <wyattpeak@gmail.com>
 Xiang Wu <hsiangwu@fb.com>
 Xiao <muzumayao@126.com> Xiao <88570037+T90REAL@users.noreply.github.com>

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -247,8 +247,7 @@ class Dyadic(Printable, EvalfMixin):
                         outstr = prettyForm(*p_term.left(sign))
                     else:
                         outstr = prettyForm(*outstr.right(sign, p_term))
-
-                return outstr
+                return outstr.__str__()
         return Fake()
 
     def __rsub__(self, other):

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,6 +1,7 @@
 from sympy import sympify, Add, ImmutableMatrix as Matrix
 from sympy.core.evalf import EvalfMixin
 from sympy.printing.defaults import Printable
+from sympy.printing.pretty.stringpict import prettyForm
 
 from mpmath.libmp.libmpf import prec_to_dps
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -209,50 +209,44 @@ class Dyadic(Printable, EvalfMixin):
             baseline = 0
 
             def render(self, *args, **kwargs):
-                ar = e.args  # just to shorten things
                 mpp = printer
-                if len(ar) == 0:
-                    return str(0)
-                bar = "\N{CIRCLED TIMES}" if printer._use_unicode else "|"
-                ol = []  # output list, to be concatenated to a string
-                for v in ar:
-                    # if the coef of the dyadic is 1, we skip the 1
-                    if v[0] == 1:
-                        ol.extend([" + ",
-                                  mpp.doprint(v[1]),
-                                  bar,
-                                  mpp.doprint(v[2])])
+                if len(e.args) == 0:
+                    return mpp._print(0)
 
-                    # if the coef of the dyadic is -1, we skip the 1
-                    elif v[0] == -1:
-                        ol.extend([" - ",
-                                  mpp.doprint(v[1]),
-                                  bar,
-                                  mpp.doprint(v[2])])
+                outstr = None
+                bar = prettyForm(u"\N{CIRCLED TIMES}" if mpp._use_unicode else "|")
+                for i, v in enumerate(e.args):
+                    p_v1 = mpp._print(v[1])
+                    p_v2 = mpp._print(v[2])
+                    p_dyad = prettyForm(*p_v1.right(bar, p_v2))
 
-                    # If the coefficient of the dyadic is not 1 or -1,
-                    # we might wrap it in parentheses, for readability.
-                    elif v[0] != 0:
-                        if isinstance(v[0], Add):
-                            arg_str = mpp._print(
-                                v[0]).parens()[0]
+                    c = v[0]
+                    if i == 0:
+                        sign = ""
+                    else:
+                        sign = " + "
+
+                    coeff, rest = c.as_coeff_Mul()
+                    if coeff < 0:
+                        if i == 0:
+                            sign = "- "
                         else:
-                            arg_str = mpp.doprint(v[0])
-                        if arg_str.startswith("-"):
-                            arg_str = arg_str[1:]
-                            str_start = " - "
-                        else:
-                            str_start = " + "
-                        ol.extend([str_start, arg_str, " ",
-                                  mpp.doprint(v[1]),
-                                  bar,
-                                  mpp.doprint(v[2])])
+                            sign = " - "
+                        c = -c
 
-                outstr = "".join(ol)
-                if outstr.startswith(" + "):
-                    outstr = outstr[3:]
-                elif outstr.startswith(" "):
-                    outstr = outstr[1:]
+                    if c == 1:
+                        p_term = p_dyad
+                    else:
+                        p_c = mpp._print(c)
+                        if isinstance(c, Add):
+                            p_c = prettyForm(*p_c.parens())
+                        p_term = prettyForm(*p_c.right(" ", p_dyad))
+
+                    if outstr is None:
+                        outstr = prettyForm(*p_term.left(sign))
+                    else:
+                        outstr = prettyForm(*outstr.right(sign, p_term))
+
                 return outstr
         return Fake()
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -359,31 +359,73 @@ def test_issue_12157():
     Test for proper pretty printing of vectors with fractions involved.
     """
 
-    d1 = (a/b) * (N.x | N.y)
+    first_test = (a/b) * (N.x | N.y)
 
-    result = ascii_vpretty(d1)
+    expected = '''\
+/a\\          \n\
+|-| (n_x|n_y)\n\
+\\b/          \
+'''    
+    uexpected = '''\
+⎛a⎞          \n\
+|-| (n_x⊗n_y)\n\
+⎝b⎠          \
+    '''
 
-    # a, b, and the basis dyad (n_x|n_y) should appear in the output
-    assert result == "a\n-\nb n_x|n_y"
+    assert ascii_vpretty(first_test) == expected
+    assert unicode_vpretty(first_test) == uexpected
 
-    # More complex case: fraction with sum in numerator
-    d2 = ((a + b)/c) * (N.x | N.y)
+    second_test = ((a + b)/c) * (N.x | N.y)
 
-    result2 = ascii_vpretty(d2)
+    expected = '''\
+/a + b\\          \n\
+|-----| (n_x|n_y)\n\
+\\  c  /           \
+'''
+    uexpected = '''\
+⎛a + b⎞          \n\
+|-----| (n_x⊗n_y)\n\
+⎝  c  ⎠          \
+'''
+    
+    assert ascii_vpretty(second_test) == expected
+    assert unicode_vpretty(second_test) == uexpected
 
-    # Basis dyad should still be present
-    assert result2 == "a + b\n-----\n  c   n_x|n_y"
 
-    # Multiple terms with fractions
-    d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
+    third_test = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
 
-    result3 = ascii_vpretty(d3)
+    expected ='''\
+/a\\             /c\\          \n\
+|-| (n_x|n_y) + |-| (n_y|n_z)\n\
+\\b/             \\b/          \
+'''
+    uexpected ='''\
+⎛a⎞             ⎛c⎞          \n\
+|-| (n_x⊗n_y) + |-| (n_y⊗n_z)\n\
+⎝b⎠             ⎝b⎠          \
+'''
 
-    assert result3 == "a\n-\nb n_x|n_y + c\n-\nb n_y|n_z"
+    assert ascii_vpretty(third_test) == expected
+    assert unicode_vpretty(third_test) == uexpected
 
-    # Test More complex case
     d = symbols('d')
-    vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
+    # This case comes from the correct output example provided by @faze-geek in the issue
+    fourth_test = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
 
-    result_vv = ascii_vpretty(vv)
-    assert result_vv =="d n_x|n_z +  2  2      2        \na *c  + a*b  + b*c*d\n--------------------\n       b + c         n_y|n_y"
+    expected = """\
+                / 2  2      2       \\          \n\
+(d) (n_x|n_z) + |a *c  + a*b + b*c*d| (n_y|n_y)\n\
+                |-------------------|          \n\
+                \\       b + c       /          \
+"""
+    uexpected = """\
+                ⎛ 2  2      2       ⎞          \n\
+(d) (n_x⊗n_z) + |a *c  + a*b + b*c*d| (n_y⊗n_y)\n\
+                |-------------------|          \n\
+                ⎝       b + c       ⎠          \
+"""
+
+    assert ascii_vpretty(fourth_test) == expected
+    assert unicode_vpretty(fourth_test) == uexpected
+    
+    

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -365,7 +365,7 @@ def test_issue_12157():
 /a\\          \n\
 |-| (n_x|n_y)\n\
 \\b/          \
-'''    
+'''
     uexpected = '''\
 ⎛a⎞          \n\
 |-| (n_x⊗n_y)\n\
@@ -387,7 +387,7 @@ def test_issue_12157():
 |-----| (n_x⊗n_y)\n\
 ⎝  c  ⎠          \
 '''
-    
+
     assert ascii_vpretty(second_test) == expected
     assert unicode_vpretty(second_test) == uexpected
 
@@ -427,5 +427,3 @@ def test_issue_12157():
 
     assert ascii_vpretty(fourth_test) == expected
     assert unicode_vpretty(fourth_test) == uexpected
-    
-    

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -188,12 +188,12 @@ def test_vector_latex_with_functions():
 def test_dyadic_pretty_print():
 
     expected = """\
- 2
+ 2                                           \n\
 a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
 """
 
     uexpected = """\
- 2
+ 2                                       \n\
 a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
 """
     assert ascii_vpretty(y) == expected
@@ -362,15 +362,15 @@ def test_issue_12157():
     first_test = (a/b) * (N.x | N.y)
 
     expected = '''\
-/a\\          \n\
-|-| (n_x|n_y)\n\
-\\b/          \
+a        \n\
+- n_x|n_y\n\
+b        \
 '''
     uexpected = '''\
-⎛a⎞          \n\
-|-| (n_x⊗n_y)\n\
-⎝b⎠          \
-    '''
+a        \n\
+─ n_x⊗n_y\n\
+b        \
+'''
 
     assert ascii_vpretty(first_test) == expected
     assert unicode_vpretty(first_test) == uexpected
@@ -378,14 +378,14 @@ def test_issue_12157():
     second_test = ((a + b)/c) * (N.x | N.y)
 
     expected = '''\
-/a + b\\          \n\
-|-----| (n_x|n_y)\n\
-\\  c  /           \
+a + b        \n\
+----- n_x|n_y\n\
+  c          \
 '''
     uexpected = '''\
-⎛a + b⎞          \n\
-|-----| (n_x⊗n_y)\n\
-⎝  c  ⎠          \
+a + b        \n\
+───── n_x⊗n_y\n\
+  c          \
 '''
 
     assert ascii_vpretty(second_test) == expected
@@ -395,14 +395,14 @@ def test_issue_12157():
     third_test = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
 
     expected ='''\
-/a\\             /c\\          \n\
-|-| (n_x|n_y) + |-| (n_y|n_z)\n\
-\\b/             \\b/          \
+a           c        \n\
+- n_x|n_y + - n_y|n_z\n\
+b           b        \
 '''
     uexpected ='''\
-⎛a⎞             ⎛c⎞          \n\
-|-| (n_x⊗n_y) + |-| (n_y⊗n_z)\n\
-⎝b⎠             ⎝b⎠          \
+a           c        \n\
+─ n_x⊗n_y + ─ n_y⊗n_z\n\
+b           b        \
 '''
 
     assert ascii_vpretty(third_test) == expected
@@ -412,18 +412,18 @@ def test_issue_12157():
     # This case comes from the correct output example provided by @faze-geek in the issue
     fourth_test = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
 
-    expected = """\
-                / 2  2      2       \\          \n\
-(d) (n_x|n_z) + |a *c  + a*b + b*c*d| (n_y|n_y)\n\
-                |-------------------|          \n\
-                \\       b + c       /          \
-"""
-    uexpected = """\
-                ⎛ 2  2      2       ⎞          \n\
-(d) (n_x⊗n_z) + |a *c  + a*b + b*c*d| (n_y⊗n_y)\n\
-                |-------------------|          \n\
-                ⎝       b + c       ⎠          \
-"""
+    expected = '''\
+             2  2      2                \n\
+            a *c  + a*b  + b*c*d        \n\
+d n_x|n_z + -------------------- n_y|n_y\n\
+                   b + c                \
+'''
+    uexpected = '''\
+             2  2      2                \n\
+            a ⋅c  + a⋅b  + b⋅c⋅d        \n\
+d n_x⊗n_z + ──────────────────── n_y⊗n_y\n\
+                   b + c                \
+'''
 
     assert ascii_vpretty(fourth_test) == expected
     assert unicode_vpretty(fourth_test) == uexpected

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -10,6 +10,7 @@ from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint,
 
 
 a, b, c = symbols('a, b, c')
+
 alpha, omega, beta = dynamicsymbols('alpha, omega, beta')
 
 A = ReferenceFrame('A')
@@ -351,3 +352,55 @@ def test_issue_14041():
         r"\left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
     assert vlatex((phid*thetad)**a*A_frame.x) == \
         r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"
+
+        
+def test_issue_12157():
+    
+    d1 = (a/b) * (N.x | N.y)
+    
+    result = ascii_vpretty(d1)
+    print(f"Result for (a/b)*(N.x|N.y):\n{result}")
+    
+    # The basis dyad (n_x|n_y) should appear in the output
+    assert 'n_x|n_y' in result or 'n_x' in result, \
+        f"Basis dyad missing or malformed in output: {result}"
+    
+    # Both 'a' and 'b' should be in the output
+    assert 'a' in result and 'b' in result, \
+        f"Fraction components missing: {result}"
+    
+    # More complex case: fraction with sum in numerator
+    d2 = ((a + b)/c) * (N.x | N.y)
+    
+    result2 = ascii_vpretty(d2)
+    print(f"\nResult for ((a+b)/c)*(N.x|N.y):\n{result2}")
+    
+    # Basis dyad should still be present
+    assert 'n_x|n_y' in result2 or 'n_x' in result2, \
+        f"Basis dyad missing in output: {result2}"
+    
+    # Multiple terms with fractions
+    d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
+    
+    result3 = ascii_vpretty(d3)
+    print(f"\nResult for (a/b)*(N.x|N.y) + (c/b)*(N.y|N.z):\n{result3}")
+    
+    # Both basis dyads should appear
+    lines = result3.split('\n')
+    full_text = ' '.join(lines)
+    
+    assert 'n_x' in full_text and 'n_y' in full_text, \
+        f"Basis vectors missing from output: {result3}"
+    
+    # Test the complex case from vv
+    d = symbols('d')
+    vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
+    
+    result_vv = ascii_vpretty(vv)
+    print(f"\nResult for vv:\n{result_vv}")
+    
+    # Both dyadic products should appear in output
+    assert 'n_x' in result_vv and 'n_z' in result_vv, \
+        f"First dyadic basis missing: {result_vv}"
+    assert 'n_y|n_y' in result_vv or result_vv.count('n_y') >= 2, \
+        f"Second dyadic basis missing or malformed: {result_vv}"

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -355,52 +355,35 @@ def test_issue_14041():
 
         
 def test_issue_12157():
+    """
+    Test for proper pretty printing of vectors with fractions involved.
+    """
     
     d1 = (a/b) * (N.x | N.y)
     
     result = ascii_vpretty(d1)
-    print(f"Result for (a/b)*(N.x|N.y):\n{result}")
     
-    # The basis dyad (n_x|n_y) should appear in the output
-    assert 'n_x|n_y' in result or 'n_x' in result, \
-        f"Basis dyad missing or malformed in output: {result}"
-    
-    # Both 'a' and 'b' should be in the output
-    assert 'a' in result and 'b' in result, \
-        f"Fraction components missing: {result}"
+    # a, b, and the basis dyad (n_x|n_y) should appear in the output
+    assert result == "a\n-\nb n_x|n_y"
     
     # More complex case: fraction with sum in numerator
     d2 = ((a + b)/c) * (N.x | N.y)
     
     result2 = ascii_vpretty(d2)
-    print(f"\nResult for ((a+b)/c)*(N.x|N.y):\n{result2}")
     
     # Basis dyad should still be present
-    assert 'n_x|n_y' in result2 or 'n_x' in result2, \
-        f"Basis dyad missing in output: {result2}"
+    assert result2 == "a + b\n-----\n  c   n_x|n_y"
     
     # Multiple terms with fractions
     d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
     
     result3 = ascii_vpretty(d3)
-    print(f"\nResult for (a/b)*(N.x|N.y) + (c/b)*(N.y|N.z):\n{result3}")
     
-    # Both basis dyads should appear
-    lines = result3.split('\n')
-    full_text = ' '.join(lines)
+    assert result3 == "a\n-\nb n_x|n_y + c\n-\nb n_y|n_z"
     
-    assert 'n_x' in full_text and 'n_y' in full_text, \
-        f"Basis vectors missing from output: {result3}"
-    
-    # Test the complex case from vv
+    # Test More complex case
     d = symbols('d')
     vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
     
     result_vv = ascii_vpretty(vv)
-    print(f"\nResult for vv:\n{result_vv}")
-    
-    # Both dyadic products should appear in output
-    assert 'n_x' in result_vv and 'n_z' in result_vv, \
-        f"First dyadic basis missing: {result_vv}"
-    assert 'n_y|n_y' in result_vv or result_vv.count('n_y') >= 2, \
-        f"Second dyadic basis missing or malformed: {result_vv}"
+    assert result_vv =="d n_x|n_z +  2  2      2        \na *c  + a*b  + b*c*d\n--------------------\n       b + c         n_y|n_y"

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -353,37 +353,37 @@ def test_issue_14041():
     assert vlatex((phid*thetad)**a*A_frame.x) == \
         r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"
 
-        
+
 def test_issue_12157():
     """
     Test for proper pretty printing of vectors with fractions involved.
     """
-    
+
     d1 = (a/b) * (N.x | N.y)
-    
+
     result = ascii_vpretty(d1)
-    
+
     # a, b, and the basis dyad (n_x|n_y) should appear in the output
     assert result == "a\n-\nb n_x|n_y"
-    
+
     # More complex case: fraction with sum in numerator
     d2 = ((a + b)/c) * (N.x | N.y)
-    
+
     result2 = ascii_vpretty(d2)
-    
+
     # Basis dyad should still be present
     assert result2 == "a + b\n-----\n  c   n_x|n_y"
-    
+
     # Multiple terms with fractions
     d3 = (a/b) * (N.x | N.y) + (c/b) * (N.y | N.z)
-    
+
     result3 = ascii_vpretty(d3)
-    
+
     assert result3 == "a\n-\nb n_x|n_y + c\n-\nb n_y|n_z"
-    
+
     # Test More complex case
     d = symbols('d')
     vv = (d)*(N.x|N.z) + ((a*b**2 + (a*c)**2 + d*b*c)/(b + c))*(N.y|N.y)
-    
+
     result_vv = ascii_vpretty(vv)
     assert result_vv =="d n_x|n_z +  2  2      2        \na *c  + a*b  + b*c*d\n--------------------\n       b + c         n_y|n_y"

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -427,4 +427,3 @@ d n_x⊗n_z + ──────────────────── n_y�
 
     assert ascii_vpretty(fourth_test) == expected
     assert unicode_vpretty(fourth_test) == uexpected
-


### PR DESCRIPTION
Fixed vector pretty printing issue with fractions
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixed #12157
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added pretty printing form to the pretty printing function for vector dyadic and added regression/unit tests for quality assurance

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  physics.vector
  *  Fixed a bug with vector dyadic printing incorrectly when fractions were involved
<!-- END RELEASE NOTES -->
