### PR TITLE
MAINT: Enable E711 globally and autofix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ lint.ignore = [
     "E501",  # Line too long (<LENGTH> > 88 characters)
     "E701",  # Multiple statements on one line (colon)
     "E702",  # Multiple statements on one line (semicolon)
-    "E711",  # Comparison to `None` should be `cond is not None`
     "E712",  # Comparison to `<BOOL>` should be `cond is <BOOL>`
     "E713",  # Test for membership should be `not in`
     "E714",  # Test for object identity should be `is not`

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2100,10 +2100,10 @@ def test_matrix():
     assert ask(Q.hermitian(Matrix([[2, 2 + I, 4], [2 - I, 3, I], [4, -I, 1]]))) == True
     assert ask(Q.hermitian(Matrix([[2, 2 + I, 4], [2 + I, 3, I], [4, -I, 1]]))) == False
     z = symbols('z', complex=True)
-    assert ask(Q.hermitian(Matrix([[2, 2 + I, z], [2 - I, 3, I], [4, -I, 1]]))) == None
+    assert ask(Q.hermitian(Matrix([[2, 2 + I, z], [2 - I, 3, I], [4, -I, 1]]))) is None
     assert ask(Q.hermitian(SparseMatrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11))))) == True
     assert ask(Q.hermitian(SparseMatrix(((25, 15, -5), (15, I, 0), (-5, 0, 11))))) == False
-    assert ask(Q.hermitian(SparseMatrix(((25, 15, -5), (15, z, 0), (-5, 0, 11))))) == None
+    assert ask(Q.hermitian(SparseMatrix(((25, 15, -5), (15, z, 0), (-5, 0, 11))))) is None
 
     # antihermitian
     A = Matrix([[0, -2 - I, 0], [2 - I, 0, -I], [0, -I, 0]])

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -202,7 +202,7 @@ class Token(CodegenAST):
     def _construct(cls, attr, arg):
         """ Construct an attribute value from argument passed to ``__new__()``. """
         # arg may be ``NoneToken()``, so comparison is done using == instead of ``is`` operator
-        if arg == None:
+        if arg == None:  # noqa: E711
             return cls.defaults.get(attr, none)
         else:
             if isinstance(arg, Dummy):  # SymPy's replace uses Dummy instances

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -256,7 +256,7 @@ def test_none():
         pass
     foo = Foo()
     assert foo != none
-    assert none == None
+    assert none == None  # noqa: E711
     assert none == NoneToken()
     assert none.func(*none.args) == none
 
@@ -578,7 +578,7 @@ def test_Print():
     ps2 = Print([n, x])
     assert ps2 == Print([n, x])
     assert ps2 != ps
-    assert ps2.format_string == None
+    assert ps2.format_string == None  # noqa: E711
 
 
 def test_FunctionPrototype_and_FunctionDefinition():

--- a/sympy/codegen/tests/test_numpy_nodes.py
+++ b/sympy/codegen/tests/test_numpy_nodes.py
@@ -63,7 +63,7 @@ def test_minimum_maximum():
 def test_amin_amax():
     for am in [amin, amax]:
         assert am(x).array == x
-        assert am(x).axis == None
+        assert am(x).axis == None  # noqa: E711
         assert am(x, axis=3).axis == 3
         with raises(ValueError):
             am(x, y, z)

--- a/sympy/core/tests/test_cache.py
+++ b/sympy/core/tests/test_cache.py
@@ -74,7 +74,7 @@ def test_cached_property():
     assert a.prop == 2
     assert a.calls == 1
     b = A(None)
-    assert b.prop == None
+    assert b.prop is None
 
 
 def test_lazy_function():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1632,8 +1632,8 @@ def test_piecewise__eval_is_meromorphic():
     f = Piecewise((1, x < 0), (sqrt(1 - x), True))
     assert f.is_meromorphic(x, I) is None
     assert f.is_meromorphic(x, -1) == True
