### PR TITLE
Fix inner Mod square bug

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -719,6 +719,7 @@ Harsh Agarwal <hagarwal9200@gmail.com>
 Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
 Harsh Jain <harshjniitr@gmail.com>
 Harsh Kasat <hkasat@waymore.io>
+Harsh Menon <harsh.menon@amd.com> harsh-nod <menonharsh@gmail.com>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
 Harshil Meena <harshil.7535@gmail.com>

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -165,7 +165,7 @@ class Mod(DefinedFunction):
 
             if q.is_Integer and q is not S.One:
                 if all(t.is_integer for t in p.args):
-                    non_mod_l = [i % q if i.is_Integer else i for i in p.args]
+                    non_mod_l = [i % q if i.is_Integer else i for i in non_mod_l]
                     if any(iq is S.Zero for iq in non_mod_l):
                         return S.Zero
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2008,6 +2008,19 @@ def test_Mod():
     assert Mod(3*xi, 2) == Mod(xi, 2)
     assert unchanged(Mod, 3*x, 2)
 
+    # issue 28744
+    x0 = Symbol('x0')
+    x0_int = Symbol('x0', integer=True)
+    expr = Mod(2*Mod(x0, 3), 5)
+    expr_int = Mod(2*Mod(x0_int, 3), 5).xreplace({x0_int: x0})
+    assert expr == expr_int
+
+    x1 = Symbol('x1')
+    x1_int = Symbol('x1', integer=True)
+    expr = 8*Mod(floor(x1/64), 4)
+    expr_int = 8*Mod(floor(x1_int/64), 4).xreplace({x1_int: x1})
+    assert expr == expr_int
+
 
 def test_Mod_Pow():
     # modular exponentiation


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28744 (see https://github.com/sympy/sympy/issues/28744 for more information)

#### Brief description of what is fixed or changed
The factors in p are divided between non_mod_l and mod_l with mod_l being the ones that are of type Mod. The reassignment of non_mod_l can include factors of p that are of type Mod meaning that those factors end up being duplicated in both mod_l and non_mod_l. This is what leads to the inner Mod being squared. It only happens if x has the integer assumption because of the is_integer check. This PR fixes that to only use terms from non_mod_l.

#### Other comments

Tests:
Added 2 tests to catch this bug.


#### Release Notes


NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * fixed bug in modulo evaluation that resulted in spurious squaring of terms when integer assumptions were on

<!-- END RELEASE NOTES -->
