### PR TITLE
Fixed NumberSymbol.equals triggering numeric evaluation

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3620,6 +3620,13 @@ class NumberSymbol(AtomicExpr):
 
     def __ne__(self, other):
         return not self == other
+    
+    def equals(self,other,failing_expression=False):
+        if self==other:
+            return True
+        if type(self) is type(other):
+            return True
+        return False
 
     def __le__(self, other):
         if self is other:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2327,3 +2327,9 @@ def test_issue_28222():
     assert Mod(2 + 3*I, 10) == Mod(2 + 3*I, 10)
     assert Mod(I, exp(1)) == Mod(I, exp(1))
     assert Mod(I, S(1.5)) == Mod(I, S(1.5))
+from sympy.core import NumberSymbol
+from sympy import pi
+def test_numbersymbol_equality():
+    assert NumberSymbol().equals(NumberSymbol()) is True
+    assert pi.equals(pi) is True
+    assert pi.equals(NumberSymbol()) is False

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2328,7 +2328,6 @@ def test_issue_28222():
     assert Mod(I, exp(1)) == Mod(I, exp(1))
     assert Mod(I, S(1.5)) == Mod(I, S(1.5))
 from sympy.core import NumberSymbol
-from sympy import pi
 def test_numbersymbol_equality():
     assert NumberSymbol().equals(NumberSymbol()) is True
     assert pi.equals(pi) is True


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #28982

#### Brief description of what is fixed or changed
`NumberSymbol` inherited `Expr.equals()`, which attempts to determine equality
by simplifying `A - B` and querying assumptions. For `NumberSymbol`, this can
trigger numeric evaluation via `evalf()` and ultimately calls `_as_mpf_val`,
which `NumberSymbol` does not implement.

This PR overrides `NumberSymbol.equals()` to resolve equality structurally,
preventing invalid numeric reasoning for atomic symbolic constants.

#### Other comments
A regression test is added to ensure that equality of `NumberSymbol` objects
does not fall back to simplification or numeric evaluation.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `NumberSymbol.equals()` triggering numeric evaluation and raising an
    `AttributeError` in equality checks.
<!-- END RELEASE NOTES -->