### PR TITLE
Apply ruff TCH001-TCH005 to improve sympy import times

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,11 @@ lint.select = [
     "PLW0602", # Global statement used but no assignment
     "SIM101",
     "SLOT",
+    "TC001",
+    "TC002",
+    "TC003",
+    "TC004",
+    "TC005",
     "TRY002",
     "BLE001", # except Exception or except BaseException
 ]

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING, overload
 
 from sympy.core import S, Add, Expr, Basic, Mul, Pow, Rational
 from sympy.core.logic import fuzzy_not
-from sympy.logic.boolalg import Boolean
 
 from sympy.assumptions import ask, Q  # type: ignore
 
 
 if TYPE_CHECKING:
+    from sympy.logic.boolalg import Boolean
     from typing import Callable
 
 

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from .expr_with_intlimits import ExprWithIntLimits
 from .summations import Sum, summation, _dummy_with_inherited_properties_concrete
-from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import Derivative
 from sympy.core.mul import Mul
@@ -12,6 +11,10 @@ from sympy.functions.combinatorial.factorials import RisingFactorial
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.polys import quo, roots
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 class Product(ExprWithIntLimits):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -6,7 +6,6 @@ from sympy.calculus.accumulationbounds import AccumulationBounds
 from .expr_with_intlimits import ExprWithIntLimits
 from .expr_with_limits import AddWithLimits
 from .gosper import gosper_sum
-from sympy.core.expr import Expr
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.function import Derivative, expand, expand_mul
@@ -38,6 +37,10 @@ from sympy.sets.contains import Contains
 from sympy.sets.sets import FiniteSet, Interval
 from sympy.utilities.iterables import sift
 import itertools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 class Sum(AddWithLimits, ExprWithIntLimits):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -643,4 +643,4 @@ def kernS(s):
 
 
 # Avoid circular import
-from .basic import Basic
+from .basic import Basic  # noqa: TC001

--- a/sympy/external/gmpy.py
+++ b/sympy/external/gmpy.py
@@ -4,7 +4,6 @@ from ctypes import c_long, sizeof
 from functools import reduce
 from typing import TYPE_CHECKING
 from warnings import warn
-from types import ModuleType
 
 from sympy.external import import_module
 
