### PR TITLE
Fix typo and grammar in docstring in trigsimp.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1652,6 +1652,7 @@ Vincent Delecroix <vincent.delecroix@labri.fr>
 Vinit Ravishankar <vinit.ravishankar@gmail.com>
 Vinzent Steinberg <vinzent.steinberg@gmail.com> <Vinzent.Steinberg@gmail.com>
 Vinzent Steinberg <vinzent.steinberg@gmail.com> <vinzent.steinberg@googlemail.com>
+Viraj Palnitkar <virajpalnitkar@gmail.com> <167699246+VirajPalnitkar@users.noreply.github.com>
 Viraj Vekaria <virajv5593@gmail.com>
 Vishal <vishalg2235@gmail.com>
 Vishesh Mangla <manglavishesh64@gmail.com>

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -56,8 +56,8 @@ def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
     A number is used to indicate that the search space should be increased.
     A function is used to indicate that said function is likely to occur in a
     simplified expression.
-    An iterable is used indicate that func(var1 + var2 + ...) is likely to
-    occur in a simplified .
+    An iterable is used to indicate that func(var1 + var2 + ...) is likely to
+    occur in a simplified expression.
     An additional generator also indicates that it is likely to occur.
     (See examples below).
 


### PR DESCRIPTION
Fix typo and grammar in docstring in trigsimp.py

This PR fixes grammatical errors and clarifies wording in a docstring in
`trigsimp.py`. The previous version contained incomplete sentences and
ambiguous phrasing. The updated text improves readability and correctness
without modifying any functional code.

This change affects documentation only. No behavior or API is modified.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

