### PR TITLE
integrals: add hypertangent test case to test_special_denom

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -397,6 +397,8 @@ Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71@gmail.com>
 Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
 Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
+Ayush Bothra <ayush9bothra@gmail.com> ayush-bothra <160741168+ayush-bothra@users.noreply.github.com>
+Ayush Bothra <ayush9bothra@gmail.com> ayush-bothra <ayush9bothra@gmail.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
 Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -103,6 +103,21 @@ def test_special_denom():
     assert special_denom(a, b, Poly(1, t), c, Poly(1, t), DE) == \
         (a, Poly(t**2/x**2 + (2/x - 1)*t, t), Poly(t**2/x**2 + (2/x - 1)*t, t), Poly(t, t))
 
+    # Example 6.2.2, adding a hypertangent case where the special denominator
+    # is not required in the reduction of the system, hence returning h = 1
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1 + t**2, t)]})
+    a = Poly(t, t, domain='ZZ')
+    ba = Poly((t - 1)*(t**2 + 1), t, domain='ZZ')
+    bd = Poly(1, t, domain='ZZ')
+    ca = Poly(1, t, domain='ZZ')
+    cd = Poly(1, t, domain='ZZ')
+    expected_a = Poly(t, t, domain='ZZ')
+    expected_b = Poly(t**3 - t**2 + t - 1, t, domain='ZZ')
+    expected_c = Poly(1, t, domain='ZZ')
+    expected_h = Poly(1, t, domain='ZZ')
+    assert special_denom(a, ba, bd, ca, cd, DE) == \
+        (expected_a, expected_b, expected_c, expected_h)
+
 def test_bound_degree_fail():
     # Primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This adds Example 6.2.2 from Bronstein's 'Symbolic Integration I' to the Risch Differential Equation tests.

- Extension: hypertangent (Dt = 1 + t^2)
- Parameters: a=t, b=(t-1)(t^2+1), c=1
- Result: n=0, N=0, and h=1

This verifies the algorithm's logic for cases where no special denominator reduction is required in the tangent case.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added a test for the hypertangent case for Risch Differential Equations
<!-- END RELEASE NOTES -->
