### PR TITLE
Fix AttributeError in FourierSeries printing for finite series

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2397,6 +2397,9 @@ class LatexPrinter(Printer):
             return self._print(s.a0)
         return self._print_Add(s.truncate()) + r' + \ldots'
 
+    def _print_FiniteFourierSeries(self, s):
+        return self._print(s.as_expr())
+
     def _print_FormalPowerSeries(self, s):
         return self._print_Add(s.infinite)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2355,6 +2355,9 @@ class PrettyPrinter(Printer):
             dots = '...'
         return self._print_Add(s.truncate()) + self._print(dots)
 
+    def _print_FiniteFourierSeries(self, s):
+        return self._print(s.as_expr())
+
     def _print_FormalPowerSeries(self, s):
         return self._print_Add(s.infinite)
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4936,6 +4936,19 @@ def test_pretty_sequences():
 def test_pretty_FourierSeries():
     f = fourier_series(x, (x, -pi, pi))
 
+    assert pretty(f) == (
+        '                      2*sin(3*x)      \n'
+        '2*sin(x) - sin(2*x) + ---------- + ...\n'
+        '                          3           ')
+
+    assert pretty(fourier_series(sin(x), (x, -pi, pi))) == 'sin(x)'
+    assert pretty(fourier_series(sin(x) + sin(2*x) + sin(3*x) + sin(4*x), (x, -pi, pi))) == (
+        'sin(x) + sin(2*x) + sin(3*x) + sin(4*x)')
+    assert pretty(fourier_series(sin(x)**2, (x, -pi, pi))) == (
+        '1   cos(2*x)\n'
+        '- - --------\n'
+        '2      2    ')
+
     ascii_str = \
 """\
                       2*sin(3*x)      \n\

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1116,6 +1116,12 @@ def test_latex_FourierSeries():
     latex_str = \
         r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
+    latex_str_sin = r'\sin{\left(x \right)}'
+    assert latex(fourier_series(sin(x), (x, -pi, pi))) == latex_str_sin
+    latex_str_4terms = r'\sin{\left(x \right)} + \sin{\left(2 x \right)} + \sin{\left(3 x \right)} + \sin{\left(4 x \right)}'
+    assert latex(fourier_series(sin(x) + sin(2*x) + sin(3*x) + sin(4*x), (x, -pi, pi))) == latex_str_4terms
+    latex_str_sin2 = r'\frac{1}{2} - \frac{\cos{\left(2 x \right)}}{2}'
+    assert latex(fourier_series(sin(x)**2, (x, -pi, pi))) == latex_str_sin2
 
 
 def test_latex_FormalPowerSeries():

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -598,6 +598,74 @@ class FiniteFourierSeries(FourierSeries):
                 + self.bn.get(pt, S.Zero) * sin(pt * (pi / self.L) * self.x)
         return _term
 
+    def as_expr(self):
+        """
+        Return the Fourier series as a single expression.
+
+        Builds the complete series directly from the a0, an, and bn
+        coefficients.
+
+        Returns
+        =======
+
+        Expr
+            The complete Fourier series as an expression.
+
+        Examples
+        ========
+
+        >>> from sympy import fourier_series, pi, sin
+        >>> from sympy.abc import x
+        >>> s = fourier_series(sin(x), (x, -pi, pi))
+        >>> s.as_expr()
+        sin(x)
+
+        """
+        return Add(*self.as_terms_list())
+
+    def as_terms_list(self):
+        """
+        Return all terms of the Fourier series as a list.
+
+        Builds the list of terms directly from the a0, an, and bn
+        coefficients. Sin and cos terms are mixed together in order
+        of increasing frequency.
+
+        Returns
+        =======
+
+        list
+            List of all non-zero terms in the Fourier series.
+
+        Examples
+        ========
+
+        >>> from sympy import fourier_series, pi, sin
+        >>> from sympy.abc import x
+        >>> s = fourier_series(sin(x) + sin(2*x), (x, -pi, pi))
+        >>> s.as_terms_list()
+        [sin(x), sin(2*x)]
+
+        """
+        terms = []
+
+        if self.a0 != S.Zero:
+            terms.append(self.a0)
+
+        all_n = sorted(set(self.an.keys()) | set(self.bn.keys()))
+
+        for n in all_n:
+            if n in self.an:
+                term = self.an[n] * cos(n * (pi / self.L) * self.x)
+                if term != S.Zero:
+                    terms.append(term)
+            if n in self.bn:
+                term = self.bn[n] * sin(n * (pi / self.L) * self.x)
+                if term != S.Zero:
+                    terms.append(term)
+
+        return terms
+
     def __add__(self, other):
         if isinstance(other, FourierSeries):
             return other.__add__(fourier_series(self.function, self.args[1],\

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -163,3 +163,34 @@ def test_FourierSeries_finite():
     assert fourier_series(cos(pi*x), (x, -1, 1)).truncate(oo) == cos(pi*x)
     assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y), (x, -1, 1)).truncate(oo) == -log(pi*y)*sin(4*pi*x)\
            - sin(4)*sin(3*pi*x) + cos(4)*cos(3*pi*x)
+
+
+def test_FiniteFourierSeries_as_expr():
+    s1 = fourier_series(sin(x), (x, -pi, pi))
+    assert s1.as_expr() == sin(x)
+
+    s2 = fourier_series(sin(x)**2, (x, -pi, pi))
+    assert s2.as_expr() == Rational(1, 2) - cos(2*x)/2
+
+    s3 = fourier_series(sin(x) + sin(2*x) + sin(3*x) + sin(4*x), (x, -pi, pi))
+    assert s3.as_expr() == sin(x) + sin(2*x) + sin(3*x) + sin(4*x)
+
+    s4 = fourier_series(sin(x) + cos(x), (x, -pi, pi))
+    assert s4.as_expr() == sin(x) + cos(x)
+
+    s5 = fourier_series(S(5), (x, -pi, pi))
+    assert s5 == 5
+
+
+def test_FiniteFourierSeries_as_terms_list():
+    s1 = fourier_series(sin(x), (x, -pi, pi))
+    assert s1.as_terms_list() == [sin(x)]
+
+    s2 = fourier_series(sin(x) + sin(2*x), (x, -pi, pi))
+    assert s2.as_terms_list() == [sin(x), sin(2*x)]
+
+    s3 = fourier_series(sin(x) + cos(x) + sin(2*x) + cos(2*x), (x, -pi, pi))
+    assert s3.as_terms_list() == [cos(x), sin(x), cos(2*x), sin(2*x)]
+
+    s4 = fourier_series(sin(x)**2, (x, -pi, pi))
+    assert s4.as_terms_list() == [Rational(1, 2), -cos(2*x)/2]


### PR DESCRIPTION
Fixes #28724

#### Brief description of what is fixed or changed

Fixed `AttributeError: 'Dict' object has no attribute 'formula'` that occurred when printing finite Fourier series (e.g., [fourier_series(sin(x), (x, -pi, pi))](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/series/fourier.py:617:0-810:49)) in Jupyter notebooks or using LaTeX/pretty printing.

The printers assumed coefficients ([an](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/series/fourier.py:163:4-165:30), [bn](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/series/fourier.py:167:4-169:30)) were always [SeqFormula](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/printing/pretty/pretty.py:2370:4-2389:41) objects with a `.formula` attribute. However, for finite Fourier series returned by [FiniteFourierSeries](cci:2://file:///Users/ayushkumarjha/Desktop/sympy/sympy/series/fourier.py:474:0-614:64), these are [Dict](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/printing/pretty/pretty.py:2456:4-2457:34) objects instead.

**Changes:**
```python
import sympy as sp
x=sp.Symbol('x',real=True)
sp.fourier_series(sp.sin(x),(x,-sp.pi,sp.pi))
```
Output:- 
```python
Before:- AttributeError
After:- FiniteFourierSeries(sin(x), (x, -pi, pi), (0, {}, {1: 1}))
```
#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed `AttributeError` when printing finite Fourier series in LaTeX and pretty formats
<!-- END RELEASE NOTES -->