### PR TITLE
Add basic type annotation to ibin

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -329,7 +329,7 @@ def multiset(seq: Sequence[T]) -> dict[T, int]:
 
 
 
-def ibin(n, bits=None, str=False):
+def ibin(n: int, bits: int | None = None, str: bool = False):
     """Return a list of length ``bits`` corresponding to the binary value
     of ``n`` with small bits to the right (last). If bits is omitted, the
     length will be the number required to represent ``n``. If the bits are


### PR DESCRIPTION
issue: #28806 

File: `sympy/utilities/iterables.py`

Add basic type annotations to `ibin` arguments.

Behavior and return values remain unchanged; annotation only improve readability and statics analysis without changing any logic and all test run & pass locally.
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->