### PR TITLE
Fix incorrect complex series expansion of asec(x) at x=0

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1839,6 +1839,7 @@ def test_asec():
         pi*(1 - sqrt(x**2)/x)/2 + sqrt(x**2)*acot(1/sqrt(x**2 - 1))/x
     assert asec(x).rewrite(acsc) == -acsc(x) + pi/2
     raises(ArgumentIndexError, lambda: asec(x).fdiff(2))
+    assert asec(x).series(x, 0, 6) == (pi/2 - acsc(x)).series(x, 0, 6)
 
 
 def test_asec_is_real():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3278,6 +3278,9 @@ class asec(InverseTrigonometricFunction):
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
         # Handling branch points
+        if arg0 is S.Zero:
+            return (pi/2 - acsc(self.args[0]))._eval_nseries(x, n, logx=logx, cdir=cdir)
+
         if arg0 is S.One:
             t = Dummy('t', positive=True)
             ser = asec(S.One + t**2).rewrite(log).nseries(t, 0, 2*n)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3279,7 +3279,8 @@ class asec(InverseTrigonometricFunction):
         arg0 = self.args[0].subs(x, 0)
         # Handling branch points
         if arg0 is S.Zero:
-            return (pi/2 - acsc(self.args[0]))._eval_nseries(x, n, logx=logx, cdir=cdir)
+            return (pi / 2 - acsc(self.args[0]))._eval_nseries(
+                x, n, logx=logx, cdir=cdir)
 
         if arg0 is S.One:
             t = Dummy('t', positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #28963

#### Brief description of what is fixed or changed
This PR fixes a bug where the series expansion of `asec(x)` at `x=0` produced incorrect complex results (specifically, the wrong branch cut sign) because it fell back to a generic `log` rewrite that did not account for the singularity correctly.

**The Fix:**
* Modified `_eval_nseries` in `sympy/functions/elementary/trigonometric.py`.
* Added an explicit check for the singularity case `arg.subs(x, 0) == 0`.
* In this specific case, the expansion is now handled using the mathematical identity `asec(x) = pi/2 - acsc(x)`. This delegates the calculation to `acsc`, which already handles the series expansion at zero correctly.

#### Other comments

#### Verification
I verified the fix locally using the reproduction script and by adding a new regression test.

**Before:**
`asec(x).series(x, 0)` -> `I*log(2) - I*log(x) ...` (Positive Imaginary part ❌)

**After:**
`asec(x).series(x, 0)` -> `-I*log(2) + I*log(x) ...` (Negative Imaginary part ✅)

This now correctly matches the identity `(pi/2 - acsc(x)).series(x, 0)`.

**Test Results:**
* Added a regression test in `sympy/functions/elementary/tests/test_trigonometric.py`.
* Ran full tests for trigonometric functions (`bin/test sympy/functions/elementary/tests/test_trigonometric.py`), all passed.
 
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `asec(x).series(x, 0)` to return the correct complex expansion (correct branch cut) by utilizing the identity `pi/2 - acsc(x)`.
<!-- END RELEASE NOTES -->
