### PR TITLE
Prevent incorrect contraction in multi-term `KroneckerDelta` sums

### DIFF
--- a/sympy/tensor/array/expressions/tests/test_convert_indexed_to_array.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_indexed_to_array.py
@@ -71,6 +71,8 @@ def test_arrayexpr_convert_index_to_array_support_function():
     assert _convert_indexed_to_array(expr) == (M, ({i, j, k, m, n}, 0))
     expr = M[i, i]
     assert _convert_indexed_to_array(expr) == (ArrayDiagonal(M, (0, 1)), (i,))
+    expr = Sum(KroneckerDelta(i, j) * A[j] * B[j], (j, 0, n - 1))
+    raises(NotImplementedError, lambda: _convert_indexed_to_array(expr))
 
 
 def test_arrayexpr_convert_indexed_to_array_expression():


### PR DESCRIPTION
If we calculate a sum involving a `KroneckerDelta` and multiple other terms it returned the wrong mathematical result. It produced a scalar instead of a vector. 
```
n = symbols('n', integer=True)
i, j = Idx('i', n), Idx('j', n)
A, B = IndexedBase('A'), IndexedBase('B')
print(convert_indexed_to_array(Sum(KroneckerDelta(i, j) * A[j] * B[j], (j, 0, n - 1))))
```
Output : 
```
ArrayContraction(ArrayTensorProduct(A, B), (0, 1))
```

It now raises a `NotImplementedError` instead of returning an incorrect answer. 

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fixed a bug where convert_indexed_to_array returned incorrect scalar results for sums involving a KroneckerDelta and multiple other terms. These cases now correctly raise NotImplementedError.
<!-- END RELEASE NOTES -->
 