### PR TITLE
Standardize array rank deprecations to ndim

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -754,6 +754,7 @@ Idan Pazi <idan.kp@gmail.com>
 Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>
+Ishan Khan <ishan372or@gmail.com> ishan372or <ishan372or@gmail.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <ishan9096137017@gmail.com>

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -139,13 +139,15 @@ is umaintained and cannot be installed on Python 3.13.
 (rename-rank-to-ndim)=
 ### Rename `get_rank` to `get_ndim` in array expressions
 
-In the array expressions subsystem, the function `get_rank(expr)` used the term
-*rank* to refer to the number of dimensions of an array, which is confusing
-because “rank” usually means matrix rank.
+In the array expressions subsystem, the function `get_rank(expr)` historically
+used the term *rank* to refer to the number of dimensions of an array. This is
+confusing, because “rank” is widely understood to mean the linear-algebraic
+matrix rank, which is a different concept.
 
-`get_rank(expr)` is deprecated and replaced by `get_ndim(expr)`.
+To avoid this ambiguity, `get_rank(expr)` is deprecated and replaced by
+`get_ndim(expr)`.
 
-Replace:
+#### Deprecated usage
 
 ```python
 get_rank(expr)

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -139,18 +139,14 @@ is umaintained and cannot be installed on Python 3.13.
 (rename-rank-to-ndim)=
 ### Rename `get_rank` to `get_ndim` in array expressions
 
-In the array expressions subsystem, the function `get_rank(expr)` historically
-used the term *rank* to refer to the number of dimensions of an array. This is
-confusing, because “rank” is widely understood to mean the linear-algebraic
-matrix rank, which is a different concept.
+In the array expressions subsystem, the function `get_rank(expr)` used the term
+*rank* to refer to the number of dimensions of an array, which is confusing
+because “rank” usually means matrix rank.
 
-To avoid this ambiguity, `get_rank(expr)` is deprecated and replaced by
-`get_ndim(expr)`.
+`get_rank(expr)` is deprecated and replaced by `get_ndim(expr)`.
 
-#### Deprecated usage
-
-```python
-get_rank(expr)
+```py
+>>> get_rank(expr)  # doctest: +SKIP
 
 (deprecated-mechanics-body-class)=
 ### Deprecated mechanics Body class

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -136,6 +136,20 @@ is umaintained and cannot be installed on Python 3.13.
 
 ## Version 1.13
 
+(rename-rank-to-ndim)=
+### Rename `get_rank` to `get_ndim` in array expressions
+
+In the array expressions subsystem, the function `get_rank(expr)` used the term
+*rank* to refer to the number of dimensions of an array, which is confusing
+because “rank” usually means matrix rank.
+
+`get_rank(expr)` is deprecated and replaced by `get_ndim(expr)`.
+
+Replace:
+
+```python
+get_rank(expr)
+
 (deprecated-mechanics-body-class)=
 ### Deprecated mechanics Body class
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -431,13 +431,13 @@ class ArrayPrinter:
         except Exception: # noqa: BLE001
             return indexed
 
-    def _get_einsum_string(self, subranks, contraction_indices):
+    def _get_einsum_string(self, ndims, contraction_indices):
         letters = self._get_letter_generator_for_einsum()
         contraction_string = ""
         counter = 0
         d = {j: min(i) for i in contraction_indices for j in i}
         indices = []
-        for rank_arg in subranks:
+        for rank_arg in ndims:
             lindices = []
             for i in range(rank_arg):
                 if counter in d:
@@ -475,7 +475,7 @@ class ArrayPrinter:
 
     def _print_ArrayTensorProduct(self, expr):
         letters = self._get_letter_generator_for_einsum()
