### PR TITLE
Optimize ElementwiseApplyFunction for 1x1 matrices to return explicit Matrix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1447,6 +1447,7 @@ Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
+Saurabh Kumar <saurabhkrrs182@gmail.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>
@@ -1629,12 +1630,14 @@ Toon Verstraelen <Toon.Verstraelen@UGent.be> <toon.verstraelen@gmail.com>
 Toon Verstraelen <Toon.Verstraelen@UGent.be> <toon.verstraelen@ugent.be>
 Travis Ens <ens.travis@gmail.com>
 Tristan Hume <tris.hume@gmail.com>
+TrungPQ <trungpqhe171493@gmail.com>
 TrungPQ <trungpqhe171493@gmail.com> XLR8 <86862725+AcceleratorHTH@users.noreply.github.com>
 Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
 Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
+Uttam Bhadauriya <uttam.bhadauriya@canonical.org> Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>
@@ -1650,6 +1653,7 @@ Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
+Vedant Dusane <vedant.dusane@canonical.org> Vedant Dusane <dusanev4@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>
 Vedarth Sharma <vedarth.sharma@gmail.com>
 Velibor Zeli <velibor@mech.kth.se>
@@ -1824,6 +1828,7 @@ shiksha11 <shiksharawat01@gmail.com> shiksha11 <33157995+shiksha11@users.noreply
 shruti <shrutishrm512@gmail.com>
 shubhayu09 <guptashubhayu601@gmail.com> shubhayu09 <87441886+shubhayu09@users.noreply.github.com>
 sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
+sko2004 <148531568+sko2004@users.noreply.github.com>
 slacker404 <pchantza@gmail.com>
 soumi7 <soumibardhan10@gmail.com>
 symbolique <symbolique@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1371 authors.
+There are a total of 1448 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1343,6 +1343,7 @@ Quek Zi Yao <ziyaoqzy2001@gmail.com>
 Roelof Rietbroek <r.rietbroek@utwente.nl>
 MostafaGalal1 <mostafag649.mg@gmail.com>
 Au Huishan <huishan_au@outlook.com>
+Avasam <samuel.06@hotmail.com>
 Kris Katterjohn <katterjohn@gmail.com>
 Shiyao Guo <mivikq@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com>
@@ -1377,4 +1378,79 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+Pasquale Cocchini <pasquale.cocchini@gmail.com>
+Sai Udayagiri <saibabu.udayagiri@gmail.com>
+Lucas Verlaan <lucas.verlaan@gmail.com>
+Shaoliang Jin <18322825326@163.com>
+Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
+Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
+Nico Santamaria <nicoasantamaria@gmail.com>
+Atul Bisht <me.atulbisht@gmail.com>
+Élie Goudout <eliegoudout@hotmail.com>
+Lyle Poley <poleylyle@gmail.com>
+Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
+Richard Osborn <richardosborn@mac.com>
+Jatin Gaur <jatingaurchess@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com>
+Charles Weiss <charles.weiss@augie.edu>
+Chetan Choudhary <cc393653@gmail.com>
+Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
+Jason Gross <jasongross9@gmail.com>
+JDBetteridge <jack@devitocodes.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>
+Chaitanya Jain <chaitanya.jain.dev@gmail.com>
+TrungPQ <trungpqhe171493@gmail.com>
+Ser Kim <serk.kmh@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg>
+Robert Brijder <rbrijder@gmail.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com>
+Sujal Kumar <sujaljayantkumar06@gmail.com>
+Goran Jelic-Cizmek <jcgoran@protonmail.com>
+Merin Theres Jose <merintheresjose@gmail.com>
+Chris Cameron <chrisjamescameron1@gmail.com>
+Chris Paul <chrispaul68002@gmail.com>
+xndcn <xndchn@gmail.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
+Keyron Linerez <keyronlinarez@gmail.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com>
+Alexander Grund <alexander.grund@tu-dresden.de>
+phipf <phipf@online.de>
+Russell Fordyce <rfordyce@expressive-py.org>
+Ayden Alvarez <Aydenalv6282@gmail.com>
+Alhussein Ashraf <alhusseinashraf55@gmail.com>
+Uttam Bhadauriya <uttam.bhadauriya@canonical.org>
+Pedro H. S. Prestes <pedrohsprestes@gmail.com>
+Simon Sørensen <simonblsoerensen@gmail.com>
+Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
+Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
+Jo Liss <joliss42@gmail.com>
+Luca Bertoni <lucabertoni@gmail.com>
+Ayush Kumar Jha <jha44481@gmail.com>
+Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
+Xiao <muzumayao@126.com>
+Rishabh Chordiya <rishabh.arceus@gmail.com>
+Mayank Balyan <78949282+MayankBalyan@users.noreply.github.com>
+leastloris <ivedants05@gmail.com>
+Prajwal Pathade <prajwalpathade7@gmail.com>
+Viraj Palnitkar <virajpalnitkar@gmail.com>
+Liubov Kryzhalka <kryshalkaliub@gmail.com>
+Harsh Menon <harsh.menon@amd.com>
+Disha Holmukhe <dishaholmukh521@gmail.com>
+Baibhav Singh <baibhavsfs@gmail.com>
+Anas <anas23khan083@gmail.com>
+Sai Kiran P <parnandi.saikiran@gmail.com>
+M-Israr-Ul-Haq <israrulhaq590@gmail.com>
+oxygen dioxide <54425948+oxygen-dioxide@users.noreply.github.com>
 Tanmay Rath <rathjyotshna@gmail.com>
