### PR TITLE
Add support for coordinate transformations in the vector module

### DIFF
--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -135,15 +135,15 @@ coincides with the origin of the 'parent' system.
   0
 
 To compute the rotation matrix of any coordinate system with respect
-to another one, use the ``transformation_matrix_from`` method.
+to another one, use the ``change_of_basis_matrix_from`` method.
 
   >>> B = A.orient_new_axis('B', a, A.k)
-  >>> B.transformation_matrix_from(A)
+  >>> B.change_of_basis_matrix_from(A)
   Matrix([
   [ cos(a), sin(a), 0],
   [-sin(a), cos(a), 0],
   [      0,      0, 1]])
-  >>> B.transformation_matrix_from(B)
+  >>> B.change_of_basis_matrix_from(B)
   Matrix([
   [1, 0, 0],
   [0, 1, 0],
@@ -199,11 +199,11 @@ similarly to methods like ``locate_new``, ``orient_new_axis`` etc.
   >>> A = CoordSys3D('A')
   >>> B = A.create_new('B', transformation='spherical')
 
-To compute the transformation matrix of any coordinate system with respect
-to another one, use the ``transformation_matrix_from`` method. For example,
-the transformation matrix from spherical coordinates to Cartesian is:
+To compute the change-of-basis matrix of any coordinate system with respect
+to another one, use the ``change_of_basis_matrix_from`` method. For example,
+the change-of-basis matrix from spherical coordinates to Cartesian is:
 
-  >>> A.transformation_matrix_from(B)
+  >>> A.change_of_basis_matrix_from(B)
   Matrix([
   [sin(B.theta)*cos(B.phi), cos(B.phi)*cos(B.theta), -sin(B.phi)],
   [sin(B.phi)*sin(B.theta), sin(B.phi)*cos(B.theta),  cos(B.phi)],

--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -135,15 +135,15 @@ coincides with the origin of the 'parent' system.
   0
 
 To compute the rotation matrix of any coordinate system with respect
-to another one, use the ``transformation_matrix`` method.
+to another one, use the ``transformation_matrix_from`` method.
 
   >>> B = A.orient_new_axis('B', a, A.k)
-  >>> B.transformation_matrix(A)
+  >>> B.transformation_matrix_from(A)
   Matrix([
   [ cos(a), sin(a), 0],
   [-sin(a), cos(a), 0],
   [      0,      0, 1]])
-  >>> B.transformation_matrix(B)
+  >>> B.transformation_matrix_from(B)
   Matrix([
   [1, 0, 0],
   [0, 1, 0],
@@ -200,10 +200,10 @@ similarly to methods like ``locate_new``, ``orient_new_axis`` etc.
   >>> B = A.create_new('B', transformation='spherical')
 
 To compute the transformation matrix of any coordinate system with respect
-to another one, use the ``transformation_matrix`` method. For example,
+to another one, use the ``transformation_matrix_from`` method. For example,
 the transformation matrix from spherical coordinates to Cartesian is:
 
-  >>> A.transformation_matrix(B)
+  >>> A.transformation_matrix_from(B)
   Matrix([
   [sin(B.theta)*cos(B.phi), cos(B.phi)*cos(B.theta), -sin(B.phi)],
   [sin(B.phi)*sin(B.theta), sin(B.phi)*cos(B.theta),  cos(B.phi)],

--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -135,15 +135,15 @@ coincides with the origin of the 'parent' system.
   0
 
 To compute the rotation matrix of any coordinate system with respect
-to another one, use the ``rotation_matrix`` method.
+to another one, use the ``transformation_matrix`` method.
 
   >>> B = A.orient_new_axis('B', a, A.k)
-  >>> B.rotation_matrix(A)
+  >>> B.transformation_matrix(A)
   Matrix([
   [ cos(a), sin(a), 0],
   [-sin(a), cos(a), 0],
   [      0,      0, 1]])
-  >>> B.rotation_matrix(B)
+  >>> B.transformation_matrix(B)
   Matrix([
   [1, 0, 0],
   [0, 1, 0],
@@ -192,12 +192,23 @@ rotate system by setting appropriate transformation equations.
   >>> B = CoordSys3D('A', transformation=lambda x,y,z: (x*sin(y), x*cos(y), z))
 
 
-In ``CoordSys3D`` is also dedicated method, ``create_new`` which works
+In ``CoordSys3D`` there is also a dedicated method, ``create_new`` which works
 similarly to methods like ``locate_new``, ``orient_new_axis`` etc.
 
   >>> from sympy.vector import CoordSys3D
   >>> A = CoordSys3D('A')
   >>> B = A.create_new('B', transformation='spherical')
+
+To compute the transformation matrix of any coordinate system with respect
+to another one, use the ``transformation_matrix`` method. For example,
+the transformation matrix from spherical coordinates to Cartesian is:
+
+  >>> A.transformation_matrix(B)
+  Matrix([
+  [sin(B.theta)*cos(B.phi), cos(B.phi)*cos(B.theta), -sin(B.phi)],
+  [sin(B.phi)*sin(B.theta), sin(B.phi)*cos(B.theta),  cos(B.phi)],
+  [           cos(B.theta),           -sin(B.theta),           0]])
+
 
 Expression of quantities in different coordinate systems
 ========================================================

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -258,7 +258,7 @@ class CoordSys3D(Basic):
 
             # detects coordinate systems like spherical/cylindrical,
             # where the Jacobian depends on the position
-            is_curvilinear = len(J.atoms(BaseScalar)) > 0
+            is_curvilinear = J.has(BaseScalar)
             if is_curvilinear:
                 # normalized jacobian
                 J = Matrix([(J.col(i) / h[i]).T for i in range(3)]).T

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -749,28 +749,28 @@ class CoordSys3D(Basic):
         fx, fy, fz = self.base_scalars()
         current = {fx: fx, fy: fy, fz: fz}
 
-        for S in systems[:root_idx]:
-            px, py, pz = S.transformation_to_parent()
-            parent = S._parent
+        for system in systems[:root_idx]:
+            px, py, pz = system.transformation_to_parent()
+            parent = system._parent
             px, py, pz = px.subs(current), py.subs(current), pz.subs(current)
             pxs, pys, pzs = parent.base_scalars()
             current = {pxs: px, pys: py, pzs: pz}
 
-        for S in systems[root_idx + 1:]:
-            if S._transformation_from_parent_lambda is None:
+        for system in systems[root_idx + 1:]:
+            if system._transformation_from_parent_lambda is None:
                 # for coordinate systems created with transformation=lambda...
                 # attempt to compute the transformation from parent
-                xp, yp, zp = S._parent.base_scalars()
+                xp, yp, zp = system._parent.base_scalars()
                 equations = [bs - t for bs, t in zip(
-                    S._parent.base_scalars(),
-                    S.transformation_to_parent())]
-                xs, ys, zs = S.base_scalars()
-                sol = solve(equations, S.base_scalars(), dict=True)[0]
-                xs, ys, zs = [sol[k] for k in S.base_scalars()]
+                    system._parent.base_scalars(),
+                    system.transformation_to_parent())]
+                xs, ys, zs = system.base_scalars()
+                sol = solve(equations, system.base_scalars(), dict=True)[0]
+                xs, ys, zs = [sol[k] for k in system.base_scalars()]
             else:
-                xs, ys, zs = S.transformation_from_parent()
+                xs, ys, zs = system.transformation_from_parent()
             xs, ys, zs = [t.subs(current) for t in [xs, ys, zs]]
-            sx, sy, sz = S.base_scalars()
+            sx, sy, sz = system.base_scalars()
             current = {sx: xs, sy: ys, sz: zs}
 
         current = {k: trigsimp(v) for k, v in current.items()}

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -531,15 +531,51 @@ class CoordSys3D(Basic):
         ========
 
         >>> from sympy.vector import CoordSys3D
-        >>> from sympy import symbols
+        >>> from sympy import symbols, Matrix
+
+        Let's consider two Cartesian systems connected by rotations:
+
         >>> q1 = symbols('q1')
         >>> N = CoordSys3D('N')
         >>> A = N.orient_new_axis('A', q1, N.i)
-        >>> N.rotation_matrix(A)
+
+        The rotation matrix from A to N is:
+
+        >>> R_fromA_toN = N.rotation_matrix(A)
+        >>> R_fromA_toN
         Matrix([
         [1,       0,        0],
         [0, cos(q1), -sin(q1)],
         [0, sin(q1),  cos(q1)]])
+
+        Because the two systems are Cartesians and connected by pure rotation,
+        the rotation matrix is equal to the transformation matrix:
+
+        >>> R_fromA_toN == N.transformation_matrix(A)
+        True
+
+        This is generally not true. Specifically if a non-Cartesian coordinate
+        system (like curvilinear system, or a scaled system, or a
+        reflected system, etc.) is in the path of two connected systems,
+        then the matrix computed by transformation_matrix is correct,
+        whereas the one computed by rotation_matrix is wrong. For example:
+
+        >>> B = A.create_new("B", transformation=lambda x,y,z: (2*x, z, y))
+        >>> C = B.orient_new_axis("C", q1, B.i)
+        >>> R_fromC_toN = N.rotation_matrix(C).simplify()
+        >>> R_fromC_toN
+        Matrix([
+        [1,         0,          0],
+        [0, cos(2*q1), -sin(2*q1)],
+        [0, sin(2*q1),  cos(2*q1)]])
+        >>> T_fromC_toN = N.transformation_matrix(C).simplify()
+        >>> T_fromC_toN
+        Matrix([
+        [2, 0, 0],
+        [0, 0, 1],
+        [0, 1, 0]])
+
+        Hence, the use of transformation_matrix is recommended.
 
         """
         from sympy.vector.functions import _path
@@ -605,33 +641,6 @@ class CoordSys3D(Basic):
         [1,       0,        0],
         [0, cos(q1), -sin(q1)],
         [0, sin(q1),  cos(q1)]])
-
-        Because the two systems are Cartesians and connected by pure rotation,
-        the transformation matrix is equal to the rotation matrix:
-
-        >>> N.transformation_matrix(A) == N.rotation_matrix(A)
-        True
-
-        This is generally not true. Specifically if a non-Cartesian coordinate
-        system (like curvilinear system, or a scaled system, or a
-        reflected system, etc.) is in the path of two connected systems,
-        then the matrix computed by transformation_matrix is correct,
-        whereas the one computed by rotation_matrix is wrong. For example:
-
-        >>> B = A.create_new("B", transformation=lambda x,y,z: (2*x, z, y))
-        >>> C = B.orient_new_axis("C", q1, B.i)
-        >>> R_fromC_toN = N.rotation_matrix(C).simplify()
-        >>> R_fromC_toN
-        Matrix([
-        [1,         0,          0],
-        [0, cos(2*q1), -sin(2*q1)],
-        [0, sin(2*q1),  cos(2*q1)]])
-        >>> T_fromC_toN = N.transformation_matrix(C).simplify()
-        >>> T_fromC_toN
-        Matrix([
-        [2, 0, 0],
-        [0, 0, 1],
-        [0, 1, 0]])
 
         The transformation matrix allows to express vectors defined
         in one system into a different system. In fact, the transformation

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -611,8 +611,8 @@ class CoordSys3D(Basic):
         >>> Cart.transformation_matrix(S)
         Matrix([
         [sin(S.theta)*cos(S.phi), cos(S.phi)*cos(S.theta), -sin(S.phi)],
-        [sin(S.phi)*sin(S.theta), sin(S.phi)*cos(S.theta), cos(S.phi)],
-        [cos(S.theta), -sin(S.theta), 0]])
+        [sin(S.phi)*sin(S.theta), sin(S.phi)*cos(S.theta),  cos(S.phi)],
+        [           cos(S.theta),           -sin(S.theta),           0]])
 
         Transformation matrix from spherical to cylindrical coordinates
         (note that the azimuthal angle of S and C are the same):

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -586,22 +586,67 @@ class CoordSys3D(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSys3D
+        >>> from sympy.vector import CoordSys3D, express
         >>> from sympy import symbols
 
-        For Cartesian systems connected by rotations, the transformation
-        matrix is equal to the rotation matrix:
+        Let's consider two Cartesian systems connected by rotations:
 
         >>> q1 = symbols('q1')
         >>> N = CoordSys3D('N')
         >>> A = N.orient_new_axis('A', q1, N.i)
-        >>> N.transformation_matrix(A)
+
+        The transformation matrix from A to N is:
+
+        >>> T_fromA_toN = N.transformation_matrix(A)
+        >>> T_fromA_toN
         Matrix([
         [1,       0,        0],
         [0, cos(q1), -sin(q1)],
         [0, sin(q1),  cos(q1)]])
+
+        Because the two systems are Cartesians and connected by pure rotation,
+        the transformation matrix is equal to the rotation matrix:
+
         >>> N.transformation_matrix(A) == N.rotation_matrix(A)
         True
+
+        This is generally not true. Specifically if a non-Cartesian coordinate
+        system (like curvilinear system, or a scaled system, or a
+        reflected system, etc.) is in the path of two connected systems,
+        then the matrix computed by transformation_matrix is correct,
+        whereas the one computed by rotation_matrix is wrong. For example:
+
+        >>> B = A.create_new("B", transformation=lambda x,y,z: (2*x, z, y))
+        >>> C = B.orient_new_axis("C", q1, B.i)
+        >>> R_fromC_toN = N.rotation_matrix(C).simplify()
+        >>> R_fromC_toN
+        Matrix([
+        [1,         0,          0],
+        [0, cos(2*q1), -sin(2*q1)],
+        [0, sin(2*q1),  cos(2*q1)]])
+        >>> T_fromC_toN = N.transformation_matrix(C).simplify()
+        >>> T_fromC_toN
+        Matrix([
+        [2, 0, 0],
+        [0, 0, 1],
+        [0, 1, 0]])
+
+        The transformation matrix allows to express vectors defined
+        in one system into a different system. In fact, the transformation
+        matrix is internally used by the ``express`` function. The following
+        example shows a direct comparison between working with matrices
+        and the vector module:
+
+        >>> vA_matrix = Matrix([1, 2, 3])
+        >>> vN_matrix = T_fromA_toN * vA_matrix
+        >>> vN_matrix
+        Matrix([
+        [                     1],
+        [-3*sin(q1) + 2*cos(q1)],
+        [2*sin(q1) + 3*cos(q1)]])
+        >>> vA = A.i + 2 * A.j + 3 * A.k
+        >>> express(vA, N)
+        N.i + (-3*sin(q1) + 2*cos(q1))*N.j + (2*sin(q1) + 3*cos(q1))*N.k
 
         Transformation matrix from spherical to Cartesian coordinates:
 

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -700,7 +700,7 @@ class CoordSys3D(Basic):
         relocated_scalars = [x - origin_coords[i]
                              for i, x in enumerate(other.base_scalars())]
 
-        vars_matrix = (self.rotation_matrix(other) *
+        vars_matrix = (self.transformation_matrix(other) *
                        Matrix(relocated_scalars))
         return {x: trigsimp(vars_matrix[i])
                 for i, x in enumerate(self.base_scalars())}

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -531,7 +531,7 @@ class CoordSys3D(Basic):
         ========
 
         >>> from sympy.vector import CoordSys3D
-        >>> from sympy import symbols, Matrix
+        >>> from sympy import symbols
 
         Let's consider two Cartesian systems connected by rotations:
 

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -587,7 +587,7 @@ class CoordSys3D(Basic):
         ========
 
         >>> from sympy.vector import CoordSys3D, express
-        >>> from sympy import symbols
+        >>> from sympy import symbols, Matrix
 
         Let's consider two Cartesian systems connected by rotations:
 
@@ -645,7 +645,8 @@ class CoordSys3D(Basic):
         [-3*sin(q1) + 2*cos(q1)],
         [2*sin(q1) + 3*cos(q1)]])
         >>> vA = A.i + 2 * A.j + 3 * A.k
-        >>> express(vA, N)
+        >>> vN = express(vA, N)
+        >>> vN
         N.i + (-3*sin(q1) + 2*cos(q1))*N.j + (2*sin(q1) + 3*cos(q1))*N.k
 
         Transformation matrix from spherical to Cartesian coordinates:

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -513,8 +513,8 @@ class CoordSys3D(Basic):
 
         Note that rotation_matrix only consider pure rotations between
         Cartesian systems. It doesn't account for changes in base vectors,
-        like curvilinear to Cartesian. Use transformation_matrix if those
-        are important.
+        like curvilinear to Cartesian. Use transformation_matrix_from if
+        those are important.
 
         Parameters
         ==========
@@ -525,7 +525,7 @@ class CoordSys3D(Basic):
         See Also
         ========
 
-        CoordSys3D.transformation_matrix
+        CoordSys3D.transformation_matrix_from
 
         Examples
         ========
@@ -551,14 +551,17 @@ class CoordSys3D(Basic):
         Because the two systems are Cartesians and connected by pure rotation,
         the rotation matrix is equal to the transformation matrix:
 
-        >>> R_fromA_toN == N.transformation_matrix(A)
+        >>> R_fromA_toN == N.transformation_matrix_from(A)
         True
 
         This is generally not true. Specifically if a non-Cartesian coordinate
         system (like curvilinear system, or a scaled system, or a
         reflected system, etc.) is in the path of two connected systems,
-        then the matrix computed by transformation_matrix is correct,
-        whereas the one computed by rotation_matrix is wrong. For example:
+        then the two matrices are different, because the one computed by
+        transformation_matrix_from considers both the change in base vectors
+        and the orientation between the systems, whereas the one computed by
+        rotation_matrix only consider the orientation between Cartesian
+        systems. For example:
 
         >>> B = A.create_new("B", transformation=lambda x,y,z: (2*x, z, y))
         >>> C = B.orient_new_axis("C", q1, B.i)
@@ -568,14 +571,14 @@ class CoordSys3D(Basic):
         [1,         0,          0],
         [0, cos(2*q1), -sin(2*q1)],
         [0, sin(2*q1),  cos(2*q1)]])
-        >>> T_fromC_toN = N.transformation_matrix(C).simplify()
+        >>> T_fromC_toN = N.transformation_matrix_from(C).simplify()
         >>> T_fromC_toN
         Matrix([
         [2, 0, 0],
         [0, 0, 1],
         [0, 1, 0]])
 
-        Hence, the use of transformation_matrix is recommended.
+        Hence, the use of transformation_matrix_from is recommended.
 
         """
         from sympy.vector.functions import _path
@@ -598,7 +601,7 @@ class CoordSys3D(Basic):
             result *= path[i]._parent_rotation_matrix.T
         return result
 
-    def transformation_matrix(self, other):
+    def transformation_matrix_from(self, other):
         """
         Returns the transformation matrix of this coordinate system with
         respect to another system, which takes into account rotation
@@ -606,7 +609,7 @@ class CoordSys3D(Basic):
 
         If v_a is a vector defined in system 'A' (in matrix format)
         and v_b is the same vector defined in system 'B', then
-        v_a = A.transformation_matrix(B) * v_b.
+        v_a = A.transformation_matrix_from(B) * v_b.
 
         A SymPy Matrix is returned.
 
@@ -635,7 +638,7 @@ class CoordSys3D(Basic):
 
         The transformation matrix from A to N is:
 
-        >>> T_fromA_toN = N.transformation_matrix(A)
+        >>> T_fromA_toN = N.transformation_matrix_from(A)
         >>> T_fromA_toN
         Matrix([
         [1,       0,        0],
@@ -665,7 +668,7 @@ class CoordSys3D(Basic):
         >>> Cart = CoordSys3D("Cart")
         >>> S = Cart.create_new("S", transformation="spherical")
         >>> C = Cart.create_new("C", transformation="cylindrical")
-        >>> Cart.transformation_matrix(S)
+        >>> Cart.transformation_matrix_from(S)
         Matrix([
         [sin(S.theta)*cos(S.phi), cos(S.phi)*cos(S.theta), -sin(S.phi)],
         [sin(S.phi)*sin(S.theta), sin(S.phi)*cos(S.theta),  cos(S.phi)],
@@ -676,7 +679,7 @@ class CoordSys3D(Basic):
 
         >>> r_s, theta_s, phi_s = S.base_scalars()
         >>> r_c, theta_c, z_c = C.base_scalars()
-        >>> C.transformation_matrix(S).subs(phi_s, theta_c).simplify()
+        >>> C.transformation_matrix_from(S).subs(phi_s, theta_c).simplify()
         Matrix([
         [sin(S.theta),  cos(S.theta), 0],
         [           0,             0, 1],

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -643,7 +643,7 @@ class CoordSys3D(Basic):
         Matrix([
         [                     1],
         [-3*sin(q1) + 2*cos(q1)],
-        [2*sin(q1) + 3*cos(q1)]])
+        [ 2*sin(q1) + 3*cos(q1)]])
         >>> vA = A.i + 2 * A.j + 3 * A.k
         >>> vN = express(vA, N)
         >>> vN

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -621,8 +621,8 @@ class CoordSys3D(Basic):
         >>> r_c, theta_c, z_c = C.base_scalars()
         >>> C.transformation_matrix(S).subs(phi_s, theta_c).simplify()
         Matrix([
-        [sin(S.theta), cos(S.theta), 0],
-        [0, 0, 1],
+        [sin(S.theta),  cos(S.theta), 0],
+        [           0,             0, 1],
         [cos(S.theta), -sin(S.theta), 0]])
 
         """

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -513,7 +513,7 @@ class CoordSys3D(Basic):
 
         Note that rotation_matrix only consider pure rotations between
         Cartesian systems. It doesn't account for changes in base vectors,
-        like curvilinear to Cartesian. Use transformation_matrix_from if
+        like curvilinear to Cartesian. Use change_of_basis_matrix_from if
         those are important.
 
         Parameters
@@ -525,7 +525,7 @@ class CoordSys3D(Basic):
         See Also
         ========
 
-        CoordSys3D.transformation_matrix_from
+        CoordSys3D.change_of_basis_matrix_from
 
         Examples
         ========
@@ -549,16 +549,16 @@ class CoordSys3D(Basic):
         [0, sin(q1),  cos(q1)]])
 
         Because the two systems are Cartesians and connected by pure rotation,
-        the rotation matrix is equal to the transformation matrix:
+        the rotation matrix is equal to the change-of-basis matrix:
 
-        >>> R_fromA_toN == N.transformation_matrix_from(A)
+        >>> R_fromA_toN == N.change_of_basis_matrix_from(A)
         True
 
         This is generally not true. Specifically if a non-Cartesian coordinate
         system (like curvilinear system, or a scaled system, or a
         reflected system, etc.) is in the path of two connected systems,
         then the two matrices are different, because the one computed by
-        transformation_matrix_from considers both the change in base vectors
+        change_of_basis_matrix_from considers both the change in base vectors
         and the orientation between the systems, whereas the one computed by
         rotation_matrix only consider the orientation between Cartesian
         systems. For example:
@@ -571,14 +571,14 @@ class CoordSys3D(Basic):
         [1,         0,          0],
         [0, cos(2*q1), -sin(2*q1)],
         [0, sin(2*q1),  cos(2*q1)]])
-        >>> T_fromC_toN = N.transformation_matrix_from(C).simplify()
+        >>> T_fromC_toN = N.change_of_basis_matrix_from(C).simplify()
         >>> T_fromC_toN
         Matrix([
         [2, 0, 0],
         [0, 0, 1],
         [0, 1, 0]])
 
-        Hence, the use of transformation_matrix_from is recommended.
+        Hence, the use of change_of_basis_matrix_from is recommended.
 
         """
         from sympy.vector.functions import _path
@@ -601,15 +601,18 @@ class CoordSys3D(Basic):
             result *= path[i]._parent_rotation_matrix.T
         return result
 
-    def transformation_matrix_from(self, other):
+    def change_of_basis_matrix_from(self, other):
         """
-        Returns the transformation matrix of this coordinate system with
-        respect to another system, which takes into account rotation
-        and scaling.
+        Returns the change-of-basis matrix from the ``other`` coordinate system
+        to this coordinate system. This matrix transforms the components of a
+        vector defined in ``other`` to componenets of a vector defined in
+        this system. The columns of this matrix represent the base vectors of
+        the ``other`` system in terms of base vectors of this
+        coordinate system.
 
         If v_a is a vector defined in system 'A' (in matrix format)
         and v_b is the same vector defined in system 'B', then
-        v_a = A.transformation_matrix_from(B) * v_b.
+        v_a = A.change_of_basis_matrix_from(B) * v_b.
 
         A SymPy Matrix is returned.
 
@@ -617,7 +620,7 @@ class CoordSys3D(Basic):
         ==========
 
         other : CoordSys3D
-            The system which the DCM is generated to.
+            The system from which the change-of-basis matrix is generated.
 
         See Also
         ========
@@ -636,17 +639,17 @@ class CoordSys3D(Basic):
         >>> N = CoordSys3D('N')
         >>> A = N.orient_new_axis('A', q1, N.i)
 
-        The transformation matrix from A to N is:
+        The change-of-basis matrix (or transformation matrix) from A to N is:
 
-        >>> T_fromA_toN = N.transformation_matrix_from(A)
+        >>> T_fromA_toN = N.change_of_basis_matrix_from(A)
         >>> T_fromA_toN
         Matrix([
         [1,       0,        0],
         [0, cos(q1), -sin(q1)],
         [0, sin(q1),  cos(q1)]])
 
-        The transformation matrix allows to express vectors defined
-        in one system into a different system. In fact, the transformation
+        The change-of-basis matrix allows to express vectors defined
+        in one system into a different system. In fact, the change-of-basis
         matrix is internally used by the ``express`` function. The following
         example shows a direct comparison between working with matrices
         and the vector module:
@@ -663,23 +666,23 @@ class CoordSys3D(Basic):
         >>> vN
         N.i + (-3*sin(q1) + 2*cos(q1))*N.j + (2*sin(q1) + 3*cos(q1))*N.k
 
-        Transformation matrix from spherical to Cartesian coordinates:
+        Change-of-basis matrix from spherical to Cartesian coordinates:
 
         >>> Cart = CoordSys3D("Cart")
         >>> S = Cart.create_new("S", transformation="spherical")
         >>> C = Cart.create_new("C", transformation="cylindrical")
-        >>> Cart.transformation_matrix_from(S)
+        >>> Cart.change_of_basis_matrix_from(S)
         Matrix([
         [sin(S.theta)*cos(S.phi), cos(S.phi)*cos(S.theta), -sin(S.phi)],
         [sin(S.phi)*sin(S.theta), sin(S.phi)*cos(S.theta),  cos(S.phi)],
         [           cos(S.theta),           -sin(S.theta),           0]])
 
-        Transformation matrix from spherical to cylindrical coordinates
+        Change-of-basis matrix from spherical to cylindrical coordinates
         (note that the azimuthal angle of S and C are the same):
 
         >>> r_s, theta_s, phi_s = S.base_scalars()
         >>> r_c, theta_c, z_c = C.base_scalars()
-        >>> C.transformation_matrix_from(S).subs(phi_s, theta_c).simplify()
+        >>> C.change_of_basis_matrix_from(S).subs(phi_s, theta_c).simplify()
         Matrix([
         [sin(S.theta),  cos(S.theta), 0],
         [           0,             0, 1],

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -83,7 +83,7 @@ def express(expr, system, system2=None, variables=False):
         parts = expr.separate()
         for x in parts:
             if x != system:
-                temp = system.transformation_matrix(x) * parts[x].to_matrix(x)
+                temp = system.transformation_matrix_from(x) * parts[x].to_matrix(x)
                 outvec += matrix_to_vector(temp, system)
             else:
                 outvec += parts[x]

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -83,7 +83,7 @@ def express(expr, system, system2=None, variables=False):
         parts = expr.separate()
         for x in parts:
             if x != system:
-                temp = system.transformation_matrix_from(x) * parts[x].to_matrix(x)
+                temp = system.change_of_basis_matrix_from(x) * parts[x].to_matrix(x)
                 outvec += matrix_to_vector(temp, system)
             else:
                 outvec += parts[x]

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -83,7 +83,7 @@ def express(expr, system, system2=None, variables=False):
         parts = expr.separate()
         for x in parts:
             if x != system:
-                temp = system.rotation_matrix(x) * parts[x].to_matrix(x)
+                temp = system.transformation_matrix(x) * parts[x].to_matrix(x)
                 outvec += matrix_to_vector(temp, system)
             else:
                 outvec += parts[x]

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -70,11 +70,11 @@ def express(expr, system, system2=None, variables=False):
             raise ValueError("system2 should not be provided for \
                                 Vectors")
         # Given expr is a Vector
+        subs_dict = {}
         if variables:
             # If variables attribute is True, substitute
             # the coordinate variables in the Vector
             system_list = {x.system for x in expr.atoms(BaseScalar, BaseVector)} - {system}
-            subs_dict = {}
             for f in system_list:
                 subs_dict.update(f.scalar_map(system))
             expr = expr.subs(subs_dict)
@@ -87,6 +87,7 @@ def express(expr, system, system2=None, variables=False):
                 outvec += matrix_to_vector(temp, system)
             else:
                 outvec += parts[x]
+        outvec = outvec.subs(subs_dict)
         return outvec
 
     elif isinstance(expr, Dyadic):

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -657,3 +657,41 @@ def test_transformation_matrix_reflection_stretch_to_cartesian():
         [0, 0, 1]
     ])
     assert B.transformation_matrix(A) == T_fromB_toA.inv()
+
+
+def test_spherical_cartesian_scalar_map():
+    C = CoordSys3D("C")
+    S = C.create_new("S", transformation="spherical")
+    assert S.scalar_map(C) == {
+        S.r: (
+            C.x * sin(S.theta) * cos(S.phi) +
+            C.y * sin(S.phi) * sin(S.theta) +
+            C.z * cos(S.theta)),
+        S.theta: (
+            C.x * cos(S.phi) * cos(S.theta) +
+            C.y * sin(S.phi) * cos(S.theta) -
+            C.z * sin(S.theta)),
+        S.phi: -C.x * sin(S.phi) + C.y * cos(S.phi)}
+    assert C.scalar_map(S) == {
+        C.x: (
+            -S.phi * sin(S.phi) +
+            S.r * sin(S.theta) * cos(S.phi) +
+            S.theta * cos(S.phi) * cos(S.theta)),
+        C.y: (
+            S.phi * cos(S.phi) +
+            S.r * sin(S.phi) * sin(S.theta) +
+            S.theta * sin(S.phi) * cos(S.theta)),
+        C.z: S.r * cos(S.theta) - S.theta * sin(S.theta)}
+
+
+def test_cylindrical_cartesian_scalar_map():
+    Cart = CoordSys3D("Cart")
+    C = Cart.create_new("C", transformation="cylindrical")
+    assert C.scalar_map(Cart) == {
+        C.r: Cart.x*cos(C.theta) + Cart.y*sin(C.theta),
+        C.theta: -Cart.x*sin(C.theta) + Cart.y*cos(C.theta),
+        C.z: Cart.z}
+    assert Cart.scalar_map(C) == {
+        Cart.x: C.r*cos(C.theta) - C.theta*sin(C.theta),
+        Cart.y: C.r*sin(C.theta) + C.theta*cos(C.theta),
+        Cart.z: C.z}

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -499,33 +499,33 @@ def test_cartesian_rotation_transformation_equations():
         zb)
 
 
-def test_transformation_matrix_from_spherical_to_cartesian():
+def test_change_of_basis_matrix_from_spherical_to_cartesian():
     C = CoordSys3D("C")
     S = C.create_new("S", transformation="spherical")
     r, theta, phi = S.base_scalars()
-    T_fromS_toC = C.transformation_matrix_from(S)
+    T_fromS_toC = C.change_of_basis_matrix_from(S)
     assert T_fromS_toC == Matrix([
         [sin(theta)*cos(phi), cos(theta)*cos(phi), -sin(phi)],
         [sin(theta)*sin(phi), cos(theta)*sin(phi), cos(phi)],
         [cos(theta), -sin(theta), 0]
     ])
-    assert S.transformation_matrix_from(C) == T_fromS_toC.T
+    assert S.change_of_basis_matrix_from(C) == T_fromS_toC.T
 
 
-def test_transformation_matrix_from_cylindrical_to_cartesian():
+def test_change_of_basis_matrix_from_cylindrical_to_cartesian():
     Cart = CoordSys3D("Cart")
     C = Cart.create_new("C", transformation="cylindrical")
     r, theta, z = C.base_scalars()
-    T_fromC_toCart = Cart.transformation_matrix_from(C)
+    T_fromC_toCart = Cart.change_of_basis_matrix_from(C)
     assert T_fromC_toCart == Matrix([
         [cos(theta), -sin(theta), 0],
         [sin(theta), cos(theta), 0],
         [0, 0, 1]
     ])
-    assert C.transformation_matrix_from(Cart) == T_fromC_toCart.T
+    assert C.change_of_basis_matrix_from(Cart) == T_fromC_toCart.T
 
 
-def test_transformation_matrix_from_spherical_to_cylindrical():
+def test_change_of_basis_matrix_from_spherical_to_cylindrical():
     # The following tests uses simplify in order to show `theta_c - phis_s`,
     # which is a reminder to the user that the azimuthal angle
     # of S and C are the same, phi_s=theta_c, [0, 2*pi[
@@ -534,38 +534,38 @@ def test_transformation_matrix_from_spherical_to_cylindrical():
     C = Cart.create_new("C", transformation="cylindrical")
     r_s, theta_s, phi_s = S.base_scalars()
     r_c, theta_c, z_c = C.base_scalars()
-    T_fromS_toC = C.transformation_matrix_from(S)
+    T_fromS_toC = C.change_of_basis_matrix_from(S)
     T_fromS_toC = T_fromS_toC.simplify().subs(theta_c - phi_s, 0)
     assert T_fromS_toC == Matrix([
         [sin(theta_s), cos(theta_s), 0],
         [0, 0, 1],
         [cos(theta_s), -sin(theta_s), 0]
     ])
-    T_fromC_toS = S.transformation_matrix_from(C).simplify()
+    T_fromC_toS = S.change_of_basis_matrix_from(C).simplify()
     T_fromC_toS = T_fromC_toS.subs(theta_c - phi_s, 0)
     assert T_fromC_toS == T_fromS_toC.T
 
 
-def test_transformation_matrix_from_simple_rotation():
+def test_change_of_basis_matrix_from_simple_rotation():
     alpha = symbols("alpha")
     A = CoordSys3D("A")
     B = A.orient_new_axis("B", alpha, A.k)
-    T_fromB_toA = A.transformation_matrix_from(B)
+    T_fromB_toA = A.change_of_basis_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [cos(alpha), -sin(alpha), 0],
         [sin(alpha), cos(alpha), 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix_from(A) == T_fromB_toA.T
+    assert B.change_of_basis_matrix_from(A) == T_fromB_toA.T
     assert T_fromB_toA == A.rotation_matrix(B)
 
 
-def test_transformation_matrix_from_three_rotations():
+def test_change_of_basis_matrix_from_three_rotations():
     a, b, g = symbols("alpha, beta, gamma")
     bo = BodyOrienter(a, b, g, "123")
     A = CoordSys3D("A")
     B = A.orient_new("B", bo)
-    T_fromB_toA = A.transformation_matrix_from(B)
+    T_fromB_toA = A.change_of_basis_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [cos(b) * cos(g), -sin(g) * cos(b), sin(b)],
         [
@@ -579,92 +579,92 @@ def test_transformation_matrix_from_three_rotations():
             cos(a) * cos(b)
         ]
     ])
-    assert B.transformation_matrix_from(A) == T_fromB_toA.T
+    assert B.change_of_basis_matrix_from(A) == T_fromB_toA.T
     assert A.rotation_matrix(B) == T_fromB_toA
 
 
-def test_transformation_matrix_from_reflection_to_cartesian():
+def test_change_of_basis_matrix_from_reflection_to_cartesian():
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
-    T_fromB_toA = A.transformation_matrix_from(B)
+    T_fromB_toA = A.change_of_basis_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix_from(A) == T_fromB_toA.T
+    assert B.change_of_basis_matrix_from(A) == T_fromB_toA.T
 
     # a chain of systems
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
     C = B.create_new("C", transformation=lambda x,y,z: (z, y, x))
-    T_fromB_toA = A.transformation_matrix_from(B)
-    T_fromC_toA = A.transformation_matrix_from(C)
-    T_fromC_toB = B.transformation_matrix_from(C)
+    T_fromB_toA = A.change_of_basis_matrix_from(B)
+    T_fromC_toA = A.change_of_basis_matrix_from(C)
+    T_fromC_toB = B.change_of_basis_matrix_from(C)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix_from(A) == T_fromB_toA.T
+    assert B.change_of_basis_matrix_from(A) == T_fromB_toA.T
     assert T_fromC_toB == Matrix([
         [0, 0, 1],
         [0, 1, 0],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix_from(B) == T_fromC_toB.T
+    assert C.change_of_basis_matrix_from(B) == T_fromC_toB.T
     assert T_fromC_toA == Matrix([
         [0, 1, 0],
         [0, 0, 1],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix_from(A) == T_fromC_toA.T
+    assert C.change_of_basis_matrix_from(A) == T_fromC_toA.T
 
     # same systems, but linked in a different way
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
     C = A.create_new("C", transformation=lambda x,y,z: (z, y, x))
-    T_fromB_toA = A.transformation_matrix_from(B)
-    T_fromC_toA = A.transformation_matrix_from(C)
-    T_fromC_toB = B.transformation_matrix_from(C)
+    T_fromB_toA = A.change_of_basis_matrix_from(B)
+    T_fromC_toA = A.change_of_basis_matrix_from(C)
+    T_fromC_toB = B.change_of_basis_matrix_from(C)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix_from(A) == T_fromB_toA.T
+    assert B.change_of_basis_matrix_from(A) == T_fromB_toA.T
     assert T_fromC_toA == Matrix([
         [0, 0, 1],
         [0, 1, 0],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix_from(A) == T_fromC_toA.T
+    assert C.change_of_basis_matrix_from(A) == T_fromC_toA.T
     assert T_fromC_toB == Matrix([
         [0, 1, 0],
         [0, 0, 1],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix_from(B) == T_fromC_toB.T
+    assert C.change_of_basis_matrix_from(B) == T_fromC_toB.T
 
 
-def test_transformation_matrix_from_reflection_stretch_to_cartesian():
+def test_change_of_basis_matrix_from_reflection_stretch_to_cartesian():
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, 2*x, z))
-    T_fromB_toA = A.transformation_matrix_from(B)
+    T_fromB_toA = A.change_of_basis_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [2, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix_from(A) == T_fromB_toA.inv()
+    assert B.change_of_basis_matrix_from(A) == T_fromB_toA.inv()
 
 
-def test_transformation_matrix_from_trigsimp():
+def test_change_of_basis_matrix_from_trigsimp():
     A = CoordSys3D("A")
     B = A.orient_new_axis('B', q, A.k)
     N = B.orient_new_axis('N', -q, B.k)
-    assert N.transformation_matrix_from(A) == eye(3)
-    assert A.transformation_matrix_from(N) == eye(3)
+    assert N.change_of_basis_matrix_from(A) == eye(3)
+    assert A.change_of_basis_matrix_from(N) == eye(3)
 
 
 def test_spherical_cartesian_scalar_map():

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -135,7 +135,7 @@ def test_coordinate_vars():
                                A.x: E.x*cos(a) - E.y*sin(a) + a,
                                A.y: E.x*sin(a) + E.y*cos(a) + b}
     assert E.scalar_map(A) == {E.x: (A.x - a)*cos(a) + (A.y - b)*sin(a),
-                               E.y: (-A.x + a)*sin(a) + (A.y - b)*cos(a),
+                               E.y: (A.x - a)*sin(a)*-1 + (A.y - b)*cos(a),
                                E.z: A.z - c}
     F = A.locate_new('F', Vector.zero)
     assert A.scalar_map(F) == {A.z: F.z, A.x: F.x, A.y: F.y}
@@ -718,7 +718,7 @@ def test_scalar_map_for_sequence_of_systems():
         B.z: C.z}
     assert C.scalar_map(A) == {
         C.x: (A.x - a) * cos(alpha) + (A.y - b) * sin(alpha),
-        C.y: (-A.x + a) * sin(alpha) + (A.y - b) * cos(alpha),
+        C.y: (A.x - a) * sin(alpha) * -1 + (A.y - b) * cos(alpha),
         C.z: A.z - c}
     assert A.scalar_map(C) == {
         A.x: C.x * cos(alpha) - C.y * sin(alpha) + a,
@@ -732,7 +732,7 @@ def test_scalar_map_for_sequence_of_systems():
     assert D.scalar_map(A) == {
         xd: (A.x - a) * cos(alpha) / 2 + (A.y - b) * sin(alpha) / 2,
         yd: A.z - c,
-        zd: (-A.x + a) * sin(alpha) + (A.y - b) * cos(alpha)}
+        zd: (A.x - a) * sin(alpha) * -1 + (A.y - b) * cos(alpha)}
     assert A.scalar_map(D) == {
         A.x: 2 * xd * cos(alpha) - zd * sin(alpha) + a,
         A.y: 2 * xd * sin(alpha) + zd * cos(alpha) + b,
@@ -742,12 +742,12 @@ def test_scalar_map_for_sequence_of_systems():
             ((A.x - a) * cos(alpha) + (A.y - b) * sin(alpha))**2 +
             (-(A.x - a) * sin(alpha) + (A.y - b) * cos(alpha))**2))
     assert res[E.theta] == atan2(
-            (-A.x + a) * sin(alpha) + (A.y - b) * cos(alpha),
+            (A.x - a) * sin(alpha) * -1 + (A.y - b) * cos(alpha),
             (A.x - a) * cos(alpha) + (A.y - b) * sin(alpha))
     assert res[E.z] == A.z - c
     assert A.scalar_map(E) == {
-        A.x: a + E.r * cos(E.theta + alpha),
-        A.y: b + E.r * sin(E.theta + alpha),
+        A.x: a - E.r * sin(E.theta) * sin(alpha) + E.r * cos(E.theta) * cos(alpha),
+        A.y: b + E.r * sin(E.theta) * cos(alpha)  + E.r * cos(E.theta) * sin(alpha),
         A.z: c + E.z}
 
     # walk up and down the path of systems

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -497,3 +497,163 @@ def test_cartesian_rotation_transformation_equations():
         xb * cos(alpha) - yb * sin(alpha),
         xb * sin(alpha) + yb * cos(alpha),
         zb)
+
+
+def test_transformation_matrix_spherical_to_cartesian():
+    C = CoordSys3D("C")
+    S = C.create_new("S", transformation="spherical")
+    r, theta, phi = S.base_scalars()
+    T_fromS_toC = C.transformation_matrix(S)
+    assert T_fromS_toC == Matrix([
+        [sin(theta)*cos(phi), cos(theta)*cos(phi), -sin(phi)],
+        [sin(theta)*sin(phi), cos(theta)*sin(phi), cos(phi)],
+        [cos(theta), -sin(theta), 0]
+    ])
+    assert S.transformation_matrix(C) == T_fromS_toC.T
+
+
+def test_transformation_matrix_cylindrical_to_cartesian():
+    Cart = CoordSys3D("Cart")
+    C = Cart.create_new("C", transformation="cylindrical")
+    r, theta, z = C.base_scalars()
+    T_fromC_toCart = Cart.transformation_matrix(C)
+    assert T_fromC_toCart == Matrix([
+        [cos(theta), -sin(theta), 0],
+        [sin(theta), cos(theta), 0],
+        [0, 0, 1]
+    ])
+    assert C.transformation_matrix(Cart) == T_fromC_toCart.T
+
+
+def test_transformation_matrix_spherical_to_cylindrical():
+    # The following tests uses simplify in order to show `theta_c - phis_s`,
+    # which is a reminder to the user that the azimuthal angle
+    # of S and C are the same, phi_s=theta_c, [0, 2*pi[
+    Cart = CoordSys3D("Cart")
+    S = Cart.create_new("S", transformation="spherical")
+    C = Cart.create_new("C", transformation="cylindrical")
+    r_s, theta_s, phi_s = S.base_scalars()
+    r_c, theta_c, z_c = C.base_scalars()
+    T_fromS_toC = C.transformation_matrix(S)
+    T_fromS_toC = T_fromS_toC.simplify().subs(theta_c - phi_s, 0)
+    assert T_fromS_toC == Matrix([
+        [sin(theta_s), cos(theta_s), 0],
+        [0, 0, 1],
+        [cos(theta_s), -sin(theta_s), 0]
+    ])
+    T_fromC_toS = S.transformation_matrix(C).simplify()
+    T_fromC_toS = T_fromC_toS.subs(theta_c - phi_s, 0)
+    assert T_fromC_toS == T_fromS_toC.T
+
+
+def test_transformation_matrix_simple_rotation():
+    alpha = symbols("alpha")
+    A = CoordSys3D("A")
+    B = A.orient_new_axis("B", alpha, A.k)
+    T_fromB_toA = A.transformation_matrix(B)
+    assert T_fromB_toA == Matrix([
+        [cos(alpha), -sin(alpha), 0],
+        [sin(alpha), cos(alpha), 0],
+        [0, 0, 1]
+    ])
+    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert T_fromB_toA == A.rotation_matrix(B)
+
+
+def test_transformation_matrix_three_rotations():
+    a, b, g = symbols("alpha, beta, gamma")
+    bo = BodyOrienter(a, b, g, "123")
+    A = CoordSys3D("A")
+    B = A.orient_new("B", bo)
+    T_fromB_toA = A.transformation_matrix(B)
+    assert T_fromB_toA == Matrix([
+        [cos(b) * cos(g), -sin(g) * cos(b), sin(b)],
+        [
+            sin(a) * sin(b) * cos(g) + sin(g) * cos(a),
+            -sin(a) * sin(b) * sin(g) + cos(a) * cos(g),
+            -sin(a) * cos(b)
+        ],
+        [
+            sin(a) * sin(g) - sin(b) * cos(a) * cos(g),
+            sin(a) * cos(g) + sin(b) * sin(g) * cos(a),
+            cos(a) * cos(b)
+        ]
+    ])
+    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert A.rotation_matrix(B) == T_fromB_toA
+
+
+def test_transformation_matrix_reflection_to_cartesian():
+    A = CoordSys3D("A")
+    B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
+    T_fromB_toA = A.transformation_matrix(B)
+    assert T_fromB_toA == Matrix([
+        [0, 1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    assert B.transformation_matrix(A) == T_fromB_toA.T
+
+    # a chain of systems
+    A = CoordSys3D("A")
+    B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
+    C = B.create_new("C", transformation=lambda x,y,z: (z, y, x))
+    T_fromB_toA = A.transformation_matrix(B)
+    T_fromC_toA = A.transformation_matrix(C)
+    T_fromC_toB = B.transformation_matrix(C)
+    assert T_fromB_toA == Matrix([
+        [0, 1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert T_fromC_toB == Matrix([
+        [0, 0, 1],
+        [0, 1, 0],
+        [1, 0, 0]
+    ])
+    assert C.transformation_matrix(B) == T_fromC_toB.T
+    assert T_fromC_toA == Matrix([
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 0]
+    ])
+    assert C.transformation_matrix(A) == T_fromC_toA.T
+
+    # same systems, but linked in a different way
+    A = CoordSys3D("A")
+    B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
+    C = A.create_new("C", transformation=lambda x,y,z: (z, y, x))
+    T_fromB_toA = A.transformation_matrix(B)
+    T_fromC_toA = A.transformation_matrix(C)
+    T_fromC_toB = B.transformation_matrix(C)
+    assert T_fromB_toA == Matrix([
+        [0, 1, 0],
+        [1, 0, 0],
+        [0, 0, 1]
+    ])
+    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert T_fromC_toA == Matrix([
+        [0, 0, 1],
+        [0, 1, 0],
+        [1, 0, 0]
+    ])
+    assert C.transformation_matrix(A) == T_fromC_toA.T
+    assert T_fromC_toB == Matrix([
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 0]
+    ])
+    assert C.transformation_matrix(B) == T_fromC_toB.T
+
+
+def test_transformation_matrix_reflection_stretch_to_cartesian():
+    A = CoordSys3D("A")
+    B = A.create_new("B", transformation=lambda x,y,z: (y, 2*x, z))
+    T_fromB_toA = A.transformation_matrix(B)
+    assert T_fromB_toA == Matrix([
+        [0, 1, 0],
+        [2, 0, 0],
+        [0, 0, 1]
+    ])
+    assert B.transformation_matrix(A) == T_fromB_toA.inv()

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -499,33 +499,33 @@ def test_cartesian_rotation_transformation_equations():
         zb)
 
 
-def test_transformation_matrix_spherical_to_cartesian():
+def test_transformation_matrix_from_spherical_to_cartesian():
     C = CoordSys3D("C")
     S = C.create_new("S", transformation="spherical")
     r, theta, phi = S.base_scalars()
-    T_fromS_toC = C.transformation_matrix(S)
+    T_fromS_toC = C.transformation_matrix_from(S)
     assert T_fromS_toC == Matrix([
         [sin(theta)*cos(phi), cos(theta)*cos(phi), -sin(phi)],
         [sin(theta)*sin(phi), cos(theta)*sin(phi), cos(phi)],
         [cos(theta), -sin(theta), 0]
     ])
-    assert S.transformation_matrix(C) == T_fromS_toC.T
+    assert S.transformation_matrix_from(C) == T_fromS_toC.T
 
 
-def test_transformation_matrix_cylindrical_to_cartesian():
+def test_transformation_matrix_from_cylindrical_to_cartesian():
     Cart = CoordSys3D("Cart")
     C = Cart.create_new("C", transformation="cylindrical")
     r, theta, z = C.base_scalars()
-    T_fromC_toCart = Cart.transformation_matrix(C)
+    T_fromC_toCart = Cart.transformation_matrix_from(C)
     assert T_fromC_toCart == Matrix([
         [cos(theta), -sin(theta), 0],
         [sin(theta), cos(theta), 0],
         [0, 0, 1]
     ])
-    assert C.transformation_matrix(Cart) == T_fromC_toCart.T
+    assert C.transformation_matrix_from(Cart) == T_fromC_toCart.T
 
 
-def test_transformation_matrix_spherical_to_cylindrical():
+def test_transformation_matrix_from_spherical_to_cylindrical():
     # The following tests uses simplify in order to show `theta_c - phis_s`,
     # which is a reminder to the user that the azimuthal angle
     # of S and C are the same, phi_s=theta_c, [0, 2*pi[
@@ -534,38 +534,38 @@ def test_transformation_matrix_spherical_to_cylindrical():
     C = Cart.create_new("C", transformation="cylindrical")
     r_s, theta_s, phi_s = S.base_scalars()
     r_c, theta_c, z_c = C.base_scalars()
-    T_fromS_toC = C.transformation_matrix(S)
+    T_fromS_toC = C.transformation_matrix_from(S)
     T_fromS_toC = T_fromS_toC.simplify().subs(theta_c - phi_s, 0)
     assert T_fromS_toC == Matrix([
         [sin(theta_s), cos(theta_s), 0],
         [0, 0, 1],
         [cos(theta_s), -sin(theta_s), 0]
     ])
-    T_fromC_toS = S.transformation_matrix(C).simplify()
+    T_fromC_toS = S.transformation_matrix_from(C).simplify()
     T_fromC_toS = T_fromC_toS.subs(theta_c - phi_s, 0)
     assert T_fromC_toS == T_fromS_toC.T
 
 
-def test_transformation_matrix_simple_rotation():
+def test_transformation_matrix_from_simple_rotation():
     alpha = symbols("alpha")
     A = CoordSys3D("A")
     B = A.orient_new_axis("B", alpha, A.k)
-    T_fromB_toA = A.transformation_matrix(B)
+    T_fromB_toA = A.transformation_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [cos(alpha), -sin(alpha), 0],
         [sin(alpha), cos(alpha), 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert B.transformation_matrix_from(A) == T_fromB_toA.T
     assert T_fromB_toA == A.rotation_matrix(B)
 
 
-def test_transformation_matrix_three_rotations():
+def test_transformation_matrix_from_three_rotations():
     a, b, g = symbols("alpha, beta, gamma")
     bo = BodyOrienter(a, b, g, "123")
     A = CoordSys3D("A")
     B = A.orient_new("B", bo)
-    T_fromB_toA = A.transformation_matrix(B)
+    T_fromB_toA = A.transformation_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [cos(b) * cos(g), -sin(g) * cos(b), sin(b)],
         [
@@ -579,92 +579,92 @@ def test_transformation_matrix_three_rotations():
             cos(a) * cos(b)
         ]
     ])
-    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert B.transformation_matrix_from(A) == T_fromB_toA.T
     assert A.rotation_matrix(B) == T_fromB_toA
 
 
-def test_transformation_matrix_reflection_to_cartesian():
+def test_transformation_matrix_from_reflection_to_cartesian():
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
-    T_fromB_toA = A.transformation_matrix(B)
+    T_fromB_toA = A.transformation_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert B.transformation_matrix_from(A) == T_fromB_toA.T
 
     # a chain of systems
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
     C = B.create_new("C", transformation=lambda x,y,z: (z, y, x))
-    T_fromB_toA = A.transformation_matrix(B)
-    T_fromC_toA = A.transformation_matrix(C)
-    T_fromC_toB = B.transformation_matrix(C)
+    T_fromB_toA = A.transformation_matrix_from(B)
+    T_fromC_toA = A.transformation_matrix_from(C)
+    T_fromC_toB = B.transformation_matrix_from(C)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert B.transformation_matrix_from(A) == T_fromB_toA.T
     assert T_fromC_toB == Matrix([
         [0, 0, 1],
         [0, 1, 0],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix(B) == T_fromC_toB.T
+    assert C.transformation_matrix_from(B) == T_fromC_toB.T
     assert T_fromC_toA == Matrix([
         [0, 1, 0],
         [0, 0, 1],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix(A) == T_fromC_toA.T
+    assert C.transformation_matrix_from(A) == T_fromC_toA.T
 
     # same systems, but linked in a different way
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, x, z))
     C = A.create_new("C", transformation=lambda x,y,z: (z, y, x))
-    T_fromB_toA = A.transformation_matrix(B)
-    T_fromC_toA = A.transformation_matrix(C)
-    T_fromC_toB = B.transformation_matrix(C)
+    T_fromB_toA = A.transformation_matrix_from(B)
+    T_fromC_toA = A.transformation_matrix_from(C)
+    T_fromC_toB = B.transformation_matrix_from(C)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [1, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix(A) == T_fromB_toA.T
+    assert B.transformation_matrix_from(A) == T_fromB_toA.T
     assert T_fromC_toA == Matrix([
         [0, 0, 1],
         [0, 1, 0],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix(A) == T_fromC_toA.T
+    assert C.transformation_matrix_from(A) == T_fromC_toA.T
     assert T_fromC_toB == Matrix([
         [0, 1, 0],
         [0, 0, 1],
         [1, 0, 0]
     ])
-    assert C.transformation_matrix(B) == T_fromC_toB.T
+    assert C.transformation_matrix_from(B) == T_fromC_toB.T
 
 
-def test_transformation_matrix_reflection_stretch_to_cartesian():
+def test_transformation_matrix_from_reflection_stretch_to_cartesian():
     A = CoordSys3D("A")
     B = A.create_new("B", transformation=lambda x,y,z: (y, 2*x, z))
-    T_fromB_toA = A.transformation_matrix(B)
+    T_fromB_toA = A.transformation_matrix_from(B)
     assert T_fromB_toA == Matrix([
         [0, 1, 0],
         [2, 0, 0],
         [0, 0, 1]
     ])
-    assert B.transformation_matrix(A) == T_fromB_toA.inv()
+    assert B.transformation_matrix_from(A) == T_fromB_toA.inv()
 
 
-def test_transformation_matrix_trigsimp():
+def test_transformation_matrix_from_trigsimp():
     A = CoordSys3D("A")
     B = A.orient_new_axis('B', q, A.k)
     N = B.orient_new_axis('N', -q, B.k)
-    assert N.transformation_matrix(A) == eye(3)
-    assert A.transformation_matrix(N) == eye(3)
+    assert N.transformation_matrix_from(A) == eye(3)
+    assert A.transformation_matrix_from(N) == eye(3)
 
 
 def test_spherical_cartesian_scalar_map():

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -182,3 +182,383 @@ def test_orthogonalize():
         [(3*sqrt(10))*C.i/10 + (sqrt(10))*C.j/10, (-sqrt(10))*C.i/10 + (3*sqrt(10))*C.j/10]
     raises(ValueError, lambda: orthogonalize(v1, v2, v3))
     raises(ValueError, lambda: orthogonalize(v6, v7))
+
+
+def test_express_from_spherical_to_cartesian():
+    C = CoordSys3D("C")
+    S = C.create_new("S", transformation="spherical")
+    r, theta, phi = S.base_scalars()
+    a, b, c = symbols("a:c")
+
+    # vector along the radial direction
+    v1 = 1 * S.i
+    assert express(v1, C) == (
+        (sin(theta) * cos(phi)) * C.i +
+        (sin(theta) * sin(phi)) * C.j +
+        cos(theta) * C.k)
+    # vector along the polar direction
+    v2 = 1 * S.j
+    assert express(v2, C) == (
+        (cos(theta) * cos(phi)) * C.i +
+        (cos(theta) * sin(phi)) * C.j +
+        (-sin(theta)) * C.k)
+    # vector along the azimuthal direction
+    v3 = 1 * S.k
+    assert express(v3, C) == -sin(phi) * C.i + cos(phi) * C.j
+    # arbitrary vector expressed in spherical coordinates
+    v4 = a * S.i + b * S.j + c * S.k
+    assert express(v4, C) == (
+        (a*cos(phi)*sin(theta) + b*cos(phi)*cos(theta) - c*sin(phi)) * C.i +
+        (a*sin(phi)*sin(theta) + b*sin(phi)*cos(theta) + c*cos(phi)) * C.j +
+        (a*cos(theta) - b*sin(theta)) * C.k)
+    # vector expressed in two coordinate systems
+    v5 = a * C.i + b * S.j
+    assert express(v5, C) == (
+        (a + b * cos(phi) * cos(theta)) * C.i +
+        (b * sin(phi) * cos(theta)) * C.j +
+        (-b * sin(theta)) * C.k)
+
+
+def test_express_from_cartesian_to_spherical():
+    C = CoordSys3D("C")
+    S = C.create_new("S", transformation="spherical")
+    r, theta, phi = S.base_scalars()
+    a, b, c = symbols("a:c")
+
+    # vector along the x-axis
+    v1 = 1 * C.i
+    assert express(v1, S) == (
+        (sin(theta) * cos(phi)) * S.i +
+        (cos(theta) * cos(phi)) * S.j +
+        (-sin(phi)) * S.k)
+    # vector along the y-axis
+    v2 = 1 * C.j
+    assert express(v2, S) == (
+        (sin(theta) * sin(phi)) * S.i +
+        (cos(theta) * sin(phi)) * S.j +
+        (cos(phi)) * S.k)
+    # vector along the z-axis
+    v3 = 1 * C.k
+    assert express(v3, S) == cos(theta) * S.i - sin(theta) * S.j
+    # arbitrary vector expressed in cartesian coordinates
+    v4 = a * C.i + b * C.j + c * C.k
+    assert express(v4, S) == (
+        (a*cos(phi)*sin(theta) + b*sin(phi)*sin(theta) + c*cos(theta)) * S.i +
+        (a*cos(phi)*cos(theta) + b*sin(phi)*cos(theta) - c*sin(theta)) * S.j +
+        (-a*sin(phi) + b*cos(phi)) * S.k)
+    # vector expressed in two coordinate systems
+    v5 = a * C.i + b * S.j
+    assert express(v5, S) == (
+        (a * cos(phi) * sin(theta)) * S.i +
+        (a * cos(phi) * cos(theta) + b) * S.j +
+        (-a * sin(phi)) * S.k)
+
+
+def test_express_from_cylindrical_to_cartesian():
+    Cart = CoordSys3D("Cart")
+    Cyl = Cart.create_new("Cyl", transformation="cylindrical")
+    r, theta, zeta = Cyl.base_scalars()
+    a, b, c = symbols("a:c")
+
+    # vector along the radial direction
+    v1 = 1 * Cyl.i
+    assert express(v1, Cart) == cos(theta) * Cart.i + sin(theta) * Cart.j
+    # vector along the theta direction
+    v2 = 1 * Cyl.j
+    assert express(v2, Cart) == -sin(theta) * Cart.i + cos(theta) * Cart.j
+    # vector along the z direction
+    v3 = 1 * Cyl.k
+    assert express(v3, Cart) == Cart.k
+    # arbitrary vector expressed in cylindrical coordinates
+    v4 = a * Cyl.i + b * Cyl.j + c * Cyl.k
+    assert express(v4, Cart) == (
+        (a*cos(theta) - b*sin(theta)) * Cart.i +
+        (a*sin(theta) + b*cos(theta)) * Cart.j +
+        c * Cart.k)
+    # vector expressed in two coordinate systems
+    v5 = a * Cart.i + b * Cyl.j
+    assert express(v5, Cart) == (
+        (a - b * sin(theta)) * Cart.i +
+        (b * cos(theta)) * Cart.j)
+
+
+def test_express_from_cartesian_to_cylindrical():
+    Cart = CoordSys3D("Cart")
+    Cyl = Cart.create_new("Cyl", transformation="cylindrical")
+    r, theta, zeta = Cyl.base_scalars()
+    a, b, c = symbols("a:c")
+
+    # vector along the x-axis
+    v1 = 1 * Cart.i
+    assert express(v1, Cyl) == cos(theta) * Cyl.i - sin(theta) * Cyl.j
+    # vector along the y-axis
+    v2 = 1 * Cart.j
+    assert express(v2, Cyl) == sin(theta) * Cyl.i + cos(theta) * Cyl.j
+    # vector along the z-axis
+    v3 = 1 * Cart.k
+    assert express(v3, Cyl) == Cyl.k
+    # arbitrary vector expressed in cartesian coordinates
+    v4 = a * Cart.i + b * Cart.j + c * Cart.k
+    assert express(v4, Cyl) == (
+        (a*cos(theta) + b*sin(theta)) * Cyl.i +
+        (-a*sin(theta) + b*cos(theta)) * Cyl.j +
+        c * Cyl.k)
+    # vector expressed in two coordinate systems
+    v5 = a * Cart.i + b * Cyl.j
+    assert express(v5, Cyl) == (
+        (a * cos(theta)) * Cyl.i +
+        (b - a * sin(theta)) * Cyl.j)
+
+
+def test_express_from_spherical_to_cylindrical():
+    Cart = CoordSys3D("Cart")
+    S = Cart.create_new("S", transformation="spherical")
+    C = Cart.create_new("C", transformation="cylindrical")
+    r_s, theta_s, phi_s = S.base_scalars()
+    r_c, theta_c, z_c = C.base_scalars()
+    a, b, c = symbols("a, b, c")
+
+    # The following tests uses simplify in order to show `theta_c - phis_s`,
+    # which is a reminder to the user that the azimuthal angle
+    # of S and C are the same, phi_s=theta_c, [0, 2*pi[
+
+    # vector along the radial direction
+    v1 = S.i
+    r1 = express(v1, C)
+    assert r1.simplify() == (
+        (sin(theta_s) * cos(theta_c - phi_s)) * C.i +
+        (-sin(theta_s) * sin(theta_c - phi_s)) * C.j +
+        (cos(theta_s)) * C.k)
+    assert r1.subs(phi_s, theta_c).simplify() == (
+        sin(theta_s) * C.i + cos(theta_s) * C.k)
+
+    # vector along the polar direction
+    v2 = S.j
+    r2 = express(v2, C)
+    assert r2.simplify() == (
+        (cos(theta_s) * cos(theta_c - phi_s)) * C.i +
+        (-cos(theta_s) * sin(theta_c - phi_s)) * C.j +
+        (-sin(theta_s)) * C.k)
+    assert r2.subs(phi_s, theta_c).simplify() == (
+        cos(theta_s) * C.i - sin(theta_s) * C.k)
+
+    # vector along the azimuthal direction
+    v3 = S.k
+    r3 = express(v3, C)
+    assert r3 == (
+        (
+            sin(C.theta)*cos(S.phi) -
+            sin(S.phi)*cos(C.theta)
+        ) * C.i +
+        (
+            sin(C.theta)*sin(S.phi) +
+            cos(C.theta)*cos(S.phi)
+        ) * C.j)
+    assert r3.simplify() == (
+        (sin(theta_c - phi_s)) * C.i +
+        (cos(theta_c - phi_s)) * C.j)
+    assert r3.subs(phi_s, theta_c).simplify() == C.j
+
+    # vector along arbitrary direction
+    v4 = a * S.i + b * S.j + c * S.k
+    r4 = express(v4, C)
+    assert r4.equals(
+        (
+            a*sin(S.theta)*cos(C.theta - S.phi) +
+            b*cos(S.theta)*cos(C.theta - S.phi) +
+            c*sin(C.theta - S.phi)
+        ) * C.i +
+        (
+            -a*sin(S.theta)*sin(C.theta - S.phi) -
+            b*sin(C.theta - S.phi)*cos(S.theta) +
+            c*cos(C.theta - S.phi)
+        ) * C.j +
+        (
+            a*cos(S.theta) - b*sin(S.theta)
+        ) * C.k)
+    assert r4.subs(phi_s, theta_c).equals(
+        (a * sin(theta_s) + b * cos(theta_s)) * C.i +
+        c * C.j +
+        (a * cos(theta_s) - b * sin(theta_s)) * C.k)
+
+
+def test_express_from_cylindrical_to_spherical():
+    Cart = CoordSys3D("Cart")
+    S = Cart.create_new("S", transformation="spherical")
+    C = Cart.create_new("C", transformation="cylindrical")
+    r_s, theta_s, phi_s = S.base_scalars()
+    r_c, theta_c, z_c = C.base_scalars()
+    a, b, c = symbols("a, b, c")
+
+    # The following tests uses simplify in order to show `theta_c - phis_s`,
+    # which is a reminder to the user that the azimuthal angle
+    # of S and C are the same, phi_s=theta_c, [0, 2*pi[
+
+    # vector along the radial direction
+    v1 = C.i
+    r1 = express(v1, S)
+    assert r1.simplify() == (
+        (sin(theta_s) * cos(theta_c - phi_s)) * S.i +
+        (cos(theta_s) * cos(theta_c - phi_s)) * S.j +
+        (sin(theta_c - phi_s)) * S.k)
+    assert r1.subs(phi_s, theta_c).simplify() == (
+        sin(theta_s) * S.i + cos(theta_s) * S.j)
+
+    # vector along the azimuthal direction
+    v2 = C.j
+    r2 = express(v2, S)
+    assert r2.simplify() == (
+        (-sin(theta_s) * sin(theta_c - phi_s)) * S.i +
+        (-cos(theta_s) * sin(theta_c - phi_s)) * S.j +
+        (cos(theta_c - phi_s)) * S.k
+    )
+    assert r2.subs(phi_s, theta_c).simplify() == S.k
+
+    # vector along the z-axis
+    v3 = C.k
+    r3 = express(v3, S)
+    assert r3 == cos(theta_s) * S.i - sin(theta_s) * S.j
+    assert r3.subs(phi_s, theta_c) == cos(theta_s) * S.i - sin(theta_s) * S.j
+
+    # vector along arbitrary direction
+    v4 = a * C.i + b * C.j + c * C.k
+    r4 = express(v4, S)
+    assert r4.simplify() == (
+        (
+            a*sin(S.theta)*cos(C.theta - S.phi) -
+            b*sin(S.theta)*sin(C.theta - S.phi) +
+            c*cos(S.theta)
+        ) * S.i +
+        (
+            a*cos(S.theta)*cos(C.theta - S.phi) -
+            b*sin(C.theta - S.phi)*cos(S.theta) -
+            c*sin(S.theta)
+        ) * S.j +
+        (
+            a*sin(C.theta - S.phi) + b*cos(C.theta - S.phi)
+        ) * S.k)
+    assert r4.subs(phi_s, theta_c).simplify() == (
+        (a * sin(theta_s) + c * cos(theta_s)) * S.i +
+        (a * cos(theta_s) - c * sin(theta_s)) * S.j +
+        b * S.k)
+
+
+def test_express_scaled_and_reflected_to_cartesian():
+    C = CoordSys3D("C")
+    A = C.create_new("A", transformation=lambda x, y, z: (y, 2*x, z))
+    a, b, c = symbols("a, b, c")
+
+    assert express(A.i, C) == 2 * C.j
+    assert express(A.j, C) == C.i
+    assert express(A.k, C) == C.k
+    assert express(a * A.i + b * A.j + c * A.k, C) == (
+        b * C.i + 2 * a * C.j + c * C.k)
+
+
+def test_express_cartesian_to_scaled_and_reflected():
+    C = CoordSys3D("C")
+    A = C.create_new("A", transformation=lambda x, y, z: (y, 2*x, z))
+    a, b, c = symbols("a, b, c")
+
+    assert express(C.i, A) == A.j
+    assert express(C.j, A) == A.i / 2
+    assert express(C.k, A) == A.k
+    assert express(a * C.i + b * C.j + c * C.k, A) == (
+        b / 2 * A.i + a * A.j + c * A.k)
+
+
+def test_cartesian_flipped_to_cartesian():
+    C1 = CoordSys3D("C1")
+    C2 = C1.create_new("C2", transformation=lambda x, y, z: (y, x, z))
+    a, b, c = symbols("a, b, c")
+
+    assert express(C2.i, C1) == C1.j
+    assert express(C2.j, C1) == C1.i
+    assert express(C2.k, C1) == C1.k
+    assert express(a * C2.i + b * C2.j + c * C2.k, C1) == (
+        b * C1.i + a * C1.j + c * C1.k)
+
+
+def test_cartesian_to_cartesian_flipped():
+    C1 = CoordSys3D("C1")
+    C2 = C1.create_new("C2", transformation=lambda x, y, z: (y, x, z))
+    a, b, c = symbols("a, b, c")
+
+    assert express(C1.i, C2) == C2.j
+    assert express(C1.j, C2) == C2.i
+    assert express(C1.k, C2) == C2.k
+    assert express(a * C1.i + b * C1.j + c * C1.k, C2) == (
+        b * C2.i + a * C2.j + c * C2.k)
+
+def test_two_cartesian_flipped_systems():
+    A = CoordSys3D("A", transformation=lambda x, y, z: (y, x, z))
+    B = A.create_new("B", transformation=lambda x, y, z: (z, y, x))
+    a, b, c = symbols("a:c")
+
+    assert express(a * B.i + b * B.j + c * B.k, A) == (
+        c * A.i + b * A.j + a * A.k)
+    assert express(a * A.i + b * A.j + c * A.k, B) == (
+        c * B.i + b * B.j + a * B.k)
+
+    C = CoordSys3D("C")
+    A = C.create_new("A", transformation=lambda x, y, z: (y, x, z))
+    B = C.create_new("B", transformation=lambda x, y, z: (z, y, x))
+    assert express(a * B.i + b * B.j + c * B.k, A) == (
+        b * A.i + c * A.j + a * A.k)
+    assert express(a * A.i + b * A.j + c * A.k, B) == (
+        c * B.i + a * B.j + b * B.k)
+
+
+def test_express_path_of_systems():
+    # C1 -> C2 (translate) -> C3 (rotate about k by alpha) -> S (spherical)
+    # Note that the transformation matrix doesn't consider translation,
+    # only rotation and scaling
+    p, alpha = symbols("p, alpha")
+    C1 = CoordSys3D("C1")
+    C2 = C1.orient_new_axis("C2", alpha, C1.k)
+    C3 = C2.locate_new("C3", p * C2.i)
+    S = C3.create_new("S", transformation="spherical")
+    r, theta, phi = S.base_scalars()
+
+    # vector along the radial direction
+    v1 = S.i
+    assert express(v1, C1) == (
+        (
+            -sin(phi) * sin(theta) * sin(alpha) +
+            cos(phi) * sin(theta) * cos(alpha)
+        ) * C1.i +
+        (
+            sin(phi) * sin(theta) * cos(alpha) +
+            cos(phi) * sin(theta) * sin(alpha)
+        ) * C1.j +
+        cos(theta) * C1.k)
+    assert express(v1, C3) == (
+        (sin(theta) * cos(phi)) * C3.i +
+        (sin(theta) * sin(phi)) * C3.j +
+        cos(theta) * C3.k)
+
+    # vector along the polar direction
+    v2 = 1 * S.j
+    assert express(v2, C1) == (
+        (
+            -sin(phi) * cos(theta) * sin(alpha) +
+            cos(phi) * cos(theta) * cos(alpha)
+        ) * C1.i +
+        (
+            sin(phi) * cos(theta) * cos(alpha) +
+            cos(phi) * cos(theta) * sin(alpha)
+        ) * C1.j +
+        (-sin(theta)) * C1.k)
+    assert express(v2, C3) == (
+        (cos(phi) * cos(theta)) * C3.i +
+        (sin(phi) * cos(theta)) * C3.j +
+        (-sin(theta)) * C3.k)
+
+    # vector along the azimuthal direction
+    v3 = 1 * S.k
+    assert express(v3, C1) == (
+        (-sin(phi) * cos(alpha) - sin(alpha) * cos(phi)) * C1.i +
+        (-sin(phi) * sin(alpha) + cos(phi) * cos(alpha)) * C1.j)
+    assert express(v3, C3) == (
+        -sin(phi) * C3.i +
+        cos(phi) * C3.j)

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -562,3 +562,34 @@ def test_express_path_of_systems():
     assert express(v3, C3) == (
         -sin(phi) * C3.i +
         cos(phi) * C3.j)
+
+
+def test_express_with_variables():
+    A = CoordSys3D("A")
+    C = A.create_new('C', transformation='cylindrical')
+
+    assert express(A.x, C, variables=False) == A.x
+    assert express(A.x, C, variables=True) == C.r * cos(C.theta)
+    assert express(A.x*A.j, C, variables=False) == (
+        A.x * sin(C.theta) * C.i + A.x * cos(C.theta) * C.j)
+    res = express(A.x*A.j, C, variables=True)
+    assert res == (
+        C.r * sin(C.theta) * cos(C.theta) * C.i +
+        C.r * cos(C.theta)**2 * C.j)
+    assert express(res, A, variables=False) == (
+        (C.r * sin(C.theta)**2 * cos(C.theta) + C.r * cos(C.theta)**3) * A.j)
+    assert express(res, A, variables=True) == (
+        (A.x**3 / (A.x**2 + A.y**2) + A.x * A.y**2 / (A.x**2 + A.y**2)) * A.j)
+
+    assert express(C.r, A, variables=False) == C.r
+    assert express(C.r, A, variables=True) == sqrt(A.x**2 + A.y**2)
+    assert express(C.r * C.i, A, variables=False) == (
+        C.r * cos(C.theta) * A.i + C.r * sin(C.theta) * A.j)
+    res = express(C.r * C.i, A, variables=True)
+    assert res == A.x * A.i + A.y * A.j
+    assert express(res, C, variables=False) == (
+        (A.x * cos(C.theta) + A.y * sin(C.theta)) * C.i +
+        (-A.x * sin(C.theta) + A.y * cos(C.theta)) * C.j)
+    assert express(res, C, variables=True) == (
+        (C.r * sin(C.theta)**2 + C.r * cos(C.theta)**2) * C.i)
+    assert express(res, C, variables=True).simplify() == C.r * C.i


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #27164

Fixes #15987

Fixes #19725

#### Brief description of what is fixed or changed

As pointed out in the issues, `CoordSys3D.rotation_matrix` only takes into account pure rotations between Cartesian coordinate system. It doesn't deal with a change of base vectors between coordinate systems. 

This PR introduces the `CoordSys3D.transformation_matrix` which consider the change of base vectors between coordinate system.

Then, it replaces `.rotation_matrix` with `.transformation_matrix` in these functions:

1. `CoordSys3D.scalar_map`
2. `express`

Thus enabling the capability to re-express vectors defined in one coordinate system to a different coordinate system (cartesian to cartesian, cartesian to curvilinear, curvilinear to cartesian, ...).


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * added support for curvilinear coordinate transformation in the `express` function.

<!-- END RELEASE NOTES -->
