### PR TITLE
nonlinsolve: Implement Complex decomposition

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1632,6 +1633,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Varad Karre <varadkarre20@gmail.com> Varad Karre <158260791+knwldgevrkr@users.noreply.github.com>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
@@ -1838,5 +1840,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Varad Karre <varadkarre20@gmail.com> <158260791+knwldgevrkr@users.noreply.github.com>
-

--- a/.mailmap
+++ b/.mailmap
@@ -1838,3 +1838,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Varad Karre <varadkarre20@gmail.com> <158260791+knwldgevrkr@users.noreply.github.com>
+

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -4078,6 +4078,20 @@ def nonlinsolve(system, *symbols):
         soln = nonlinsolve(system, symbols)
         return FiniteSet(*[tuple(i.xreplace(swap) for i in s) for s in soln])
 
+    from sympy import re, im
+
+# Guard ONLY the ambiguous case:
+# single symbol + explicit re/im usage
+    if len(symbols) == 1:
+        sym = symbols[0]
+        if any(eq.has(re(sym)) or eq.has(im(sym)) for eq in system):
+            raise ValueError(
+                "nonlinsolve does not support re(x)/im(x) with a single complex symbol. "
+                "Introduce explicit real variables, e.g. x = a + b*I, and solve for [a, b]."
+            )
+
+
+
     if len(system) == 1 and len(symbols) == 1:
         return _solveset_work(system, symbols)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -4146,7 +4146,7 @@ def nonlinsolve(system, *symbols):
             # This fixes the x**2 + 1 case where r = -2*I was returned by "solve".
             is_valid_sol = True
             for s, val in sol_map.items():
-                if s.is_real and val.has(I):
+                if s.is_real and val.is_real is False:
                     is_valid_sol = False
                     break
             if not is_valid_sol:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -33,7 +33,7 @@ from sympy.functions import (log, tan, cot, sin, cos, sec, csc, exp,
                              acos, asin, atan, acot, acsc, asec,
                              piecewise_fold, Piecewise)
 from sympy.functions.combinatorial.numbers import totient
-from sympy.functions.elementary.complexes import Abs, arg, re, im
+from sympy.functions.elementary.complexes import Abs, arg, re, im, conjugate
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
                             sinh, cosh, tanh, coth, sech, csch,
                             asinh, acosh, atanh, acoth, asech, acsch)
@@ -3899,6 +3899,58 @@ def _handle_poly(polys, symbols):
 
     return poly_sol, poly_eqs
 
