### PR TITLE
Add Mul postprocessor for Vector

### DIFF
--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -481,3 +481,14 @@ def test_issue_28559():
     simple_eq = f(R.a).diff(R.a)
     simple_result = simple_eq.simplify()
     assert simple_result == simple_eq
+
+
+def test_issue_28727():
+    C1 = CoordSys3D("C1")
+    C2 = C1.locate_new("C2", 2 * C1.i)
+    S = C2.create_new("S", transformation="spherical")
+
+    expr = S.r**2*sin(S.phi)**2*sin(S.theta)**2 + S.r**2*sin(S.theta)**2*cos(S.phi)**2
+    result = expr.simplify()
+    expected = S.r**2*sin(S.theta)**2
+    assert simplify(result - expected) == 0

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -498,6 +498,7 @@ def test_cartesian_rotation_transformation_equations():
         xb * sin(alpha) + yb * cos(alpha),
         zb)
 
+
 def test_issue_28727():
     C1 = CoordSys3D("C1")
     C2 = C1.locate_new("C2", 2 * C1.i)

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -497,8 +497,7 @@ def test_cartesian_rotation_transformation_equations():
         xb * cos(alpha) - yb * sin(alpha),
         xb * sin(alpha) + yb * cos(alpha),
         zb)
-    
-    
+
 def test_issue_28727():
     C1 = CoordSys3D("C1")
     C2 = C1.locate_new("C2", 2 * C1.i)

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -341,3 +341,70 @@ def test_scalar():
     assert v1.is_scalar is False
     assert (v1.dot(v2)).is_scalar is True
     assert (v1.cross(v2)).is_scalar is False
+
+
+def test_postprocessor_add_scalar_vector():
+    raises(TypeError, lambda: Add(1, C.i))
+    raises(TypeError, lambda: Add(C.i, 2))
+    raises(TypeError, lambda: Add(a, C.j))
+    raises(TypeError, lambda: Add(1.5, C.i))
+    raises(TypeError, lambda: Add(I, C.j))
+    raises(TypeError, lambda: Add(Rational(3, 2), C.k))
+
+
+def test_postprocessor_mul_scalar_vector():
+    x, y = symbols('x y')
+
+    result = Mul(2, C.i)
+    assert result == 2*C.i
+    assert isinstance(result, VectorMul)
+    assert result.measure_number == 2
+
+    result2 = Mul(2, 3, C.i)
+    assert result2 == 6*C.i
+    assert result2.measure_number == 6
+
+    result3 = Mul(x, C.i)
+    assert result3 == x*C.i
+    assert result3.measure_number == x
+
+    result4 = Mul(x, y, C.j)
+    assert result4 == x*y*C.j
+    assert result4.measure_number == x*y
+
+    result_neg = Mul(-1, C.i)
+    assert result_neg == -C.i
+    assert result_neg.measure_number == -1
+
+    result_identity = Mul(1, C.j)
+    assert result_identity == C.j
+
+    result_rational = Mul(Rational(3, 2), C.k)
+    assert result_rational == Rational(3, 2)*C.k
+    assert result_rational.measure_number == Rational(3, 2)
+
+
+def test_postprocessor_mul_vector_vector():
+    raises(ValueError, lambda: Mul(C.i, C.j))
+    raises(ValueError, lambda: Mul(C.j, C.k))
+
+
+def test_postprocessor_add_vector_vector():
+    result = Add(C.i, C.j)
+    assert result == C.i + C.j
+    assert isinstance(result, VectorAdd)
+
+    v1 = C.x * C.i + C.z * C.z * C.j
+    v2 = C.x * C.i + C.y * C.j + C.z * C.k
+    result2 = Add(v1, v2)
+    assert isinstance(result2, VectorAdd)
+    assert result2 == v1 + v2
+
+    result_zero = Add(C.i, Vector.zero)
+    assert result_zero == C.i
+
+    result_inverse = Add(C.i, -C.i)
+    assert result_inverse == Vector.zero
+
+    result_same = Add(C.i, C.i)
+    assert result_same == 2*C.i

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -410,17 +410,17 @@ def test_postprocessor_add_vector_vector():
     assert result_same == 2*C.i
 
 def test_postprocessor_pow_vector():
