### PR TITLE
Fix strict evalf precision loss for log(1+eps) cancellation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -343,6 +343,7 @@ Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
 Ansh Mishra <anshmishra471@gmail.com>
 Anshul Sharma <anshulsharma4605@gmail.com>
+Ansh Soni <anshsoni702@gmail.com> <145273012+AnshMNSoni@users.noreply.github.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -345,7 +345,8 @@ Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
 Ansh Mishra <anshmishra471@gmail.com>
 Anshul Sharma <anshulsharma4605@gmail.com>
-Ansh Soni <anshsoni702@gmail.com> AnshMNSoni <anshsoni702@gmail.com>
+AnshMNSoni <anshsoni702@gmail.com> Ansh Soni <anshsoni702@gmail.com>
+AnshMNSoni <anshsoni702@gmail.com> ansh.mn.soni <145273012+AnshMNSoni@users.noreply.github.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
 # The .mailmap file
-# =================
+# ==================
 #
 # This file records the name and email address of each contributor to SymPy as
 # it should appear in the AUTHORS file. Contributors should not update the

--- a/.mailmap
+++ b/.mailmap
@@ -343,7 +343,7 @@ Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
 Ansh Mishra <anshmishra471@gmail.com>
 Anshul Sharma <anshulsharma4605@gmail.com>
-Ansh Soni <anshsoni702@gmail.com> <145273012+AnshMNSoni@users.noreply.github.com>
+Ansh Soni <anshsoni702@gmail.com> AnshMNSoni <anshsoni702@gmail.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -955,6 +955,7 @@ def evalf_trig(v: Expr, prec: int, options: OPT_DICT) -> TMP_RES:
 
 
 def evalf_log(expr: 'log', prec: int, options: OPT_DICT) -> TMP_RES:
+    from sympy import S
     if len(expr.args)>1:
         expr = expr.doit()
         return evalf(expr, prec, options)
@@ -964,6 +965,15 @@ def evalf_log(expr: 'log', prec: int, options: OPT_DICT) -> TMP_RES:
     if result is S.ComplexInfinity:
         return result
     xre, xim, xacc, _ = result
+    
+    # STRICT MODE: detect cancellation of (1 + eps) → 1
+    if options.get('strict', False):
+        # arg is symbolically not 1, but numerically rounded to 1
+        if arg != S.One and xre == fone:
+            raise PrecisionExhausted(
+                "Argument rounded to 1 causing log(1+ε) cancellation. "
+                "Increase output precision n."
+            )
 
     # evalf can return NoneTypes if chop=True
     # issue 18516, 19623
@@ -987,27 +997,49 @@ def evalf_log(expr: 'log', prec: int, options: OPT_DICT) -> TMP_RES:
         return re[0], im, re[2], prec
 
     imaginary_term = (mpf_cmp(xre, fzero) < 0)
-
+    
     re = mpf_log(mpf_abs(xre), prec, rnd)
     size = fastlog(re)
+    
+    # Check if we're computing log(1 + small_number) which needs special handling
+    # to avoid catastrophic cancellation
     if prec - size > workprec:
         from .add import Add
-        # We actually need to compute x-1 accurately, not x
+
+        # Compute x = arg - 1 accurately
         add = Add(S.NegativeOne, arg, evaluate=False)
         xre, xim, xre_acc, _ = evalf_add(add, prec, options)
+
+        # STRICT MODE: catastrophic cancellation detection
+        if options.get('strict', False):
+            # If x rounded to zero or accuracy is insufficient, fail
+            if xre == fzero or xre_acc is None or xre_acc < prec:
+                raise PrecisionExhausted(
+                    "log(1+x) lost precision due to catastrophic cancellation. "
+                    "Increase output precision n."
+                )
+
+        # Compute log(1+x) safely
         if xre != fzero and (xre_acc is None or xre_acc > 1):
             prec2 = workprec - fastlog(xre)
-            # xre is now x - 1 so we add 1 back here to calculate x
             re = mpf_log(mpf_abs(mpf_add(xre, fone, prec2)), prec, rnd)
+            re_acc = prec
+        else:
+            re = mpf_log(mpf_abs(xre or fzero), prec, rnd)
+            re_acc = prec
+
+        if imaginary_term:
+            return re, mpf_pi(prec), re_acc, prec
+        else:
+            return re, None, re_acc, None
 
     re_acc = prec
-
     if imaginary_term:
         return re, mpf_pi(prec), re_acc, prec
     else:
         return re, None, re_acc, None
 
-
+    
 def evalf_atan(v: 'atan', prec: int, options: OPT_DICT) -> TMP_RES:
     arg = v.args[0]
     result = evalf(arg, prec + 5, options)
@@ -1677,6 +1709,25 @@ class EvalfMixin:
         re, im, re_acc, im_acc = result
         if re is S.NaN or im is S.NaN:
             return S.NaN
