### PR TITLE
Add: Added `refine_sin_cos` function to handle simplifications for cos and sin

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -420,13 +420,14 @@ def refine_sin_cos(expr, assumptions):
                 rem_terms.append(term)
         else:
             rem_terms.append(term)
-    k = Add(*k_terms, evaluate=False)
-    rem = Add(*rem_terms, evaluate=False)
+    k = Add(*k_terms)
     if isinstance(expr, sin):
-        k = Add(k, -1, evaluate=False)
+        k -= 1
     if ask(Q.odd(k), assumptions):
+        rem = Add(*rem_terms)
         return ((-1)**((k + 1) / 2)) * sin(rem)
     elif ask(Q.even(k), assumptions):
+        rem = Add(*rem_terms)
         return ((-1)**(k / 2)) * cos(rem)
     return expr
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -444,25 +444,19 @@ def refine_sin_cos(expr, assumptions):
     if not integer_coeffs_of_pi_half:
         return expr
 
-    even_coeff = 0
-    odd_coeff = 0
+    parity_known_coeff = 0
     unknown_parity_coeff = 0
     for coeff in integer_coeffs_of_pi_half:
-        if ask(Q.even(coeff), assumptions):
-            even_coeff += coeff
-        elif ask(Q.odd(coeff), assumptions):
-            odd_coeff += coeff
+        if ask(Q.even(coeff), assumptions) or ask(Q.odd(coeff), assumptions):
+            parity_known_coeff += coeff
         else:
             unknown_parity_coeff += coeff
 
-    if ask(Q.even(unknown_parity_coeff), assumptions):
-        even_coeff += unknown_parity_coeff
-        unknown_parity_coeff = 0
-    elif ask(Q.odd(unknown_parity_coeff), assumptions):
-        odd_coeff += unknown_parity_coeff
+    if ask(Q.even(unknown_parity_coeff), assumptions) or \
+        ask(Q.odd(unknown_parity_coeff), assumptions):
+        parity_known_coeff += unknown_parity_coeff
         unknown_parity_coeff = 0
 
-    parity_known_coeff = even_coeff + odd_coeff
     if parity_known_coeff == 0:
         return expr
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -443,10 +443,11 @@ def refine_sin_cos(expr, assumptions):
         else:
             remaining_terms.append(term)
 
-    # As `sin(x) = cos(x-pi/2)`, solving things for `cos` will allow us to use
-    # same logic for both functions by decreasing the coefficient of pi/2 by 1.
     if not integer_coeffs_of_pi_half:
         return expr
+
+    # As `sin(x) = cos(x-pi/2)`, solving things for `cos` will allow us to use
+    # same logic for both functions by decreasing the coefficient of pi/2 by 1.
     integer_coeff_of_pi_half = sum(integer_coeffs_of_pi_half)
     if isinstance(expr, sin):
         integer_coeff_of_pi_half -= 1

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -253,5 +253,7 @@ def test_sin_cos():
     assert refine(cos(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2)) * sin(x)
     assert refine(sin(x + y + 2*n*pi), Q.integer(n)) == sin(x + y)
     assert refine(cos(x + y + 2*n*pi), Q.integer(n)) == cos(x + y)
-    assert refine(cos(x + n * pi + m * pi / 2), Q.integer(n) & Q.even(m)) == (-1) ** (n + m / 2) * cos(x)
-    assert refine(cos(x + n * pi + m * pi / 2), Q.integer(n) & Q.odd(m)) == (-1) ** (n + (m + 1) / 2) * sin(x)
+    assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.even(m)) == \
+        (-1)**(n + m / 2) * cos(x)
+    assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.odd(m)) == \
+        (-1)**(n + (m + 1)/2) * sin(x)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -246,12 +246,18 @@ def test_sin_cos():
     assert refine(cos(x + n*pi), Q.even(n)) == cos(x)
     assert refine(sin(x + n*pi), Q.odd(n)) == -sin(x)
     assert refine(cos(x + n*pi), Q.odd(n)) == -cos(x)
+    assert refine(sin(x - n*pi), Q.odd(n)) == -sin(x)
+    assert refine(cos(x - n*pi), Q.even(n)) == cos(x)
     assert refine(sin(x + n*pi/2), Q.even(n)) == ((-1)**(n/2)) * sin(x)
     assert refine(cos(x + n*pi/2), Q.even(n)) == ((-1)**(n/2)) * cos(x)
     assert refine(sin(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 3)/2)) * cos(x)
     assert refine(cos(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2)) * sin(x)
