### PR TITLE
Add type annotation to is_sequence in sympy.utilities.iterables

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, overload, cast, Any, Optional, Type, Tuple, Union
-
+from typing_extensions import TypeGuard
 from collections import Counter, defaultdict, OrderedDict
 from itertools import (
     chain, combinations, combinations_with_replacement, cycle, islice,
@@ -3115,7 +3115,7 @@ def iterable(i, exclude=(str, dict, NotIterable)):
 def is_sequence(
     i: Any,
     include: Optional[Union[Type[Any], Tuple[Type[Any], ...]]] = None
-) -> bool:
+) -> TypeGuard[Iterable[Any]]:
     """
     Return a boolean indicating whether ``i`` is a sequence in the SymPy
     sense. If anything that fails the test below should be included as

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload, cast, Any, Optional, Type, Tuple, Union
-from typing_extensions import TypeGuard
+from typing import TYPE_CHECKING, overload, cast, Any, Optional, Type, Tuple, Union, Iterable
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 from collections import Counter, defaultdict, OrderedDict
 from itertools import (
     chain, combinations, combinations_with_replacement, cycle, islice,
@@ -3115,7 +3116,7 @@ def iterable(i, exclude=(str, dict, NotIterable)):
 def is_sequence(
     i: Any,
     include: Optional[Union[Type[Any], Tuple[Type[Any], ...]]] = None
-) -> TypeGuard[Iterable[Any]]:
+) -> "TypeGuard[Iterable[Any]]":
     """
     Return a boolean indicating whether ``i`` is a sequence in the SymPy
     sense. If anything that fails the test below should be included as

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -21,10 +21,9 @@ from sympy.utilities.decorator import deprecated
 
 if TYPE_CHECKING:
     from typing import (
-        Any, Optional, Type, Tuple, Union,
-        Iterable, Callable, Literal, Sequence, Iterator, TypeVar,
+        Any, Iterable, Callable, Literal, Sequence, Iterator, TypeVar,
     )
-    from typing_extensions import TypeGuard
+    from typing_extensions import TypeIs
     T = TypeVar("T")
     T1 = TypeVar("T1")
     T2 = TypeVar("T2")
@@ -3115,10 +3114,24 @@ def iterable(i, exclude=(str, dict, NotIterable)):
     return True
 
 
+@overload
 def is_sequence(
-    i: Any,
-    include: Optional[Union[Type[Any], Tuple[Type[Any], ...]]] = None
-) -> "TypeGuard[Iterable[Any]]":
+    i: Sequence[T] | Iterable[T],
+    include: type | tuple[type, ...] | None = None,
+) -> TypeIs[Sequence[T]]: ...
+
+
+@overload
+def is_sequence(
+    i: object,
+    include: type | tuple[type, ...] | None = None,
+) -> TypeIs[Sequence[Any]]: ...
+
+
+def is_sequence(
+    i: object,
+    include: type | tuple[type, ...] | None = None,
+) -> "TypeIs[Sequence[Any]]":
     """
     Return a boolean indicating whether ``i`` is a sequence in the SymPy
     sense. If anything that fails the test below should be included as

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload, cast, Any, Optional, Type, Tuple, Union, Iterable
-if TYPE_CHECKING:
-    from typing_extensions import TypeGuard
+from typing import TYPE_CHECKING, overload, cast
 from collections import Counter, defaultdict, OrderedDict
 from itertools import (
     chain, combinations, combinations_with_replacement, cycle, islice,
@@ -22,7 +20,11 @@ from sympy.utilities.decorator import deprecated
 
 
 if TYPE_CHECKING:
-    from typing import Iterable, Callable, Literal, Sequence, Iterator, TypeVar
+    from typing import (
+        Any, Optional, Type, Tuple, Union,
+        Iterable, Callable, Literal, Sequence, Iterator, TypeVar,
+    )
+    from typing_extensions import TypeGuard
     T = TypeVar("T")
     T1 = TypeVar("T1")
     T2 = TypeVar("T2")

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -3131,7 +3131,7 @@ def is_sequence(
 def is_sequence(
     i: object,
     include: type | tuple[type, ...] | None = None,
-) -> "TypeIs[Sequence[Any]]":
+) -> TypeIs[Sequence[Any]]:
     """
     Return a boolean indicating whether ``i`` is a sequence in the SymPy
     sense. If anything that fails the test below should be included as

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload, cast
+from typing import TYPE_CHECKING, overload, cast, Any, Optional, Type, Tuple, Union
 
 from collections import Counter, defaultdict, OrderedDict
 from itertools import (
@@ -3112,7 +3112,10 @@ def iterable(i, exclude=(str, dict, NotIterable)):
     return True
 
 
-def is_sequence(i, include=None):
+def is_sequence(
+    i: Any,
+    include: Optional[Union[Type[Any], Tuple[Type[Any], ...]]] = None
+) -> bool:
     """
     Return a boolean indicating whether ``i`` is a sequence in the SymPy
     sense. If anything that fails the test below should be included as
@@ -3146,10 +3149,10 @@ def is_sequence(i, include=None):
     True
 
     """
-    return (hasattr(i, '__getitem__') and
-            iterable(i) or
-            bool(include) and
-            isinstance(i, include))
+    return (
+        (hasattr(i, '__getitem__') and iterable(i))
+        or (include is not None and isinstance(i, include))
+    )
 
 
 @deprecated(


### PR DESCRIPTION
his PR improves type annotations in `sympy/utilities/iterables.py`, specifically for the` is_sequence` utility, to ensure compatibility with static type checkers like mypy and improve overall code clarity.
Issue:  #28806 

### Changes
- Refined type annotations for the include parameter in is_sequence
- Adjusted isinstance usage to satisfy mypy’s expected _ClassInfo types
- Preserved existing runtime behavior


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