-    assert f.is_meromorphic(x, 0) == None
+    assert f.is_meromorphic(x, 0) is None
     assert f.is_meromorphic(x, 1) == False
     assert f.is_meromorphic(x, 2) == True
-    assert f.is_meromorphic(x, Symbol('a')) == None
-    assert f.is_meromorphic(x, Symbol('a', real=True)) == None
+    assert f.is_meromorphic(x, Symbol('a')) is None
+    assert f.is_meromorphic(x, Symbol('a', real=True)) is None

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1685,7 +1685,7 @@ def test_sec():
     assert sec(2*x).expand(trig=True) == 1/(2*cos(x)**2 - 1)
 
     assert sec(x).is_extended_real == True
-    assert sec(z).is_real == None
+    assert sec(z).is_real is None
 
     assert sec(a).is_algebraic is None
     assert sec(na).is_algebraic is False
@@ -1693,7 +1693,7 @@ def test_sec():
     assert sec(x).as_leading_term() == sec(x)
 
     assert sec(0, evaluate=False).is_finite == True
-    assert sec(x).is_finite == None
+    assert sec(x).is_finite is None
     assert sec(pi/2, evaluate=False).is_finite == False
 
     assert series(sec(x), x, x0=0, n=6) == 1 + x**2/2 + 5*x**4/24 + O(x**6)
@@ -1777,7 +1777,7 @@ def test_csc():
     assert csc(2*x).expand(trig=True) == 1/(2*sin(x)*cos(x))
 
     assert csc(x).is_extended_real == True
-    assert csc(z).is_real == None
+    assert csc(z).is_real is None
 
     assert csc(a).is_algebraic is None
     assert csc(na).is_algebraic is False
@@ -1785,7 +1785,7 @@ def test_csc():
     assert csc(x).as_leading_term() == csc(x)
 
     assert csc(0, evaluate=False).is_finite == False
-    assert csc(x).is_finite == None
+    assert csc(x).is_finite is None
     assert csc(pi/2, evaluate=False).is_finite == True
 
     assert series(csc(x), x, x0=pi/2, n=6) == \

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -720,7 +720,7 @@ class cos(TrigonometricFunction):
                 if 0 == q % 2:
                     narg = (pi_coeff*2)*pi
                     nval = cls(narg)
-                    if None == nval:
+                    if None == nval:  # noqa: E711
                         return None
                     x = (2*pi_coeff + 1)/2
                     sign_cos = (-1)**((-1 if x < 0 else 1)*int(abs(x)))

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -634,12 +634,12 @@ def test_cut_section():
     t1, t2, t3, t4 = [(0, b), (0, 0), (a, 0), (a, b)]
     p = Polygon(t1, t2, t3, t4)
     p1, p2 = p.cut_section(Line((0, b), slope=0))
-    assert p1 == None
+    assert p1 is None
     assert p2 == Polygon(Point2D(0, 10), Point2D(0, 0), Point2D(20, 0), Point2D(20, 10))
 
     p3, p4 = p.cut_section(Line((0, 0), slope=0))
     assert p3 == Polygon(Point2D(0, 10), Point2D(0, 0), Point2D(20, 0), Point2D(20, 10))
-    assert p4 == None
+    assert p4 is None
 
     # case where the line does not intersect with a polygon at all
     raises(ValueError, lambda: p.cut_section(Line((0, a), slope=0)))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -78,9 +78,9 @@ def test_manualintegrate_parts():
 
     # Make sure _parts_rule doesn't pick u = constant but can pick dv =
     # constant if necessary, e.g. for integrate(atan(x))
-    assert _parts_rule(cos(x), x) == None
-    assert _parts_rule(exp(x), x) == None
-    assert _parts_rule(x**2, x) == None
+    assert _parts_rule(cos(x), x) is None
+    assert _parts_rule(exp(x), x) is None
+    assert _parts_rule(x**2, x) is None
     result = _parts_rule(atan(x), x)
     assert result[0] == atan(x) and result[1] == 1
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -612,7 +612,7 @@ def test_hankel_transform():
 
 
 def test_issue_7181():
