### PR TITLE
utilities: add type annotations to variations arguments

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -401,7 +401,7 @@ def ibin(n, bits=None, str=False):
             return (f'{i:b}'.rjust(n, "0") for i in range(2**n))
 
 
-def variations(seq, n: int, repetition: bool = False):
+def variations(seq: Iterable[T], n: int, repetition: bool = False) -> Iterable[tuple[T, ...]]:
     r"""Returns an iterator over the n-sized variations of ``seq`` (size N).
     ``repetition`` controls whether items in ``seq`` can appear more than once;
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -401,7 +401,7 @@ def ibin(n, bits=None, str=False):
             return (f'{i:b}'.rjust(n, "0") for i in range(2**n))
 
 
-def variations(seq, n, repetition=False):
+def variations(seq, n: int, repetition: bool = False):
     r"""Returns an iterator over the n-sized variations of ``seq`` (size N).
     ``repetition`` controls whether items in ``seq`` can appear more than once;
 


### PR DESCRIPTION
issue: #28806

Add explicit type annotations to variations parameters to improve readability and static analysis. No functional changes.
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->