### PR TITLE
Annotated __new__, binary_symbols, and as_set methods with type hints.

### DIFF
--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -10,7 +10,6 @@ from sympy.utilities.misc import func_name
 from sympy.sets.sets import Set
 
 
-
 class Contains(Boolean):
     """
     Asserts that x is an element of the set S.

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from sympy.core import S
 from sympy.core.basic import Basic
 from sympy.core.sympify import sympify
-from sympy.core.relational import Eq, Ne
 from sympy.core.parameters import global_parameters
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.misc import func_name
@@ -34,6 +33,11 @@ class Contains(Boolean):
 
     .. [1] https://en.wikipedia.org/wiki/Element_%28mathematics%29
     """
+    if TYPE_CHECKING:
+        @property
+        def args(self) -> tuple[Basic, Set]:
+            ...
+
     def __new__(cls, x: Basic, s: Set, evaluate: bool | None = None) -> Boolean:  # type: ignore[misc]
         x = sympify(x)
         s = sympify(s)
@@ -61,10 +65,8 @@ class Contains(Boolean):
 
     @property
     def binary_symbols(self) -> set[Basic]:
-        return set().union(*[i.binary_symbols  # type: ignore[attr-defined]
-            for i in self.args[1].args
-            if i.is_Boolean or i.is_Symbol or
-            isinstance(i, (Eq, Ne))])
+        bool_args = [a for a in self.args[1].args if isinstance(a, Boolean)]
+        return set().union(*[i.binary_symbols for i in bool_args])
 
     def as_set(self) -> Set:
-        return self.args[1]  # type: ignore[return-value]
+        return self.args[1]

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from sympy.core import S
+from sympy.core.basic import Basic
 from sympy.core.sympify import sympify
 from sympy.core.relational import Eq, Ne
 from sympy.core.parameters import global_parameters
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.misc import func_name
-from .sets import Set
 
+if TYPE_CHECKING:
+    from sympy.sets.sets import Set
 
 class Contains(Boolean):
     """
@@ -28,12 +33,14 @@ class Contains(Boolean):
 
     .. [1] https://en.wikipedia.org/wiki/Element_%28mathematics%29
     """
-    def __new__(cls, x, s, evaluate=None):
+    def __new__(cls, x: Basic, s: Set, evaluate: bool | None = None) -> Boolean:
         x = sympify(x)
         s = sympify(s)
 
         if evaluate is None:
             evaluate = global_parameters.evaluate
+
+        from sympy.sets.sets import Set
 
         if not isinstance(s, Set):
             raise TypeError('expecting Set, not %s' % func_name(s))
@@ -53,11 +60,11 @@ class Contains(Boolean):
         return super().__new__(cls, x, s)
 
     @property
-    def binary_symbols(self):
+    def binary_symbols(self) -> set[Basic]:
         return set().union(*[i.binary_symbols
             for i in self.args[1].args
             if i.is_Boolean or i.is_Symbol or
             isinstance(i, (Eq, Ne))])
 
-    def as_set(self):
+    def as_set(self) -> Set:
         return self.args[1]

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -7,9 +7,8 @@ from sympy.core.sympify import sympify
 from sympy.core.parameters import global_parameters
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.misc import func_name
+from sympy.sets.sets import Set
 
-if TYPE_CHECKING:
-    from sympy.sets.sets import Set
 
 
 class Contains(Boolean):
@@ -45,7 +44,6 @@ class Contains(Boolean):
         if evaluate is None:
             evaluate = global_parameters.evaluate
 
-        from sympy.sets.sets import Set
         if not isinstance(s, Set):
             raise TypeError('expecting Set, not %s' % func_name(s))
 

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -12,6 +12,7 @@ from sympy.utilities.misc import func_name
 if TYPE_CHECKING:
     from sympy.sets.sets import Set
 
+
 class Contains(Boolean):
     """
     Asserts that x is an element of the set S.
@@ -33,7 +34,7 @@ class Contains(Boolean):
 
     .. [1] https://en.wikipedia.org/wiki/Element_%28mathematics%29
     """
-    def __new__(cls, x: Basic, s: Set, evaluate: bool | None = None) -> Boolean:
+    def __new__(cls, x: Basic, s: Set, evaluate: bool | None = None) -> Boolean:  # type: ignore[misc]
         x = sympify(x)
         s = sympify(s)
 
@@ -41,7 +42,6 @@ class Contains(Boolean):
             evaluate = global_parameters.evaluate
 
         from sympy.sets.sets import Set
-
         if not isinstance(s, Set):
             raise TypeError('expecting Set, not %s' % func_name(s))
 
@@ -61,10 +61,10 @@ class Contains(Boolean):
 
     @property
     def binary_symbols(self) -> set[Basic]:
-        return set().union(*[i.binary_symbols
+        return set().union(*[i.binary_symbols  # type: ignore[attr-defined]
             for i in self.args[1].args
             if i.is_Boolean or i.is_Symbol or
             isinstance(i, (Eq, Ne))])
 
     def as_set(self) -> Set:
-        return self.args[1]
+        return self.args[1]  # type: ignore[return-value]


### PR DESCRIPTION
#### Description of changes

Added type annotations to `sympy/sets/contains.py` as part of the ongoing typing effort.
- Annotated `__new__`, `binary_symbols`, and `as_set`.
- Added `from __future__ import annotations`.
- Handled circular imports for `Set` using `TYPE_CHECKING` and local imports inside `__new__`.

#### Issue number

Issue: https://github.com/sympy/sympy/issues/28806

#### References to other Issues or PRs

#### Brief description of what is fixed or changed

#### Other comments

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* sets
  * Added type hints to `contains.py`
<!-- END RELEASE NOTES -->
