### PR TITLE
Add type annotation to ordinal()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -342,6 +342,7 @@ Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
 Ansh Mishra <anshmishra471@gmail.com>
+Anshul Sharma <anshulsharma4605@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -481,7 +481,7 @@ def translate(s, a, b=None, c=None):
     return s.translate(n)
 
 
-def ordinal(num):
+def ordinal(num: SupportsIndex) -> str:
     """Return ordinal number string of num, e.g. 1 becomes 1st.
     """
     # modified from https://codereview.stackexchange.com/questions/41298/producing-ordinal-numbers


### PR DESCRIPTION
This PR adds a type annotation to the ordinal function in
`sympy.utilities.misc.`

See gh-28806

### Summary of changes:
- Add a return type annotation to ordinal
- Keep the implementation and docstring unchanged
- No functional behavior is modified

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
