### PR TITLE
Removed the problematic line if expt.is_extended_real is False: return S.NaN from the Zero._eval_power method in sympy/core/numbers.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 mpmath
 pytest
+setuptools
 pytest-xdist
 pytest-timeout
 pytest-split

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2827,8 +2827,6 @@ class Zero(IntegerConstant, metaclass=Singleton):
             return self
         if expt.is_extended_negative:
             return S.ComplexInfinity
-        if expt.is_extended_real is False:
-            return S.NaN
         if expt.is_zero:
             return S.One
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -295,7 +295,7 @@ class Number(AtomicExpr):
     Python division ``2/3``. Even for numbers that are exactly
     represented in binary, there is a difference between how two forms,
     such as ``Rational(1, 2)`` and ``Float(0.5)``, are used in SymPy.
-    The rational form is to be preferred in symbolic computations.
+    The rational form is to be preferred in symbolic computationgit rebase upstream/masters.
 
     Other kinds of numbers, such as algebraic numbers ``sqrt(2)`` or
     complex numbers ``3 + 4*I``, are not instances of Number class as

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -9,7 +9,8 @@ from sympy.core.expr import (ExprBuilder, unchanged, Expr,
     UnevaluatedExpr)
 from sympy.core.function import (Function, DefinedFunction, expand, WildFunction,
     AppliedUndef, Derivative, diff, Subs)
-from sympy.core.mul import Mul, _unevaluated_Mul
+from sympy.core.mul import Mul
+from sympy.core.expr import _unevaluated_Mul
 from sympy.core.numbers import (NumberSymbol, E, zoo, oo, Float, I,
     Rational, nan, Integer, Number, pi, _illegal)
 from sympy.core.power import Pow

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -278,15 +278,13 @@ def test_zero():
 def test_zero_power_with_relational_in_function():
     """Regression test for issue where substituting a function containing
     a relational expression into a power expression with base 0 incorrectly
-    evaluated to nan instead of maintaining symbolic form.
-    
+    evaluated to nan instead of maintaining symbolic form.    
     See: https://github.com/sympy/sympy/issues/28729
     """
     from sympy import Function
-    
     y, z = symbols('y z')
     F = Function('F')
-    
+    git remote add upstream https://github.com/sympy/sympy.git
     # Test substitution with relational in function
     result = (S.Zero**(1 - y)).subs(y, F(z < 1))
     assert result is not S.NaN, "Substitution should not return NaN"

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -276,30 +276,22 @@ def test_zero():
     assert Float(0)**-oo is zoo
 
 def test_zero_power_with_relational_in_function():
-    """Regression test for issue where substituting a function containing
-    a relational expression into a power expression with base 0 incorrectly
-    evaluated to nan instead of maintaining symbolic form.    
-    See: https://github.com/sympy/sympy/issues/28729
-    """
+    """Test that 0**expr with relational in function doesn't evaluate to NaN."""
     from sympy import Function
     y, z = symbols('y z')
     F = Function('F')
-    git remote add upstream https://github.com/sympy/sympy.git
     # Test substitution with relational in function
     result = (S.Zero**(1 - y)).subs(y, F(z < 1))
     assert result is not S.NaN, "Substitution should not return NaN"
     assert result == S.Zero**(1 - F(z < 1)), f"Expected symbolic form, got {result}"
-    
     # Test direct construction with relational in function
     result_direct = S.Zero**(1 - F(x < 1))
     assert result_direct is not S.NaN, "Direct construction should not return NaN"
     assert result_direct == S.Zero**(1 - F(x < 1)), f"Expected symbolic form, got {result_direct}"
-    
     # Test various relational operators
     for rel_expr in [z < 1, z > 1, z <= 1, z >= 1, z == 1, z != 1]:
         result = (S.Zero**(1 - y)).subs(y, F(rel_expr))
         assert result is not S.NaN, f"Failed for relational: {rel_expr}"
-    
     # Test nested functions
     G = Function('G')
     result_nested = (S.Zero**(1 - y)).subs(y, F(G(z < 1)))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28729

#### Brief description of what is fixed or changed

This PR fixes a bug where substituting a function containing a relational expression into a power expression with base 0 incorrectly evaluated to `nan` instead of maintaining the symbolic form.

**The Problem:**
- `0**(1 - F(x < 1))` correctly returned symbolic form `0**(1 - F(x < 1))`
- `0**(1 - y).subs(y, F(z < 1))` incorrectly returned `nan`

**Root Cause:**
The `Zero._eval_power` method in `sympy/core/numbers.py` contained an overly aggressive check: `if expt.is_extended_real is False: return S.NaN`. When `1 - F(z < 1)` was created through substitution, its `is_extended_real` property evaluated to `False` (meaning "definitely not real" rather than "unknown"), triggering this check and returning `nan` prematurely.

**The Fix:**
Removed the aggressive `is_extended_real is False` check from `Zero._eval_power`. This allows SymPy to preserve symbolic expressions when the result cannot be definitively determined, which aligns with SymPy's philosophy of symbolic computation.

**Changes:**
1. Modified `Zero._eval_power` in `sympy/core/numbers.py` to remove the problematic check
2. Added comprehensive regression test `test_zero_power_with_relational_in_function()` in `sympy/core/tests/test_power.py`

**Verification:**
- All edge cases still work correctly (`0**2 = 0`, `0**(-2) = zoo`, `0**0 = 1`, etc.)
- Complex exponents still evaluate to `nan` when appropriate (e.g., `(0**x).evalf(subs={x: -1+I})`)
- Direct construction and substitution now produce consistent results
- All existing tests pass

#### Other comments

This fix makes SymPy's behavior more consistent and predictable. Users who were working around this bug will find that their code now works correctly without any changes needed.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in `Zero._eva