+    assert refine(sin(x - n*pi/2), Q.odd(n)) == ((-1)**((n + 3)/2)) * -cos(x)
+    assert refine(cos(x - n*pi / 2), Q.even(n)) == ((-1)**(n/2)) * cos(x)
     assert refine(sin(x + y + 2*n*pi), Q.integer(n)) == sin(x + y)
     assert refine(cos(x + y + 2*n*pi), Q.integer(n)) == cos(x + y)
+    assert refine(sin(x + n * pi), Q.zero(n)) == sin(x)
+    assert refine(sin(x + n * pi), Q.zero(-n)) == sin(x)
     m = Symbol('m')
     assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.even(m)) == \
         (-1)**(n + m / 2) * cos(x)
@@ -259,8 +265,12 @@ def test_sin_cos():
         (-1)**(n + (m + 1)/2) * sin(x)
     assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.integer(m)) == \
         (-1)**(n) * cos(x + m*pi / 2)
-    assert refine(cos(x + (2*n + 1)*pi + m*pi / 2), Q.integer(n) & Q.integer(m)) == \
+    assert refine(cos(x + (2*n + 1)*pi + m*pi / 2), \
+        Q.integer(n) & Q.integer(m)) == \
         - cos(x + m*pi / 2)
+    assert refine(sin(x - (2*n)*pi + m*pi/2), \
+        Q.integer(n) & Q.integer(m)) == \
+        sin(x + m*pi / 2)
     k = Symbol('k')
     assert refine(cos(x + n*pi + k*pi/2 + m*pi/2), \
                   Q.integer(n) & Q.odd(k) & Q.integer(m)) == \

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -261,3 +261,13 @@ def test_sin_cos():
         (-1)**(n) * cos(x + m*pi / 2)
     assert refine(cos(x + (2*n + 1)*pi + m*pi / 2), Q.integer(n) & Q.integer(m)) == \
         - cos(x + m*pi / 2)
+    k = Symbol('k')
+    assert refine(cos(x + n*pi + k*pi/2 + m*pi/2), \
+                  Q.integer(n) & Q.odd(k) & Q.integer(m)) == \
+        (-1)**(n + (k + 1)/2) * sin(x + m*pi/2)
+    assert refine(sin(x + n*pi + k*pi/2 + m*pi/2), \
+                  Q.integer(n) & Q.odd(k) & Q.integer(m)) == \
+        (-1)**(n + (k + 3)/2) * cos(x + m*pi/2)
+    assert refine(cos(x + n*pi/2 + k*pi/2 + m*pi/2), \
+                  Q.odd(n) & Q.odd(k) & Q.integer(m)) == \
+        (-1)**((n + k)/2) * cos(x + m*pi/2)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -7,7 +7,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -225,3 +225,30 @@ def test_matrixelement():
     assert refine(x[1, 0], Q.symmetric(x)) == x[0, 1]
     assert refine(x[i, j], Q.symmetric(x)) == x[j, i]
     assert refine(x[j, i], Q.symmetric(x)) == x[j, i]
+
+
+def test_sin_cos():
+    n = Symbol('n')
+    assert refine(cos(n*pi/2), Q.odd(n)) == 0
+    assert refine(cos(n*pi), Q.even(n)) == 1
+    assert refine(cos(n*pi), Q.odd(n)) == -1
+    assert refine(sin(n*pi), Q.integer(n)) == 0
+    assert refine(sin(n*pi/2), Q.odd(n) & Q.even((n-1)/2)) == 1
+    assert refine(sin(n*pi/2), Q.odd(n) & Q.odd((n-1)/2)) == -1
+    assert refine(cos(n*pi), Q.integer(n)) == (-1)**n
+    assert refine(sin(n*pi/2), Q.even(n)) == 0
+    assert refine(cos(n*pi/2), Q.even(n)) == (-1)**(n/2)
+    assert refine(sin(n*pi/2), Q.odd(n)) == (-1)**((n + 3)/2)
+    assert refine(cos(n*pi/2), Q.odd(n)) == 0
+    assert refine(sin(x + n*pi), Q.integer(n)) == ((-1)**n) * sin(x)
+    assert refine(cos(x + n*pi), Q.integer(n)) == ((-1)**n) * cos(x)
+    assert refine(sin(x + n*pi), Q.even(n)) == sin(x)
+    assert refine(cos(x + n*pi), Q.even(n)) == cos(x)
+    assert refine(sin(x + n*pi), Q.odd(n)) == -sin(x)
+    assert refine(cos(x + n*pi), Q.odd(n)) == -cos(x)
+    assert refine(sin(x + n*pi/2), Q.even(n)) == ((-1)**(n/2)) * sin(x)
+    assert refine(cos(x + n*pi/2), Q.even(n)) == ((-1)**(n/2)) * cos(x)
+    assert refine(sin(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 3)/2)) * cos(x)
+    assert refine(cos(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2)) * sin(x)
+    assert refine(sin(x + y + 2*n*pi), Q.integer(n)) == sin(x + y)
+    assert refine(cos(x + y + 2*n*pi), Q.integer(n)) == cos(x + y)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -229,6 +229,7 @@ def test_matrixelement():
 
 def test_sin_cos():
     n = Symbol('n')
