### PR TITLE
Better latex/pretty rendering of base scalars for curvilinear coordinate systems 

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2865,6 +2865,14 @@ class LatexPrinter(Printer):
     def _print_CovarDerivativeOp(self, cvd):
         return r'\mathbb{\nabla}_{%s}' % self._print(cvd._wrt)
 
+    def _print_BaseScalar(self, expr):
+        coord_sys_name, scalar_name = expr.name.split(".")
+        if scalar_name in greek_letters_set:
+            scalar_name = r"\%s" % scalar_name
+        elif scalar_name in tex_greek_dictionary:
+            scalar_name = tex_greek_dictionary[scalar_name]
+        return r"\boldsymbol{%s}_{\textbf{%s}}" % (scalar_name, coord_sys_name)
+
     def _print_BaseScalarField(self, field):
         string = field._coord_sys.symbols[field._index].name
         return r'\mathbf{{{}}}'.format(self._print(Symbol(string)))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2819,6 +2819,12 @@ class PrettyPrinter(Printer):
     def _print_CoordSystem(self, coords):
         return self._print(coords.name)
 
+    def _print_BaseScalar(self, expr):
+        coord_sys_name, scalar_name = expr.name.split(".")
+        if scalar_name in greek_unicode:
+            scalar_name = greek_unicode[scalar_name]
+        return self._print(pretty_symbol(scalar_name + "_" + coord_sys_name))
+
     def _print_BaseScalarField(self, field):
         string = field._coord_sys.symbols[field._index].name
         return self._print(pretty_symbol(string))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -361,7 +361,7 @@ def test_latex_vector_expressions():
     A = CoordSys3D('A')
 
     assert latex(Cross(A.i, A.j*A.x*3+A.k)) == \
-        r"\mathbf{\hat{i}_{A}} \times \left(\left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+        r"\mathbf{\hat{i}_{A}} \times \left(\left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
     assert latex(Cross(A.i, A.j)) == \
         r"\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}"
     assert latex(x*Cross(A.i, A.j)) == \
@@ -370,23 +370,23 @@ def test_latex_vector_expressions():
         r'- \mathbf{\hat{j}_{A}} \times \left(\left(x\right)\mathbf{\hat{i}_{A}}\right)'
 
     assert latex(Curl(3*A.x*A.j)) == \
-        r"\nabla\times \left(\left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\times \left(\left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}}\right)"
     assert latex(Curl(3*A.x*A.j+A.i)) == \
-        r"\nabla\times \left(\mathbf{\hat{i}_{A}} + \left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\times \left(\mathbf{\hat{i}_{A}} + \left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}}\right)"
     assert latex(Curl(3*x*A.x*A.j)) == \
-        r"\nabla\times \left(\left(3 \mathbf{{x}_{A}} x\right)\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\times \left(\left(3 \boldsymbol{x}_{\textbf{A}} x\right)\mathbf{\hat{j}_{A}}\right)"
     assert latex(x*Curl(3*A.x*A.j)) == \
-        r"x \left(\nabla\times \left(\left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}}\right)\right)"
+        r"x \left(\nabla\times \left(\left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}}\right)\right)"
 
     assert latex(Divergence(3*A.x*A.j+A.i)) == \
-        r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + \left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + \left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}}\right)"
     assert latex(Divergence(3*A.x*A.j)) == \
-        r"\nabla\cdot \left(\left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\cdot \left(\left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}}\right)"
     assert latex(x*Divergence(3*A.x*A.j)) == \
-        r"x \left(\nabla\cdot \left(\left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}}\right)\right)"
+        r"x \left(\nabla\cdot \left(\left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}}\right)\right)"
 
     assert latex(Dot(A.i, A.j*A.x*3+A.k)) == \
