### PR TITLE
agglomerate singleton matrices together in Kronecker product

### DIFF
--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -341,10 +341,26 @@ def explicit_kronecker_product(kron):
     return matrix_kronecker_product(*kron.args)
 
 
+def kronecker_product_extract_singleton_matrices(kron: KroneckerProduct):
+    singleton_matrices = []
+    args = []
+    for arg in kron.args:
+        if isinstance(arg, MatrixExpr) and arg.shape == (1, 1):
+            singleton_matrices.append(arg)
+        else:
+            args.append(arg)
+    if len(singleton_matrices) > 1:
+        args.append(MatMul(*singleton_matrices))
+        return KroneckerProduct(*args)
+    else:
+        return kron
+
+
 rules = (unpack,
          explicit_kronecker_product,
          flatten,
-         extract_commutative)
+         extract_commutative,
+         kronecker_product_extract_singleton_matrices)
 
 canonicalize = exhaust(condition(lambda x: isinstance(x, KroneckerProduct),
                                  do_one(*rules)))

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -148,3 +148,12 @@ def test_KroneckerProduct_entry():
     B = MatrixSymbol('B', o, p)
 
     assert KroneckerProduct(A, B)._entry(i, j) == A[Mod(floor(i/o), n), Mod(floor(j/p), m)]*B[Mod(i, o), Mod(j, p)]
+
+
+def test_KroneckerProduct_singletons():
+    A = MatrixSymbol('A', 3, 3)
+    A1 = MatrixSymbol('A1', 1, 1)
+    B = MatrixSymbol('B', 3, 3)
+    B1 = MatrixSymbol('B1', 1, 1)
+
+    assert KroneckerProduct(A, A1, B, B1).doit() == KroneckerProduct(A, B, A1*B1)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from sympy import MatMul
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
 from sympy.core.add import Add
@@ -7707,7 +7708,7 @@ H    \n\
 
 def test_issue_15560():
     a = MatrixSymbol('a', 1, 1)
-    e = pretty(a*(KroneckerProduct(a, a)))
+    e = pretty(MatMul(a, KroneckerProduct(a, a)))
     result = 'a*(a x a)'
     assert e == result
 


### PR DESCRIPTION
Singleton matrices of shape `(1, 1)` can be agglomerated together in Kronecker product expressions, as they do not change the output.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
