### PR TITLE
Fix incorrect computation of vector transformation equations

### DIFF
--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -131,14 +131,14 @@ class CoordSys3D(Basic):
 
         if isinstance(transformation, Tuple):
             lambda_transformation = CoordSys3D._compose_rotation_and_translation(
-                transformation[0],
+                transformation[0].T,
                 transformation[1],
                 parent
             )
             r, l = transformation
             l = l._projections
             lambda_lame = CoordSys3D._get_lame_coeff('cartesian')
-            lambda_inverse = lambda x, y, z: r.inv()*Matrix(
+            lambda_inverse = lambda x, y, z: r*Matrix(
                 [x-l[0], y-l[1], z-l[2]])
         elif isinstance(transformation, Str):
             trname = transformation.name

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -481,3 +481,19 @@ def test_issue_28559():
     simple_eq = f(R.a).diff(R.a)
     simple_result = simple_eq.simplify()
     assert simple_result == simple_eq
+
+
+def test_cartesian_rotation_transformation_equations():
+    alpha = symbols("alpha")
+    A = CoordSys3D("A")
+    B = A.orient_new_axis("B", alpha, A.k)
+    xa, ya, za = A.base_scalars()
+    xb, yb, zb = B.base_scalars()
+    assert B.transformation_from_parent() == Matrix([
+        xa * cos(alpha) + ya * sin(alpha),
+        -xa * sin(alpha) + ya * cos(alpha),
+        za])
+    assert B.transformation_to_parent() == (
+        xb * cos(alpha) - yb * sin(alpha),
+        xb * sin(alpha) + yb * cos(alpha),
+        zb)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28770


#### Brief description of what is fixed or changed

Wrong rotation matrices were used to compute the transformation equations. This PR uses the correct matrices.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Fixed a bug which caused the computation of wrong transformation equations 
     for a rotated Cartesian system.

<!-- END RELEASE NOTES -->