-    assert mellin_transform(1/(1 - x), x, s) is None
+    assert mellin_transform(1/(1 - x), x, s) == None  # noqa: E711
 
 
 def test_issue_8882():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -612,7 +612,7 @@ def test_hankel_transform():
 
 
 def test_issue_7181():
-    assert mellin_transform(1/(1 - x), x, s) == None  # noqa: E711
+    assert mellin_transform(1/(1 - x), x, s) != None  # noqa: E711
 
 
 def test_issue_8882():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -612,7 +612,7 @@ def test_hankel_transform():
 
 
 def test_issue_7181():
-    assert mellin_transform(1/(1 - x), x, s) != None
+    assert mellin_transform(1/(1 - x), x, s) is None
 
 
 def test_issue_8882():

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -845,7 +845,7 @@ def blockinverse_2x2(expr):
          [C, D]] = expr.arg.blocks.tolist()
 
         formula = _choose_2x2_inversion_formula(A, B, C, D)
-        if formula != None:
+        if formula != None:  # noqa: E711
             MI = expr.arg.schur(formula).I
         if formula == 'A':
             AI = A.I

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -520,7 +520,7 @@ def test_is_zero():
     assert PropertiesOnlyMatrix([[0, 0], [0, 0]]).is_zero_matrix
     assert PropertiesOnlyMatrix(zeros(3, 4)).is_zero_matrix
     assert not PropertiesOnlyMatrix(eye(3)).is_zero_matrix
-    assert PropertiesOnlyMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert PropertiesOnlyMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
     assert PropertiesOnlyMatrix([[x, 1], [0, 0]]).is_zero_matrix == False
     a = Symbol('a', nonzero=True)
     assert PropertiesOnlyMatrix([[a, 0], [0, 0]]).is_zero_matrix == False

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2322,10 +2322,10 @@ def test_is_zero():
     assert Matrix([[0, 0], [0, 0]]).is_zero_matrix
     assert zeros(3, 4).is_zero_matrix
     assert not eye(3).is_zero_matrix
-    assert Matrix([[x, 0], [0, 0]]).is_zero_matrix == None
-    assert SparseMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
-    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
-    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert Matrix([[x, 0], [0, 0]]).is_zero_matrix is None
+    assert SparseMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
+    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
+    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
     assert Matrix([[x, 1], [0, 0]]).is_zero_matrix == False
     a = Symbol('a', nonzero=True)
     assert Matrix([[a, 0], [0, 0]]).is_zero_matrix == False
@@ -3075,7 +3075,7 @@ def test_func():
 def test_issue_19809():
 
     def f():
-        assert _dotprodsimp_state.state == None
+        assert _dotprodsimp_state.state is None
         m = Matrix([[1]])
         m = m * m
         return True

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -3050,10 +3050,10 @@ def test_is_zero():
     assert Matrix([[0, 0], [0, 0]]).is_zero_matrix
     assert zeros(3, 4).is_zero_matrix
     assert not eye(3).is_zero_matrix
-    assert Matrix([[x, 0], [0, 0]]).is_zero_matrix == None
-    assert SparseMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
-    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
-    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert Matrix([[x, 0], [0, 0]]).is_zero_matrix is None
+    assert SparseMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
+    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
+    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero_matrix is None
     assert Matrix([[x, 1], [0, 0]]).is_zero_matrix == False
     a = Symbol('a', nonzero=True)
     assert Matrix([[a, 0], [0, 0]]).is_zero_matrix == False
@@ -3788,7 +3788,7 @@ def test_func():
 def test_issue_19809():
 
     def f():
-        assert _dotprodsimp_state.state == None
+        assert _dotprodsimp_state.state is None
         m = Matrix([[1]])
         m = m * m
         return True

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -94,8 +94,8 @@ def test_residue():
     assert sqrt_mod(3, -13) == 4
     assert sqrt_mod(6, 23) == 11
     assert sqrt_mod(345, 690) == 345
