### PR TITLE
Add type annotations to sympy.utilities.misc

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -380,6 +380,7 @@ Arthur Ryman <arthur.ryman@gmail.com>
 Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
 Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
 Ashish Kumar Gaurav <ashishkg0022@gmail.com>
+Ashita Chauhan <ashitachauhan2006@gmail.com>
 Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1450 authors.
+There are a total of 1371 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1343,7 +1343,6 @@ Quek Zi Yao <ziyaoqzy2001@gmail.com>
 Roelof Rietbroek <r.rietbroek@utwente.nl>
 MostafaGalal1 <mostafag649.mg@gmail.com>
 Au Huishan <huishan_au@outlook.com>
-Avasam <samuel.06@hotmail.com>
 Kris Katterjohn <katterjohn@gmail.com>
 Shiyao Guo <mivikq@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com>
@@ -1379,82 +1378,3 @@ Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
 Tanmay Rath <rathjyotshna@gmail.com>
-Ashita Chauhan <ashitachauhan2006@gmail.com>
-Pasquale Cocchini <pasquale.cocchini@gmail.com>
-Sai Udayagiri <saibabu.udayagiri@gmail.com>
-Lucas Verlaan <lucas.verlaan@gmail.com>
-Shaoliang Jin <18322825326@163.com>
-Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
-Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
-Nico Santamaria <nicoasantamaria@gmail.com>
-Atul Bisht <me.atulbisht@gmail.com>
-Élie Goudout <eliegoudout@hotmail.com>
-Lyle Poley <poleylyle@gmail.com>
-Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
-Richard Osborn <richardosborn@mac.com>
-Jatin Gaur <jatingaurchess@gmail.com>
-Manav Sharma <maanav.vashist@gmail.com>
-Charles Weiss <charles.weiss@augie.edu>
-Chetan Choudhary <cc393653@gmail.com>
-Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
-Jason Gross <jasongross9@gmail.com>
-JDBetteridge <jack@devitocodes.com>
-Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>
-Chaitanya Jain <chaitanya.jain.dev@gmail.com>
-TrungPQ <trungpqhe171493@gmail.com>
-Ser Kim <serk.kmh@gmail.com>
-SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg>
-Robert Brijder <rbrijder@gmail.com>
-Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com>
-Sujal Kumar <sujaljayantkumar06@gmail.com>
-Goran Jelic-Cizmek <jcgoran@protonmail.com>
-Merin Theres Jose <merintheresjose@gmail.com>
-Chris Cameron <chrisjamescameron1@gmail.com>
-Chris Paul <chrispaul68002@gmail.com>
-xndcn <xndchn@gmail.com>
-Paul Scofield <Cerebral.Paul@gmail.com>
-Keyron Linerez <keyronlinarez@gmail.com>
-Oldrich Klimanek <oldrich.klimanek@gmail.com>
-Alexander Grund <alexander.grund@tu-dresden.de>
-phipf <phipf@online.de>
-Russell Fordyce <rfordyce@expressive-py.org>
-Ayden Alvarez <Aydenalv6282@gmail.com>
-Alhussein Ashraf <alhusseinashraf55@gmail.com>
-Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
-Pedro H. S. Prestes <pedrohsprestes@gmail.com>
-Simon Sørensen <simonblsoerensen@gmail.com>
-Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
-Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
-Jo Liss <joliss42@gmail.com>
-Luca Bertoni <lucabertoni@gmail.com>
-Ayush Kumar Jha <jha44481@gmail.com>
-Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
-Xiao <muzumayao@126.com>
-Rishabh Chordiya <rishabh.arceus@gmail.com>
-Mayank Balyan <78949282+MayankBalyan@users.noreply.github.com>
-leastloris <ivedants05@gmail.com>
-Prajwal Pathade <prajwalpathade7@gmail.com>
-Viraj Palnitkar <virajpalnitkar@gmail.com>
-Liubov Kryzhalka <kryshalkaliub@gmail.com>
-Harsh Menon <harsh.menon@amd.com>
-Disha Holmukhe <dishaholmukh521@gmail.com>
-Baibhav Singh <baibhavsfs@gmail.com>
-Anas <anas23khan083@gmail.com>
-Sai Kiran P <parnandi.saikiran@gmail.com>
-M-Israr-Ul-Haq <israrulhaq590@gmail.com>
-oxygen dioxide <54425948+oxygen-dioxide@users.noreply.github.com>
-Tanmay Rath <rathjyotshna@gmail.com>
-Suneet Mishra <suee.suneet@gmail.com>
-Gagandeep Singh <Gmadaan450@gmail.com>
-Vivek Gaddam <vivek.gaddam2005@gmail.com>
-Vedant Dusane <dusanev4@gmail.com>
-Ishan Khan <ishan372or@gmail.com>
-Abhijith Shaji <abhijithshajikp@gmail.com>
-Alex Sun <alexsun.srand.nums@gmail.com>
-Ayush Bothra <ayush9bothra@gmail.com>
-Anshul Sharma <anshulsharma4605@gmail.com>
-Tien Nguyen <viettien23102006@gmail.com>
-Avanish Salunke <avanishsalunke16@gmail.com>
-Harsh Gupta <harsh2125gupta@gmail.com>
-Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
-Mayank Singh <mayanksingh020607@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1378,3 +1378,4 @@ Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
 Tanmay Rath <rathjyotshna@gmail.com>
