### PR TITLE
Add type annotation to func_name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1640,6 +1640,7 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>
 Vedarth Sharma <vedarth.sharma@gmail.com>
 Velibor Zeli <velibor@mech.kth.se>
@@ -1841,4 +1842,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1841,3 +1841,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -19,7 +19,7 @@ class Undecidable(ValueError):
     pass
 
 
-def filldedent(s, w=70, **kwargs):
+def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     """
     Strips leading and trailing empty lines from a copy of ``s``, then dedents,
     fills and returns it.

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -304,7 +304,7 @@ def find_executable(executable, path=None):
     return None
 
 
-def func_name(x, short=False):
+def func_name(x: Any, short: bool = False) -> str:
     """Return function name of `x` (if defined) else the `type(x)`.
     If short is True and there is a shorter alias for the result,
     return the alias.

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -330,12 +330,12 @@ def func_name(x: Any, short: bool = False) -> str:
     'Equality': 'Eq',
     'Unequality': 'Ne',
     }
-    typ: type | str = type(x)
+    typ = str(type(x))
     if str(typ).startswith("<type '"):
         typ = str(typ).split("'")[1].split("'")[0]
     elif str(typ).startswith("<class '"):
         typ = str(typ).split("'")[1].split("'")[0]
-    rv: str = getattr(getattr(x, 'func', x), '__name__', str(typ))
+    rv = getattr(getattr(x, 'func', x), '__name__', typ)
     if '.' in rv:
         rv = rv.split('.')[-1]
     if short:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -331,10 +331,10 @@ def func_name(x: Any, short: bool = False) -> str:
     'Unequality': 'Ne',
     }
     typ = str(type(x))
-    if str(typ).startswith("<type '"):
-        typ = str(typ).split("'")[1].split("'")[0]
-    elif str(typ).startswith("<class '"):
-        typ = str(typ).split("'")[1].split("'")[0]
+    if typ.startswith("<type '"):
+        typ = typ.split("'")[1].split("'")[0]
+    elif typ.startswith("<class '"):
+        typ = typ.split("'")[1].split("'")[0]
     rv = getattr(getattr(x, 'func', x), '__name__', typ)
     if '.' in rv:
         rv = rv.split('.')[-1]

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -330,12 +330,12 @@ def func_name(x: Any, short: bool = False) -> str:
     'Equality': 'Eq',
     'Unequality': 'Ne',
     }
-    typ = type(x)
+    typ: type | str = type(x)
     if str(typ).startswith("<type '"):
         typ = str(typ).split("'")[1].split("'")[0]
     elif str(typ).startswith("<class '"):
         typ = str(typ).split("'")[1].split("'")[0]
-    rv = getattr(getattr(x, 'func', x), '__name__', typ)
+    rv: str = getattr(getattr(x, 'func', x), '__name__', str(typ))
     if '.' in rv:
         rv = rv.split('.')[-1]
     if short:


### PR DESCRIPTION
This PR fixes mypy type checking issues in sympy.utilities.misc.

Changes include:
- Simplifying `func_name` by handling `typ` as a string consistently,
  resolving mypy errors and improving readability.
- Adding type annotations to `filldedent`.
No functional behavior is changed. All tests pass locally
(sympy/utilities/tests/test_misc.py).
<!-- BEGIN RELEASE NOTES -->
* utilities
  * Add type annotation to `func_name` in `sympy.utilities.misc`.
<!-- END RELEASE NOTES -->
