### PR TITLE
Doc: Replace insecure MiniSat link with GitHub URL

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1831,3 +1831,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1831,4 +1831,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sai Kiran P <parnandi.saikiran@gmail.com> Sai Kiran <parnandi.saikiran@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1831,5 +1831,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sai Kiran P <parnandi.saikiran@gmail.com> Sai Kiran <parnandi.saikiran@gmail.com>
-Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
+Sai Kiran P <parnandi.saikiran@gmail.com>
+saikiranp-24 <parnandi.saikiran@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1377,3 +1377,4 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+Sai Kiran P <parnandi.saikiran@gmail.com>

--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -153,7 +153,7 @@ solvers if they are installed. Note that `satisfiable()` is also used by
 
 - **pysat**: [Pysat](https://pysathq.github.io/) is a library which wraps many
   SAT solvers. It can also be used as a backend to `satisfiable()`. Presently,
-  only [Minisat](http://minisat.se/MiniSat.html) is implemented, using
+  only [Minisat](https://github.com/niklasso/minisat) is implemented, using
   `satisfiable(algorithm=minisat22')`.
 
 ### Plotting


### PR DESCRIPTION

#### References to other Issues or PRs
Fixes #24140

#### Brief description of what is fixed or changed
Replaced the insecure/broken HTTP link for `MiniSat` in `doc/src/contributing/dependencies.md`.
The original website (`minisat.se`) does not support HTTPS. I have replaced it with the official GitHub repository link to ensure stability and security.

#### Other comments
First contribution!

<!-- BEGIN RELEASE NOTES -->

#### Release Notes
* documentation
  * Replaced insecure http link for MiniSat with official GitHub repository.

<!-- END RELEASE NOTES -->