-        r"\mathbf{\hat{i}_{A}} \cdot \left(\left(3 \mathbf{{x}_{A}}\right)\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+        r"\mathbf{\hat{i}_{A}} \cdot \left(\left(3 \boldsymbol{x}_{\textbf{A}}\right)\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
     assert latex(Dot(A.i, A.j)) == \
         r"\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}"
     assert latex(Dot(x*A.i, A.j)) == \
@@ -394,17 +394,17 @@ def test_latex_vector_expressions():
     assert latex(x*Dot(A.i, A.j)) == \
         r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
 
-    assert latex(Gradient(A.x)) == r"\nabla \mathbf{{x}_{A}}"
+    assert latex(Gradient(A.x)) == r"\nabla \boldsymbol{x}_{\textbf{A}}"
     assert latex(Gradient(A.x + 3*A.y)) == \
-        r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
-    assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{x}_{A}}\right)"
-    assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{x}_{A}} x\right)"
+        r"\nabla \left(\boldsymbol{x}_{\textbf{A}} + 3 \boldsymbol{y}_{\textbf{A}}\right)"
+    assert latex(x*Gradient(A.x)) == r"x \left(\nabla \boldsymbol{x}_{\textbf{A}}\right)"
+    assert latex(Gradient(x*A.x)) == r"\nabla \left(\boldsymbol{x}_{\textbf{A}} x\right)"
 
-    assert latex(Laplacian(A.x)) == r"\Delta \mathbf{{x}_{A}}"
+    assert latex(Laplacian(A.x)) == r"\Delta \boldsymbol{x}_{\textbf{A}}"
     assert latex(Laplacian(A.x + 3*A.y)) == \
-        r"\Delta \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
-    assert latex(x*Laplacian(A.x)) == r"x \left(\Delta \mathbf{{x}_{A}}\right)"
-    assert latex(Laplacian(x*A.x)) == r"\Delta \left(\mathbf{{x}_{A}} x\right)"
+        r"\Delta \left(\boldsymbol{x}_{\textbf{A}} + 3 \boldsymbol{y}_{\textbf{A}}\right)"
+    assert latex(x*Laplacian(A.x)) == r"x \left(\Delta \boldsymbol{x}_{\textbf{A}}\right)"
+    assert latex(Laplacian(x*A.x)) == r"\Delta \left(\boldsymbol{x}_{\textbf{A}} x\right)"
 
 def test_latex_symbols():
     Gamma, lmbda, rho = symbols('Gamma, lambda, rho')

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -1,6 +1,5 @@
 from sympy.core import AtomicExpr, Symbol, S
 from sympy.core.sympify import _sympify
-from sympy.printing.pretty.stringpict import prettyForm
 from sympy.printing.precedence import PRECEDENCE
 from sympy.core.kind import NumberKind
 
@@ -55,12 +54,6 @@ class BaseScalar(AtomicExpr):
         if self == s:
             return S.One
         return S.Zero
-
-    def _latex(self, printer=None):
-        return self._latex_form
-
-    def _pretty(self, printer=None):
-        return prettyForm(self._pretty_form)
 
     precedence = PRECEDENCE['Atom']
 

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -141,12 +141,12 @@ def test_latex_printing():
     assert latex(v[2]) == '- \\mathbf{\\hat{i}_{N}}'
     assert latex(v[5]) == ('\\left(a\\right)\\mathbf{\\hat{i}_{N}} + ' +
                            '\\left(- b\\right)\\mathbf{\\hat{j}_{N}}')