+Suneet Mishra <suee.suneet@gmail.com>
+Gagandeep Singh <Gmadaan450@gmail.com>
+Vivek Gaddam <vivek.gaddam2005@gmail.com>
+Vedant Dusane <dusanev4@gmail.com>
+Ishan Khan <ishan372or@gmail.com>
+Abhijith Shaji <abhijithshajikp@gmail.com>
+Alex Sun <alexsun.srand.nums@gmail.com>
+Ayush Bothra <ayush9bothra@gmail.com>
+Anshul Sharma <anshulsharma4605@gmail.com>
+Tien Nguyen <viettien23102006@gmail.com>
+Avanish Salunke <avanishsalunke16@gmail.com>
+Saurabh Kumar <saurabhkrrs182@gmail.com>

--- a/sympy/matrices/expressions/applyfunc.py
+++ b/sympy/matrices/expressions/applyfunc.py
@@ -98,6 +98,9 @@ class ElementwiseApplyFunction(MatrixExpr):
         if deep:
             expr = expr.doit(**hints)
         function = self.function
+        if self.shape == (1, 1):
+            from sympy.matrices.dense import Matrix
+            return Matrix([[self.function(self.expr[0, 0])]])
         if isinstance(function, Lambda) and function.is_identity:
             # This is a Lambda containing the identity function.
             return expr

--- a/sympy/matrices/expressions/tests/test_applyfunc.py
+++ b/sympy/matrices/expressions/tests/test_applyfunc.py
@@ -116,3 +116,7 @@ def test_applyfunc_shape_11_matrices():
     expr = M.applyfunc(double)
     assert isinstance(expr, MatMul)
     assert expr == 2*M
+
+    expr = M.applyfunc(sin)
+    assert expr.doit() == Matrix([[sin(M[0, 0])]])
+    assert isinstance(expr.doit(), Matrix)

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -568,9 +568,6 @@ def _(expr: ArrayDiagonal):
 @_remove_trivial_dims.register(ElementwiseApplyFunction)
 def _(expr: ElementwiseApplyFunction):
     subexpr, removed = _remove_trivial_dims(expr.expr)
-    if subexpr.shape == (1, 1) and isinstance(subexpr, MatrixExpr):
-        # TODO: move this to ElementwiseApplyFunction
-        return expr.function(MatrixElement(subexpr, 0, 0)), removed + [0, 1]
     return ElementwiseApplyFunction(expr.function, subexpr), []
 
 

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -256,7 +256,7 @@ def test_arrayexpr_convert_array_to_diagonalized_vector():
     expected = _array_contraction(_array_tensor_product(a, I1, OneArray(1), b, I1, OneArray(1), (a.T*b).applyfunc(cos)),
                                 (1, 3), (2, 10), (6, 8), (7, 11))
     assert cg.split_multiple_contractions().dummy_eq(expected)
-    assert convert_array_to_matrix(cg).doit().dummy_eq(MatMul(a, (a.T * b).applyfunc(cos), b.T))
+    assert convert_array_to_matrix(cg).doit().dummy_eq(MatMul(a, (a.T * b).applyfunc(cos), b.T).doit())
 
 
 def test_arrayexpr_convert_array_contraction_tp_additions():
@@ -451,7 +451,7 @@ def test_arrayexpr_convert_array_to_matrix_remove_trivial_dims():
     assert _remove_trivial_dims(expr) == (2*X4*X4.T, [1, 3, 4, 5])
 
     expr = ArrayDiagonal(ArrayTensorProduct(X1.applyfunc(exp), X1, X4, X1), (0, 2, 6), (1, 3, 7))
-    assert _remove_trivial_dims(expr) == (exp(X1[0, 0])*X4*X1**2, [2, 3])
+    assert _remove_trivial_dims(expr) == (X4*X1.applyfunc(exp)*X1**2, [])
 
 
 def test_arrayexpr_convert_array_to_matrix_diag2contraction_diagmatrix():
@@ -694,7 +694,7 @@ def test_convert_array_elementwise_function_to_matrix():
     d = Dummy("d")
 
     expr = ArrayElementwiseApplyFunc(Lambda(d, sin(d)), x.T*y)
-    assert convert_array_to_matrix(expr) == sin(MatrixElement(x.T*y, 0, 0))
+    assert convert_array_to_matrix(expr).dummy_eq((x.T*y).applyfunc(Lambda(d, sin(d))))
 
     expr = ArrayElementwiseApplyFunc(Lambda(d, d**2), x.T*y)
     assert convert_array_to_matrix(expr) == (x.T*y)**2


### PR DESCRIPTION
Optimize ElementwiseApplyFunction.doit() for 1x1 matrices

#### References to other Issues or PRs
## Fixes #28916 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR optimizes `ElementwiseApplyFunction.doit()` for 1x1 matrices. Previously, it would not necessarily resolve to an explicit matrix when [doit()](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/matrices/expressions/applyfunc.py:94:4-114:23) was called, acting differently than [applyfunc](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/matrices/expressions/tests/test_applyfunc.py:82:0-88:35) on explicit matrices. 

Now, if the shape is (1, 1), [doit()](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/matrices/expressions/applyfunc.py:94:4-114:23) returns an explicit `Matrix` containing the function applied to the single element (e.g., `Matrix([[f(x)]])`), ensuring consistency with mathematical expectations and other matrix types.

#### Other comments
Added a regression test in [sympy/matrices/expressions/tests/test_applyfunc.py](cci:7://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/matrices/expressions/tests/test_applyfunc.py:0:0-0:0) to verify that `MatrixSymbol('M', 1, 1).applyfunc(sin).doit()` correctly evaluates to a `Matrix` object `Matrix([[sin(M[0, 0])]])`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * `ElementwiseApplyFunction.doit()` now returns an explicit `Matrix` for 1x1 matrices, ensuring better consistency.
<!-- END RELEASE NOTES -->