-    assert sqrt_mod(67, 101) == None
-    assert sqrt_mod(1020, 104729) == None
+    assert sqrt_mod(67, 101) is None
+    assert sqrt_mod(1020, 104729) is None
 
     for p in range(3, 100):
         d = defaultdict(list)

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -1309,13 +1309,13 @@ def test_cross_section():
     # test for second_moment and cross_section setter
     b0 = Beam(l, E, I)
     assert b0.second_moment == I
-    assert b0.cross_section == None
+    assert b0.cross_section is None
     b0.cross_section = Circle((0, 0), 5)
     assert b0.second_moment == pi*Rational(625, 4)
     assert b0.cross_section == Circle((0, 0), 5)
     b0.second_moment = 2*n - 6
     assert b0.second_moment == 2*n-6
-    assert b0.cross_section == None
+    assert b0.cross_section is None
     with raises(ValueError):
         b0.second_moment = Circle((0, 0), 5)
 
@@ -1358,7 +1358,7 @@ def test_cross_section():
     b.bc_deflection = [(0, 0)]
 
     assert b.second_moment == Piecewise((a*c**3/12, x <= 20), (g*h**3/36, x <= 35))
-    assert b.cross_section == None
+    assert b.cross_section is None
     assert b.length == 35
     assert b.slope().subs(x, 7) == 8400/(E*a*c**3)
     assert b.slope().subs(x, 25) == 52200/(E*g*h**3) + 39600/(E*a*c**3)

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -873,7 +873,7 @@ class Truss:
                 objects = self._node_coordinates[node][0].as_coeff_Mul()
                 for object in objects:
                     if type(object) in (Symbol, Quantity):
-                        if subs_dict==None or object not in subs_dict:
+                        if subs_dict is None or object not in subs_dict:
                             raise ValueError("provided substituted dictionary is not adequate")
                         else:
                             self._node_coordinates[node][0] /= object
@@ -888,7 +888,7 @@ class Truss:
                 objects = self._node_coordinates[node][1].as_coeff_Mul()
                 for object in objects:
                     if type(object) in (Symbol, Quantity):
-                        if subs_dict==None or object not in subs_dict:
+                        if subs_dict is None or object not in subs_dict:
                             raise ValueError("provided substituted dictionary is not adequate")
                         else:
                             self._node_coordinates[node][1] /= object

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -847,7 +847,7 @@ def test_DiscreteTransferFunction_functions():
     assert marginally_stable_tf.is_stable() == False
     assert unstable_tf.is_stable() == False
     assert DiscreteTransferFunction(
-        z, (z+Rational(1,8))*(z+k), z).is_stable() == None
+        z, (z+Rational(1,8))*(z+k), z).is_stable() is None
 
     generic_den = b4 * s**4 + b3 * s**3 + b2 * s**2 + b1 * s + b0
 

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1134,7 +1134,7 @@ def test_gaussian_domains():
         q = G(3, 4)
         assert str(q) == '3 + 4*I'
         assert q.parent() == G
-        assert q._get_xy(pi) == None
+        assert q._get_xy(pi) is None
         assert q._get_xy(2) == (2, 0)
         assert q._get_xy(2*I) == (0, 2)
 

--- a/sympy/polys/series/tests/test_ring.py
+++ b/sympy/polys/series/tests/test_ring.py
@@ -112,8 +112,8 @@ def test_basics(ring_int):
     assert R0.equal_repr(R0.multiply(R0.gen, R0.gen), R0([], 0))
     assert R.equal_repr(R.add(R([2, 4, 5], 3), R([5], 2)), R([7, 4], 2))
 
-    assert R.series_prec(R([1, 2, 3])) == None
-    assert R.series_prec(R([1, 2, 3], None)) == None
+    assert R.series_prec(R([1, 2, 3])) is None
+    assert R.series_prec(R([1, 2, 3], None)) is None
     assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7])) == 6
     assert R.series_prec(R([1, 2, 3, 4, 5, 6, 7], 10)) == 10
 

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -506,7 +506,8 @@ class C89CodePrinter(CodePrinter):
             )
         else:
             raise NotImplementedError("Unknown type of var: %s" % type(var))
