### PR TITLE
Add conservative type annotations to sympy/core/multidimensional.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1470,6 +1470,7 @@ Seshagiri Prabhu <seshagiriprabhu@gmail.com>
 Seth Ebner <murgrehk@gmail.com>
 Seth Poulsen <poulsenseth@yahoo.com>
 Seth Troisi <sethtroisi@google.com>
+Shahid Rahaman <shahidrahman333@gmail.com>
 Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
 Shaoliang Jin <18322825326@163.com> 0382 <18322825326@163.com>
 Shaoliang Jin <18322825326@163.com> jinshaoliang <18322825326@163.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1470,7 +1470,7 @@ Seshagiri Prabhu <seshagiriprabhu@gmail.com>
 Seth Ebner <murgrehk@gmail.com>
 Seth Poulsen <poulsenseth@yahoo.com>
 Seth Troisi <sethtroisi@google.com>
-Shahid Rahaman <shahidrahman333@gmail.com>
+Shahid Rahaman <shahidrahman333@gmail.com> Shahid Rahaman <44476706+shahid-rahaman@users.noreply.github.com>
 Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
 Shaoliang Jin <18322825326@163.com> 0382 <18322825326@163.com>
 Shaoliang Jin <18322825326@163.com> jinshaoliang <18322825326@163.com>

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -5,15 +5,17 @@ Read the vectorize docstring for more details.
 """
 
 from functools import wraps
-from typing import Any, Callable, Union, Iterable
+from typing import Any, Callable, Iterable, TypeVar, Union, TypeAlias
 
+T = TypeVar("T")
+NestedIterable: TypeAlias = Iterable[Union[T, "NestedIterable"]]
 
 def apply_on_element(
-    f: Callable[..., Any],
+    f: Callable[..., T],
     args: list[Any],
     kwargs: dict[str, Any],
-    n: Union[int, str],
-) -> list[Any]:
+    n: int | str,
+) -> list[T]:
 
     """
     Returns a structure with the same dimension as the specified argument,
@@ -44,14 +46,14 @@ def apply_on_element(
     return list(map(f_reduced, structure))
 
 
-def iter_copy(structure: Iterable[Any]) -> list[Any]:
+def iter_copy(structure: Iterable[T]) -> list[Union[T, NestedIterable]]:
     """
     Returns a copy of an iterable object (also copying all embedded iterables).
     """
     return [iter_copy(i) if hasattr(i, "__iter__") else i for i in structure]
 
 
-def structure_copy(structure: Any) -> Any:
+def structure_copy(structure: Iterable[T]) -> Iterable[T] | NestedIterable:
     """
     Returns a copy of the given structure (numpy-array, list, iterable, ..).
     """

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -5,9 +5,16 @@ Read the vectorize docstring for more details.
 """
 
 from functools import wraps
+from typing import Any, Callable, Union, Iterable
 
 
-def apply_on_element(f, args, kwargs, n):
+def apply_on_element(
+    f: Callable[..., Any],
+    args: list[Any],
+    kwargs: dict[str, Any],
+    n: Union[int, str],
+) -> list[Any]:
+
     """
     Returns a structure with the same dimension as the specified argument,
     where each basic element is replaced by the function f applied on it. All
@@ -37,20 +44,21 @@ def apply_on_element(f, args, kwargs, n):
     return list(map(f_reduced, structure))
 
 
-def iter_copy(structure):
+def iter_copy(structure: Iterable[Any]) -> list[Any]:
     """
     Returns a copy of an iterable object (also copying all embedded iterables).
     """
     return [iter_copy(i) if hasattr(i, "__iter__") else i for i in structure]
 
 
-def structure_copy(structure):
+def structure_copy(structure: Any) -> Any:
     """
     Returns a copy of the given structure (numpy-array, list, iterable, ..).
     """
     if hasattr(structure, "copy"):
         return structure.copy()
     return iter_copy(structure)
+
 
 
 class vectorize:


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed

This PR adds conservative type annotations to a small set of helper functions
in `sympy/core/multidimensional.py`. The annotations are intentionally broad,
do not change runtime behavior, and all existing tests pass.

#### Other comments

Happy to adjust or extend this if needed.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
