### PR TITLE
Fix: Fixes Doc Build Error because of `sphinx>=9.0.0`

### DIFF
--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -45,6 +45,8 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         title_re = re.compile(pattern, re.IGNORECASE | re.DOTALL)
         lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
+        if inspect.isbuiltin(obj):
+            return
         doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
         doc = str(doc)
         lines[:] = doc.split(u_NL)

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -47,10 +47,10 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     else:
         try:
             doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
-            doc = str(doc)
-            lines[:] = doc.split(u_NL)
         except ValueError:
             return
+        doc = str(doc)
+        lines[:] = doc.split(u_NL)
 
     if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and
             obj.__name__):

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -45,11 +45,12 @@ def mangle_docstrings(app, what, name, obj, options, lines,
         title_re = re.compile(pattern, re.IGNORECASE | re.DOTALL)
         lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
-        if inspect.isbuiltin(obj):
+        try:
+            doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
+            doc = str(doc)
+            lines[:] = doc.split(u_NL)
+        except ValueError:
             return
-        doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
-        doc = str(doc)
-        lines[:] = doc.split(u_NL)
 
     if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and
             obj.__name__):

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,7 @@ matplotlib-inline
 mpmath
 myst-parser
 scipy
-Sphinx < 9
+Sphinx
 sphinx-autobuild
 sphinx-copybutton
 sphinx-math-dollar

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -276,7 +276,7 @@ def dotprint(expr,
     # repeat works by adding a signature tuple to the end of each node for its
     # position in the graph. For example, for expr = Add(x, Pow(x, 2)), the x in the
     # Pow will have the tuple (1, 0), meaning it is expr.args[1].args[0].
-    if styles == None:
+    if styles is None:
         styles = default_styles
     graphstyle = _graphstyle.copy()
     graphstyle.update(kwargs)

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -184,7 +184,7 @@ template = \
 _graphstyle = {'rankdir': 'TD', 'ordering': 'out'}
 
 def dotprint(expr,
-    styles=default_styles, atom=lambda x: not isinstance(x, Basic),
+    styles=None, atom=lambda x: not isinstance(x, Basic),
     maxdepth=None, repeat=True, labelfunc=str, **kwargs):
     """DOT description of a SymPy expression tree
 
@@ -276,6 +276,8 @@ def dotprint(expr,
     # repeat works by adding a signature tuple to the end of each node for its
     # position in the graph. For example, for expr = Add(x, Pow(x, 2)), the x in the
     # Pow will have the tuple (1, 0), meaning it is expr.args[1].args[0].
+    if styles == None:
+        styles = default_styles
     graphstyle = _graphstyle.copy()
     graphstyle.update(kwargs)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Issue/Fixes: #28954

#### Brief description of what is fixed or changed
Recently doc build was failing because of the newer release of `myst-parser` which unpinned `sphinx < 9`. `Sphinx==9.0.0` had some major changes in `autodoc`. 

A temporary fix was made to pin `sphinx<9`  in `doc/requirements.txt` (#28955). PR aims to fix the issue with the `numpydoc` extension. The whole discussion can be followed in issue #28954 's comments.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
