### PR TITLE
DOC: Clarify limitations of assumptions inference

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1377,3 +1377,4 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+Kunal Chandra <kunalchandra2008@gmail.com>

--- a/doc/src/guides/assumptions.rst
+++ b/doc/src/guides/assumptions.rst
@@ -73,6 +73,12 @@ number. That *assumption* can make it possible to simplify expressions or
 might allow other manipulations to work. It is usually a good idea to be as
 precise as possible about the assumptions on a symbol when creating it.
 
+.. note:: SymPy does not attempt to infer all mathematical properties automatically.
+          Only explicitly stated assumptions or those that follow from simple logical
+          rules are used. A result of ``None`` from an assumptions query indicates that
+          the value is unknown, not that the query is incorrect.
+
+
 
 The (old) assumptions system
 ============================


### PR DESCRIPTION
### What is changed
This PR clarifies limitations of the old assumptions system, especially cases
where inference returns `None` even for expressions that are mathematically
always positive.

### Why this change is needed
Users often misinterpret `None` as an error rather than "unknown". The updated
text explicitly explains this behavior and gives examples.

### Scope
- Documentation only
- No code changes

### Checklist
- [x] Documentation builds locally
- [x] No behavioral changes

Related to #28068

<!-- BEGIN RELEASE NOTES -->
* core
  * Clarify limitations of assumptions inference returning ``None``.
<!-- END RELEASE NOTES -->
