### PR TITLE
Add regression tests for Issue #24726

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1242,6 +1242,7 @@ Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
 Pradyumna <pradyu1993@gmail.com>
 Prafullkumar P. Tale <hector1618@gmail.com> <Hector1618@gmail.com>
 Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
+Prajwal Pathade <prajwalpathade7@gmail.com> Prajwal <prajwalpathade7@gmail.com>
 Pramod Ch <pramodch14@gmail.com>
 Pranjal Tale <pranjaltale16@gmail.com>
 Prashant Tandon <102211549+PT-10@users.noreply.github.com>\

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -25,6 +25,7 @@ from sympy.core.relational import Eq, Ne, Le, Lt, LessThan
 from sympy.logic import And, Or, Xor
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 from sympy.utilities.iterables import cartes
+from sympy import solveset, Integers
 
 from sympy.abc import x, y, z, m, n
 
@@ -1770,3 +1771,28 @@ def test_issue_28711():
     assert (nats + reals) == (reals + nats)
     assert (nats + fin1) == (fin1 + nats)
     assert (reals + fin1) == (fin1 + reals)
+
+
+def test_issue_24726():
+    t, n = symbols('t, n')
+    sin_zeros = solveset(sin(t), t, domain=S.Reals)
+
+    assert sin_zeros.intersect(Interval(-10, 10)) == {-3*pi, -2*pi, -pi, 0, pi, 2*pi, 3*pi}
+
+    assert sin_zeros.intersect(Interval(-oo, oo)) == sin_zeros
+
+    odd_integers = ImageSet(Lambda(n, 2*n + 1), Integers)
+    res = odd_integers.intersect(Interval(-10, oo))
+    assert res == ImageSet(Lambda(n, 2*n - 9), Range(0, oo, 1))
+
+    expected_case_4 = Union(ImageSet(Lambda(n, 2*n*pi - 3*pi), Range(0, oo, 1)),
+                            ImageSet(Lambda(n, 2*n*pi - 2*pi), Range(0, oo, 1)))
+    assert sin_zeros.intersect(Interval(-10, oo)).dummy_eq(expected_case_4)
+
+    expected_case_5 = Union(ImageSet(Lambda(n, -2*n*pi + 2*pi), Range(0, oo, 1)),
+                            ImageSet(Lambda(n, -2*n*pi + 3*pi), Range(0, oo, 1)))
+    assert sin_zeros.intersect(Interval(-oo, 10)).dummy_eq(expected_case_5)
+
+    expected_case_6 = Union(ImageSet(Lambda(n, 2*n*pi + 4*pi), Range(0, oo, 1)),
+                            ImageSet(Lambda(n, 2*n*pi + 5*pi), Range(0, oo, 1)))
+    assert sin_zeros.intersect(Interval(10, oo)).dummy_eq(expected_case_6)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #24726

#### Brief description of what is fixed or changed
This PR adds regression tests for the intersection of `sin_zeros` with various Intervals and ImageSets.

The underlying bug was previously fixed in PR #26872, but the issue remained open for regression tests. These tests ensure the correct behavior is preserved.

#### Other comments
Tests cover the three cases mentioned in the issue description:
1. Intersection with finite interval (-10, 10)
2. Intersection with infinite interval (-oo, oo)
3. Intersection of odd integers with an infinite interval

#### Release Notes
<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