+def _handle_complex_components(system, symbols):
+    """
+    Experimental helper: decompose symbols appearing inside re()/im()/conjugate()
+    into real variables and reconstruct solutions.
+    """
+    # We define the list of functions that requires decomposition
+    complex_projections = (re, im, conjugate, Abs, arg)
+
+    new_system = list(system)
+    sym_mapping = {}
+    reconstruction = {}
+
+    dirty = False
+
+    for sym in symbols:
+        # Skip if already real and also real infinities(this is inserted after checking predefined test cases)
+        if sym.is_real or sym.is_extended_real:
+            continue
+
+        # Check if the symbol is trapped inside ANY of the projection functions
+        # (re, im, conjugate, Abs, arg)
+        is_projected = any(
+            any(eq.has(func(sym)) for func in complex_projections) 
+            for eq in system
+        )
+
+        if is_projected:
+            dirty = True
+            #creating dummies which will help us avoid namespace collision
+            r = Dummy(f're_{sym.name}', real=True)
+            i = Dummy(f'im_{sym.name}', real=True)
+
+            decomposition = r + I*i
+
+            sym_mapping[sym] = (r, i)
+            reconstruction[sym] = decomposition
+
+            # Replacing the decomposed form in the entire system (ex: x -> r + I*i)
+            new_system = [eq.subs(sym, decomposition) for eq in new_system]
+
+    if not dirty:
+        return None, None, None
+
+    new_symbols = []
+    for sym in symbols:
+        if sym in sym_mapping:
+            new_symbols.extend(sym_mapping[sym])
+        else:
+            new_symbols.append(sym)
+
+    return new_system, new_symbols, reconstruction
+
 
 def nonlinsolve(system, *symbols):
     r"""
@@ -4073,23 +4125,49 @@ def nonlinsolve(system, *symbols):
 
     symbols = list(map(_sympify, symbols))
     system = [_sympify(eq) for eq in system]
+    #calling helper function to decompose complex projection to 2-D real constraints
+    res = _handle_complex_components(system, symbols)
+    
+    if res[0] is not None:
+        res_system, res_symbols, reconstruction = res
+
+        # Recursively calling nonlinsolve to solve the new "Real" system
+        raw = nonlinsolve(res_system, res_symbols)
+
+        if raw is S.EmptySet or isinstance(raw, ConditionSet):
+            return raw
+
+        rebuilt = set()
+        for sol in raw:
+            # Mapping the solved values to the dummy symbols
+            sol_map = dict(zip(res_symbols, sol))
+            
+            # --- filtering step: Reject "Real" variables that turned out Imaginary ---
+            # This fixes the x**2 + 1 case where r = -2*I was returned by "solve".
+            is_valid_sol = True
+            for s, val in sol_map.items():
+                if s.is_real and val.has(I):
+                    is_valid_sol = False
+                    break
+            if not is_valid_sol:
+                continue
+
+            final_tuple = []
+            for s in symbols:
+                if s in reconstruction:
+                    # Reconstructing complex ( ex: x = r + I*i)
+                    final_tuple.append(reconstruction[s].subs(sol_map))
+                else:
+                    final_tuple.append(sol_map[s])
+            
+            rebuilt.add(tuple(final_tuple))
+
+        return FiniteSet(*rebuilt)
+
     system, symbols, swap = recast_to_symbols(system, symbols)
     if swap:
         soln = nonlinsolve(system, symbols)
         return FiniteSet(*[tuple(i.xreplace(swap) for i in s) for s in soln])
-
-    from sympy import re, im
-
-# Guard ONLY the ambiguous case:
-# single symbol + explicit re/im usage
-    if len(symbols) == 1:
-        sym = symbols[0]
-        if any(eq.has(re(sym)) or eq.has(im(sym)) for eq in system):
-            raise ValueError(
-                "nonlinsolve does not support re(x)/im(x) with a single complex symbol. "
-                "Introduce explicit real variables, e.g. x = a + b*I, and solve for [a, b]."
-            )
-
 
 
     if len(system) == 1 and len(symbols) == 1:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3901,7 +3901,7 @@ def _handle_poly(polys, symbols):
 
 def _handle_complex_components(system, symbols):
     """
