### PR TITLE
fix(matrices): handle repeated eigenvalues

### DIFF
--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -5,8 +5,6 @@ Iterables
 .. py:class:: T
 .. py:class:: collections.defaultdict
 
-.. py:class:: T
-
 .. automodule:: sympy.utilities.iterables
    :members:
 

--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -3,6 +3,8 @@ Iterables
 =========
 
 
+.. py:class:: T
+
 .. automodule:: sympy.utilities.iterables
    :members:
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3669,8 +3669,18 @@ class Expr(Basic, EvalfMixin):
         return (expr, hit)
 
     @cacheit
-    def expand(self, deep=True, modulus=None, power_base=True, power_exp=True,
-            mul=True, log=True, multinomial=True, basic=True, **hints):
+    def expand(
+        self,
+        deep=True,
+        modulus=None,
+        power_base=True,
+        power_exp=True,
+        mul=True,
+        log=True,
+        multinomial=True,
+        basic=True,
+        **hints,
+    ) -> Expr:
         """
         Expand an expression using hints.
 

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -1,5 +1,5 @@
 from sympy.core.evalf import N
-from sympy.core.numbers import (Float, I, Rational)
+from sympy.core.numbers import (Float, I, Rational, pi)
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -13,6 +13,7 @@ from sympy.simplify.simplify import simplify
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.testing.pytest import slow
 from sympy.testing.matrices import allclose
+from sympy import expand
 
 
 def test_eigen():
@@ -725,3 +726,49 @@ def test_issue_25282():
         mat.append(rotate(ds, i) + rotate(dd, i))
 
     assert sum(Matrix(mat).eigenvals().values()) == 24
+
+
+def test_issue_28793():
+    # https://github.com/sympy/sympy/issues/28793
+
+    A = Matrix([
+        [3*sqrt(2)*I*pi*(1 + sqrt(2))/4, 0, -sqrt(2)*I*pi/4, 0, 0, 0, 0, 0],
+        [0, sqrt(2)*I*pi*(1 + sqrt(2))/2, 0, -I*pi/2, 0, 0, 0, 0],
+        [-sqrt(2)*I*pi/4, 0, 3*sqrt(2)*I*pi*(1 + sqrt(2))/4, 0, 0, 0, 0, 0],
+        [0, -I*pi/2, 0, sqrt(2)*I*pi*(1 + sqrt(2))/2, 0, 0, -I*pi/2, 0],
+        [0, 0, 0, 0, sqrt(2)*I*pi*(1 + sqrt(2))/2, 0, 0, 0],
+        [0, 0, 0, 0, 0, sqrt(2)*I*pi*(1 + sqrt(2))/4, 0, -sqrt(2)*I*pi/4],
+        [0, 0, 0, -I*pi/2, 0, 0, sqrt(2)*I*pi*(1 + sqrt(2))/2, 0],
+        [0, 0, 0, 0, 0, -sqrt(2)*I*pi/4, 0, sqrt(2)*I*pi*(1 + sqrt(2))/4]
+    ])
+
+    z = Symbol('z')
+    expected = (
+        z**8
+        + z**7*(-8*I*pi - 4*sqrt(2)*I*pi)
+        + z**6*(-81*pi**2/2 - 55*sqrt(2)*pi**2/2)
+        + z**5*(181*sqrt(2)*I*pi**3/2 + 128*I*pi**3)
+        + z**4*(3991*pi**4/16 + 1413*sqrt(2)*pi**4/8)
+        + z**3*(-1699*sqrt(2)*I*pi**5/8 - 1201*I*pi**5/4)
+        + z**2*(-6927*pi**6/32 - 2449*sqrt(2)*pi**6/16)
+        + z*(1919*sqrt(2)*I*pi**7/32 + 1357*I*pi**7/16)
+        + 309*sqrt(2)*pi**8/32 + 437*pi**8/32
+    )
+    assert A.charpoly(z).as_expr().collect(z, expand) == expected
+
+    vals = A.eigenvals()
+    assert sorted(vals.values()) == [1, 1, 1, 1, 1, 1, 2]
+    assert A.eigenvects() == [
+        (I*pi/2, 1, [Matrix([[0, 0, 0, 0, 0, 1, 0, 1]]).T]),
+        (I*pi, 1, [Matrix([[0, 1, 0, sqrt(2), 0, 0, 1, 0]]).T]),
+        (I*pi/2 + sqrt(2)*I*pi/2, 1, [Matrix([[0, 0, 0, 0, 0, -1, 0, 1]]).T]),
+        (I*pi + sqrt(2)*I*pi, 1, [Matrix([[0, 1, 0, -sqrt(2), 0, 0, 1, 0]]).T]),
+        (-sqrt(2)*I*pi/4 + 3*I*pi*(sqrt(2) + 2)/4, 1, [Matrix([[1, 0, 1, 0, 0, 0, 0, 0]]).T]),
+        (sqrt(2)*I*pi/4 + 3*I*pi*(sqrt(2) + 2)/4, 1, [Matrix([[-1, 0, 1, 0, 0, 0, 0, 0]]).T]),
+        (sqrt(2)*I*pi/2 + I*pi, 2, [Matrix([[0, 0, 0, 0, 1, 0, 0, 0]]).T,
+                                    Matrix([[0, -1, 0, 0, 0, 0, 1, 0]]).T])
+    ]
+
+    P, J = A.jordan_form()
+    assert P.det() == 16*sqrt(2)
+    assert expand(P*J*P.inv()) == expand(A)

--- a/sympy/matrices/utilities.py
+++ b/sympy/matrices/utilities.py
@@ -78,7 +78,7 @@ def _is_zero_after_expand_mul(x):
     return expand_mul(x) == 0
 
 
-def _simplify(expr):
+def _simplify(expr: Expr) -> Expr:
     """ Wrapper to avoid circular imports. """
     from sympy.simplify.simplify import simplify
     return simplify(expr)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1,5 +1,8 @@
 """Algorithms for computing symbolic roots of polynomials. """
 
+from __future__ import annotations
+
+from typing import overload, Any, Literal
 
 import math
 from functools import reduce
@@ -838,6 +841,37 @@ def preprocess_roots(poly):
         poly = poly_func(poly)
     return coeff, poly
 
+
+@overload
+def roots(
+    f,
+    *gens,
+    auto: bool = True,
+    cubics: bool = True,
+    trig: bool = False,
+    quartics: bool = True,
+    quintics: bool = False,
+    multiple: Literal[False] = False,
+    filter: None = None,
+    predicate: None = None,
+    strict: bool = False,
+    **flags: Any,
+) -> dict[Expr, int]: ...
+@overload
+def roots(
+    f,
+    *gens,
+    auto: bool = True,
+    cubics: bool = True,
+    trig: bool = False,
+    quartics: bool = True,
+    quintics: bool = False,
+    multiple: Literal[True],
+    filter: None = None,
+    predicate: None = None,
+    strict: bool = False,
+    **flags: Any,
+) -> list[tuple[Expr, int]]: ...
 
 @public
 def roots(f, *gens,

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3668,7 +3668,18 @@ class Poly(Basic):
         else:
             return group(reals, multiple=False)
 
-    def all_roots(f, multiple=True, radicals=True):
+    @overload
+    def all_roots(
+        f, multiple: Literal[True] = True, radicals: bool = True
+    ) -> list[Expr]: ...
+    @overload
+    def all_roots(
+        f, multiple: Literal[False], *, radicals: bool = True
+    ) -> list[tuple[Expr, int]]: ...
+
+    def all_roots(
+        f, multiple: bool = True, radicals: bool = True
+    ) -> list[Expr] | list[tuple[Expr, int]]:
         """
         Return a list of real and complex roots with multiplicities.
 

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -173,6 +173,8 @@ def _sort_factors(factors, **args):
     def order_key(factor):
         if isinstance(factor, _GF_types):
             return int(factor)
