### PR TITLE
Fix nonlinsolve returning incorrect parametric solution with Abs

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3574,7 +3574,9 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                 if (depen1.has(Abs) or depen2.has(Abs)) and solver == solveset_complex:
                     # Absolute values cannot be inverted in the
                     # complex domain
-                    continue
+                    raise NotImplementedError(
+                        "nonlinsolve cannot solve equations with Abs in the complex domain"
+                    )
                 soln_imageset = {}
                 for sym in unsolved_syms:
                     not_solvable = False

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1866,8 +1866,10 @@ def test_nonlinsolve_basic():
 
 
 def test_nonlinsolve_abs():
-    soln = FiniteSet((y, y), (-y, y))
-    assert nonlinsolve([Abs(x) - y], x, y) == soln
+    raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - y], x, y))
+    raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 1, x - y], x, y))
+    raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 1, y - 2], x, y))
+    raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 2, x + y], x, y))
 
 
 def test_raise_exception_nonlinsolve():


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28742

#### Brief description of what is fixed or changed
nonlinsolve`([Abs(x) - 1, x - y], x, y)` was incorrectly returning parametric solution {(y, y)} instead of raising an exception. nonlinsolve now raises NotImplementedError when encountering equations with Abs in the complex domain, as it cannot properly represent the continuous solution sets (e.g., points on the unit circle).

As already mentioned here https://github.com/sympy/sympy/issues/28742#issuecomment-3639351587 `Abs(x) - 1` this got skipped
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, [log(-x)](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:1971:0-2026:13) incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* solvers
  * Fixed [nonlinsolve](cci:1://file:///Users/ayushkumarjha/Desktop/sympy/sympy/solvers/solveset.py:3905:0-4138:27) returning incorrect parametric solutions for systems containing `Abs` functions. Now correctly returns concrete solutions when both `Abs` and linear equations are present.

<!-- END RELEASE NOTES -->