### PR TITLE
Handle 1x1 matrices as scalars in joint RV pdf (#28837)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1633,6 +1633,7 @@ Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
 Vansh Agarwal <vanshagbly6@gmail.com> <148854295+VanshAgarwal24036@users.noreply.github.com>
+Vansh Agarwal <vanshagbly6@gmail.com> <vanshagbly6@gmail.com>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1632,6 +1632,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Vansh Agarwal <vanshagbly6@gmail.com> <148854295+VanshAgarwal24036@users.noreply.github.com>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -171,14 +171,21 @@ class MultivariateNormalDistribution(JointDistribution):
     def pdf(self, *args):
         mu, sigma = self.mu, self.sigma
         k = mu.shape[0]
-        if len(args) == 1 and args[0].is_Matrix:
-            args = args[0]
+        if len(args) == 1 and getattr(args[0], "is_Matrix", False):
+            arg = args[0]
+            if getattr(arg, "shape", None) == (1, 1):
+                args = ImmutableMatrix([arg[0, 0]])
+            else:
+                args = arg
         else:
             args = ImmutableMatrix(args)
         x = args - mu
-        density = S.One/sqrt((2*pi)**(k)*det(sigma))*exp(
-            Rational(-1, 2)*x.transpose()*(sigma.inv()*x))
+        density = S.One/sqrt((2*pi)**k * det(sigma)) * exp(
+            Rational(-1, 2) * x.transpose() * (sigma.inv() * x)
+        )
         return MatrixElement(density, 0, 0)
+
+
 
     def _marginal_distribution(self, indices, sym):
         sym = ImmutableMatrix([Indexed(sym, i) for i in indices])

--- a/sympy/stats/tests/test_joint_rv_types.py
+++ b/sympy/stats/tests/test_joint_rv_types.py
@@ -1,0 +1,9 @@
+from sympy import Matrix
+from sympy.stats import MultivariateNormal, density
+
+def test_singleton_matrix_pdf_equals_scalar():
+    M = Matrix([[1]])
+    X = MultivariateNormal('X', M, M)
+    pdf = density(X)
+
+    assert pdf(Matrix([[1]])) == pdf(1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #28837

#### Brief description of what is fixed or changed

Passing a 1×1 matrix as the observation to the PDF of a joint random
variable (such as `MultivariateNormal`) previously caused it to be
treated as a matrix-valued argument rather than as a scalar. This could
lead to inconsistent expression structure compared with scalar
arguments, and also surface attribute-access issues when the argument
was not a SymPy object.

This PR normalizes 1×1 matrix observations so that they are treated as
scalars inside `JointRandomDistribution.pdf`, while leaving higher-
dimensional matrices unchanged. Matrix detection is done safely using
`getattr` so that plain Python objects do not raise errors.

A regression test is added to ensure that:

```python
density(X)(Matrix([[1]])) == density(X)(1)```

#### Other comments

This preserves the previous symbolic form for genuine matrix
observations and improves consistency for singleton matrices.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* stats
  * 1×1 matrix observations in joint random variable PDFs are now treated as scalars for consistency with scalar inputs.
<!-- END RELEASE NOTES -->