### PR TITLE
docs: improve hyperexpand g-function documentation links

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -569,7 +569,7 @@ Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
 Diane Tchuindjo <dtchuindjo@gmail.com>
 Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
 Dimitra Konomi <t8130064@dias.aueb.gr>
-Disha Holmukhe <dishaholmukhe521@gmail.com>
+Disha Holmukhe <dishaholmukh521@gmail.com> Kiwi-520 <161978494+Kiwi-520@users.noreply.github.com>
 Divyanshu Thakur <divyanshu@iiitmanipur.ac.in> Divyanshu <divyanshu@iiitmanipur.ac.in>
 Dmitry Batkovich <batya239@gmail.com>
 Dmitry Savransky <dsavransky@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -569,6 +569,7 @@ Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
 Diane Tchuindjo <dtchuindjo@gmail.com>
 Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
 Dimitra Konomi <t8130064@dias.aueb.gr>
+Disha Holmukhe <dishaholmukhe521@gmail.com>
 Divyanshu Thakur <divyanshu@iiitmanipur.ac.in> Divyanshu <divyanshu@iiitmanipur.ac.in>
 Dmitry Batkovich <batya239@gmail.com>
 Dmitry Savransky <dsavransky@gmail.com>

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -8,8 +8,7 @@ def _generate_doc():
     from sympy.core.function import AppliedUndef, Function
 
     FUNCTION_LINKS = {
-        # Special functions 
-        # gamma family
+        # Special functions - gamma family
         'gamma': ':func:`~sympy.functions.special.gamma_functions.gamma`',
         'lowergamma': ':func:`~sympy.functions.special.gamma_functions.lowergamma`',
         'uppergamma': ':func:`~sympy.functions.special.gamma_functions.uppergamma`',

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -40,7 +40,7 @@ def _generate_doc():
         'sqrt': ':func:`~sympy.functions.elementary.miscellaneous.sqrt`',
         'root': ':func:`~sympy.functions.elementary.miscellaneous.root`',
 
-        # trigonometric 
+        # trigonometric
         'cos': ':func:`~sympy.functions.elementary.trigonometric.cos`',
         'sin': ':func:`~sympy.functions.elementary.trigonometric.sin`',
 

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -7,7 +7,6 @@ def _generate_doc():
     from sympy.simplify.hyperexpand import FormulaCollection
     from sympy.core.function import AppliedUndef, Function
 
-    
     FUNCTION_LINKS = {
         # Special functions 
         # gamma family
@@ -43,7 +42,7 @@ def _generate_doc():
         'sqrt': ':func:`~sympy.functions.elementary.miscellaneous.sqrt`',
         'root': ':func:`~sympy.functions.elementary.miscellaneous.root`',
 
-        # trignometric 
+        # trigonometric 
         'cos': ':func:`~sympy.functions.elementary.trigonometric.cos`',
         'sin': ':func:`~sympy.functions.elementary.trigonometric.sin`',
 
@@ -52,7 +51,7 @@ def _generate_doc():
         'sinh': ':func:`~sympy.functions.elementary.hyperbolic.sinh`',
 
         # Combinatorial functions
-        'rf': ':func:`~sympy.functions.combinatorial.factorials.RisingFactorial`',
+        'RisingFactorial': ':func:`~sympy.functions.combinatorial.factorials.RisingFactorial`',
         'factorial': ':func:`~sympy.functions.combinatorial.factorials.factorial`',
 
         # Other special functions
@@ -61,7 +60,7 @@ def _generate_doc():
     }
 
     def get_special_functions_used(expr):
-        '''Extract special function names from an expression'''
+        """Extract special function names from an expression"""
         func_names = set()
         for atom in expr.atoms(Function):
             if not isinstance(atom, AppliedUndef):

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -58,7 +58,7 @@ def _generate_doc():
     }
 
     def get_special_functions_used(expr):
-        """Extract special function names from an expression"""
+        """Extract special function names from an expression."""
         func_names = set()
         for atom in expr.atoms(Function):
             if not isinstance(atom, AppliedUndef):
@@ -69,22 +69,33 @@ def _generate_doc():
 
     c = FormulaCollection()
 
-    doc = ""
+    lines = []
 
     for f in c.formulae:
         obj = Eq(hyper(f.func.ap, f.func.bq, f.z),
                 f.closed_form.rewrite('nonrepsmall'))
-        doc += ".. math::\n  %s\n" % latex(obj)
+        lines.append(".. math::")
+        lines.append("")
+        lines.append("    %s" % latex(obj))
+        lines.append("")
         # Add links to special functions used
         special_funcs = get_special_functions_used(f.closed_form)
         if special_funcs:
-            doc += "\n"
-            if len(special_funcs) == 1:
-                doc += "This formula uses %s.\n" % FUNCTION_LINKS[special_funcs[0]]
+            lines.append("")
+            n = len(special_funcs)
+            if n == 1:
+                lines.append("This formula involves %s." % FUNCTION_LINKS[special_funcs[0]])
+            elif n == 2:
+                lines.append("This formula involves %s and %s." % (
+                    FUNCTION_LINKS[special_funcs[0]],
+                    FUNCTION_LINKS[special_funcs[1]]
+                ))
             else:
-                func_links = ', '.join(FUNCTION_LINKS[fn] for fn in special_funcs[:-1])
-                doc += "This formula uses %s and %s.\n" % (func_links, FUNCTION_LINKS[special_funcs[-1]])
-            doc += "\n"
-    return doc
+                raise NotImplementedError(
+                    "Expected at most 2 special functions, got %d: %s. "
+                    % (n, special_funcs)
+                )
+            lines.append("")
+    return '\n'.join(lines)
 
 __doc__ = _generate_doc()

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -91,7 +91,6 @@ def _generate_doc():
                     FUNCTION_LINKS[special_funcs[1]]
                 ))
             else:
-                # Handle 3+ functions 
                 func_links = ', '.join(FUNCTION_LINKS[fn] for fn in special_funcs[:-1])
                 lines.append("This formula involves %s, and %s."% (
                     func_links,

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -1,18 +1,94 @@
 """ This module cooks up a docstring when imported. Its only purpose is to
     be displayed in the sphinx documentation. """
 
-from sympy.core.relational import Eq
-from sympy.functions.special.hyper import hyper
-from sympy.printing.latex import latex
-from sympy.simplify.hyperexpand import FormulaCollection
+def _generate_doc():
+    from sympy import Eq, hyper
+    from sympy.printing.latex import latex
+    from sympy.simplify.hyperexpand import FormulaCollection
+    from sympy.core.function import AppliedUndef, Function
 
-c = FormulaCollection()
+    
+    FUNCTION_LINKS = {
+        # Special functions 
+        # gamma family
+        'gamma': ':func:`~sympy.functions.special.gamma_functions.gamma`',
+        'lowergamma': ':func:`~sympy.functions.special.gamma_functions.lowergamma`',
+        'uppergamma': ':func:`~sympy.functions.special.gamma_functions.uppergamma`',
 
-doc = ""
+        # Bessel functions
+        'besselj': ':func:`~sympy.functions.special.bessel.besselj`',
+        'besseli': ':func:`~sympy.functions.special.bessel.besseli`',
 
-for f in c.formulae:
-    obj = Eq(hyper(f.func.ap, f.func.bq, f.z),
-             f.closed_form.rewrite('nonrepsmall'))
-    doc += ".. math::\n  %s\n" % latex(obj)
+        # Error functions
+        'erf': ':func:`~sympy.functions.special.error_functions.erf`',
+        'expint': ':func:`~sympy.functions.special.error_functions.expint`',
+        'Ei': ':func:`~sympy.functions.special.error_functions.Ei`',
+        'Ci': ':func:`~sympy.functions.special.error_functions.Ci`',
+        'Si': ':func:`~sympy.functions.special.error_functions.Si`',
+        'Shi': ':func:`~sympy.functions.special.error_functions.Shi`',
+        'Chi': ':func:`~sympy.functions.special.error_functions.Chi`',
+        'fresnels': ':func:`~sympy.functions.special.error_functions.fresnels`',
+        'fresnelc': ':func:`~sympy.functions.special.error_functions.fresnelc`',
 
-__doc__ = doc
+        # Elliptic integrals
+        'elliptic_k': ':func:`~sympy.functions.special.elliptic_integrals.elliptic_k`',
+        'elliptic_e': ':func:`~sympy.functions.special.elliptic_integrals.elliptic_e`',
+
+        # Elementary functions 
+        # exponential
+        'exp': ':func:`~sympy.functions.elementary.exponential.exp`',
+        'log': ':func:`~sympy.functions.elementary.exponential.log`',
+
+        # miscellaneous
+        'sqrt': ':func:`~sympy.functions.elementary.miscellaneous.sqrt`',
+        'root': ':func:`~sympy.functions.elementary.miscellaneous.root`',
+
+        # trignometric 
+        'cos': ':func:`~sympy.functions.elementary.trigonometric.cos`',
+        'sin': ':func:`~sympy.functions.elementary.trigonometric.sin`',
+
+        # hyperbolic
+        'cosh': ':func:`~sympy.functions.elementary.hyperbolic.cosh`',
+        'sinh': ':func:`~sympy.functions.elementary.hyperbolic.sinh`',
+
+        # Combinatorial functions
+        'rf': ':func:`~sympy.functions.combinatorial.factorials.RisingFactorial`',
+        'factorial': ':func:`~sympy.functions.combinatorial.factorials.factorial`',
+
+        # Other special functions
+        'lerchphi': ':func:`~sympy.functions.special.zeta_functions.lerchphi`',
+
+    }
+
+    def get_special_functions_used(expr):
+        '''Extract special function names from an expression'''
+        func_names = set()
+        for atom in expr.atoms(Function):
+            if not isinstance(atom, AppliedUndef):
+                func_name = atom.func.__name__
+                if func_name in FUNCTION_LINKS:
+                    func_names.add(func_name)
+        return sorted(func_names)
+
+    c = FormulaCollection()
+
+    doc = ""
+
+    for f in c.formulae:
+        obj = Eq(hyper(f.func.ap, f.func.bq, f.z),
+                f.closed_form.rewrite('nonrepsmall'))
+        doc += ".. math::\n  %s\n" % latex(obj)
+
+        # Add links to special functions used
+        special_funcs = get_special_functions_used(f.closed_form)
+        if special_funcs:
+            doc += "\n"
+            if len(special_funcs) == 1:
+                doc += "This formula uses %s.\n" % FUNCTION_LINKS[special_funcs[0]]
+            else:
+                func_links = ', '.join(FUNCTION_LINKS[fn] for fn in special_funcs[:-1])
+                doc += "This formula uses %s and %s.\n" % (func_links, FUNCTION_LINKS[special_funcs[-1]])
+            doc += "\n"
+    return doc
+
+__doc__ = _generate_doc()

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -32,8 +32,7 @@ def _generate_doc():
         'elliptic_k': ':func:`~sympy.functions.special.elliptic_integrals.elliptic_k`',
         'elliptic_e': ':func:`~sympy.functions.special.elliptic_integrals.elliptic_e`',
 
-        # Elementary functions 
-        # exponential
+        # Elementary functions - exponential
         'exp': ':func:`~sympy.functions.elementary.exponential.exp`',
         'log': ':func:`~sympy.functions.elementary.exponential.log`',
 
@@ -76,7 +75,6 @@ def _generate_doc():
         obj = Eq(hyper(f.func.ap, f.func.bq, f.z),
                 f.closed_form.rewrite('nonrepsmall'))
         doc += ".. math::\n  %s\n" % latex(obj)
-
         # Add links to special functions used
         special_funcs = get_special_functions_used(f.closed_form)
         if special_funcs:

--- a/sympy/simplify/hyperexpand_doc.py
+++ b/sympy/simplify/hyperexpand_doc.py
@@ -91,10 +91,12 @@ def _generate_doc():
                     FUNCTION_LINKS[special_funcs[1]]
                 ))
             else:
-                raise NotImplementedError(
-                    "Expected at most 2 special functions, got %d: %s. "
-                    % (n, special_funcs)
-                )
+                # Handle 3+ functions 
+                func_links = ', '.join(FUNCTION_LINKS[fn] for fn in special_funcs[:-1])
+                lines.append("This formula involves %s, and %s."% (
+                    func_links,
+                    FUNCTION_LINKS[special_funcs[-1]]
+                ))
             lines.append("")
     return '\n'.join(lines)
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #6002


#### Brief description of what is fixed or changed
This PR improves the hyperexpand and g-function documentation by adding hyperlinks
to the documentation of the special functions referenced in the formula tables.

These links make the tables easier to navigate and help readers quickly
understand the mathematical objects used in each formula.


#### Other comments
- The documentation was built locally using `make html` to verify the output.
- The **“Implemented Hypergeometric Formulae”** section renders correctly, with
  all relevant special functions appearing as clickable links.
- Build warnings related to `gmpy2` references are pre-existing and unrelated
  to this change.
- Screenshots of the rendered documentation are included for verification.
<img width="1867" height="958" alt="Screenshot 2025-12-13 170934" src="https://github.com/user-attachments/assets/542eb7fd-79b7-408c-81aa-ac8aac007e5b" />
<img width="1827" height="946" alt="Screenshot 2025-12-13 171018" src="https://github.com/user-attachments/assets/68e260c8-66ba-49c6-8f8d-5eb1cc5e4e30" />



#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Improved hyperexpand g-function documentation by adding links to the
    corresponding special-function documentation.
<!-- END RELEASE NOTES -->