-    raises(ValueError, lambda: C.i**2)
-    raises(ValueError, lambda: C.j**3)
-    raises(ValueError, lambda: (C.i + C.j)**2)
-    raises(ValueError, lambda: Mul(C.i, C.i))
-    raises(ValueError, lambda: Mul(C.j, C.j))
-    raises(ValueError, lambda: Pow(C.i, 2))
-    raises(ValueError, lambda: Pow(C.j, S.Half))
-    raises(ValueError, lambda: Pow(C.k, -1))
+    raises(TypeError, lambda: C.i**2)
+    raises(TypeError, lambda: C.j**3)
+    raises(TypeError, lambda: (C.i + C.j)**2)
+    raises(TypeError, lambda: Mul(C.i, C.i))
+    raises(TypeError, lambda: Mul(C.j, C.j))
+    raises(TypeError, lambda: Pow(C.i, 2))
+    raises(TypeError, lambda: Pow(C.j, S.Half))
+    raises(TypeError, lambda: Pow(C.k, -1))
     v1 = C.i + C.j
     v2 = 2*C.k
-    raises(ValueError, lambda: v1**2)
-    raises(ValueError, lambda: v2**3)
-    raises(ValueError, lambda: Pow(v1, 2))
-    raises(ValueError, lambda: Pow(v2, a))
+    raises(TypeError, lambda: v1**2)
+    raises(TypeError, lambda: v2**3)
+    raises(TypeError, lambda: Pow(v1, 2))
+    raises(TypeError, lambda: Pow(v2, a))

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -424,3 +424,6 @@ def test_postprocessor_pow_vector():
     raises(TypeError, lambda: v2**3)
     raises(TypeError, lambda: Pow(v1, 2))
     raises(TypeError, lambda: Pow(v2, a))
+    raises(TypeError, lambda: 2**C.i)
+    raises(TypeError, lambda: a**C.j)
+    raises(TypeError, lambda: Pow(2, C.k))

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -1,4 +1,4 @@
-from sympy.core import Rational, S, Add, Mul, I
+from sympy.core import Rational, S, Add, Mul, Pow, I
 from sympy.simplify import simplify, trigsimp
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.numbers import pi
@@ -408,3 +408,19 @@ def test_postprocessor_add_vector_vector():
 
     result_same = Add(C.i, C.i)
     assert result_same == 2*C.i
+
+def test_postprocessor_pow_vector():
+    raises(ValueError, lambda: C.i**2)
+    raises(ValueError, lambda: C.j**3)
+    raises(ValueError, lambda: (C.i + C.j)**2)
+    raises(ValueError, lambda: Mul(C.i, C.i))
+    raises(ValueError, lambda: Mul(C.j, C.j))
+    raises(ValueError, lambda: Pow(C.i, 2))
+    raises(ValueError, lambda: Pow(C.j, S.Half))
+    raises(ValueError, lambda: Pow(C.k, -1))
+    v1 = C.i + C.j
+    v2 = 2*C.k
+    raises(ValueError, lambda: v1**2)
+    raises(ValueError, lambda: v2**3)
+    raises(ValueError, lambda: Pow(v1, 2))
+    raises(ValueError, lambda: Pow(v2, a))

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -418,18 +418,22 @@ class Vector(BasisDependent):
 
 def get_postprocessor(cls):
     def _postprocessor(expr):
-        vec_class = {Add: VectorAdd, Mul: VectorMul}[cls]
+        vec_class = {Add: VectorAdd, Mul: VectorMul, Pow: None}[cls]
 
         if vec_class == VectorAdd:
             return VectorAdd(*expr.args).doit(deep=False)
-        if vec_class == VectorMul:
+        elif vec_class == VectorMul:
             return VectorMul(*expr.args).doit(deep=False)
