### PR TITLE
Add type annotations to flatten in utilities.iterables

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -107,7 +107,6 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         else:
             raise ValueError(
                 "expected non-negative number of levels, got %s" % levels)
-         
         from typing import Any, Optional, Type, Callable, List
 
         cls: Optional[Type[Any]]

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -107,7 +107,7 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         else:
             raise ValueError(
                 "expected non-negative number of levels, got %s" % levels)
-        from typing import Any, Optional, Type, Callable, List
+        from typing import Any, Optional, Type
 
         cls: Optional[Type[Any]]
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -107,15 +107,21 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         else:
             raise ValueError(
                 "expected non-negative number of levels, got %s" % levels)
+         
+        from typing import Any, Optional, Type, Callable, List
+
+        cls: Optional[Type[Any]]
+
+        reducible: Callable[[Any], bool]
 
     if cls is None:
-        def reducible(x):
+        def reducible(x: Any) -> bool:
             return is_sequence(x, set)
     else:
-        def reducible(x):
+        def reducible(x: Any) -> bool:
             return isinstance(x, cls)
 
-    result = []
+    result: list[Any] = []
 
     for el in iterable:
         if reducible(el):


### PR DESCRIPTION
This PR adds basic type annotations to the `flatten` function in
`sympy/utilities/iterables.py`.

Scope:
- Annotated the internal `reducible` callable
- Added a type annotation for the `result` list
- No functional changes intended

This is a small, focused change as discussed in #28806.


 Related issue: #28806

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
 