### PR TITLE
utilities.memoization: add minimal typing for recurrence_memo 

### DIFF
--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, List, Union, cast, TYPE_CHECKING
+from typing import Callable, cast, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     class _RecurrenceFunc(Protocol[T]):
         def __call__(self, n: int) -> T: ...
         cache_length: Callable[[], int]
-        fetch_item: Callable[[Union[int, slice]], Union[T, List[T]]]
+        fetch_item: Callable[[int | slice], T | list[T]]
 else:
     # Runtime-safe fallbacks (avoid Protocol/TypeVar at runtime)
     T = object
@@ -78,10 +78,13 @@ def assoc_recurrence_memo(base_seq):
                 return cache[n][m]
 
             for i in range(L, n + 1):
+                # get base sequence
                 F_i0 = base_seq(i)
                 F_i_cache = [F_i0]
                 cache.append(F_i_cache)
 
+                # XXX only works for m <= n cases
+                # generate assoc sequence
                 for j in range(1, i + 1):
                     F_ij = f(i, j, cache)
                     F_i_cache.append(F_ij)

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,7 +1,19 @@
 from functools import wraps
+from typing import Callable, List, Protocol, TypeVar, Union, cast
+
+T = TypeVar("T")
 
 
-def recurrence_memo(initial):
+class _RecurrenceFunc(Protocol[T]):
+    def __call__(self, n: int) -> T: ...
+    cache_length: Callable[[], int]
+    fetch_item: Callable[[Union[int, slice]], Union[T, List[T]]]
+
+
+def recurrence_memo(initial: List[T]) -> Callable[
+    [Callable[[int, List[T]], T]],
+    _RecurrenceFunc[T],
+]:
     """
     Memo decorator for sequences defined by recurrence
 
@@ -9,33 +21,35 @@ def recurrence_memo(initial):
     ========
 
     >>> from sympy.utilities.memoization import recurrence_memo
-    >>> @recurrence_memo([1]) # 0! = 1
+    >>> @recurrence_memo([1])  # 0! = 1
     ... def factorial(n, prev):
     ...     return n * prev[-1]
     >>> factorial(4)
     24
-    >>> factorial(3) # use cache values
+    >>> factorial(3)  # use cache values
     6
-    >>> factorial.cache_length() # cache length can be obtained
+    >>> factorial.cache_length()  # cache length can be obtained
     5
     >>> factorial.fetch_item(slice(2, 4))
     [2, 6]
-
     """
-    cache = initial
+    cache: List[T] = initial.copy()
 
-    def decorator(f):
+    def decorator(f: Callable[[int, List[T]], T]) -> _RecurrenceFunc[T]:
         @wraps(f)
-        def g(n):
+        def g(n: int) -> T:
             L = len(cache)
             if n < L:
                 return cache[n]
             for i in range(L, n + 1):
                 cache.append(f(i, cache))
             return cache[-1]
-        g.cache_length = lambda: len(cache)
-        g.fetch_item = lambda x: cache[x]
-        return g
+
+        rf = cast(_RecurrenceFunc[T], g)
+        rf.cache_length = lambda: len(cache)
+        rf.fetch_item = lambda x: cache[x]
+        return rf
+
     return decorator
 
 
@@ -48,7 +62,6 @@ def assoc_recurrence_memo(base_seq):
     XXX works only for Pn0 = base_seq(0) cases
     XXX works only for m <= n cases
     """
-
     cache = []
 
     def decorator(f):
@@ -59,13 +72,10 @@ def assoc_recurrence_memo(base_seq):
                 return cache[n][m]
 
             for i in range(L, n + 1):
-                # get base sequence
                 F_i0 = base_seq(i)
                 F_i_cache = [F_i0]
                 cache.append(F_i_cache)
 
-                # XXX only works for m <= n cases
-                # generate assoc sequence
                 for j in range(1, i + 1):
                     F_ij = f(i, j, cache)
                     F_i_cache.append(F_ij)
@@ -73,4 +83,5 @@ def assoc_recurrence_memo(base_seq):
             return cache[n][m]
 
         return g
+
     return decorator


### PR DESCRIPTION
This PR adds minimal type annotations to `recurrence_memo` so that static type
checkers can understand the return type of functions decorated with it.

The annotations describe the extra attributes (`cache_length` and `fetch_item`)
added by the decorator. There are no runtime or behavior changes.
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->