### PR TITLE
Add type annotations to _iproduct2

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -18,11 +18,16 @@ from sympy.utilities.enumerative import (
 
 from sympy.utilities.misc import as_int
 from sympy.utilities.decorator import deprecated
+from typing import cast, TypeVar
+
+_T = TypeVar("_T")
 
 
 if TYPE_CHECKING:
-    from typing import TypeVar, Iterable, Callable, Literal, Sequence
-    T = TypeVar('T')
+    from typing import Iterable, Callable, Literal, Sequence, Iterator
+    T = TypeVar("T")
+    T1 = TypeVar("T1")
+    T2 = TypeVar("T2")
 
 
 def is_palindromic(s: Sequence[T], i: int = 0, j: int | None = None) -> bool:
@@ -231,20 +236,23 @@ def group(
     return [(k, len(list(g))) for k, g in groupby(seq)]
 
 
-def _iproduct2(iterable1, iterable2):
+def _iproduct2(
+    iterable1: Iterable[T1],
+    iterable2: Iterable[T2],
+) -> Iterator[tuple[T1, T2]]:
     '''Cartesian product of two possibly infinite iterables'''
 
     it1 = iter(iterable1)
     it2 = iter(iterable2)
 
-    elems1 = []
-    elems2 = []
+    elems1: list[T1] = []
+    elems2: list[T2] = []
 
     sentinel = object()
-    def append(it, elems):
+    def append(it: Iterator[_T], elems: list[_T]) -> None:
         e = next(it, sentinel)
         if e is not sentinel:
-            elems.append(e)
+            elems.append(cast(_T, e))
 
     n = 0
     append(it1, elems1)

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, overload, cast
 
 from collections import Counter, defaultdict, OrderedDict
 from itertools import (
@@ -18,7 +18,6 @@ from sympy.utilities.enumerative import (
 
 from sympy.utilities.misc import as_int
 from sympy.utilities.decorator import deprecated
-from typing import cast
 
 
 if TYPE_CHECKING:

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -18,13 +18,11 @@ from sympy.utilities.enumerative import (
 
 from sympy.utilities.misc import as_int
 from sympy.utilities.decorator import deprecated
-from typing import cast, TypeVar
-
-_T = TypeVar("_T")
+from typing import cast
 
 
 if TYPE_CHECKING:
-    from typing import Iterable, Callable, Literal, Sequence, Iterator
+    from typing import Iterable, Callable, Literal, Sequence, Iterator, TypeVar
     T = TypeVar("T")
     T1 = TypeVar("T1")
     T2 = TypeVar("T2")
@@ -249,10 +247,10 @@ def _iproduct2(
     elems2: list[T2] = []
 
     sentinel = object()
-    def append(it: Iterator[_T], elems: list[_T]) -> None:
+    def append(it: Iterator[T], elems: list[T]) -> None:
         e = next(it, sentinel)
         if e is not sentinel:
-            elems.append(cast(_T, e))
+            elems.append(cast("T", e))
 
     n = 0
     append(it1, elems1)


### PR DESCRIPTION
Issue: gh-28806

This PR adds and refines type annotations for the internal _iproduct2 helper in sympy.utilities.iterables.

Summary of changes:

-Added type annotations to _iproduct2

-Fixed indentation and formatting issues

-Switched to built-in generics (tuple[T1, T2])

-Added missing annotations for the inner helper function

-Replaced the undefined runtime T3 with a runtime-safe TypeVar

-Imported cast at runtime to avoid NameError

-Resolved all ruff, mypy, pytest, and doctest failures

Tests pass locally on Windows.
<!-- BEGIN RELEASE NOTES -->

* utilities
  * Add type annotations to the internal helper function `_iproduct2`.
    This change does not affect runtime behavior.

<!-- END RELEASE NOTES -->