### PR TITLE
Change frozen dataclass to use slots for efficiency

### DIFF
--- a/sympy/physics/biomechanics/curve.py
+++ b/sympy/physics/biomechanics/curve.py
@@ -1741,7 +1741,7 @@ class FiberForceVelocityInverseDeGroote2016(CharacteristicCurveFunction):
         return r'\left( \operatorname{fv}^M \right)^{-1} \left( %s \right)' % _fv_M
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CharacteristicCurveCollection:
     """Simple data container to group together related characteristic curves."""
     tendon_force_length: CharacteristicCurveFunction


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Changed a frozen dataclass in biomechanics to use slots now that we dropped Python 3.9 and lower support. Should be faster and save memory, but not allow dynamics attrs. Not an issue since the dataclass is frozen anyway.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
