### PR TITLE
Fix subs on Derivative of matrix expressions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -238,6 +238,7 @@ Advait Pote <apote2050@gmail.com> Advait Pote <92469698+AdvaitPote@users.noreply
 Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.21>
 Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.2>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
+Aerex0 <suyash.ranjan.min24@itbhu.ac.in>
 Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1716,6 +1716,7 @@ class Derivative(Expr):
         return self.args[0].kind
 
     def _eval_subs(self, old, new):
+        from sympy.matrices.expressions.matexpr import MatrixExpr
         # The substitution (old, new) cannot be done inside
         # Derivative(expr, vars) for a variety of reasons
         # as handled below.
@@ -1769,7 +1770,16 @@ class Derivative(Expr):
             syms = {vi: Dummy() for vi in self._wrt_variables
                 if not vi.is_Symbol}
             wrt = {syms.get(vi, vi) for vi in self._wrt_variables}
-            forbidden = args[0].xreplace(syms).free_symbols & wrt
+
+            
+            expr = args[0]
+
+            if isinstance(expr, MatrixExpr):
+                # Safe path for matrix expressions
+                new_expr = expr.subs(old, new)
+                return self.func(new_expr, *self.variables)
+
+            forbidden = expr.xreplace(syms).free_symbols & wrt
             nfree = new.xreplace(syms).free_symbols
             ofree = old.xreplace(syms).free_symbols
             if (nfree - ofree) & forbidden:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1771,15 +1771,15 @@ class Derivative(Expr):
                 if not vi.is_Symbol}
             wrt = {syms.get(vi, vi) for vi in self._wrt_variables}
             expr = args[0]
+            def _renamed_free_symbols(obj, syms):
+                fs = obj.free_symbols
+                if not syms:
+                    return fs
+                return {syms.get(s, s) for s in fs}
 
-            if isinstance(expr, MatrixExpr):
-                # Safe path for matrix expressions
-                new_expr = expr.subs(old, new)
-                return self.func(new_expr, *self.variables)
-
-            forbidden = expr.xreplace(syms).free_symbols & wrt
-            nfree = new.xreplace(syms).free_symbols
-            ofree = old.xreplace(syms).free_symbols
+            forbidden = _renamed_free_symbols(expr, syms) & wrt
+            nfree = _renamed_free_symbols(new, syms)
+            ofree = _renamed_free_symbols(old, syms)
             if (nfree - ofree) & forbidden:
                 return Subs(self, old, new)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -53,35 +53,19 @@ from .singleton import S
 from .sympify import sympify, _sympify
 
 from .sorting import default_sort_key, ordered
-from sympy.utilities.exceptions import (
-    sympy_deprecation_warning,
-    SymPyDeprecationWarning,
-    ignore_warnings,
-)
-from sympy.utilities.iterables import (
-    has_dups,
-    sift,
-    iterable,
-    is_sequence,
-    uniq,
-    topological_sort,
-)
+from sympy.utilities.exceptions import (sympy_deprecation_warning,
+                                        SymPyDeprecationWarning, ignore_warnings)
+from sympy.utilities.iterables import (has_dups, sift, iterable,
+    is_sequence, uniq, topological_sort)
 from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
 from sympy.utilities.misc import as_int, filldedent, func_name
 
 import mpmath
-from sympy.external.mpmath import (
-    prec_to_dps,
-    mpf,
-    mpc,
-    mp,
-    workprec,
-    diff as mpmath_diff,
-)
+from sympy.external.mpmath import (prec_to_dps, mpf, mpc, mp, workprec, diff as
+                                   mpmath_diff)
 
 import inspect
 from collections import Counter
-
 
 def _coeff_isneg(a):
     """Return True if the leading Number is negative.
@@ -123,21 +107,17 @@ class PoleError(Exception):
 
 class ArgumentIndexError(ValueError):
     def __str__(self):
-        return "Invalid operation with argument number %s for Function %s" % (
-            self.args[1],
-            self.args[0],
-        )
+        return ("Invalid operation with argument number %s for Function %s" %
+               (self.args[1], self.args[0]))
 
 
 class BadSignatureError(TypeError):
-    """Raised when a Lambda is created with an invalid signature"""
-
+    '''Raised when a Lambda is created with an invalid signature'''
     pass
 
 
 class BadArgumentsError(TypeError):
-    """Raised when a Lambda is called with an incorrect number of arguments"""
-
+    '''Raised when a Lambda is called with an incorrect number of arguments'''
     pass
 
 
@@ -162,16 +142,16 @@ def arity(cls):
     >>> arity(lambda *x: sum(x)) is None
     True
     """
-    eval_ = getattr(cls, "eval", cls)
+    eval_ = getattr(cls, 'eval', cls)
 
     parameters = inspect.signature(eval_).parameters.items()
     if [p for _, p in parameters if p.kind == p.VAR_POSITIONAL]:
         return
     p_or_k = [p for _, p in parameters if p.kind == p.POSITIONAL_OR_KEYWORD]
     # how many have no default and how many have a default value
-    no, yes = map(len, sift(p_or_k, lambda p: p.default == p.empty, binary=True))
+    no, yes = map(len, sift(p_or_k,
+        lambda p:p.default == p.empty, binary=True))
     return no if not yes else tuple(range(no, no + yes + 1))
-
 
 class FunctionClass(type):
     """
@@ -180,16 +160,15 @@ class FunctionClass(type):
     Use Function('<function name>' [ , signature ]) to create
     undefined function classes.
     """
-
     _new = type.__new__
 
     def __init__(cls, *args, **kwargs):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
-        nargs = kwargs.pop("nargs", cls.__dict__.get("nargs", arity(cls)))
-        if nargs is None and "nargs" not in cls.__dict__:
+        nargs = kwargs.pop('nargs', cls.__dict__.get('nargs', arity(cls)))
+        if nargs is None and 'nargs' not in cls.__dict__:
             for supcls in cls.__mro__:
-                if hasattr(supcls, "_nargs"):
+                if hasattr(supcls, '_nargs'):
                     nargs = supcls._nargs
                     break
                 else:
@@ -198,18 +177,13 @@ class FunctionClass(type):
         # Canonicalize nargs here; change to set in nargs.
         if is_sequence(nargs):
             if not nargs:
-                raise ValueError(
-                    filldedent(
-                        """
+                raise ValueError(filldedent('''
                     Incorrectly specified nargs as %s:
                     if there are no arguments, it should be
                     `nargs = 0`;
                     if there are any number of arguments,
                     it should be
-                    `nargs = None`"""
-                        % str(nargs)
-                    )
-                )
+                    `nargs = None`''' % str(nargs)))
             nargs = tuple(ordered(set(nargs)))
         elif nargs is not None:
             nargs = (as_int(nargs),)
@@ -220,10 +194,8 @@ class FunctionClass(type):
         # called with the usual (name, bases, namespace) type() signature.
         if len(args) == 3:
             namespace = args[2]
-            if "eval" in namespace and not isinstance(namespace["eval"], classmethod):
-                raise TypeError(
-                    "eval on Function subclasses should be a class method (defined with @classmethod)"
-                )
+            if 'eval' in namespace and not isinstance(namespace['eval'], classmethod):
+                raise TypeError("eval on Function subclasses should be a class method (defined with @classmethod)")
 
     @property
     def __signature__(self):
@@ -287,13 +259,12 @@ class FunctionClass(type):
         1
         """
         from sympy.sets.sets import FiniteSet
-
         # XXX it would be nice to handle this in __init__ but there are import
         # problems with trying to import FiniteSet there
         return FiniteSet(*self._nargs) if self._nargs else S.Naturals0
 
-    def _valid_nargs(self, n: int) -> bool:
-        """Return True if the specified integer is a valid number of arguments
+    def _valid_nargs(self, n : int) -> bool:
+        """ Return True if the specified integer is a valid number of arguments
 
         The number of arguments n is guaranteed to be an integer and positive
 
@@ -327,10 +298,10 @@ class Application(Basic, metaclass=FunctionClass):
         from sympy.sets.sets import FiniteSet
 
         args = list(map(sympify, args))
-        evaluate = options.pop("evaluate", global_parameters.evaluate)
+        evaluate = options.pop('evaluate', global_parameters.evaluate)
         # WildFunction (and anything else like it) may have nargs defined
         # and we throw that value away here
-        options.pop("nargs", None)
+        options.pop('nargs', None)
 
         if options:
             raise ValueError("Unknown options: %s" % options)
@@ -403,14 +374,9 @@ class Application(Basic, metaclass=FunctionClass):
         return self.__class__
 
     def _eval_subs(self, old, new):
-        if (
-            old.is_Function
-            and new.is_Function
-            and callable(old)
-            and callable(new)
-            and old == self.func
-            and len(self.args) in new.nargs
-        ):
+        if (old.is_Function and new.is_Function and
+            callable(old) and callable(new) and
+            old == self.func and len(self.args) in new.nargs):
             return new(*[i._subs(old, new) for i in self.args])
 
 
@@ -494,22 +460,16 @@ class Function(Application, Expr):
             # for example, https://github.com/numpy/numpy/issues/1697.
             # The ideal solution would be just to attach metadata to
             # the exception and change NumPy to take advantage of this.
-            temp = (
-                "%(name)s takes %(qual)s %(args)s "
-                "argument%(plural)s (%(given)s given)"
-            )
-            raise TypeError(
-                temp
-                % {
-                    "name": cls,
-                    "qual": "exactly" if len(cls.nargs) == 1 else "at least",
-                    "args": min(cls.nargs),
-                    "plural": "s" * (min(cls.nargs) != 1),
-                    "given": n,
-                }
-            )
+            temp = ('%(name)s takes %(qual)s %(args)s '
+                   'argument%(plural)s (%(given)s given)')
+            raise TypeError(temp % {
+                'name': cls,
+                'qual': 'exactly' if len(cls.nargs) == 1 else 'at least',
+                'args': min(cls.nargs),
+                'plural': 's'*(min(cls.nargs) != 1),
+                'given': n})
 
-        evaluate = options.get("evaluate", global_parameters.evaluate)
+        evaluate = options.get('evaluate', global_parameters.evaluate)
         result = super().__new__(cls, *args, **options)
         if evaluate and isinstance(result, cls) and result.args:
             _should_evalf = [cls._should_evalf(a) for a in result.args]
@@ -547,22 +507,21 @@ class Function(Application, Expr):
     @classmethod
     def class_key(cls):
         from sympy.sets.fancysets import Naturals0
-
         funcs = {
-            "exp": 10,
-            "log": 11,
-            "sin": 20,
-            "cos": 21,
-            "tan": 22,
-            "cot": 23,
-            "sinh": 30,
-            "cosh": 31,
-            "tanh": 32,
-            "coth": 33,
-            "conjugate": 40,
-            "re": 41,
-            "im": 42,
-            "arg": 43,
+            'exp': 10,
+            'log': 11,
+            'sin': 20,
+            'cos': 21,
+            'tan': 22,
+            'cot': 23,
+            'sinh': 30,
+            'cosh': 31,
+            'tanh': 32,
+            'coth': 33,
+            'conjugate': 40,
+            're': 41,
+            'im': 42,
+            'arg': 43,
         }
         name = cls.__name__
 
@@ -587,7 +546,7 @@ class Function(Application, Expr):
                     return None
             return getattr(mpmath, fname)
 
-        _eval_mpmath = getattr(self, "_eval_mpmath", None)
+        _eval_mpmath = getattr(self, '_eval_mpmath', None)
         if _eval_mpmath is None:
             func = _get_mpmath_func(self.func.__name__)
             args = self.args
@@ -596,7 +555,7 @@ class Function(Application, Expr):
 
         # Fall-back evaluation
         if func is None:
-            imp = getattr(self, "_imp_", None)
+            imp = getattr(self, '_imp_', None)
             if imp is None:
                 return None
             try:
@@ -611,7 +570,6 @@ class Function(Application, Expr):
         #     we be more intelligent about it?
         try:
             args = [arg._to_mpmath(prec + 5) for arg in args]
-
             def bad(m):
                 # the precision of an mpf value is the last element
                 # if that is 1 (and m[1] is not 1 which would indicate a
@@ -622,13 +580,13 @@ class Function(Application, Expr):
                 # pass
                 if isinstance(m, mpf):
                     m = m._mpf_
-                    return m[1] != 1 and m[-1] == 1
+                    return m[1] !=1 and m[-1] == 1
                 elif isinstance(m, mpc):
                     m, n = m._mpc_
-                    return m[1] != 1 and m[-1] == 1 and n[1] != 1 and n[-1] == 1
+                    return m[1] !=1 and m[-1] == 1 and \
+                        n[1] !=1 and n[-1] == 1
                 else:
                     return False
-
             if any(bad(a) for a in args):
                 raise ValueError  # one or more args failed to compute with significance
         except ValueError:
@@ -687,9 +645,8 @@ class Function(Application, Expr):
         if ss in (True, None, False):
             return ss
 
-        return fuzzy_or(
-            a.is_infinite if s is S.ComplexInfinity else (a - s).is_zero for s in ss
-        )
+        return fuzzy_or(a.is_infinite if s is S.ComplexInfinity
+                        else (a - s).is_zero for s in ss)
 
     def _eval_aseries(self, n, args0, x, logx):
         """
@@ -698,14 +655,9 @@ class Function(Application, Expr):
         be called directly; derived classes can overwrite this to implement
         asymptotic expansions.
         """
-        raise PoleError(
-            filldedent(
-                """
+        raise PoleError(filldedent('''
             Asymptotic expansion of %s around %s is
-            not implemented."""
-                % (type(self), args0)
-            )
-        )
+            not implemented.''' % (type(self), args0)))
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         """
@@ -733,12 +685,10 @@ class Function(Application, Expr):
         from .symbol import uniquely_named_symbol
         from sympy.series.order import Order
         from sympy.sets.sets import FiniteSet
-
         args = self.args
         args0 = [t.limit(x, 0) for t in args]
         if any(t.is_finite is False for t in args0):
             from .numbers import oo, zoo, nan
-
             a = [t.as_leading_term(x, logx=logx) for t in args]
             a0 = [t.limit(x, 0) for t in a]
             if any(t.has(oo, -oo, zoo, nan) for t in a0):
@@ -770,16 +720,14 @@ class Function(Application, Expr):
             s = s.removeO()
             s = s.subs(v, zi).expand() + Order(o.expr.subs(v, zi), x)
             return s
-        if (
-            self.func.nargs is S.Naturals0
-            or (self.func.nargs == FiniteSet(1) and args0[0])
-            or any(c > 1 for c in self.func.nargs)
-        ):
+        if (self.func.nargs is S.Naturals0
+                or (self.func.nargs == FiniteSet(1) and args0[0])
+                or any(c > 1 for c in self.func.nargs)):
             e = self
             e1 = e.expand()
             if e == e1:
-                # for example when e = sin(x+1) or e = sin(cos(x))
-                # let's try the general algorithm
+                #for example when e = sin(x+1) or e = sin(cos(x))
+                #let's try the general algorithm
                 if len(e.args) == 1:
                     # issue 14411
                     e = e.func(e.args[0].cancel())