+        elif vec_class is None:
+            if isinstance(expr.args[0], Vector):
+                raise ValueError("Power operation is not supported for vectors")
     return _postprocessor
 
 
 Basic._constructor_postprocessor_mapping[Vector] = {
     "Add": [get_postprocessor(Add)],
     "Mul": [get_postprocessor(Mul)],
+    "Pow": [get_postprocessor(Pow)],
 }
 
 class BaseVector(Vector, AtomicExpr):

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -498,9 +498,6 @@ class VectorAdd(BasisDependentAdd, Vector):
     """
 
     def __new__(cls, *args, **options):
-        for arg in args:
-            if not isinstance(arg, Vector):
-                raise TypeError("VectorAdd expects all arguments to be Vector instances")
         obj = BasisDependentAdd.__new__(cls, *args, **options)
         return obj
 

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -423,9 +423,7 @@ def _mul_vector_postprocessor(expr: Mul) -> Vector:
     return VectorMul(*expr.args).doit(deep=False)
 
 def _pow_vector_postprocessor(expr: Pow):
-    if isinstance(expr.args[0], Vector):
-        raise TypeError("Power operation is not supported for vectors")
-    return expr
+    raise TypeError("Power operation is not supported for vectors")
 
 
 Basic._constructor_postprocessor_mapping[Vector] = {

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -426,7 +426,7 @@ def get_postprocessor(cls):
             return VectorMul(*expr.args).doit(deep=False)
         elif vec_class is None:
             if isinstance(expr.args[0], Vector):
-                raise ValueError("Power operation is not supported for vectors")
+                raise TypeError("Power operation is not supported for vectors")
     return _postprocessor
 
 

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -416,24 +416,22 @@ class Vector(BasisDependent):
 
 # The following is adapted from the matrices.expressions.matexpr file
 
-def get_postprocessor(cls):
-    def _postprocessor(expr):
-        vec_class = {Add: VectorAdd, Mul: VectorMul, Pow: None}[cls]
+def _add_vector_postprocessor(expr: Add) -> Vector:
+    return VectorAdd(*expr.args).doit(deep=False)
 
-        if vec_class == VectorAdd:
-            return VectorAdd(*expr.args).doit(deep=False)
-        elif vec_class == VectorMul:
-            return VectorMul(*expr.args).doit(deep=False)
-        elif vec_class is None:
-            if isinstance(expr.args[0], Vector):
-                raise TypeError("Power operation is not supported for vectors")
-    return _postprocessor
+def _mul_vector_postprocessor(expr: Mul) -> Vector:
+    return VectorMul(*expr.args).doit(deep=False)
+
+def _pow_vector_postprocessor(expr: Pow):
+    if isinstance(expr.args[0], Vector):
+        raise TypeError("Power operation is not supported for vectors")
+    return expr
 
 
 Basic._constructor_postprocessor_mapping[Vector] = {
-    "Add": [get_postprocessor(Add)],
-    "Mul": [get_postprocessor(Mul)],
-    "Pow": [get_postprocessor(Pow)],
+    "Add": [_add_vector_postprocessor],
+    "Mul": [_mul_vector_postprocessor],
+    "Pow": [_pow_vector_postprocessor],
 }
 
 class BaseVector(Vector, AtomicExpr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to gh-26121 and gh-26623.

#### Brief description of what is fixed or changed

When [simplify()](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/tests/test_vector.py:193:0-225:60) traverses expression trees using `bottom_up()`, it reconstructs nodes via `.func(*args)`. This caused [VectorMul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) objects to become [Mul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) objects, which then failed type checks in `CoordSys3D.__new__()` with `TypeError: location should be a Vector`.

This PR adds a postprocessor for [Mul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) (similar to the existing [Add](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:498:0-517:27) postprocessor from gh-26623) to ensure [Mul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) operations on vectors return [VectorMul](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/vector/vector.py:520:0-539:35) objects.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Fixed TypeError when simplifying vector expressions. VectorMul objects are now preserved during simplification.

<!-- END RELEASE NOTES -->