### PR TITLE
Drop Python 3.9 and bump Python versions in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip setuptools
 
       - run: pip install -r requirements-dev.txt
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install mpmath mypy hypothesis
 
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install sphinx-lint
 
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install mpmath
       - run: bin/mailmap_check.py
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install mpmath
       - run: bin/doctest --force-colors
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pytest -n auto
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     name: ${{ matrix.python-version }} Optional Dendendencies
 
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: |
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install python-flint gmpy2
@@ -258,8 +258,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          # tensorflow not yet available for 3.13
-          python-version: '3.12'
+          # tensorflow not yet available for 3.14
+          python-version: '3.13'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install numpy scipy tensorflow
@@ -276,7 +276,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
@@ -293,7 +293,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
       - run: pip install numpy symengine
@@ -328,9 +328,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15', 'pypy-3.11']
         exclude:
-          - python-version: 3.13
+          - python-version: 3.14
 
     name: ${{ matrix.python-version }} Tests
 
@@ -354,9 +354,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15', 'pypy-3.11']
         exclude:
-          - python-version: 3.13
+          - python-version: 3.14
 
     name: ${{ matrix.python-version }} Doctests
 
@@ -383,7 +383,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install git+https://github.com/mpmath/mpmath.git@master
       - run: pip install -r requirements-dev.txt
@@ -399,7 +399,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: doc/aptinstall.sh
       - run: pip install -r doc/requirements.txt
       - run: bin/test_sphinx.sh
@@ -439,7 +439,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip build
       - run: python -m build --sdist
       - run: release/compare_tar_against_git.py dist/*.tar.gz .
@@ -457,7 +457,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: pip install asv virtualenv packaging
       - run: git submodule add https://github.com/sympy/sympy_benchmarks.git
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extra_kwargs = {
 }
 
 # Keep in sync with sympy/__init__.py and python_requires below
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     print("SymPy requires Python 3.9 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
@@ -347,7 +347,7 @@ if __name__ == '__main__':
                     'sdist': sdist_sympy,
                     },
           # Keep in sync with version check above and sympy/__init__.py
-          python_requires='>=3.9',
+          python_requires='>=3.10',
           classifiers=[
             'License :: OSI Approved :: BSD License',
             'Operating System :: OS Independent',

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -455,7 +455,11 @@ def test_plot_and_save_6(adaptive):
             test_stacklevel=False,
         ):
             p = plot(expr, (x, 1e-6, 1e-2), adaptive=adaptive, n=10)
-            p.save(os.path.join(tmpdir, filename))
+            # Ignore the depreaction warning that comes from matplotlib using
+            # some deprecated thing in pyparsing. This was only seen in Python
+            # 3.9 or in pyodide.
+            with ignore_warnings(DeprecationWarning):
+                p.save(os.path.join(tmpdir, filename))
 
 
 @pytest.mark.parametrize("adaptive", [True, False])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Optional dependency tests have started failing on Python 3.9 due to a new release of pyparsing triggering warnings in matplotlib. Python 3.9 is EOL now so we just bump the minimum Python requirement to 3.10.

Also bump all versions tested in CI.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
