### PR TITLE
NumPyPrinter: Add support for Contains(x, S.Integers)

### DIFF
--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -75,6 +75,12 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
             return '({})'.format(').dot('.join(self._print(i) for i in expr_list))
         return '({})'.format(').dot('.join(self._print(i) for i in expr.args))
 
+    def _print_Contains(self, expr):
+        item, s = expr.args
+        if s == S.Integers:
+            return "equal(mod({}, 1), 0)".format(self._print(item))
+        raise NotImplementedError(f"NumPy printing for Contains({item}, {s}) not implemented")
+
     def _print_MatPow(self, expr):
         "Matrix power printer"
         return '{}({}, {})'.format(self._module_format(self._module + '.linalg.matrix_power'),

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -11,7 +11,7 @@ from sympy.matrices.expressions.blockmatrix import BlockMatrix
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
 from sympy.utilities.lambdify import lambdify
-from sympy import symbols, Min, Max
+from sympy import symbols, Min, Max, Contains, S
 
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.core import Pow
@@ -379,3 +379,11 @@ def test_scipy_print_methods():
     assert prntr.doprint(polygamma(k, x)) == "scipy.special.polygamma(k, x)"
     assert prntr.doprint(Si(x)) == "scipy.special.sici(x)[0]"
     assert prntr.doprint(Ci(x)) == "scipy.special.sici(x)[1]"
+
+def test_numpy_contains_integers():
+    x = symbols('x')
+    f = lambdify(x, Contains(x, S.Integers), modules="numpy")
+    arr = np.array([1.0, 1.5, 2.0])
+    result = f(arr)
+    expected = np.array([True, False, True])
+    assert np.array_equal(result, expected)

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -381,6 +381,9 @@ def test_scipy_print_methods():
     assert prntr.doprint(Ci(x)) == "scipy.special.sici(x)[1]"
 
 def test_numpy_contains_integers():
+    if not np:
+        skip("NumPy not installed")
+
     x = symbols('x')
     f = lambdify(x, Contains(x, S.Integers), modules="numpy")
     arr = np.array([1.0, 1.5, 2.0])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

None

#### Brief description of what is fixed or changed

Currently, lambdify fails with a NotImplementedError when converting Contains(x, S.Integers) to NumPy code because the printer does not support it. This PR adds support by translating the expression to equal(mod(x, 1), 0)

#### Other comments
Before
``` 
In [4]: import numpy as np

In [5]: from sympy import lambdify, Contains, S, symbols

In [6]: x= symbols('x')

In [7]: f= lambdify(x, Contains(x, S.Integers), modules="numpy")
---------------------------------------------------------------------------
PrintMethodNotImplementedError            Traceback (most recent call last)
```

After adding the contains

```
In [1]: import numpy as np

In [2]: from sympy import lambdify, Con
   ...: tains, S, symbols

In [3]: x= symbols('x')

In [4]: f= lambdify(x, Contains(x, S.In
   ...: tegers), modules="numpy")

In [5]: f(np.array([1.5, 2.0]))
Out[5]: array([False,  True])
```

This implementation uses numpy.equal(numpy.mod(x, 1), 0) to check for integers, which handles both scalars and arrays correctly.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Added support for Contains(x, S.Integers) in lambdify with the NumPy backend.
<!-- END RELEASE NOTES -->