+Ashita Chauhan <ashitachauhan2006@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 1371 authors.
+There are a total of 1450 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -1343,6 +1343,7 @@ Quek Zi Yao <ziyaoqzy2001@gmail.com>
 Roelof Rietbroek <r.rietbroek@utwente.nl>
 MostafaGalal1 <mostafag649.mg@gmail.com>
 Au Huishan <huishan_au@outlook.com>
+Avasam <samuel.06@hotmail.com>
 Kris Katterjohn <katterjohn@gmail.com>
 Shiyao Guo <mivikq@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com>
@@ -1377,4 +1378,81 @@ Mathis Cros <mathis.cros@telecom-paris.fr>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com>
 KJaybhaye <krushnajaybhaye01@gmail.com>
+Pasquale Cocchini <pasquale.cocchini@gmail.com>
+Sai Udayagiri <saibabu.udayagiri@gmail.com>
+Lucas Verlaan <lucas.verlaan@gmail.com>
+Shaoliang Jin <18322825326@163.com>
+Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
+Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
+Nico Santamaria <nicoasantamaria@gmail.com>
+Atul Bisht <me.atulbisht@gmail.com>
+Élie Goudout <eliegoudout@hotmail.com>
+Lyle Poley <poleylyle@gmail.com>
+Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
+Richard Osborn <richardosborn@mac.com>
+Jatin Gaur <jatingaurchess@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com>
+Charles Weiss <charles.weiss@augie.edu>
+Chetan Choudhary <cc393653@gmail.com>
+Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
+Jason Gross <jasongross9@gmail.com>
+JDBetteridge <jack@devitocodes.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>
+Chaitanya Jain <chaitanya.jain.dev@gmail.com>
+TrungPQ <trungpqhe171493@gmail.com>
+Ser Kim <serk.kmh@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg>
+Robert Brijder <rbrijder@gmail.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com>
+Sujal Kumar <sujaljayantkumar06@gmail.com>
+Goran Jelic-Cizmek <jcgoran@protonmail.com>
+Merin Theres Jose <merintheresjose@gmail.com>
+Chris Cameron <chrisjamescameron1@gmail.com>
+Chris Paul <chrispaul68002@gmail.com>
+xndcn <xndchn@gmail.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
+Keyron Linerez <keyronlinarez@gmail.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com>
+Alexander Grund <alexander.grund@tu-dresden.de>
+phipf <phipf@online.de>
+Russell Fordyce <rfordyce@expressive-py.org>
+Ayden Alvarez <Aydenalv6282@gmail.com>
+Alhussein Ashraf <alhusseinashraf55@gmail.com>
+Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
+Pedro H. S. Prestes <pedrohsprestes@gmail.com>
+Simon Sørensen <simonblsoerensen@gmail.com>
+Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
+Laura Pazini Medeiros <laurapazinimedeiros@gmail.com>
+Jo Liss <joliss42@gmail.com>
+Luca Bertoni <lucabertoni@gmail.com>
+Ayush Kumar Jha <jha44481@gmail.com>
+Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
+Xiao <muzumayao@126.com>
+Rishabh Chordiya <rishabh.arceus@gmail.com>
+Mayank Balyan <78949282+MayankBalyan@users.noreply.github.com>
+leastloris <ivedants05@gmail.com>
+Prajwal Pathade <prajwalpathade7@gmail.com>
+Viraj Palnitkar <virajpalnitkar@gmail.com>
+Liubov Kryzhalka <kryshalkaliub@gmail.com>
+Harsh Menon <harsh.menon@amd.com>
+Disha Holmukhe <dishaholmukh521@gmail.com>
+Baibhav Singh <baibhavsfs@gmail.com>
+Anas <anas23khan083@gmail.com>
+Sai Kiran P <parnandi.saikiran@gmail.com>
+M-Israr-Ul-Haq <israrulhaq590@gmail.com>
+oxygen dioxide <54425948+oxygen-dioxide@users.noreply.github.com>
 Tanmay Rath <rathjyotshna@gmail.com>