@@ -789,7 +737,7 @@ class Function(Application, Expr):
                 series = term
                 fact = S.One
 
-                _x = uniquely_named_symbol("xi", self)
+                _x = uniquely_named_symbol('xi', self)
                 e = e.subs(x, _x)
                 for i in range(1, n):
                     fact *= Rational(i)
@@ -800,7 +748,7 @@ class Function(Application, Expr):
                         subs = e.limit(_x, S.Zero)
                     if subs.is_finite is False:
                         raise PoleError("Cannot expand %s around 0" % (self))
-                    term = subs * (x**i) / fact
+                    term = subs*(x**i)/fact
                     term = term.expand()
                     series += term
                 return series + Order(x**n, x)
@@ -812,7 +760,7 @@ class Function(Application, Expr):
         nterms = n + 2
         cf = Order(arg.as_leading_term(x), x).getn()
         if cf != 0:
-            nterms = (n / cf).ceiling()
+            nterms = (n/cf).ceiling()
         for i in range(nterms):
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)
@@ -839,8 +787,8 @@ class Function(Application, Expr):
                 return _derivative_dispatch(self, A)
 
         # See issue 4624 and issue 4719, 5600 and 8510
-        D = Dummy("xi_%i" % argindex, dummy_index=hash(A))
-        args = self.args[:ix] + (D,) + self.args[ix + 1 :]
+        D = Dummy('xi_%i' % argindex, dummy_index=hash(A))
+        args = self.args[:ix] + (D,) + self.args[ix + 1:]
         return Subs(Derivative(self.func(*args), D), D, A)
 
     def _eval_as_leading_term(self, x, logx, cdir):
@@ -850,7 +798,6 @@ class Function(Application, Expr):
         See, for example, cos._eval_as_leading_term.
         """
         from sympy.series.order import Order
-
         args = [a.as_leading_term(x, logx=logx) for a in self.args]
         o = Order(1, x)
         if any(x in a.free_symbols and o.contains(a) for a in args):
@@ -868,8 +815,7 @@ class Function(Application, Expr):
             #      sin(x)        x        <- _eval_as_leading_term needed
             #
             raise NotImplementedError(
-                "%s has no _eval_as_leading_term routine" % self.func
-            )
+                '%s has no _eval_as_leading_term routine' % self.func)
         else:
             return self
 
@@ -896,10 +842,8 @@ class AppliedUndef(Function):
         args = tuple(map(sympify, args))
         u = [a.name for a in args if isinstance(a, UndefinedFunction)]
         if u:
-            raise TypeError(
-                "Invalid argument: expecting an expression, not UndefinedFunction%s: %s"
-                % ("s" * (len(u) > 1), ", ".join(u))
-            )
+            raise TypeError('Invalid argument: expecting an expression, not UndefinedFunction%s: %s' % (
+                's'*(len(u) > 1), ', '.join(u)))
         obj: Expr = super().__new__(cls, *args, **options)  # type: ignore
         return obj
 
@@ -929,16 +873,13 @@ class UndefSageHelper:
     """
     Helper to facilitate Sage conversion.
     """
-
     def __get__(self, ins, typ):
         import sage.all as sage
-
         if ins is None:
             return lambda: sage.function(typ.__name__)
         else:
             args = [arg._sage_() for arg in ins.args]
-            return lambda: sage.function(ins.__class__.__name__)(*args)
-
+            return lambda : sage.function(ins.__class__.__name__)(*args)
 
 _undef_sage_helper = UndefSageHelper()
 
@@ -947,15 +888,11 @@ class UndefinedFunction(FunctionClass):
     """
     The (meta)class of undefined functions.
     """
-
     name: str
     _sage_: UndefSageHelper
 
-    def __new__(
-        mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs
-    ) -> type[AppliedUndef]:
+    def __new__(mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs) -> type[AppliedUndef]:
         from .symbol import _filter_assumptions
-
         # Allow Function('f', real=True)
         # and/or Function(Symbol('f', real=True))
         assumptions, kwargs = _filter_assumptions(kwargs)
@@ -963,15 +900,15 @@ class UndefinedFunction(FunctionClass):
             assumptions = name._merge(assumptions)
             name = name.name
         elif not isinstance(name, str):
-            raise TypeError("expecting string or Symbol for name")
+            raise TypeError('expecting string or Symbol for name')
         else:
-            commutative = assumptions.get("commutative", None)
+            commutative = assumptions.get('commutative', None)
             assumptions = Symbol(name, **assumptions).assumptions0
             if commutative is None:
-                assumptions.pop("commutative")
+                assumptions.pop('commutative')
         __dict__ = __dict__ or {}
         # put the `is_*` for into __dict__
-        __dict__.update({"is_%s" % k: v for k, v in assumptions.items()})
+        __dict__.update({'is_%s' % k: v for k, v in assumptions.items()})
         # You can add other attributes, although they do have to be hashable
         # (but seriously, if you want to add anything other than assumptions,
         # just subclass Function)
@@ -979,9 +916,9 @@ class UndefinedFunction(FunctionClass):
         # add back the sanitized assumptions without the is_ prefix
         kwargs.update(assumptions)
         # Save these for __eq__
-        __dict__.update({"_kwargs": kwargs})
+        __dict__.update({'_kwargs': kwargs})
         # do this for pickling
-        __dict__["__module__"] = None
+        __dict__['__module__'] = None
         obj = super().__new__(mcl, name, bases, __dict__)  # type: ignore
         obj.name = name
         obj._sage_ = _undef_sage_helper
@@ -996,11 +933,9 @@ class UndefinedFunction(FunctionClass):
         return hash((self.class_key(), frozenset(self._kwargs.items())))
 
     def __eq__(self, other):
-        return (
-            isinstance(other, self.__class__)
-            and self.class_key() == other.class_key()
-            and self._kwargs == other._kwargs
-        )
+        return (isinstance(other, self.__class__) and
+            self.class_key() == other.class_key() and
+            self._kwargs == other._kwargs)
 
     def __ne__(self, other):
         return not self == other
@@ -1018,10 +953,8 @@ class UndefinedFunction(FunctionClass):
 def _reduce_undef(f):
     return (_rebuild_undef, (f.name, f._kwargs))
 
-
 def _rebuild_undef(name, kwargs):
     return Function(name, **kwargs)
-
 
 copyreg.pickle(UndefinedFunction, _reduce_undef)
 
@@ -1088,9 +1021,8 @@ class WildFunction(Function, AtomicExpr):  # type: ignore
 
     def __init__(cls, name, **assumptions):
         from sympy.sets.sets import Set, FiniteSet
-
         cls.name = name
-        nargs = assumptions.pop("nargs", S.Naturals0)
+        nargs = assumptions.pop('nargs', S.Naturals0)
         if not isinstance(nargs, Set):
             # Canonicalize nargs here.  See also FunctionClass.
             if is_sequence(nargs):
@@ -1338,14 +1270,9 @@ class Derivative(Expr):
         has_symbol_set = isinstance(symbols_or_none, set)
 
         if not has_symbol_set:
-            raise ValueError(
-                filldedent(
-                    """
+            raise ValueError(filldedent('''
                 Since there are no variables in the expression %s,
-                it cannot be differentiated."""
-                    % expr
-                )
-            )
+                it cannot be differentiated.''' % expr))
 
         # determine value for variables if it wasn't given
         if not variables:
@@ -1354,25 +1281,15 @@ class Derivative(Expr):
                 if expr.is_number:
                     return S.Zero
                 if len(variables) == 0:
