### PR TITLE
Doc: Add examples to Permutation.mul_inv

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1309,7 +1309,24 @@ class Permutation(Atom):
 
     def mul_inv(self, other):
         """
-        other*~self, self and other have _array_form
+        Calculates the product of ``other`` and the inverse of ``self``.
+
+        Explanation
+        ===========
+
+        Mathematically, this computes ``other * ~self``.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation
+        >>> p = Permutation([1, 2, 0])
+        >>> q = Permutation([2, 0, 1])
+        >>> p.mul_inv(q)
+        (0 1 2)
+        >>> q * ~p
+        (0 1 2)
+
         """
         a = _af_invert(self._array_form)
         b = other._array_form


### PR DESCRIPTION
Doc: Add examples to Permutation.mul_inv

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added a docstring example to the `Permutation.mul_inv` method in `sympy/combinatorics/permutations.py`.
Previously, the method lacked examples and relied on mathematical notation (`other*~self`) which was not immediately clear to users.
I added a concrete example using the values verified in my local testing.

#### Other comments
Verified locally using bin/doctest. No functional code changes were made, only documentation improvements.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added usage examples to `Permutation.mul_inv`.
<!-- END RELEASE NOTES -->