### PR TITLE
fix TypeError in MarginalDistribution by making count iterable

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -337,7 +337,7 @@ Anjul Kumar Tyagi <anjul.ten@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
-Ankush <ankushhhkumar07@gmail.com>
+Ankush <ankushhhkumar07@gmail.com> Ankush <team07aloneboy@gmail.com>
 Ansh Mishra <anshmishra471@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -337,6 +337,7 @@ Anjul Kumar Tyagi <anjul.ten@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
+Ankush <ankushhhkumar07@gmail.com>
 Ansh Mishra <anshmishra471@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -337,7 +337,7 @@ Anjul Kumar Tyagi <anjul.ten@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
-Ankush <ankushhhkumar07@gmail.com> Ankush <team07aloneboy@gmail.com>
+Ankush <ankushhhkumar07@gmail. com> Ankush <team07aloneboy@gmail.com>
 Ansh Mishra <anshmishra471@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -337,7 +337,7 @@ Anjul Kumar Tyagi <anjul.ten@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
-Ankush <ankushhhkumar07@gmail. com> Ankush <team07aloneboy@gmail.com>
+Ankush <ankushhhkumar07@gmail.com> Ankush <team07aloneboy@gmail.com>
 Ansh Mishra <anshmishra471@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -389,7 +389,7 @@ class MarginalDistribution(Distribution):
         if isinstance(expr, JointDistribution):
             count = len(expr.domain.args)
             x = Dummy('x', real=True)
-            syms = tuple(Indexed(x, i) for i in count)
+            syms = tuple(Indexed(x, i) for i in range(count))
             expr = expr.pdf(syms)
         else:
             syms = tuple(rv.pspace.symbol if isinstance(rv, RandomSymbol) else rv.args[0] for rv in rvs)

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -434,3 +434,14 @@ def test_issue_21057_pymc():
                     assert tuple(s.flatten()) in p.pspace.distribution.set
         except NotImplementedError:
             continue
+
+
+def test_marginal_distribution_pdf_multivariate_28763():
+    from sympy.stats import MultivariateNormal
+    from sympy.stats.joint_rv import MarginalDistribution
+    from sympy import Matrix, eye
+
+    M = MultivariateNormal('M', Matrix([0, 0]), eye(2))
+    m = MarginalDistribution(M, (M[0],))
+    result = m.pdf(M[0])
+    assert result is not None


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* stats
  * Verified that `MarginalDistribution.pdf()` correctly handles multivariate normal distributions without raising `AttributeError` or `SyntaxError`.
<!-- END RELEASE NOTES -->

## Investigation Summary

I investigated this issue using the latest master branch as a first-year ISE student. It appears the original `AttributeError`/`SyntaxError` mentioned in the description has not yet been resolved in recent versions of SymPy.

### Reproduction Attempt

I attempted to reproduce the bug using the following code:
<img width="831" height="340" alt="image" src="https://github.com/user-attachments/assets/74beee33-130e-4f79-9c16-e18d584f1944" />

**Output:** 
TypeError : 'int' object is not iterable as expected.

### Suggested Code Improvement

A possible code refinement can be made as highlighted below:
<img width="920" height="210" alt="Screenshot 2025-12-14 114445" src="https://github.com/user-attachments/assets/f089d1fe-bc06-4fab-9c10-846c6dff9f55" />
Since the code runs successfully, it could potentially be refactored for clarity while maintaining the same functionality.

### Test Code for Checking the Fixed Error
<img width="831" height="340" alt="image" src="https://github.com/user-attachments/assets/74beee33-130e-4f79-9c16-e18d584f1944" />


 **Output**
<img width="680" height="73" alt="Screenshot 2025-12-14 115636" src="https://github.com/user-attachments/assets/1b8d9139-581f-4cc1-9b42-c30b2036c35d" />

### Recommendation

"I initially thought this was resolved, but i had a local modification masking the bug. I have confirmed that master does indeed crash with TypeError, and this PR fixes it by iterating over range(count) instead of count"
