### PR TITLE
perf(manualintegrate): remove dataclasses

### DIFF
--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -8,10 +8,9 @@ this stuff for general purpose.
 """
 
 from __future__ import annotations
-from typing import Optional
 
 # Type of a fuzzy bool
-FuzzyBool = Optional[bool]
+FuzzyBool = bool | None
 
 
 def _torf(args):
@@ -148,7 +147,7 @@ def fuzzy_and(args):
     return rv
 
 
-def fuzzy_not(v):
+def fuzzy_not(v: bool | None) -> bool | None:
     """
     Not in fuzzy logic
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -24,7 +24,6 @@ To enable simple substitutions, add the match to find_substitutions.
 from __future__ import annotations
 from typing import NamedTuple, Type, Callable, Sequence
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from collections import defaultdict
 from collections.abc import Mapping
 
@@ -72,10 +71,42 @@ from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
 
-@dataclass
 class Rule(ABC):
+
+    __slots__ = ('integrand', 'variable')
+
     integrand: Expr
     variable: Symbol
+
+    def __init__(self, integrand: Expr, variable: Symbol):
+        self.integrand = integrand
+        self.variable = variable
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return all(
+            getattr(self, attr) == getattr(other, attr) for attr in self._get_slots()
+        )
+
+    def __repr__(self) -> str:
+        parts = [f"{self.__class__.__name__}("]
+        for i, name in enumerate(self._get_slots()):
+            if i:
+                parts.append(", ")
+            parts.append(f"{name}={getattr(self, name)!r}")
+        parts.append(")")
+        return "".join(parts)
+
+    def _get_slots(self):
+        seen = {()}
+        slots = []
+        for cls in self.__class__.__mro__[::-1]:
+            key = tuple(getattr(cls, "__slots__", ()))
+            if key not in seen:
+                seen.add(key)
+                slots.extend(key)
+        return slots
 
     @abstractmethod
     def eval(self) -> Expr:
@@ -86,26 +117,45 @@ class Rule(ABC):
         pass
 
 
-@dataclass
 class AtomicRule(Rule, ABC):
     """A simple rule that does not depend on other rules"""
+
+    __slots__ = ()
+
     def contains_dont_know(self) -> bool:
         return False
 
 
-@dataclass
 class ConstantRule(AtomicRule):
     """integrate(a, x)  ->  a*x"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return self.integrand * self.variable
 
 
-@dataclass
 class ConstantTimesRule(Rule):
     """integrate(a*f(x), x)  ->  a*integrate(f(x), x)"""
+
+    __slots__ = ('constant', 'other', 'substep')
+
     constant: Expr
     other: Expr
     substep: Rule
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        constant: Expr,
+        other: Expr,
+        substep: Rule,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.constant = constant
+        self.other = other
+        self.substep = substep
 
     def eval(self) -> Expr:
         return self.constant * self.substep.eval()
@@ -114,11 +164,20 @@ class ConstantTimesRule(Rule):
         return self.substep.contains_dont_know()
 
 
-@dataclass
 class PowerRule(AtomicRule):
     """integrate(x**a, x)"""
+
+    __slots__ = ("base", "exp")
+
     base: Expr
     exp: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, base: Expr, exp: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.base = base
+        self.exp = exp
 
     def eval(self) -> Expr:
         return Piecewise(
@@ -127,11 +186,20 @@ class PowerRule(AtomicRule):
         )
 
 
-@dataclass
 class NestedPowRule(AtomicRule):
     """integrate((x**a)**b, x)"""
+
+    __slots__ = ("base", "exp")
+
     base: Expr
     exp: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, base: Expr, exp: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.base = base
+        self.exp = exp
 
     def eval(self) -> Expr:
         m = self.base * self.integrand
@@ -139,10 +207,16 @@ class NestedPowRule(AtomicRule):
                          (m * log(self.base), True))
 
 
-@dataclass
 class AddRule(Rule):
     """integrate(f(x) + g(x), x) -> integrate(f(x), x) + integrate(g(x), x)"""
+
+    __slots__ = ("substeps",)
+
     substeps: list[Rule]
+
+    def __init__(self, integrand: Expr, variable: Symbol, substeps: list[Rule]) -> None:
+        super().__init__(integrand, variable)
+        self.substeps = substeps
 
     def eval(self) -> Expr:
         return Add(*(substep.eval() for substep in self.substeps))
@@ -151,12 +225,27 @@ class AddRule(Rule):
         return any(substep.contains_dont_know() for substep in self.substeps)
 
 
-@dataclass
 class URule(Rule):
     """integrate(f(g(x))*g'(x), x) -> integrate(f(u), u), u = g(x)"""
+
+    __slots__ = ("u_var", "u_func", "substep")
+
     u_var: Symbol
     u_func: Expr
     substep: Rule
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        u_var: Symbol,
+        u_func: Expr,
+        substep: Rule,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.u_var = u_var
+        self.u_func = u_func
+        self.substep = substep
 
     def eval(self) -> Expr:
         result = self.substep.eval()
@@ -171,13 +260,30 @@ class URule(Rule):
         return self.substep.contains_dont_know()
 
 
-@dataclass
 class PartsRule(Rule):
     """integrate(u(x)*v'(x), x) -> u(x)*v(x) - integrate(u'(x)*v(x), x)"""
+
+    __slots__ = ("u", "dv", "v_step", "second_step")
+
     u: Symbol
     dv: Expr
     v_step: Rule
     second_step: Rule | None  # None when is a substep of CyclicPartsRule
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        u: Symbol,
+        dv: Expr,
+        v_step: Rule,
+        second_step: Rule | None = None,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.u = u
+        self.dv = dv
+        self.v_step = v_step
+        self.second_step = second_step
 
     def eval(self) -> Expr:
         assert self.second_step is not None
@@ -189,11 +295,24 @@ class PartsRule(Rule):
             self.second_step is not None and self.second_step.contains_dont_know())
 
 
