### PR TITLE
Fix infinite recursion in lambdify with JointRandomSymbol

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -17,7 +17,7 @@ import weakref
 from sympy.external import import_module # noqa:F401
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.decorator import doctest_depends_on
-from sympy.utilities.iterables import (is_sequence, iterable,
+from sympy.utilities.iterables import (iterable,
     NotIterable, flatten)
 from sympy.utilities.misc import filldedent
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1439,7 +1439,7 @@ def _imp_namespace(expr, namespace=None):
     if namespace is None:
         namespace = {}
     # tuples, lists, dicts are valid expressions
-    if is_sequence(expr):
+    if isinstance(expr, (list, tuple)):
         for arg in expr:
             _imp_namespace(arg, namespace)
         return namespace

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -35,6 +35,7 @@ from sympy.integrals.integrals import Integral
 from sympy.logic.boolalg import (And, false, ITE, Not, Or, true)
 from sympy.matrices.expressions.dotproduct import DotProduct
 from sympy.simplify.cse_main import cse
+from sympy.stats import MultivariateNormal
 from sympy.tensor.array import derive_by_array, Array
 from sympy.tensor.array.expressions import ArraySymbol
 from sympy.tensor.indexed import IndexedBase, Idx
@@ -2317,3 +2318,14 @@ def test_array_symbol():
     a = ArraySymbol('a', (3,))
     f = lambdify((a), a)
     assert numpy.all(f(numpy.array([1,2,3])) == numpy.array([1,2,3]))
+
+def test_issue_28803_jointrandonsymbol_recursion():
+    """Test that JointRandomSymbol doesn't cause infinite recursion in lambdify."""
+    
+    # Used to cause infinite recursion
+    K = MatrixSymbol("K", 4, 4)
+    z = MultivariateNormal("z", [0] * 4, K)
+    a = symbols("a")
+    
+    # Should not raise RecursionError
+    f = lambdify(a, z * a)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2321,11 +2321,11 @@ def test_array_symbol():
 
 def test_issue_28803_jointrandonsymbol_recursion():
     """Test that JointRandomSymbol doesn't cause infinite recursion in lambdify."""
-    
+
     # Used to cause infinite recursion
     K = MatrixSymbol("K", 4, 4)
     z = MultivariateNormal("z", [0] * 4, K)
     a = symbols("a")
-    
+
     # Should not raise RecursionError
     f = lambdify(a, z * a)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2319,6 +2319,7 @@ def test_array_symbol():
     f = lambdify((a), a)
     assert numpy.all(f(numpy.array([1,2,3])) == numpy.array([1,2,3]))
 
+
 def test_issue_28803_jointrandonsymbol_recursion():
     """Test that JointRandomSymbol doesn't cause infinite recursion in lambdify."""
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2328,4 +2328,4 @@ def test_issue_28803_jointrandonsymbol_recursion():
     a = symbols("a")
 
     # Should not raise RecursionError
-    f = lambdify(a, z * a)
+    lambdify(a, z * a)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28803

#### Brief description of what is fixed or changed
`JointRandomSymbol` (and other objects with `__getitem__`) caused infinite recursion in `lambdify` because `is_sequence()` returned `True` for them. 

Changed the check in `_imp_namespace` from `is_sequence(expr)` to `isinstance(expr, (list, tuple))` to match what `_recursive_to_string` actually supports. The printer only handles `list` and `tuple`, raising `NotImplementedError` for other iterables, so this aligns the behavior throughout lambdify.

#### Other comments
Added a regression test to ensure `JointRandomSymbol` no longer causes recursion errors.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fixed infinite recursion in `lambdify` with objects like `JointRandomSymbol` that have `__getitem__` but aren't meant to be iterated over.
<!-- END RELEASE NOTES -->