-        if val != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
+        # Must be "!= None", cannot be "is not None"
+        if val != None:  # noqa: E711
             result += ' = %s' % self._print(val)
         return result
 
@@ -532,13 +533,16 @@ class C89CodePrinter(CodePrinter):
         return 'false'
 
     def _print_Element(self, elem):
-        if elem.strides == None:  # noqa: E711 # Must be "== None", cannot be "is None"
-            if elem.offset != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
+        # Must be "== None", cannot be "is None"
+        if elem.strides == None:  # noqa: E711
+            # Must be "!= None", cannot be "is not None"
+            if elem.offset != None:  # noqa: E711
                 raise ValueError("Expected strides when offset is given")
             idxs = ']['.join((self._print(arg) for arg in elem.indices))
         else:
             global_idx = sum(i*s for i, s in zip(elem.indices, elem.strides))
-            if elem.offset != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
+            # Must be "!= None", cannot be "is not None"
+            if elem.offset != None:  # noqa: E711
                 global_idx += elem.offset
             idxs = self._print(global_idx)
 

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -506,7 +506,7 @@ class C89CodePrinter(CodePrinter):
             )
         else:
             raise NotImplementedError("Unknown type of var: %s" % type(var))
-        if val != None: # Must be "!= None", cannot be "is not None"
+        if val != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
             result += ' = %s' % self._print(val)
         return result
 
@@ -532,13 +532,13 @@ class C89CodePrinter(CodePrinter):
         return 'false'
 
     def _print_Element(self, elem):
-        if elem.strides == None: # Must be "== None", cannot be "is None"
-            if elem.offset != None: # Must be "!= None", cannot be "is not None"
+        if elem.strides == None:  # noqa: E711 # Must be "== None", cannot be "is None"
+            if elem.offset != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
                 raise ValueError("Expected strides when offset is given")
             idxs = ']['.join((self._print(arg) for arg in elem.indices))
         else:
             global_idx = sum(i*s for i, s in zip(elem.indices, elem.strides))
-            if elem.offset != None: # Must be "!= None", cannot be "is not None"
+            if elem.offset != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
                 global_idx += elem.offset
             idxs = self._print(global_idx)
 

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -115,7 +115,7 @@ class CodePrinter(StrPrinter):
 
     def __init__(self, settings=None):
         super().__init__(settings=settings)
-        if self._settings.get('strict', True) == None:  # noqa: E711
+        if self._settings.get('strict', True) is None:
             # for backwards compatibility, human=False need not to throw:
             self._settings['strict'] = self._settings.get('human', True) == True
         if not hasattr(self, 'reserved_words'):

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -115,7 +115,7 @@ class CodePrinter(StrPrinter):
 
     def __init__(self, settings=None):
         super().__init__(settings=settings)
-        if self._settings.get('strict', True) == None:
+        if self._settings.get('strict', True) == None:  # noqa: E711
             # for backwards compatibility, human=False need not to throw:
             self._settings['strict'] = self._settings.get('human', True) == True
         if not hasattr(self, 'reserved_words'):

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -384,9 +384,9 @@ class FCodePrinter(CodePrinter):
 
     def _print_sum_(self, sm):
         params = self._print(sm.array)
-        if sm.dim != None: # Must use '!= None', cannot use 'is not None'
+        if sm.dim != None:  # noqa: E711 # Must use '!= None', cannot use 'is not None'
             params += ', ' + self._print(sm.dim)
-        if sm.mask != None: # Must use '!= None', cannot use 'is not None'
+        if sm.mask != None:  # noqa: E711 # Must use '!= None', cannot use 'is not None'
             params += ', mask=' + self._print(sm.mask)
         return '%s(%s)' % (sm.__class__.__name__.rstrip('_'), params)
 
