### PR TITLE
Add type annotations to find_executable

### DIFF
--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Optional
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -21,22 +21,18 @@ class Undecidable(ValueError):
 
 def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     """
-    Strip leading and trailing empty lines from a copy of ``s``, then dedent,
-    fill, and return the resulting string.
+Strips leading and trailing empty lines from a copy of ``s``, then dedents,
+fills and returns it.
 
-    Parameters
-    ==========
-    s : str
-        Input string.
-    w : int, optional
-        Line width used for wrapping. Default is 70.
-    **kwargs
-        Additional keyword arguments passed to ``textwrap.fill``.
+Empty line stripping serves to deal with docstrings like this one that
+start with a newline after the initial triple quote, inserting an empty
+line at the beginning of the string.
 
-    Returns
-    =======
-    str
-        The processed string.
+Additional keyword arguments will be passed to ``textwrap.fill()``.
+
+See Also
+========
+strlines, rawlines
     """
 
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
@@ -265,7 +261,7 @@ def debugf(string, args):
         print(string%args, file=sys.stderr)
 
 
-def find_executable(executable, path=None):
+def find_executable(executable: str, path: Optional[str] = None) -> Optional[str]:
     """Try to find 'executable' in the directories listed in 'path' (a
     string listing directories separated by 'os.pathsep'; defaults to
     os.environ['PATH']).  Returns the complete filename or None if not

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -21,20 +21,24 @@ class Undecidable(ValueError):
 
 def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     """
-    Strips leading and trailing empty lines from a copy of ``s``, then dedents,
-    fills and returns it.
+    Strip leading and trailing empty lines from a copy of ``s``, then dedent,
+    fill, and return the resulting string.
 
-    Empty line stripping serves to deal with docstrings like this one that
-    start with a newline after the initial triple quote, inserting an empty
-    line at the beginning of the string.
+    Parameters
+    ==========
+    s : str
+        Input string.
+    w : int, optional
+        Line width used for wrapping. Default is 70.
+    **kwargs
+        Additional keyword arguments passed to ``textwrap.fill``.
 
-    Additional keyword arguments will be passed to ``textwrap.fill()``.
-
-    See Also
-    ========
-    strlines, rawlines
-
+    Returns
+    =======
+    str
+        The processed string.
     """
+
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 


### PR DESCRIPTION
This PR adds explicit parameter and return type annotations to
`find_executable` in `sympy.utilities.misc`.

The function clearly returns either the path to an executable or `None`,
and this change makes that behavior visible to static type checkers.
No functional changes are made.
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
