### PR TITLE
Add type annotations to sympy/logic/inference.py

### DIFF
--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -1,12 +1,13 @@
 """Inference in propositional logic"""
 
+from typing import Any, Dict, Generator, Union, Optional
 from sympy.logic.boolalg import And, Not, conjuncts, to_cnf, BooleanFunction
 from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
 
 
-def literal_symbol(literal):
+def literal_symbol(literal: Any) -> Any:
     """
     The symbol in this literal (without the negation).
 
@@ -30,7 +31,7 @@ def literal_symbol(literal):
         raise ValueError("Argument must be a boolean literal.")
 
 
-def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_theory=False):
+def satisfiable(expr: Any, algorithm: Optional[str] = None, all_models: bool = False, minimal: bool = False, use_lra_theory: bool = False) -> Union[Dict[Any, bool], bool, Generator[Union[Dict[Any, bool], bool], None, None]]:
     """
     Check satisfiability of a propositional sentence.
     Returns a model when it succeeds.
@@ -117,7 +118,7 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_t
     raise NotImplementedError
 
 
-def valid(expr):
+def valid(expr: Any) -> bool:
     """
     Check validity of a propositional sentence.
     A valid propositional sentence is True under every assignment.
@@ -141,7 +142,7 @@ def valid(expr):
     return not satisfiable(Not(expr))
 
 
-def pl_true(expr, model=None, deep=False):
+def pl_true(expr: Any, model: Optional[Dict[Any, bool]] = None, deep: bool = False) -> Optional[bool]:
     """
     Returns whether the given assignment is a model or not.
 
@@ -214,7 +215,7 @@ def pl_true(expr, model=None, deep=False):
     return None
 
 
-def entails(expr, formula_set=None):
+def entails(expr: Any, formula_set: Optional[list] = None) -> bool:
     """
     Check whether the given expr_set entail an expr.
     If formula_set is empty then it returns the validity of expr.
@@ -249,29 +250,29 @@ def entails(expr, formula_set=None):
 
 class KB:
     """Base class for all knowledge bases"""
-    def __init__(self, sentence=None):
-        self.clauses_ = set()
+    def __init__(self, sentence: Optional[Any] = None) -> None:
+        self.clauses_: set = set()
         if sentence:
             self.tell(sentence)
 
-    def tell(self, sentence):
+    def tell(self, sentence: Any) -> None:
         raise NotImplementedError
 
-    def ask(self, query):
+    def ask(self, query: Any) -> Any:
         raise NotImplementedError
 
-    def retract(self, sentence):
+    def retract(self, sentence: Any) -> None:
         raise NotImplementedError
 
     @property
-    def clauses(self):
+    def clauses(self) -> list:
         return list(ordered(self.clauses_))
 
 
 class PropKB(KB):
     """A KB for Propositional Logic.  Inefficient, with no indexing."""
 
-    def tell(self, sentence):
+    def tell(self, sentence: Any) -> None:
         """Add the sentence's clauses to the KB
 
         Examples
@@ -295,7 +296,7 @@ class PropKB(KB):
         for c in conjuncts(to_cnf(sentence)):
             self.clauses_.add(c)
 
-    def ask(self, query):
+    def ask(self, query: Any) -> bool:
         """Checks if the query is true given the set of clauses.
 
         Examples
@@ -313,7 +314,7 @@ class PropKB(KB):
         """
         return entails(query, self.clauses_)
 
-    def retract(self, sentence):
+    def retract(self, sentence: Any) -> None:
         """Remove the sentence's clauses from the KB
 
         Examples


### PR DESCRIPTION
- Add type hints to literal_symbol(), satisfiable(), valid(), pl_true()
- Add type hints to entails() function
- Add type hints to KB base class and all methods
- Add type hints to PropKB class methods
- Improve code clarity with proper type signatures
- Fixes gh-28806

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
