### PR TITLE
Add type annotations to memoization decorators

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -4,6 +4,7 @@ from ctypes import c_long, sizeof
 from functools import reduce
 from typing import TYPE_CHECKING
 from warnings import warn
+from types import ModuleType
 
 from sympy.external import import_module
 
@@ -151,8 +152,10 @@ def _get_gmpy2(sympy_ground_types):
 # SYMPY_GROUND_TYPES can be flint, gmpy, gmpy2, python or auto (default)
 #
 _SYMPY_GROUND_TYPES = os.environ.get('SYMPY_GROUND_TYPES', 'auto').lower()
-_flint = None
-_gmpy = None
+
+_flint:  ModuleType | None = None
+_gmpy:  ModuleType | None = None
+
 
 #
 # First handle auto-detection of flint/gmpy2. We will prefer flint if available


### PR DESCRIPTION
This PR adds type annotations to recurrence_memo and
assoc_recurrence_memo in sympy.utilities.memoization
without changing runtime behavior.
<!-- BEGIN RELEASE NOTES -->
* utilities
  * Add type annotations to memoization decorators without changing runtime behavior.
<!-- END RELEASE NOTES -->
