### PR TITLE
utilities.misc: add type annotations to helper functions

### DIFF
--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -322,7 +322,7 @@ def func_name(x: Any, short: bool = False) -> str:
     >>> func_name(x < 1, short=True)
     'Lt'
     """
-    alias = {
+    alias: dict[str, str] = {
     'GreaterThan': 'Ge',
     'StrictGreaterThan': 'Gt',
     'LessThan': 'Le',


### PR DESCRIPTION
This PR adds type annotations to selected functions in
`sympy.utilities.misc` without changing runtime behavior.

Changes were tested locally with:
- pytest sympy/utilities/misc.py
- pytest sympy/testing/tests/test_code_quality.py
- mypy --follow-imports=skip
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->