### PR TITLE
Fix nonlinsolve incorrectly handling Interval solutions (Issue #28970)

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3603,7 +3603,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # corresponding complex soln.
                             if not isinstance(soln, (ImageSet, ConditionSet)):
                                 soln += solveset_complex(eq2, sym)  # might give ValueError with Abs
-                        
+
                         if not isinstance(soln, (FiniteSet, ImageSet, ConditionSet, Union)) and soln is not S.EmptySet:
                             raise NotImplementedError(
                                 f"nonlinsolve cannot handle solution of type {type(soln).__name__} "

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3582,11 +3582,6 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                     not_solvable = False
                     try:
                         soln = solver(eq2, sym)
-                        if isinstance(soln, Interval):
-                            raise NotImplementedError(
-                                f"Cannot solve system: solving for {sym} returned an Interval "
-                                f"which cannot be substituted into remaining equations"
-                            )
                         total_solvest_call += 1
                         soln_new = S.EmptySet
                         if isinstance(soln, Complement):
@@ -3608,6 +3603,12 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # corresponding complex soln.
                             if not isinstance(soln, (ImageSet, ConditionSet)):
                                 soln += solveset_complex(eq2, sym)  # might give ValueError with Abs
+                        
+                        if not isinstance(soln, (FiniteSet, ImageSet, ConditionSet, Union)) and soln is not S.EmptySet:
+                            raise NotImplementedError(
+                                f"nonlinsolve cannot handle solution of type {type(soln).__name__} "
+                                f"for symbol {sym}. Got {soln} from equation {eq2}."
+                            )
                     except ValueError:
                         # If solveset is not able to solve equation `eq2`. Next
                         # time we may get soln using next equation `eq2`

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3582,6 +3582,11 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                     not_solvable = False
                     try:
                         soln = solver(eq2, sym)
+                        if isinstance(soln, Interval):
+                            raise NotImplementedError(
+                                f"Cannot solve system: solving for {sym} returned an Interval "
+                                f"which cannot be substituted into remaining equations"
+                            )
                         total_solvest_call += 1
                         soln_new = S.EmptySet
                         if isinstance(soln, Complement):
@@ -3603,7 +3608,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # corresponding complex soln.
                             if not isinstance(soln, (ImageSet, ConditionSet)):
                                 soln += solveset_complex(eq2, sym)  # might give ValueError with Abs
-                    except (NotImplementedError, ValueError):
+                    except ValueError:
                         # If solveset is not able to solve equation `eq2`. Next
                         # time we may get soln using next equation `eq2`
                         continue

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1872,6 +1872,13 @@ def test_nonlinsolve_abs():
     raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 2, x + y], x, y))
 
 
+def test_nonlinsolve_sign():
+    raises(NotImplementedError, lambda: nonlinsolve([sign(x) - 1, x*y - 4], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([sign(x) - 1, x - y], [x, y]))
+    result = nonlinsolve([sign(x) - 1], [x])
+    assert isinstance(result, FiniteSet)
+
+
 def test_raise_exception_nonlinsolve():
     raises(IndexError, lambda: nonlinsolve([x**2 -1], []))
     raises(ValueError, lambda: nonlinsolve([x**2 -1]))


### PR DESCRIPTION
Fixes #28970

#### Brief description of what is fixed or changed
Fixed a bug where nonlinsolve returned incorrect solutions or crashed when solveset returned an `Interval` (e.g., for sign(x)). The fix explicitly raises `NotImplementedError` in these cases and ensures it propagates to the user instead of being silently ignored.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a bug in nonlinsolve where systems involving functions returning intervals (like sign(x)) would crash with TypeError. Now properly raises NotImplementedError.
<!-- END RELEASE NOTES -->