### PR TITLE
ntheory: add an internal RLock in the Sieve class

### DIFF
--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -1,5 +1,7 @@
 from bisect import bisect, bisect_left
 
+import pytest
+
 from sympy.functions.combinatorial.numbers import mobius, totient
 from sympy.ntheory.generate import (sieve, Sieve)
 
@@ -49,6 +51,7 @@ def test__primepi():
     assert _primepi(2000) == 303
 
 
+@pytest.mark.thread_unsafe(reason="resets the global sieve state")
 def test_composite():
     from sympy.ntheory.generate import sieve
     sieve._reset()
@@ -89,6 +92,7 @@ def test_compositepi():
     assert compositepi(2321) == 1976
 
 
+@pytest.mark.thread_unsafe(reason="resets the global sieve state")
 def test_generate():
     from sympy.ntheory.generate import sieve
     sieve._reset()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

c.f. https://github.com/sympy/sympy/issues/28239#issuecomment-3652002429


#### Brief description of what is fixed or changed

The ntheory Sieve class and global `sieve` singleton aren't thread-safe. To fix this, I've added an internal RLock and I lock it whenever the internal state is accessed.

This approach is safe but may not scale well. I doubt multithreaded scaling is as important as safety. I haven't done any multithreaded performance testing.

Tested locally on free-threaded 3.14.2 using a locally-installed version of sympy.

#### Other comments

Not sure what the correct approach is for the new internal methods I added. I could also make the diff even bigger and add more spots where I indent to make sure code is locked using the RLock context manager. Let me know what you prefer.

Not sure what to do about the new pytest marks. I don't see any existing uses and we probably shouldn't break users who don't have pytest-run-parallel installed. I can install dummy marks - I've done that in a few projects. Like here: https://github.com/python-cffi/cffi/blob/ee1a87bc489f14681dacd3fdc518dd40bbab81ea/testing/conftest.py#L6-L26. Let me know what you'd prefer.

Marked as a draft for now until I get some comments.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* ntheory
    * the Sieve class and sympy.ntheory.generate module are now thread-safe.

<!-- END RELEASE NOTES -->
