### PR TITLE
Fix simplify_logic ignoring dontcare argument

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -207,6 +207,8 @@ Abdullah Javed Nesar <abduljaved1994@gmail.com>
 Abhay_Dhiman <abhaysdhimans@gmail.com>
 Abhi58 <abhijithbharadwaj58@gmail.com>
 Abhigyan Khaund <mail@abhigyan.xyz>
+Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
+Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>
 Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2875,16 +2875,16 @@ def simplify_logic(expr, form=None, deep=True, force=False, dontcare=None):
         elif form == 'dnf':
             form_ok = is_dnf(expr)
 
-        if form_ok and all(is_literal(a)
-                for a in expr.args):
-            return expr
+        if form_ok and dontcare is None and all(is_literal(a)
+               for a in expr.args):
+           return expr
     from sympy.core.relational import Relational
     if deep:
         variables = expr.atoms(Relational)
         from sympy.simplify.simplify import simplify
         s = tuple(map(simplify, variables))
         expr = expr.xreplace(dict(zip(variables, s)))
-    if not isinstance(expr, BooleanFunction):
+    if not isinstance(expr, BooleanFunction) and dontcare is None:
         return expr
     # Replace Relationals with Dummys to possibly
     # reduce the number of variables

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1457,3 +1457,12 @@ def test_evaluate_false():
     expr = Equivalent(x, x, x, evaluate=False)
     assert isinstance(expr, Equivalent)
     assert expr.args == (x, x, x)
+
+def test_simplify_logic_dontcare_issue_28369():
+   A, B = symbols('A B')
+
+   # Test 1: Fast path symbol check
+   assert simplify_logic(A, dontcare=~A) is S.true
+
+   # Test 2: Fast path form check
+   assert simplify_logic(A | B, dontcare=A, form='dnf') == B


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* logic
    * Fixed simplify_logic ignoring dontcare argument when input is already in the requested form or is a simple symbol.
    * Fixes #28369

<!-- END RELEASE NOTES -->