-        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.subranks])
+        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.ndims])
         return '%s("%s", %s)' % (
                 self._module_format(self._module + "." + self._einsum),
                 contraction_string,
@@ -489,7 +489,7 @@ class ArrayPrinter:
 
         if isinstance(base, ArrayTensorProduct):
             elems = ",".join(["%s" % (self._print(arg)) for arg in base.args])
-            ranks = base.subranks
+            ranks = base.ndims
         else:
             elems = self._print(base)
             ranks = [len(base.shape)]
@@ -512,12 +512,12 @@ class ArrayPrinter:
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
         diagonal_indices = list(expr.diagonal_indices)
         if isinstance(expr.expr, ArrayTensorProduct):
-            subranks = expr.expr.subranks
+            ndims = expr.expr.ndims
             elems = expr.expr.args
         else:
-            subranks = expr.subranks
+            ndims = expr.ndims
             elems = [expr.expr]
-        diagonal_string, letters_free, letters_dum = self._get_einsum_string(subranks, diagonal_indices)
+        diagonal_string, letters_free, letters_dum = self._get_einsum_string(ndims, diagonal_indices)
         elems = [self._print(i) for i in elems]
         return '%s("%s", %s)' % (
             self._module_format(self._module + "." + self._einsum),

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -105,7 +105,7 @@ def _util_contraction_diagonal(array, *contraction_or_diagonal_axes):
                 raise ValueError("cannot contract or diagonalize between axes of different dimension")
             taken_dims.add(d)
 
-    ndim = array.ndim()
+    ndim = array.rank()
 
     remaining_shape = [dim for i, dim in enumerate(array.shape) if i not in taken_dims]
     cum_shape = [0]*ndim
@@ -434,7 +434,7 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     if not isinstance(perm, Permutation):
         perm = Permutation(list(perm))
 
-    if perm.size != expr.ndim():
+    if perm.size != expr.rank():
         raise ValueError("wrong permutation size")
 
     # Get the inverse permutation:

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -105,14 +105,14 @@ def _util_contraction_diagonal(array, *contraction_or_diagonal_axes):
                 raise ValueError("cannot contract or diagonalize between axes of different dimension")
             taken_dims.add(d)
 
-    rank = array.rank()
+    ndim = array.ndim()
 
     remaining_shape = [dim for i, dim in enumerate(array.shape) if i not in taken_dims]
-    cum_shape = [0]*rank
+    cum_shape = [0]*ndim
     _cumul = 1
-    for i in range(rank):
-        cum_shape[rank - i - 1] = _cumul
-        _cumul *= int(array.shape[rank - i - 1])
+    for i in range(ndim):
+        cum_shape[ndim - i - 1] = _cumul
+        _cumul *= int(array.shape[ndim - i - 1])
 
     # DEFINITION: by absolute position it is meant the position along the one
     # dimensional array containing all the tensor components.
@@ -122,7 +122,7 @@ def _util_contraction_diagonal(array, *contraction_or_diagonal_axes):
 
     # Determine absolute positions of the uncontracted indices:
     remaining_indices = [[cum_shape[i]*j for j in range(array.shape[i])]
-                         for i in range(rank) if i not in taken_dims]
+                         for i in range(ndim) if i not in taken_dims]
 
     # Determine absolute positions of the contracted indices:
     summed_deltas = []
@@ -422,8 +422,8 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     from sympy.tensor.array.expressions.array_expressions import _permute_dims
     from sympy.matrices.expressions.matexpr import MatrixSymbol
     from sympy.tensor.array.expressions import PermuteDims
-    from sympy.tensor.array.expressions.array_expressions import get_rank
-    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_rank(expr))
+    from sympy.tensor.array.expressions.array_expressions import get_ndim
+    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_ndim(expr))
     if isinstance(expr, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
         return _permute_dims(expr, perm)
 
@@ -434,7 +434,7 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     if not isinstance(perm, Permutation):
         perm = Permutation(list(perm))
 
-    if perm.size != expr.rank():
+    if perm.size != expr.ndim():
         raise ValueError("wrong permutation size")
 
     # Get the inverse permutation:

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -30,11 +30,12 @@ from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.indexed import (Indexed, IndexedBase)
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.utils import _apply_recursively_over_nested_lists, _sort_contraction_indices, \
-    _get_mapping_from_subranks, _build_push_indices_up_func_transformation, _get_contraction_links, \
+    _get_mapping_from_ndims, _build_push_indices_up_func_transformation, _get_contraction_links, \
     _build_push_indices_down_func_transformation
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import _af_invert
 from sympy.core.sympify import _sympify
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 
 class _ArrayExpr(Expr):
@@ -215,11 +216,12 @@ class _CodegenArrayAbstract(Expr):
     is_Atom = True
 
     @property
-    def subranks(self):
+    def ndims(self):
         """
-        Returns the ranks of the objects in the uppermost tensor product inside
-        the current object.  In case no tensor products are contained, return
-        the atomic ranks.
+        Returns the number of dimensions (ndim) of the objects in the
+        uppermost tensor product inside the current object.
+
+        In case no tensor products are contained, return the atomic ndims.
 
         Examples
         ========
@@ -230,23 +232,43 @@ class _CodegenArrayAbstract(Expr):
         >>> N = MatrixSymbol("N", 3, 3)
         >>> P = MatrixSymbol("P", 3, 3)
 
-        Important: do not confuse the rank of the matrix with the rank of an array.
+
 
         >>> tp = tensorproduct(M, N, P)
-        >>> tp.subranks
+        >>> tp.ndims
         [2, 2, 2]
 
         >>> co = tensorcontraction(tp, (1, 2), (3, 4))
-        >>> co.subranks
+        >>> co.ndims
         [2, 2, 2]
+
         """
-        return self._subranks[:]
+        return self._ndims[:]
+
+    def ndim_total(self):
+        """
+        The total number of dimensions (ndim), equal to the sum of ``ndims``.
+        """
+        return sum(self.ndims)
+
+    @property
+    def subranks(self):
+        sympy_deprecation_warning(
+            "subranks is deprecated; use ndims instead.",
+            deprecated_since_version="1.13",
+            active_deprecations_target="arrayexpr-subranks",
+            stacklevel=7
+        )
+        return self.ndims
 
     def subrank(self):
-        """
-        The sum of ``subranks``.
-        """
-        return sum(self.subranks)
+        sympy_deprecation_warning(
+            "subrank is deprecated; use ndim_total instead.",
+            deprecated_since_version="1.13",
+            active_deprecations_target="arrayexpr-subrank",
+            stacklevel=7
+        )
+        return self.ndim_total()
 
     @property
     def shape(self):
@@ -270,10 +292,10 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
 
         canonicalize = kwargs.pop("canonicalize", False)
 
-        ranks = [get_rank(arg) for arg in args]
+        ndims = [get_ndim(arg) for arg in args]
 
         obj = Basic.__new__(cls, *args)
-        obj._subranks = ranks
+        obj._ndims = ndims
         shapes = [get_shape(i) for i in args]
 
         if any(i is None for i in shapes):
@@ -288,7 +310,7 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         args = self.args
         args = self._flatten(args)
 
-        ranks = [get_rank(arg) for arg in args]
+        ndims = [get_ndim(arg) for arg in args]
 
         # Check if there are nested ArraySum objects:
         array_sums_i = []
@@ -315,10 +337,10 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         for i, arg in enumerate(args):
             if not isinstance(arg, PermuteDims):
                 continue
-            permutation_cycles.extend([[k + sum(ranks[:i]) for k in j] for j in arg.permutation.cyclic_form])
+            permutation_cycles.extend([[k + sum(ndims[:i]) for k in j] for j in arg.permutation.cyclic_form])
             args[i] = arg.expr
         if permutation_cycles:
-            return _permute_dims(_array_tensor_product(*args), Permutation(sum(ranks)-1)*Permutation(permutation_cycles))
+            return _permute_dims(_array_tensor_product(*args), Permutation(sum(ndims)-1)*Permutation(permutation_cycles))
 
         if len(args) == 1:
             return args[0]
@@ -332,31 +354,31 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         # expression into `ArrayContraction`:
         contractions = {i: arg for i, arg in enumerate(args) if isinstance(arg, ArrayContraction)}
         if contractions:
-            ranks = [_get_subrank(arg) if isinstance(arg, ArrayContraction) else get_rank(arg) for arg in args]
-            cumulative_ranks = list(accumulate([0] + ranks))[:-1]
+            ndims = [_get_ndim_total(arg) if isinstance(arg, ArrayContraction) else get_ndim(arg) for arg in args]
+            cumulative_ndims = list(accumulate([0] + ndims))[:-1]
             tp = _array_tensor_product(*[arg.expr if isinstance(arg, ArrayContraction) else arg for arg in args])
-            contraction_indices = [tuple(cumulative_ranks[i] + k for k in j) for i, arg in contractions.items() for j in arg.contraction_indices]
+            contraction_indices = [tuple(cumulative_ndims[i] + k for k in j) for i, arg in contractions.items() for j in arg.contraction_indices]
             return _array_contraction(tp, *contraction_indices)
 
         diagonals = {i: arg for i, arg in enumerate(args) if isinstance(arg, ArrayDiagonal)}
         if diagonals:
             inverse_permutation = []
             last_perm = []
-            ranks = [get_rank(arg) for arg in args]
-            cumulative_ranks = list(accumulate([0] + ranks))[:-1]
+            ndims = [get_ndim(arg) for arg in args]
+            cumulative_ndims = list(accumulate([0] + ndims))[:-1]
             for i, arg in enumerate(args):
                 if isinstance(arg, ArrayDiagonal):
-                    i1 = get_rank(arg) - len(arg.diagonal_indices)
+                    i1 = get_ndim(arg) - len(arg.diagonal_indices)
                     i2 = len(arg.diagonal_indices)
-                    inverse_permutation.extend([cumulative_ranks[i] + j for j in range(i1)])
-                    last_perm.extend([cumulative_ranks[i] + j for j in range(i1, i1 + i2)])
+                    inverse_permutation.extend([cumulative_ndims[i] + j for j in range(i1)])
+                    last_perm.extend([cumulative_ndims[i] + j for j in range(i1, i1 + i2)])
                 else:
-                    inverse_permutation.extend([cumulative_ranks[i] + j for j in range(get_rank(arg))])
+                    inverse_permutation.extend([cumulative_ndims[i] + j for j in range(get_ndim(arg))])
             inverse_permutation.extend(last_perm)
             tp = _array_tensor_product(*[arg.expr if isinstance(arg, ArrayDiagonal) else arg for arg in args])
-            ranks2 = [_get_subrank(arg) if isinstance(arg, ArrayDiagonal) else get_rank(arg) for arg in args]
-            cumulative_ranks2 = list(accumulate([0] + ranks2))[:-1]
-            diagonal_indices = [tuple(cumulative_ranks2[i] + k for k in j) for i, arg in diagonals.items() for j in arg.diagonal_indices]
+            ndims2 = [_get_ndim_total(arg) if isinstance(arg, ArrayDiagonal) else get_ndim(arg) for arg in args]
+            cumulative_ndims2 = list(accumulate([0] + ndims2))[:-1]
+            diagonal_indices = [tuple(cumulative_ndims2[i] + k for k in j) for i, arg in diagonals.items() for j in arg.diagonal_indices]
             return _permute_dims(_array_diagonal(tp, *diagonal_indices), _af_invert(inverse_permutation))
 
         return self.func(*args, canonicalize=False)
@@ -377,10 +399,10 @@ class ArrayAdd(_CodegenArrayAbstract):
 
     def __new__(cls, *args, **kwargs):
         args = [_sympify(arg) for arg in args]
-        ranks = [get_rank(arg) for arg in args]
-        ranks = list(set(ranks))
-        if len(ranks) != 1:
-            raise ValueError("summing arrays of different ranks")
+        ndims = [get_ndim(arg) for arg in args]
+        ndims = list(set(ndims))
+        if len(ndims) != 1:
+            raise ValueError("summing arrays of different ndims")
         shapes = [arg.shape if hasattr(arg, "shape") else () for arg in args]
         if len({i for i in shapes if i is not None}) > 1:
             raise ValueError("mismatching shapes in addition")
@@ -388,7 +410,7 @@ class ArrayAdd(_CodegenArrayAbstract):
         canonicalize = kwargs.pop("canonicalize", False)
 
         obj = Basic.__new__(cls, *args)
-        obj._subranks = ranks
+        obj._ndims = ndims
         if any(i is None for i in shapes):
             obj._shape = None
         else:
@@ -506,17 +528,17 @@ class PermuteDims(_CodegenArrayAbstract):
     def __new__(cls, expr, permutation=None, index_order_old=None, index_order_new=None, **kwargs):
         from sympy.combinatorics import Permutation
         expr = _sympify(expr)
-        expr_rank = get_rank(expr)
-        permutation = cls._get_permutation_from_arguments(permutation, index_order_old, index_order_new, expr_rank)
+        expr_ndim = get_ndim(expr)
+        permutation = cls._get_permutation_from_arguments(permutation, index_order_old, index_order_new, expr_ndim)
         permutation = Permutation(permutation)
         permutation_size = permutation.size
-        if permutation_size != expr_rank:
+        if permutation_size != expr_ndim:
             raise ValueError("Permutation size must be the length of the shape of expr")
 
         canonicalize = kwargs.pop("canonicalize", False)
 
         obj = Basic.__new__(cls, expr, permutation)
-        obj._subranks = [get_rank(expr)]
+        obj._ndims = [get_ndim(expr)]
         shape = get_shape(expr)
         if shape is None:
             obj._shape = None
@@ -559,7 +581,7 @@ class PermuteDims(_CodegenArrayAbstract):
         perm_image_form = _af_invert(permutation.array_form)
         args = list(expr.args)
         # Starting index global position for every arg:
-        cumul = list(accumulate([0] + expr.subranks))
+        cumul = list(accumulate([0] + expr.ndims))
         # Split `perm_image_form` into a list of list corresponding to the indices
         # of every argument:
         perm_image_form_in_components = [perm_image_form[cumul[i]:cumul[i+1]] for i in range(len(args))]
@@ -585,18 +607,18 @@ class PermuteDims(_CodegenArrayAbstract):
         if not isinstance(expr.expr, ArrayTensorProduct):
             return expr, permutation
         args = expr.expr.args
-        subranks = [get_rank(arg) for arg in expr.expr.args]
+        ndims = [get_ndim(arg) for arg in expr.expr.args]
 
         contraction_indices = expr.contraction_indices
         contraction_indices_flat = [j for i in contraction_indices for j in i]
-        cumul = list(accumulate([0] + subranks))
+        cumul = list(accumulate([0] + ndims))
 
         # Spread the permutation in its array form across the args in the corresponding
         # tensor-product arguments with free indices:
         permutation_array_blocks_up = []
         image_form = _af_invert(permutation.array_form)
         counter = 0
-        for i in range(len(subranks)):
+        for i in range(len(ndims)):
             current = []
             for j in range(cumul[i], cumul[i+1]):
                 if j in contraction_indices_flat:
@@ -606,7 +628,7 @@ class PermuteDims(_CodegenArrayAbstract):
             permutation_array_blocks_up.append(current)
 
         # Get the map of axis repositioning for every argument of tensor-product:
-        index_blocks = [list(range(cumul[i], cumul[i+1])) for i, e in enumerate(expr.subranks)]
+        index_blocks = [list(range(cumul[i], cumul[i+1])) for i, e in enumerate(expr.ndims)]
         index_blocks_up = expr._push_indices_up(expr.contraction_indices, index_blocks)
         inverse_permutation = permutation**(-1)
         index_blocks_up_permuted = [[inverse_permutation(j) for j in i if j is not None] for i in index_blocks_up]
@@ -629,9 +651,9 @@ class PermuteDims(_CodegenArrayAbstract):
 
     @classmethod
     def _check_permutation_mapping(cls, expr, permutation):
-        subranks = expr.subranks
-        index2arg = [i for i, arg in enumerate(expr.args) for j in range(expr.subranks[i])]
-        permuted_indices = [permutation(i) for i in range(expr.subrank())]
+        ndims = expr.ndims
+        index2arg = [i for i, arg in enumerate(expr.args) for j in range(expr.ndims[i])]
+        permuted_indices = [permutation(i) for i in range(expr.ndim_total())]
         new_args = list(expr.args)
         arg_candidate_index = index2arg[permuted_indices[0]]
         current_indices = []
@@ -643,8 +665,8 @@ class PermuteDims(_CodegenArrayAbstract):
                 current_indices = []
                 arg_candidate_index = index2arg[idx]
             current_indices.append(idx)
-            arg_candidate_rank = subranks[arg_candidate_index]
-            if len(current_indices) == arg_candidate_rank:
+            arg_candidate_ndim = ndims[arg_candidate_index]
+            if len(current_indices) == arg_candidate_ndim:
                 new_permutation.extend(sorted(current_indices))
                 local_current_indices = [j - min(current_indices) for j in current_indices]
                 i1 = index2arg[i]
@@ -658,9 +680,9 @@ class PermuteDims(_CodegenArrayAbstract):
         args_positions = list(range(len(new_args)))
         # Get possible shifts:
         maps = {}
-        cumulative_subranks = [0] + list(accumulate(subranks))
-        for i in range(len(subranks)):
-            s = {index2arg[new_permutation[j]] for j in range(cumulative_subranks[i], cumulative_subranks[i+1])}
+        cumulative_ndims = [0] + list(accumulate(ndims))
+        for i in range(len(ndims)):
+            s = {index2arg[new_permutation[j]] for j in range(cumulative_ndims[i], cumulative_ndims[i+1])}
             if len(s) != 1:
                 continue
             elem = next(iter(s))
@@ -690,7 +712,7 @@ class PermuteDims(_CodegenArrayAbstract):
                 args_positions[line[(i + 1) % len(line)]] = e
 
         # TODO: function in order to permute the args:
-        permutation_blocks = [[new_permutation[cumulative_subranks[i] + j] for j in range(e)] for i, e in enumerate(subranks)]
+        permutation_blocks = [[new_permutation[cumulative_ndims[i] + j] for j in range(e)] for i, e in enumerate(ndims)]
         new_args = [new_args[i] for i in args_positions]
         new_permutation_blocks = [permutation_blocks[i] for i in args_positions]
         new_permutation2 = [j for i in new_permutation_blocks for j in i]
@@ -699,18 +721,18 @@ class PermuteDims(_CodegenArrayAbstract):
     @classmethod
     def _check_if_there_are_closed_cycles(cls, expr, permutation):
         args = list(expr.args)
-        subranks = expr.subranks
+        ndims = expr.ndims
         cyclic_form = permutation.cyclic_form
-        cumulative_subranks = [0] + list(accumulate(subranks))
+        cumulative_ndims = [0] + list(accumulate(ndims))
         cyclic_min = [min(i) for i in cyclic_form]
         cyclic_max = [max(i) for i in cyclic_form]
         cyclic_keep = []
         for i, cycle in enumerate(cyclic_form):
             flag = True
-            for j in range(len(cumulative_subranks) - 1):
-                if cyclic_min[i] >= cumulative_subranks[j] and cyclic_max[i] < cumulative_subranks[j+1]:
+            for j in range(len(cumulative_ndims) - 1):
+                if cyclic_min[i] >= cumulative_ndims[j] and cyclic_max[i] < cumulative_ndims[j+1]:
                     # Found a sinkable cycle.
-                    args[j] = _permute_dims(args[j], Permutation([[k - cumulative_subranks[j] for k in cycle]]))
+                    args[j] = _permute_dims(args[j], Permutation([[k - cumulative_ndims[j] for k in cycle]]))
                     flag = False
                     break
             if flag:
@@ -814,7 +836,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
             return expr
         obj = Basic.__new__(cls, expr, *diagonal_indices)
         obj._positions = positions
-        obj._subranks = _get_subranks(expr)
+        obj._ndims = _get_ndims(expr)
         obj._shape = shape
         if canonicalize:
             return obj._canonicalize()
@@ -828,20 +850,20 @@ class ArrayDiagonal(_CodegenArrayAbstract):
             trivial_pos = {e[0]: i for i, e in enumerate(diagonal_indices) if len(e) == 1}
             diag_pos = {e: i for i, e in enumerate(diagonal_indices) if len(e) > 1}
             diagonal_indices_short = [i for i in diagonal_indices if len(i) > 1]
-            rank1 = get_rank(self)
-            rank2 = len(diagonal_indices)
-            rank3 = rank1 - rank2
+            ndim1 = get_ndim(self)
+            ndim2 = len(diagonal_indices)
+            ndim3 = ndim1 - ndim2
             inv_permutation = []
             counter1 = 0
-            indices_down = ArrayDiagonal._push_indices_down(diagonal_indices_short, list(range(rank1)), get_rank(expr))
+            indices_down = ArrayDiagonal._push_indices_down(diagonal_indices_short, list(range(ndim1)), get_ndim(expr))
             for i in indices_down:
                 if i in trivial_pos:
-                    inv_permutation.append(rank3 + trivial_pos[i])
+                    inv_permutation.append(ndim3 + trivial_pos[i])
                 elif isinstance(i, (Integer, int)):
                     inv_permutation.append(counter1)
                     counter1 += 1
                 else:
-                    inv_permutation.append(rank3 + diag_pos[i])
+                    inv_permutation.append(ndim3 + diag_pos[i])
             permutation = _af_invert(inv_permutation)
             if len(diagonal_indices_short) > 0:
                 return _permute_dims(_array_diagonal(expr, *diagonal_indices_short), permutation)
@@ -887,9 +909,9 @@ class ArrayDiagonal(_CodegenArrayAbstract):
 
     @staticmethod
     def _flatten(expr: ArrayDiagonal, *outer_diagonal_indices):
-        inddown = ArrayDiagonal._push_indices_down(outer_diagonal_indices, list(range(get_rank(expr))), get_rank(expr))
+        inddown = ArrayDiagonal._push_indices_down(outer_diagonal_indices, list(range(get_ndim(expr))), get_ndim(expr))
         inddown = tuple(i for i in inddown if i)
-        inddow2 = ArrayDiagonal._push_indices_down(expr.diagonal_indices, inddown, get_rank(expr.expr))
+        inddow2 = ArrayDiagonal._push_indices_down(expr.diagonal_indices, inddown, get_ndim(expr.expr))
         new_diag_indices = []
         for i in inddow2:
             if not isinstance(i, (tuple, Tuple)):
@@ -914,7 +936,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
     @classmethod
     def _ArrayDiagonal_denest_PermuteDims(cls, expr: PermuteDims, *diagonal_indices):
         back_diagonal_indices = [[expr.permutation(j) for j in i] for i in diagonal_indices]
-        nondiag = [i for i in range(get_rank(expr)) if not any(i in j for j in diagonal_indices)]
+        nondiag = [i for i in range(get_ndim(expr)) if not any(i in j for j in diagonal_indices)]
         back_nondiag = [expr.permutation(i) for i in nondiag]
         remap = {e: i for i, e in enumerate(sorted(back_nondiag))}
         new_permutation1 = [remap[i] for i in back_nondiag]
@@ -943,14 +965,14 @@ class ArrayDiagonal(_CodegenArrayAbstract):
         return _apply_recursively_over_nested_lists(transform, indices)
 
     @classmethod
-    def _push_indices_down(cls, diagonal_indices, indices, rank):
-        positions, shape = cls._get_positions_shape(range(rank), diagonal_indices)
+    def _push_indices_down(cls, diagonal_indices, indices, ndim):
+        positions, shape = cls._get_positions_shape(range(ndim), diagonal_indices)
         transform = lambda x: positions[x] if x < len(positions) else None
         return _apply_recursively_over_nested_lists(transform, indices)
 
     @classmethod
-    def _push_indices_up(cls, diagonal_indices, indices, rank):
-        positions, shape = cls._get_positions_shape(range(rank), diagonal_indices)
+    def _push_indices_up(cls, diagonal_indices, indices, ndim):
+        positions, shape = cls._get_positions_shape(range(ndim), diagonal_indices)
 
         def transform(x):
             for i, e in enumerate(positions):
@@ -985,7 +1007,7 @@ class ArrayElementwiseApplyFunc(_CodegenArrayAbstract):
             function = Lambda(d, function(d))
 
         obj = _CodegenArrayAbstract.__new__(cls, function, element)
-        obj._subranks = _get_subranks(element)
+        obj._ndims = _get_ndims(element)
         return obj
 
     @property
@@ -1066,10 +1088,10 @@ class ArrayContraction(_CodegenArrayAbstract):
         canonicalize = kwargs.get("canonicalize", False)
 
         obj = Basic.__new__(cls, expr, *contraction_indices)
-        obj._subranks = _get_subranks(expr)
-        obj._mapping = _get_mapping_from_subranks(obj._subranks)
+        obj._ndims = _get_ndims(expr)
+        obj._mapping = _get_mapping_from_ndims(obj._ndims)
 
-        free_indices_to_position = {i: i for i in range(sum(obj._subranks)) if all(i not in cind for cind in contraction_indices)}
+        free_indices_to_position = {i: i for i in range(sum(obj._ndims)) if all(i not in cind for cind in contraction_indices)}
         obj._free_indices_to_position = free_indices_to_position
 
         shape = get_shape(expr)
@@ -1162,8 +1184,8 @@ class ArrayContraction(_CodegenArrayAbstract):
             raise NotImplementedError()
         if not isinstance(expr, ArrayTensorProduct):
             return expr, contraction_indices
-        subranks = expr.subranks
-        cumranks = list(accumulate([0] + subranks))
+        ndims = expr.ndims
+        cumndims = list(accumulate([0] + ndims))
         contraction_indices_remaining = []
         contraction_indices_args = [[] for i in expr.args]
         backshift = set()
@@ -1171,16 +1193,16 @@ class ArrayContraction(_CodegenArrayAbstract):
             for j in range(len(expr.args)):
                 if not isinstance(expr.args[j], ArrayAdd):
                     continue
-                if all(cumranks[j] <= k < cumranks[j+1] for k in contraction_group):
-                    contraction_indices_args[j].append([k - cumranks[j] for k in contraction_group])
+                if all(cumndims[j] <= k < cumndims[j+1] for k in contraction_group):
+                    contraction_indices_args[j].append([k - cumndims[j] for k in contraction_group])
                     backshift.update(contraction_group)
                     break
             else:
                 contraction_indices_remaining.append(contraction_group)
         if len(contraction_indices_remaining) == len(contraction_indices):
             return expr, contraction_indices
-        total_rank = get_rank(expr)
-        shifts = list(accumulate([1 if i in backshift else 0 for i in range(total_rank)]))
+        total_ndim = get_ndim(expr)
+        shifts = list(accumulate([1 if i in backshift else 0 for i in range(total_ndim)]))
         contraction_indices_remaining = [Tuple.fromiter(j - shifts[j] for j in i) for i in contraction_indices_remaining]
         ret = _array_tensor_product(*[
             _array_contraction(arg, *contr) for arg, contr in zip(expr.args, contraction_indices_args)
@@ -1346,15 +1368,15 @@ class ArrayContraction(_CodegenArrayAbstract):
         inner_contraction_indices = expr.contraction_indices
         all_inner = [j for i in inner_contraction_indices for j in i]
         all_inner.sort()
-        # TODO: add API for total rank and cumulative rank:
-        total_rank = _get_subrank(expr)
-        inner_rank = len(all_inner)
-        outer_rank = total_rank - inner_rank
-        shifts = [0 for i in range(outer_rank)]
+        # TODO: add API for total ndim and cumulative ndim:
+        total_ndim = _get_ndim_total(expr)
+        inner_ndim = len(all_inner)
+        outer_ndim = total_ndim - inner_ndim
+        shifts = [0 for i in range(outer_ndim)]
         counter = 0
         pointer = 0
-        for i in range(outer_rank):
-            while pointer < inner_rank and counter >= all_inner[pointer]:
+        for i in range(outer_ndim):
+            while pointer < inner_ndim and counter >= all_inner[pointer]:
                 counter += 1
                 pointer += 1
             shifts[i] += pointer
@@ -1403,7 +1425,7 @@ class ArrayContraction(_CodegenArrayAbstract):
     @classmethod
     def _ArrayContraction_denest_ArrayDiagonal(cls, expr: 'ArrayDiagonal', *contraction_indices):
         diagonal_indices = list(expr.diagonal_indices)
-        down_contraction_indices = expr._push_indices_down(expr.diagonal_indices, contraction_indices, get_rank(expr.expr))
+        down_contraction_indices = expr._push_indices_down(expr.diagonal_indices, contraction_indices, get_ndim(expr.expr))
         # Flatten diagonally contracted indices:
         down_contraction_indices = [[k for j in i for k in (j if isinstance(j, (tuple, Tuple)) else [j])] for i in down_contraction_indices]
         new_contraction_indices = []
@@ -1428,7 +1450,7 @@ class ArrayContraction(_CodegenArrayAbstract):
     def _sort_fully_contracted_args(cls, expr, contraction_indices):
         if expr.shape is None:
             return expr, contraction_indices
-        cumul = list(accumulate([0] + expr.subranks))
+        cumul = list(accumulate([0] + expr.ndims))
         index_blocks = [list(range(cumul[i], cumul[i+1])) for i in range(len(expr.args))]
         contraction_indices_flat = {j for i in contraction_indices for j in i}
         fully_contracted = [all(j in contraction_indices_flat for j in range(cumul[i], cumul[i+1])) for i, arg in enumerate(expr.args)]
@@ -1473,10 +1495,10 @@ class ArrayContraction(_CodegenArrayAbstract):
 
     @staticmethod
     def _contraction_tuples_to_contraction_indices(expr, contraction_tuples):
-        # TODO: check that `expr` has `.subranks`:
-        ranks = expr.subranks
-        cumulative_ranks = [0] + list(accumulate(ranks))
-        return [tuple(cumulative_ranks[j]+k for j, k in i) for i in contraction_tuples]
+        # TODO: check that `expr` has `.ndims`:
+        ndims = expr.ndims
+        cumulative_ndims = [0] + list(accumulate(ndims))
+        return [tuple(cumulative_ndims[j]+k for j, k in i) for i in contraction_tuples]
 
     @property
     def free_indices(self):
@@ -1498,11 +1520,11 @@ class ArrayContraction(_CodegenArrayAbstract):
         expr = self.expr
         if not isinstance(expr, ArrayTensorProduct):
             raise NotImplementedError("only for contractions of tensor products")
-        ranks = expr.subranks
+        ndims = expr.ndims
         mapping = {}
         counter = 0
-        for i, rank in enumerate(ranks):
-            for j in range(rank):
+        for i, ndim in enumerate(ndims):
+            for j in range(ndim):
                 mapping[counter] = (i, j)
                 counter += 1
         return mapping
@@ -1585,7 +1607,7 @@ class ArrayContraction(_CodegenArrayAbstract):
         `(2, 0)` respectively. `(0, 1)` is the index slot 1 (the 2nd) of
         argument in position 0 (that is, `A_{\ldot j}`), and so on.
         """
-        args, dlinks = _get_contraction_links([self], self.subranks, *self.contraction_indices)
+        args, dlinks = _get_contraction_links([self], self.ndims, *self.contraction_indices)
         return dlinks
 
     def as_explicit(self):
@@ -1679,7 +1701,7 @@ class _ArgE:
     def __init__(self, element, indices: list[int | None] | None = None):
         self.element = element
         if indices is None:
-            self.indices = [None for i in range(get_rank(element))]
+            self.indices = [None for i in range(get_ndim(element))]
         else:
             self.indices = indices
 
@@ -1729,14 +1751,14 @@ class _EditArrayContraction:
         diagonalized: tuple[tuple[int, ...], ...]
         contraction_indices: list[tuple[int]]
         if isinstance(base_array, ArrayContraction):
-            mapping = _get_mapping_from_subranks(base_array.subranks)
+            mapping = _get_mapping_from_ndims(base_array.ndims)
             expr = base_array.expr
             contraction_indices = base_array.contraction_indices
             diagonalized = ()
         elif isinstance(base_array, ArrayDiagonal):
 
             if isinstance(base_array.expr, ArrayContraction):
-                mapping = _get_mapping_from_subranks(base_array.expr.subranks)
+                mapping = _get_mapping_from_ndims(base_array.expr.ndims)
                 expr = base_array.expr.expr
                 diagonalized = ArrayContraction._push_indices_down(base_array.expr.contraction_indices, base_array.diagonal_indices)
                 contraction_indices = base_array.expr.contraction_indices
@@ -1772,7 +1794,7 @@ class _EditArrayContraction:
         self.number_of_contraction_indices: int = len(contraction_indices)
         self._track_permutation: list[list[int]] | None = None
 
-        mapping = _get_mapping_from_subranks(base_array.subranks)
+        mapping = _get_mapping_from_ndims(base_array.ndims)
 
         # Trick: add diagonalized indices as negative indices into the editor object:
         for i, e in enumerate(diagonalized):
@@ -1984,7 +2006,7 @@ class _EditArrayContraction:
         raise IndexError("argument not found")
 
 
-def get_rank(expr):
+def get_ndim(expr):
     if isinstance(expr, (MatrixExpr, MatrixElement)):
         return 2
     if isinstance(expr, _CodegenArrayAbstract):
@@ -2003,18 +2025,49 @@ def get_rank(expr):
         return len(expr.shape)
     return 0
 
+def get_rank(expr):
+    sympy_deprecation_warning(
+        """
+        get_rank() is deprecated.
+
+        In array expressions, "rank" refers to the number of dimensions, not
+        the linear-algebraic rank of a matrix. Use get_ndim(expr) instead.
+        """,
+        deprecated_since_version="1.13",
+        active_deprecations_target="rename-rank-to-ndim",
+        stacklevel=7
+    )
+    return get_ndim(expr)
+
+def _get_ndims(expr):
+    if isinstance(expr, _CodegenArrayAbstract):
+        return expr.ndims
+    else:
+        return [get_ndim(expr)]
+
+def _get_ndim_total(expr):
+    if isinstance(expr, _CodegenArrayAbstract):
+        return expr.ndim_total()
+    return get_ndim(expr)
 
 def _get_subrank(expr):
-    if isinstance(expr, _CodegenArrayAbstract):
-        return expr.subrank()
-    return get_rank(expr)
+    sympy_deprecation_warning(
+        "_get_subrank is deprecated; use _get_ndim_total instead.",
+        deprecated_since_version="1.13",
+        active_deprecations_target="arrayexpr-get-subrank",
+        stacklevel=7
+)
+    return _get_ndim_total(expr)
 
 
 def _get_subranks(expr):
-    if isinstance(expr, _CodegenArrayAbstract):
-        return expr.subranks
-    else:
-        return [get_rank(expr)]
+    sympy_deprecation_warning(
+        "_get_subranks is deprecated; use _get_ndims instead.",
+        deprecated_since_version="1.13",
+        active_deprecations_target="arrayexpr-get-subranks",
+        stacklevel=7
+    )
+    return _get_ndims(expr)
 
 
 def get_shape(expr):

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -14,7 +14,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.tensor.array.expressions.array_expressions import (
     _ArrayExpr, ZeroArray, ArraySymbol, ArrayTensorProduct, ArrayAdd,
-    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_rank,
+    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_ndim,
     get_shape, ArrayContraction, _array_tensor_product, _array_contraction,
     _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum)
 from sympy.tensor.array.expressions.from_matrix_to_array import convert_matrix_to_array
@@ -136,8 +136,8 @@ def _(expr: Inverse, x: Expr):
 
 @array_derive.register(ElementwiseApplyFunction)
 def _(expr: ElementwiseApplyFunction, x: Expr):
-    assert get_rank(expr) == 2
-    assert get_rank(x) == 2
+    assert get_ndim(expr) == 2
+    assert get_ndim(x) == 2
     fdiff = expr._get_function_fdiff()
     dexpr = array_derive(expr.expr, x)
     tp = _array_tensor_product(
@@ -159,8 +159,8 @@ def _(expr: ArrayElementwiseApplyFunc, x: Expr):
         dsubexpr,
         ArrayElementwiseApplyFunc(fdiff, subexpr)
     )
-    b = get_rank(x)
-    c = get_rank(expr)
+    b = get_ndim(x)
+    c = get_ndim(expr)
     diag_indices = [(b + i, b + c + i) for i in range(c)]
     return _array_diagonal(tp, *diag_indices)
 
@@ -197,17 +197,17 @@ def _(expr: HadamardProduct, x: Expr):
 @array_derive.register(ArrayContraction)
 def _(expr: ArrayContraction, x: Expr):
     fd = array_derive(expr.expr, x)
-    rank_x = len(get_shape(x))
+    ndim_x = len(get_shape(x))
     contraction_indices = expr.contraction_indices
-    new_contraction_indices = [tuple(j + rank_x for j in i) for i in contraction_indices]
+    new_contraction_indices = [tuple(j + ndim_x for j in i) for i in contraction_indices]
     return _array_contraction(fd, *new_contraction_indices)
 
 
 @array_derive.register(ArrayDiagonal)
 def _(expr: ArrayDiagonal, x: Expr):
     dsubexpr = array_derive(expr.expr, x)
-    rank_x = len(get_shape(x))
-    diag_indices = [[j + rank_x for j in i] for i in expr.diagonal_indices]
+    ndim_x = len(get_shape(x))
+    diag_indices = [[j + ndim_x for j in i] for i in expr.diagonal_indices]
     return _array_diagonal(dsubexpr, *diag_indices)
 
 

--- a/sympy/tensor/array/expressions/from_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/from_array_to_indexed.py
@@ -4,7 +4,7 @@ from itertools import accumulate
 
 from sympy import Mul, Sum, Dummy, Add
 from sympy.tensor.array.expressions import PermuteDims, ArrayAdd, ArrayElementwiseApplyFunc, Reshape
-from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, get_rank, ArrayContraction, \
+from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, get_ndim, ArrayContraction, \
     ArrayDiagonal, get_shape, _get_array_element_or_slice, _ArrayExpr
 from sympy.tensor.array.expressions.utils import _apply_permutation_to_list
 
@@ -20,11 +20,11 @@ class _ConvertArrayToIndexed:
 
     def do_convert(self, expr, indices):
         if isinstance(expr, ArrayTensorProduct):
-            cumul = list(accumulate([0] + [get_rank(arg) for arg in expr.args]))
+            cumul = list(accumulate([0] + [get_ndim(arg) for arg in expr.args]))
             indices_grp = [indices[cumul[i]:cumul[i+1]] for i in range(len(expr.args))]
             return Mul.fromiter(self.do_convert(arg, ind) for arg, ind in zip(expr.args, indices_grp))
         if isinstance(expr, ArrayContraction):
-            new_indices = [None for i in range(get_rank(expr.expr))]
+            new_indices = [None for i in range(get_ndim(expr.expr))]
             limits = []
             bottom_shape = get_shape(expr.expr)
             for contraction_index_grp in expr.contraction_indices:
@@ -42,8 +42,8 @@ class _ConvertArrayToIndexed:
             newexpr = self.do_convert(expr.expr, new_indices)
             return Sum(newexpr, *limits)
         if isinstance(expr, ArrayDiagonal):
-            new_indices = [None for i in range(get_rank(expr.expr))]
-            ind_pos = expr._push_indices_down(expr.diagonal_indices, list(range(len(indices))), get_rank(expr))
+            new_indices = [None for i in range(get_ndim(expr.expr))]
+            ind_pos = expr._push_indices_down(expr.diagonal_indices, list(range(len(indices))), get_ndim(expr))
             for i, index in zip(ind_pos, indices):
                 if isinstance(i, collections.abc.Iterable):
                     for j in i:

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -20,10 +20,10 @@ from sympy.matrices.matrixbase import MatrixBase
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.array_expressions import PermuteDims, ArrayDiagonal, \
-    ArrayTensorProduct, OneArray, get_rank, _get_subrank, ZeroArray, ArrayContraction, \
+    ArrayTensorProduct, OneArray, get_ndim, _get_ndim_total, ZeroArray, ArrayContraction, \
     ArrayAdd, _CodegenArrayAbstract, get_shape, ArrayElementwiseApplyFunc, _ArrayExpr, _EditArrayContraction, _ArgE, \
     ArrayElement, _array_tensor_product, _array_contraction, _array_diagonal, _array_add, _permute_dims, ArraySum
-from sympy.tensor.array.expressions.utils import _get_mapping_from_subranks
+from sympy.tensor.array.expressions.utils import _get_mapping_from_ndims
 
 
 def _get_candidate_for_matmul_from_contraction(scan_indices: list[int | None], remaining_args: list[_ArgE]) -> tuple[_ArgE | None, bool, int]:
@@ -161,7 +161,7 @@ def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
                         first = MatMul.fromiter(margs[:j+1])
                         second = MatMul.fromiter(margs[j+1:])
                         break
-        counter += get_rank(arg)
+        counter += get_ndim(arg)
     if pos is None:
         return expr, []
     args[pos] = (first*MatMul.fromiter(i for i in trivial_matrices)*second).doit()
@@ -173,7 +173,7 @@ def _find_trivial_kronecker_products_broadcast(expr: ArrayTensorProduct):
     removed = []
     count_dims = 0
     for arg in expr.args:
-        count_dims += get_rank(arg)
+        count_dims += get_ndim(arg)
         shape = get_shape(arg)
         current_range = [count_dims-i for i in range(len(shape), 0, -1)]
         if (shape == (1, 1) and len(newargs) > 0 and 1 not in get_shape(newargs[-1]) and
@@ -198,7 +198,7 @@ def _array2matrix(expr):
 
 @_array2matrix.register(ZeroArray)
 def _(expr: ZeroArray):
-    if get_rank(expr) == 2:
+    if get_ndim(expr) == 2:
         return ZeroMatrix(*expr.shape)
     else:
         return expr
@@ -213,7 +213,7 @@ def _(expr: ArrayTensorProduct):
 def _(expr: ArraySum):
     new_function = _array2matrix(expr.function)
     output = expr.func(new_function, *expr.limits).simplify()
-    if isinstance(output, ZeroArray) and get_rank(output) == 2:
+    if isinstance(output, ZeroArray) and get_ndim(output) == 2:
         return ZeroMatrix(*output.shape)
     return output
 
@@ -240,7 +240,7 @@ def _(expr: ArrayContraction):
     if isinstance(subexpr, ArrayTensorProduct):
         newexpr = _array_contraction(_array2matrix(subexpr), *contraction_indices)
         contraction_indices = newexpr.contraction_indices
-        if any(i > 2 for i in newexpr.subranks):
+        if any(i > 2 for i in newexpr.ndims):
             addends = _array_add(*[_a2m_tensor_product(*j) for j in itertools.product(*[i.args if isinstance(i,
                                                                                                                              ArrayAdd) else [i] for i in expr.expr.args])])
             newexpr = _array_contraction(addends, *contraction_indices)
@@ -275,14 +275,14 @@ def _(expr: PermuteDims):
     if expr.permutation.array_form == [1, 0]:
         return _a2m_transpose(_array2matrix(expr.expr))
     elif isinstance(expr.expr, ArrayTensorProduct):
-        ranks = expr.expr.subranks
+        ndims = expr.expr.ndims
         inv_permutation = expr.permutation**(-1)
-        newrange = [inv_permutation(i) for i in range(sum(ranks))]
+        newrange = [inv_permutation(i) for i in range(sum(ndims))]
         newpos = []
         counter = 0
-        for rank in ranks:
-            newpos.append(newrange[counter:counter+rank])
-            counter += rank
+        for ndim in ndims:
+            newpos.append(newrange[counter:counter+ndim])
+            counter += ndim
         newargs = []
         newperm = []
         scalars = []
@@ -367,7 +367,7 @@ def _(expr: ArrayTensorProduct):
 
     removed = []
     newargs = []
-    cumul = list(accumulate([0] + [get_rank(arg) for arg in expr.args]))
+    cumul = list(accumulate([0] + [get_ndim(arg) for arg in expr.args]))
     pending = None
     prev_i = None
     for i, arg in enumerate(expr.args):
@@ -491,13 +491,13 @@ def _(expr: ArrayContraction):
         new_expr2, removed1 = _remove_trivial_dims(_array2matrix(new_expr))
         removed = _combine_removed(-1, removed0, removed1)
         return new_expr2, removed
-    rank1 = get_rank(expr)
+    ndim1 = get_ndim(expr)
     expr, removed1 = remove_identity_matrices(expr)
     if not isinstance(expr, ArrayContraction):
         expr2, removed2 = _remove_trivial_dims(expr)
-        return expr2, _combine_removed(rank1, removed1, removed2)
+        return expr2, _combine_removed(ndim1, removed1, removed2)
     newexpr, removed2 = _remove_trivial_dims(expr.expr)
-    shifts = list(accumulate([1 if i in removed2 else 0 for i in range(get_rank(expr.expr))]))
+    shifts = list(accumulate([1 if i in removed2 else 0 for i in range(get_ndim(expr.expr))]))
     new_contraction_indices = [tuple(j for j in i if j not in removed2) for i in expr.contraction_indices]
     # Remove possible empty tuples "()":
     new_contraction_indices = [i for i in new_contraction_indices if len(i) > 0]
@@ -506,7 +506,7 @@ def _(expr: ArrayContraction):
     new_contraction_indices = [tuple(j - shifts[j] for j in i) for i in new_contraction_indices]
     # Shift removed2:
     removed2 = ArrayContraction._push_indices_up(expr.contraction_indices, removed2)
-    removed = _combine_removed(rank1, removed1, removed2)
+    removed = _combine_removed(ndim1, removed1, removed2)
     return _array_contraction(newexpr, *new_contraction_indices), list(removed)
 
 
@@ -534,21 +534,21 @@ def _remove_diagonalized_identity_matrices(expr: ArrayDiagonal):
                 other_range = editor.get_absolute_range(other)
                 removed.extend([other_range[0] + none_index])
     editor.args_with_ind = [i for i in editor.args_with_ind if i.element is not None]
-    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, get_rank(expr.expr))
+    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, get_ndim(expr.expr))
     return editor.to_array_contraction(), removed
 
 
 @_remove_trivial_dims.register(ArrayDiagonal)
 def _(expr: ArrayDiagonal):
     newexpr, removed = _remove_trivial_dims(expr.expr)
-    shifts = list(accumulate([0] + [1 if i in removed else 0 for i in range(get_rank(expr.expr))]))
+    shifts = list(accumulate([0] + [1 if i in removed else 0 for i in range(get_ndim(expr.expr))]))
     new_diag_indices_map = {i: tuple(j for j in i if j not in removed) for i in expr.diagonal_indices}
     for old_diag_tuple, new_diag_tuple in new_diag_indices_map.items():
         if len(new_diag_tuple) == 1:
             removed = [i for i in removed if i not in old_diag_tuple]
     new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices_map.values()]
-    rank = get_rank(expr.expr)
-    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, rank)
+    ndim = get_ndim(expr.expr)
+    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, ndim)
     removed = sorted(set(removed))
     # If there are single axes to diagonalize remaining, it means that their
     # corresponding dimension has been removed, they no longer need diagonalization:
@@ -666,10 +666,10 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
     if isinstance(expr.expr, ArrayTensorProduct):
         args = list(expr.expr.args)
         diag_indices = list(expr.diagonal_indices)
-        mapping = _get_mapping_from_subranks([_get_subrank(arg) for arg in args])
+        mapping = _get_mapping_from_ndims([_get_ndim_total(arg) for arg in args])
         tuple_links = [[mapping[j] for j in i] for i in diag_indices]
         contr_indices = []
-        total_rank = get_rank(expr)
+        total_ndim = get_ndim(expr)
         replaced = [False for arg in args]
         for i, (abs_pos, rel_pos) in enumerate(zip(diag_indices, tuple_links)):
             if len(abs_pos) != 2:
@@ -677,7 +677,7 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
             (pos1_outer, pos1_inner), (pos2_outer, pos2_inner) = rel_pos
             arg1 = args[pos1_outer]
             arg2 = args[pos2_outer]
-            if get_rank(arg1) != 2 or get_rank(arg2) != 2:
+            if get_ndim(arg1) != 2 or get_ndim(arg2) != 2:
                 if replaced[pos1_outer]:
                     diag_indices[i] = None
                 if replaced[pos2_outer]:
@@ -692,7 +692,7 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
                     darg1 = arg1
                 args.append(darg1)
                 contr_indices.append(((pos2_outer, pos2_inner), (len(args)-1, pos1_inner)))
-                total_rank += 1
+                total_ndim += 1
                 diag_indices[i] = None
                 args[pos1_outer] = OneArray(arg1.shape[pos1_in2])
                 replaced[pos1_outer] = True
@@ -703,12 +703,12 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
                     darg2 = arg2
                 args.append(darg2)
                 contr_indices.append(((pos1_outer, pos1_inner), (len(args)-1, pos2_inner)))
-                total_rank += 1
+                total_ndim += 1
                 diag_indices[i] = None
                 args[pos2_outer] = OneArray(arg2.shape[pos2_in2])
                 replaced[pos2_outer] = True
         diag_indices_new = [i for i in diag_indices if i is not None]
-        cumul = list(accumulate([0] + [get_rank(arg) for arg in args]))
+        cumul = list(accumulate([0] + [get_ndim(arg) for arg in args]))
         contr_indices2 = [tuple(cumul[a] + b for a, b in i) for i in contr_indices]
         tc = _array_contraction(
             _array_tensor_product(*args), *contr_indices2
@@ -941,7 +941,7 @@ def remove_identity_matrices(expr: ArrayContraction):
 
     removed.sort()
 
-    shifts = list(accumulate([1 if i in removed else 0 for i in range(get_rank(expr))]))
+    shifts = list(accumulate([1 if i in removed else 0 for i in range(get_ndim(expr))]))
     for (last_removed, ind), non_identity_indices in update_pairs.items():
         pos = [free_map[non_identity] + i for i, e in enumerate(non_identity_indices) if e == ind]
         assert len(pos) == 1
@@ -953,7 +953,7 @@ def remove_identity_matrices(expr: ArrayContraction):
     permutation = []
     counter = 0
     counter2 = 0
-    for j in range(get_rank(expr)):
+    for j in range(get_ndim(expr)):
         if j in removed:
             continue
         if counter2 in permutation_map:

--- a/sympy/tensor/array/expressions/utils.py
+++ b/sympy/tensor/array/expressions/utils.py
@@ -4,20 +4,30 @@ from collections import defaultdict
 from sympy.combinatorics import Permutation
 from sympy.core.containers import Tuple
 from sympy.core.numbers import Integer
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 
-def _get_mapping_from_subranks(subranks):
+def _get_mapping_from_ndims(ndims):
     mapping = {}
     counter = 0
-    for i, rank in enumerate(subranks):
-        for j in range(rank):
+    for i, ndim in enumerate(ndims):
+        for j in range(ndim):
             mapping[counter] = (i, j)
             counter += 1
     return mapping
 
+def _get_mapping_from_subranks(ndims):
+    sympy_deprecation_warning(
+        "_get_mapping_from_subranks is deprecated; use _get_mapping_from_ndims instead.",
+        deprecated_since_version="1.13",
+        active_deprecations_target="arrayexpr-mapping-from-subranks",
+        stacklevel=7
+    )
+    return _get_mapping_from_ndims(ndims)
 
-def _get_contraction_links(args, subranks, *contraction_indices):
-    mapping = _get_mapping_from_subranks(subranks)
+
+def _get_contraction_links(args, ndims, *contraction_indices):
+    mapping = _get_mapping_from_ndims(ndims)
     contraction_tuples = [[mapping[j] for j in i] for i in contraction_indices]
     dlinks = defaultdict(dict)
     for links in contraction_tuples:


### PR DESCRIPTION
Deprecate rank-based array helpers in favor of ndim equivalents

#### References to other Issues or PRs
Fixes #28848

#### Brief description of what is fixed or changed
This PR completes the transition from using “rank” to “ndim” terminology in
array expressions.

- Deprecates `get_rank` in favor of `get_ndim`
- Deprecates `subrank`, `subranks`, and related private helpers
- Routes deprecated APIs to their `ndim`-based replacements
- Uses `sympy_deprecation_warning` with correct stacklevel handling
- No functional behavior changes

#### Other comments
All tests pass. Deprecation warnings are expected and intentional.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