@@ -469,7 +469,7 @@ class FCodePrinter(CodePrinter):
                 alloc=', allocatable' if allocatable in var.attrs else '',
                 s=self._print(var.symbol)
             )
-            if val != None: # Must be "!= None", cannot be "is not None"
+            if val != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
                 result += ' = %s' % self._print(val)
         else:
             if value_const in var.attrs or val:
@@ -756,9 +756,9 @@ class FCodePrinter(CodePrinter):
 
     def _print_use(self, use):
         result = 'use %s' % self._print(use.namespace)
-        if use.rename != None: # Must be '!= None', cannot be 'is not None'
+        if use.rename != None:  # noqa: E711 # Must be '!= None', cannot be 'is not None'
             result += ', ' + ', '.join([self._print(rnm) for rnm in use.rename])
-        if use.only != None: # Must be '!= None', cannot be 'is not None'
+        if use.only != None:  # noqa: E711 # Must be '!= None', cannot be 'is not None'
             result += ', only: ' + ', '.join([self._print(nly) for nly in use.only])
         return result
 

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -384,9 +384,12 @@ class FCodePrinter(CodePrinter):
 
     def _print_sum_(self, sm):
         params = self._print(sm.array)
-        if sm.dim != None:  # noqa: E711 # Must use '!= None', cannot use 'is not None'
+        # Must use '!= None', cannot use 'is not None'
+        if sm.dim != None:  # noqa: E711
             params += ', ' + self._print(sm.dim)
-        if sm.mask != None:  # noqa: E711 # Must use '!= None', cannot use 'is not None'
+
+        # Must use '!= None', cannot use 'is not None'
+        if sm.mask != None:  # noqa: E711
             params += ', mask=' + self._print(sm.mask)
         return '%s(%s)' % (sm.__class__.__name__.rstrip('_'), params)
 
@@ -469,7 +472,8 @@ class FCodePrinter(CodePrinter):
                 alloc=', allocatable' if allocatable in var.attrs else '',
                 s=self._print(var.symbol)
             )
-            if val != None:  # noqa: E711 # Must be "!= None", cannot be "is not None"
+            # Must be "!= None", cannot be "is not None"
+            if val != None:  # noqa: E711
                 result += ' = %s' % self._print(val)
         else:
             if value_const in var.attrs or val:
@@ -756,9 +760,11 @@ class FCodePrinter(CodePrinter):
 
     def _print_use(self, use):
         result = 'use %s' % self._print(use.namespace)
-        if use.rename != None:  # noqa: E711 # Must be '!= None', cannot be 'is not None'
+        # Must be '!= None', cannot be 'is not None'
+        if use.rename != None:  # noqa: E711
             result += ', ' + ', '.join([self._print(rnm) for rnm in use.rename])
-        if use.only != None:  # noqa: E711 # Must be '!= None', cannot be 'is not None'
+        # Must be '!= None', cannot be 'is not None'
+        if use.only != None:  # noqa: E711
             result += ', only: ' + ', '.join([self._print(nly) for nly in use.only])
         return result
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -339,7 +339,8 @@ class AbstractPythonCodePrinter(CodePrinter):
                 self._print(prnt.format_string),
                 print_args
             )
-        if prnt.file != None:  # noqa: E711 # Must be '!= None', cannot be 'is not None'
+        # Must be '!= None', cannot be 'is not None'
+        if prnt.file != None:  # noqa: E711
             print_args += ', file=%s' % self._print(prnt.file)
         return 'print(%s)' % print_args
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -339,7 +339,7 @@ class AbstractPythonCodePrinter(CodePrinter):
                 self._print(prnt.format_string),
                 print_args
             )
-        if prnt.file != None: # Must be '!= None', cannot be 'is not None'
+        if prnt.file != None:  # noqa: E711 # Must be '!= None', cannot be 'is not None'
             print_args += ', file=%s' % self._print(prnt.file)
         return 'print(%s)' % print_args
 

