### PR TITLE
fix(sets): Remove Set._infimum_key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,10 @@ module = [
 ]
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = "flint.*"
+follow_imports = "skip"
+
 # Third-party untyped code:
 [[tool.mypy.overrides]]
 module = [

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -192,7 +192,7 @@ def test_not_empty_in():
     assert not_empty_in(FiniteSet(x**2/(x + 2)).intersect(Interval(1, oo)), x) == \
         Union(Interval(-2, -1, True, False), Interval(2, oo))
     raises(ValueError, lambda: not_empty_in(x))
-    raises(ValueError, lambda: not_empty_in(Interval(0, 1), x))
+    raises(NotImplementedError, lambda: not_empty_in(Interval(0, 1), x))
     raises(NotImplementedError,
            lambda: not_empty_in(FiniteSet(x).intersect(S.Reals), x, a))
 

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.partitions import (Partition, IntegerPartition,
                                             random_integer_partition)
 from sympy.testing.pytest import raises
 from sympy.utilities.iterables import partitions
-from sympy.sets.sets import Set, FiniteSet
+from sympy.sets.sets import FiniteSet
 
 
 def test_partition_constructor():
@@ -115,4 +115,4 @@ def test_rgs():
 def test_ordered_partition_9608():
     a = Partition([1, 2, 3], [4])
     b = Partition([1, 2], [3, 4])
-    assert list(ordered([a,b], Set._infimum_key))
+    assert list(ordered([a,b]))

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -32,6 +32,14 @@ if TYPE_CHECKING:
         BooleanTrue as _BooleanTrue,
         BooleanFalse as _BooleanFalse,
     )
+    from sympy.sets.fancysets import (
+        Naturals as _Naturals,
+        Naturals0 as _Naturals0,
+        Integers as _Integers,
+        Rationals as _Rationals,
+        Reals as _Reals,
+        Complexes as _Complexes,
+    )
 
     from .basic import Basic
     from .expr import Expr
@@ -135,6 +143,13 @@ class SingletonRegistry(Registry):
 
     true: _BooleanTrue
     false: _BooleanFalse
+
+    Naturals: _Naturals
+    Naturals0: _Naturals0
+    Integers: _Integers
+    Rationals: _Rationals
+    Reals: _Reals
+    Complexes: _Complexes
 
     # Also allow things like S(5)
     @overload

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -119,20 +119,6 @@ class Set(Basic, EvalfMixin):
 
         n = evalf
 
-    @staticmethod
-    def _infimum_key(expr):
-        """
-        Return infimum (if possible) else S.Infinity.
-        """
-        try:
-            infimum = expr.inf
-            assert infimum.is_comparable
-            infimum = infimum.evalf()  # issue #18505
-        except (NotImplementedError,
-                AttributeError, AssertionError, ValueError):
-            infimum = S.Infinity
-        return infimum
-
     def union(self, other):
         """
         Returns the union of ``self`` and ``other``.
@@ -1347,6 +1333,11 @@ class Union(Set, LatticeOp):
     """
     is_Union = True
 
+    if TYPE_CHECKING:
+        @property
+        def args(self) -> tuple[Set, ...]:
+            ...
+
     @property
     def identity(self):
         return S.EmptySet
@@ -1366,15 +1357,11 @@ class Union(Set, LatticeOp):
             args = list(cls._new_args_filter(args))
             return simplify_union(args)
 
-        args = list(ordered(args, Set._infimum_key))
+        args = list(ordered(args))
 
         obj = Basic.__new__(cls, *args)
         obj._argset = frozenset(args)
         return obj
-
-    @property
-    def args(self):
-        return self._args
 
     def _complement(self, universe):
         # DeMorgan's Law
@@ -1556,7 +1543,7 @@ class Intersection(Set, LatticeOp):
             args = list(cls._new_args_filter(args))
             return simplify_intersection(args)
 
-        args = list(ordered(args, Set._infimum_key))
+        args = list(ordered(args))
 
         obj = Basic.__new__(cls, *args)
         obj._argset = frozenset(args)
@@ -2021,7 +2008,7 @@ class FiniteSet(Set):
                     # e.g. i = class without args like `Interval`
                     dargs[i] = i
         _args_set = set(dargs.values())
-        args = list(ordered(_args_set, Set._infimum_key))
+        args = list(ordered(_args_set))
         obj = Basic.__new__(cls, *args)
         obj._args_set = _args_set
         return obj

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -215,7 +215,7 @@ def test_union():
     x = Symbol('x')
     assert Union(Interval(0, 1), FiniteSet(1, x)) == Union(
         Interval(0, 1), FiniteSet(x))
-    assert unchanged(Union, Interval(0, 1), FiniteSet(2, x))
+    assert unchanged(Union, FiniteSet(2, x), Interval(0, 1))
 
     assert Interval(1, 2).union(Interval(2, 3)) == \
         Interval(1, 2) + Interval(2, 3)
@@ -1487,7 +1487,7 @@ def test_issue_10931():
 
 
 def test_issue_11174():
-    soln = Intersection(Interval(-oo, oo), FiniteSet(-x), evaluate=False)
+    soln = Intersection(S.Reals, FiniteSet(-x), evaluate=False)
     assert Intersection(FiniteSet(-x), S.Reals) == soln
 
     soln = Intersection(S.Reals, FiniteSet(x), evaluate=False)

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import random
 import itertools
-from typing import Sequence as tSequence
+from typing import Sequence as tSequence, ClassVar
 from sympy.concrete.summations import Sum
 from sympy.core.add import Add
 from sympy.core.basic import Basic
@@ -180,7 +180,7 @@ class StochasticProcess(Basic):
     DiscreteTimeStochasticProcess
     """
 
-    index_set = S.Reals
+    index_set: ClassVar[Set] = S.Reals
 
     def __new__(cls, sym, state_space=S.Reals, **kwargs):
         sym = _symbol_converter(sym)


### PR DESCRIPTION
This method is used to try to sort sets by their infumums but that does not work in general and is unnecessary anyway since a canonical ordering is possible without the use of numerical evaluation. This commit removes the method and adjusts some other code that made faulty assumptions about the ordering of unions and intersections.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * The internal Set._infimum_key method was removed and now the order of sets in a Union or Intersection maybe different than it was before. 
<!-- END RELEASE NOTES -->