-                    raise ValueError(
-                        filldedent(
-                            """
+                    raise ValueError(filldedent('''
                         Since there are no variables in the expression,
                         the variable(s) of differentiation must be supplied
-                        to differentiate %s"""
-                            % expr
-                        )
-                    )
+                        to differentiate %s''' % expr))
                 else:
-                    raise ValueError(
-                        filldedent(
-                            """
+                    raise ValueError(filldedent('''
                         Since there is more than one variable in the
                         expression, the variable(s) of differentiation
-                        must be supplied to differentiate %s"""
-                            % expr
-                        )
-                    )
+                        must be supplied to differentiate %s''' % expr))
 
         # Split the list of variables into a list of the variables we are diff
         # wrt, where each element of the list has the form (s, count) where
@@ -1385,7 +1302,9 @@ class Derivative(Expr):
 
         for i, v in enumerate(variables):
             if isinstance(v, UndefinedFunction):
-                raise TypeError("cannot differentiate wrt " "UndefinedFunction: %s" % v)
+                raise TypeError(
+                    "cannot differentiate wrt "
+                    "UndefinedFunction: %s" % v)
 
             if isinstance(v, array_likes):
                 if len(v) == 0:
@@ -1413,9 +1332,7 @@ class Derivative(Expr):
                 count = v
                 prev, prevcount = variable_count[-1]
                 if prevcount != 1:
-                    raise TypeError(
-                        "tuple {} followed by number {}".format((prev, prevcount), v)
-                    )
+                    raise TypeError("tuple {} followed by number {}".format((prev, prevcount), v))
                 if count == 0:
                     variable_count.pop()
                 else:
@@ -1430,7 +1347,8 @@ class Derivative(Expr):
         for t in variable_count:
             v, c = t
             if c.is_negative:
-                raise ValueError("order of differentiation must be nonnegative")
+                raise ValueError(
+                    'order of differentiation must be nonnegative')
             if merged and merged[-1][0] == v:
                 c += merged[-1][1]
                 if not c:
@@ -1447,29 +1365,24 @@ class Derivative(Expr):
         for v, c in variable_count:
             # v must have _diff_wrt True
             if not v._diff_wrt:
-                __ = ""  # filler to make error message neater
-                raise ValueError(
-                    filldedent(
-                        """
-                    Can't calculate derivative wrt %s.%s"""
-                        % (v, __)
-                    )
-                )
+                __ = ''  # filler to make error message neater
+                raise ValueError(filldedent('''
+                    Can't calculate derivative wrt %s.%s''' % (v,
+                    __)))
 
         # We make a special case for 0th derivative, because there is no
         # good way to unambiguously print this.
         if len(variable_count) == 0:
             return expr
 
-        evaluate = kwargs.get("evaluate", False)
+        evaluate = kwargs.get('evaluate', False)
 
         if evaluate:
             if isinstance(expr, Derivative):
                 expr = expr.canonical
             variable_count = [
                 (v.canonical if isinstance(v, Derivative) else v, c)
-                for v, c in variable_count
-            ]
+                for v, c in variable_count]
 
             # Look for a quick exit if there are symbols that don't appear in
             # expression at all. Note, this cannot check non-symbols like
@@ -1508,7 +1421,7 @@ class Derivative(Expr):
                 return cls._get_zero_with_shape_like(expr)
 
             # make the order of symbols canonical
-            # TODO: check if assumption of discontinuous derivatives exist
+            #TODO: check if assumption of discontinuous derivatives exist
             variable_count = cls._sort_variable_count(variable_count)
 
         # denest
@@ -1519,7 +1432,7 @@ class Derivative(Expr):
 
         # we return here if evaluate is False or if there is no
         # _eval_derivative method
-        if not evaluate or not hasattr(expr, "_eval_derivative"):
+        if not evaluate or not hasattr(expr, '_eval_derivative'):
             # return an unevaluated Derivative
             if evaluate and variable_count == [(expr, 1)] and expr.is_scalar:
                 # special hack providing evaluation for classes
@@ -1534,26 +1447,25 @@ class Derivative(Expr):
         nderivs = 0  # how many derivatives were performed
         unhandled = []
         from sympy.matrices.matrixbase import MatrixBase
-
         for i, (v, count) in enumerate(variable_count):
 
             old_expr = expr
             old_v = None
 
-            is_symbol = v.is_symbol or isinstance(
-                v, (Iterable, Tuple, MatrixBase, NDimArray)
-            )
+            is_symbol = v.is_symbol or isinstance(v,
+                (Iterable, Tuple, MatrixBase, NDimArray))
 
             if not is_symbol:
                 old_v = v
-                v = Dummy("xi")
+                v = Dummy('xi')
                 expr = expr.xreplace({old_v: v})
                 # Derivatives and UndefinedFunctions are independent
                 # of all others
                 clashing = not (isinstance(old_v, (Derivative, AppliedUndef)))
                 if v not in expr.free_symbols and not clashing:
                     return expr.diff(v)  # expr's version of 0
-                if not old_v.is_scalar and not hasattr(old_v, "_eval_derivative"):
+                if not old_v.is_scalar and not hasattr(
+                        old_v, '_eval_derivative'):
                     # special hack providing evaluation for classes
                     # that have defined is_scalar=True but have no
                     # _eval_derivative defined
@@ -1584,7 +1496,9 @@ class Derivative(Expr):
             expr = obj
 
         # what we have so far can be made canonical
-        expr = expr.replace(lambda x: isinstance(x, Derivative), lambda x: x.canonical)
+        expr = expr.replace(
+            lambda x: isinstance(x, Derivative),
+            lambda x: x.canonical)
 
         if unhandled:
             if isinstance(expr, Derivative):
@@ -1592,16 +1506,16 @@ class Derivative(Expr):
                 expr = expr.expr
             expr = Expr.__new__(cls, expr, *unhandled)
 
-        if (nderivs > 1) == True and kwargs.get("simplify", True):
+        if (nderivs > 1) == True and kwargs.get('simplify', True):
             from .exprtools import factor_terms
             from sympy.simplify.simplify import signsimp
-
             expr = factor_terms(signsimp(expr))
         return expr
 
     @property
     def canonical(cls):
-        return cls.func(cls.expr, *Derivative._sort_variable_count(cls.variable_count))
+        return cls.func(cls.expr,
+            *Derivative._sort_variable_count(cls.variable_count))
 
     @classmethod
     def _sort_variable_count(cls, vc):
@@ -1661,7 +1575,6 @@ class Derivative(Expr):
         E = []
         v = lambda i: vc[i][0]
         D = Dummy()
-
         def _block(d, v, wrt=False):
             # return True if v should not come before d else False
             if d == v:
@@ -1673,7 +1586,8 @@ class Derivative(Expr):
                 # v; the wrt flag will return True for an exact match
                 # and will cause an AppliedUndef to block if v is in
                 # the arguments
-                if any(_block(k, v, wrt=True) for k in d._wrt_variables):
+                if any(_block(k, v, wrt=True)
+                        for k in d._wrt_variables):
                     return True
                 return False
             if not wrt and isinstance(d, AppliedUndef):
@@ -1683,11 +1597,10 @@ class Derivative(Expr):
             if isinstance(v, AppliedUndef):
                 return _block(d.xreplace({v: D}), D)
             return d.free_symbols & v.free_symbols
-
         for i in range(len(vc)):
             for j in range(i):
                 if _block(v(j), v(i)):
-                    E.append((j, i))
+                    E.append((j,i))
         # this is the default ordering to use in case of ties
         O = dict(zip(ordered(uniq([i for i, c in vc])), range(len(vc))))
         ix = topological_sort((V, E), key=lambda i: O[v(i)])
