### PR TITLE
Fix matrix summation with null range returning Zero instead of ZeroMatrix

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -26,6 +26,7 @@ from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.functions.special.zeta_functions import zeta
 from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import And, Not
+from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.polys.partfrac import apart
 from sympy.polys.polyerrors import PolynomialError, PolificationFailed
 from sympy.polys.polytools import parallel_poly_from_expr, Poly, factor
@@ -189,7 +190,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # cancel out. This only answers whether the summand is zero; if
         # not then None is returned since we don't analyze whether all
         # terms cancel out.
-        if self.function.is_zero or self.has_empty_sequence:
+        if self.function.is_zero:
+            return True
+
+        if self.has_empty_sequence and not self.function.is_Matrix:
             return True
 
     def _eval_is_extended_real(self):
@@ -1666,8 +1670,10 @@ def _eval_matrix_sum(expression):
     for limit in expression.limits:
         i, a, b = limit
         dif = b - a
+        if dif == -1:
+            return ZeroMatrix(*f.shape)
         if dif.is_Integer:
-            if (dif < 0) == True:
+            if dif.is_negative:
                 a, b = b + 1, a - 1
                 f = -f
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1542,6 +1542,15 @@ def test_issue_21651():
     a = Sum(floor(2*2**(-i)), (i, S.One, 2))
     assert a.doit() == S.One
 
+def test_issue_28721():
+    from sympy.matrices.expressions.special import ZeroMatrix
+    M = MatrixSymbol('M', 3, 3)
+    i = Symbol('i')
+    expr = Sum(M, (i, 0, -1))
+    assert expr.doit() == ZeroMatrix(3, 3)
+    assert isinstance(expr.doit(), ZeroMatrix)
+    assert expr.simplify() == ZeroMatrix(3, 3)
+    assert isinstance(expr.simplify(), ZeroMatrix)
 
 @XFAIL
 def test_matrixsymbol_summation_symbolic_limits():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28721


#### Brief description of what is fixed or changed
Summation of matrices over a null range returning scalar Zero instead of ZeroMatrix when `.doit()` or `.simplify()` was called is fixed; test cases are added.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  * Fixed a bug where matrix summation over a null range returned Zero instead of ZeroMatrix. 
<!-- END RELEASE NOTES -->