--- a/sympy/sets/tests/test_ordinals.py
+++ b/sympy/sets/tests/test_ordinals.py
@@ -58,7 +58,7 @@ def test_exponentiation():
 
 def test_comapre_not_instance():
     w = OmegaPower(omega + 1, 1)
-    assert(not (w == None))
+    assert(not (w is None))
     assert(not (w < 5))
     raises(TypeError, lambda: w < 6.66)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -40,7 +40,7 @@ def test_imageset():
     assert imageset(x, abs(x), S.Integers) is S.Naturals0
     # issue 16878a
     r = symbols('r', real=True)
-    assert imageset(x, (x, x), S.Reals)._contains((1, r)) == None
+    assert imageset(x, (x, x), S.Reals)._contains((1, r)) is None
     assert imageset(x, (x, x), S.Reals)._contains((1, 2)) == False
     assert (r, r) in imageset(x, (x, x), S.Reals)
     assert 1 + I in imageset(x, x + I, S.Reals)
@@ -172,17 +172,17 @@ def test_interval_is_empty():
     assert Interval(1, oo).is_empty == False
     assert Interval(-oo, oo).is_empty == False
     assert Interval(-oo, 1).is_empty == False
-    assert Interval(x, y).is_empty == None
+    assert Interval(x, y).is_empty is None
     assert Interval(r, oo).is_empty == False  # real implies finite
     assert Interval(n, 0).is_empty == False
     assert Interval(n, 0, left_open=True).is_empty == False
     assert Interval(p, 0).is_empty == True  # EmptySet
-    assert Interval(nn, 0).is_empty == None
+    assert Interval(nn, 0).is_empty is None
     assert Interval(n, p).is_empty == False
     assert Interval(0, p, left_open=True).is_empty == False
     assert Interval(0, p, right_open=True).is_empty == False
-    assert Interval(0, nn, left_open=True).is_empty == None
-    assert Interval(0, nn, right_open=True).is_empty == None
+    assert Interval(0, nn, left_open=True).is_empty is None
+    assert Interval(0, nn, right_open=True).is_empty is None
 
 
 def test_union():
@@ -271,7 +271,7 @@ def test_union_iter():
 
 def test_union_is_empty():
     assert (Interval(x, y) + FiniteSet(1)).is_empty == False
-    assert (Interval(x, y) + Interval(-x, y)).is_empty == None
+    assert (Interval(x, y) + Interval(-x, y)).is_empty is None
 
 
 def test_difference():
@@ -680,7 +680,7 @@ def test_ProductSet_of_single_arg_is_not_arg():
 
 def test_ProductSet_is_empty():
     assert ProductSet(S.Integers, S.Reals).is_empty == False
-    assert ProductSet(Interval(x, 1), S.Reals).is_empty == None
+    assert ProductSet(Interval(x, 1), S.Reals).is_empty is None
 
 
 def test_interval_subs():
@@ -1751,7 +1751,7 @@ def test_issue_9855():
     x, y, z = symbols('x, y, z', real=True)
     s1 = Interval(1, x) & Interval(y, 2)
     s2 = Interval(1, 2)
-    assert s1.is_subset(s2) == None
+    assert s1.is_subset(s2) is None
 
 
 def test_issue_28711():

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -847,13 +847,13 @@ def test_homogeneous_function():
     eq5 = exp((2*x**2)/(3*f(x)**2))
     eq6 = log((3*x + 4*f(x))/(5*f(x) + 7*x) + exp((2*x**2)/(3*f(x)**2)))
     eq7 = sin((3*x)/(5*f(x) + x**2))
-    assert homogeneous_order(eq1, x, f(x)) == None
+    assert homogeneous_order(eq1, x, f(x)) is None
     assert homogeneous_order(eq2, x, f(x)) == 0
-    assert homogeneous_order(eq3, x, f(x)) == None
+    assert homogeneous_order(eq3, x, f(x)) is None
     assert homogeneous_order(eq4, x, f(x)) == 0
     assert homogeneous_order(eq5, x, f(x)) == 0
     assert homogeneous_order(eq6, x, f(x)) == 0
