### PR TITLE
Printing: Improve error message when lambdifying a Derivative

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -475,11 +475,18 @@ class CodePrinter(StrPrinter):
         if pmeth is None:     
             if self._settings.get('strict', False):
                 msg = (
+<<<<<<< Updated upstream
                        f"Unsupported by {type(self)}: {type(expr)}\n"
                        "Lambdify cannot translate a Derivative into code. "
                        "Please calculate the derivative using .doit() first.\n"
                        "Set the printer option 'strict' to False to ignore this."
                        )
+=======
+                        f"Unsupported by {type(self)}: {type(expr)}\n"
+                        "Lambdify cannot translate a symbolic Derivative into code.\n"
+                        "Set the printer option 'strict' to False to ignore this."
+)
+>>>>>>> Stashed changes
                 raise PrintMethodNotImplementedError(msg)
             return self._print_not_supported(expr)
         orders = dict(wrt_order_pairs)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -475,18 +475,10 @@ class CodePrinter(StrPrinter):
         if pmeth is None:     
             if self._settings.get('strict', False):
                 msg = (
-<<<<<<< Updated upstream
-                       f"Unsupported by {type(self)}: {type(expr)}\n"
-                       "Lambdify cannot translate a Derivative into code. "
-                       "Please calculate the derivative using .doit() first.\n"
-                       "Set the printer option 'strict' to False to ignore this."
-                       )
-=======
-                        f"Unsupported by {type(self)}: {type(expr)}\n"
-                        "Lambdify cannot translate a symbolic Derivative into code.\n"
-                        "Set the printer option 'strict' to False to ignore this."
-)
->>>>>>> Stashed changes
+                f"Unsupported by {type(self)}: {type(expr)}\n"
+                "Lambdify cannot translate a symbolic Derivative into code.\n"
+                "Set the printer option 'strict' to False to ignore this."
+                    )
                 raise PrintMethodNotImplementedError(msg)
             return self._print_not_supported(expr)
         orders = dict(wrt_order_pairs)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -472,13 +472,15 @@ class CodePrinter(StrPrinter):
                                  self.__class__.__name__)
         meth_name = '_print_Derivative_%s' % obj.func.__name__
         pmeth = getattr(self, meth_name, None)
-        if pmeth is None:
+        if pmeth is None:     
             if self._settings.get('strict', False):
-                raise PrintMethodNotImplementedError(
-                    f"Unsupported by {type(self)}: {type(expr)}" +
-                    f"\nPrinter has no method: {meth_name}" +
-                    "\nSet the printer option 'strict' to False in order to generate partially printed code."
-                )
+                msg = (
+                       f"Unsupported by {type(self)}: {type(expr)}\n"
+                       "Lambdify cannot translate a Derivative into code. "
+                       "Please calculate the derivative using .doit() first.\n"
+                       "Set the printer option 'strict' to False to ignore this."
+                       )
+                raise PrintMethodNotImplementedError(msg)
             return self._print_not_supported(expr)
         orders = dict(wrt_order_pairs)
         seq_orders = [orders[arg] for arg in obj.args]


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #9339

#### Brief description of what is fixed or changed
Currently,`lambdify` raises a `PrintMethodNotImplementedError` (or `NameError` in older versions) when passed an un-evaluated `Derivative`. The error message is confusing because it implies a missing printer method rather than an unsupported mathematical operation.

This PR adds a specific check in `_print_Derivative` to raise a helpful error message guiding the user to use `.doit()` before lambdifying.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->

* printing
  * `lambdify` now raises a clearer error message when passed a symbolic `Derivative`, suggesting the use of `.doit()`.

<!-- END RELEASE NOTES -->