### PR TITLE
Removing curly brackets around \middle| in the Latex representation of Dyadics

### DIFF
--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -216,7 +216,7 @@ class BaseDyadic(Dyadic, AtomicExpr):
         obj._sys = vector1._sys
         obj._pretty_form = ('(' + vector1._pretty_form + '|' +
                              vector2._pretty_form + ')')
-        obj._latex_form = (r'\left(' + vector1._latex_form + r"{\middle|}" +
+        obj._latex_form = (r'\left(' + vector1._latex_form + r"\middle|" +
                            vector2._latex_form + r'\right)')
 
         return obj

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -148,16 +148,16 @@ def test_latex_printing():
                            ' db\\right)\\mathbf{\\hat{k}_{N}}')
     assert latex(s) == '3 \\mathbf{{y}_{C}} \\mathbf{{x}_{N}}^{2}'
     assert latex(d[0]) == '(\\mathbf{\\hat{0}}|\\mathbf{\\hat{0}})'
-    assert latex(d[4]) == ('\\left(a\\right)\\left(\\mathbf{\\hat{i}_{N}}{\\middle|}' +
+    assert latex(d[4]) == ('\\left(a\\right)\\left(\\mathbf{\\hat{i}_{N}}\\middle|' +
                            '\\mathbf{\\hat{k}_{N}}\\right)')
-    assert latex(d[9]) == ('\\left(\\mathbf{\\hat{k}_{C}}{\\middle|}' +
+    assert latex(d[9]) == ('\\left(\\mathbf{\\hat{k}_{C}}\\middle|' +
                            '\\mathbf{\\hat{k}_{N}}\\right) + \\left(' +
-                           '\\mathbf{\\hat{i}_{N}}{\\middle|}\\mathbf{' +
+                           '\\mathbf{\\hat{i}_{N}}\\middle|\\mathbf{' +
                            '\\hat{k}_{N}}\\right)')
     assert latex(d[11]) == ('\\left(a^{2} + b\\right)\\left(\\mathbf{\\hat{i}_{N}}' +
-                            '{\\middle|}\\mathbf{\\hat{k}_{N}}\\right) + ' +
+                            '\\middle|\\mathbf{\\hat{k}_{N}}\\right) + ' +
                             '\\left(\\int f{\\left(b \\right)}\\, db\\right)\\left(' +
-                            '\\mathbf{\\hat{k}_{N}}{\\middle|}\\mathbf{' +
+                            '\\mathbf{\\hat{k}_{N}}\\middle|\\mathbf{' +
                             '\\hat{k}_{N}}\\right)')
 
 def test_issue_23058():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28856

#### Brief description of what is fixed or changed

Renderers like MathJax (used by Jupyter Notebook/Lab) do not support full Latex. As shown in the issue, MathJax is unable to render `{\middle|}`. Here, curly brackets are used to create a group, or local scope, which is a region of input where changes and effects are confined. In this case, the group has no effect, so the braces can be removed without changing the meaning.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Fixed Latex representation of dyadics for them to be rendered by MathJax.

<!-- END RELEASE NOTES -->