+    m = Symbol('m')
     assert refine(cos(n*pi/2), Q.odd(n)) == 0
     assert refine(cos(n*pi), Q.even(n)) == 1
     assert refine(cos(n*pi), Q.odd(n)) == -1
@@ -252,3 +253,5 @@ def test_sin_cos():
     assert refine(cos(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2)) * sin(x)
     assert refine(sin(x + y + 2*n*pi), Q.integer(n)) == sin(x + y)
     assert refine(cos(x + y + 2*n*pi), Q.integer(n)) == cos(x + y)
+    assert refine(cos(x + n * pi + m * pi / 2), Q.integer(n) & Q.even(m)) == (-1) ** (n + m / 2) * cos(x)
+    assert refine(cos(x + n * pi + m * pi / 2), Q.integer(n) & Q.odd(m)) == (-1) ** (n + (m + 1) / 2) * sin(x)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -256,8 +256,10 @@ def test_sin_cos():
     assert refine(cos(x - n*pi / 2), Q.even(n)) == ((-1)**(n/2)) * cos(x)
     assert refine(sin(x + y + 2*n*pi), Q.integer(n)) == sin(x + y)
     assert refine(cos(x + y + 2*n*pi), Q.integer(n)) == cos(x + y)
-    assert refine(sin(x + n * pi), Q.zero(n)) == sin(x)
-    assert refine(sin(x + n * pi), Q.zero(-n)) == sin(x)
+    assert refine(sin(x + n*pi), Q.zero(n)) == sin(x)
+    assert refine(sin(x + n*pi), Q.zero(-n)) == sin(x)
+    assert refine(cos(x + n*pi/2), Q.integer(n)) == cos(x + n*pi/2)
+    assert refine(cos(x + y + n*pi/2), Q.integer(n)) == cos(x + y + n*pi/2)
     m = Symbol('m')
     assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.even(m)) == \
         (-1)**(n + m / 2) * cos(x)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -229,7 +229,6 @@ def test_matrixelement():
 
 def test_sin_cos():
     n = Symbol('n')
-    m = Symbol('m')
     assert refine(cos(n*pi/2), Q.odd(n)) == 0
     assert refine(cos(n*pi), Q.even(n)) == 1
     assert refine(cos(n*pi), Q.odd(n)) == -1
@@ -253,7 +252,12 @@ def test_sin_cos():
     assert refine(cos(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2)) * sin(x)
     assert refine(sin(x + y + 2*n*pi), Q.integer(n)) == sin(x + y)
     assert refine(cos(x + y + 2*n*pi), Q.integer(n)) == cos(x + y)
+    m = Symbol('m')
     assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.even(m)) == \
         (-1)**(n + m / 2) * cos(x)
     assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.odd(m)) == \
         (-1)**(n + (m + 1)/2) * sin(x)
+    assert refine(cos(x + n*pi + m*pi / 2), Q.integer(n) & Q.integer(m)) == \
+        (-1)**(n) * cos(x + m*pi / 2)
+    assert refine(cos(x + (2*n + 1)*pi + m*pi / 2), Q.integer(n) & Q.integer(m)) == \
+        - cos(x + m*pi / 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes in part #27888

#### Brief description of what is fixed or changed
This PR adds a function in `refine.py`, `refine_sin_cos`. This function handles simplification of sin and cos. 

I have added tests for the same function in `test_refine.py`

#### Other comments

#### AI Generation Disclosure

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Enable `refine` to perform simplifications of sin and cos functions.
<!-- END RELEASE NOTES -->
