### PR TITLE
Fix mypy Optional[ModuleType] annotation in gmpy

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -4,6 +4,7 @@ from ctypes import c_long, sizeof
 from functools import reduce
 from typing import TYPE_CHECKING
 from warnings import warn
+from types import ModuleType
 
 from sympy.external import import_module
 
@@ -151,8 +152,10 @@ def _get_gmpy2(sympy_ground_types):
 # SYMPY_GROUND_TYPES can be flint, gmpy, gmpy2, python or auto (default)
 #
 _SYMPY_GROUND_TYPES = os.environ.get('SYMPY_GROUND_TYPES', 'auto').lower()
-_flint = None
-_gmpy = None
+
+_flint:  ModuleType | None = None
+_gmpy:  ModuleType | None = None
+
 
 #
 # First handle auto-detection of flint/gmpy2. We will prefer flint if available


### PR DESCRIPTION
issue: #28717
Fixes a mypy error by correctly annotating optional gmpy/flint module imports.
No runtime behavior changes.
All tests and mypy pass.
<!-- BEGIN RELEASE NOTES -->
* polys
  * Correctly annotate optional gmpy/flint imports to fix a mypy type‑checking error (no runtime changes; tests and mypy pass).

<!-- END RELEASE NOTES -->