+Suneet Mishra <suee.suneet@gmail.com>
+Gagandeep Singh <Gmadaan450@gmail.com>
+Vivek Gaddam <vivek.gaddam2005@gmail.com>
+Vedant Dusane <dusanev4@gmail.com>
+Ishan Khan <ishan372or@gmail.com>
+Abhijith Shaji <abhijithshajikp@gmail.com>
+Alex Sun <alexsun.srand.nums@gmail.com>
+Ayush Bothra <ayush9bothra@gmail.com>
+Anshul Sharma <anshulsharma4605@gmail.com>
+Tien Nguyen <viettien23102006@gmail.com>
+Avanish Salunke <avanishsalunke16@gmail.com>
+Harsh Gupta <harsh2125gupta@gmail.com>
+Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
+Mayank Singh <mayanksingh020607@gmail.com>

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -73,7 +73,7 @@ def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
     if '\n' in s:
         return rawlines(s).splitlines()
     q = '"' if repr(s).startswith('"') else "'"
-    q = (q,)*2
+    q = q *2
     if '\\' in s:  # use r-string
         m = '(\nr%s%%s%s\n)' % q
         j = '%s\nr%s' % q

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,7 +1,6 @@
 """Miscellaneous stuff that does not really fit anywhere else."""
 
 from __future__ import annotations
-from typing import List
 
 import operator
 import sys
@@ -40,7 +39,7 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
 
 
 
-def strlines(s: str, c: int = 64, short: bool = False) -> List[str]:
+def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -71,15 +71,16 @@ def strlines(s: str, c: int = 64, short: bool = False) -> str:
         raise ValueError('expecting string input')
     if '\n' in s:
         return rawlines(s)
-    q = '"' if repr(s).startswith('"') else "'"
-    q = (q,)*2
+    q = "'" if repr(s).startswith("'") else '"'
+    qq = (q, q)
+
     if '\\' in s:  # use r-string
-        m = '(\nr%s%%s%s\n)' % q
-        j = '%s\nr%s' % q
+        m = '(\nr%s%%s%s\n)' % qq
+        j = '%s\nr%s' % qq
         c -= 3
     else:
-        m = '(\n%s%%s%s\n)' % q
-        j = '%s\n%s' % q
+        m = '(\n%s%%s%s\n)' % qq
+        j = '%s\n%s' % qq
         c -= 2
     out = []
     while s:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -38,7 +38,9 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
