### PR TITLE
integrals: Add G&R 2.263.3 reduction for quadratic forms

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1650,7 +1650,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
         delta = 4*a*c - b**2
         R = c*x**2 + b*x + a
 
-        term_denom = (2*k - 1) * delta * sqrt(R**(2*k-1))
+        term_denom = (2*k - 1) * delta * (R**(S(2*k - 1)/2))
         constant_term = f*2*(2*c*x+b) / term_denom
         coeff = (8*c*(k-1))/((2*k-1) * delta)
         expr = f * R**(S(1)/2 - k)
@@ -1690,14 +1690,13 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
         generic_step = RewriteRule(integrand, x, rewritten, substep)
     elif n == -1:
         generic_step = sqrt_quadratic_denom_rule(f_poly, integrand)
-    else:
+    elif f_poly.degree() == 0:
         # The numerator must be a const, the formula assumes this
-        if f_poly.degree() == 0:
-            generic_step = sqrt_quadratic_reduction_rule(integrand, n)
-        else:
-            # Handle non-constant numerators (eg. x / R**(-3/2))
-            # This requires splitting the integral as A*(2ax+b) + B form
-            return None
+        generic_step = sqrt_quadratic_reduction_rule(integrand, n)
+    else:
+        # Handle non-constant numerators (eg. x / R**(-3/2))
+        # This requires splitting the integral as A*(2ax+b) + B form
+        return None
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -18,7 +18,7 @@ from sympy.functions.special.polynomials import (assoc_laguerre, chebyshevt, che
 from sympy.functions.special.zeta_functions import polylog
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.logic.boolalg import And
-from sympy.simplify.simplify import simplify
+from sympy import factor
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
     _parts_rule, integral_steps, manual_subs)
 from sympy.testing.pytest import raises, slow
@@ -790,44 +790,47 @@ def test_manualintegrate_sqrt_quadratic():
 
 def test_manualintegrate_sqrt_quadratic_reduction():
     # Tests for Gradshteyn & Ryzhik 2.263.3 reduction rule (n < -1 odd)
-    # These test cases are slightly messy due to limitations in simplify()
-    # regarding fractional powers and symbol assumptions
     a = symbols('a', nonzero=True)
     b, c, f, x = symbols('b c f x')
 
-    # 1. Base Case: n = -3
-    assert_is_integral_of(1/(x**2 + 1)**(S(3)/2), x/sqrt(x**2 + 1))
-    assert_is_integral_of(8/(x**2 + 1)**(S(3)/2), 8*x/sqrt(x**2 + 1))
+    # Base Case: n = -3
+    assert_is_integral_of(
+        1/(x**2 + 1)**(S(3)/2),
+        x/(x**2 + 1)**(S(1)/2)
+    )
+    assert_is_integral_of(
+        8/(x**2 + 1)**(S(3)/2),
+        8*x/(x**2 + 1)**(S(1)/2)
+    )
 
-    # 2. Complex Numeric Case (x^2 + 2x + 2)
-    # We use diff check here because the numeric coefficients are messy
-    term_complex = 1/(x**2 + 2*x + 2)**(S(3)/2)
-    res_complex = manualintegrate(term_complex, x)
-    assert simplify(diff(res_complex, x) - term_complex) == 0
+    # Complex Numeric Case (x^2 + 2x + 2)
+    assert_is_integral_of(
+        1/(x**2 + 2*x + 2)**(S(3)/2),
+        (4*x + 4)/(4*(x**2 + 2*x + 2)**(S(1)/2))
+    )
 
-    # 3. Recursive Case: n = -5
-    # We match the EXACT output format here to avoid simplification issues
-    # simplify().rewrite() struggles to equate sqrt((x**2 + 1)**3) with (x**2 + 1)**(3/2).
-    term_n5 = 1/(x**2 + 1)**(S(5)/2)
-    res_n5 = manualintegrate(term_n5, x)
-    expected = x/(3*sqrt((x**2 + 1)**3)) + 2*x/(3*sqrt(x**2 + 1))
-    assert res_n5 == expected
+    # Recursive Case: n = -5
+    assert_is_integral_of(
+        1/(x**2 + 1)**(S(5)/2),
+        x/(3*(x**2 + 1)**(S(3)/2)) + 2*x/(3*(x**2 + 1)**(S(1)/2))
+    )
+    assert_is_integral_of(
+        5/(x**2 + 1)**(S(5)/2),
+        5*x/(3*(x**2 + 1)**(S(3)/2)) + 10*x/(3*(x**2 + 1)**(S(1)/2))
+    )
 
-    assert manualintegrate(5/(x**2 + 1)**(S(5)/2), x) == 5*expected
+    # For even larger n
+    assert_is_integral_of(
+        1/(x**2 + 1)**(S(7)/2),
+        x/(5*(x**2 + 1)**(S(5)/2)) +
+        4*x/(15*(x**2 + 1)**(S(3)/2)) +
+        8*x/(15*(x**2 + 1)**(S(1)/2))
+    )
 