-@dataclass
 class CyclicPartsRule(Rule):
     """Apply PartsRule multiple times to integrate exp(x)*sin(x)"""
+
+    __slots__ = ("parts_rules", "coefficient")
+
     parts_rules: list[PartsRule]
     coefficient: Expr
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        parts_rules: list[PartsRule],
+        coefficient: Expr,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.parts_rules = parts_rules
+        self.coefficient = coefficient
 
     def eval(self) -> Expr:
         result = []
@@ -207,124 +326,184 @@ class CyclicPartsRule(Rule):
         return any(substep.contains_dont_know() for substep in self.parts_rules)
 
 
-@dataclass
 class TrigRule(AtomicRule, ABC):
-    pass
+    __slots__ = ()
 
 
-@dataclass
 class SinRule(TrigRule):
     """integrate(sin(x), x) -> -cos(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return -cos(self.variable)
 
 
-@dataclass
 class CosRule(TrigRule):
     """integrate(cos(x), x) -> sin(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return sin(self.variable)
 
 
-@dataclass
 class SecTanRule(TrigRule):
     """integrate(sec(x)*tan(x), x) -> sec(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return sec(self.variable)
 
 
-@dataclass
 class CscCotRule(TrigRule):
     """integrate(csc(x)*cot(x), x) -> -csc(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return -csc(self.variable)
 
 
-@dataclass
 class Sec2Rule(TrigRule):
     """integrate(sec(x)**2, x) -> tan(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return tan(self.variable)
 
 
-@dataclass
 class Csc2Rule(TrigRule):
     """integrate(csc(x)**2, x) -> -cot(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return -cot(self.variable)
 
 
-@dataclass
 class HyperbolicRule(AtomicRule, ABC):
-    pass
+    __slots__ = ()
 
 
-@dataclass
 class SinhRule(HyperbolicRule):
     """integrate(sinh(x), x) -> cosh(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return cosh(self.variable)
 
 
-@dataclass
 class CoshRule(HyperbolicRule):
     """integrate(cosh(x), x) -> sinh(x)"""
+
+    __slots__ = ()
+
     def eval(self):
         return sinh(self.variable)
 
 
-@dataclass
 class ExpRule(AtomicRule):
     """integrate(a**x, x) -> a**x/ln(a)"""
+
+    __slots__ = ("base", "exp")
+
     base: Expr
     exp: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, base: Expr, exp: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.base = base
+        self.exp = exp
 
     def eval(self) -> Expr:
         return self.integrand / log(self.base)
 
 
-@dataclass
 class ReciprocalRule(AtomicRule):
     """integrate(1/x, x) -> ln(x)"""
+
+    __slots__ = ("base",)
+
     base: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, base: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.base = base
 
     def eval(self) -> Expr:
         return log(self.base)
 
 
-@dataclass
 class ArcsinRule(AtomicRule):
     """integrate(1/sqrt(1-x**2), x) -> asin(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return asin(self.variable)
 
 
-@dataclass
 class ArcsinhRule(AtomicRule):
     """integrate(1/sqrt(1+x**2), x) -> asin(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return asinh(self.variable)
 
 
-@dataclass
 class ReciprocalSqrtQuadraticRule(AtomicRule):
     """integrate(1/sqrt(a+b*x+c*x**2), x) -> log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)"""
+
+    __slots__ = ("a", "b", "c")
+
     a: Expr
     b: Expr
     c: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr, c: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
         return log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)
 
 
-@dataclass
 class SqrtQuadraticDenomRule(AtomicRule):
     """integrate(poly(x)/sqrt(a+b*x+c*x**2), x)"""
+
+    __slots__ = ("a", "b", "c", "coeffs")
+
     a: Expr
     b: Expr
     c: Expr
     coeffs: list[Expr]
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        a: Expr,
+        b: Expr,
+        c: Expr,
+        coeffs: list[Expr],
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
+        self.coeffs = coeffs
 
     def eval(self) -> Expr:
         a, b, c, coeffs, x = self.a, self.b, self.c, self.coeffs.copy(), self.variable
@@ -354,22 +533,40 @@ class SqrtQuadraticDenomRule(AtomicRule):
                      for i in range(len(result_coeffs))), e/c)*s + I0
 
 
-@dataclass
 class SqrtQuadraticRule(AtomicRule):
     """integrate(sqrt(a+b*x+c*x**2), x)"""
+
+    __slots__ = ("a", "b", "c")
+
     a: Expr
     b: Expr
     c: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr, c: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
 
     def eval(self) -> Expr:
         step = sqrt_quadratic_rule(IntegralInfo(self.integrand, self.variable), degenerate=False)
         return step.eval()
 
 
-@dataclass
 class AlternativeRule(Rule):
     """Multiple ways to do integration."""
+
+    __slots__ = ("alternatives",)
+
     alternatives: list[Rule]
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, alternatives: list[Rule]
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.alternatives = alternatives
 
     def eval(self) -> Expr:
         return self.alternatives[0].eval()
@@ -378,9 +575,11 @@ class AlternativeRule(Rule):
         return any(substep.contains_dont_know() for substep in self.alternatives)
 
 
-@dataclass
 class DontKnowRule(Rule):
     """Leave the integral as is."""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         return Integral(self.integrand, self.variable)
 
@@ -388,9 +587,11 @@ class DontKnowRule(Rule):
         return True
 
 
-@dataclass
 class DerivativeRule(AtomicRule):
     """integrate(f'(x), x) -> f(x)"""
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         assert isinstance(self.integrand, Derivative)
         variable_count = list(self.integrand.variable_count)
@@ -401,11 +602,20 @@ class DerivativeRule(AtomicRule):
         return Derivative(self.integrand.expr, *variable_count)
 
 
-@dataclass
 class RewriteRule(Rule):
     """Rewrite integrand to another form that is easier to handle."""
+
+    __slots__ = ("rewritten", "substep")
+
     rewritten: Expr
     substep: Rule
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, rewritten: Expr, substep: Rule
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.rewritten = rewritten
+        self.substep = substep
 
     def eval(self) -> Expr:
         return self.substep.eval()
@@ -414,15 +624,25 @@ class RewriteRule(Rule):
         return self.substep.contains_dont_know()
 
 
-@dataclass
 class CompleteSquareRule(RewriteRule):
     """Rewrite a+b*x+c*x**2 to a-b**2/(4*c) + c*(x+b/(2*c))**2"""
-    pass
+    __slots__ = ()
 
 
-@dataclass
 class PiecewiseRule(Rule):
+
+    __slots__ = ("subfunctions",)
+
     subfunctions: Sequence[tuple[Rule, bool | Boolean]]
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        subfunctions: Sequence[tuple[Rule, bool | Boolean]],
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.subfunctions = subfunctions
 
     def eval(self) -> Expr:
         return Piecewise(*[(substep.eval(), cond)
@@ -432,11 +652,26 @@ class PiecewiseRule(Rule):
         return any(substep.contains_dont_know() for substep, _ in self.subfunctions)
 
 
-@dataclass
 class HeavisideRule(Rule):
+
+    __slots__ = ("harg", "ibnd", "substep")
+
     harg: Expr
     ibnd: Expr
     substep: Rule
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        harg: Expr,
+        ibnd: Expr,
+        substep: Rule,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.harg = harg
+        self.ibnd = ibnd
+        self.substep = substep
 
     def eval(self) -> Expr:
         # If we are integrating over x and the integrand has the form
@@ -450,11 +685,21 @@ class HeavisideRule(Rule):
         return self.substep.contains_dont_know()
 
 
-@dataclass
 class DiracDeltaRule(AtomicRule):
+
+    __slots__ = ("n", "a", "b")
+
     n: Expr
     a: Expr
     b: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, n: Expr, a: Expr, b: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.n = n
+        self.a = a
+        self.b = b
 
     def eval(self) -> Expr:
         n, a, b, x = self.n, self.a, self.b, self.variable
@@ -463,13 +708,32 @@ class DiracDeltaRule(AtomicRule):
         return DiracDelta(a+b*x, n-1)/b
 
 
-@dataclass
 class TrigSubstitutionRule(Rule):
+
+    __slots__ = ("theta", "func", "rewritten", "substep", "restriction")
+
     theta: Expr
     func: Expr
     rewritten: Expr
     substep: Rule
     restriction: bool | Boolean
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        theta: Expr,
+        func: Expr,
+        rewritten: Expr,
+        substep: Rule,
+        restriction: bool | Boolean,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.theta = theta
+        self.func = func
+        self.rewritten = rewritten
+        self.substep = substep
+        self.restriction = restriction
 
     def eval(self) -> Expr:
         theta, func, x = self.theta, self.func, self.variable
@@ -514,27 +778,52 @@ class TrigSubstitutionRule(Rule):
         return self.substep.contains_dont_know()
 
 
-@dataclass
 class ArctanRule(AtomicRule):
     """integrate(a/(b*x**2+c), x) -> a/b / sqrt(c/b) * atan(x/sqrt(c/b))"""
+
+    __slots__ = ("a", "b", "c")
+
     a: Expr
     b: Expr
     c: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr, c: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
         return a/b / sqrt(c/b) * atan(x/sqrt(c/b))
 
 
-@dataclass
 class OrthogonalPolyRule(AtomicRule, ABC):
+
+    __slots__ = ("n",)
+
     n: Expr
 
+    def __init__(self, integrand: Expr, variable: Symbol, n: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.n = n
 
-@dataclass
+
 class JacobiRule(OrthogonalPolyRule):
+
+    __slots__ = ("a", "b")
+
     a: Expr
     b: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, n: Expr, a: Expr, b: Expr
+    ) -> None:
+        super().__init__(integrand, variable, n)
+        self.a = a
+        self.b = b
 
     def eval(self) -> Expr:
         n, a, b, x = self.n, self.a, self.b, self.variable
@@ -544,9 +833,15 @@ class JacobiRule(OrthogonalPolyRule):
             ((a + b + 2)*x**2/4 + (a - b)*x/2, Eq(n, 1)))
 
 
-@dataclass
 class GegenbauerRule(OrthogonalPolyRule):
+
+    __slots__ = ("a",)
+
     a: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, n: Expr, a: Expr) -> None:
+        super().__init__(integrand, variable, n)
+        self.a = a
 
     def eval(self) -> Expr:
         n, a, x = self.n, self.a, self.variable
@@ -556,8 +851,10 @@ class GegenbauerRule(OrthogonalPolyRule):
             (S.Zero, True))
 
 
-@dataclass
 class ChebyshevTRule(OrthogonalPolyRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         n, x = self.n, self.variable
         return Piecewise(
@@ -566,8 +863,10 @@ class ChebyshevTRule(OrthogonalPolyRule):
             (x**2/2, True))
 
 
-@dataclass
 class ChebyshevURule(OrthogonalPolyRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         n, x = self.n, self.variable
         return Piecewise(
@@ -575,88 +874,129 @@ class ChebyshevURule(OrthogonalPolyRule):
             (S.Zero, True))
 
 
-@dataclass
 class LegendreRule(OrthogonalPolyRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         n, x = self.n, self.variable
         return(legendre(n + 1, x) - legendre(n - 1, x))/(2*n + 1)
 
 
-@dataclass
 class HermiteRule(OrthogonalPolyRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         n, x = self.n, self.variable
         return hermite(n + 1, x)/(2*(n + 1))
 
 
-@dataclass
 class LaguerreRule(OrthogonalPolyRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         n, x = self.n, self.variable
         return laguerre(n, x) - laguerre(n + 1, x)
 
 
-@dataclass
 class AssocLaguerreRule(OrthogonalPolyRule):
+
+    __slots__ = ("a",)
+
     a: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, n: Expr, a: Expr) -> None:
+        super().__init__(integrand, variable, n)
+        self.a = a
 
     def eval(self) -> Expr:
         return -assoc_laguerre(self.n + 1, self.a - 1, self.variable)
 
 
-@dataclass
 class IRule(AtomicRule, ABC):
+
+    __slots__ = ("a", "b")
+
     a: Expr
     b: Expr
 
+    def __init__(self, integrand: Expr, variable: Symbol, a: Expr, b: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
 
-@dataclass
+
 class CiRule(IRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         a, b, x = self.a, self.b, self.variable
         return cos(b)*Ci(a*x) - sin(b)*Si(a*x)
 
 
-@dataclass
 class ChiRule(IRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         a, b, x = self.a, self.b, self.variable
         return cosh(b)*Chi(a*x) + sinh(b)*Shi(a*x)
 
 
-@dataclass
 class EiRule(IRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         a, b, x = self.a, self.b, self.variable
         return exp(b)*Ei(a*x)
 
 
-@dataclass
 class SiRule(IRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         a, b, x = self.a, self.b, self.variable
         return sin(b)*Ci(a*x) + cos(b)*Si(a*x)
 
 
-@dataclass
 class ShiRule(IRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         a, b, x = self.a, self.b, self.variable
         return sinh(b)*Chi(a*x) + cosh(b)*Shi(a*x)
 
 
-@dataclass
 class LiRule(IRule):
+
+    __slots__ = ()
+
     def eval(self) -> Expr:
         a, b, x = self.a, self.b, self.variable
         return li(a*x + b)/a
 
 
-@dataclass
 class ErfRule(AtomicRule):
+
+    __slots__ = ("a", "b", "c")
+
     a: Expr
     b: Expr
     c: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr, c: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
@@ -670,11 +1010,21 @@ class ErfRule(AtomicRule):
                 erfi((2*a*x + b)/(2*sqrt(a)))
 
 
-@dataclass
 class FresnelCRule(AtomicRule):
+
+    __slots__ = ("a", "b", "c")
+
     a: Expr
     b: Expr
     c: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr, c: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
@@ -683,11 +1033,21 @@ class FresnelCRule(AtomicRule):
             sin(b**2/(4*a) - c)*fresnels((2*a*x + b)/sqrt(2*a*S.Pi)))
 
 
-@dataclass
 class FresnelSRule(AtomicRule):
+
+    __slots__ = ("a", "b", "c")
+
     a: Expr
     b: Expr
     c: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr, c: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+        self.c = c
 
     def eval(self) -> Expr:
         a, b, c, x = self.a, self.b, self.c, self.variable
@@ -696,38 +1056,66 @@ class FresnelSRule(AtomicRule):
             sin(b**2/(4*a) - c)*fresnelc((2*a*x + b)/sqrt(2*a*S.Pi)))
 
 
-@dataclass
 class PolylogRule(AtomicRule):
+
+    __slots__ = ("a", "b")
+
     a: Expr
     b: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, a: Expr, b: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
 
     def eval(self) -> Expr:
         return polylog(self.b + 1, self.a * self.variable)
 
 
-@dataclass
 class UpperGammaRule(AtomicRule):
+
+    __slots__ = ("a", "e")
+
     a: Expr
     e: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, a: Expr, e: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.e = e
 
     def eval(self) -> Expr:
         a, e, x = self.a, self.e, self.variable
         return x**e * (-a*x)**(-e) * uppergamma(e + 1, -a*x)/a
 
 
-@dataclass
 class EllipticFRule(AtomicRule):
+
+    __slots__ = ("a", "d")
+
     a: Expr
     d: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, a: Expr, d: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.d = d
 
     def eval(self) -> Expr:
         return elliptic_f(self.variable, self.d/self.a)/sqrt(self.a)
 
 
-@dataclass
 class EllipticERule(AtomicRule):
+
+    __slots__ = ("a", "d")
+
     a: Expr
     d: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, a: Expr, d: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.d = d
 
     def eval(self) -> Expr:
         return elliptic_e(self.variable, self.d/self.a)*sqrt(self.a)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/pull/28919#issuecomment-3733452564

#### Brief description of what is fixed or changed

Remove dataclasses from the manualintegrate module.

Given this script
```
import sympy
import sys

expr = sympy.parse_expr(sys.argv[1])
sym = sympy.parse_expr(sys.argv[2])

print(sympy.integrate(expr, sym))
```
With the PR it is
```
$ time python t.py 'x**2 + 1' 'x'
x**3/3 + x

real	0m0.652s
user	0m0.591s
sys	0m0.061s
```
With master it is
```
$ time python t.py 'x**2 + 1' 'x'
x**3/3 + x

real	0m0.719s
user	0m0.636s
sys	0m0.083s
```
Exact timings vary from run to run but it is roughly a 10% speedup in import time for anything that uses `integrate`.

#### Other comments

Previous PRs optimised import time but what is measured here does not show up in `import sympy` because `integrate` uses a delayed import to integrate manualintegrate.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Import time was made faster by not using dataclasses in manualintegrate.
<!-- END RELEASE NOTES -->
