### PR TITLE
solvers: respect assumptions and support ILP in simplex solver

### DIFF
--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -262,3 +262,21 @@ def test_28104():
     val, var = lpmax(0, [x >= 0, y >= 0])
     assert var[y] is S.Zero
     assert var[x] is S.Zero
+
+
+def test_assumptions():
+    # nonnegative assumption
+    b0, b1 = symbols('b0 b1', nonnegative=True)
+    # The fix ensures that symbols with nonnegative=True are treated as >= 0
+    # even if not explicitly constrained in the list.
+    assert lpmin(b0 + b1, [b0 + b1 >= 1]) == (1, {b0: 1, b1: 0})
+
+    # integer assumption
+    x0, x1 = symbols('x0 x1', integer=True, nonnegative=True)
+    # 2*x0 + 2*x1 >= 1, x0, x1 >= 0 integers. 
+    # Min is 1 (e.g. at x0=1, x1=0), not 0.5.
+    assert lpmin(x0 + x1, [2*x0 + 2*x1 >= 1]) == (1, {x0: 1, x1: 0})
+
+    # infeasible integer
+    x = symbols('x', integer=True)
+    raises(InfeasibleLPError, lambda: lpmin(x, [x >= Rational(1, 10), x <= Rational(9, 10)]))

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -273,7 +273,7 @@ def test_assumptions():
 
     # integer assumption
     x0, x1 = symbols('x0 x1', integer=True, nonnegative=True)
-    # 2*x0 + 2*x1 >= 1, x0, x1 >= 0 integers. 
+    # 2*x0 + 2*x1 >= 1, x0, x1 >= 0 integers.
     # Min is 1 (e.g. at x0=1, x1=0), not 0.5.
     assert lpmin(x0 + x1, [2*x0 + 2*x1 >= 1]) == (1, {x0: 1, x1: 0})
 


### PR DESCRIPTION
**solvers: Support assumptions and Integer Linear Programming in simplex module**
#### References to other Issues or PRs
Fixes #28747
#### Brief description of what is fixed or changed
This pull request modifies the simplex solver ([lpmin](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:848:0-885:30) and [lpmax](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:887:0-920:30)) to correctly handle symbol assumptions. Specifically:
- **Assumptions as bounds**: Variables with `nonnegative=True` are now automatically bounded. Previously, the solver would often raise an [UnboundedLPError](cci:2://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:80:0-96:8) in these cases because explicit constraints like `x >= 0` simplify to `True` during expression evaluation, causing the solver to lose the intended bounding information.
- **Integer Linear Programming (ILP)**: Implemented a Branch and Bound algorithm within the [simplex](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:159:0-371:42) module. When symbols are defined with the `integer=True` assumption, the solver will now perform branching to find an optimal integer solution instead of returning fractional results.
- **Documentation**: Updated docstrings for [lpmin](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:848:0-885:30), [lpmax](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:887:0-920:30), and [_lp](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:723:0-845:25) to explicitly state that assumptions are supported and to describe the new ILP behavior.
#### Other comments
This change resolves an inconsistency where the simplex module ignored the core SymPy assumptions system. Added a new test suite [test_assumptions](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/tests/test_simplex.py:266:0-281:93) in [sympy/solvers/tests/test_simplex.py](cci:7://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/tests/test_simplex.py:0:0-0:0) to verify these improvements and prevent regression.
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * [lpmin](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:848:0-885:30) and [lpmax](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:887:0-920:30) now respect the `nonnegative=True` symbol assumption.
  * Implemented Integer Linear Programming in [lpmin](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:848:0-885:30) and [lpmax](cci:1://file:///c:/Users/saura/Desktop/SYMPY/sympy/sympy/solvers/simplex.py:887:0-920:30) for symbols with the `integer=True` assumption using a Branch and Bound algorithm.
<!-- END RELEASE NOTES -->