### PR TITLE
Fix: ask(False, False) returns False instead of raising ValueError

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -6,7 +6,6 @@ from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
 from sympy.core import sympify
 from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
-from sympy.core.singleton import S
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
 from sympy.utilities.exceptions import (sympy_deprecation_warning,
@@ -502,7 +501,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
 
-    if assumptions is S.false:
+    if satisfiable(assumptions) is False:
         raise ValueError("inconsistent assumptions")
 
     if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -6,6 +6,7 @@ from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
 from sympy.core import sympify
 from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
+from sympy.core.singleton import S
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
 from sympy.utilities.exceptions import (sympy_deprecation_warning,
@@ -500,6 +501,9 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
+
+    if assumptions is S.false:
+        raise ValueError("inconsistent assumptions")
 
     if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2583,3 +2583,6 @@ def test_issue_28127():
     assert ask(Q.gt(y,x), Q.lt(x,y)) is True
     assert ask(Q.lt(y,x), Q.gt(x,y)) is True
     assert ask(Q.le(y,x), Q.ge(x,y)) is True
+
+def test_issue_27964():
+    raises(ValueError, lambda: ask(False, False))

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2586,3 +2586,5 @@ def test_issue_28127():
 
 def test_issue_27964():
     raises(ValueError, lambda: ask(False, False))
+    raises(ValueError, lambda: ask(False, Q.is_true(x) & ~Q.is_true(x)))
+    raises(ValueError, lambda: ask(False, (x | y) & ~x & ~y))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Issue: #27964

#### Brief description of PR
`ask(False, False)` returns False which is mathematically incorrect because the logical implication False $\implies$ False is True.

However as discussed in #27964 passing `False` as an assumption indicates logical error. So instead of returning True, it is better to raise a `ValueError`. 

A new test case has been added to `assumptions/tests/test_query.py` to ensure consistent behavior


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added a check to raise `ValueError` immediately is assumptions is `S.false` in the function `ask`
<!-- END RELEASE NOTES -->
