### PR TITLE
Fix `FpSubgroup.__contains__`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -444,6 +444,7 @@ Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>
+Boris Bilich <bilichboris1999@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
 Boris Timokhin <qoqenator@gmail.com>
 Bradley Dowling <34559056+btdow@users.noreply.github.com>

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -614,7 +614,7 @@ class FpSubgroup(DefaultPrinting):
                             # start, end
                             r1, r2 = w2[0][0], w2[0][0]**-1
                         else:
-                            r1, r2 = w2[0], w2[len(w1)-1]
+                            r1, r2 = w2[0], w2[len(w2)-1]
 
                         # p1 and p2 are w1 and w2 or, in case when
                         # w1 or w2 is an infinite family, a representative

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -195,6 +195,10 @@ def test_fp_subgroup():
     S = FpSubgroup(f, H)
     _test_subgroup(K, T, S)
 
+    F, x, y = free_group("x, y")
+    H = FpSubgroup(F, [x*y, x])
+    assert x in H
+
 def test_permutation_methods():
     F, x, y = free_group("x, y")
     # DihedralGroup(8)


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Standard index access typo is fixed. Minimal code snippet to reproduce the fixed bug:

```
from sympy.combinatorics import free_group
from sympy.combinatorics.fp_groups import FpSubgroup

F, x, y = free_group("x, y")

# Subgroup generators have different word lengths: x (len=1) and x*y (len=2)
H = FpSubgroup(F, [x*y, x])

# Triggers __contains__ preprocessing and crashes
print(x in H)

```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* combinatorics
   * Fixed `FpSubgroup.__contains__`

<!-- END RELEASE NOTES -->
