### PR TITLE
Add regression tests for complex Mod 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -651,6 +651,7 @@ Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
 Gagan Mishra <simonsimple305@gmail.com> Gagan Mishra <70949548+GaganMishra305@users.noreply.github.com>
+Gagandeep Singh <Gmadaan450@gmail.com> Gagandeep61 <gmadaan450@gmail.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <36567889+czgdp1807@users.noreply.github.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <czgdp1807@gmail.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <gdp.1807@gmail.com>

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2316,3 +2316,14 @@ def test_all_close():
     assert not all_close(x + exp(2.*x)*y, 1.*x + 2*exp(2*x)*y)
     assert not all_close(x + exp(2.*x)*y, 1.*x + exp(3*x)*y)
     assert not all_close(x + 2.*y, 1.*x + 3*y)
+
+
+def test_issue_28222():
+    from sympy import I, pi, Mod, exp, S
+    # These cases previously raised TypeError due to invalid comparison of complex numbers
+    assert Mod(I, 200) == Mod(I, 200)
+    assert Mod(I, pi**(2*pi)) == Mod(I, pi**(2*pi))
+    assert Mod(-I, 5) == Mod(-I, 5)
+    assert Mod(2 + 3*I, 10) == Mod(2 + 3*I, 10)
+    assert Mod(I, exp(1)) == Mod(I, exp(1))
+    assert Mod(I, S(1.5)) == Mod(I, S(1.5))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28222

#### Brief description of what is fixed or changed
Added regression tests for `Mod` with complex arguments. Previously, cases like `Mod(I, 200)` raised a `TypeError` due to invalid comparisons between real and non-real numbers. This PR ensures those cases, along with transcendental and mixed complex edge cases, are formally tested and verified.

#### Other comments
The core logic issue was addressed in a related fix, but as requested by maintainers, this PR provides the necessary test coverage to officially close the issue. Verified locally with `bin/test sympy/core/tests/test_numbers.py`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
