### PR TITLE
Fix outdated MathJax documentation link in latex printer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1858,3 +1858,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Sarvan Singh <sarvan07tiwana@gmail.com> sarvantiwana07 <sarvan07tiwana@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1449,6 +1449,7 @@ Sanya Khurana <sanya@monica.in>
 Saptarshi Mandal <sapta.iitkgp@gmail.com>
 Saroj Adhikari <adh.saroj@gmail.com>
 Sartaj Singh <singhsartaj94@gmail.com>
+Sarvan Singh <sarvan07tiwana@gmail.com> sarvantiwana07 <sarvan07tiwana@gmail.com>
 Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
@@ -1858,4 +1859,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Sarvan Singh <sarvan07tiwana@gmail.com> sarvantiwana07 <sarvan07tiwana@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 # Hand-picked functions which can be used directly in both LaTeX and MathJax
 # Complete list at
-# https://docs.mathjax.org/en/latest/tex.html#supported-latex-commands
+# https://docs.mathjax.org/en/latest/input/tex/index.html #supported-latex-commands
 # This variable only contains those functions which SymPy uses.
 accepted_latex_functions = ['arcsin', 'arccos', 'arctan', 'sin', 'cos', 'tan',
                             'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec',


### PR DESCRIPTION
Fix a broken/outdated MathJax documentation link in sympy/printing/latex.py.

The previous URL was no longer valid. This updates it to the correct current
MathJax documentation page for supported LaTeX commands.

This is a comment-only change and does not affect any code behavior.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->