@@ -1709,9 +1622,7 @@ class Derivative(Expr):
         if v not in self._wrt_variables:
             dedv = self.expr.diff(v)
             if isinstance(dedv, Derivative):
-                return dedv.func(
-                    dedv.expr, *(self.variable_count + dedv.variable_count)
-                )
+                return dedv.func(dedv.expr, *(self.variable_count + dedv.variable_count))
             # dedv (d(self.expr)/dv) could have simplified things such that the
             # derivative wrt things in self.variables can now be done. Thus,
             # we set evaluate=True to see if there are any other derivatives
@@ -1727,15 +1638,15 @@ class Derivative(Expr):
 
     def doit(self, **hints):
         expr = self.expr
-        if hints.get("deep", True):
+        if hints.get('deep', True):
             expr = expr.doit(**hints)
-        hints["evaluate"] = True
+        hints['evaluate'] = True
         rv = self.func(expr, *self.variable_count, **hints)
-        if rv != self and rv.has(Derivative):
-            rv = rv.doit(**hints)
+        if rv!= self and rv.has(Derivative):
+            rv =  rv.doit(**hints)
         return rv
 
-    @_sympifyit("z0", NotImplementedError)
+    @_sympifyit('z0', NotImplementedError)
     def doit_numerically(self, z0):
         """
         Evaluate the derivative at z numerically.
@@ -1744,7 +1655,7 @@ class Derivative(Expr):
         into the normal evalf. For now, we need a special method.
         """
         if len(self.free_symbols) != 1 or len(self.variables) != 1:
-            raise NotImplementedError("partials and higher order derivatives")
+            raise NotImplementedError('partials and higher order derivatives')
         z = list(self.free_symbols)[0]
 
         # XXX: This should not depend on the precision that is set in mp.
@@ -1777,15 +1688,11 @@ class Derivative(Expr):
         rv = []
         for v, count in self.variable_count:
             if not count.is_Integer:
-                raise TypeError(
-                    filldedent(
-                        """
+                raise TypeError(filldedent('''
                 Cannot give expansion for symbolic count. If you just
                 want a list of all variables of differentiation, use
-                _wrt_variables."""
-                    )
-                )
-            rv.extend([v] * count)
+                _wrt_variables.'''))
+            rv.extend([v]*count)
         return tuple(rv)
 
     @property
@@ -1810,26 +1717,24 @@ class Derivative(Expr):
 
     def _eval_subs(self, old, new):
         from sympy.matrices.expressions.matexpr import MatrixExpr
-
         # The substitution (old, new) cannot be done inside
         # Derivative(expr, vars) for a variety of reasons
         # as handled below.
         if old in self._wrt_variables:
             # first handle the counts
-            expr = self.func(
-                self.expr, *[(v, c.subs(old, new)) for v, c in self.variable_count]
-            )
+            expr = self.func(self.expr, *[(v, c.subs(old, new))
+                for v, c in self.variable_count])
             if expr != self:
                 return expr._eval_subs(old, new)
             # quick exit case
-            if not getattr(new, "_diff_wrt", False):
+            if not getattr(new, '_diff_wrt', False):
                 # case (0): new is not a valid variable of
                 # differentiation
                 if isinstance(old, Symbol):
                     # don't introduce a new symbol if the old will do
                     return Subs(self, old, new)
                 else:
-                    xi = Dummy("xi")
+                    xi = Dummy('xi')
                     return Subs(self.xreplace({old: xi}), xi, new)
 
         # If both are Derivatives with the same expr, check if old is
@@ -1845,9 +1750,7 @@ class Derivative(Expr):
             old_vars = Counter(dict(reversed(old.variable_count)))
             self_vars = Counter(dict(reversed(self.variable_count)))
             if _subset(old_vars, self_vars):
-                return _derivative_dispatch(
-                    new, *(self_vars - old_vars).items()
-                ).canonical
+                return _derivative_dispatch(new, *(self_vars - old_vars).items()).canonical
 
         args = list(self.args)
         newargs = [x._subs(old, new) for x in args]
@@ -1864,9 +1767,9 @@ class Derivative(Expr):
             # for Derivative(f(x, g(y)), y), x cannot be replaced with
             # anything that has y in it; for f(g(x), g(y)).diff(g(y))
             # g(x) cannot be replaced with anything that has g(y)
-            syms = {vi: Dummy() for vi in self._wrt_variables if not vi.is_Symbol}
+            syms = {vi: Dummy() for vi in self._wrt_variables
+                if not vi.is_Symbol}
             wrt = {syms.get(vi, vi) for vi in self._wrt_variables}
-
             expr = args[0]
 
             if isinstance(expr, MatrixExpr):
@@ -1900,7 +1803,7 @@ class Derivative(Expr):
                 if not vi._diff_wrt:
                     # case (3) invalid differentiation expression so
                     # create a replacement dummy
-                    xi = Dummy("xi_%i" % i)
+                    xi = Dummy('xi_%i' % i)
                     # replace the old valid variable with the dummy
                     # in the expression
                     newe = newe.xreplace({oldv[i]: xi})
@@ -1930,7 +1833,7 @@ class Derivative(Expr):
         dx = self.variables
         rv = [self.func(a, *dx) for a in Add.make_args(arg.removeO())]
         if o:
-            rv.append(o / x)
+            rv.append(o/x)
         return Add(*rv)
 
     def _eval_as_leading_term(self, x, logx, cdir):
@@ -1943,7 +1846,7 @@ class Derivative(Expr):
         return d
 
     def as_finite_difference(self, points=1, x0=None, wrt=None):
-        """Expresses a Derivative instance as a finite difference.
+        """ Expresses a Derivative instance as a finite difference.
 
         Parameters
         ==========
@@ -2029,7 +1932,6 @@ class Derivative(Expr):
 
         """
         from sympy.calculus.finite_diff import _as_finite_diff
-
         return _as_finite_diff(self, points, x0, wrt)
 
     @classmethod
@@ -2049,18 +1951,9 @@ def _derivative_dispatch(expr, *variables, **kwargs):
     from sympy.matrices.matrixbase import MatrixBase
     from sympy.matrices.expressions.matexpr import MatrixExpr
     from sympy.tensor.array import NDimArray
-
     array_types = (MatrixBase, MatrixExpr, NDimArray, list, tuple, Tuple)
-    if isinstance(expr, array_types) or any(
-        (
-            isinstance(i[0], array_types)
-            if isinstance(i, (tuple, list, Tuple))
-            else isinstance(i, array_types)
-        )
-        for i in variables
-    ):
+    if isinstance(expr, array_types) or any(isinstance(i[0], array_types) if isinstance(i, (tuple, list, Tuple)) else isinstance(i, array_types) for i in variables):
         from sympy.tensor.array.array_derivatives import ArrayDerivative
-
         return ArrayDerivative(expr, *variables, **kwargs)
     return Derivative(expr, *variables, **kwargs)
 
@@ -2103,7 +1996,6 @@ class Lambda(Expr):
     x + y*z
 
     """
-
     is_Function = True
 
     def __new__(cls, signature, expr) -> Lambda:
@@ -2118,7 +2010,7 @@ class Lambda(Expr):
             )
             signature = tuple(signature)
         _sig = signature if iterable(signature) else (signature,)
-        sig: Tuple = sympify(_sig)  # type: ignore
+        sig: Tuple = sympify(_sig) # type: ignore
         cls._check_signature(sig)
 
         if len(sig) == 1 and sig[0] == expr:
@@ -2139,10 +2031,8 @@ class Lambda(Expr):
                 elif isinstance(a, Tuple):
                     rcheck(a)
                 else:
-                    raise BadSignatureError(
-                        "Lambda signature should be only tuples"
-                        " and symbols, not %s" % a
-                    )
+                    raise BadSignatureError("Lambda signature should be only tuples"
+                        " and symbols, not %s" % a)
 
         if not isinstance(sig, Tuple):
             raise BadSignatureError("Lambda signature should be a tuple not %s" % sig)
@@ -2162,20 +2052,17 @@ class Lambda(Expr):
     @property
     def variables(self):
         """The variables used in the internal representation of the function"""
-
         def _variables(args):
             if isinstance(args, Tuple):
                 for arg in args:
                     yield from _variables(arg)
             else:
                 yield args
-
         return tuple(_variables(self.signature))
 
     @property
     def nargs(self):
         from sympy.sets.sets import FiniteSet
-
         return FiniteSet(len(self.signature))
 
     bound_symbols = variables
@@ -2193,19 +2080,13 @@ class Lambda(Expr):
             # The ideal solution would be just to attach metadata to
             # the exception and change NumPy to take advantage of this.
             ## XXX does this apply to Lambda? If not, remove this comment.
-            temp = (
-                "%(name)s takes exactly %(args)s "
-                "argument%(plural)s (%(given)s given)"
-            )
-            raise BadArgumentsError(
-                temp
-                % {
-                    "name": self,
-                    "args": list(self.nargs)[0],
-                    "plural": "s" * (list(self.nargs)[0] != 1),
-                    "given": n,
-                }
-            )
+            temp = ('%(name)s takes exactly %(args)s '
+                   'argument%(plural)s (%(given)s given)')
+            raise BadArgumentsError(temp % {
+                'name': self,
+                'args': list(self.nargs)[0],
+                'plural': 's'*(list(self.nargs)[0] != 1),
+                'given': n})
 
         d = self._match_signature(self.signature, args)
 
@@ -2230,7 +2111,7 @@ class Lambda(Expr):
 
     @property
     def is_identity(self):
-        """Return ``True`` if this ``Lambda`` is an identity function."""
+        """Return ``True`` if this ``Lambda`` is an identity function. """
         return self.signature == self.expr
 
     def _eval_evalf(self, prec):
@@ -2322,7 +2203,6 @@ class Subs(Expr):
     >>> s, ss
     (Subs(x, x, 0), Subs(y, y, 0))
     """
-
     def __new__(cls, expr, variables, point, **assumptions):
         if not is_sequence(variables, Tuple):
             variables = [variables]
@@ -2330,22 +2210,16 @@ class Subs(Expr):
 
         if has_dups(variables):
             repeated = [str(v) for v, i in Counter(variables).items() if i > 1]
-            __ = ", ".join(repeated)
-            raise ValueError(
-                filldedent(
-                    """
+            __ = ', '.join(repeated)
+            raise ValueError(filldedent('''
                 The following expressions appear more than once: %s
