### PR TITLE
Refactor argument transposition logic in ArrayTensorProduct

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -387,6 +387,7 @@ Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.norepl
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>
+Avanish Salunke <avanishsalunke16@gmail.com> AvanishSalunke <avanishsalunke16@gmail.com>
 Avasam <samuel.06@hotmail.com>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>
 Avichal Dayal <avichal.dayal@gmail.com>


### PR DESCRIPTION
Implemented an "Extract Method" refactor on the `ArrayTensorProduct` class.
Extracted the logic for calculating argument transpositions from `_check_permutation_mapping` into a new class method: `_get_arg_transposition`.




#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->


* tensor
  * Refactored argument transposition logic in ArrayTensorProduct into a separate helper method to improve code maintainability.

<!-- END RELEASE NOTES -->
