### PR TITLE
Add type annotations to ntheory/digits.py and utilities/iterables.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -984,6 +984,7 @@ Lukas Zorich <lukas.zorich@gmail.com>
 Luke Peterson <hazelnusse@gmail.com>
 Luv Agarwal <agarwal.iiit@gmail.com>
 Lyle Poley <poleylyle@gmail.com>
+M-Israr-Ul-Haq <israrulhaq590@gmail.com>
 Maciej Baranski <getrox.sc@gmail.com>
 Maciej Skórski <maciej.skorski@gmail.com>
 Madeleine Ball <mpball@gmail.com>

--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -2,6 +2,7 @@
 Iterables
 =========
 
+.. py:class:: T
 
 .. automodule:: sympy.utilities.iterables
    :members:

--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -3,6 +3,7 @@ Iterables
 =========
 
 .. py:class:: T
+.. py:class:: collections.defaultdict
 
 .. automodule:: sympy.utilities.iterables
    :members:

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -113,6 +113,8 @@ def count_digits(n: SupportsIndex, b: SupportsIndex = 10) -> defaultdict[int, in
     ========
     sympy.core.intfunc.num_digits, digits
     """
+    n = as_int(n)
+    b = as_int(b)
     rv = defaultdict(int, multiset(digits(n, b)).items())
     rv.pop(b) if b in rv else rv.pop(-b)  # b or -b is there
     return rv

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import SupportsIndex
 
@@ -5,7 +7,7 @@ from sympy.utilities.iterables import multiset, is_palindromic as _palindromic
 from sympy.utilities.misc import as_int
 
 
-def digits(n: SupportsIndex, b: int = 10, digits: int | None = None) -> list[int]:
+def digits(n: SupportsIndex, b: SupportsIndex = 10, digits: int | None = None) -> list[int]:
     """
     Return a list of the digits of ``n`` in base ``b``. The first
     element in the list is ``b`` (or ``-b`` if ``n`` is negative).
@@ -72,7 +74,7 @@ def digits(n: SupportsIndex, b: int = 10, digits: int | None = None) -> list[int
         return y
 
 
-def count_digits(n: SupportsIndex, b: int = 10) -> defaultdict[int, int]:
+def count_digits(n: SupportsIndex, b: SupportsIndex = 10) -> defaultdict[int, int]:
     """
     Return a dictionary whose keys are the digits of ``n`` in the
     given base, ``b``, with keys indicating the digits appearing in the
@@ -116,7 +118,7 @@ def count_digits(n: SupportsIndex, b: int = 10) -> defaultdict[int, int]:
     return rv
 
 
-def is_palindromic(n: SupportsIndex, b: int = 10) -> bool:
+def is_palindromic(n: SupportsIndex, b: SupportsIndex = 10) -> bool:
     """return True if ``n`` is the same when read from left to right
     or right to left in the given base, ``b``.
 

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
+from typing import SupportsIndex
 
 from sympy.utilities.iterables import multiset, is_palindromic as _palindromic
 from sympy.utilities.misc import as_int
 
 
-def digits(n, b=10, digits=None):
+def digits(n: SupportsIndex, b: int = 10, digits: int | None = None) -> list[int]:
     """
     Return a list of the digits of ``n`` in base ``b``. The first
     element in the list is ``b`` (or ``-b`` if ``n`` is negative).
@@ -71,7 +72,7 @@ def digits(n, b=10, digits=None):
         return y
 
 
-def count_digits(n, b=10):
+def count_digits(n: SupportsIndex, b: int = 10) -> defaultdict[int, int]:
     """
     Return a dictionary whose keys are the digits of ``n`` in the
     given base, ``b``, with keys indicating the digits appearing in the
@@ -115,7 +116,7 @@ def count_digits(n, b=10):
     return rv
 
 
-def is_palindromic(n, b=10):
+def is_palindromic(n: SupportsIndex, b: int = 10) -> bool:
     """return True if ``n`` is the same when read from left to right
     or right to left in the given base, ``b``.
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -21,11 +21,11 @@ from sympy.utilities.decorator import deprecated
 
 
 if TYPE_CHECKING:
-    from typing import TypeVar, Iterable, Callable
+    from typing import TypeVar, Iterable, Callable, Sequence
     T = TypeVar('T')
 
 
-def is_palindromic(s, i=0, j=None):
+def is_palindromic(s: Sequence[T], i: int = 0, j: int | None = None) -> bool:
     """
     Return True if the sequence is the same from left to right as it
     is from right to left in the whole sequence (default) or in the
@@ -293,7 +293,7 @@ def iproduct(*iterables):
             yield (ef,) + eo
 
 
-def multiset(seq):
+def multiset(seq: Sequence[T]) -> dict[T, int]:
     """Return the hashable sequence in multiset form with values being the
     multiplicity of the item in the sequence.
 


### PR DESCRIPTION
This PR adds type annotations to functions in `sympy/ntheory/digits.py` and `sympy/utilities/iterables.py`.

Issue: https://github.com/sympy/sympy/issues/28806

## Changes

**sympy/ntheory/digits.py:**
- `digits(n: SupportsIndex, b: int = 10, digits: int | None = None) -> list[int]`
- `count_digits(n: SupportsIndex, b: int = 10) -> defaultdict[int, int]`
- `is_palindromic(n: SupportsIndex, b: int = 10) -> bool`
- Added `SupportsIndex` import (these functions use `as_int()`)

**sympy/utilities/iterables.py:**
- `is_palindromic(s: Sequence[T], i: int = 0, j: int | None = None) -> bool`
- `multiset(seq: Sequence[T]) -> dict[T, int]`
- Added `Sequence` to TYPE_CHECKING imports

Ran the test suites and type checkers - everything passes with no errors.

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added type annotations to `digits`, `count_digits`, and `is_palindromic` functions

* utilities
  * Added type annotations to `is_palindromic` and `multiset` functions in iterables module
<!-- END RELEASE NOTES -->