### PR TITLE
Fix logic dontcare

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1830,3 +1830,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Abhijith Shaji <abhijithshajikp@gmail.com> <abhijithshaji@unknown.home>
+Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -207,6 +207,8 @@ Abdullah Javed Nesar <abduljaved1994@gmail.com>
 Abhay_Dhiman <abhaysdhimans@gmail.com>
 Abhi58 <abhijithbharadwaj58@gmail.com>
 Abhigyan Khaund <mail@abhigyan.xyz>
+Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
+Abhijith Shaji <abhijithshajikp@gmail.com> <abhijithshaji@unknown.home>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>
 Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>
@@ -1830,5 +1832,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Abhijith Shaji <abhijithshajikp@gmail.com> <abhijithshaji@unknown.home>
-Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2875,17 +2875,17 @@ def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
         elif form == 'dnf':
             form_ok = is_dnf(expr)
 
-        if form_ok and all(is_literal(a)
-                for a in expr.args):
-            return expr
+        if form_ok and dontcare is None and all(is_literal(a)
+               for a in expr.args):
+           return expr
     from sympy.core.relational import Relational
     if deep:
         variables = expr.atoms(Relational)
         from sympy.simplify.simplify import simplify
         s = tuple(map(simplify, variables))
         expr = expr.xreplace(dict(zip(variables, s)))
-    if not isinstance(expr, BooleanFunction):
-        return expr
+    if not isinstance(expr, BooleanFunction) and dontcare is None:
+       return expr
     # Replace Relationals with Dummys to possibly
     # reduce the number of variables
     repl = {}

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1457,3 +1457,12 @@ def test_evaluate_false():
     expr = Equivalent(x, x, x, evaluate=False)
     assert isinstance(expr, Equivalent)
     assert expr.args == (x, x, x)
+
+def test_simplify_logic_dontcare_issue_28369():
+   A, B = symbols('A B')
+
+   # Test 1: Fast path symbol check
+   assert simplify_logic(A, dontcare=~A) is S.true
+
+   # Test 2: Fast path form check
+   assert simplify_logic(A | B, dontcare=A, form='dnf') == B

--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -86,9 +86,9 @@ def test_issue_28740():
     A2 = Operator('A2')
     B1 = Operator('B1')
     B2 = Operator('B2')
-
     # This used to fail (return 2 terms instead of 4)
     comm = Comm(A1 + A2, B1 + B2)
     assert comm.expand(commutator=True) == \
         Comm(A1, B1) + Comm(A1, B2) + \
         Comm(A2, B1) + Comm(A2, B2)
+    

--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -91,5 +91,3 @@ def test_issue_28740():
     assert comm.expand(commutator=True) == \
         Comm(A1, B1) + Comm(A1, B2) + \
         Comm(A2, B1) + Comm(A2, B2)
-    
-    

--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -92,3 +92,4 @@ def test_issue_28740():
         Comm(A1, B1) + Comm(A1, B2) + \
         Comm(A2, B1) + Comm(A2, B2)
     
+    

--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -79,3 +79,16 @@ def test_eval_commutator():
     assert Comm(F, T**2).expand(commutator=True).doit() == -2*T
     assert Comm(T**2, F).expand(commutator=True).doit() == 2*T
     assert Comm(T**2, F**3).expand(commutator=True).doit() == 2*F*T*F + 2*F**2*T + 2*T*F**2
+
+
+def test_issue_28740():
+    A1 = Operator('A1')
+    A2 = Operator('A2')
+    B1 = Operator('B1')
+    B2 = Operator('B2')
+
+    # This used to fail (return 2 terms instead of 4)
+    comm = Comm(A1 + A2, B1 + B2)
+    assert comm.expand(commutator=True) == \
+        Comm(A1, B1) + Comm(A1, B2) + \
+        Comm(A2, B1) + Comm(A2, B2)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

* logic
  * Fixed `simplify_logic` ignoring `dontcare` argument when input is already in the requested form or is a simple symbol.

<!-- END RELEASE NOTES -->