-    Experimental helper: decompose symbols appearing inside re()/im()/conjugate()
+    Decompose symbols appearing inside re()/im()/conjugate()
     into real variables and reconstruct solutions.
     """
     # We define the list of functions that requires decomposition
@@ -3940,7 +3940,7 @@ def _handle_complex_components(system, symbols):
             new_system = [eq.subs(sym, decomposition) for eq in new_system]
 
     if not dirty:
-        return None, None, None
+        return None
 
     new_symbols = []
     for sym in symbols:
@@ -4128,7 +4128,7 @@ def nonlinsolve(system, *symbols):
     #calling helper function to decompose complex projection to 2-D real constraints
     res = _handle_complex_components(system, symbols)
 
-    if res[0] is not None:
+    if res is not None:
         res_system, res_symbols, reconstruction = res
 
         # Recursively calling nonlinsolve to solve the new "Real" system

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3921,7 +3921,7 @@ def _handle_complex_components(system, symbols):
         # Check if the symbol is trapped inside ANY of the projection functions
         # (re, im, conjugate, Abs, arg)
         is_projected = any(
-            any(eq.has(func(sym)) for func in complex_projections) 
+            any(eq.has(func(sym)) for func in complex_projections)
             for eq in system
         )
 
@@ -4127,7 +4127,7 @@ def nonlinsolve(system, *symbols):
     system = [_sympify(eq) for eq in system]
     #calling helper function to decompose complex projection to 2-D real constraints
     res = _handle_complex_components(system, symbols)
-    
+
     if res[0] is not None:
         res_system, res_symbols, reconstruction = res
 
@@ -4141,7 +4141,7 @@ def nonlinsolve(system, *symbols):
         for sol in raw:
             # Mapping the solved values to the dummy symbols
             sol_map = dict(zip(res_symbols, sol))
-            
+
             # --- filtering step: Reject "Real" variables that turned out Imaginary ---
             # This fixes the x**2 + 1 case where r = -2*I was returned by "solve".
             is_valid_sol = True
@@ -4159,7 +4159,7 @@ def nonlinsolve(system, *symbols):
                     final_tuple.append(reconstruction[s].subs(sol_map))
                 else:
                     final_tuple.append(sol_map[s])
-            
+
             rebuilt.add(tuple(final_tuple))
 
         return FiniteSet(*rebuilt)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1877,6 +1877,17 @@ def test_raise_exception_nonlinsolve():
     raises(ValueError, lambda: nonlinsolve([x**2 -1]))
 
 
+def test_nonlinsolve_re_im_single_symbol_raises():
+    from sympy import symbols, re, im
+    from sympy.solvers.solveset import nonlinsolve
+    from pytest import raises
+
+    x = symbols('x')
+    with raises(ValueError):
+        nonlinsolve([re(x) - 1, im(x) - 2], [x])
+
+
+
 def test_trig_system():
     # TODO: add more simple testcases when solveset returns
     # simplified soln for Trig eq

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1945,7 +1945,6 @@ def test_nonlinsolve_complex_regressions():
 def test_nonlinsolve_trig_safety():
     # Ensure the decomposition logic doesn't interfere with trigonometric solving
     x = symbols('x')
-    n = symbols('n', integer=True)
 
     # 1. Standard Intersection
     res = nonlinsolve([cos(x) - S.Half, sin(x) - sqrt(3)/2], [x])

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1972,6 +1972,14 @@ def test_nonlinsolve_formerly_failing_abs_cases():
     assert sol_y == 2
 
 
+def test_nonlinsolve_casus_irreducibilis():
+    # these test verifies whether the implementation is correctly resolving valid real roots that contain I (Casus Irreducibilis).
+    x = symbols('x', real=True)
+    eq = 2*x**3 - 9*x**2 - 67*x + 3
+    sol = nonlinsolve([eq], [x])
+    assert len(sol) == 3
+
+
 def test_raise_exception_nonlinsolve():
     raises(IndexError, lambda: nonlinsolve([x**2 -1], []))
     raises(ValueError, lambda: nonlinsolve([x**2 -1]))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #28851


#### Brief description of what is fixed or changed

This PR fixes incorrect EmptySet results in `nonlinsolve` for systems involving non-holomorphic complex projections such as `re`, `im`, `Abs`, `conjugate`, and `arg`.

Previously, `nonlinsolve` attempted to solve such systems using standard polynomial algebra directly on the complex symbol x. This fails when x is implicitly constrained through non-holomorphic functions, because x is not treated as `x = re(x) + I*im(x)`, causing the solver to be unable to isolate the variable and incorrectly return EmptySet even when valid solutions exist.

This PR introduces a implementation  based on decomposition strategy:

- Detection: The solver scans equations to detect symbols trapped inside non-holomorphic functions (re, im, Abs, conjugate, arg).

- Decomposition: Such symbols are decomposed into real components using fresh dummy variables:
x → r + I*d, where r and d represent the real and imaginary parts.

- Transformation: The original system is rewritten in terms of these real components, converting complex projections into real polynomial or linear constraints.

- Filtering: solutions that violate real/imaginary consistency (e.g., re(x) evaluated to imaginary values) are filtered out. for ex:  case `[x**2 + 1, im(x) - 1]`  which outputs `[{x: -I, re(x): -2*I, im(x): 1}, {x: I, re(x): 0, im(x): 1}]` using `solve` but the fact ` re(x): -2*I` doesn't make any sense.

- Reconstruction: Valid solutions are reconstructed back into complex form for the final result.

This allows nonlinsolve to correctly solve systems involving complex projections instead of misleadingly return of `EmptySet`.

Example:

```python
from sympy import *
x = symbols("x")
nonlinsolve([re(x) - 1, im(x) - 2], [x])
```
Before: Returned `EmptySet`
Now: `{(1 + 2*I,)}`

#### Other comments

- The decomposition uses internally generated dummy symbols to avoid namespace collisions.
- The fix resolves the original motivation of the issue rather than masking it with an error.
- Extensive tests were validated against solve where applicable, and discrepancies in solve behavior are now made explicit.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->

* solvers
  * Improved `nonlinsolve` handling of complex systems involving non-holomorphic functions (`re`, `im`, `Abs`, `conjugate`,`arg`) by decomposing complex symbols into real components, enabling correct solution reconstruction instead of returning incorrect `EmptySet`

<!-- END RELEASE NOTES -->