-                """
-                    % __
-                )
-            )
+                ''' % __))
 
         point = Tuple(*(point if is_sequence(point, Tuple) else [point]))
 
         if len(point) != len(variables):
-            raise ValueError(
-                "Number of point values must be the same as " "the number of variables."
-            )
+            raise ValueError('Number of point values must be the same as '
+                             'the number of variables.')
 
         if not point:
             return sympify(expr)
@@ -2363,30 +2237,26 @@ class Subs(Expr):
         pre = "_"
         pts = sorted(set(point), key=default_sort_key)
         from sympy.printing.str import StrPrinter
-
         class CustomStrPrinter(StrPrinter):
             def _print_Dummy(self, expr):
                 return str(expr) + str(expr.dummy_index)
-
         def mystr(expr, **settings):
             p = CustomStrPrinter(settings)
             return p.doprint(expr)
-
         while 1:
             s_pts = {p: Symbol(pre + mystr(p)) for p in pts}
-            reps = [(v, s_pts[p]) for v, p in zip(variables, point)]
+            reps = [(v, s_pts[p])
+                for v, p in zip(variables, point)]
             # if any underscore-prepended symbol is already a free symbol
             # and is a variable with a different point value, then there
             # is a clash, e.g. _0 clashes in Subs(_0 + _1, (_0, _1), (1, 0))
             # because the new symbol that would be created is _1 but _1
             # is already mapped to 0 so __0 and __1 are used for the new
             # symbols
-            if any(
-                r in expr.free_symbols
-                and r in variables
-                and Symbol(pre + mystr(point[variables.index(r)])) != r
-                for _, r in reps
-            ):
+            if any(r in expr.free_symbols and
+                   r in variables and
+                   Symbol(pre + mystr(point[variables.index(r)])) != r
+                   for _, r in reps):
                 pre += "_"
                 continue
             break
@@ -2404,8 +2274,8 @@ class Subs(Expr):
         # remove self mappings
         for i, (vi, pi) in enumerate(zip(v, p)):
             if vi == pi:
-                v = v[:i] + v[i + 1 :]
-                p = p[:i] + p[i + 1 :]
+                v = v[:i] + v[i + 1:]
+                p = p[:i] + p[i + 1:]
         if not v:
             return self.expr
 
@@ -2454,7 +2324,7 @@ class Subs(Expr):
         else:
             rv = e.doit(**hints).subs(list(zip(v, p)))
 
-        if hints.get("deep", True) and rv != self:
+        if hints.get('deep', True) and rv != self:
             rv = rv.doit(**hints)
         return rv
 
@@ -2482,25 +2352,21 @@ class Subs(Expr):
 
     @property
     def free_symbols(self):
-        return self.expr.free_symbols - set(self.variables) | set(
-            self.point.free_symbols
-        )
+        return (self.expr.free_symbols - set(self.variables) |
+            set(self.point.free_symbols))
 
     @property
     def expr_free_symbols(self):
-        sympy_deprecation_warning(
-            """
+        sympy_deprecation_warning("""
         The expr_free_symbols property is deprecated. Use free_symbols to get
         the free symbols of an expression.
         """,
             deprecated_since_version="1.9",
-            active_deprecations_target="deprecated-expr-free-symbols",
-        )
+            active_deprecations_target="deprecated-expr-free-symbols")
         # Don't show the warning twice from the recursive call
         with ignore_warnings(SymPyDeprecationWarning):
-            return self.expr.expr_free_symbols - set(self.variables) | set(
-                self.point.expr_free_symbols
-            )
+            return (self.expr.expr_free_symbols - set(self.variables) |
+                    set(self.point.expr_free_symbols))
 
     def __eq__(self, other):
         if not isinstance(other, Subs):
@@ -2508,21 +2374,15 @@ class Subs(Expr):
         return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):
-        return not (self == other)
+        return not(self == other)
 
     def __hash__(self):
         return super().__hash__()
 
     def _hashable_content(self):
-        return (self._expr.xreplace(self.canonical_variables),) + tuple(
-            ordered(
-                [
-                    (v, p)
-                    for v, p in zip(self.variables, self.point)
-                    if not self.expr.has(v)
-                ]
-            )
-        )
+        return (self._expr.xreplace(self.canonical_variables),
+            ) + tuple(ordered([(v, p) for v, p in
+            zip(self.variables, self.point) if not self.expr.has(v)]))
 
     def _eval_subs(self, old, new):
         # Subs doit will do the variables in order; the semantics
@@ -2531,7 +2391,8 @@ class Subs(Expr):
         #    foo.doit().subs(reps) == foo.subs(reps).doit()
         pt = list(self.point)
         if old in self.variables:
-            if _atomic(new) == {new} and not any(i.has(new) for i in self.args):
+            if _atomic(new) == {new} and not any(
+                    i.has(new) for i in self.args):
                 # the substitution is neutral
                 return self.xreplace({old: new})
             # any occurrence of old before this point will get
