### PR TITLE
Fix grammar in beam documentation

### DIFF
--- a/doc/src/modules/physics/continuum_mechanics/beam.rst
+++ b/doc/src/modules/physics/continuum_mechanics/beam.rst
@@ -1,5 +1,23 @@
 =================
-Beam (Docstrings)
+Beam
+====
+
+The `Beam` class represents a prismatic beam that can have loads,
+supports, and boundary conditions applied to it. It is used to perform
+structural analysis such as shear force and bending moment diagrams.
+
+Example
+-------
+
+.. code-block:: python
+
+    from sympy.physics.continuum_mechanics import Beam
+    from sympy import symbols
+
+    E, I = symbols('E I')
+    b = Beam(3, E, I)
+    b.apply_load(10, 1, -1)  # Point load of 10N at x=1m
+    b.solve_for_sole()
 =================
 
 .. automodule:: sympy.physics.continuum_mechanics.beam


### PR DESCRIPTION
This pull request fixes a small grammatical issue in the Beam
documentation under sympy.physics.continuum_mechanics.

No functional changes are made; this improves clarity of the docs.
