### PR TITLE
Fix #28767: Distinguish LaTeX symbols for KroneckerProduct and ArrayTensorProduct

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1867,7 +1867,7 @@ class LatexPrinter(Printer):
         prec = PRECEDENCE['Pow']
         parens = self.parenthesize
 
-        return r' \otimes '.join(
+        return r' \boxtimes '.join(
             (parens(arg, prec, strict=True) for arg in args))
 
     def _print_MatPow(self, expr):
@@ -2044,6 +2044,14 @@ class LatexPrinter(Printer):
         return "{{%s}_{%s}}" % (
             self.parenthesize(expr.name, PRECEDENCE["Func"], True),
             ", ".join([f"{self._print(i)}" for i in expr.indices]))
+
+    def _print_ArrayTensorProduct(self, expr):
+        args = expr.args
+        prec = PRECEDENCE['Pow']
+        parens = self.parenthesize
+
+        return r' \otimes '.join(
+            (parens(arg, prec, strict=True) for arg in args))
 
     def _print_UniversalSet(self, expr):
         return r"\mathbb{U}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2608,7 +2608,14 @@ def test_DotProduct_printing():
 def test_KroneckerProduct_printing():
     A = MatrixSymbol('A', 3, 3)
     B = MatrixSymbol('B', 2, 2)
-    assert latex(KroneckerProduct(A, B)) == r'A \otimes B'
+    assert latex(KroneckerProduct(A, B)) == r'A \boxtimes B'
+
+
+def test_ArrayTensorProduct_printing():
+    from sympy.tensor.array.expressions import ArrayTensorProduct, ArraySymbol
+    M = ArraySymbol('M', (2, 2))
+    N = ArraySymbol('N', (2, 2))
+    assert latex(ArrayTensorProduct(M, N)) == r'M \otimes N'
 
 
 def test_Series_printing():


### PR DESCRIPTION
Fixes #28767 by using distinct LaTeX symbols to differentiate between `KroneckerProduct` and `ArrayTensorProduct`.

<!-- BEGIN RELEASE NOTES -->
* printing
  * Changed LaTeX representation of `KroneckerProduct` to use `\boxtimes` instead of `\otimes` to distinguish it from `ArrayTensorProduct`.
<!-- END RELEASE NOTES -->
