### PR TITLE
test: Add regression test for recursion error in gaussian integral

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -313,6 +313,7 @@ Amit Kumar <dtu.amit@gmail.com> <dtu.amit+gh@gmail.com>
 Amit Manchanda <amitdelhi1995@gmail.com>
 Amit Saha <amitsaha.in@gmail.com> <asaha@redhat.com>
 Ananya H <ananyaha93@gmail.com>
+Anas <anas23khan083@gmail.com>
 Anatolii Koval <weralwolf@gmail.com>
 Andre de Fortier Smit <freevryheid@gmail.com>
 Andreas Klöckner <inform@tiker.net> Andreas Kloeckner <inform@tiker.net>

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2224,7 +2224,7 @@ def test_issue_15566():
 
     expr = (S(1) / sqrt(2 * pi * s**2)) * (t + m) * exp(-t**2 / (2 * s**2))
     result = integrate(expr, (t, a - m, oo))
-    
+
     assert isinstance(result, Piecewise)
-    
+
     assert result.has(erf)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2217,7 +2217,6 @@ def test_integration_of_piecewise_with_simbolic_boundaries():
         Piecewise((2*t1, t1 < 0), (2*Min(1, t1), t1 <= Min(1, t1)), (nan, True))
 
 
-
 def test_issue_15566():
     a, m, s = symbols('a m s', real=True)
     t = symbols('t')

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2215,3 +2215,16 @@ def test_integration_of_piecewise_with_simbolic_boundaries():
 
     assert integrate( Piecewise( (2,t2<1) , (nan , True)) , (t2,0,t1) ) == \
         Piecewise((2*t1, t1 < 0), (2*Min(1, t1), t1 <= Min(1, t1)), (nan, True))
+
+
+
+def test_issue_15566():
+    a, m, s = symbols('a m s', real=True)
+    t = symbols('t')
+
+    expr = (S(1) / sqrt(2 * pi * s**2)) * (t + m) * exp(-t**2 / (2 * s**2))
+    result = integrate(expr, (t, a - m, oo))
+    
+    assert isinstance(result, Piecewise)
+    
+    assert result.has(erf)


### PR DESCRIPTION
#### References to other Issues or PRs
test for #15566 but expression has not been simplified


#### Brief description of what is fixed or changed
Added a regression test for issue #15566. Previously, evaluating a specific Gaussian-like integral caused a RecursionError. The underlying issue has been resolved in the codebase, and the integral now evaluates correctly (returning a Piecewise result involving erf).

This PR adds a test case to sympy/integrals/tests/test_integrals.py to ensure this specific integral continues to evaluate without raising a RecursionError and prevents future regressions.

#### Other comments
This PR provides the regression test requested by @smichr  to verify the fix and close the issue.
It specifically addresses the items summarized by @dniku in the issue thread:
1. Add a test to confirm that the original integral evaluates: This PR fulfills this requirement. The test asserts that the result is a Piecewise instance containing erf, confirming the integration logic executes fully without crashing.

2. Resolve args into a simpler piecewise representation: As noted by @dniku and @oscarbenjamin , the output currently contains complex conditions on args even when symbols are real. This PR focuses strictly on regression testing the crash.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added a regression test for a Gaussian integral that previously caused infinite recursion.
<!-- END RELEASE NOTES -->