-    # 4. Symbolic Verification (General Case)
-    # here as well, simplify cant be sure of a being nonzero
-    # So I am declaring it as such because thats the only
-    # case for quadratics anyways
-    term_n3 = f/(a*x**2 + b*x + c)**(S(3)/2)
-    res_n3 = manualintegrate(term_n3, x)
-    assert simplify(diff(res_n3, x) - term_n3) == 0
-
-    # The general recursive case (n = -5) generates a massive expression
-    # that simplify() currently cannot reduce to zero.
-    # term_n5 = f/(a*x**2 + b*x + c)**(S(5)/2)
-    # res_n5 = manualintegrate(term_n5, x)
-    # assert simplify(diff(res_n5, x) - term_n5) == 0
+    # Symbolic Verification (General Case)
+    term_n5 = f/(a*x**2 + b*x + c)**(S(5)/2)
+    intg_result = manualintegrate(term_n5, x)
+    assert factor(intg_result.diff(x) - term_n5) == 0
 
 def test_mul_pow_derivative():
     assert_is_integral_of(x*sec(x)*tan(x), x*sec(x) - log(tan(x) + sec(x)))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -18,6 +18,7 @@ from sympy.functions.special.polynomials import (assoc_laguerre, chebyshevt, che
 from sympy.functions.special.zeta_functions import polylog
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.logic.boolalg import And
+from sympy.simplify.simplify import simplify
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
     _parts_rule, integral_steps, manual_subs)
 from sympy.testing.pytest import raises, slow
@@ -786,6 +787,47 @@ def test_manualintegrate_sqrt_quadratic():
     assert_is_integral_of(x*sqrt(x**2+2*x+4),
                           (x**2/3 + x/6 + S(5)/6)*sqrt(x**2 + 2*x + 4) - 3*asinh(sqrt(3)*(x + 1)/3)/2)
 
+
+def test_manualintegrate_sqrt_quadratic_reduction():
+    # Tests for Gradshteyn & Ryzhik 2.263.3 reduction rule (n < -1 odd)
+    # These test cases are slightly messy due to limitations in simplify()
+    # regarding fractional powers and symbol assumptions
+    a = symbols('a', nonzero=True)
+    b, c, f, x = symbols('b c f x')
+
+    # 1. Base Case: n = -3
+    assert_is_integral_of(1/(x**2 + 1)**(S(3)/2), x/sqrt(x**2 + 1))
+    assert_is_integral_of(8/(x**2 + 1)**(S(3)/2), 8*x/sqrt(x**2 + 1))
+
+    # 2. Complex Numeric Case (x^2 + 2x + 2)
+    # We use diff check here because the numeric coefficients are messy
+    term_complex = 1/(x**2 + 2*x + 2)**(S(3)/2)
+    res_complex = manualintegrate(term_complex, x)
+    assert simplify(diff(res_complex, x) - term_complex) == 0
+
+    # 3. Recursive Case: n = -5
+    # We match the EXACT output format here to avoid simplification issues
+    # simplify().rewrite() struggles to equate sqrt((x**2 + 1)**3) with (x**2 + 1)**(3/2).
+    term_n5 = 1/(x**2 + 1)**(S(5)/2)
+    res_n5 = manualintegrate(term_n5, x)
+    expected = x/(3*sqrt((x**2 + 1)**3)) + 2*x/(3*sqrt(x**2 + 1))
+    assert res_n5 == expected
+
+    assert manualintegrate(5/(x**2 + 1)**(S(5)/2), x) == 5*expected
+
+    # 4. Symbolic Verification (General Case)
+    # here as well, simplify cant be sure of a being nonzero
+    # So I am declaring it as such because thats the only
+    # case for quadratics anyways
+    term_n3 = f/(a*x**2 + b*x + c)**(S(3)/2)
+    res_n3 = manualintegrate(term_n3, x)
+    assert simplify(diff(res_n3, x) - term_n3) == 0
+
+    # The general recursive case (n = -5) generates a massive expression
+    # that simplify() currently cannot reduce to zero.
+    # term_n5 = f/(a*x**2 + b*x + c)**(S(5)/2)
+    # res_n5 = manualintegrate(term_n5, x)
+    # assert simplify(diff(res_n5, x) - term_n5) == 0
 
 def test_mul_pow_derivative():
     assert_is_integral_of(x*sec(x)*tan(x), x*sec(x) - log(tan(x) + sec(x)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Implemented a recursive reduction rule for integrals involving powers of quadratic forms: `(ax^2 + bx + c)**(n/2)` where `n` is an odd integer < -1.

Previously, manualintegrate would fail to evaluate integrals with higher odd powers, such as `n = -5`. This change allows it to reduce these integrals recursively to lower powers until they reach a solvable base case.

Example:
```python
In [1]: manualintegrate(1 / (x**2 + 4*x + 5)**(S(5)/2), x)
Out[1]: (4*x + 8)/(12*sqrt((x**2 + 4*x + 5)**3)) + (4*x + 8)/(6*sqrt(x**2 + 4*x + 5))
```
#### Other comments
Reference: Gradshteyn & Ryzhik 2.263.3.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added reduction rule for quadratic forms `(ax^2 + bx + c)**(n/2)` where `n` is an odd integer < -1 (e.g. -3, -5), allowing `manualintegrate` to handle these recursive cases.
<!-- END RELEASE NOTES -->
