### PR TITLE
typ: annotations for Basic.has and related functions

### DIFF
--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from sympy.core import Add, Mul, Pow, S
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
@@ -181,10 +182,15 @@ class AccumulationBounds(Expr):
     calculations, use ``mpmath.iv`` instead.
     """
 
+    if TYPE_CHECKING:
+        @property
+        def args(self) -> tuple[Expr, Expr]:
+            ...
+
     is_extended_real = True
     is_number = False
 
-    def __new__(cls, min, max) -> Expr: # type: ignore
+    def __new__(cls, min: Expr | complex, max: Expr | complex) -> Expr: # type: ignore
 
         min = _sympify(min)
         max = _sympify(max)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -182,9 +182,10 @@ class Pow(Expr):
             elif exp == -1 and not base:
                 return S.ComplexInfinity
             elif exp.__class__.__name__ == "AccumulationBounds":
-                if base == S.Exp1:
-                    from sympy.calculus.accumulationbounds import AccumBounds
-                    return AccumBounds(Pow(base, exp.min), Pow(base, exp.max))
+                from sympy.calculus.accumulationbounds import AccumBounds
+                if isinstance(exp, AccumBounds):
+                    if base == S.Exp1:
+                        return AccumBounds(Pow(base, exp.min), Pow(base, exp.max))
             # autosimplification if base is a number and exp odd/even
             # if base is Number then the base will end up positive; we
             # do not do this with arbitrary expressions since symbolic

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from sympy.core.basic import Basic
     from sympy.core.expr import Expr
     from sympy.core.numbers import Integer, Float
+    from sympy.logic.boolalg import BooleanFalse, BooleanTrue
 
     Tbasic = TypeVar('Tbasic', bound=Basic)
 
@@ -111,7 +112,9 @@ def _convert_numpy_types(a, **sympify_args):
 
 
 @overload
-def sympify(a: int, *, strict: bool = False) -> Integer: ... # type: ignore
+def sympify(a: bool, *, strict: bool = False) -> BooleanFalse | BooleanTrue: ... # type: ignore
+@overload
+def sympify(a: int, *, strict: bool = False) -> Integer: ...
 @overload
 def sympify(a: float, *, strict: bool = False) -> Float: ...
 @overload
@@ -511,7 +514,20 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     return expr
 
 
-def _sympify(a):
+@overload
+def _sympify(a: bool) -> BooleanFalse | BooleanTrue: ... # type: ignore
+@overload
+def _sympify(a: int) -> Integer: ...
+@overload
+def _sympify(a: float) -> Float: ...
+@overload
+def _sympify(a: Expr | complex) -> Expr: ...
+@overload
+def _sympify(a: Tbasic) -> Tbasic: ...
+@overload
+def _sympify(a: Any) -> Basic: ...
+
+def _sympify(a: Any) -> Basic:
     """
     Short version of :func:`~.sympify` for internal usage for ``__add__`` and
     ``__eq__`` methods where it is ok to allow some things (like Python

--- a/sympy/core/traversal.py
+++ b/sympy/core/traversal.py
@@ -9,7 +9,7 @@ from sympy.utilities.iterables import iterable
 
 
 
-def iterargs(expr):
+def iterargs(expr: Basic) -> Iterator[Basic]:
     """Yield the args of a Basic object in a breadth-first traversal.
     Depth-traversal stops if `arg.args` is either empty or is not
     an iterable.
@@ -34,7 +34,7 @@ def iterargs(expr):
         args.extend(i.args)
 
 
-def iterfreeargs(expr, _first=True):
+def iterfreeargs(expr: Basic, _first: bool = True) -> Iterator[Basic]:
     """Yield the args of a Basic object in a breadth-first traversal.
     Depth-traversal stops if `arg.args` is either empty or is not
     an iterable. The bound objects of an expression will be returned


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/28806

#### Brief description of what is fixed or changed

Add type annotations for Basic.has and a few related functions that came up in the process.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
