### PR TITLE
Fix broken GitHub anchor in Autolev parser documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1829,3 +1829,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Tanmay Rath <rathjyotshna@gmail.com> DeadlyPancakes45 <rathjyotshna@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1558,6 +1558,8 @@ Szymon Mieszczak <szymon.mieszczak@gmail.com>
 Takafumi Arakaki <aka.tkf@gmail.com>
 Takumasa Nakamura <n.takumasa@gmail.com>
 Tanay Agrawal <tanay_agrawal@hotmail.com>
+Tanmay Rath <rathjyotshna@gmail.com> DeadlyPancakes45 <rathjyotshna@gmail.com>
+Tanmay Rath <rathjyotshna@gmail.com> Tanmay Rath <144689448+Tanthetaa45@users.noreply.github.com>
 Tanu Hari Dixit <tokencolour@gmail.com>
 Tarang Patel <tarangrockr@gmail.com> <tarang@ubuntu.ubuntu-domain>
 Tarun Gaba <tarun.gaba7@gmail.com>
@@ -1829,5 +1831,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Tanmay Rath <rathjyotshna@gmail.com> DeadlyPancakes45 <rathjyotshna@gmail.com>
-Tanmay Rath <rathjyotshna@gmail.com> Tanmay Rath <144689448+Tanthetaa45@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1830,3 +1830,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
 Tanmay Rath <rathjyotshna@gmail.com> DeadlyPancakes45 <rathjyotshna@gmail.com>
+Tanmay Rath <rathjyotshna@gmail.com> Tanmay Rath <144689448+Tanthetaa45@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1377,3 +1377,4 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+Tanmay Rath<rathjyotshna@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1377,4 +1377,4 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
-Tanmay Rath<rathjyotshna@gmail.com>
+Tanmay Rath <rathjyotshna@gmail.com>

--- a/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
+++ b/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
@@ -342,7 +342,7 @@ Gotchas
 
 - Need to change ``me.dynamicsymbols._t`` to ``me.dynamicsymbols('t')`` for
   all occurrences of it in the Kane's equations. For example have a look at
-  line 10 of this `spring damper example <https://github.com/sympy/sympy/blob/master/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py#L10>`_.
+  line 10 of this `spring damper example <https://github.com/sympy/sympy/blob/master/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py>`_.
   This equation is used in forming the Kane's equations so we need to
   change ``me.dynamicsymbols._t`` to ``me.dynamicsymbols('t')`` in this case.
 


### PR DESCRIPTION
The documentation referenced a GitHub line anchor (`#L10`) in the spring
damper example which no longer exists, causing Sphinx linkcheck to report
an error.

The link now points to the file instead of a specific line number to avoid
future breakage when the file contents change.

#### References to other Issues or PRs
Fixes #24140

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->