### PR TITLE
Add type annotations to generate.py

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -2,7 +2,7 @@
 Generating and counting primes.
 
 """
-
+from __future__ import annotations
 from bisect import bisect, bisect_left
 from itertools import count
 # Using arrays for sieving instead of lists greatly reduces

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -3,6 +3,7 @@ Generating and counting primes.
 
 """
 from __future__ import annotations
+from typing import Iterator
 from bisect import bisect, bisect_left
 from itertools import count
 # Using arrays for sieving instead of lists greatly reduces
@@ -368,7 +369,7 @@ class Sieve:
 # Generate a global object for repeated use in trial division etc
 sieve = Sieve()
 
-def prime(nth):
+def prime(nth: int) -> int:
     r"""
     Return the nth prime number, where primes are indexed starting from 1:
     prime(1) = 2, prime(2) = 3, etc.
@@ -445,7 +446,7 @@ def prime(nth):
 The `sympy.ntheory.generate.primepi` has been moved to `sympy.functions.combinatorial.numbers.primepi`.""",
 deprecated_since_version="1.13",
 active_deprecations_target='deprecated-ntheory-symbolic-functions')
-def primepi(n):
+def primepi(n: int) -> int:
     r""" Represents the prime counting function pi(n) = the number
         of prime numbers less than or equal to n.
 
@@ -533,7 +534,7 @@ def primepi(n):
     return func_primepi(n)
 
 
-def _primepi(n:int) -> int:
+def _primepi(n: int) -> int:
     r""" Represents the prime counting function pi(n) = the number
     of prime numbers less than or equal to n.
 
@@ -631,7 +632,7 @@ def _primepi(n:int) -> int:
     return arr2[1]
 
 
-def nextprime(n, ith=1):
+def nextprime(n: int, ith: int = 1) -> int:
     """ Return the ith prime greater than n.
 
         Parameters
@@ -714,7 +715,7 @@ def nextprime(n, ith=1):
         n += 4
 
 
-def prevprime(n):
+def prevprime(n: int) -> int:
     """ Return the largest prime smaller than n.
 
         Notes
@@ -761,7 +762,7 @@ def prevprime(n):
         n -= 4
 
 
-def primerange(a, b=None):
+def primerange(a: int, b: int | None = None) -> Iterator[int]:
     """ Generate a list of all prime numbers in the range [2, a),
         or [a, b).
 
@@ -866,7 +867,7 @@ def primerange(a, b=None):
             return
 
 
-def randprime(a, b):
+def randprime(a: int, b: int) -> int | None:
     """ Return a random prime number in the range [a, b).
 
         Bertrand's postulate assures that
@@ -910,7 +911,7 @@ def randprime(a, b):
     return p
 
 
-def primorial(n, nth=True):
+def primorial(n: int, nth: bool = True) -> int:
     """
     Returns the product of the first n primes (default) or
     the primes less than or equal to n (when ``nth=False``).
@@ -976,7 +977,7 @@ def primorial(n, nth=True):
     return p
 
 
-def cycle_length(f, x0, nmax=None, values=False):
+def cycle_length(f, x0: int, nmax: int | None = None, values: bool = False) -> int | tuple[int, list[int]]:
     """For a given iterated sequence, return a generator that gives
     the length of the iterated cycle (lambda) and the length of terms
     before the cycle begins (mu); if ``values`` is True then the
@@ -1064,7 +1065,7 @@ def cycle_length(f, x0, nmax=None, values=False):
         yield lam, mu
 
 
