### PR TITLE
typ(utilities): add typing annotations for memoization decorators

### DIFF
--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,47 +1,93 @@
 from functools import wraps
+from typing import (
+    TypeVar,
+    Callable,
+    List,
+    Protocol,
+    cast,
+    Union,
+    TYPE_CHECKING,
+)
 
+
+
+T = TypeVar("T")   # Elements of the main sequence
+U = TypeVar("U")   # Elements of associated sequences
+
+
+
+class RecurrenceFunc(Protocol[T]):
+    def __call__(self, n: int) -> T: ...
+    cache_length: Callable[[], int]
+    fetch_item: Callable[[Union[int, slice]], Union[T, List[T]]]
+
+if TYPE_CHECKING:
+    recurrence_memo: Callable[
+        [List[T]],
+        Callable[[Callable[[int, List[T]], T]], RecurrenceFunc[T]],
+    ]
+
+    assoc_recurrence_memo: Callable[
+        [Callable[[int], U]],
+        Callable[
+            [Callable[[int, int, List[List[U]]], U]],
+            Callable[[int, int], U],
+        ],
+    ]
 
 def recurrence_memo(initial):
+
     """
-    Memo decorator for sequences defined by recurrence
+    Memo decorator for sequences defined by recurrence.
+
+    Returns
+    =======
+    callable
+        Function that can be called with an integer argument ``n``.
+
+        The returned function has additional attributes:
+
+        * ``cache_length()`` - return the current cache size
+        * ``fetch_item(x)`` - return cached item(s) for an index or slice
 
     Examples
     ========
 
     >>> from sympy.utilities.memoization import recurrence_memo
-    >>> @recurrence_memo([1]) # 0! = 1
+    >>> @recurrence_memo([1])  # 0! = 1
     ... def factorial(n, prev):
     ...     return n * prev[-1]
     >>> factorial(4)
     24
-    >>> factorial(3) # use cache values
+    >>> factorial(3)
     6
-    >>> factorial.cache_length() # cache length can be obtained
+    >>> factorial.cache_length()
     5
     >>> factorial.fetch_item(slice(2, 4))
     [2, 6]
-
     """
-    cache = initial
+    cache: List[T] = initial.copy()
 
-    def decorator(f):
+    def decorator(f: Callable[[int, List[T]], T]) -> RecurrenceFunc[T]:
         @wraps(f)
-        def g(n):
+        def g(n: int) -> T:
             L = len(cache)
             if n < L:
                 return cache[n]
             for i in range(L, n + 1):
                 cache.append(f(i, cache))
             return cache[-1]
-        g.cache_length = lambda: len(cache)
-        g.fetch_item = lambda x: cache[x]
-        return g
-    return decorator
 
+        rf = cast(RecurrenceFunc[T], g)
+        rf.cache_length = lambda: len(cache)
+        rf.fetch_item = lambda x: cache[x]
+        return rf
+
+    return decorator
 
 def assoc_recurrence_memo(base_seq):
     """
-    Memo decorator for associated sequences defined by recurrence starting from base
+    Memo decorator for associated sequences defined by recurrence starting from base.
 
     base_seq(n) -- callable to get base sequence elements
 
@@ -49,23 +95,20 @@ def assoc_recurrence_memo(base_seq):
     XXX works only for m <= n cases
     """
 
-    cache = []
+    cache: List[List[U]] = []
 
-    def decorator(f):
+    def decorator(f: Callable[[int, int, List[List[U]]], U]) -> Callable[[int, int], U]:
         @wraps(f)
-        def g(n, m):
+        def g(n: int, m: int) -> U:
             L = len(cache)
             if n < L:
                 return cache[n][m]
 
             for i in range(L, n + 1):
-                # get base sequence
                 F_i0 = base_seq(i)
-                F_i_cache = [F_i0]
+                F_i_cache: List[U] = [F_i0]
                 cache.append(F_i_cache)
 
-                # XXX only works for m <= n cases
-                # generate assoc sequence
                 for j in range(1, i + 1):
                     F_ij = f(i, j, cache)
                     F_i_cache.append(F_ij)
@@ -73,4 +116,5 @@ def assoc_recurrence_memo(base_seq):
             return cache[n][m]
 
         return g
+
     return decorator


### PR DESCRIPTION
Add precise typing annotations for the memoization decorators in
`sympy.utilities.memoization`.

This PR only affects typing and docstrings and does not change runtime
behavior. It is a clean submission containing only the intended changes.
<!-- BEGIN RELEASE NOTES -->
* utilities
  * Add type annotations to memoization decorators without changing runtime behavior.
<!-- END RELEASE NOTES -->