### PR TITLE
fix(ntheory): Make ntheory functions thread-safe

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -9,6 +9,8 @@ Number Theory
 Ntheory Class Reference
 =======================
 
+.. py:class:: array.array
+
 .. autoclass:: sympy.ntheory.generate.Sieve
    :members:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest-xdist
 pytest-timeout
 pytest-split
 pytest-doctestplus
+pytest-run-parallel
 hypothesis
 flake8
 flake8-comprehensions

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -11,26 +11,32 @@ from itertools import count
 
 def _pre():
     maxn = 10**5
-    global _factor, _totient
-    _factor = [0]*maxn
-    _totient = [1]*maxn
+    factor = [0]*maxn
+    totient = [1]*maxn
     lim = int(maxn**0.5) + 5
     for i in range(2, lim):
-        if _factor[i] == 0:
+        if factor[i] == 0:
             for j in range(i*i, maxn, i):
-                if _factor[j] == 0:
-                    _factor[j] = i
+                if factor[j] == 0:
+                    factor[j] = i
     for i in range(2, maxn):
-        if _factor[i] == 0:
-            _factor[i] = i
-            _totient[i] = i-1
+        if factor[i] == 0:
+            factor[i] = i
+            totient[i] = i-1
             continue
-        x = _factor[i]
+        x = factor[i]
         y = i//x
         if y % x == 0:
-            _totient[i] = _totient[y]*x
+            totient[i] = totient[y]*x
         else:
-            _totient[i] = _totient[y]*(x - 1)
+            totient[i] = totient[y]*(x - 1)
+
+    # Assign the global variables once atomically when their values are
+    # fully correct. In multithreading this ensures that one thread does not
+    # overwrite the values while another thread thinks they are safe to read.
+    global _factor, _totient
+    _factor = factor
+    _totient = totient
 
 def _a(n, k, prec):
     """ Compute the inner sum in HRR formula [1]_

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import pytest
 from sympy.core.containers import Dict
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
@@ -206,6 +207,7 @@ def test_perfect_power():
     assert perfect_power(Rational(-3, 2)**3) == (-3*S.Half, 3)
 
 
+@pytest.mark.thread_unsafe(reason="test relies on mutating a global cache")
 def test_factor_cache():
     factor_cache.cache_clear()
     raises(ValueError, lambda: factor_cache.__setitem__(1, 5))

--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -103,10 +103,8 @@ def test_generate():
     assert prevprime(19) == 17
     assert prevprime(20) == 19
 
-    sieve.extend_to_no(9)
-    assert sieve._list[-1] == 23
-
-    assert sieve._list[-1] < 31
+    _list = sieve._extend_to_no(9)
+    assert _list[-1] >= 23
     assert 31 in sieve
 
     assert nextprime(90) == 97
@@ -134,7 +132,7 @@ def test_generate():
         s = Sieve(sieve_interval=sieve_interval)
         for head in range(s._list[-1] + 1, (s._list[-1] + 1)**2, 2):
             for tail in range(head + 1, (s._list[-1] + 1)**2):
-                A = list(s._primerange(head, tail))
+                A = list(s._primerange(head, tail, s._list))
                 B = primelist[bisect(primelist, head):bisect_left(primelist, tail)]
                 assert A == B
         for k in range(s._list[-1], primelist[-1] - 1, 2):
@@ -242,10 +240,10 @@ def test_randprime():
 
 def test_primorial():
     assert primorial(1) == 2
-    assert primorial(1, nth=0) == 1
+    assert primorial(1, nth=False) == 1
     assert primorial(2) == 6
-    assert primorial(2, nth=0) == 2
-    assert primorial(4, nth=0) == 6
+    assert primorial(2, nth=False) == 2
+    assert primorial(4, nth=False) == 6
 
 
 def test_search():

--- a/sympy/ntheory/tests/test_qs.py
+++ b/sympy/ntheory/tests/test_qs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import math
 from sympy.core.random import _randint
 from sympy.ntheory import qs, qs_factor
@@ -20,6 +21,7 @@ def test_qs_1():
         {18640889198609, 20991129234731}
 
 
+@pytest.mark.thread_unsafe(reason="Uses a global RNG that is shared across threads")
 def test_qs_2() -> None:
     n = 10009202107
     M = 50


### PR DESCRIPTION
#### References to other Issues or PRs

General issue gh-28239 but see specifically https://github.com/sympy/sympy/issues/28239#issuecomment-3652002429

Alternative approach to gh-28768 which uses a threading lock whereas here we use RCU for lock free updating of the sieve's internal state.

#### Brief description of what is fixed or changed

A number of functions in ntheory use global variables, and can fail under multithreading. This commit makes them thead-safe by only allowing atomic reassignment of the global state using the Read, Copy, Update (RCU) memory model.

https://en.wikipedia.org/wiki/Read-copy-update

Since module level globals or instance attributes are stored in dicts and dicts in Python use per-object locks for thread-safety we depend on the atomicity of setting an item in a dict to give an atomic update step and all mutations are done by making a local copy of the global state and only updating when the state is fully complete and correct.

The arrays in the Sieve class are now only extended with
```python
    _list = _list + array(...)
```
rather than
```python
    _list += array(...)
```
meaning that a new array is created rather than mutating the existing array in place. Note that at the C level, += still makes a copy of the buffer to the new memory location. The extra overhead here from not using += is just creating a new Python object that wraps the new memory buffer rather than reassigning the newly copied buffer inside the existing Python object.

Also, any method that depends on the array being a certain size should hold a local copy of the array e.g.
```python
    _list = self.extend(N)
    answer = _list[-1]
    self._list = _list
    return answer
```
This ensures that the array `_list` is not mutated by other threads (since they do not use `+=`) even though other threads may have reassigned `self._list` to a different array. It is possible that two threads could call extend at the same time but either way self._list will only ever be assigned some correct list of some size and every thread can depend on knowing that after `_list = self._list` or `_list = self.extend(N)` they have a local variable that is not going to be mutated by other threads.

With these changes the ntheory functions mostly pass tests under pytest-run-parallel e.g.
```python
    $ pip install pytest-run-parallel
    $ pytest --parallel-threads=4 sympy/ntheory
```
The above can be tested both with a GIL build of CPython and with a free-threaded build.

Some tests have been marked to be skipped under `--parallel-threads` since they use the warnings filter (catch_warnings) which does not work under multithreading or they use other global state such as a global RNG.

#### Other comments

There are still some tests that sometimes fail non-deterministically under multithreading specifically

- `test_qs_factor`
- `test_residue`
- `test_partition_rec`

In the case of test_residue it seems that some functions like _discrete_log_pollard_rho and _discrete_log_index_calculus use RNGs and sometimes fail depending on the RNG state. It is not clear if the non-deterministic failures should be expected behaviour for these functions given that they use RNGs so it is possible that just the test suite is making faulty assumptions about the RNG state rather than that there is a bug in the functions being tested.

For qs_factor there is potentially a bug to do with the factor cache not being thread-safe but I have not investigated this closely.

The test_partition_rec test fails sometimes because recurrence_memo does not work correctly under multithreading.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
   * Some function in the ntheory module were made thread-safe. These functions are indirectly used by other top-level sympy functions such as factorial so this change prevents e.g. factorial from returning incorrect results when used under high contention multithreading.
<!-- END RELEASE NOTES -->