### PR TITLE
Change Hadamard product/power LaTeX symbol from \circ to \odot

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1852,14 +1852,14 @@ class LatexPrinter(Printer):
         prec = PRECEDENCE['Pow']
         parens = self.parenthesize
 
-        return r' \circ '.join(
+        return r' \odot '.join(
             (parens(arg, prec, strict=True) for arg in args))
 
     def _print_HadamardPower(self, expr):
         if precedence_traditional(expr.exp) < PRECEDENCE["Mul"]:
-            template = r"%s^{\circ \left({%s}\right)}"
+            template = r"%s^{\odot \left({%s}\right)}"
         else:
-            template = r"%s^{\circ {%s}}"
+            template = r"%s^{\odot {%s}}"
         return self._helper_print_standard_power(expr, template)
 
     def _print_KroneckerProduct(self, expr):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2161,8 +2161,8 @@ def test_Transpose():
     assert latex(Transpose(X)) == r'X^{T}'
     assert latex(Transpose(X + Y)) == r'\left(X + Y\right)^{T}'
 
-    assert latex(Transpose(HadamardPower(X, 2))) == r'\left(X^{\circ {2}}\right)^{T}'
-    assert latex(HadamardPower(Transpose(X), 2)) == r'\left(X^{T}\right)^{\circ {2}}'
+    assert latex(Transpose(HadamardPower(X, 2))) == r'\left(X^{\odot {2}}\right)^{T}'
+    assert latex(HadamardPower(Transpose(X), 2)) == r'\left(X^{T}\right)^{\odot {2}}'
     assert latex(Transpose(MatPow(X, 2))) == r'\left(X^{2}\right)^{T}'
     assert latex(MatPow(Transpose(X), 2)) == r'\left(X^{T}\right)^{2}'
     m = Matrix(((1, 2), (3, 4)))
@@ -2183,23 +2183,23 @@ def test_Hadamard():
     from sympy.matrices.expressions import MatAdd, MatMul, MatPow
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
-    assert latex(HadamardProduct(X, Y*Y)) == r'X \circ Y^{2}'
-    assert latex(HadamardProduct(X, Y)*Y) == r'\left(X \circ Y\right) Y'
+    assert latex(HadamardProduct(X, Y*Y)) == r'X \odot Y^{2}'
+    assert latex(HadamardProduct(X, Y)*Y) == r'\left(X \odot Y\right) Y'
 
-    assert latex(HadamardPower(X, 2)) == r'X^{\circ {2}}'
-    assert latex(HadamardPower(X, -1)) == r'X^{\circ \left({-1}\right)}'
+    assert latex(HadamardPower(X, 2)) == r'X^{\odot {2}}'
+    assert latex(HadamardPower(X, -1)) == r'X^{\odot \left({-1}\right)}'
     assert latex(HadamardPower(MatAdd(X, Y), 2)) == \
-        r'\left(X + Y\right)^{\circ {2}}'
+        r'\left(X + Y\right)^{\odot {2}}'
     assert latex(HadamardPower(MatMul(X, Y), 2)) == \
-        r'\left(X Y\right)^{\circ {2}}'
+        r'\left(X Y\right)^{\odot {2}}'
 
     assert latex(HadamardPower(MatPow(X, -1), -1)) == \
-        r'\left(X^{-1}\right)^{\circ \left({-1}\right)}'
+        r'\left(X^{-1}\right)^{\odot \left({-1}\right)}'
     assert latex(MatPow(HadamardPower(X, -1), -1)) == \
-        r'\left(X^{\circ \left({-1}\right)}\right)^{-1}'
+        r'\left(X^{\odot \left({-1}\right)}\right)^{-1}'
 
     assert latex(HadamardPower(X, n+1)) == \
-        r'X^{\circ \left({n + 1}\right)}'
+        r'X^{\odot \left({n + 1}\right)}'
 
 
 def test_MatPow():


### PR DESCRIPTION
Fixes #28766

Changed LaTeX representation of `HadamardProduct` and `HadamardPower` to use `\odot` (⊙) instead of `\circ` (∘).

**Rationale:**
- `\odot` is the standard notation for Hadamard products in mathematical literature and Wikipedia
- `\circ` is commonly used for function composition, which can cause confusion
- This aligns SymPy with widely accepted mathematical conventions

**Changes:**
- Updated `_print_HadamardProduct` to use `\odot`
- Updated `_print_HadamardPower` to use `\odot`
- Updated all related tests

<!-- BEGIN RELEASE NOTES -->
* printing
  * Changed LaTeX representation of `HadamardProduct` and `HadamardPower` to use `\odot` instead of `\circ` to align with standard mathematical notation.
<!-- END RELEASE NOTES -->