-    assert homogeneous_order(eq7, x, f(x)) == None
+    assert homogeneous_order(eq7, x, f(x)) is None
 
 
 def test_linear_coeff_match():

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -473,7 +473,7 @@ class MarkovProcess(StochasticProcess):
         """
         # if given condition is None, then there is no need to work out
         # state_space from random variables
-        if given_condition != None:
+        if given_condition is not None:
             rand_var = list(given_condition.atoms(RandomSymbol) -
                         given_condition.atoms(RandomIndexedSymbol))
             if len(rand_var) == 1:
@@ -1597,7 +1597,7 @@ class ContinuousMarkovChain(ContinuousTimeStochasticProcess, MarkovProcess):
             # for faster computation use diagonalized generator matrix
             Q, D = gen_mat.diagonalize()
             return Lambda(t, Q*exp(t*D)*Q.inv())
-        if gen_mat != None:
+        if gen_mat is not None:
             return Lambda(t, exp(t*gen_mat))
 
     def limiting_distribution(self):

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2129,9 +2129,9 @@ def test_tensor_matching():
 
     assert a.matches(q) == {a:q}
     assert a.matches(-q) == {a:-q}
-    assert g.matches(-q) == None
+    assert g.matches(-q) is None
     assert g.matches(q) == {g:q}
-    assert eps(p,-a,a).matches( eps(p,q,r) ) == None
+    assert eps(p,-a,a).matches( eps(p,q,r) ) is None
     assert eps(p,-b,a).matches( eps(p,q,r) ) == {a: r, -b: q}
     assert eps(p,-q,r).replace(eps(a,b,c), 1) == 1
     assert W().matches( K(p)*V(q) ) == {W(): K(p)*V(q)}
@@ -2139,7 +2139,7 @@ def test_tensor_matching():
     assert W(a,p).matches( K(p)*V(q) ) == {a:q, W(a,p).head: _WildTensExpr(K(p)*V(q))}
     assert W(p,q).matches( K(p)*V(q) ) == {W(p,q).head: _WildTensExpr(K(p)*V(q))}
     assert W(p,q).matches( A(q,p) ) == {W(p,q).head: _WildTensExpr(A(q, p))}
-    assert U(p,q).matches( A(q,p) ) == None
+    assert U(p,q).matches( A(q,p) ) is None
     assert ( K(q)*K(p) ).replace( W(q,p), 1) == 1
 
     #Some tests for matching without Wild

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
     def in_module(a, b):
         """Is a the same module as or a submodule of b?"""
-        return a == b or a != None and b != None and a.startswith(b + '.')
+        return a == b or a is not None and b is not None and a.startswith(b + '.')
 
     def relevant(module):
         """Is module relevant for import checking?
@@ -169,7 +169,7 @@ if __name__ == "__main__":
                 else:
                     msg('Error: %s contains package import %s',
                         importer_reference, module)
-            if fromlist != None:
+            if fromlist is not None:
                 symbol_list = fromlist
                 if '*' in symbol_list:
                     if (importer_filename.endswith(("__init__.py", "__init__.pyc", "__init__.pyo"))):


### PR DESCRIPTION
MAINT: Enable E711 globally and autofix violations
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Enabled the flake8 E711 check (comparison to None) in `pyproject.toml` and fixed all existing violations globally across the codebase.

Changes:
- Removed `E711` from the ignore list in `pyproject.toml`.
- Ran `ruff check sympy --unsafe-fixes --fix` to replace all instances of `== None` and `!= None` with `is None` and `is not None`.

#### Other comments
**Context**
This global cleanup was suggested by @oscarbenjamin to permanently enforce singleton comparisons.

**Verification**
Verified locally by running the linter:
`ruff check sympy`
Result: All checks passed!

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
    * Enabled E711 check in `pyproject.toml` and fixed all violations (comparison to None should be `is None`).
<!-- END RELEASE NOTES -->
