### PR TITLE
Fix nsimplify returning ridiculous outputs for simple integer strings

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -13,7 +13,7 @@ from sympy.core.exprtools import factor_nc
 from sympy.core.parameters import global_parameters
 from sympy.core.function import (expand_log, count_ops, _mexpand,
     nfloat, expand_mul, expand)
-from sympy.core.numbers import Float, I, pi, Rational, equal_valued
+from sympy.core.numbers import Float, I, Integer, pi, Rational, equal_valued
 from sympy.core.relational import Relational
 from sympy.core.rules import Transform
 from sympy.core.sorting import ordered
@@ -47,7 +47,6 @@ from sympy.simplify.sqrtdenest import sqrtdenest
 from sympy.simplify.trigsimp import trigsimp, exptrigsimp
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import has_variety, sift, subsets, iterable
-from sympy.utilities.misc import as_int
 
 from sympy.external.mpmath import (
     prec_to_dps,
@@ -1455,14 +1454,13 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     sympy.core.function.nfloat
 
     """
-    try:
-        return sympify(as_int(expr))
-    except (TypeError, ValueError):
-        pass
-    expr = sympify(expr).xreplace({
+    expr = sympify(expr)
+    if isinstance(expr, Integer):
+        return expr
+    expr = expr.xreplace({
         Float('inf'): S.Infinity,
         Float('-inf'): S.NegativeInfinity,
-        })
+    })
     if expr is S.Infinity or expr is S.NegativeInfinity:
         return expr
     if rational or expr.free_symbols:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1456,8 +1456,6 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
 
     """
     try:
-        if isinstance(expr, str):  # string parsing is outside `as_int()`'s scope
-            expr = Rational(expr)  # Rational or Integer, keeping given precision
         return sympify(as_int(expr))
     except (TypeError, ValueError):
         pass

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1456,6 +1456,8 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
 
     """
     try:
+        if isinstance(expr, str):  # string parsing is outside `as_int()`'s scope
+            expr = Rational(expr)  # Rational or Integer, keeping given precision
         return sympify(as_int(expr))
     except (TypeError, ValueError):
         pass

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -436,6 +436,23 @@ def test_nsimplify():
     # Make sure nsimplify on expressions uses full precision
     assert nsimplify(pi.evalf(100)*x, rational_conversion='exact').evalf(100) == pi.evalf(100)*x
 
+    # issue 23822 make sure simple integer strings don't result in complicated, fractional outputs
+    assert nsimplify("4678") == 4678
+    assert str(nsimplify("4678")) == "4678"
+    assert all(str(nsimplify(a)) == a for a in map(str, range(-10000,10000)))
+    assert all(nsimplify(f"{a}/10", rational=True) == Rational(a,10) for a in range(-10000,10000))
+    # still behaves the same for different input precisions
+    for expr_str, expr_decimal, expected in [
+        ["1/3", 1/3, "1/3"],
+        [".3333", .3333, "3333/10000"],
+        [".33333333", .33333333, "1/3"],
+        [str(pi.evalf(15)), pi.evalf(15), "314159265358979/100000000000000"],  # precision cutoff at 15
+        [str(pi.evalf(16)), pi.evalf(16), "3141592653589793/1000000000000000"],
+    ]:
+        a = nsimplify(expr_str)
+        b = nsimplify(expr_decimal)
+        assert str(a) == str(b) == str(expected)
+
 
 def test_issue_9448():
     tmp = sympify("1/(1 - (-1)**(2/3) - (-1)**(1/3)) + 1/(1 + (-1)**(2/3) + (-1)**(1/3))")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for #23822

#### Brief description of what is fixed or changed

Adds a path to try and parse string inputs to `Rational` before the integer shortcut in `nsimplify()`. Previously `as_int()` would raise an Exception for all string inputs, skipping the shortcut, so some unlucky integers would result in huge, fractional outputs, such as `"4678"`

From the original Issue:

```
In [41]: nsimplify(4678)
Out[41]: 4678

In [42]: nsimplify("4678")
Out[42]: 
                         51      
                         ──      
             7/16  7/40  80 8 ___
13841287201⋅2    ⋅3    ⋅5  ⋅╲╱ 7 
─────────────────────────────────
             17280000  
```

#### Other comments

`Integer()` isn't sufficient as it will round and consume floats!

Two other changes in `nsimplify()` could make sense to review in this or another PR
* should any given `rational` arg be passed to the main call to `sympify(expr)`?
* should the `tolerance` arg be used in the internal precision calculation? (see comments)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* simplify
  * String integers passed to `nsimplify()` no longer arbitrarily result in large, fractional outputs due to raising an Exception in the integer shortcut which wasn't intended for strings

<!-- END RELEASE NOTES -->