-    assert latex(v[6]) == ('\\left(\\mathbf{{x}_{N}} + a^{2}\\right)\\mathbf{\\hat{i}_' +
+    assert latex(v[6]) == ('\\left(\\boldsymbol{x}_{\\textbf{N}} + a^{2}\\right)\\mathbf{\\hat{i}_' +
                           '{N}} + \\mathbf{\\hat{k}_{N}}')
-    assert latex(v[8]) == ('\\mathbf{\\hat{j}_{N}} + \\left(\\mathbf{{x}_' +
-                           '{C}}^{2} - \\int f{\\left(b \\right)}\\,' +
+    assert latex(v[8]) == ('\\mathbf{\\hat{j}_{N}} + \\left(\\boldsymbol{x}_' +
+                           '{\\textbf{C}}^{2} - \\int f{\\left(b \\right)}\\,' +
                            ' db\\right)\\mathbf{\\hat{k}_{N}}')
-    assert latex(s) == '3 \\mathbf{{y}_{C}} \\mathbf{{x}_{N}}^{2}'
+    assert latex(s) == '3 \\boldsymbol{y}_{\\textbf{C}} \\boldsymbol{x}_{\\textbf{N}}^{2}'
     assert latex(d[0]) == '(\\mathbf{\\hat{0}}|\\mathbf{\\hat{0}})'
     assert latex(d[4]) == ('\\left(a\\right)\\left(\\mathbf{\\hat{i}_{N}}\\middle|' +
                            '\\mathbf{\\hat{k}_{N}}\\right)')
@@ -168,22 +168,18 @@ def test_latex_base_scalars():
     D = Cart.create_new(
         "D", transformation="cartesian", variable_names=["α", "β", "γ"])
 
-    e1 = Cart.x * Cart.y * Cart.z
-    assert latex(e1) == (r"\boldsymbol{x}_{\textbf{Cart}} " +
-                         r"\boldsymbol{y}_{\textbf{Cart}} " +
-                         r"\boldsymbol{z}_{\textbf{Cart}}")
-    e2 = S.r * S.theta * S.phi
-    assert latex(e2) == (r"\boldsymbol{\phi}_{\textbf{S}} " +
-                         r"\boldsymbol{r}_{\textbf{S}} " +
-                         r"\boldsymbol{\theta}_{\textbf{S}}")
-    e3 = C.r * C.theta * C.z
-    assert latex(e3) == (r"\boldsymbol{r}_{\textbf{C}} " +
-                         r"\boldsymbol{\theta}_{\textbf{C}} " +
-                         r"\boldsymbol{z}_{\textbf{C}}")
-    e4 = D.α * D.β * D.γ
-    assert latex(e4) == (r"\boldsymbol{α}_{\textbf{D}} " +
-                         r"\boldsymbol{β}_{\textbf{D}} " +
-                         r"\boldsymbol{γ}_{\textbf{D}}")
+    assert latex(Cart.x) == r"\boldsymbol{x}_{\textbf{Cart}}"
+    assert latex(Cart.y) == r"\boldsymbol{y}_{\textbf{Cart}}"
+    assert latex(Cart.z) == r"\boldsymbol{z}_{\textbf{Cart}}"
+    assert latex(S.phi) == r"\boldsymbol{\phi}_{\textbf{S}}"
+    assert latex(S.r) == r"\boldsymbol{r}_{\textbf{S}}"
+    assert latex(S.theta) == r"\boldsymbol{\theta}_{\textbf{S}}"
+    assert latex(C.r) == r"\boldsymbol{r}_{\textbf{C}}"
+    assert latex(C.theta) == r"\boldsymbol{\theta}_{\textbf{C}}"
+    assert latex(C.z) == r"\boldsymbol{z}_{\textbf{C}}"
+    assert latex(D.α) == r"\boldsymbol{α}_{\textbf{D}}"
+    assert latex(D.β) == r"\boldsymbol{β}_{\textbf{D}}"
+    assert latex(D.γ) == r"\boldsymbol{γ}_{\textbf{D}}"
 
 
 def test_pretty_base_scalars():
@@ -193,21 +189,18 @@ def test_pretty_base_scalars():
     D = Cart.create_new(
         "D", transformation="cartesian", variable_names=["α", "β", "γ"])
 
-    e1 = Cart.x * Cart.y * Cart.z
-    assert pretty(e1) == "x_Cart*y_Cart*z_Cart"
-    assert upretty(e1) == "x_Cart⋅y_Cart⋅z_Cart"
-
-    e2 = S.r * S.theta * S.phi
-    assert pretty(e2) == "φ_S*r_S*θ_S"
-    assert upretty(e2) == "φ_S⋅r_S⋅θ_S"
-
-    e3 = C.r * C.theta * C.z
-    assert pretty(e3) == "r_C*θ_C*z_C"
-    assert upretty(e3) == "r_C⋅θ_C⋅z_C"
-
-    e4 = D.α * D.β * D.γ
-    assert pretty(e4) == "α_D*β_D*γ_D"
-    assert upretty(e4) == "α_D⋅β_D⋅γ_D"
+    assert pretty(Cart.x) == "x_Cart"
+    assert pretty(Cart.y) == "y_Cart"
+    assert pretty(Cart.z) == "z_Cart"
+    assert pretty(S.r) == "r_S"
+    assert pretty(S.theta) == "θ_S"
+    assert pretty(S.phi) == "φ_S"
+    assert pretty(C.r) == "r_C"
+    assert pretty(C.theta) == "θ_C"
+    assert pretty(C.z) == "z_C"
+    assert pretty(D.α) == "α_D"
+    assert pretty(D.β) == "β_D"
+    assert pretty(D.γ) == "γ_D"
 
 
 def test_issue_23058():

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -160,6 +160,56 @@ def test_latex_printing():
                             '\\mathbf{\\hat{k}_{N}}\\middle|\\mathbf{' +
                             '\\hat{k}_{N}}\\right)')
 
+
+def test_latex_base_scalars():
+    Cart = CoordSys3D("Cart")
+    S = Cart.create_new("S", transformation="spherical")
+    C = Cart.create_new("C", transformation="cylindrical")
+    D = Cart.create_new(
+        "D", transformation="cartesian", variable_names=["α", "β", "γ"])
+
+    e1 = Cart.x * Cart.y * Cart.z
+    assert latex(e1) == (r"\boldsymbol{x}_{\textbf{Cart}} " +
+                         r"\boldsymbol{y}_{\textbf{Cart}} " +
+                         r"\boldsymbol{z}_{\textbf{Cart}}")
+    e2 = S.r * S.theta * S.phi
+    assert latex(e2) == (r"\boldsymbol{\phi}_{\textbf{S}} " +
+                         r"\boldsymbol{r}_{\textbf{S}} " +
+                         r"\boldsymbol{\theta}_{\textbf{S}}")
+    e3 = C.r * C.theta * C.z
+    assert latex(e3) == (r"\boldsymbol{r}_{\textbf{C}} " +
+                         r"\boldsymbol{\theta}_{\textbf{C}} " +
+                         r"\boldsymbol{z}_{\textbf{C}}")
+    e4 = D.α * D.β * D.γ
+    assert latex(e4) == (r"\boldsymbol{α}_{\textbf{D}} " +
+                         r"\boldsymbol{β}_{\textbf{D}} " +
+                         r"\boldsymbol{γ}_{\textbf{D}}")
+
+
+def test_pretty_base_scalars():
+    Cart = CoordSys3D("Cart")
+    S = Cart.create_new("S", transformation="spherical")
+    C = Cart.create_new("C", transformation="cylindrical")
+    D = Cart.create_new(
+        "D", transformation="cartesian", variable_names=["α", "β", "γ"])
+
+    e1 = Cart.x * Cart.y * Cart.z
+    assert pretty(e1) == "x_Cart*y_Cart*z_Cart"
+    assert upretty(e1) == "x_Cart⋅y_Cart⋅z_Cart"
+
+    e2 = S.r * S.theta * S.phi
+    assert pretty(e2) == "φ_S*r_S*θ_S"
+    assert upretty(e2) == "φ_S⋅r_S⋅θ_S"
+
+    e3 = C.r * C.theta * C.z
+    assert pretty(e3) == "r_C*θ_C*z_C"
+    assert upretty(e3) == "r_C⋅θ_C⋅z_C"
+
+    e4 = D.α * D.β * D.γ
+    assert pretty(e4) == "α_D*β_D*γ_D"
+    assert upretty(e4) == "α_D⋅β_D⋅γ_D"
+
+
 def test_issue_23058():
     from sympy import symbols, sin, cos, pi, UnevaluatedExpr
 
@@ -209,6 +259,7 @@ def test_issue_23058():
 ⎝2⋅10  ⋅cos⎝t⋅10 ⎠⋅sin⎝y_C⋅10  ⎠⎠ i_C \
 """
     assert upretty(vecB) == vecB_str
+
 
 def test_custom_names():
     A = CoordSys3D('A', vector_names=['x', 'y', 'z'],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28867

#### Brief description of what is fixed or changed

Curvilinear systems may use greek symbols to denote a base scalar (for example, `theta, phi` denote the azimuthal and polar angle in a spherical coordinate system). This PR implements nice rendering of these greek symbols when displaying a scalar or vector field using Latex or pretty.

#### Other comments

Previously, base scalars were rendered with the following Latex command: `\mathbf{scalarName_{systemName}}`. But `\mathbf` is unable to apply bold font to greek symbols. This PR uses this Latex command: `\boldsymbol{scalarName}_\textbf{systemName}`. Here is a comparison before/after this PR, showing the base scalars of a Cartesian system and a spherical system.

For latex printing:

<img width="235" height="119" alt="image" src="https://github.com/user-attachments/assets/895e8181-9fde-4846-b371-c0af5af094f5" />

For pretty printing:

```text
before: (x_Cart, y_Cart, z_Cart)
 after: (x_Cart, y_Cart, z_Cart)
before: (r_S, theta_S, phi_S)
 after: (r_S, θ_S, φ_S)
```


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Implemented nice latex/pretty rendering of base scalars for curvilinear coordinate system.

<!-- END RELEASE NOTES -->
