### PR TITLE
typing: add return type annotation to Expr.__trunc__

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -415,7 +415,7 @@ class Expr(Basic, EvalfMixin):
         from .relational import StrictLessThan
         return StrictLessThan(self, other)
 
-    def __trunc__(self):
+    def __trunc__(self): -> Integer:
         if not self.is_number:
             raise TypeError("Cannot truncate symbols and expressions")
         else:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, overload, Literal
 from collections.abc import Iterable, Mapping
 from functools import reduce
 import re
+from sympy.core.numbers import Integers
+
 
 from .sympify import sympify, _sympify
 from .basic import Basic, Atom
@@ -415,7 +417,7 @@ class Expr(Basic, EvalfMixin):
         from .relational import StrictLessThan
         return StrictLessThan(self, other)
 
-    def __trunc__(self): -> Integer:
+ def __trunc__(self) -> Integer:
         if not self.is_number:
             raise TypeError("Cannot truncate symbols and expressions")
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR adds a return type annotation to `Expr.__trunc__`, which returns
an `Integer` when the expression is numeric and raises `TypeError`
otherwise. This improves static type checking without changing runtime
behavior.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the sub package
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