@@ -2551,9 +2412,8 @@ class Subs(Expr):
         # Apply the chain rule of the derivative on the substitution variables:
         f = self.expr
         vp = V, P = self.variables, self.point
-        val = Add.fromiter(
-            p.diff(s) * Subs(f.diff(v), *vp).doit() for v, p in zip(V, P)
-        )
+        val = Add.fromiter(p.diff(s)*Subs(f.diff(v), *vp).doit()
+            for v, p in zip(V, P))
 
         # these are all the free symbols in the expr
         efree = f.free_symbols
@@ -2667,24 +2527,14 @@ def diff(f, *symbols, **kwargs):
     idiff: computes the derivative implicitly
 
     """
-    if hasattr(f, "diff"):
+    if hasattr(f, 'diff'):
         return f.diff(*symbols, **kwargs)
-    kwargs.setdefault("evaluate", True)
+    kwargs.setdefault('evaluate', True)
     return _derivative_dispatch(f, *symbols, **kwargs)
 
 
-def expand(
-    e,
-    deep=True,
-    modulus=None,
-    power_base=True,
-    power_exp=True,
-    mul=True,
-    log=True,
-    multinomial=True,
-    basic=True,
-    **hints,
-):
+def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
+        mul=True, log=True, multinomial=True, basic=True, **hints):
     r"""
     Expand an expression using methods given as hints.
 
