### PR TITLE
convert array to matrix: do not use Hadamard products on singleton matrices

### DIFF
--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -822,7 +822,14 @@ def identify_hadamard_products(expr: ArrayContraction | ArrayDiagonal):
 
         # This is a Hadamard product:
 
-        hp = hadamard_product(*[i.element if check_transpose(i.indices) else Transpose(i.element) for i in hadamard_factors])
+        elems = [i.element if check_transpose(i.indices) else Transpose(i.element) for i in hadamard_factors]
+
+        if elems[0].shape == (1, 1):
+            # In this case, the Hadamard product is equivalent to the matrix multiplication:
+            hp = MatMul(*elems).doit()
+        else:
+            hp = hadamard_product(*elems)
+
         hp_indices = v[0].indices
         if not check_transpose(hadamard_factors[0].indices):
             hp_indices = list(reversed(hp_indices))

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -450,6 +450,9 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
     expr = ArrayTensorProduct(X4, ArrayAdd(ArrayTensorProduct(X4, I1), PermuteDims(ArrayTensorProduct(I1, X4), [2, 3, 0, 1])))
     assert _remove_trivial_dims(expr) == (2*X4*X4.T, [1, 3, 4, 5])
 
+    expr = ArrayDiagonal(ArrayTensorProduct(X1.applyfunc(exp), X1, X4, X1), (0, 2, 6), (1, 3, 7))
+    assert _remove_trivial_dims(expr) == (exp(X1[0, 0])*X4*X1**2, [2, 3])
+
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():
     cg = _array_diagonal(_array_tensor_product(M, a), (1, 2))
@@ -691,7 +694,7 @@ def test_convert_array_elementwise_function_to_matrix():
     d = Dummy("d")
 
     expr = ArrayElementwiseApplyFunc(Lambda(d, sin(d)), x.T*y)
-    assert convert_array_to_matrix(expr) == sin(x.T*y)
+    assert convert_array_to_matrix(expr).dummy_eq(sin((x.T*y)[0, 0]))
 
     expr = ArrayElementwiseApplyFunc(Lambda(d, d**2), x.T*y)
     assert convert_array_to_matrix(expr) == (x.T*y)**2

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,4 +1,4 @@
-from sympy import Lambda, S, Dummy, KroneckerProduct, Array
+from sympy import Lambda, S, Dummy, KroneckerProduct, Array, exp
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
@@ -621,6 +621,9 @@ def test_convert_array_to_hadamard_products():
 
     cg = ArrayTensorProduct(X4, ArrayAdd(ArrayTensorProduct(X4, I1), PermuteDims(ArrayTensorProduct(I1, X4), [2, 3, 0, 1])))
     assert convert_array_to_matrix(cg) == 2*X4*X4.T
+
+    cg = ArrayDiagonal(ArrayTensorProduct(X1.applyfunc(exp), X1, X4, X1), (0, 2, 6), (1, 3, 7))
+    assert convert_array_to_matrix(cg).dummy_eq(X4*X1.applyfunc(exp)*X1**2)
 
 
 def test_identify_removable_identity_matrices():


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/28834

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
