### PR TITLE
Implemented gradient of a vector field

### DIFF
--- a/sympy/testing/quality_unicode.py
+++ b/sympy/testing/quality_unicode.py
@@ -25,9 +25,9 @@ unicode_whitelist = [
     # output.
     r'*/sympy/testing/tests/test_code_quality.py',
     r'*/sympy/physics/vector/tests/test_printing.py',
-    r'*/sympy/physics/vector/tests/test_field_functions.py',
     r'*/physics/quantum/tests/test_printing.py',
     r'*/sympy/vector/tests/test_printing.py',
+    r'*/sympy/vector/tests/test_field_functions.py',
     r'*/sympy/parsing/tests/test_sympy_parser.py',
     r'*/sympy/printing/pretty/stringpict.py',
     r'*/sympy/printing/pretty/tests/test_pretty.py',

--- a/sympy/testing/quality_unicode.py
+++ b/sympy/testing/quality_unicode.py
@@ -25,6 +25,7 @@ unicode_whitelist = [
     # output.
     r'*/sympy/testing/tests/test_code_quality.py',
     r'*/sympy/physics/vector/tests/test_printing.py',
+    r'*/sympy/physics/vector/tests/test_field_functions.py',
     r'*/physics/quantum/tests/test_printing.py',
     r'*/sympy/vector/tests/test_printing.py',
     r'*/sympy/parsing/tests/test_sympy_parser.py',

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -6,6 +6,7 @@ from sympy.vector.dyadic import (Dyadic, DyadicAdd, DyadicMul,
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.deloperator import Del
 from sympy.vector.functions import (express, matrix_to_vector,
+                                    matrix_to_dyadic,
                                     laplacian, is_conservative,
                                     is_solenoidal, scalar_potential,
                                     directional_derivative,
@@ -33,7 +34,8 @@ __all__ = [
 
     'CoordSys3D',
 
-    'express', 'matrix_to_vector', 'laplacian', 'is_conservative',
+    'express', 'matrix_to_vector', 'matrix_to_dyadic',
+    'laplacian', 'is_conservative',
     'is_solenoidal', 'scalar_potential', 'directional_derivative',
     'scalar_potential_difference',
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -8,7 +8,7 @@ from sympy.core.function import diff
 from sympy.core.singleton import S
 from sympy.integrals.integrals import integrate
 from sympy.core import sympify
-from sympy.vector.dyadic import Dyadic
+from sympy.vector.dyadic import Dyadic, DyadicAdd
 
 
 def express(expr, system, system2=None, variables=False):
@@ -498,12 +498,12 @@ def matrix_to_dyadic(matrix, system):
     if (n != 3) or (m != 3):
         raise ShapeError("A 3 x 3 matrix is required.")
 
-    out = Dyadic.zero
+    args = []
     vects = system.base_vectors()
     for i in range(3):
         for j in range(3):
-            out += matrix[i, j] * (vects[i] | vects[j])
-    return out
+            args.append(matrix[i, j] * (vects[i] | vects[j]))
+    return DyadicAdd(*args)
 
 
 def _path(from_object, to_object):

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -144,7 +144,7 @@ def directional_derivative(field, direction_vector):
     The two definitions differs by the magnitude of the direction vector.
     This function does not normalize direction_vector. If the user wants
     to compute the directional derivative according to the first definition,
-    it is user's resposibility to normalize the direction vector before
+    it is the user's resposibility to normalize the direction vector before
     giving it to this function.
 
     The directional derivative of a vector field $\mathbf{\vec{f}}(\mathbf{x})$
@@ -153,7 +153,7 @@ def directional_derivative(field, direction_vector):
     $$\nabla_{\mathbf{\vec{v}}} f(\mathbf{x}) = \mathbf{\vec{v}} \cdot \nabla \mathbf{\vec{f}}(\mathbf{x})$$
 
     This term frequently appears in continuum mechanics's partial differential
-    equations, in particul the advection equation.
+    equations, in particular the advection equation.
 
     Parameters
     ==========
@@ -491,8 +491,9 @@ def matrix_to_dyadic(matrix, system):
     >>> C = CoordSys3D('C')
     >>> m = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> d = matrix_to_dyadic(m, C)
-    >>> d
-    (C.i|C.i) + 2*(C.i|C.j) + 3*(C.i|C.k) + 4*(C.j|C.i) + 5*(C.j|C.j) + 6*(C.j|C.k) + 7*(C.k|C.i) + 8*(C.k|C.j) + 9*(C.k|C.k)
+    >>> d     # doctest: +NORMALIZE_WHITESPACE
+    (C.i|C.i) + 2*(C.i|C.j) + 3*(C.i|C.k) + 4*(C.j|C.i) + 5*(C.j|C.j)
+    + 6*(C.j|C.k) + 7*(C.k|C.i) + 8*(C.k|C.j) + 9*(C.k|C.k)
     >>> d.to_matrix(C) == m
     True
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -2,8 +2,8 @@ from sympy.matrices.exceptions import ShapeError
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.deloperator import Del
 from sympy.vector.scalar import BaseScalar
-from sympy.vector.vector import Vector, BaseVector
-from sympy.vector.operators import gradient, curl, divergence
+from sympy.vector.vector import Vector, BaseVector, Dot
+from sympy.vector.operators import gradient, curl, divergence, Gradient
 from sympy.core.function import diff
 from sympy.core.singleton import S
 from sympy.integrals.integrals import integrate
@@ -126,9 +126,34 @@ def express(expr, system, system2=None, variables=False):
 
 
 def directional_derivative(field, direction_vector):
-    """
+    r"""
     Returns the directional derivative of a scalar or vector field computed
-    along a given vector in coordinate system which parameters are expressed.
+    along a given vector in a coordinate system.
+
+    Note that there are two definitions of directional derivative for a
+    differentiable scalar function $f$. Let $\vec{v}$ be an arbitrary direction
+    vector, and $\hat{v}$ be the normalized direction vector. Some authors
+    define the directional derivative as:
+
+    $$\nabla_{\mathbf{\vec{v}}} f(\mathbf{x}) = \mathbf{\hat{v}} \cdot \nabla f(\mathbf{x})$$
+
+    Other authors define it as:
+
+    $$\nabla_{\vec{v}} f(\mathbf{x}) = \vec{v} \cdot \nabla f(\mathbf{x})$$
+
+    The two definitions differs by the magnitude of the direction vector.
+    This function does not normalize direction_vector. If the user wants
+    to compute the directional derivative according to the first definition,
+    it is user's resposibility to normalize the direction vector before
+    giving it to this function.
+
+    The directional derivative of a vector field $\mathbf{\vec{f}}(\mathbf{x})$
+    along the vector $\mathbf{\vec{v}}}$ is:
+
+    $$\nabla_{\mathbf{\vec{v}}} f(\mathbf{x}) = \mathbf{\vec{v}} \cdot \nabla \mathbf{\vec{f}}(\mathbf{x})$$
+
+    This term frequently appears in continuum mechanics's partial differential
+    equations, in particul the advection equation.
 
     Parameters
     ==========
@@ -139,39 +164,51 @@ def directional_derivative(field, direction_vector):
     direction_vector : Vector
         The vector to calculated directional derivative along them.
 
-
     Examples
     ========
 
     >>> from sympy.vector import CoordSys3D, directional_derivative
     >>> R = CoordSys3D('R')
+
+    Directional derivative of a scalar field with an arbitrary direction
+    vector:
+
     >>> f1 = R.x*R.y*R.z
     >>> v1 = 3*R.i + 4*R.j + R.k
     >>> directional_derivative(f1, v1)
     R.x*R.y + 4*R.x*R.z + 3*R.y*R.z
-    >>> f2 = 5*R.x**2*R.z
-    >>> directional_derivative(f2, v1)
-    5*R.x**2 + 30*R.x*R.z
+
+    Directional derivative of a scalar field with a unit vector:
+
+    >>> directional_derivative(f1, v1.normalize())
+    sqrt(26)*R.x*R.y/26 + 2*sqrt(26)*R.x*R.z/13 + 3*sqrt(26)*R.y*R.z/26
+
+    Directional derivate of a vector field in a cylindrical coordinate system:
+
+    >>> C = CoordSys3D("C", transformation="cylindrical")
+    >>> r, theta, z = C.base_scalars()
+    >>> e_r, e_theta, e_z = C.base_vectors()
+    >>> u, v, w = [Function(s)(r, theta, z) for s in ["u", "v", "w"]]
+    >>> vec = u * e_r + v * e_theta + w * e_z
+    >>> direction = e_theta
+    >>> directional_derivative(vec, direction)
+    (-v(C.r, C.theta, C.z)/C.r + Derivative(u(C.r, C.theta, C.z), C.theta)/C.r)*C.i + (u(C.r, C.theta, C.z)/C.r + Derivative(v(C.r, C.theta, C.z), C.theta)/C.r)*C.j + (Derivative(w(C.r, C.theta, C.z), C.theta)/C.r)*C.k
 
     """
     from sympy.vector.operators import _get_coord_systems
     coord_sys = _get_coord_systems(field)
-    if len(coord_sys) > 0:
-        # TODO: This gets a random coordinate system in case of multiple ones:
-        coord_sys = next(iter(coord_sys))
-        field = express(field, coord_sys, variables=True)
-        i, j, k = coord_sys.base_vectors()
-        x, y, z = coord_sys.base_scalars()
-        out = Vector.dot(direction_vector, i) * diff(field, x)
-        out += Vector.dot(direction_vector, j) * diff(field, y)
-        out += Vector.dot(direction_vector, k) * diff(field, z)
-        if out == 0 and isinstance(field, Vector):
-            out = Vector.zero
-        return out
-    elif isinstance(field, Vector):
-        return Vector.zero
-    else:
+    if len(coord_sys) == 0:
+        if isinstance(field, Vector):
+            return Vector.zero
         return S.Zero
+
+    coord_sys = next(iter(coord_sys))
+    field = express(field, coord_sys, variables=True)
+    grad = gradient(field)
+
+    if isinstance(grad, Gradient):
+        return Dot(direction_vector, grad)
+    return direction_vector & grad
 
 
 def laplacian(expr):

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -192,8 +192,10 @@ def directional_derivative(field, direction_vector):
     >>> u, v, w = [Function(s)(r, theta, z) for s in ["u", "v", "w"]]
     >>> vec = u * e_r + v * e_theta + w * e_z
     >>> direction = e_theta
-    >>> directional_derivative(vec, direction)
-    (-v(C.r, C.theta, C.z)/C.r + Derivative(u(C.r, C.theta, C.z), C.theta)/C.r)*C.i + (u(C.r, C.theta, C.z)/C.r + Derivative(v(C.r, C.theta, C.z), C.theta)/C.r)*C.j + (Derivative(w(C.r, C.theta, C.z), C.theta)/C.r)*C.k
+    >>> directional_derivative(vec, direction)  # doctest: +NORMALIZE_WHITESPACE
+    (-v(C.r, C.theta, C.z)/C.r + Derivative(u(C.r, C.theta, C.z), C.theta)/C.r)*C.i
+    + (u(C.r, C.theta, C.z)/C.r + Derivative(v(C.r, C.theta, C.z), C.theta)/C.r)*C.j
+    + (Derivative(w(C.r, C.theta, C.z), C.theta)/C.r)*C.k
 
     """
     from sympy.vector.operators import _get_coord_systems

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -131,9 +131,9 @@ def directional_derivative(field, direction_vector):
     along a given vector in a coordinate system.
 
     Note that there are two definitions of directional derivative for a
-    differentiable scalar function $f$. Let $\vec{v}$ be an arbitrary direction
-    vector, and $\hat{v}$ be the normalized direction vector. Some authors
-    define the directional derivative as:
+    differentiable scalar function $f$. Let $\mathbf{\vec{v}}$ be an arbitrary
+    direction vector, and $\mathbf{\hat{v}}$ be the normalized direction
+    vector. Some authors define the directional derivative as:
 
     $$\nabla_{\mathbf{\vec{v}}} f(\mathbf{x}) = \mathbf{\hat{v}} \cdot \nabla f(\mathbf{x})$$
 
@@ -148,7 +148,7 @@ def directional_derivative(field, direction_vector):
     giving it to this function.
 
     The directional derivative of a vector field $\mathbf{\vec{f}}(\mathbf{x})$
-    along the vector $\mathbf{\vec{v}}}$ is:
+    along the vector $\mathbf{\vec{v}}$ is:
 
     $$\nabla_{\mathbf{\vec{v}}} f(\mathbf{x}) = \mathbf{\vec{v}} \cdot \nabla \mathbf{\vec{f}}(\mathbf{x})$$
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,3 +1,4 @@
+from sympy.matrices.exceptions import ShapeError
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.deloperator import Del
 from sympy.vector.scalar import BaseScalar
@@ -427,6 +428,45 @@ def matrix_to_vector(matrix, system):
     for i, x in enumerate(matrix):
         outvec += x * vects[i]
     return outvec
+
+
+def matrix_to_dyadic(matrix, system):
+    """
+    Converts a 3 x 3 matrix to a Dyadic instance.
+
+    Parameters
+    ==========
+
+    matrix : Matrix, Dimensions: (3, 3)
+        The matrix to be converted to a dyadic
+
+    system : CoordSys3D
+        The coordinate system the dyadic is to be defined in
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+    >>> from sympy.vector import CoordSys3D, matrix_to_vector
+    >>> C = CoordSys3D('C')
+    >>> m = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> d = matrix_to_dyadic(m, C)
+    >>> d
+    (C.i|C.i) + 2*(C.i|C.j) + 3*(C.i|C.k) + 4*(C.j|C.i) + 5*(C.j|C.j) + 6*(C.j|C.k) + 7*(C.k|C.i) + 8*(C.k|C.j) + 9*(C.k|C.k)
+    >>> d.to_matrix(C) == m
+    True
+
+    """
+    n, m = matrix.shape
+    if (n != 3) or (m != 3):
+        raise ShapeError("A 3 x 3 matrix is required.")
+
+    out = Dyadic.zero
+    vects = system.base_vectors()
+    for i in range(3):
+        for j in range(3):
+            out += matrix[i, j] * (vects[i] | vects[j])
+    return out
 
 
 def _path(from_object, to_object):

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -167,6 +167,7 @@ def directional_derivative(field, direction_vector):
     Examples
     ========
 
+    >>> from sympy import Function
     >>> from sympy.vector import CoordSys3D, directional_derivative
     >>> R = CoordSys3D('R')
 
@@ -484,7 +485,7 @@ def matrix_to_dyadic(matrix, system):
     ========
 
     >>> from sympy import Matrix
-    >>> from sympy.vector import CoordSys3D, matrix_to_vector
+    >>> from sympy.vector import CoordSys3D, matrix_to_dyadic
     >>> C = CoordSys3D('C')
     >>> m = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> d = matrix_to_dyadic(m, C)

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -294,13 +294,13 @@ def gradient(field, doit=True):
 
     >>> C = CoordSys3D("C", transformation="cylindrical")
     >>> e_r, e_theta, e_z = C.base_vectors()
-    >>> r, θ, z = C.base_scalars()
-    >>> v_r = Function('v_r')(r, θ, z)
-    >>> v_θ = Function('v_θ')(r, θ, z)
-    >>> v_z = Function('v_z')(r, θ, z)
-    >>> v = v_r * e_r + v_θ * e_theta + v_z * e_z
+    >>> r, theta, z = C.base_scalars()
+    >>> v_r = Function('v_r')(r, theta, z)
+    >>> v_theta = Function('v_theta')(r, theta, z)
+    >>> v_z = Function('v_z')(r, theta, z)
+    >>> v = v_r * e_r + v_theta * e_theta + v_z * e_z
     >>> gradient(v)
-    >>> (Derivative(v_r(C.r, C.theta, C.z), C.r))*(C.i|C.i) + (Derivative(v_θ(C.r, C.theta, C.z), C.r))*(C.i|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.r))*(C.i|C.k) + (-v_θ(C.r, C.theta, C.z)/C.r + Derivative(v_r(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.i) + (v_r(C.r, C.theta, C.z)/C.r + Derivative(v_θ(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.k) + (Derivative(v_r(C.r, C.theta, C.z), C.z))*(C.k|C.i) + (Derivative(v_θ(C.r, C.theta, C.z), C.z))*(C.k|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.z))*(C.k|C.k)
+    (Derivative(v_r(C.r, C.theta, C.z), C.r))*(C.i|C.i) + (Derivative(v_theta(C.r, C.theta, C.z), C.r))*(C.i|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.r))*(C.i|C.k) + (-v_theta(C.r, C.theta, C.z)/C.r + Derivative(v_r(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.i) + (v_r(C.r, C.theta, C.z)/C.r + Derivative(v_theta(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.k) + (Derivative(v_r(C.r, C.theta, C.z), C.z))*(C.k|C.i) + (Derivative(v_theta(C.r, C.theta, C.z), C.z))*(C.k|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.z))*(C.k|C.k)
 
     """
     coord_sys = _get_coord_systems(field)

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -319,9 +319,9 @@ def gradient(field, doit=True):
     if not isinstance(field, (Vector, Dyadic)):
         # scalar field
         if len(coord_sys) > 1:
-            if isinstance(field, (Add, VectorAdd)):
+            if isinstance(field, Add):
                 return VectorAdd.fromiter(gradient(i) for i in field.args)
-            if isinstance(field, (Mul, VectorMul)):
+            if isinstance(field, Mul):
                 s = _split_mul_args_wrt_coordsys(field)
                 return VectorAdd.fromiter(field / i * gradient(i) for i in s)
             return Gradient(field)

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -341,9 +341,9 @@ def gradient(field, doit=True):
     elif isinstance(field, Vector):
         # vector field
         if len(coord_sys) > 1:
-            if isinstance(field, (Add, VectorAdd)):
+            if isinstance(field, VectorAdd):
                 return DyadicAdd.fromiter(gradient(i) for i in field.args)
-            if isinstance(field, (Mul, VectorMul)):
+            if isinstance(field, VectorMul):
                 s = _split_mul_args_wrt_coordsys(field)
                 return DyadicAdd.fromiter(field / i * gradient(i) for i in s)
             return Gradient(field)

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -300,8 +300,16 @@ def gradient(field, doit=True):
     >>> v_theta = Function('v_theta')(r, theta, z)
     >>> v_z = Function('v_z')(r, theta, z)
     >>> v = v_r * e_r + v_theta * e_theta + v_z * e_z
-    >>> gradient(v)
-    (Derivative(v_r(C.r, C.theta, C.z), C.r))*(C.i|C.i) + (Derivative(v_theta(C.r, C.theta, C.z), C.r))*(C.i|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.r))*(C.i|C.k) + (-v_theta(C.r, C.theta, C.z)/C.r + Derivative(v_r(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.i) + (v_r(C.r, C.theta, C.z)/C.r + Derivative(v_theta(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.k) + (Derivative(v_r(C.r, C.theta, C.z), C.z))*(C.k|C.i) + (Derivative(v_theta(C.r, C.theta, C.z), C.z))*(C.k|C.j) + (Derivative(v_z(C.r, C.theta, C.z), C.z))*(C.k|C.k)
+    >>> gradient(v)     # doctest: +NORMALIZE_WHITESPACE
+    (Derivative(v_r(C.r, C.theta, C.z), C.r))*(C.i|C.i)
+    + (Derivative(v_theta(C.r, C.theta, C.z), C.r))*(C.i|C.j)
+    + (Derivative(v_z(C.r, C.theta, C.z), C.r))*(C.i|C.k)
+    + (-v_theta(C.r, C.theta, C.z)/C.r + Derivative(v_r(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.i)
+    + (v_r(C.r, C.theta, C.z)/C.r + Derivative(v_theta(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.j)
+    + (Derivative(v_z(C.r, C.theta, C.z), C.theta)/C.r)*(C.j|C.k)
+    + (Derivative(v_r(C.r, C.theta, C.z), C.z))*(C.k|C.i)
+    + (Derivative(v_theta(C.r, C.theta, C.z), C.z))*(C.k|C.j)
+    + (Derivative(v_z(C.r, C.theta, C.z), C.z))*(C.k|C.k)
 
     """
     coord_sys = _get_coord_systems(field)

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -278,6 +278,7 @@ def gradient(field, doit=True):
     Examples
     ========
 
+    >>> from sympy import Function
     >>> from sympy.vector import CoordSys3D, gradient
 
     The gradient of a scalar field is a vector field:

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -489,8 +489,8 @@ def test_issue_27427():
 
 def test_laplacian_vector_field_cartesian_system(setup_cartesian_system):
     C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
-    res = laplacian(vec)
-    assert res == (
+
+    assert laplacian(vec) == (
         (u.diff(x, 2) + u.diff(y, 2) + u.diff(z, 2)) * i +
         (v.diff(x, 2) + v.diff(y, 2) + v.diff(z, 2)) * j +
         (w.diff(x, 2) + w.diff(y, 2) + w.diff(z, 2)) * k)
@@ -499,8 +499,7 @@ def test_laplacian_vector_field_cartesian_system(setup_cartesian_system):
 def test_laplacian_vector_field_cylindrical_system(setup_cylindrical_system):
     C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
 
-    res = laplacian(vec).expand()
-    assert res == (
+    assert laplacian(vec).expand() == (
         (u.diff(r, 2) + u.diff(θ, 2) / r**2 + u.diff(z, 2) + u.diff(r) / r - v.diff(θ) * 2 / r**2 - u / r**2) * e_r +
         (v.diff(r, 2) + v.diff(θ, 2) / r**2 + v.diff(z, 2) + v.diff(r) / r + u.diff(θ) * 2 / r**2 - v / r**2) * e_θ +
         (w.diff(r, 2) + w.diff(θ, 2) / r**2 + w.diff(z, 2) + w.diff(r) / r) * e_z)
@@ -509,7 +508,6 @@ def test_laplacian_vector_field_cylindrical_system(setup_cylindrical_system):
 def test_laplacian_vector_field_spherical_system(setup_spherical_system):
     S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
 
-    res = laplacian(vec).expand()
     expected_c1 = (
         ((r**2 * u).diff(r) / r**2).diff(r)
         + (sin(θ) * u.diff(θ)).diff(θ) / (r**2 * sin(θ))
@@ -528,7 +526,7 @@ def test_laplacian_vector_field_spherical_system(setup_spherical_system):
         + w.diff(𐌘, 2) / (r**2 * sin(θ)**2)
         + 2 * u.diff(𐌘) / (r**2 * sin(θ))
         + 2 * cos(θ) / (r**2 * sin(θ)**2) * v.diff(𐌘)).expand()
-    assert res == (
+    assert laplacian(vec).expand() == (
         expected_c1 * e_r +
         expected_c2 * e_θ +
         expected_c3 * e_𐌘)
@@ -536,30 +534,30 @@ def test_laplacian_vector_field_spherical_system(setup_spherical_system):
 
 def test_divergence_cartesian_system(setup_cartesian_system):
     C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+
     assert divergence(vec) == u.diff(x) + v.diff(y) + w.diff(z)
 
 
 def test_divergence_cylindrical_system(setup_cylindrical_system):
     C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
 
-    res = divergence(vec)
     expected = ((r * u).diff(r) + v.diff(θ) + r * w.diff(z)) / r
-    assert res.expand() == expected.expand()
+    assert divergence(vec).expand() == expected.expand()
 
 
 def test_divergence_spherical_system(setup_spherical_system):
     S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
 
-    res = divergence(vec)
     expected = (
         sin(θ) * (r**2 * u).diff(r)
         + r * (v * sin(θ)).diff(θ)
         + r * w.diff(𐌘)) / (r**2 * sin(θ))
-    assert res.expand() == expected.expand()
+    assert divergence(vec).expand() == expected.expand()
 
 
 def test_curl_cartesian_system(setup_cartesian_system):
     C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+
     assert curl(vec) == (
         (w.diff(y) - v.diff(z)) * i +
         (u.diff(z) - w.diff(x)) * j +
@@ -569,20 +567,16 @@ def test_curl_cartesian_system(setup_cartesian_system):
 def test_curl_cylindrical_system(setup_cylindrical_system):
     C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
 
-    res = curl(vec)
-    assert res.expand() == (
+    assert curl(vec).expand() == (
         (w.diff(θ) / r - v.diff(z)) * e_r +
         (u.diff(z) - w.diff(r)) * e_θ +
-        (v / r + v.diff(r) - u.diff(θ) / r) * e_z
-    )
+        (v / r + v.diff(r) - u.diff(θ) / r) * e_z)
 
 
 def test_curl_spherical_system(setup_spherical_system):
     S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
 
-    res = curl(vec)
-    assert res.expand() == (
+    assert curl(vec).expand() == (
         (w * cos(θ) / (r * sin(θ)) + w.diff(θ) / r - v.diff(𐌘) / (r * sin(θ))) * e_r +
         (u.diff(𐌘) / (r * sin(θ)) - w / r - w.diff(r)) * e_θ +
-        (v.diff(r) + v / r - u.diff(θ) / r) * e_𐌘
-    )
+        (v.diff(r) + v / r - u.diff(θ) / r) * e_𐌘)

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -548,3 +548,37 @@ def test_laplacian_vector_field_spherical_system():
         expected_c1 * e_r +
         expected_c2 * e_theta +
         expected_c3 * e_phi)
+
+
+def test_divergence_cartesian_system():
+    C = CoordSys3D("C")
+    x, y, z = C.base_scalars()
+    i, j, k = C.base_vectors()
+    u, v, w = [Function(s)(x, y, z) for s in ["u", "v", "w"]]
+    vec = u * i + v * j + w * k
+    assert divergence(vec) == u.diff(x) + v.diff(y) + w.diff(z)
+
+
+def test_divergence_cylindrical_system():
+    C = CoordSys3D("C", transformation="cylindrical")
+    r, theta, z = C.base_scalars()
+    e_r, e_theta, e_z = C.base_vectors()
+    u, v, w = [Function(s)(r, theta, z) for s in ["u", "v", "w"]]
+    vec = u * e_r + v * e_theta + w * e_z
+    res = divergence(vec)
+    expected = ((r * u).diff(r) + v.diff(theta) + r * w.diff(z)) / r
+    assert res.expand() == expected.expand()
+
+
+def test_divergence_spherical_system():
+    S = CoordSys3D("S", transformation="spherical")
+    r, theta, phi = S.base_scalars()
+    e_r, e_theta, e_phi = S.base_vectors()
+    u, v, w = [Function(s)(r, theta, phi) for s in ["u", "v", "w"]]
+    vec = u * e_r + v * e_theta + w * e_phi
+    res = divergence(vec)
+    expected = (
+        sin(theta) * (r**2 * u).diff(r)
+        + r * (v * sin(theta)).diff(theta)
+        + r * w.diff(phi)) / (r**2 * sin(theta))
+    assert res.expand() == expected.expand()

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -26,7 +26,7 @@ a, b, c, q = symbols('a b c q')
 
 
 @functools.cache
-def setup_cartesian_system():
+def _setup_cartesian_system():
     C = CoordSys3D("C")
     x, y, z = C.base_scalars()
     i, j, k = C.base_vectors()
@@ -36,7 +36,7 @@ def setup_cartesian_system():
 
 
 @functools.cache
-def setup_cylindrical_system():
+def _setup_cylindrical_system():
     C = CoordSys3D("C", transformation="cylindrical")
     r, θ, z = C.base_scalars()
     e_r, e_θ, e_z = C.base_vectors()
@@ -46,7 +46,7 @@ def setup_cylindrical_system():
 
 
 @functools.cache
-def setup_spherical_system():
+def _setup_spherical_system():
     S = CoordSys3D("S", transformation="spherical")
     r, θ, 𐌘 = S.base_scalars()
     e_r, e_θ, e_𐌘 = S.base_vectors()
@@ -250,7 +250,7 @@ def test_directional_derivative():
 
 
 def test_directional_derivative_vector_field_cartesian_systems():
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
+    C, x, y, z, i, j, k, u, v, w, vec = _setup_cartesian_system()
     ux, uy, uz = [u.diff(s) for s in [x, y, z]]
     vx, vy, vz = [v.diff(s) for s in [x, y, z]]
     wx, wy, wz = [w.diff(s) for s in [x, y, z]]
@@ -264,7 +264,7 @@ def test_directional_derivative_vector_field_cartesian_systems():
 
 
 def test_directional_derivative_vector_field_cylindrical_systems():
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = _setup_cylindrical_system()
     ur, ut, uz = [u.diff(s) for s in [r, θ, z]]
     vr, vt, vz = [v.diff(s) for s in [r, θ, z]]
     wr, wt, wz = [w.diff(s) for s in [r, θ, z]]
@@ -278,7 +278,7 @@ def test_directional_derivative_vector_field_cylindrical_systems():
 
 
 def test_directional_derivative_vector_field_spherical_systems():
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = _setup_spherical_system()
     ur, ut, up = [u.diff(s) for s in [r, θ, 𐌘]]
     vr, vt, vp = [v.diff(s) for s in [r, θ, 𐌘]]
     wr, wt, wp = [w.diff(s) for s in [r, θ, 𐌘]]
@@ -399,7 +399,7 @@ def test_mixed_coordinates():
 
 
 def test_gradient_of_vector_cartesian_coordinates():
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
+    C, x, y, z, i, j, k, u, v, w, vec = _setup_cartesian_system()
 
     res = gradient(vec)
     assert isinstance(res, Dyadic)
@@ -412,7 +412,7 @@ def test_gradient_of_vector_cartesian_coordinates():
 
 
 def test_gradient_of_vector_cylindrical_coordinates():
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = _setup_cylindrical_system()
 
     res = gradient(vec)
     assert isinstance(res, Dyadic)
@@ -425,7 +425,7 @@ def test_gradient_of_vector_cylindrical_coordinates():
 
 
 def test_gradient_of_vector_spherical_coordinates():
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = _setup_spherical_system()
 
     res = gradient(vec)
     assert isinstance(res, Dyadic)
@@ -488,7 +488,7 @@ def test_issue_27427():
 
 
 def test_laplacian_vector_field_cartesian_system():
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
+    C, x, y, z, i, j, k, u, v, w, vec = _setup_cartesian_system()
 
     assert laplacian(vec) == (
         (u.diff(x, 2) + u.diff(y, 2) + u.diff(z, 2)) * i +
@@ -497,7 +497,7 @@ def test_laplacian_vector_field_cartesian_system():
 
 
 def test_laplacian_vector_field_cylindrical_system():
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = _setup_cylindrical_system()
 
     assert laplacian(vec).expand() == (
         (u.diff(r, 2) + u.diff(θ, 2) / r**2 + u.diff(z, 2) + u.diff(r) / r - v.diff(θ) * 2 / r**2 - u / r**2) * e_r +
@@ -506,7 +506,7 @@ def test_laplacian_vector_field_cylindrical_system():
 
 
 def test_laplacian_vector_field_spherical_system():
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = _setup_spherical_system()
 
     expected_c1 = (
         ((r**2 * u).diff(r) / r**2).diff(r)
@@ -533,20 +533,20 @@ def test_laplacian_vector_field_spherical_system():
 
 
 def test_divergence_cartesian_system():
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
+    C, x, y, z, i, j, k, u, v, w, vec = _setup_cartesian_system()
 
     assert divergence(vec) == u.diff(x) + v.diff(y) + w.diff(z)
 
 
 def test_divergence_cylindrical_system():
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = _setup_cylindrical_system()
 
     expected = ((r * u).diff(r) + v.diff(θ) + r * w.diff(z)) / r
     assert divergence(vec).expand() == expected.expand()
 
 
 def test_divergence_spherical_system():
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = _setup_spherical_system()
 
     expected = (
         sin(θ) * (r**2 * u).diff(r)
@@ -556,7 +556,7 @@ def test_divergence_spherical_system():
 
 
 def test_curl_cartesian_system():
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
+    C, x, y, z, i, j, k, u, v, w, vec = _setup_cartesian_system()
 
     assert curl(vec) == (
         (w.diff(y) - v.diff(z)) * i +
@@ -565,7 +565,7 @@ def test_curl_cartesian_system():
 
 
 def test_curl_cylindrical_system():
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = _setup_cylindrical_system()
 
     assert curl(vec).expand() == (
         (w.diff(θ) / r - v.diff(z)) * e_r +
@@ -574,7 +574,7 @@ def test_curl_cylindrical_system():
 
 
 def test_curl_spherical_system():
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = _setup_spherical_system()
 
     assert curl(vec).expand() == (
         (w * cos(θ) / (r * sin(θ)) + w.diff(θ) / r - v.diff(𐌘) / (r * sin(θ))) * e_r +

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -16,7 +16,7 @@ from sympy.vector.functions import (
         laplacian, scalar_potential_difference,
         matrix_to_dyadic)
 from sympy.testing.pytest import raises
-import pytest
+import functools
 
 C = CoordSys3D('C')
 i, j, k = C.base_vectors()
@@ -25,7 +25,7 @@ delop = Del()
 a, b, c, q = symbols('a b c q')
 
 
-@pytest.fixture(scope="module")
+@functools.cache
 def setup_cartesian_system():
     C = CoordSys3D("C")
     x, y, z = C.base_scalars()
@@ -35,7 +35,7 @@ def setup_cartesian_system():
     return C, x, y, z, i, j, k, u, v, w, vec
 
 
-@pytest.fixture(scope="module")
+@functools.cache
 def setup_cylindrical_system():
     C = CoordSys3D("C", transformation="cylindrical")
     r, θ, z = C.base_scalars()
@@ -45,7 +45,7 @@ def setup_cylindrical_system():
     return C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec
 
 
-@pytest.fixture(scope="module")
+@functools.cache
 def setup_spherical_system():
     S = CoordSys3D("S", transformation="spherical")
     r, θ, 𐌘 = S.base_scalars()
@@ -249,8 +249,8 @@ def test_directional_derivative():
     assert directional_derivative(5*r**2*phi, 3*e_r + 4*e_theta + e_phi) == 5*r/sin(theta) + 30*r*phi
 
 
-def test_directional_derivative_vector_field_cartesian_systems(setup_cartesian_system):
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+def test_directional_derivative_vector_field_cartesian_systems():
+    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
     ux, uy, uz = [u.diff(s) for s in [x, y, z]]
     vx, vy, vz = [v.diff(s) for s in [x, y, z]]
     wx, wy, wz = [w.diff(s) for s in [x, y, z]]
@@ -263,8 +263,8 @@ def test_directional_derivative_vector_field_cartesian_systems(setup_cartesian_s
         (wx + wy + wz) * k)
 
 
-def test_directional_derivative_vector_field_cylindrical_systems(setup_cylindrical_system):
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
+def test_directional_derivative_vector_field_cylindrical_systems():
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
     ur, ut, uz = [u.diff(s) for s in [r, θ, z]]
     vr, vt, vz = [v.diff(s) for s in [r, θ, z]]
     wr, wt, wz = [w.diff(s) for s in [r, θ, z]]
@@ -277,8 +277,8 @@ def test_directional_derivative_vector_field_cylindrical_systems(setup_cylindric
         (wr + wt / r + wz) * e_z)
 
 
-def test_directional_derivative_vector_field_spherical_systems(setup_spherical_system):
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
+def test_directional_derivative_vector_field_spherical_systems():
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
     ur, ut, up = [u.diff(s) for s in [r, θ, 𐌘]]
     vr, vt, vp = [v.diff(s) for s in [r, θ, 𐌘]]
     wr, wt, wp = [w.diff(s) for s in [r, θ, 𐌘]]
@@ -398,8 +398,8 @@ def test_mixed_coordinates():
                 a.x*b.x**2*Dot(b.i, c.i)
 
 
-def test_gradient_of_vector_cartesian_coordinates(setup_cartesian_system):
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+def test_gradient_of_vector_cartesian_coordinates():
+    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
 
     res = gradient(vec)
     assert isinstance(res, Dyadic)
@@ -411,8 +411,8 @@ def test_gradient_of_vector_cartesian_coordinates(setup_cartesian_system):
     assert delop(vec).doit() == res
 
 
-def test_gradient_of_vector_cylindrical_coordinates(setup_cylindrical_system):
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
+def test_gradient_of_vector_cylindrical_coordinates():
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
 
     res = gradient(vec)
     assert isinstance(res, Dyadic)
@@ -424,8 +424,8 @@ def test_gradient_of_vector_cylindrical_coordinates(setup_cylindrical_system):
     assert delop(vec).doit() == res
 
 
-def test_gradient_of_vector_spherical_coordinates(setup_spherical_system):
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
+def test_gradient_of_vector_spherical_coordinates():
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
 
     res = gradient(vec)
     assert isinstance(res, Dyadic)
@@ -487,8 +487,8 @@ def test_issue_27427():
     assert directional_derivative(v, v) == expected
 
 
-def test_laplacian_vector_field_cartesian_system(setup_cartesian_system):
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+def test_laplacian_vector_field_cartesian_system():
+    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
 
     assert laplacian(vec) == (
         (u.diff(x, 2) + u.diff(y, 2) + u.diff(z, 2)) * i +
@@ -496,8 +496,8 @@ def test_laplacian_vector_field_cartesian_system(setup_cartesian_system):
         (w.diff(x, 2) + w.diff(y, 2) + w.diff(z, 2)) * k)
 
 
-def test_laplacian_vector_field_cylindrical_system(setup_cylindrical_system):
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
+def test_laplacian_vector_field_cylindrical_system():
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
 
     assert laplacian(vec).expand() == (
         (u.diff(r, 2) + u.diff(θ, 2) / r**2 + u.diff(z, 2) + u.diff(r) / r - v.diff(θ) * 2 / r**2 - u / r**2) * e_r +
@@ -505,8 +505,8 @@ def test_laplacian_vector_field_cylindrical_system(setup_cylindrical_system):
         (w.diff(r, 2) + w.diff(θ, 2) / r**2 + w.diff(z, 2) + w.diff(r) / r) * e_z)
 
 
-def test_laplacian_vector_field_spherical_system(setup_spherical_system):
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
+def test_laplacian_vector_field_spherical_system():
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
 
     expected_c1 = (
         ((r**2 * u).diff(r) / r**2).diff(r)
@@ -532,21 +532,21 @@ def test_laplacian_vector_field_spherical_system(setup_spherical_system):
         expected_c3 * e_𐌘)
 
 
-def test_divergence_cartesian_system(setup_cartesian_system):
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+def test_divergence_cartesian_system():
+    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
 
     assert divergence(vec) == u.diff(x) + v.diff(y) + w.diff(z)
 
 
-def test_divergence_cylindrical_system(setup_cylindrical_system):
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
+def test_divergence_cylindrical_system():
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
 
     expected = ((r * u).diff(r) + v.diff(θ) + r * w.diff(z)) / r
     assert divergence(vec).expand() == expected.expand()
 
 
-def test_divergence_spherical_system(setup_spherical_system):
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
+def test_divergence_spherical_system():
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
 
     expected = (
         sin(θ) * (r**2 * u).diff(r)
@@ -555,8 +555,8 @@ def test_divergence_spherical_system(setup_spherical_system):
     assert divergence(vec).expand() == expected.expand()
 
 
-def test_curl_cartesian_system(setup_cartesian_system):
-    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system
+def test_curl_cartesian_system():
+    C, x, y, z, i, j, k, u, v, w, vec = setup_cartesian_system()
 
     assert curl(vec) == (
         (w.diff(y) - v.diff(z)) * i +
@@ -564,8 +564,8 @@ def test_curl_cartesian_system(setup_cartesian_system):
         (v.diff(x) - u.diff(y)) * k)
 
 
-def test_curl_cylindrical_system(setup_cylindrical_system):
-    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system
+def test_curl_cylindrical_system():
+    C, r, θ, z, e_r, e_θ, e_z, u, v, w, vec = setup_cylindrical_system()
 
     assert curl(vec).expand() == (
         (w.diff(θ) / r - v.diff(z)) * e_r +
@@ -573,8 +573,8 @@ def test_curl_cylindrical_system(setup_cylindrical_system):
         (v / r + v.diff(r) - u.diff(θ) / r) * e_z)
 
 
-def test_curl_spherical_system(setup_spherical_system):
-    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system
+def test_curl_spherical_system():
+    S, r, θ, 𐌘, e_r, e_θ, e_𐌘, u, v, w, vec = setup_spherical_system()
 
     assert curl(vec).expand() == (
         (w * cos(θ) / (r * sin(θ)) + w.diff(θ) / r - v.diff(𐌘) / (r * sin(θ))) * e_r +

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -1,11 +1,13 @@
 from sympy.vector.vector import Vector
 from sympy.vector.coordsysrect import CoordSys3D
-from sympy.vector.functions import express, matrix_to_vector, orthogonalize
+from sympy.vector.functions import (
+    express, matrix_to_vector, matrix_to_dyadic, orthogonalize)
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.matrices.exceptions import ShapeError
 from sympy.matrices.immutable import ImmutableDenseMatrix as Matrix
 from sympy.testing.pytest import raises
 
@@ -163,6 +165,21 @@ def test_matrix_to_vector():
            Vector.zero
     m = Matrix([[q1], [q2], [q3]])
     assert matrix_to_vector(m, N) == q1*N.i + q2*N.j + q3*N.k
+
+
+def test_matrix_to_dyadic():
+    raises(ShapeError, lambda: matrix_to_dyadic(Matrix([0]), N))
+    raises(
+        ShapeError,
+        lambda: matrix_to_dyadic(Matrix([[0, 1, 2], [3, 4, 5]]), N))
+
+    m = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    expected = (
+        1 * (N.i | N.i) + 2 * (N.i | N.j) + 3 * (N.i | N.k) +
+        4 * (N.j | N.i) + 5 * (N.j | N.j) + 6 * (N.j | N.k) +
+        7 * (N.k | N.i) + 8 * (N.k | N.j) + 9 * (N.k | N.k)
+    )
+    assert matrix_to_dyadic(m, N) == expected
 
 
 def test_orthogonalize():

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -1,5 +1,8 @@
 from sympy.vector import CoordSys3D, Gradient, Divergence, Curl, VectorZero, Laplacian
 from sympy.printing.repr import srepr
+from sympy.vector.operators import _christoffel_symbol_2nd_kind
+from sympy import zeros, Matrix, sin, cos
+
 
 R = CoordSys3D('R')
 s1 = R.x*R.y*R.z  # type: ignore
@@ -41,3 +44,41 @@ def test_Laplacian():
     assert Laplacian(v3).doit() == 2*R.i + 2*R.j + 2*R.k
     assert srepr(Laplacian(s3)) == \
             'Laplacian(Add(Pow(R.x, Integer(2)), Pow(R.y, Integer(2)), Pow(R.z, Integer(2))))'
+
+
+def test_christoffel_symbol_2nd_kind_cylindrical_system():
+    C = CoordSys3D("C", transformation="cylindrical")
+    r, theta, z = q = C.base_scalars()
+    h = C.lame_coefficients()
+
+    Gamma_r = zeros(3)
+    Gamma_theta = zeros(3)
+    Gamma_z = zeros(3)
+    for i in range(3):
+        for j in range(3):
+            Gamma_r[i, j] = _christoffel_symbol_2nd_kind(h, q, i, j, 0).doit()
+            Gamma_theta[i, j] = _christoffel_symbol_2nd_kind(h, q, i, j, 1).doit()
+            Gamma_z[i, j] = _christoffel_symbol_2nd_kind(h, q, i, j, 2).doit()
+
+    assert Gamma_r == Matrix([[0, 0, 0], [0, -r, 0], [0, 0, 0]])
+    assert Gamma_theta == Matrix([[0, 1/r, 0], [1/r, 0, 0], [0, 0, 0]])
+    assert Gamma_z == zeros(3)
+
+
+def test_christoffel_symbol_2nd_kind_spherical_system():
+    S = CoordSys3D("C", transformation="spherical")
+    r, theta, phi = q = S.base_scalars()
+    h = S.lame_coefficients()
+
+    Gamma_r = zeros(3)
+    Gamma_theta = zeros(3)
+    Gamma_phi = zeros(3)
+    for i in range(3):
+        for j in range(3):
+            Gamma_r[i, j] = _christoffel_symbol_2nd_kind(h, q, i, j, 0).doit()
+            Gamma_theta[i, j] = _christoffel_symbol_2nd_kind(h, q, i, j, 1).doit()
+            Gamma_phi[i, j] = _christoffel_symbol_2nd_kind(h, q, i, j, 2).doit()
+
+    assert Gamma_r == Matrix([[0, 0, 0], [0, -r, 0], [0, 0, -r*sin(theta)**2]])
+    assert Gamma_theta == Matrix([[0, 1/r, 0], [1/r, 0, 0], [0, 0, -sin(theta)*cos(theta)]])
+    assert Gamma_phi == Matrix([[0, 0, 1/r], [0, 0, cos(theta)/sin(theta)], [1/r, cos(theta)/sin(theta), 0]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #24465
Fixes #19212
Fixes #27427


#### Brief description of what is fixed or changed

This PR implements the gradient of a vector field in a 3D orthogonal system (Cartesian and curvilinear), which allows the correct computation of curl, divergence, laplacian and directional derivatives.

#### Other comments

Theory and test cases comes from [Tensor calculus, by Taha Sochi](https://hal.science/hal-04764264v1)


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Implemented gradient of a vector field, which allows the correct computation of curl, divergence, laplacian and directional derivatives in curvilinear systems.

<!-- END RELEASE NOTES -->
