### PR TITLE
Add round-trip consistency test for convert_to

### DIFF
--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -196,3 +196,12 @@ def test_check_dimensions_error_message():
     with raises(ValueError) as excinfo:
         check_dimensions(meter + second)
     assert str(excinfo.value) == "addends have incompatible dimensions: (((Dimension(length, L), 1),), ((Dimension(time, T), 1),))"
+
+def test_convert_to_roundtrip():
+    # Test round-trip consistency: converting to another unit and back should return original
+    assert convert_to(convert_to(5*meter, centimeter), meter) == 5*meter
+    assert convert_to(convert_to(10*kilometer, meter), kilometer) == 10*kilometer
+    assert convert_to(convert_to(2*hour, second), hour) == 2*hour
+    assert convert_to(convert_to(mile, kilometer), mile) == mile
+    assert convert_to(convert_to(3*kilogram, gram), kilogram) == 3*kilogram
+    assert convert_to(convert_to(speed_of_light, meter/second), speed_of_light) == speed_of_light


### PR DESCRIPTION
Fixes #28781

Added `test_convert_to_roundtrip()` to ensure round-trip consistency when converting between unit systems.

**Test coverage:**
- Length: meter ↔ centimeter, kilometer ↔ meter
- Time: hour ↔ second  
- Distance: mile ↔ kilometer
- Mass: kilogram ↔ gram
- Speed: speed_of_light ↔ meter/second

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
