### PR TITLE
Add type annotations to memoization decorators

### DIFF
--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -4,6 +4,7 @@ from ctypes import c_long, sizeof
 from functools import reduce
 from typing import TYPE_CHECKING
 from warnings import warn
+from types import ModuleType
 
 from sympy.external import import_module
 
@@ -151,8 +152,10 @@ def _get_gmpy2(sympy_ground_types):
 # SYMPY_GROUND_TYPES can be flint, gmpy, gmpy2, python or auto (default)
 #
 _SYMPY_GROUND_TYPES = os.environ.get('SYMPY_GROUND_TYPES', 'auto').lower()
-_flint = None
-_gmpy = None
+
+_flint:  ModuleType | None = None
+_gmpy:  ModuleType | None = None
+
 
 #
 # First handle auto-detection of flint/gmpy2. We will prefer flint if available

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -239,6 +239,25 @@ def test_eigenvects():
         assert M*vec_list[0] == val*vec_list[0]
 
 
+@slow
+def test_eigenvects_slow():
+    # https://github.com/sympy/sympy/issues/28507
+    # This test is slow because of issues/28486
+    # After the fix, this test should be moved to test_eigenvects
+    M = Matrix([
+        [123, 45, 67, 89, sqrt(13)/2],
+        [45, 234, 56, 78, Rational(19, 43)],
+        [67, 56, 345, 90, 5*sqrt(7)/3],
+        [Rational(17, 3), 12, 34, 456, sqrt(11)/7],
+        [Rational(55, 17), sqrt(11)/5, 12, 34, 56]
+    ])
+    vecs = M.eigenvects()
+    for val, mult, vec_list in vecs:
+        assert len(vec_list) == 1
+        diff = (M*vec_list[0]).n() - (val*vec_list[0]).n()
+        assert all(abs(x) < 1e-10 for x in diff)
+
+
 def test_left_eigenvects():
     M = Matrix([[0, 1, 1],
                 [1, 0, 0],

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3972,19 +3972,23 @@ class Poly(Basic):
         return f._which_roots(candidates, f.degree())
 
     def _which_roots(f, candidates, num_roots):
+        fe = f.as_expr()
+        x = f.gens[0]
         prec = 10
-        # using Counter bc its like an ordered set
-        root_counts = Counter(candidates)
-        while len(root_counts) > num_roots:
-            for r in list(root_counts.keys()):
-                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
-                f_r = f(r).evalf(prec, maxn=2*prec)
-                if abs(f_r)._prec >= 2:
-                    root_counts.pop(r)
+        candidates = list(Counter(candidates).keys())
 
+        while len(candidates) > num_roots:
+            potential_candidates = []
+            for r in candidates:
+                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
+                f_r = fe.xreplace({x: r}).evalf(prec, maxn=2*prec)
+                if abs(f_r)._prec < 2:
+                    potential_candidates.append(r)
+
+            candidates = potential_candidates
             prec *= 2
 
-        return list(root_counts.keys())
+        return candidates
 
     def same_root(f, a, b):
         """

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,71 +1,105 @@
 from functools import wraps
+from typing import TypeVar, Callable, List, Protocol, cast, Union
 
 
-def recurrence_memo(initial):
+T = TypeVar("T")   # Elements of the main sequence
+U = TypeVar("U")   # Elements of associated sequences
+T_co = TypeVar("T_co", covariant=True)
+
+
+class RecurrenceFunc(Protocol[T_co]):
+    def __call__(self, n: int) -> T_co: ...
+    cache_length: Callable[[], int]
+    fetch_item: Callable[[Union[int, slice]], Union[T_co, List[T_co]]]
+
+
+def recurrence_memo(initial: List[T]) -> Callable[
+    [Callable[[int, List[T]], T]],
+    RecurrenceFunc[T],
+]:
     """
-    Memo decorator for sequences defined by recurrence
+    Memo decorator for sequences defined by recurrence.
+
+    Returns
+    =======
+    callable
+        Function that can be called with an integer argument ``n``.
+
+        The returned function has additional attributes:
+
+        * ``cache_length()`` – return the current cache size
+        * ``fetch_item(x)`` – return cached item(s) for an index or slice
 
     Examples
     ========
 
     >>> from sympy.utilities.memoization import recurrence_memo
-    >>> @recurrence_memo([1]) # 0! = 1
+    >>> @recurrence_memo([1])  # 0! = 1
     ... def factorial(n, prev):
     ...     return n * prev[-1]
     >>> factorial(4)
     24
-    >>> factorial(3) # use cache values
+    >>> factorial(3)
     6
-    >>> factorial.cache_length() # cache length can be obtained
+    >>> factorial.cache_length()
     5
     >>> factorial.fetch_item(slice(2, 4))
     [2, 6]
-
     """
-    cache = initial
+    cache: List[T] = initial.copy()
 
-    def decorator(f):
+    def decorator(f: Callable[[int, List[T]], T]) -> RecurrenceFunc[T]:
         @wraps(f)
-        def g(n):
+        def g(n: int) -> T:
             L = len(cache)
             if n < L:
                 return cache[n]
             for i in range(L, n + 1):
                 cache.append(f(i, cache))
             return cache[-1]
-        g.cache_length = lambda: len(cache)
-        g.fetch_item = lambda x: cache[x]
-        return g
+
+        rf = cast(RecurrenceFunc[T], g)
+        rf.cache_length = lambda: len(cache)
+        rf.fetch_item = lambda x: cache[x]
+        return rf
+
     return decorator
 
 
-def assoc_recurrence_memo(base_seq):
+def assoc_recurrence_memo(base_seq: Callable[[int], U]) -> Callable[
+    [Callable[[int, int, List[List[U]]], U]],
+    Callable[[int, int], U],
+]:
     """
-    Memo decorator for associated sequences defined by recurrence starting from base
+    Memo decorator for associated sequences defined by recurrence.
 
-    base_seq(n) -- callable to get base sequence elements
+    ``base_seq(n)`` should return the base sequence element for index ``n``.
 
-    XXX works only for Pn0 = base_seq(0) cases
-    XXX works only for m <= n cases
+    Returns
+    =======
+    callable
+        Function that can be called with integers ``n`` and ``m``.
+        Results are cached to avoid repeated computation.
+
+    Notes
+    =====
+    * Works only for cases with ``Pn0 = base_seq(0)``
+    * Works only when ``m <= n``
     """
+    cache: List[List[U]] = []
 
-    cache = []
-
-    def decorator(f):
+    def decorator(f: Callable[[int, int, List[List[U]]], U]) -> Callable[[int, int], U]:
         @wraps(f)
-        def g(n, m):
+        def g(n: int, m: int) -> U:
             L = len(cache)
             if n < L:
                 return cache[n][m]
 
             for i in range(L, n + 1):
-                # get base sequence
                 F_i0 = base_seq(i)
-                F_i_cache = [F_i0]
+                F_i_cache: List[U] = [F_i0]
                 cache.append(F_i_cache)
 
-                # XXX only works for m <= n cases
-                # generate assoc sequence
                 for j in range(1, i + 1):
                     F_ij = f(i, j, cache)
                     F_i_cache.append(F_ij)
@@ -73,4 +107,5 @@ def assoc_recurrence_memo(base_seq):
             return cache[n][m]
 
         return g
+
     return decorator


### PR DESCRIPTION
This PR adds type annotations to recurrence_memo and
assoc_recurrence_memo in sympy.utilities.memoization
without changing runtime behavior.
<!-- BEGIN RELEASE NOTES -->
* utilities
  * Add type annotations to memoization decorators without changing runtime behavior.
<!-- END RELEASE NOTES -->
