### PR TITLE
series: Pass `dir` to recursive limit calls in `pow_heuristics`

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -177,18 +177,18 @@ class Limit(Expr):
         return isyms
 
 
-    def pow_heuristics(self, e, z, z0):
+    def pow_heuristics(self, e, z, z0, dir):
         b1, e1 = e.base, e.exp
         if not b1.has(z):
-            res = limit(e1*log(b1), z, z0)
+            res = limit(e1*log(b1), z, z0, dir=dir)
             return exp(res)
 
-        ex_lim = limit(e1, z, z0)
-        base_lim = limit(b1, z, z0)
+        ex_lim = limit(e1, z, z0, dir=dir)
+        base_lim = limit(b1, z, z0, dir=dir)
 
         if base_lim is S.One:
             if ex_lim in (S.Infinity, S.NegativeInfinity):
-                res = limit(e1*(b1 - 1), z, z0)
+                res = limit(e1*(b1 - 1), z, z0, dir=dir)
                 return exp(res)
         if base_lim is S.NegativeInfinity and ex_lim is S.Infinity:
             return S.ComplexInfinity
@@ -338,7 +338,7 @@ class Limit(Expr):
             from sympy.simplify.powsimp import powsimp
             e = powsimp(e)
             if e.is_Pow:
-                r = self.pow_heuristics(e, z, z0)
+                r = self.pow_heuristics(e, z, z0, dir)
                 if r is not None:
                     return r
             try:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1468,3 +1468,14 @@ def test_issue_28558():
     # The original problematic case now raises NotImplementedError instead of TypeError
     # This confirms the fix - the TypeError about missing 'cdir' is resolved
     raises(NotImplementedError, lambda: limit(log(x)*cos(x), x, oo, dir='-'))
+
+
+def test_issue_28975():
+    assert limit(2**(1/x), x, 0, dir='-') == 0
+    assert limit(2**(1/x), x, 0, dir='+') == oo
+    assert limit((1/2)**(1/x), x, 0, dir='-') == oo
+    assert limit((1/2)**(1/x), x, 0, dir='+') == 0
+    assert limit(3**(1/(x-1)), x, 1, dir='-') == 0
+    assert limit(3**(1/(x-1)), x, 1, dir='+') == oo
+    assert limit(3**(tan(x)), x, pi/2, dir='-') == oo
+    assert limit(3**(tan(x)), x, pi/2, dir='+') == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes: #28975 

#### Brief description of what is fixed or changed
This PR adds `dir` attribute to `pow_heuristics`, Inside the `Limit.doit()` when `pow_heuristics` is called, `dir` is not passed, thus losing out on the direction for the limit.

Adding a `dir` attribute fixes things where the limit change for `Pow` functions if direction is different. For example

```python
limit(2**(1/x), x, 0, dir='-') # gives 0 after the fix, gives oo right now, expected 0
limit(2**(1/x), x, 0, dir='+') # gives oo, expected oo
```

I have also added tests for the same in `test_limits.py`
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed direction handling in `pow_heuristics` while evaluating limit of `pow` functions.
<!-- END RELEASE NOTES -->
