### PR TITLE
Fix intersection of ImageSet with Integers for irrational linear maps

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1694,6 +1694,7 @@ Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
 Yeshwanth N <yeshsurya@gmail.com> <yeshwanth.nagaraj@aptean.com>
 YiDing Jiang <yidinggjiangg@gmail.com>
 Yicong Guo <guoyicong100@gmail.com>
+Yifan Deng <1282545992@qq.com>
 Yogesh Mishra <ymishra013@gmail.com> yogesh1997 <ymishra013@gmail.com>
 Your Name <your.email@example.com>
 Yu Kobayashi <yukoba@accelart.jp>

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -279,10 +279,10 @@ def _(self, other):
             # TypeError if equation not polynomial with rational coeff.
             # NotImplementedError if correct format but no solver.
 
-            # Fallback：handel issue #18081
+            # Fallback: handel issue #18081
             # ImageSet(Lambda(n, f(n)), Integers).intersection(S.Integers)
-            # f(n) is linear in n（f(n) = a*n + b），
-            # Moreover, diophantine failed due to non-rational coefficients.
+            # f(n) is linear in n (f(n) = a*n + b), a != 0, 
+            # Moreover, diophantine failed due to non-rational coefficients
             if other is S.Integers and gm == m:
                 # f(n) = self.lamda.expr
                 f = fn
@@ -299,13 +299,14 @@ def _(self, other):
                         elif value0.is_rational:
                             return S.EmptySet
                     else:
-                        # a != 0，f(n) = a*n + b， If there is an integer solution at this point,
+                        # f(n) = a*n + b. If there is an integer solution in this case,
                         # It can only be n=0, and the corresponding value is f (0)=b.
                         if value0.is_integer:
                             return FiniteSet(value0)
                         elif value0.is_rational:
                             return S.EmptySet
 
+            #Leave other more complex situations to the default logic for processing
             return
         # 3 cases are possible for solns:
         # - empty set,

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -281,7 +281,7 @@ def _(self, other):
 
             # Fallback: handel issue #18081
             # ImageSet(Lambda(n, f(n)), Integers).intersection(S.Integers)
-            # f(n) is linear in n (f(n) = a*n + b), a != 0, 
+            # f(n) is linear in n (f(n) = a*n + b), a != 0,
             # Moreover, diophantine failed due to non-rational coefficients
             if other is S.Integers and gm == m:
                 # f(n) = self.lamda.expr

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -292,7 +292,7 @@ def _(self, other):
                     a = fprime
                     value0 = f.subs(n, 0)
 
-                    # a == 0: f (n) is a constant mapping {value0}
+                    # a == 0: f(n) is a constant mapping {value0}
                     if a.is_zero:
                         if value0.is_integer:
                             return FiniteSet(value0)

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -279,7 +279,7 @@ def _(self, other):
             # TypeError if equation not polynomial with rational coeff.
             # NotImplementedError if correct format but no solver.
 
-            # Fallback: handel issue #18081
+            # Fallback: handle issue #18081
             # ImageSet(Lambda(n, f(n)), Integers).intersection(S.Integers)
             # f(n) is linear in n (f(n) = a*n + b), a != 0,
             # Moreover, diophantine failed due to non-rational coefficients

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -300,7 +300,7 @@ def _(self, other):
                             return S.EmptySet
                     else:
                         # f(n) = a*n + b. If there is an integer solution in this case,
-                        # It can only be n=0, and the corresponding value is f (0)=b.
+                        # It can only be n=0, and the corresponding value is f(0)=b.
                         if value0.is_integer:
                             return FiniteSet(value0)
                         elif value0.is_rational:

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -69,10 +69,10 @@ def test_imageset():
         Add(x, y), Interval(1, 2), Interval(2, 3)).dummy_eq(
         ImageSet(Lambda((x1, x2), x1 + x2),
         Interval(1, 2), Interval(2, 3)))
-        
+
 def test_imageset_integer_intersection_irrational():
     # Regression Test: Issue # 18081
-    # #Imageset (Lambda (n, n * log (2)), S.Integer)&S.Integer should be {0}
+    # Imageset (Lambda (n, n * log (2)), S.Integer)&S.Integer should be {0}
     ints = S.Integers
     A = imageset(n, n*log(2), ints)
     assert A.intersection(ints) == FiniteSet(0)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -9,6 +9,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
+from sympy import log
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.logic.boolalg import (false, true)
@@ -68,6 +69,14 @@ def test_imageset():
         Add(x, y), Interval(1, 2), Interval(2, 3)).dummy_eq(
         ImageSet(Lambda((x1, x2), x1 + x2),
         Interval(1, 2), Interval(2, 3)))
+        
+def test_imageset_integer_intersection_irrational():
+    # Regression Test: Issue # 18081
+    # #Imageset (Lambda (n, n * log (2)), S.Integer)&S.Integer should be {0}
+    ints = S.Integers
+    A = imageset(n, n*log(2), ints)
+    assert A.intersection(ints) == FiniteSet(0)
+
 
 
 def test_is_empty():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #18081

#### Brief description of what is fixed or changed

When intersecting an `ImageSet` over `S.Integers` with `S.Integers`, the `intersection_sets(ImageSet, Set)` handler currently calls:

```python
diophantine(fn - gm, syms=(n, m), permute=True)
```

If `fn` is an affine function of `n` with non-rational coefficients (e.g. `fn = n*log(2)`), `diophantine` raises `TypeError` and the intersection is left unevaluated. As a result, expressions such as:

```python
imageset(Lambda(n, n*log(2)), S.Integers).intersection(S.Integers)
```

do not simplify to a concrete set.

This PR adds a small, conservative fallback for the simple linear case:

```python
ImageSet(Lambda(n, f(n)), S.Integers).intersection(S.Integers)
```

where `f(n)` is affine in `n`. When `diophantine` fails and `f(n)` is linear in `n`, the code checks the value of `f(0)`:

- if `f(0)` is an integer, the intersection is `{f(0)}`;
- if `f(0)` is a non-integer rational, the intersection is `EmptySet`.

More complicated cases are left to the existing logic.

A regression test is added to `sympy/sets/tests/test_sets.py` to cover:

```python
imageset(Lambda(n, n*log(2)), S.Integers).intersection(S.Integers)
```

which should now return `{0}`.

#### Other comments

The fallback is intentionally restricted to a simple and mathematically well-understood case (affine maps in one integer variable, with `diophantine` not applicable due to non-rational coefficients), so as not to interfere with other uses of `intersection_sets(ImageSet, Set)`.

I am happy to adjust the structure or conditions if there is a preferred pattern for handling similar special cases.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed the intersection of `ImageSet` over integers with `S.Integers` when the image
    map is an affine function with non-rational coefficients. For example,
    `imageset(Lambda(n, n*log(2)), S.Integers).intersection(S.Integers)` now correctly
    returns `{0}`.
<!-- END RELEASE NOTES -->
