### PR TITLE
Add missing 'cd sympy' step in dev setup guide

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1058,6 +1058,7 @@ Matthias Toews <mat.toews@googlemail.com>
 Mauro Garavello <mauro.garavello@unimib.it>
 Max Hutchinson <maxhutch@gmail.com>
 Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
+Mayank Balyan <78949282+MayankBalyan@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank <54908605+mayankray2020@users.noreply.github.com>
 Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>

--- a/doc/src/contributing/new-contributors-guide/dev-setup.md
+++ b/doc/src/contributing/new-contributors-guide/dev-setup.md
@@ -149,10 +149,11 @@ Then, on your machine browse to where you would like to store SymPy, and clone (
 $ git clone https://github.com/sympy/sympy
 ```
 
-Then assign your read-and-write repo to a remote called "github" (replace
+Then navigate into the cloned directory and assign your read-and-write repo to a remote called "github" (replace
 `<your-github-username>` with your GitHub username):
 
 ```
+cd sympy
 git remote add github git@github.com:<your-github-username>/sympy.git
 ```
 
@@ -182,7 +183,6 @@ $ conda create -n sympy-dev -c conda-forge --file requirements-dev.txt
 If you prefer to use `pip` and `venv`, you can use something like
 
 ```bash
-cd sympy
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements-dev.txt


### PR DESCRIPTION

#### References to other Issues or PRs
None

#### Brief description of what is fixed or changed
This PR adds a missing `cd sympy` command to the "Development Setup" guide.

Previously, the instructions told users to `git clone` the repository and then immediately run `git remote add upstream`. This causes a `fatal: not a git repository` error for beginners because they are not yet inside the created `sympy/` directory.

I added the explicit `cd sympy` step to fix this flow.

#### Other comments
I found this issue while setting up my own development environment as a new contributor.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->