-def composite(nth):
+def composite(nth: int) -> int:
     """ Return the nth composite number, with the composite numbers indexed as
         composite(1) = 4, composite(2) = 6, etc....
 
@@ -1129,7 +1130,7 @@ def composite(nth):
     return a
 
 
-def compositepi(n):
+def compositepi(n: int) -> int:
     """ Return the number of positive composite numbers less than or equal to n.
         The first positive composite is 4, i.e. compositepi(4) = 1.
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -845,7 +845,7 @@ def primerange(a: SupportsIndex, b: SupportsIndex | None = None) -> Iterator[int
     yield from _primerange(a, b)
 
 def _primerange(a: int, b: int | None = None) -> Iterator[int]:
-    """ Internal implementation of primerange. """   
+    """ Internal implementation of primerange. """
     if b is None:
         a, b = 2, a
     if a >= b:

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -841,13 +841,14 @@ def primerange(a: SupportsIndex, b: SupportsIndex | None = None) -> Iterator[int
         .. [2] https://primes.utm.edu/notes/gaps.html
     """
     a = as_int(a)
-    b = as_int(b) if b is not None else None
-    yield from _primerange(a, b)
-
-def _primerange(a: int, b: int | None = None) -> Iterator[int]:
-    """ Internal implementation of primerange. """
     if b is None:
         a, b = 2, a
+    else:
+        b = as_int(b)
+    yield from _primerange(a, b)
+
+def _primerange(a: int, b: int) -> Iterator[int]:
+    """ Internal implementation of primerange. """
     if a >= b:
         return
     # If we already have the range, return it.

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -534,7 +534,7 @@ def primepi(n: SupportsIndex) -> int:
     return func_primepi(as_int(n))
 
 
-def _primepi(n: SupportsIndex) -> int:
+def _primepi(n: int) -> int:
     r""" Represents the prime counting function pi(n) = the number
     of prime numbers less than or equal to n.
 
@@ -594,7 +594,6 @@ def _primepi(n: SupportsIndex) -> int:
     n : int
 
     """
-    n = as_int(n)
     if n < 2:
         return 0
     if n <= sieve._list[-1]:
@@ -673,47 +672,50 @@ def nextprime(n: SupportsIndex, ith: SupportsIndex = 1) -> int:
         primerange : Generate all primes in a given range
 
     """
-    n_int = int(as_int(n))
-    i = int(as_int(ith))
+    return _nextprime(as_int(n), as_int(ith))
+
+def _nextprime(n: int, ith: int = 1) -> int:
+    """ Internal implementation of nextprime. """
+    i = ith
     if i <= 0:
         raise ValueError("ith should be positive")
-    if n_int < 2:
-        n_int = 2
+    if n < 2:
+        n = 2
         i -= 1
-    if n_int <= sieve._list[-2]:
-        l, _ = sieve.search(n_int)
+    if n <= sieve._list[-2]:
+        l, _ = sieve.search(n)
         if l + i - 1 < len(sieve._list):
             return sieve._list[l + i - 1]
-        n_int = sieve._list[-1]
+        n = sieve._list[-1]
         i += l - len(sieve._list)
-    nn = 6*(n_int//6)
-    if nn == n_int:
-        n_int += 1
-        if isprime(n_int):
+    nn = 6*(n//6)
+    if nn == n:
+        n += 1
+        if isprime(n):
             i -= 1
             if not i:
-                return n_int
-        n_int += 4
-    elif n_int - nn == 5:
-        n_int += 2
-        if isprime(n_int):
+                return n
+        n += 4
+    elif n - nn == 5:
+        n += 2
+        if isprime(n):
             i -= 1
             if not i:
-                return n_int
-        n_int += 4
+                return n
+        n += 4
     else:
-        n_int = nn + 5
+        n = nn + 5
     while 1:
-        if isprime(n_int):
+        if isprime(n):
             i -= 1
             if not i:
-                return n_int
-        n_int += 2
-        if isprime(n_int):
+                return n
+        n += 2
+        if isprime(n):
             i -= 1
             if not i:
-                return n_int
-        n_int += 4
+                return n
+        n += 4
 
 
 def prevprime(n: SupportsIndex) -> int:
@@ -735,7 +737,7 @@ def prevprime(n: SupportsIndex) -> int:
         nextprime : Return the ith prime greater than n
         primerange : Generates all primes in a given range
     """
-    n = int( _as_int_ceiling(n))
+    n = int(_as_int_ceiling(n))
     if n < 3:
         raise ValueError("no preceding primes")
     if n < 8:
@@ -838,38 +840,41 @@ def primerange(a: SupportsIndex, b: SupportsIndex | None = None) -> Iterator[int
         .. [1] https://en.wikipedia.org/wiki/Prime_number
         .. [2] https://primes.utm.edu/notes/gaps.html
     """
-    a_int = int(as_int(a))
-    b_int: int
+    a = as_int(a)
+    b = as_int(b) if b is not None else None
+    yield from _primerange(a, b)
+
+def _primerange(a: int, b: int | None = None) -> Iterator[int]:
+    """ Internal implementation of primerange. """   
     if b is None:
-        a_int, b_int = 2, a_int
-    else:
-        b_int = int(as_int(b))
-    if a_int >= b_int:
+        a, b = 2, a
+    if a >= b:
         return
     # If we already have the range, return it.
     largest_known_prime = sieve._list[-1]
-    if b_int <= largest_known_prime:
-        yield from sieve.primerange(a_int, b_int)
+    if b <= largest_known_prime:
+        yield from sieve.primerange(a, b)
         return
     # If we know some of it, return it.
-    if a_int <= largest_known_prime:
-        yield from sieve._list[bisect_left(sieve._list, a_int):]
-        a_int = largest_known_prime + 1
-    elif a_int % 2:
-        a_int -= 1
-    tail = min(b_int, (largest_known_prime)**2)
-    if a_int < tail:
-        yield from sieve._primerange(a_int, tail)
-        a_int = tail
-    if b_int <= a_int:
+    if a <= largest_known_prime:
+        yield from sieve._list[bisect_left(sieve._list, a):]
+        a = largest_known_prime + 1
+    elif a % 2:
+        a -= 1
+    tail = min(b, (largest_known_prime)**2)
+    if a < tail:
+        yield from sieve._primerange(a, tail)
+        a = tail
+    if b <= a:
         return
     # otherwise compute, without storing, the desired range.
-    while True:
-        a_int = nextprime(a_int)
-        if a_int < b_int:
-            yield a_int
+    while 1:
+        a = nextprime(a)
+        if a < b:
+            yield a
         else:
             return
+
 
 def randprime(a: SupportsIndex, b: SupportsIndex) -> int | None:
     """ Return a random prime number in the range [a, b).
@@ -917,7 +922,7 @@ def randprime(a: SupportsIndex, b: SupportsIndex) -> int | None:
     return p
 
 
-def primorial(n: SupportsIndex, nth: bool = True) -> int:
+def primorial(n: int, nth: bool = True) -> int:
     """
     Returns the product of the first n primes (default) or
     the primes less than or equal to n (when ``nth=False``).

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -17,7 +17,7 @@ from sympy.utilities.decorator import deprecated
 from sympy.utilities.misc import as_int
 
 
-def _as_int_ceiling(a):
+def _as_int_ceiling(a) -> int:
     """ Wrapping ceiling in as_int will raise an error if there was a problem
         determining whether the expression was exactly an integer or not."""
     from sympy.functions.elementary.integers import ceiling
@@ -41,9 +41,14 @@ class Sieve:
     >>> sieve._list
     array('L', [2, 3, 5, 7, 11, 13, 17, 19, 23])
     """
+    _n: int
+    _list: _array[int]
+    _tlist: _array[int]
+    _mlist: _array[int]
+    sieve_interval: int
 
     # data shared (and updated) by all Sieve instances
-    def __init__(self, sieve_interval=1_000_000):
+    def __init__(self, sieve_interval: int = 1_000_000) -> None:
         """ Initial parameters for the Sieve class.
 
         Parameters
@@ -67,7 +72,7 @@ class Sieve:
         self.sieve_interval = sieve_interval
         assert all(len(i) == self._n for i in (self._list, self._tlist, self._mlist))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ("<%s sieve (%i): %i, %i, %i, ... %i, %i\n"
              "%s sieve (%i): %i, %i, %i, ... %i, %i\n"
              "%s sieve (%i): %i, %i, %i, ... %i, %i>") % (
@@ -81,7 +86,12 @@ class Sieve:
                  self._mlist[0], self._mlist[1],
                  self._mlist[2], self._mlist[-2], self._mlist[-1])
 
-    def _reset(self, prime=None, totient=None, mobius=None):
+    def _reset(
+        self,
+        prime: bool | None = None,
+        totient: bool | None = None,
+        mobius: bool | None = None,
+    ) -> None:
         """Reset all caches (default). To reset one or more set the
             desired keyword to True."""
         if all(i is None for i in (prime, totient, mobius)):
@@ -93,7 +103,7 @@ class Sieve:
         if mobius:
             self._mlist = self._mlist[:self._n]
 
-    def extend(self, n):
+    def extend(self, n: int) -> None:
         """Grow the sieve to cover all primes <= n.
 
         Examples
@@ -118,7 +128,7 @@ class Sieve:
         # Merge the sieves
         self._list += _array('L', self._primerange(num, n + 1))
 
-    def _primerange(self, a, b):
+    def _primerange(self, a: int, b: int) -> Iterator[int]:
         """ Generate all prime numbers in the range (a, b).
 
         Parameters
@@ -159,7 +169,7 @@ class Sieve:
                     yield a + 2 * idx + 1
             a += 2 * block_size
 
-    def extend_to_no(self, i):
+    def extend_to_no(self, i: int) -> None:
         """Extend to include the ith prime number.
 
         Parameters
@@ -186,7 +196,7 @@ class Sieve:
         while len(self._list) < i:
             self.extend(int(self._list[-1] * 1.5))
 
-    def primerange(self, a, b=None):
+    def primerange(self, a: int, b: int | None = None) -> Iterator[int]:
         """Generate all prime numbers in the range [2, a) or [a, b).
 
         Examples
@@ -222,7 +232,7 @@ class Sieve:
         yield from self._list[bisect_left(self._list, a):
                               bisect_left(self._list, b)]
 
-    def totientrange(self, a, b):
+    def totientrange(self, a: int, b: int) -> Iterator[int]:
         """Generate all totient numbers for the range [a, b).
 
         Examples
@@ -259,7 +269,7 @@ class Sieve:
                 if i >= a:
                     yield self._tlist[i]
 
-    def mobiusrange(self, a, b):
+    def mobiusrange(self, a: int, b: int) -> Iterator[int]:
         """Generate all mobius numbers for the range [a, b).
 
         Parameters
@@ -303,7 +313,7 @@ class Sieve:
                 if i >= a:
                     yield mi
 
-    def search(self, n):
+    def search(self, n: int) -> tuple[int, int]:
         """Return the indices i, j of the primes that bound n.
 
         If n is prime then i == j.
@@ -332,7 +342,7 @@ class Sieve:
         else:
             return b, b + 1
 
-    def __contains__(self, n):
+    def __contains__(self, n: int) -> bool:
         try:
             n = as_int(n)
             assert n >= 2
@@ -343,11 +353,19 @@ class Sieve:
         a, b = self.search(n)
         return a == b
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         for n in count(1):
             yield self[n]
 
-    def __getitem__(self, n):
+    @overload
+    def __getitem__(self, n: int) -> int:
+        ...
+
+    @overload
+    def __getitem__(self, n: slice) -> _array[int]:
+        ...
+
+    def __getitem__(self, n: int | slice) -> int | _array[int]:
         """Return the nth prime number"""
         if isinstance(n, slice):
             self.extend_to_no(n.stop)


### PR DESCRIPTION
Extracting type annotations from gh-28769 to separate the type annotations from thread-safety changes.

This adds type annotations to functions in `sympy/ntheory/generate.py` without changing any logic.

Still working on completing all function signatures.

Related to gh-28806, gh-28769

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added type annotations to functions in generate module.
<!-- END RELEASE NOTES -->