@@ -38,6 +37,9 @@ from .ntheory import (
     is_bpsw_prp as python_is_bpsw_prp,
     is_strong_bpsw_prp as python_is_strong_bpsw_prp,
 )
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 __all__ = [

--- a/sympy/functions/elementary/_trigonometric_special.py
+++ b/sympy/functions/elementary/_trigonometric_special.py
@@ -33,14 +33,16 @@ References
 .. [*] https://resources.wolframcloud.com/FunctionRepository/resources/Cos2PiOverFermatPrime
 """
 from __future__ import annotations
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 from functools import reduce
-from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.intfunc import igcdex
 from sympy.core.numbers import Integer
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.core.cache import cacheit
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 def migcdex(*x: int) -> tuple[tuple[int, ...], int]:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -3,7 +3,6 @@ from itertools import product
 
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
-from sympy.core.expr import Expr
 from sympy.core.function import (DefinedFunction, ArgumentIndexError, expand_log,
     expand_mul, FunctionClass, PoleError, expand_multinomial, expand_complex)
 from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
@@ -19,6 +18,10 @@ from sympy.functions.elementary.complexes import arg, unpolarify, im, re, Abs
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
 from sympy.ntheory.factor_ import factorint
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
-from sympy.core.expr import Expr
 from sympy.core.function import DefinedFunction, ArgumentIndexError, PoleError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool, fuzzy_and
 from sympy.core.mod import Mod
@@ -23,6 +22,10 @@ from sympy.logic.boolalg import And
 from sympy.ntheory import factorint
 from sympy.polys.specialpolys import symmetric_poly
 from sympy.utilities.iterables import numbered_symbols
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 ###############################################################################

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import diff
@@ -35,6 +34,7 @@ from sympy.utilities.misc import filldedent
 
 
 if TYPE_CHECKING:
+    from sympy.core.containers import Tuple
     SymbolLimits = Expr | tuple[Expr, Expr] | tuple[Expr, Expr, Expr]
 
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -22,7 +22,7 @@ To enable simple substitutions, add the match to find_substitutions.
 """
 
 from __future__ import annotations
-from typing import NamedTuple, Type, Callable, Sequence
+from typing import NamedTuple, Type, Callable, Sequence, TYPE_CHECKING
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from collections import defaultdict
@@ -31,7 +31,6 @@ from collections.abc import Mapping
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
 from sympy.core.containers import Dict
-from sympy.core.expr import Expr
 from sympy.core.function import Derivative
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
@@ -70,6 +69,9 @@ from sympy.solvers.solvers import solve
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 @dataclass

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -32,7 +32,6 @@ import itertools
 from sympy import SYMPY_DEBUG
 from sympy.core import S, Expr
 from sympy.core.add import Add
-from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.exprtools import factor_terms
@@ -295,6 +294,10 @@ def _create_lookup_table(table):
 ####################################################################
 
 from sympy.utilities.timeutils import timethis
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.basic import Basic
 timeit = timethis('meijerg')
 
 

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -2,15 +2,17 @@
     be displayed in the sphinx documentation. """
 
 from __future__ import annotations
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from sympy.integrals.meijerint import _create_lookup_table
 from sympy.core.add import Add
-from sympy.core.basic import Basic
-from sympy.core.expr import Expr
 from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol
 from sympy.printing.latex import latex
+
+if TYPE_CHECKING:
+    from sympy.core.basic import Basic
+    from sympy.core.expr import Expr
 
 t: dict[tuple[type[Basic], ...], list[Any]] = {}
 _create_lookup_table(t)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -4,7 +4,6 @@ Boolean algebra module for SymPy
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, overload, Any, Callable
-from collections.abc import Iterable, Mapping
 
 from collections import defaultdict
 from itertools import chain, combinations, product, permutations
@@ -23,6 +22,9 @@ from sympy.core.sorting import ordered
 from sympy.core.sympify import _sympy_converter, _sympify, sympify
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 
 try:  # sys.version_info >= (3, 10)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -5,7 +5,6 @@ from sympy.core import S, Integer, Basic, Mul, Add
 from sympy.core.assumptions import check_assumptions
 from sympy.core.decorators import call_highest_priority
 from sympy.core.expr import Expr, ExprBuilder
-from sympy.core.logic import FuzzyBool
 from sympy.core.symbol import Str, Dummy, symbols, Symbol
 from sympy.core.sympify import SympifyError, _sympify
 from sympy.external.gmpy import SYMPY_INTS
@@ -16,6 +15,10 @@ from sympy.matrices.kind import MatrixKind
 from sympy.matrices.matrixbase import MatrixBase
 from sympy.multipledispatch import dispatch
 from sympy.utilities.misc import filldedent
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.logic import FuzzyBool
 
 
 def _sympifyit(arg, retval=None):

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -30,7 +30,6 @@ from sympy.functions.combinatorial.factorials import binomial, factorial
 
 from collections.abc import Callable
 from sympy.utilities.iterables import reshape
-from sympy.core.expr import Expr
 from sympy.core.power import Pow
 from sympy.core.symbol import uniquely_named_symbol
 
@@ -91,6 +90,7 @@ from .graph import (
 
 
 if TYPE_CHECKING:
+    from sympy.core.expr import Expr
     from abc import ABCMeta, abstractmethod
 else:
     from abc import abstractmethod

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal, SupportsIndex, cast, overload
+from typing import Literal, SupportsIndex, cast, overload, TYPE_CHECKING
 
 from sympy.external.gmpy import (MPZ, gcd, lcm, invert, sqrt, jacobi,
                                  bit_scan1, remove)
-from sympy.core.expr import Expr
 from sympy.polys import Poly
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt1, gf_crt2, linear_congruence, gf_csolve
@@ -19,6 +18,9 @@ from sympy.utilities.iterables import iproduct
 from sympy.core.random import _randint
 
 from itertools import product
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 def n_order(a, n):

--- a/sympy/physics/units/systems/mksa.py
+++ b/sympy/physics/units/systems/mksa.py
@@ -12,7 +12,10 @@ from sympy.physics.units.definitions.dimension_definitions import (
     magnetic_density, magnetic_flux, voltage)
 from sympy.physics.units.prefixes import PREFIXES, prefix_unit
 from sympy.physics.units.systems.mks import MKS, dimsys_length_weight_time
-from sympy.physics.units.quantities import Quantity
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.physics.units.quantities import Quantity
 
 dims = (voltage, impedance, conductance, current, capacitance, inductance, charge,
         magnetic_density, magnetic_flux)

--- a/sympy/physics/units/systems/si.py
+++ b/sympy/physics/units/systems/si.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from sympy.physics.units import DimensionSystem, Dimension, dHg0
 
-from sympy.physics.units.quantities import Quantity
 
 from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
@@ -42,6 +41,10 @@ from sympy.physics.units.definitions import (
 )
 from sympy.physics.units.prefixes import PREFIXES, prefix_unit
 from sympy.physics.units.systems.mksa import MKSA, dimsys_MKSA
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.physics.units.quantities import Quantity
 
 derived_dims = (frequency, force, pressure, energy, power, charge, voltage,
                 capacitance, conductance, magnetic_flux,

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -9,9 +9,12 @@ from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.physics.units.dimensions import _QuantityMapper
-from sympy.physics.units.quantities import Quantity
 
 from .dimensions import Dimension
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.physics.units.quantities import Quantity
 
 
 class UnitSystem(_QuantityMapper):

--- a/sympy/polys/compatibility.py
+++ b/sympy/polys/compatibility.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Generic, Mapping, Any, cast, overload
-from sympy.external.gmpy import MPZ
 from sympy.polys.domains.domain import Domain, Er, Es, Ef, Eeuclid, Eordered, Eabs
-from sympy.polys.domains.field import Field
-from sympy.polys.domains.algebraicfield import Alg, AlgebraicField
 from sympy.polys.densebasic import dup, dmp
 
 if TYPE_CHECKING:
+    from sympy.external.gmpy import MPZ
+    from sympy.polys.domains.algebraicfield import Alg, AlgebraicField
+    from sympy.polys.domains.field import Field
     from typing import TypeAlias
     from sympy.core.expr import Expr
     from sympy.polys.orderings import MonomialOrder

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from sympy.polys.domains.domain import Domain, Er, Ef, Eeuclid, Eabs, Eordered
 
 from sympy.polys.densebasic import (
     dup, dmp, _dup, _dmp, _dmp_ground,
@@ -15,6 +14,10 @@ from sympy.polys.densebasic import (
     dmp_one_p, dmp_one,
     dmp_ground, dmp_zeros)
 from sympy.polys.polyerrors import (ExactQuotientFailed, PolynomialDivisionFailed)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.polys.domains.domain import Domain, Er, Ef, Eeuclid, Eabs, Eordered
 
 
 def dup_add_term(f: dup[Er], c: Er, i: int, K: Domain[Er]) -> dup[Er]:

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar, Callable, Any, cast
 from typing import Iterable # noqa: F401
 
-from sympy.external.gmpy import MPZ
 from sympy.core import igcd
-from sympy.core.expr import Expr
-from sympy.polys.domains.domain import Domain, Er, Es, Eg
 from sympy.polys.monomials import monomial_min, monomial_ldiv
 from sympy.polys.orderings import monomial_key, MonomialOrder
 
@@ -37,6 +34,9 @@ monom: TypeAlias = "tuple[int, ...]"
 
 
 if TYPE_CHECKING:
+    from sympy.external.gmpy import MPZ
+    from sympy.polys.domains.domain import Domain, Er, Es, Eg
+    from sympy.core.expr import Expr
     from typing import TypeAlias
     from sympy.polys.rings import PolyElement
     from sympy.polys.domains.polynomialring import PolynomialRing

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from sympy.polys.domains.domain import Domain, Er, Eg, Ef, Eeuclid
-from sympy.polys.domains.field import Field
 from sympy.polys.densearith import (
     dup_add_term, dmp_add_term,
     dup_lshift, dup_rshift,
@@ -44,6 +42,8 @@ from math import ceil as _ceil, log2 as _log2, sqrt
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sympy.polys.domains.field import Field
+    from sympy.polys.domains.domain import Domain, Er, Eg, Ef, Eeuclid
     from sympy.external.gmpy import MPQ
     from sympy.polys.domains.ringextension import RingExtension
     from sympy.polys.domains.algebraicfield import AlgebraicField, Alg

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from sympy.core.add import Add
 from sympy.core.mul import Mul
-from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, symbols
 from sympy.external.gmpy import MPQ
-from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -16,6 +14,11 @@ from sympy.polys.domains.ringextension import RingExtension
 from sympy.polys.polyclasses import ANP, DMP
 from sympy.polys.polyerrors import CoercionFailed, DomainError, NotAlgebraic, IsomorphismFailed
 from sympy.utilities import public
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.polys.domains.domain import Domain
+    from sympy.core.expr import Expr
 
 
 Alg = ANP[MPQ]

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -5,14 +5,11 @@ from typing import Generic, TypeVar, Any, TYPE_CHECKING
 
 from sympy.external.gmpy import MPZ, MPQ
 from sympy.core.numbers import I
-from sympy.core.expr import Expr
 from sympy.polys.polyclasses import DMP
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.domains.integerring import ZZ, IntegerRing
 from sympy.polys.domains.rationalfield import QQ, RationalField
-from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.domains.algebraicfield import AlgebraicField
-from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.ring import Ring
@@ -24,6 +21,9 @@ Telem = TypeVar('Telem', bound="GaussianElement")
 
 
 if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.polys.domains.polynomialring import PolynomialRing
+    from sympy.polys.domains.domain import Domain
     from typing import Self
 
 

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
-from sympy.core.expr import Expr
-from sympy.polys.orderings import MonomialOrder
 from sympy.polys.domains.domain import Er, Domain
 from sympy.polys.domains.ring import Ring
 from sympy.polys.domains.ringextension import RingExtension
@@ -15,6 +13,8 @@ from sympy.utilities import public
 
 
 if TYPE_CHECKING:
+    from sympy.polys.orderings import MonomialOrder
+    from sympy.core.expr import Expr
     import sys
     if sys.version_info >= (3, 13):
         from typing import TypeIs

--- a/sympy/polys/domains/powerseriesring.py
+++ b/sympy/polys/domains/powerseriesring.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import cached_property
-from sympy.core.expr import Expr
 from sympy.polys.domains.ring import Ring
 from sympy.polys.domains.compositedomain import CompositeDomain
 from sympy.polys.domains.domain import Er, Domain
@@ -13,6 +12,7 @@ from sympy.polys.series.ring import (
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from sympy.core.expr import Expr
     import sys
     if sys.version_info >= (3, 13):
         from typing import TypeIs

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import overload, Literal
+from typing import overload, Literal, TYPE_CHECKING
 
-from sympy.polys.domains.domain import Domain, Er, Ef
-from sympy.polys.domains.field import Field
 from sympy.polys.densearith import (
     dup_sub_mul,
     dup_neg, dmp_neg,
@@ -51,6 +49,10 @@ from sympy.polys.polyerrors import (
     HomomorphismFailed,
     NotInvertible,
     DomainError)
+
+if TYPE_CHECKING:
+    from sympy.polys.domains.field import Field
+    from sympy.polys.domains.domain import Domain, Er, Ef
 
 
 def dup_half_gcdex(f: dup[Ef], g: dup[Ef], K: Field[Ef]) -> tuple[dup[Ef], dup[Ef]]:

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Generic, Protocol, Any
+from typing import Generic, Protocol, Any, TYPE_CHECKING
 
 from functools import reduce
 
@@ -17,7 +17,6 @@ from sympy.core.sympify import CantSympify, sympify
 from sympy.functions.elementary.exponential import ExpBase
 from sympy.polys.domains.domain import Domain, Er, Es
 from sympy.polys.domains.domainelement import DomainElement
-from sympy.polys.domains.field import Field
 from sympy.polys.domains.fractionfield import FractionField
 from sympy.polys.domains.polynomialring import PolynomialRing
 from sympy.polys.constructor import construct_domain
@@ -30,6 +29,9 @@ from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.magic import pollute
+
+if TYPE_CHECKING:
+    from sympy.polys.domains.field import Field
 
 
 class FracElementConstructor(Protocol[Er]):

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 
 from math import ceil as _ceil, sqrt as _sqrt, prod
 
 from sympy.core.random import uniform, _randint
 from sympy.external.gmpy import MPZ, invert
-from sympy.polys.domains.domain import Domain
-from sympy.polys.densebasic import dup
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import _sort_factors_single, _sort_factors_multiple
+
+if TYPE_CHECKING:
+    from sympy.polys.densebasic import dup
+    from sympy.polys.domains.domain import Domain
 
 
 def gf_crt(U: list[MPZ], M: list[MPZ], K: Domain[MPZ]) -> MPZ:

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -11,7 +11,7 @@ as unifying matrices with different domains.
 """
 from __future__ import annotations
 
-from typing import overload
+from typing import overload, TYPE_CHECKING
 
 from collections import Counter
 from functools import reduce
@@ -21,7 +21,6 @@ from sympy.utilities.decorator import doctest_depends_on
 
 from sympy.core.sympify import _sympify
 
-from ..domains import Domain
 
 from ..constructor import construct_domain
 
@@ -58,6 +57,9 @@ from .sdm import SDM
 from .dfm import DFM
 
 from .rref import _dm_rref, _dm_rref_den
+
+if TYPE_CHECKING:
+    from ..domains import Domain
 
 
 if GROUND_TYPES != 'flint':

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -13,6 +13,9 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from sympy.polys.orderings import MonomialOrder
+    from sympy.polys.domains.polynomialring import PolynomialRing
+    from sympy.core.expr import Expr
     from typing import Self, TypeAlias
     from sympy.polys.rings import PolyElement
 
@@ -20,14 +23,11 @@ from sympy.external.gmpy import GROUND_TYPES, MPQ
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
 
-from sympy.core.expr import Expr
 from sympy.core.numbers import oo, NegativeInfinity
 from sympy.core.sympify import CantSympify
 from sympy.polys.polyutils import PicklableWithSlots, _sort_factors
 from sympy.polys.domains import Domain, ZZ, QQ
 from sympy.polys.domains.domain import Er, Es, Et, Eg
-from sympy.polys.domains.polynomialring import PolynomialRing
-from sympy.polys.orderings import MonomialOrder
 
 from sympy.polys.polyerrors import (
     CoercionFailed,

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 __all__ = ["Options"]
 
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
 from sympy.core.sympify import sympify
 from sympy.polys.polyerrors import GeneratorsError, OptionError, FlagError
 from sympy.utilities import numbered_symbols, topological_sort, public
@@ -14,6 +13,10 @@ from sympy.utilities.iterables import has_dups, is_sequence
 import sympy.polys
 
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 class Option:
     """Base class for all kinds of options. """

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import overload, Any, Literal
+from typing import overload, Any, Literal, TYPE_CHECKING
 
 import math
 from functools import reduce
 
 from sympy.core import S, I, pi
-from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import _mexpand
 from sympy.core.logic import fuzzy_not
@@ -32,6 +31,9 @@ from sympy.polys.rationaltools import together
 from sympy.polys.specialpolys import cyclotomic_poly
 from sympy.utilities import public
 from sympy.utilities.misc import filldedent
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Optional, overload, Literal, Any, cast, Callab
 from functools import wraps, reduce
 from operator import mul
 from collections import Counter, defaultdict
-from collections.abc import Iterator
 
 from sympy.core import (
     S, Expr, Add, Tuple
@@ -30,7 +29,6 @@ from sympy.logic.boolalg import BooleanAtom
 from sympy.polys import polyoptions as options
 from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import FF, QQ, ZZ
-from sympy.polys.domains.domain import Domain
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.fglmtools import matrix_fglm
 from sympy.polys.groebnertools import groebner as _groebner
@@ -67,6 +65,8 @@ from sympy.external.mpmath import local_workdps, NoConvergence
 
 
 if TYPE_CHECKING:
+    from sympy.polys.domains.domain import Domain
+    from collections.abc import Iterator
     from typing import Self
 
 

--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from sympy.core import Basic, Add, sympify
-from sympy.core.expr import Expr
 from sympy.core.exprtools import gcd_terms
 from sympy.utilities import public
 from sympy.utilities.iterables import iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 @public

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -18,7 +18,6 @@ from operator import add, mul, lt, le, gt, ge
 from functools import reduce
 from types import GeneratorType
 
-from sympy.external.gmpy import MPQ
 from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
 from sympy.core.intfunc import igcd
@@ -58,6 +57,7 @@ from sympy.utilities.magic import pollute
 
 
 if TYPE_CHECKING:
+    from sympy.external.gmpy import MPQ
     import sys
     if sys.version_info >= (3, 13):
         from typing import TypeIs

--- a/sympy/polys/rootconditions.py
+++ b/sympy/polys/rootconditions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from sympy.polys.densebasic import dup
-from sympy.polys.domains.domain import Er, Domain
 from sympy.core.numbers import I
 
 from sympy.polys.densearith import dup_exquo_ground
@@ -9,9 +8,13 @@ from sympy.polys.domains import EXRAW, EX, QQ, ZZ
 from sympy.polys.densebasic import dup_convert
 from sympy.polys.densetools import dup_clear_denoms, dup_transform, dup_eval
 from sympy.core.exprtools import factor_terms
-from sympy.core.expr import Expr
 from sympy.simplify.simplify import signsimp
 from sympy.core.mul import Mul
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.polys.domains.domain import Er, Domain
 
 
 def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:

--- a/sympy/polys/series/base.py
+++ b/sympy/polys/series/base.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Protocol, Sequence, TypeVar
-from sympy.polys.domains import Domain
+from typing import Protocol, Sequence, TypeVar, TYPE_CHECKING
 from sympy.polys.domains.domain import Ef, Er
 from sympy.polys.densebasic import dup, dup_pretty
+
+if TYPE_CHECKING:
+    from sympy.polys.domains import Domain
 
 
 TSeries = TypeVar("TSeries")

--- a/sympy/polys/series/ring.py
+++ b/sympy/polys/series/ring.py
@@ -9,10 +9,7 @@ from sympy.core.add import Add
 from sympy.core.power import Pow
 from sympy.core.sympify import CantSympify, sympify
 from sympy.polys.domains.domain import Er, Ef, Domain, DomainElement
-from sympy.polys.densebasic import dup
-from sympy.polys.domains.field import Field
 from sympy.polys.polyerrors import GeneratorsError
-from sympy.polys.series.base import PowerSeriesRingProto, PowerSeriesRingFieldProto
 from sympy.polys.series.tring import TSeriesElement, _power_series_ring
 from sympy.series.order import Order
 
@@ -20,6 +17,9 @@ from sympy.series.order import Order
 from typing import Generic, overload, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sympy.polys.series.base import PowerSeriesRingProto, PowerSeriesRingFieldProto
+    from sympy.polys.domains.field import Field
+    from sympy.polys.densebasic import dup
     import sys
     if sys.version_info >= (3, 13):
         from typing import TypeIs

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sympy.polys.domains.field import Field
+    from sympy.polys.domains.domain import Er, Ef
     from typing import TypeAlias, Union
 
 
@@ -30,8 +32,6 @@ from sympy.polys.densetools import (
 )
 from sympy.polys.polyerrors import NotReversible, ExactQuotientFailed
 from sympy.polys.domains import Domain, QQ, ZZ
-from sympy.polys.domains.domain import Er, Ef
-from sympy.polys.domains.field import Field
 from sympy.polys.series.base import series_pprint
 from sympy.external.gmpy import MPZ, MPQ
 from sympy.polys.ring_series import _giant_steps

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -3,13 +3,15 @@ Mathematica code printer
 """
 
 from __future__ import annotations
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-from sympy.core import Basic, Expr, Float
 from sympy.core.sorting import default_sort_key
 
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence
+
+if TYPE_CHECKING:
+    from sympy.core import Basic, Expr, Float
 
 # Used in MCodePrinter._print_Function(self)
 known_functions = {

--- a/sympy/series/approximants.py
+++ b/sympy/series/approximants.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 
-from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.polys.polytools import lcm
 from sympy.utilities import public
 from sympy import Poly
 from sympy.polys.polytools import gcdex_steps
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from collections.abc import Iterator
 
 @public
 def approximants(l, X=Symbol('x'), simplify=False):

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sympy.core import S
-from sympy.core.basic import Basic
 from sympy.core.sympify import sympify
 from sympy.core.parameters import global_parameters
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.misc import func_name
 from sympy.sets.sets import Set
+
+if TYPE_CHECKING:
+    from sympy.core.basic import Basic
 
 
 class Contains(Boolean):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, overload
 from functools import reduce
 from collections import defaultdict
-from collections.abc import Mapping, Iterable
 import inspect
 
 from sympy.core.kind import Kind, UndefinedKind, NumberKind
@@ -32,6 +31,9 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import (iproduct, sift, roundrobin, iterable,
                                        subsets)
 from sympy.utilities.misc import func_name, filldedent
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Iterable
 
 
 tfn: dict[bool | Boolean | None, Boolean | None] = defaultdict(lambda: None, {

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -32,12 +32,10 @@ from sympy.functions.special.bessel import (BesselBase, besselj, besseli,
                                             besselk, bessely, jn)
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.integrals.integrals import Integral
-from sympy.logic.boolalg import Boolean
 from sympy.matrices.expressions import (MatrixExpr, MatAdd, MatMul,
                                             MatPow, MatrixSymbol)
 from sympy.polys import together, cancel, factor
 from sympy.polys.numberfields.minpoly import _is_sum_surds, _minimal_polynomial_sq
-from sympy.sets.sets import Set
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.simplify.hyperexpand import hyperexpand
@@ -57,6 +55,8 @@ from sympy.external.mpmath import (
 
 
 if TYPE_CHECKING:
+    from sympy.logic.boolalg import Boolean
+    from sympy.sets.sets import Set
     from typing import Literal
 
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -3,13 +3,12 @@
 #
 
 from __future__ import annotations
-from typing import ClassVar, Iterator
+from typing import ClassVar, Iterator, TYPE_CHECKING
 
 from .riccati import match_riccati, solve_riccati
 from sympy.core import Add, S, Pow, Rational
 from sympy.core.cache import cached_property
 from sympy.core.exprtools import factor_terms
-from sympy.core.expr import Expr
 from sympy.core.function import AppliedUndef, Derivative, diff, Function, expand, Subs, _mexpand
 from sympy.core.numbers import zoo
 from sympy.core.relational import Equality, Eq
@@ -31,6 +30,9 @@ from .nonhomogeneous import _get_euler_characteristic_eq_sols, _get_const_charac
     _solve_undetermined_coefficients, _solve_variation_of_parameters, _test_term, _undetermined_coefficients_match, \
         _get_simplified_sol
 from .lie_group import _ode_lie_group
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 class ODEMatchError(NotImplementedError):

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
-from collections.abc import Sequence, Iterable
+from typing import Any, TYPE_CHECKING
 
 import itertools
 
 from sympy import Dummy
 from sympy.core import S
-from sympy.core.expr import Expr
 from sympy.core.exprtools import factor_terms
 from sympy.core.sorting import default_sort_key
 from sympy.logic.boolalg import Boolean
@@ -30,6 +28,10 @@ from sympy.utilities.iterables import cartes
 from sympy.utilities.misc import filldedent
 from sympy.logic.boolalg import Or, And
 from sympy.core.relational import Eq
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence, Iterable
+    from sympy.core.expr import Expr
 
 
 class SolveFailed(Exception):

--- a/sympy/strategies/core.py
+++ b/sympy/strategies/core.py
@@ -1,8 +1,10 @@
 """ Generic SymPy-Independent Strategies """
 from __future__ import annotations
-from collections.abc import Callable, Mapping
-from typing import TypeVar
+from typing import TypeVar, TYPE_CHECKING
 from sys import stdout
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
 
 _S = TypeVar('_S')

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 from sympy.core.singleton import S
-from sympy.core.basic import Basic
 from sympy.strategies.core import (
     null_safe, exhaust, memoize, condition,
     chain, tryit, do_one, debug, switch, minimize)
 from io import StringIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.basic import Basic
 
 
 def posdec(x: int) -> int:

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from sympy.core.expr import Expr
 from sympy.core.function import Derivative
 from sympy.core.numbers import Integer
 from sympy.matrices.matrixbase import MatrixBase
@@ -9,6 +8,10 @@ from .arrayop import derive_by_array
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.matrices.expressions.matexpr import _matrix_derivative
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 class ArrayDerivative(Derivative):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
* Enable ruff TCH rules to improve import times of submodules

#### Other comments
From discussion over here: https://github.com/sympy/sympy/pull/28919 since
import time is an optimization priority. Saves 40+ms on my intel macbook
even more. If you make it a cold cache via git checkout, saves 250->+750ms

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * reduce overhead from typing imports
<!-- END RELEASE NOTES -->
