### PR TITLE
tensor: fix ArrayDiagonal._flatten to preserve index 0

### DIFF
--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -888,7 +888,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
     @staticmethod
     def _flatten(expr: ArrayDiagonal, *outer_diagonal_indices):
         inddown = ArrayDiagonal._push_indices_down(outer_diagonal_indices, list(range(get_rank(expr))), get_rank(expr))
-        inddown = tuple(i for i in inddown if i)
+        inddown = tuple(i for i in inddown if i is not None)
         inddow2 = ArrayDiagonal._push_indices_down(expr.diagonal_indices, inddown, get_rank(expr.expr))
         new_diag_indices = []
         for i in inddow2:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28818

#### Brief description of what is fixed or changed
The `ArrayDiagonal._flatten` method was incorrectly using a truthy check `if i` when processing indices. In Python, the integer `0` is evaluated as `False`, which caused the 0-th index to be accidentally discarded during the flattening process of array expressions.

This PR changes the check to `if i is not None`. This ensures that the 0-th index is correctly preserved as a valid coordinate, allowing matrix derivatives of multivariate distributions (which rely on these indices) to be calculated without raising an `IndexError`.

#### Other comments
I have verified this fix by:
1. Running the reproduction script provided in issue #28818 (it now completes successfully).
2. Running the existing test suite: `sympy/tensor/array/expressions/tests/test_array_expressions.py`. All 27 tests passed, ensuring no regressions.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fixed a bug in `ArrayDiagonal` where index `0` was incorrectly removed during flattening, causing errors in matrix derivatives.
<!-- END RELEASE NOTES -->