### PR TITLE
Doc: Replace insecure MiniSat link and register author

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1396,6 +1396,7 @@ Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
 Sai Udayagiri <saibabu.udayagiri@gmail.com> <144413200+saiudayagiri@users.noreply.github.com>
 Sai Udayagiri <saibabu.udayagiri@gmail.com> Sai Udayagiri <saibabu.udayagiri@email.com>

--- a/doc/src/contributing/dependencies.md
+++ b/doc/src/contributing/dependencies.md
@@ -153,7 +153,7 @@ solvers if they are installed. Note that `satisfiable()` is also used by
 
 - **pysat**: [Pysat](https://pysathq.github.io/) is a library which wraps many
   SAT solvers. It can also be used as a backend to `satisfiable()`. Presently,
-  only [Minisat](http://minisat.se/MiniSat.html) is implemented, using
+  only [Minisat](https://github.com/niklasso/minisat) is implemented, using
   `satisfiable(algorithm=minisat22')`.
 
 ### Plotting


### PR DESCRIPTION
Doc: Replace insecure MiniSat link and register author

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #24140

#### Brief description of what is fixed or changed
Replaced the insecure/broken HTTP link for `MiniSat` in `doc/src/contributing/dependencies.md`.
The original website (`minisat.se`) does not support HTTPS. I have replaced it with the official GitHub repository link to ensure stability and security.

I have also added an entry to .mailmap to ensure correct author attribution in CI checks.

#### Other comments
I ran a `grep` search for other `http` instances in the directory. The remaining matches were XML namespaces (for SVGs) or intentional example URLs, so I left them untouched to ensure functionality/rendering wasn't broken.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Replaced insecure http link for MiniSat with official GitHub repository.
<!-- END RELEASE NOTES -->
