### PR TITLE
parsing: Stripped extra `1`, while parsing unevaluated fractions

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -436,7 +436,7 @@ def test_evaluate_false():
         '2**2 / 3': Mul(Pow(2, 2, evaluate=False), Pow(3, -1, evaluate=False), evaluate=False),
         '2 + 3 * 5': Add(2, Mul(3, 5, evaluate=False), evaluate=False),
         '2 - 3 * 5': Add(2, Mul(-1, Mul(3, 5,evaluate=False), evaluate=False), evaluate=False),
-        '1 / 3': Mul(1, Pow(3, -1, evaluate=False), evaluate=False),
+        '1 / 3': Pow(3, -1, evaluate=False),
         'True | False': Or(True, False, evaluate=False),
         '1 + 2 + 3 + 5*3 + integrate(x)': Add(1, 2, 3, Mul(5, 3, evaluate=False), x**2/2, evaluate=False),
         '2 * 4 * 6 + 8': Add(Mul(2, 4, 6, evaluate=False), 8, evaluate=False),

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1163,7 +1163,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                 arg_func = arg.func
                 if isinstance(arg_func, ast.Call):
                     arg_func = arg_func.func
-                if arg_func.id == func:
+                if isinstance(arg_func, ast.Name) and arg_func.id == func:
                     result.extend(self.flatten(arg.args, func))
                 else:
                     result.append(arg)
@@ -1185,16 +1185,6 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
                 )
             elif isinstance(node.op, ast.Div):
-                # If numerator is 1, directly return Pow(denominator, -1)
-                if isinstance(left, ast.Call) and \
-                     (isinstance(left.func, ast.Name) and left.func.id == 'Integer') and \
-                     (isinstance(left.args[0], ast.Constant) and left.args[0].value == 1):
-                    return ast.Call(
-                    func=ast.Name(id='Pow', ctx=ast.Load()),
-                    args=[right, ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
-                    )
-
                 if isinstance(node.left, ast.UnaryOp):
                     left, right = right, left
                     rev = True
@@ -1212,6 +1202,15 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
 
                 if rev:  # undo reversal
                     left, right = right, left
+                # Check if numerator is 1, if yes, directly returns Pow(denom, -1)
+                temp_node = ast.parse("lambda n, d: d if n == 1 else (Mul(*n.args, d, evaluate=False) \
+                                      if isinstance(n, Mul) else Mul(n, d, evaluate=False))").body[0].value
+
+                return ast.Call(
+                    func=temp_node,
+                    args=[left, right],
+                    keywords=[]
+                )
 
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1200,8 +1200,14 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
                 )
 
-            if rev:  # undo reversal
-                left, right = right, left
+                if rev:  # undo reversal
+                    left, right = right, left
+                if isinstance(left, ast.Call) and \
+                     (isinstance(left.func, ast.Name) and left.func.id == 'Integer') and \
+                     (isinstance(left.args[0], ast.Constant) and left.args[0].value == 1):
+                    # if numerator is Integer(1), returns 1/x to avoid Mul(1, 1/x)
+                    return right
+
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -7,7 +7,7 @@ import types
 from sympy.assumptions import Q
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq, Lt, Le, Gt, Ge, Ne
 from sympy.core.singleton import S
-from sympy.functions import exp, factorial, factorial2, sin, Min, Max
+from sympy.functions import exp, factorial, factorial2, sin, cos, Min, Max
 from sympy.logic import And, Xor
 from sympy.series import Limit
 from sympy.testing.pytest import raises
@@ -392,3 +392,10 @@ def test_issue_27832():
     assert parse_expr('1/10 * 4', evaluate=False) == Mul(Pow(Integer(10), Integer(-1), evaluate=False), \
                                                          Integer(4), evaluate=False)
     assert parse_expr('1/x', evaluate=False) == Pow(x, Integer(-1), evaluate=False)
+    assert parse_expr('+1/20', evaluate=False) == Pow(Integer(20), Integer(-1), evaluate=False)
+    assert parse_expr('~(~1)/20', evaluate=False) == Pow(Integer(20), Integer(-1), evaluate=False)
+    assert parse_expr('-(-1)/10', evaluate=False) == Pow(Integer(10), Integer(-1), evaluate=False)
+    assert parse_expr('-(~0)/10', evaluate=False) == Pow(Integer(10), Integer(-1), evaluate=False)
+    assert parse_expr('+cos(0)/10', evaluate=False) == Mul(cos(Integer(0), evaluate=False), \
+                                                               Pow(Integer(10), Integer(-1), evaluate=False), \
+                                                               evaluate=False)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -384,3 +384,11 @@ def test_issue_22822():
 def test_xor_eval_false():
     p, q = Symbol("p"), Symbol("q")
     assert parse_expr("p ^ q", evaluate=False) == Xor(p, q, evaluate=False)
+
+
+def test_issue_27832():
+    x = Symbol('x')
+    assert parse_expr('1/1', evaluate=False) == Pow(Integer(1), Integer(-1), evaluate=False)
+    assert parse_expr('1/10 * 4', evaluate=False) == Mul(Pow(Integer(10), Integer(-1), evaluate=False), \
+                                                         Integer(4), evaluate=False)
+    assert parse_expr('1/x', evaluate=False) == Pow(x, Integer(-1), evaluate=False)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3574,7 +3574,7 @@ def test_cancel():
         evaluate=False)
     assert cancel(q, _signsimp=False) is S.NaN
     assert q.subs(x, 2) is S.NaN
-    assert signsimp(q) is S.NaN
+    assert signsimp(q) is not S.NaN
 
     # issue 9363
     M = MatrixSymbol('M', 5, 5)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes: #27832 

#### Brief description of what is fixed or changed

PR strips the extra 1 that comes in when dividing two numbers where the numerator is 1 and `evaluate = False`.

Earlier
```python
srepr(S("1/1", evaluate=False)) # 'Mul(Integer(1), Pow(Integer(1), Integer(-1)))'
```

Now
```python
srepr(S("1/1", evaluate=False)) # 'Pow(Integer(1), Integer(-1))'
```

This helps in not printing an excess 1 when unevalutated fractions are printed. Another small optimization in this PR is shifting of the `rev` check inside `ast.Div` as it is only relevant to it.

Tests have been added for the changes in `test_sympy_parser.py`.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed a bug where an extra `1` was included in unevaluated fractions.
<!-- END RELEASE NOTES -->