-def strlines(s, c=64, short=False):
+from typing import List
+
+def strlines(s: str, c: int = 64, short: bool = False) -> List[str]:
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,6 +1,7 @@
 """Miscellaneous stuff that does not really fit anywhere else."""
 
 from __future__ import annotations
+from typing import List
 
 import operator
 import sys
@@ -38,7 +39,6 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
-from typing import List
 
 def strlines(s: str, c: int = 64, short: bool = False) -> List[str]:
     """Return a cut-and-pastable string that, when printed, is

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -71,7 +71,7 @@ def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
     if not isinstance(s, str):
         raise ValueError('expecting string input')
     if '\n' in s:
-        return rawlines(s)
+        return rawlines(s).splitlines()
     q = '"' if repr(s).startswith('"') else "'"
     q = (q,)*2
     if '\\' in s:  # use r-string
@@ -87,8 +87,8 @@ def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
         out.append(s[:c])
         s=s[c:]
     if short and len(out) == 1:
-        return (m % out[0]).splitlines()[1]  # strip bounding (\n...\n)
-    return m % j.join(out)
+        return [(m % out[0]).splitlines()[1]]  # strip bounding (\n...\n)
+    return (m % j.join(out)).splitlines()
 
 
 def rawlines(s):

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,6 +1,8 @@
 """Miscellaneous stuff that does not really fit anywhere else."""
 
 from __future__ import annotations
+from typing import overload
+from typing_extensions import Literal
 
 import operator
 import sys
@@ -39,7 +41,18 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
 
 
 
-def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
+@overload
+def strlines(
+    s: str, c: int = 64, short: Literal[False] = False
+) -> list[str]: ...
+    
+@overload
+def strlines(
+    s: str, c: int = 64, short: Literal[True] = True
+) -> str: ...
+
+
+def strlines(s: str, c: int = 64, short: bool = False):
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)
@@ -71,9 +84,9 @@ def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
     if not isinstance(s, str):
         raise ValueError('expecting string input')
     if '\n' in s:
-        return rawlines(s).splitlines()
+        return rawlines(s)
     q = '"' if repr(s).startswith('"') else "'"
-    q = q *2
+    q = (q,)*2
     if '\\' in s:  # use r-string
         m = '(\nr%s%%s%s\n)' % q
         j = '%s\nr%s' % q
@@ -87,8 +100,8 @@ def strlines(s: str, c: int = 64, short: bool = False) -> list[str]:
         out.append(s[:c])
         s=s[c:]
     if short and len(out) == 1:
-        return [(m % out[0]).splitlines()[1]]  # strip bounding (\n...\n)
-    return (m % j.join(out)).splitlines()
+        return (m % out[0]).splitlines()[1]  # strip bounding (\n...\n)
+    return m % j.join(out)
 
 
 def rawlines(s):

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,8 +1,6 @@
 """Miscellaneous stuff that does not really fit anywhere else."""
 
 from __future__ import annotations
-from typing import overload
-from typing_extensions import Literal
 
 import operator
 import sys
@@ -41,18 +39,8 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
 
 
 
-@overload
-def strlines(
-    s: str, c: int = 64, short: Literal[False] = False
-) -> list[str]: ...
-    
-@overload
-def strlines(
-    s: str, c: int = 64, short: Literal[True] = True
-) -> str: ...
 
-
-def strlines(s: str, c: int = 64, short: bool = False):
+def strlines(s: str, c: int = 64, short: bool = False) -> str:
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -38,9 +38,7 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
-
-
-def strlines(s: str, c: int = 64, short: bool = False) -> str:
+def strlines(s, c=64, short=False):
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -38,7 +38,7 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
-def strlines(s, c=64, short=False):
+def strlines(s: str, c: int = 64, short: bool = False) -> str:
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)


### PR DESCRIPTION
This PR adds type annotations to a few utility functions in `sympy/utilities/misc.py` as part of issue #28806.

The changes are limited to type hints only and do not modify runtime behavior.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->