### PR TITLE
Remove vectorize decorator from ode module and fix resulting regressions.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1470,6 +1470,7 @@ Seshagiri Prabhu <seshagiriprabhu@gmail.com>
 Seth Ebner <murgrehk@gmail.com>
 Seth Poulsen <poulsenseth@yahoo.com>
 Seth Troisi <sethtroisi@google.com>
+Shahid Rahaman <shahidrahman333@gmail.com> <44476706+shahid-rahaman@users.noreply.github.com>
 Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
 Shaoliang Jin <18322825326@163.com> 0382 <18322825326@163.com>
 Shaoliang Jin <18322825326@163.com> jinshaoliang <18322825326@163.com>

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -233,7 +233,6 @@ from sympy.core.containers import Tuple
 from sympy.core.expr import AtomicExpr, Expr
 from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
     expand, expand_mul, Subs)
-from sympy.core.multidimensional import vectorize
 from sympy.core.numbers import nan, zoo, Number
 from sympy.core.relational import Equality, Eq
 from sympy.core.sorting import default_sort_key, ordered
@@ -1567,7 +1566,6 @@ def check_nonlinear_3eq_order2(eq, func, func_coef):
     return None
 
 
-@vectorize(0)
 def odesimp(ode, eq, func, hint):
     r"""
     Simplifies solutions of ODEs, including trying to solve for ``func`` and
@@ -1922,8 +1920,8 @@ def __remove_linear_redundancies(expr, Cs):
         return Eq(lhs, rhs)
     else:
         return _recursive_walk(expr)
-
-@vectorize(0)
+    
+    
 def constantsimp(expr, constants):
     r"""
     Simplifies an expression with arbitrary constants in it.

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -1920,8 +1920,8 @@ def __remove_linear_redundancies(expr, Cs):
         return Eq(lhs, rhs)
     else:
         return _recursive_walk(expr)
-    
-    
+
+
 def constantsimp(expr, constants):
     r"""
     Simplifies an expression with arbitrary constants in it.

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -30,6 +30,7 @@ from .nonhomogeneous import _get_euler_characteristic_eq_sols, _get_const_charac
     _solve_undetermined_coefficients, _solve_variation_of_parameters, _test_term, _undetermined_coefficients_match, \
         _get_simplified_sol
 from .lie_group import _ode_lie_group
+from sympy.utilities.iterables import iterable
 
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
@@ -1721,16 +1722,16 @@ class HomogeneousCoeffBest(HomogeneousCoeffSubsIndepDivDep, HomogeneousCoeffSubs
         # There are two substitutions that solve the equation, u1=y/x and u2=x/y
         # # They produce different integrals, so try them both and see which
         # # one is easier
-        sol1 = HomogeneousCoeffSubsIndepDivDep._get_general_solution(self)
-        sol2 = HomogeneousCoeffSubsDepDivIndep._get_general_solution(self)
+        [sol1] = HomogeneousCoeffSubsIndepDivDep._get_general_solution(self)
+        [sol2] = HomogeneousCoeffSubsDepDivIndep._get_general_solution(self)
         fx = self.ode_problem.func
         if simplify_flag:
-            sol1 = odesimp(self.ode_problem.eq, *sol1, fx, "1st_homogeneous_coeff_subs_indep_div_dep")
-            sol2 = odesimp(self.ode_problem.eq, *sol2, fx, "1st_homogeneous_coeff_subs_dep_div_indep")
+            sol1 = odesimp(self.ode_problem.eq, sol1, fx, "1st_homogeneous_coeff_subs_indep_div_dep")
+            sol2 = odesimp(self.ode_problem.eq, sol2, fx, "1st_homogeneous_coeff_subs_dep_div_indep")
         # XXX: not simplify should be not simplify_flag. mypy correctly complains
-        return min([sol1, sol2], key=lambda x: ode_sol_simplicity(x, fx, trysolving=not simplify)) # type: ignore
-
-
+        return min([sol1,sol2], key=lambda x: ode_sol_simplicity(x, fx, trysolving=not simplify_flag)) # type: ignore
+    
+    
 class LinearCoefficients(HomogeneousCoeffBest):
     r"""
     Solves a differential equation with linear coefficients.

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -30,7 +30,6 @@ from .nonhomogeneous import _get_euler_characteristic_eq_sols, _get_const_charac
     _solve_undetermined_coefficients, _solve_variation_of_parameters, _test_term, _undetermined_coefficients_match, \
         _get_simplified_sol
 from .lie_group import _ode_lie_group
-from sympy.utilities.iterables import iterable
 
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
@@ -1729,9 +1728,9 @@ class HomogeneousCoeffBest(HomogeneousCoeffSubsIndepDivDep, HomogeneousCoeffSubs
             sol1 = odesimp(self.ode_problem.eq, sol1, fx, "1st_homogeneous_coeff_subs_indep_div_dep")
             sol2 = odesimp(self.ode_problem.eq, sol2, fx, "1st_homogeneous_coeff_subs_dep_div_indep")
         # XXX: not simplify should be not simplify_flag. mypy correctly complains
-        return min([sol1,sol2], key=lambda x: ode_sol_simplicity(x, fx, trysolving=not simplify_flag)) # type: ignore
-    
-    
+        return min([sol1, sol2], key=lambda x: ode_sol_simplicity(x, fx, trysolving=not simplify_flag)) # type: ignore
+
+
 class LinearCoefficients(HomogeneousCoeffBest):
     r"""
     Solves a differential equation with linear coefficients.

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1727,8 +1727,16 @@ class HomogeneousCoeffBest(HomogeneousCoeffSubsIndepDivDep, HomogeneousCoeffSubs
         if simplify_flag:
             sol1 = odesimp(self.ode_problem.eq, sol1, fx, "1st_homogeneous_coeff_subs_indep_div_dep")
             sol2 = odesimp(self.ode_problem.eq, sol2, fx, "1st_homogeneous_coeff_subs_dep_div_indep")
-        # XXX: not simplify should be not simplify_flag. mypy correctly complains
-        return min([sol1, sol2], key=lambda x: ode_sol_simplicity(x, fx, trysolving=not simplify_flag)) # type: ignore
+        if not isinstance(sol1, list):
+            sol1 = [sol1]
+        if not isinstance(sol2, list):
+            sol2 = [sol2]
+        sol1_max_complexity = max(ode_sol_simplicity(sol, fx, trysolving= not simplify_flag) for sol in sol1)
+        sol2_max_complexity = max(ode_sol_simplicity(sol, fx, trysolving= not simplify_flag) for sol in sol2)
+        if sol2_max_complexity < sol1_max_complexity:
+            return sol2
+        else:
+            return sol1
 
 
 class LinearCoefficients(HomogeneousCoeffBest):


### PR DESCRIPTION
#### References to other Issues or PRs
#28968 


#### Brief description of what is fixed or changed
Removed @vectorize decorator from ode.py.

#### Other comments
Removal of the concerned code induced some errors for dealing the arguments. These errors were addressed and resolved.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * odesimp no longer accepts a list of equations.
  * _get_general_solution method of HomogeneousCoeffBest class returns list[Eq] consistently.
<!-- END RELEASE NOTES -->
