### PR TITLE
[WIP] Adds `Mul` to the vector postprocessor

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -196,6 +196,7 @@ Aaron Gokaslan <aaronGokaslan@gmail.com>
 Aaron Meurer <asmeurer@gmail.com>
 Aaron Miller <acmiller273@gmail.com> <78561124+aaron-skydio@users.noreply.github.com>
 Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
+Aaryan Dadu <aaryandadu5157@gmail.com> Aaryan Dadu <aaryandadu5157@gmail.com>
 Aaryan Dewan <aaryandewan@yahoo.com> Aaryan Dewan <49852384+aaryandewan@users.noreply.github.com>
 Aasim Ali <aasim250205@gmail.com> Aasim Ali <94692076+aasim-maverick@users.noreply.github.com>
 Aasim Ali <aasim250205@gmail.com> aasim-maverick <aasim250205@gmail.com>

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -341,3 +341,10 @@ def test_scalar():
     assert v1.is_scalar is False
     assert (v1.dot(v2)).is_scalar is True
     assert (v1.cross(v2)).is_scalar is False
+
+
+def test_postprocessor_for_vector():
+    from sympy.vector import CoordSys3D
+    C1 = CoordSys3D("C1")
+    assert Mul(2, C1.i).is_Vector is True
+    assert Add(2, C1.i).is_Vector is True

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from itertools import product
 
-from sympy.core import Add, Basic
+from sympy.core import Add, Mul, Basic
 from sympy.core.assumptions import StdFactKB
 from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.power import Pow
@@ -418,7 +418,7 @@ class Vector(BasisDependent):
 
 def get_postprocessor(cls):
     def _postprocessor(expr):
-        vec_class = {Add: VectorAdd}[cls]
+        vec_class = {Add: VectorAdd, Mul: VectorMul}[cls]
         vectors = []
         for term in expr.args:
             if isinstance(term.kind, VectorKind):
@@ -426,11 +426,15 @@ def get_postprocessor(cls):
 
         if vec_class == VectorAdd:
             return VectorAdd(*vectors).doit(deep=False)
+
+        if vec_class == VectorMul:
+            return VectorMul(*vectors).doit(deep=False)
     return _postprocessor
 
 
 Basic._constructor_postprocessor_mapping[Vector] = {
     "Add": [get_postprocessor(Add)],
+    "Mul": [get_postprocessor(Mul)],
 }
 
 class BaseVector(Vector, AtomicExpr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28727. Related to https://github.com/sympy/sympy/issues/26121

#### Brief description of what is fixed or changed
This PR:
- Adds `Mul` to the vector postprocessor mapping alongside `Add`.
- Adds a test to verify that `Mul` and `Add` expressions with vectors
  are correctly identified as vectors

It is more of an extension (or completion) of https://github.com/sympy/sympy/pull/26623

#### Other comments
Now, the simplification works perfectly fine as it will now always use VectorMul and VectorAdd while involvement of vectors instead of Mul or Add in some cases. This fix is mathematically accurate but affects few printing and vector tests which were dependent on unevaluated cross products. These will be updated in follow up commits

<img width="973" height="466" alt="Screenshot From 2025-12-17 00-58-19" src="https://github.com/user-attachments/assets/d7521316-a47d-4f89-bde3-e3abda1c6bdc" />


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
   * Fixed a bug in which the scalar multiplication of vector was not uniformly recognised as vector expressions which in some cases resulted in TypeError.
<!-- END RELEASE NOTES -->