@@ -3006,17 +2856,15 @@ def expand(
 
     """
     # don't modify this; modify the Expr.expand method
-    hints["power_base"] = power_base
-    hints["power_exp"] = power_exp
-    hints["mul"] = mul
-    hints["log"] = log
-    hints["multinomial"] = multinomial
-    hints["basic"] = basic
+    hints['power_base'] = power_base
+    hints['power_exp'] = power_exp
+    hints['mul'] = mul
+    hints['log'] = log
+    hints['multinomial'] = multinomial
+    hints['basic'] = basic
     return sympify(e).expand(deep=deep, modulus=modulus, **hints)
 
-
 # This is a special application of two hints
-
 
 def _mexpand(expr, recursive=False):
     # expand multinomials and then expand products; this may not always
@@ -3049,15 +2897,8 @@ def expand_mul(expr, deep=True):
     x*exp(x + y)*log(x*y**2) + y*exp(x + y)*log(x*y**2)
 
     """
-    return sympify(expr).expand(
-        deep=deep,
-        mul=True,
-        power_exp=False,
-        power_base=False,
-        basic=False,
-        multinomial=False,
-        log=False,
-    )
+    return sympify(expr).expand(deep=deep, mul=True, power_exp=False,
+    power_base=False, basic=False, multinomial=False, log=False)
 
 
 def expand_multinomial(expr, deep=True):
@@ -3074,15 +2915,8 @@ def expand_multinomial(expr, deep=True):
     x**2 + 2*x*exp(x + 1) + exp(2*x + 2)
 
     """
-    return sympify(expr).expand(
-        deep=deep,
-        mul=False,
-        power_exp=False,
-        power_base=False,
-        basic=False,
-        multinomial=True,
-        log=False,
-    )
+    return sympify(expr).expand(deep=deep, mul=False, power_exp=False,
+    power_base=False, basic=False, multinomial=True, log=False)
 
 
 def expand_log(expr, deep=True, force=False, factor=False):
@@ -3101,9 +2935,7 @@ def expand_log(expr, deep=True, force=False, factor=False):
     """
     from sympy.functions.elementary.exponential import log
     from sympy.simplify.radsimp import fraction
-
     if factor is False:
-
         def _handleMul(x):
             # look for the simple case of expanded log(b**a)/log(b) -> a in args
             n, d = fraction(x)
@@ -3113,39 +2945,23 @@ def expand_log(expr, deep=True, force=False, factor=False):
                 n = n[0]
                 d = d[0]
                 from sympy import multiplicity
-
                 m = multiplicity(d.args[0], n.args[0])
                 if m:
-                    r = m + log(n.args[0] // d.args[0] ** m) / d
-                    x = x.subs(n, d * r)
+                    r = m + log(n.args[0]//d.args[0]**m)/d
+                    x = x.subs(n, d*r)
             x1 = expand_mul(expand_log(x, deep=deep, force=force, factor=True))
             if x1.count(log) <= x.count(log):
                 return x1
             return x
 
         expr = expr.replace(
-            lambda x: x.is_Mul
-            and all(
-                any(
-                    isinstance(i, log) and i.args[0].is_Rational
-                    for i in Mul.make_args(j)
-                )
-                for j in x.as_numer_denom()
-            ),
-            _handleMul,
-        )
+        lambda x: x.is_Mul and all(any(isinstance(i, log) and i.args[0].is_Rational
+        for i in Mul.make_args(j)) for j in x.as_numer_denom()),
+        _handleMul)
 
-    return sympify(expr).expand(
-        deep=deep,
-        log=True,
-        mul=False,
-        power_exp=False,
-        power_base=False,
-        multinomial=False,
-        basic=False,
-        force=force,
-        factor=factor,
-    )
+    return sympify(expr).expand(deep=deep, log=True, mul=False,
+        power_exp=False, power_base=False, multinomial=False,
+        basic=False, force=force, factor=factor)
 
 
 def expand_func(expr, deep=True):
@@ -3162,16 +2978,8 @@ def expand_func(expr, deep=True):
     x*(x + 1)*gamma(x)
 
     """
-    return sympify(expr).expand(
-        deep=deep,
-        func=True,
-        basic=False,
-        log=False,
-        mul=False,
-        power_exp=False,
-        power_base=False,
-        multinomial=False,
-    )
+    return sympify(expr).expand(deep=deep, func=True, basic=False,
+    log=False, mul=False, power_exp=False, power_base=False, multinomial=False)
 
 
 def expand_trig(expr, deep=True):
@@ -3188,16 +2996,8 @@ def expand_trig(expr, deep=True):
     (x + y)*(sin(x)*cos(y) + sin(y)*cos(x))
 
     """
-    return sympify(expr).expand(
-        deep=deep,
-        trig=True,
-        basic=False,
-        log=False,
-        mul=False,
-        power_exp=False,
-        power_base=False,
-        multinomial=False,
-    )
+    return sympify(expr).expand(deep=deep, trig=True, basic=False,
+    log=False, mul=False, power_exp=False, power_base=False, multinomial=False)
 
 
 def expand_complex(expr, deep=True):
@@ -3220,16 +3020,8 @@ def expand_complex(expr, deep=True):
 
     sympy.core.expr.Expr.as_real_imag
     """
-    return sympify(expr).expand(
-        deep=deep,
-        complex=True,
-        basic=False,
-        log=False,
-        mul=False,
-        power_exp=False,
-        power_base=False,
-        multinomial=False,
-    )
+    return sympify(expr).expand(deep=deep, complex=True, basic=False,
+    log=False, mul=False, power_exp=False, power_base=False, multinomial=False)
 
 
 def expand_power_base(expr, deep=True, force=False):
@@ -3312,16 +3104,9 @@ def expand_power_base(expr, deep=True, force=False):
     expand
 
     """
-    return sympify(expr).expand(
-        deep=deep,
-        log=False,
-        mul=False,
-        power_exp=False,
-        power_base=True,
-        multinomial=False,
-        basic=False,
-        force=force,
-    )
+    return sympify(expr).expand(deep=deep, log=False, mul=False,
+        power_exp=False, power_base=True, multinomial=False,
+        basic=False, force=force)
 
 
 def expand_power_exp(expr, deep=True):
@@ -3347,16 +3132,8 @@ def expand_power_exp(expr, deep=True):
     >>> expand_power_exp(Symbol('x', zero=False)**(y + 2))
     x**2*x**y
     """
-    return sympify(expr).expand(
-        deep=deep,
-        complex=False,
-        basic=False,
-        log=False,
-        mul=False,
-        power_exp=True,
-        power_base=False,
-        multinomial=False,
-    )
+    return sympify(expr).expand(deep=deep, complex=False, basic=False,
+    log=False, mul=False, power_exp=True, power_base=False, multinomial=False)
 
 
 def count_ops(expr, visual=False):
@@ -3442,11 +3219,11 @@ def count_ops(expr, visual=False):
 
         ops = []
         args = [expr]
-        NEG = Symbol("NEG")
-        DIV = Symbol("DIV")
-        SUB = Symbol("SUB")
-        ADD = Symbol("ADD")
-        EXP = Symbol("EXP")
+        NEG = Symbol('NEG')
+        DIV = Symbol('DIV')
+        SUB = Symbol('SUB')
+        ADD = Symbol('ADD')
+        EXP = Symbol('EXP')
         while args:
             a = args.pop()
 
@@ -3455,7 +3232,7 @@ def count_ops(expr, visual=False):
             # since it is the intention that all args of Basic
             # should themselves be Basic
             if a.is_Rational:
-                # -1/3 = NEG + DIV
+                #-1/3 = NEG + DIV
                 if a is not S.One:
                     if a.p < 0:
                         ops.append(NEG)
@@ -3514,10 +3291,9 @@ def count_ops(expr, visual=False):
             if a.is_Mul or isinstance(a, LatticeOp):
                 o = Symbol(a.func.__name__.upper())
                 # count the args
-                ops.append(o * (len(a.args) - 1))
+                ops.append(o*(len(a.args) - 1))
             elif a.args and (
-                a.is_Pow or a.is_Function or isinstance(a, (Derivative, Integral, Sum))
-            ):
+                    a.is_Pow or a.is_Function or isinstance(a, (Derivative, Integral, Sum))):
                 # if it's not in the list above we don't
                 # consider a.func something to count, e.g.
                 # Tuple, MatrixSymbol, etc...
@@ -3531,10 +3307,8 @@ def count_ops(expr, visual=False):
                 args.extend(a.args)
 
     elif isinstance(expr, Dict):
-        ops = [
-            count_ops(k, visual=visual) + count_ops(v, visual=visual)
-            for k, v in expr.items()
-        ]
+        ops = [count_ops(k, visual=visual) +
+               count_ops(v, visual=visual) for k, v in expr.items()]
     elif iterable(expr):
         ops = [count_ops(i, visual=visual) for i in expr]
     elif isinstance(expr, (Relational, BooleanFunction)):
@@ -3557,7 +3331,7 @@ def count_ops(expr, visual=False):
                 if a.args:
                     o = Symbol(type(a).__name__.upper())
                     if a.is_Boolean:
-                        ops.append(o * (len(a.args) - 1))
+                        ops.append(o*(len(a.args)-1))
                     else:
                         ops.append(o)
                     args.extend(a.args)
@@ -3610,7 +3384,8 @@ def nfloat(expr, n=15, exponent=False, dkeys=False):
     if iterable(expr, exclude=str):
         if isinstance(expr, (dict, Dict)):
             if dkeys:
-                args = [tuple((nfloat(i, **kw) for i in a)) for a in expr.items()]
+                args = [tuple((nfloat(i, **kw) for i in a))
+                    for a in expr.items()]
             else:
                 args = [(k, nfloat(v, **kw)) for k, v in expr.items()]
             if isinstance(expr, dict):
@@ -3639,15 +3414,14 @@ def nfloat(expr, n=15, exponent=False, dkeys=False):
         args_nfloat = (nfloat(arg, **kw) for arg in rv.args)
         return rv.func(*args_nfloat)
 
+
     # watch out for RootOf instances that don't like to have
     # their exponents replaced with Dummies and also sometimes have
     # problems with evaluating at low precision (issue 6393)
     from sympy.polys.rootoftools import RootOf
-
     rv = rv.xreplace({ro: ro.n(n) for ro in rv.atoms(RootOf)})
 
     from .power import Pow
-
     if not exponent:
         reps = [(p, Pow(p.base, Dummy())) for p in rv.atoms(Pow)]
         rv = rv.xreplace(dict(reps))
@@ -3657,19 +3431,13 @@ def nfloat(expr, n=15, exponent=False, dkeys=False):
     else:
         # Pow._eval_evalf special cases Integer exponents so if
         # exponent is suppose to be handled we have to do so here
-        rv = rv.xreplace(
-            Transform(
-                lambda x: Pow(x.base, Float(x.exp, n)),
-                lambda x: x.is_Pow and x.exp.is_Integer,
-            )
-        )
+        rv = rv.xreplace(Transform(
+            lambda x: Pow(x.base, Float(x.exp, n)),
+            lambda x: x.is_Pow and x.exp.is_Integer))
 
-    return rv.xreplace(
-        Transform(
-            lambda x: x.func(*nfloat(x.args, n, exponent)),
-            lambda x: isinstance(x, Function) and not isinstance(x, AppliedUndef),
-        )
-    )
+    return rv.xreplace(Transform(
+        lambda x: x.func(*nfloat(x.args, n, exponent)),
+        lambda x: isinstance(x, Function) and not isinstance(x, AppliedUndef)))
 
 
 from .symbol import Dummy, Symbol

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1716,7 +1716,6 @@ class Derivative(Expr):
         return self.args[0].kind
 
     def _eval_subs(self, old, new):
-        from sympy.matrices.expressions.matexpr import MatrixExpr
         # The substitution (old, new) cannot be done inside
         # Derivative(expr, vars) for a variety of reasons
         # as handled below.

--- a/sympy/matrices/expressions/tests/test_matpow_base_is_matrix.py
+++ b/sympy/matrices/expressions/tests/test_matpow_base_is_matrix.py
@@ -1,0 +1,8 @@
+from sympy import MatrixSymbol, symbols, Derivative
+
+def test_derivative_subs_matrix_power():
+    j = symbols('j')
+    A = MatrixSymbol('A', 2, 2)
+
+    d = Derivative(A**j, A)
+    d.subs(j, 3)

--- a/sympy/matrices/expressions/tests/test_matpow_base_is_matrix.py
+++ b/sympy/matrices/expressions/tests/test_matpow_base_is_matrix.py
@@ -1,8 +1,8 @@
 from sympy import MatrixSymbol, symbols, Derivative
 
-def test_derivative_subs_matrix_power():
-    j = symbols('j')
-    A = MatrixSymbol('A', 2, 2)
 
+def test_derivative_subs_matrix_power():
+    j = symbols("j")
+    A = MatrixSymbol("A", 2, 2)
     d = Derivative(A**j, A)
     d.subs(j, 3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28641 

#### Brief description of what is fixed or changed
Fix a bug where calling `subs` on a `Derivative` of a matrix expression could raise a `TypeError`. This occurred because `Derivative._eval_subs` used `xreplace`, which is not safe for `MatrixExpr` and could lead to invalid `MatPow` reconstruction.

The fix adds a matrix-safe substitution path that is triggered when the differentiated expression is a MatrixExpr. In this case, `subs` is used instead of `xreplace`, while the existing behavior for scalar expressions is preserved.

#### Other comments
A regression test (test_matpow_base_is_matrix.py) has been added to ensure that `Derivative(A**j, A).subs(j, 3)` works as expected.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed an error when substituting into a `Derivative` of a matrix expression involving matrix powers.
<!-- END RELEASE NOTES -->