+        elif isinstance(factor, Expr):
+            return factor.sort_key()
         elif isinstance(factor, list):
             return [order_key(f) for f in factor]
         else:

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from collections import Counter, defaultdict, OrderedDict
 from itertools import (
@@ -21,7 +21,7 @@ from sympy.utilities.decorator import deprecated
 
 
 if TYPE_CHECKING:
-    from typing import TypeVar, Iterable, Callable
+    from typing import TypeVar, Iterable, Callable, Literal
     T = TypeVar('T')
 
 
@@ -197,7 +197,14 @@ def reshape(seq, how):
     return type(seq)(rv)
 
 
-def group(seq, multiple=True):
+@overload
+def group(seq: Iterable[T], multiple: Literal[True] = True) -> list[list[T]]: ...
+@overload
+def group(seq: Iterable[T], multiple: Literal[False]) -> list[tuple[T, int]]: ...
+
+def group(
+    seq: Iterable[T], multiple: bool = True
+) -> list[list[T]] | list[tuple[T, int]]:
     """
     Splits a sequence into a list of lists of equal, adjacent elements.
 


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/28793

The Matrix.eignvals() method splits a matrix into blocks and computes their eigenvalues separately. In some situations this can mean that the same eigenvalue is found in two different blocks and they need to be combined to get the multiplicity correct. This was already handled but assumed that the expressions for the eigenvalues returned by roots will always be identical and can fail if an equivalent but not identical expression is returned like `pi + sqrt(2)*pi` vs `pi*(1 + sqrt(2))`.

If the repeated eigenvalue is not detected then the expressions returned for the eigenvalues are correct in some sense but not recognising the multiplicity leads to incorrect results from eigenvects and Jordan forms.

This commit uses expand() as a simple way to check if two different root expressions are equivalent. This is not robust enough in general and so a proper fix would be to have a function (perhaps roots?) that can find the roots of a list of polynomials correctly accounting for their multiplicities.

Also adds some type annotations for functions that are called by the eigenvals routine.

<!-- BEGIN RELEASE NOTES -->
* matrices
   * A bug in eigenvals was fixed where it might sometimes compute equivalent but non-identical expressions for a repeated eigenvalue in matrices with block structure. The bug could lead to incorrect results from eigenvects and jordan_form because although the expressions returned are correct eigenvalue expressions the multiplicity was not reognised.
<!-- END RELEASE NOTES -->
