### PR TITLE
Import TypeIs from typing_extensions for python version less than 3.13

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -271,7 +271,7 @@ Alex Lindsay <adlinds3@ncsu.edu> Alex Lindsay <alexlindsay239@gmail.com>
 Alex Lubbock <code@alexlubbock.com>
 Alex Malins <github@alexmalins.com>
 Alex Meiburg <timeroot.alex@gmail.com>
-Alex Sun <alexsun.srand.nums@gmail.com>ß
+Alex Sun <alexsun.srand.nums@gmail.com>
 AlexCQY <alex_chua@u.nus.edu>
 Alexander Behrens <alex.git@gmx.net> Alex <Alex031544@users.noreply.github.com>
 Alexander Behrens <alex.git@gmx.net> Alex031544 <alex.git@gmx.net>

--- a/.mailmap
+++ b/.mailmap
@@ -271,6 +271,7 @@ Alex Lindsay <adlinds3@ncsu.edu> Alex Lindsay <alexlindsay239@gmail.com>
 Alex Lubbock <code@alexlubbock.com>
 Alex Malins <github@alexmalins.com>
 Alex Meiburg <timeroot.alex@gmail.com>
+Alex Sun <alexsun.srand.nums@gmail.com>ß
 AlexCQY <alex_chua@u.nus.edu>
 Alexander Behrens <alex.git@gmx.net> Alex <Alex031544@users.noreply.github.com>
 Alexander Behrens <alex.git@gmx.net> Alex031544 <alex.git@gmx.net>

--- a/bin/test_import
+++ b/bin/test_import
@@ -19,15 +19,31 @@ from get_sympy import path_hack
 
 def test():
     t = run("python bin/test_import.py", cwd=path_hack())
-    t = float(t)
-    return t
+    print(t)
+    if not t or t.strip() == b'':
+        print("Warning: Empty response from subprocess, skipping this run")
+        return None
+    try:
+        t = float(t)
+        return t
+    except ValueError as e:
+        print(f"Error converting '{t}' to float: {e}")
+        return None
 
-
-tests = [test() for x in range(n_tests + 1)]
+print("Start to Run Test:")
+all_tests = [test() for x in range(n_tests + 1)]
+# Filter out None values (failed runs)
+tests = [t for t in all_tests if t is not None]
 print("Note: the first run (warm up) was not included in the average + std dev")
 print("All runs (including warm up):")
 print(tests)
-# skip the first run (warm up):
-tests = tests[1:]
-print("Number of tests: %d" % (n_tests))
-print('The speed of "import sympy" is: %f +- %f' % (mean(tests), std(tests)))
+# skip the first run (warm up) if it exists:
+if tests:
+    tests = tests[1:]
+    print("Number of successful tests: %d" % (len(tests)))
+    if tests:
+        print('The speed of "import sympy" is: %f +- %f' % (mean(tests), std(tests)))
+    else:
+        print("No successful tests after warm up")
+else:
+    print("No successful tests at all")

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -1,6 +1,7 @@
 """Implementation of :class:`Domain` class. """
 
 from __future__ import annotations
+import sys
 from typing import Any, Generic, TypeVar, Protocol, Callable, Iterable, TYPE_CHECKING
 
 from sympy.core.numbers import AlgebraicNumber
@@ -16,7 +17,10 @@ from sympy.utilities.iterables import is_sequence
 
 
 if TYPE_CHECKING:
-    from typing import TypeIs
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
     from sympy.polys.polytools import Poly
     from sympy.polys.domains.ring import Ring
     from sympy.polys.domains.field import Field

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -1,7 +1,7 @@
 """Implementation of :class:`FractionField` class. """
 
 from __future__ import annotations
-
+import sys
 from typing import Generic, TYPE_CHECKING
 
 from sympy.polys.domains.domain import Er
@@ -12,7 +12,10 @@ from sympy.utilities import public
 
 
 if TYPE_CHECKING:
-    from typing import TypeIs
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
     from sympy.polys.domains.domain import Domain
     from sympy.polys.fields import FracField, FracElement
 

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -1,7 +1,7 @@
 """Implementation of :class:`PolynomialRing` class. """
 
 from __future__ import annotations
-
+import sys
 from typing import TYPE_CHECKING
 
 from sympy.core.expr import Expr
@@ -16,7 +16,10 @@ from sympy.utilities import public
 
 
 if TYPE_CHECKING:
-    from typing import TypeIs
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
     from sympy.polys.rings import PolyRing, PolyElement
 
 

--- a/sympy/polys/domains/powerseriesring.py
+++ b/sympy/polys/domains/powerseriesring.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-
+import sys
 from sympy.core.expr import Expr
 from sympy.polys.domains.ring import Ring
 from sympy.polys.domains.compositedomain import CompositeDomain
@@ -14,7 +14,10 @@ from sympy.polys.series.ring import (
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from typing import TypeIs
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
     from sympy.polys.densebasic import dup
     from sympy.polys.series.tring import TSeriesElement
     from sympy.polys.series.base import PowerSeriesRingProto

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import (
     Generic,
     overload,
@@ -58,7 +59,10 @@ from sympy.utilities.magic import pollute
 
 
 if TYPE_CHECKING:
-    from typing import TypeIs
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
     from sympy.polys.fields import FracField
     from types import NotImplementedType
 

--- a/sympy/polys/series/ring.py
+++ b/sympy/polys/series/ring.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import sys
 from functools import reduce
 from operator import add, mul
 
@@ -21,7 +21,10 @@ from sympy.series.order import Order
 from typing import Generic, overload, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import TypeIs
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
 
 
 @overload


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Issue:  Improvement based on research on issue [#28806](https://github.com/sympy/sympy/issues/28806)


#### Brief description of what is fixed or changed
While running mypy on the codebase, noticed type error related to TypeIs,  based on my research, for python version less than 3.13, the type should be imported from typing_extensions.

#### Other comments
See reference at this link : https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Not a complete fix for the related issue, this address some mypy issue on some imports.
<!-- END RELEASE NOTES -->