+        
+        # Check if strict mode is enabled and verify precision was achieved
+        if strict:
+            from .evalf import PrecisionExhausted
+            # Check real part accuracy
+            if re and re_acc < prec:
+                raise PrecisionExhausted(
+                    f"Failed to compute real part to {n} digits precision. "
+                    f"Achieved accuracy: {prec_to_dps(re_acc)} digits. "
+                    f"Try increasing maxn or the output precision n."
+                )
+            # Check imaginary part accuracy
+            if im and im_acc < prec:
+                raise PrecisionExhausted(
+                    f"Failed to compute imaginary part to {n} digits precision. "
+                    f"Achieved accuracy: {prec_to_dps(im_acc)} digits. "
+                    f"Try increasing maxn or the output precision n."
+                )
+        
         if re:
             p = max(min(prec, re_acc), 1)
             re = Float._new(re, p)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -154,6 +154,30 @@ def test_evalf_complex_cancellation():
     assert NS((A + B*I)*(
         C + D*I) - F*I, 5) in ('6.4471e-6 + 0.e-14*I', '6.4471e-6 - 0.e-14*I')
 
+def test_evalf_strict_precision_loss():
+    """Test that strict=True catches precision loss (issue #28514)"""
+    from sympy import symbols, log, Rational
+    from sympy.core.evalf import PrecisionExhausted
+    
+    b = symbols('b')
+    y = b/(b + 1)
+    z = b
+    
+    substitutions = {b: Rational('1e-22')}
+    
+    # This should raise PrecisionExhausted with default precision
+    # because log(1 + 1e-22) requires high precision
+    raises(PrecisionExhausted, 
+           lambda: log(y/z).evalf(subs=substitutions, strict=True, maxn=1e300))
+    
+    # With sufficient output precision, it should work
+    result1 = log(y/z).evalf(subs=substitutions, n=50, strict=True, maxn=1e300)
+    result2 = (log(y) - log(z)).evalf(subs=substitutions, n=50, strict=True, maxn=1e300)
+    
+    # Both should give the same non-zero result
+    assert result1 != 0
+    assert abs(result1 - result2) < 1e-40
+    assert abs(result1 + Rational('1e-22')) < 1e-40  # Should be approximately -1e-22
 
 def test_evalf_logs():
     assert NS("log(3+pi*I)", 15) == '1.46877619736226 + 0.808448792630022*I'

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -740,6 +740,13 @@ def test_manualintegrate_sqrt_linear():
                           sqrt(2*x + sqrt(4*x + 5) + 3) *
                           (9*x/10 + 11*(4*x + 5)**(S(3)/2)/40 + sqrt(4*x + 5)/40 + (4*x + 5)**2/10 + S(11)/10)/2)
 
+def test_manualintegrate_sqrt_ratio():
+    """Test integration of sqrt(a - x) / (x * sqrt(a + x))"""
+    # Just test that manualintegrate returns the expected form
+    # The derivative check in assert_is_integral_of may timeout for complex expressions
+    result = manualintegrate(sqrt(a - x)/(x*sqrt(a + x)), x)
+    expected = 2*log(sqrt(a + x) + sqrt(a - x)) - log(x)
+    assert result == expected
 
 def test_manualintegrate_sqrt_quadratic():
     assert_is_integral_of(1/sqrt((x - I)**2-1), log(2*x + 2*sqrt(x**2 - 2*I*x - 2) - 2*I))
@@ -831,6 +838,7 @@ def test_manualintegrate_sqrt_quadratic_reduction():
     term_n5 = f/(a*x**2 + b*x + c)**(S(5)/2)
     intg_result = manualintegrate(term_n5, x)
     assert factor(intg_result.diff(x) - term_n5) == 0
+
 
 def test_mul_pow_derivative():
     assert_is_integral_of(x*sec(x)*tan(x), x*sec(x) - log(tan(x) + sec(x)))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28514


#### Brief description of what is fixed or changed
This PR fixes a numerical correctness issue in evalf_log where strict=True
failed to detect catastrophic cancellation in expressions of the form
log(1 + ε) when ε is smaller than the working precision.

Previously, expressions such as log(1/(1 + 1e-22)) could incorrectly evaluate
to zero under strict mode due to rounding of 1 + ε → 1. This PR adds detection
for symbolic-numeric inconsistency and raises PrecisionExhausted when
cancellation destroys significant digits.

A regression test is included.


#### Other comments
This change improves numerical reliability of strict evalf and aligns its
behavior with the documented semantics of PrecisionExhausted. The fix
detects cases where an argument is symbolically distinct from 1 but
numerically rounded to 1 due to insufficient precision.


#### Release Notes
* core.evalf
  * Fixed strict evalf failing to detect catastrophic cancellation in
    log(1+ε)-type expressions, which could silently return zero for
    tiny ε. Strict mode now raises PrecisionExhausted as intended.