### PR TITLE
Rank

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -190,7 +190,6 @@
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
 *Ulrich Hecht <ulrich.hecht@gmail.com>
 2torus <boris.ettinger@gmail.com>
-SACHokstack <sach.ab.cr7@gmail.com> <133003875+SACHokstack@users.noreply.github.com>
 Aadit Kamat <aadit.k12@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
 Aaron Gokaslan <aaronGokaslan@gmail.com>
@@ -1391,6 +1390,7 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+SACHokstack <sach.ab.cr7@gmail.com> <133003875+SACHokstack@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -190,6 +190,7 @@
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
 *Ulrich Hecht <ulrich.hecht@gmail.com>
 2torus <boris.ettinger@gmail.com>
+SACHokstack <sach.ab.cr7@gmail.com> <133003875+SACHokstack@users.noreply.github.com>
 Aadit Kamat <aadit.k12@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
 Aaron Gokaslan <aaronGokaslan@gmail.com>

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1740,6 +1740,21 @@ See the discussion on issue [#17881](https://github.com/sympy/sympy/pull/17881).
 
 ## Version 1.4
 
+(array-expressions-subranks)=
+### Array expression `subranks` and `get_rank` deprecations
+
+The `subranks` attribute and related helper functions in
+`sympy.tensor.array.expressions` are deprecated.
+
+They have been replaced by clearer naming that distinguishes between
+node-level dimensionality and argument-level dimensionality:
+
+- `subranks` → `args_ndims`
+- `get_rank()` → `get_ndim()`
+
+The old API remains available with deprecation warnings and will be
+removed in a future SymPy release.
+
 (deprecated-tensorindextype-attrs)=
 ### `TensorIndexType.data` and related methods
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -431,15 +431,15 @@ class ArrayPrinter:
         except Exception: # noqa: BLE001
             return indexed
 
-    def _get_einsum_string(self, subranks, contraction_indices):
+    def _get_einsum_string(self, args_ndims, contraction_indices):
         letters = self._get_letter_generator_for_einsum()
         contraction_string = ""
         counter = 0
         d = {j: min(i) for i in contraction_indices for j in i}
         indices = []
-        for rank_arg in subranks:
+        for ndim_arg in args_ndims:
             lindices = []
-            for i in range(rank_arg):
+            for i in range(ndim_arg):
                 if counter in d:
                     lindices.append(d[counter])
                 else:
@@ -475,7 +475,7 @@ class ArrayPrinter:
 
     def _print_ArrayTensorProduct(self, expr):
         letters = self._get_letter_generator_for_einsum()
-        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.subranks])
+        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.args_ndims])
         return '%s("%s", %s)' % (
                 self._module_format(self._module + "." + self._einsum),
                 contraction_string,
@@ -489,12 +489,12 @@ class ArrayPrinter:
 
         if isinstance(base, ArrayTensorProduct):
             elems = ",".join(["%s" % (self._print(arg)) for arg in base.args])
-            ranks = base.subranks
+            ndims = base.args_ndims
         else:
             elems = self._print(base)
-            ranks = [len(base.shape)]
+            ndims = [len(base.shape)]
 
-        contraction_string, letters_free, letters_dum = self._get_einsum_string(ranks, contraction_indices)
+        contraction_string, letters_free, letters_dum = self._get_einsum_string(ndims, contraction_indices)
 
         if not contraction_indices:
             return self._print(base)
@@ -512,12 +512,12 @@ class ArrayPrinter:
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
         diagonal_indices = list(expr.diagonal_indices)
         if isinstance(expr.expr, ArrayTensorProduct):
-            subranks = expr.expr.subranks
+            args_ndims = expr.expr.args_ndims
             elems = expr.expr.args
         else:
-            subranks = expr.subranks
+            args_ndims = expr.args_ndims
             elems = [expr.expr]
-        diagonal_string, letters_free, letters_dum = self._get_einsum_string(subranks, diagonal_indices)
+        diagonal_string, letters_free, letters_dum = self._get_einsum_string(args_ndims, diagonal_indices)
         elems = [self._print(i) for i in elems]
         return '%s("%s", %s)' % (
             self._module_format(self._module + "." + self._einsum),

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -422,8 +422,8 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     from sympy.tensor.array.expressions.array_expressions import _permute_dims
     from sympy.matrices.expressions.matexpr import MatrixSymbol
     from sympy.tensor.array.expressions import PermuteDims
-    from sympy.tensor.array.expressions.array_expressions import get_rank
-    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_rank(expr))
+    from sympy.tensor.array.expressions.array_expressions import get_ndim
+    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_ndim(expr))
     if isinstance(expr, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
         return _permute_dims(expr, perm)
 

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -2046,7 +2046,7 @@ def get_rank(expr):
         not the linear-algebraic rank of a matrix.
         """,
         deprecated_since_version="1.14",
-        active_deprecations_target="array-expressions-get-rank",
+        active_deprecations_target="array-expressions-subranks",
         stacklevel=3,
     )
     return get_ndim(expr)

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -14,7 +14,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.tensor.array.expressions.array_expressions import (
     _ArrayExpr, ZeroArray, ArraySymbol, ArrayTensorProduct, ArrayAdd,
-    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_rank,
+    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_ndim,
     get_shape, ArrayContraction, _array_tensor_product, _array_contraction,
     _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum)
 from sympy.tensor.array.expressions.from_matrix_to_array import convert_matrix_to_array
@@ -136,8 +136,8 @@ def _(expr: Inverse, x: Expr):
 
 @array_derive.register(ElementwiseApplyFunction)
 def _(expr: ElementwiseApplyFunction, x: Expr):
-    assert get_rank(expr) == 2
-    assert get_rank(x) == 2
+    assert get_ndim(expr) == 2
+    assert get_ndim(x) == 2
     fdiff = expr._get_function_fdiff()
     dexpr = array_derive(expr.expr, x)
     tp = _array_tensor_product(
@@ -159,8 +159,8 @@ def _(expr: ArrayElementwiseApplyFunc, x: Expr):
         dsubexpr,
         ArrayElementwiseApplyFunc(fdiff, subexpr)
     )
-    b = get_rank(x)
-    c = get_rank(expr)
+    b = get_ndim(x)
+    c = get_ndim(expr)
     diag_indices = [(b + i, b + c + i) for i in range(c)]
     return _array_diagonal(tp, *diag_indices)
 

--- a/sympy/tensor/array/expressions/from_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/from_array_to_indexed.py
@@ -4,7 +4,7 @@ from itertools import accumulate
 
 from sympy import Mul, Sum, Dummy, Add
 from sympy.tensor.array.expressions import PermuteDims, ArrayAdd, ArrayElementwiseApplyFunc, Reshape
-from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, get_rank, ArrayContraction, \
+from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, get_ndim, ArrayContraction, \
     ArrayDiagonal, get_shape, _get_array_element_or_slice, _ArrayExpr
 from sympy.tensor.array.expressions.utils import _apply_permutation_to_list
 
@@ -20,11 +20,11 @@ class _ConvertArrayToIndexed:
 
     def do_convert(self, expr, indices):
         if isinstance(expr, ArrayTensorProduct):
-            cumul = list(accumulate([0] + [get_rank(arg) for arg in expr.args]))
+            cumul = list(accumulate([0] + [get_ndim(arg) for arg in expr.args]))
             indices_grp = [indices[cumul[i]:cumul[i+1]] for i in range(len(expr.args))]
             return Mul.fromiter(self.do_convert(arg, ind) for arg, ind in zip(expr.args, indices_grp))
         if isinstance(expr, ArrayContraction):
-            new_indices = [None for i in range(get_rank(expr.expr))]
+            new_indices = [None for i in range(get_ndim(expr.expr))]
             limits = []
             bottom_shape = get_shape(expr.expr)
             for contraction_index_grp in expr.contraction_indices:
@@ -42,8 +42,8 @@ class _ConvertArrayToIndexed:
             newexpr = self.do_convert(expr.expr, new_indices)
             return Sum(newexpr, *limits)
         if isinstance(expr, ArrayDiagonal):
-            new_indices = [None for i in range(get_rank(expr.expr))]
-            ind_pos = expr._push_indices_down(expr.diagonal_indices, list(range(len(indices))), get_rank(expr))
+            new_indices = [None for i in range(get_ndim(expr.expr))]
+            ind_pos = expr._push_indices_down(expr.diagonal_indices, list(range(len(indices))), get_ndim(expr))
             for i, index in zip(ind_pos, indices):
                 if isinstance(i, collections.abc.Iterable):
                     for j in i:

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -20,10 +20,10 @@ from sympy.matrices.matrixbase import MatrixBase
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.array_expressions import PermuteDims, ArrayDiagonal, \
-    ArrayTensorProduct, OneArray, get_rank, _get_subrank, ZeroArray, ArrayContraction, \
+    ArrayTensorProduct, OneArray, get_ndim, _get_args_ndims_total, ZeroArray, ArrayContraction, \
     ArrayAdd, _CodegenArrayAbstract, get_shape, ArrayElementwiseApplyFunc, _ArrayExpr, _EditArrayContraction, _ArgE, \
     ArrayElement, _array_tensor_product, _array_contraction, _array_diagonal, _array_add, _permute_dims, ArraySum
-from sympy.tensor.array.expressions.utils import _get_mapping_from_subranks
+from sympy.tensor.array.expressions.utils import _get_mapping_from_args_ndims
 
 
 def _get_candidate_for_matmul_from_contraction(scan_indices: list[int | None], remaining_args: list[_ArgE]) -> tuple[_ArgE | None, bool, int]:
@@ -161,7 +161,7 @@ def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
                         first = MatMul.fromiter(margs[:j+1])
                         second = MatMul.fromiter(margs[j+1:])
                         break
-        counter += get_rank(arg)
+        counter += get_ndim(arg)
     if pos is None:
         return expr, []
     args[pos] = (first*MatMul.fromiter(i for i in trivial_matrices)*second).doit()
@@ -173,7 +173,7 @@ def _find_trivial_kronecker_products_broadcast(expr: ArrayTensorProduct):
     removed = []
     count_dims = 0
     for arg in expr.args:
-        count_dims += get_rank(arg)
+        count_dims += get_ndim(arg)
         shape = get_shape(arg)
         current_range = [count_dims-i for i in range(len(shape), 0, -1)]
         if (shape == (1, 1) and len(newargs) > 0 and 1 not in get_shape(newargs[-1]) and
@@ -198,7 +198,7 @@ def _array2matrix(expr):
 
 @_array2matrix.register(ZeroArray)
 def _(expr: ZeroArray):
-    if get_rank(expr) == 2:
+    if get_ndim(expr) == 2:
         return ZeroMatrix(*expr.shape)
     else:
         return expr
@@ -213,7 +213,7 @@ def _(expr: ArrayTensorProduct):
 def _(expr: ArraySum):
     new_function = _array2matrix(expr.function)
     output = expr.func(new_function, *expr.limits).simplify()
-    if isinstance(output, ZeroArray) and get_rank(output) == 2:
+    if isinstance(output, ZeroArray) and get_ndim(output) == 2:
         return ZeroMatrix(*output.shape)
     return output
 
@@ -240,7 +240,7 @@ def _(expr: ArrayContraction):
     if isinstance(subexpr, ArrayTensorProduct):
         newexpr = _array_contraction(_array2matrix(subexpr), *contraction_indices)
         contraction_indices = newexpr.contraction_indices
-        if any(i > 2 for i in newexpr.subranks):
+        if any(i > 2 for i in newexpr.args_ndims):
             addends = _array_add(*[_a2m_tensor_product(*j) for j in itertools.product(*[i.args if isinstance(i,
                                                                                                                              ArrayAdd) else [i] for i in expr.expr.args])])
             newexpr = _array_contraction(addends, *contraction_indices)
@@ -275,7 +275,7 @@ def _(expr: PermuteDims):
     if expr.permutation.array_form == [1, 0]:
         return _a2m_transpose(_array2matrix(expr.expr))
     elif isinstance(expr.expr, ArrayTensorProduct):
-        ranks = expr.expr.subranks
+        ranks = expr.expr.args_ndims
         inv_permutation = expr.permutation**(-1)
         newrange = [inv_permutation(i) for i in range(sum(ranks))]
         newpos = []
@@ -367,7 +367,7 @@ def _(expr: ArrayTensorProduct):
 
     removed = []
     newargs = []
-    cumul = list(accumulate([0] + [get_rank(arg) for arg in expr.args]))
+    cumul = list(accumulate([0] + [get_ndim(arg) for arg in expr.args]))
     pending = None
     prev_i = None
     for i, arg in enumerate(expr.args):
@@ -491,13 +491,13 @@ def _(expr: ArrayContraction):
         new_expr2, removed1 = _remove_trivial_dims(_array2matrix(new_expr))
         removed = _combine_removed(-1, removed0, removed1)
         return new_expr2, removed
-    rank1 = get_rank(expr)
+    rank1 = get_ndim(expr)
     expr, removed1 = remove_identity_matrices(expr)
     if not isinstance(expr, ArrayContraction):
         expr2, removed2 = _remove_trivial_dims(expr)
         return expr2, _combine_removed(rank1, removed1, removed2)
     newexpr, removed2 = _remove_trivial_dims(expr.expr)
-    shifts = list(accumulate([1 if i in removed2 else 0 for i in range(get_rank(expr.expr))]))
+    shifts = list(accumulate([1 if i in removed2 else 0 for i in range(get_ndim(expr.expr))]))
     new_contraction_indices = [tuple(j for j in i if j not in removed2) for i in expr.contraction_indices]
     # Remove possible empty tuples "()":
     new_contraction_indices = [i for i in new_contraction_indices if len(i) > 0]
@@ -534,20 +534,20 @@ def _remove_diagonalized_identity_matrices(expr: ArrayDiagonal):
                 other_range = editor.get_absolute_range(other)
                 removed.extend([other_range[0] + none_index])
     editor.args_with_ind = [i for i in editor.args_with_ind if i.element is not None]
-    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, get_rank(expr.expr))
+    removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, get_ndim(expr.expr))
     return editor.to_array_contraction(), removed
 
 
 @_remove_trivial_dims.register(ArrayDiagonal)
 def _(expr: ArrayDiagonal):
     newexpr, removed = _remove_trivial_dims(expr.expr)
-    shifts = list(accumulate([0] + [1 if i in removed else 0 for i in range(get_rank(expr.expr))]))
+    shifts = list(accumulate([0] + [1 if i in removed else 0 for i in range(get_ndim(expr.expr))]))
     new_diag_indices_map = {i: tuple(j for j in i if j not in removed) for i in expr.diagonal_indices}
     for old_diag_tuple, new_diag_tuple in new_diag_indices_map.items():
         if len(new_diag_tuple) == 1:
             removed = [i for i in removed if i not in old_diag_tuple]
     new_diag_indices = [tuple(j - shifts[j] for j in i) for i in new_diag_indices_map.values()]
-    rank = get_rank(expr.expr)
+    rank = get_ndim(expr.expr)
     removed = ArrayDiagonal._push_indices_up(expr.diagonal_indices, removed, rank)
     removed = sorted(set(removed))
     # If there are single axes to diagonalize remaining, it means that their
@@ -666,10 +666,10 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
     if isinstance(expr.expr, ArrayTensorProduct):
         args = list(expr.expr.args)
         diag_indices = list(expr.diagonal_indices)
-        mapping = _get_mapping_from_subranks([_get_subrank(arg) for arg in args])
+        mapping = _get_mapping_from_args_ndims([_get_args_ndims_total(arg) for arg in args])
         tuple_links = [[mapping[j] for j in i] for i in diag_indices]
         contr_indices = []
-        total_rank = get_rank(expr)
+        total_rank = get_ndim(expr)
         replaced = [False for arg in args]
         for i, (abs_pos, rel_pos) in enumerate(zip(diag_indices, tuple_links)):
             if len(abs_pos) != 2:
@@ -677,7 +677,7 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
             (pos1_outer, pos1_inner), (pos2_outer, pos2_inner) = rel_pos
             arg1 = args[pos1_outer]
             arg2 = args[pos2_outer]
-            if get_rank(arg1) != 2 or get_rank(arg2) != 2:
+            if get_ndim(arg1) != 2 or get_ndim(arg2) != 2:
                 if replaced[pos1_outer]:
                     diag_indices[i] = None
                 if replaced[pos2_outer]:
@@ -708,7 +708,7 @@ def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
                 args[pos2_outer] = OneArray(arg2.shape[pos2_in2])
                 replaced[pos2_outer] = True
         diag_indices_new = [i for i in diag_indices if i is not None]
-        cumul = list(accumulate([0] + [get_rank(arg) for arg in args]))
+        cumul = list(accumulate([0] + [get_ndim(arg) for arg in args]))
         contr_indices2 = [tuple(cumul[a] + b for a, b in i) for i in contr_indices]
         tc = _array_contraction(
             _array_tensor_product(*args), *contr_indices2
@@ -941,7 +941,7 @@ def remove_identity_matrices(expr: ArrayContraction):
 
     removed.sort()
 
-    shifts = list(accumulate([1 if i in removed else 0 for i in range(get_rank(expr))]))
+    shifts = list(accumulate([1 if i in removed else 0 for i in range(get_ndim(expr))]))
     for (last_removed, ind), non_identity_indices in update_pairs.items():
         pos = [free_map[non_identity] + i for i, e in enumerate(non_identity_indices) if e == ind]
         assert len(pos) == 1
@@ -953,7 +953,7 @@ def remove_identity_matrices(expr: ArrayContraction):
     permutation = []
     counter = 0
     counter2 = 0
-    for j in range(get_rank(expr)):
+    for j in range(get_ndim(expr)):
         if j in removed:
             continue
         if counter2 in permutation_map:

--- a/sympy/tensor/array/expressions/utils.py
+++ b/sympy/tensor/array/expressions/utils.py
@@ -4,20 +4,40 @@ from collections import defaultdict
 from sympy.combinatorics import Permutation
 from sympy.core.containers import Tuple
 from sympy.core.numbers import Integer
+from sympy.utilities.exceptions import sympy_deprecation_warning
 
 
-def _get_mapping_from_subranks(subranks):
+def _get_mapping_from_args_ndims(args_ndims):
+    """
+    Create a mapping from flat index to (arg_index, rel_index) tuple.
+    """
     mapping = {}
     counter = 0
-    for i, rank in enumerate(subranks):
-        for j in range(rank):
+    for i, ndim in enumerate(args_ndims):
+        for j in range(ndim):
             mapping[counter] = (i, j)
             counter += 1
     return mapping
 
 
-def _get_contraction_links(args, subranks, *contraction_indices):
-    mapping = _get_mapping_from_subranks(subranks)
+def _get_mapping_from_subranks(subranks):
+    """
+    Deprecated. Use ``_get_mapping_from_args_ndims`` instead.
+    """
+    sympy_deprecation_warning(
+        """
+        The _get_mapping_from_subranks() function is deprecated.
+        Use _get_mapping_from_args_ndims() instead.
+        """,
+        deprecated_since_version="1.14",
+        active_deprecations_target="array-expressions-subranks",
+        stacklevel=3,
+    )
+    return _get_mapping_from_args_ndims(subranks)
+
+
+def _get_contraction_links(args, args_ndims, *contraction_indices):
+    mapping = _get_mapping_from_args_ndims(args_ndims)
     contraction_tuples = [[mapping[j] for j in i] for i in contraction_indices]
     dlinks = defaultdict(dict)
     for links in contraction_tuples:


### PR DESCRIPTION
# tensor.array: unmix ndim naming between node and subnode

#### References to other Issues or PRs
Fixes #28848

#### Brief description of what is fixed or changed
This PR clarifies the distinction between node-level and argument-level
dimensionality in array expressions.

- Introduces `args_ndims` for argument-level ndims
- Introduces `get_ndim()` for node-level ndims
- Preserves `subranks`/`get_rank` via deprecations (documented)
- Updates all internal usages to the new naming

All array expression tests pass.

#### Other comments
No backward-incompatible changes; old API triggers deprecation warnings.
Tests and printers updated accordingly.

<!-- BEGIN RELEASE NOTES -->
* other
  * `args_ndims` added for argument-level dimensionality in array expressions
  * `get_ndim()` added for node-level dimensionality
  * Deprecated `subranks` and `get_rank()` with deprecation warnings
<!-- END RELEASE NOTES -->
