### PR TITLE
Add type annotation to filldedent

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1552,6 +1552,7 @@ Sujal Kumar <sujaljayantkumar06@gmail.com> Sujal Kumar <91939382+SujalKumar06@us
 Suman mondal <smondal.qwerty@gmail.com>
 Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
 Sumith Kulal <sumith1896@gmail.com>
+Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1836,3 +1836,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Vedant Dusane <dusanev4@gmail.com>

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -561,6 +561,8 @@ def _per(M):
     import itertools
 
     m, n = M.shape
+    if m == 0 or n == 0:
+        return S.One
     if m > n:
         M = M.T
         m, n = n, m

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -178,6 +178,15 @@ def test_permanent():
     M = Matrix([a1, a2, a3, a4, a5])
     assert M.per() == M.T.per() == a1 + a2 + a3 + a4 + a5
 
+    M = Matrix.zeros(0,0)
+    assert M.per() == 1
+
+    M = Matrix.zeros(0,1)
+    assert M.per() == 1
+
+    M = Matrix.zeros(1,0)
+    assert M.per() == 1
+
 def test_adjugate():
     x = Symbol('x')
     e = Matrix(4, 4,

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from sympy.core import S
+from sympy.core.basic import Basic
 from sympy.core.sympify import sympify
-from sympy.core.relational import Eq, Ne
 from sympy.core.parameters import global_parameters
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.misc import func_name
-from .sets import Set
+from sympy.sets.sets import Set
 
 
 class Contains(Boolean):
@@ -28,7 +31,12 @@ class Contains(Boolean):
 
     .. [1] https://en.wikipedia.org/wiki/Element_%28mathematics%29
     """
-    def __new__(cls, x, s, evaluate=None):
+    if TYPE_CHECKING:
+        @property
+        def args(self) -> tuple[Basic, Set]:
+            ...
+
+    def __new__(cls, x: Basic, s: Set, evaluate: bool | None = None) -> Boolean:  # type: ignore[misc]
         x = sympify(x)
         s = sympify(s)
 
@@ -53,11 +61,9 @@ class Contains(Boolean):
         return super().__new__(cls, x, s)
 
     @property
-    def binary_symbols(self):
-        return set().union(*[i.binary_symbols
-            for i in self.args[1].args
-            if i.is_Boolean or i.is_Symbol or
-            isinstance(i, (Eq, Ne))])
+    def binary_symbols(self) -> set[Basic]:
+        bool_args = [a for a in self.args[1].args if isinstance(a, Boolean)]
+        return set().union(*[i.binary_symbols for i in bool_args])
 
-    def as_set(self):
+    def as_set(self) -> Set:
         return self.args[1]

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -822,7 +822,14 @@ def identify_hadamard_products(expr: ArrayContraction | ArrayDiagonal):
 
         # This is a Hadamard product:
 
-        hp = hadamard_product(*[i.element if check_transpose(i.indices) else Transpose(i.element) for i in hadamard_factors])
+        elems = [i.element if check_transpose(i.indices) else Transpose(i.element) for i in hadamard_factors]
+
+        if elems[0].shape == (1, 1):
+            # In this case, the Hadamard product is equivalent to the matrix multiplication:
+            hp = MatMul(*elems).doit()
+        else:
+            hp = hadamard_product(*elems)
+
         hp_indices = v[0].indices
         if not check_transpose(hadamard_factors[0].indices):
             hp_indices = list(reversed(hp_indices))

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -450,6 +450,9 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
     expr = ArrayTensorProduct(X4, ArrayAdd(ArrayTensorProduct(X4, I1), PermuteDims(ArrayTensorProduct(I1, X4), [2, 3, 0, 1])))
     assert _remove_trivial_dims(expr) == (2*X4*X4.T, [1, 3, 4, 5])
 
+    expr = ArrayDiagonal(ArrayTensorProduct(X1.applyfunc(exp), X1, X4, X1), (0, 2, 6), (1, 3, 7))
+    assert _remove_trivial_dims(expr) == (exp(X1[0, 0])*X4*X1**2, [2, 3])
+
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():
     cg = _array_diagonal(_array_tensor_product(M, a), (1, 2))
@@ -691,7 +694,7 @@ def test_convert_array_elementwise_function_to_matrix():
     d = Dummy("d")
 
     expr = ArrayElementwiseApplyFunc(Lambda(d, sin(d)), x.T*y)
-    assert convert_array_to_matrix(expr) == sin(x.T*y)
+    assert convert_array_to_matrix(expr).dummy_eq(sin((x.T*y)[0, 0]))
 
     expr = ArrayElementwiseApplyFunc(Lambda(d, d**2), x.T*y)
     assert convert_array_to_matrix(expr) == (x.T*y)**2

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -1,4 +1,4 @@
-from sympy import Lambda, S, Dummy, KroneckerProduct, Array
+from sympy import Lambda, S, Dummy, KroneckerProduct, Array, exp
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
@@ -621,6 +621,9 @@ def test_convert_array_to_hadamard_products():
 
     cg = ArrayTensorProduct(X4, ArrayAdd(ArrayTensorProduct(X4, I1), PermuteDims(ArrayTensorProduct(I1, X4), [2, 3, 0, 1])))
     assert convert_array_to_matrix(cg) == 2*X4*X4.T
+
+    cg = ArrayDiagonal(ArrayTensorProduct(X1.applyfunc(exp), X1, X4, X1), (0, 2, 6), (1, 3, 7))
+    assert convert_array_to_matrix(cg).dummy_eq(X4*X1.applyfunc(exp)*X1**2)
 
 
 def test_identify_removable_identity_matrices():

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -107,7 +107,6 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         else:
             raise ValueError(
                 "expected non-negative number of levels, got %s" % levels)
-         
         from typing import Any, Optional, Type, Callable, List
 
         cls: Optional[Type[Any]]

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -107,7 +107,7 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         else:
             raise ValueError(
                 "expected non-negative number of levels, got %s" % levels)
-        from typing import Any, Optional, Type, Callable, List
+        from typing import Any, Optional, Type
 
         cls: Optional[Type[Any]]
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -107,15 +107,21 @@ def flatten(iterable, levels=None, cls=None):  # noqa: F811
         else:
             raise ValueError(
                 "expected non-negative number of levels, got %s" % levels)
+         
+        from typing import Any, Optional, Type, Callable, List
+
+        cls: Optional[Type[Any]]
+
+        reducible: Callable[[Any], bool]
 
     if cls is None:
-        def reducible(x):
+        def reducible(x: Any) -> bool:
             return is_sequence(x, set)
     else:
-        def reducible(x):
+        def reducible(x: Any) -> bool:
             return isinstance(x, cls)
 
-    result = []
+    result: list[Any] = []
 
     for el in iterable:
         if reducible(el):

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -19,7 +19,7 @@ class Undecidable(ValueError):
     pass
 
 
-def filldedent(s, w=70, **kwargs):
+def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     """
     Strips leading and trailing empty lines from a copy of ``s``, then dedents,
     fills and returns it.


### PR DESCRIPTION
This PR adds a type annotation to the `filldedent` function in `sympy/utilities/misc.py`.

- Annotated `filldedent` with: 
  - `s: str`
  - `w: int = 70`
  - `**kwargs: Any`
  - Returns `str`

The change is minimal and improves code readability and type safety. Tests pass locally. Only `filldedent` is annotated as per mentor feedback.
<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added type annotations to the `filldedent` function in misc.py
<!-- END RELEASE NOTES -->
