### PR TITLE
[quantum] Add invalid argument tests for quantum fidelity

### DIFF
--- a/sympy/physics/continuum_mechanics/tests/test_arch.py
+++ b/sympy/physics/continuum_mechanics/tests/test_arch.py
@@ -17,7 +17,7 @@ def test_arch_init():
     a.change_support_type(left_support='roller')
     a.add_member(0.5)
     assert a.supports == {'left':'roller', 'right':'hinge'}
-    assert simplify(a.get_shape_eqn) == simplify(9/5 - (x - 6)**2/20)
+    assert simplify(a.get_shape_eqn) == x*(12 - x)/20
 
 def test_arch_support():
     a = Arch((0,0),(40,0),crown_x=20,crown_y=12)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -4483,13 +4483,16 @@ class MIMOFeedback(MIMOLinearTimeInvariant):
         |    [  -    -----]    [-  -]   |     [  -    -----]
         \    [  1      s  ]{t} [1  1]{t}/     [  1      s  ]{t}
         >>> pprint(F_1.doit(), use_unicode=False)
-        [  -s           s - 1       ]
-        [-------     -----------    ]
-        [6*s - 1     s*(6*s - 1)    ]
-        [                           ]
-        [5*s - 5  (s - 1)*(6*s + 24)]
-        [-------  ------------------]
-        [6*s - 1     s*(6*s - 1)    ]{t}
+        [  -s          s - 1      ]
+        [-------      --------    ]
+        [6*s - 1         2        ]
+        [             6*s  - s    ]
+        [                         ]
+        [            2            ]
+        [5*s - 5  6*s  + 18*s - 24]
+        [-------  ----------------]
+        [6*s - 1         2        ]
+        [             6*s  - s    ]{t}
 
         If the user wants the resultant ``TransferFunctionMatrix`` object without
         canceling the common factors then the ``cancel`` kwarg should be passed ``False``.

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -2720,8 +2720,8 @@ def test_MIMOFeedback_functions():
         (-2*s**4 + s**2)*(s**2 - s + 1), s*(s**2 - s + 1)**2, s), TransferFunction(-2*s**4 + 2*s**3, s**2 - s + 1, s)),
         (TransferFunction(0, 1, s), TransferFunction(-s**2 + s, 1, s))))
     assert F_2.doit() == \
-        TransferFunctionMatrix(((TransferFunction(s*(-2*s**2 + s*(2*s - 1) + 1), s**2 - s + 1, s),
-        TransferFunction(-2*s**3*(s - 1), s**2 - s + 1, s)), (TransferFunction(0, 1, s), TransferFunction(s*(1 - s), 1, s))))
+        TransferFunctionMatrix(((TransferFunction(-s**2 + s, s**2 - s + 1, s), TransferFunction(-2*s**4 + 2*s**3, s**2 - s + 1, s)),
+        (TransferFunction(0, 1, s), TransferFunction(-s**2 + s, 1, s))))
     assert F_2.doit(expand=True) == \
         TransferFunctionMatrix(((TransferFunction(-s**2 + s, s**2 - s + 1, s), TransferFunction(-2*s**4 + 2*s**3, s**2 - s + 1, s)),
         (TransferFunction(0, 1, s), TransferFunction(-s**2 + s, 1, s))))
@@ -2763,11 +2763,10 @@ def test_MIMOFeedback_functions():
              DiscreteTransferFunction(-s**2 + s, 1, s, 0.4))))
     assert dF_2.doit() == \
         TransferFunctionMatrix(((
-            DiscreteTransferFunction(s*(-2*s**2 + s*(2*s - 1) + 1),
-                               s**2 - s + 1, s, 0.4),
-            DiscreteTransferFunction(-2*s**3*(s - 1), s**2 - s + 1, s, 0.4)),
-            (DiscreteTransferFunction(0, 1, s, 0.4), DiscreteTransferFunction(s*(1 - s),
-                                                                  1, s, 0.4))))
+            DiscreteTransferFunction(-s**2 + s, s**2 - s + 1, s, 0.4),
+            DiscreteTransferFunction(-2*s**4 + 2*s**3, s**2 - s + 1, s, 0.4)),
+            (DiscreteTransferFunction(0, 1, s, 0.4),
+             DiscreteTransferFunction(-s**2 + s, 1, s, 0.4))))
     assert dF_2.doit(expand=True) == \
         TransferFunctionMatrix(((
             DiscreteTransferFunction(-s**2 + s, s**2 - s + 1, s, 0.4),

--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -266,7 +266,6 @@ def test_fidelity():
     assert abs(fidelity(d1, d2) - 0.996) < 1e-3
     assert abs(fidelity(d1, d2) - fidelity(d2, d1)) < 1e-3
 
-    #TODO: test for invalid arguments
     # non-square matrix
     mat1 = [[0, 0],
             [0, 0],
@@ -287,3 +286,10 @@ def test_fidelity():
     # unsupported data-type
     x, y = 1, 2  # random values that is not a matrix
     raises(ValueError, lambda: fidelity(x, y))
+
+    # check density objs of different sizes
+    d1 = Density([Qubit('0'), 1])
+    d2 = Density([Qubit('00'), 1])
+    raises(ValueError, lambda: fidelity(d1, d2))
+
+    raises(ValueError, lambda: fidelity(d1, 123))

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1975,8 +1975,6 @@ def rs_min_pow(expr, series_rs, a):
 
 
 def _rs_series(expr, series_rs, a, prec):
-    # TODO Use _parallel_dict_from_expr instead of sring as sring is
-    # inefficient. For details, read the todo in sring.
     args = expr.args
     R = series_rs.ring
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -242,30 +242,6 @@ def sring(exprs, *symbols, **options):
     else:
         return (_ring, polys)
 
-def sring_old(exprs, *symbols, **options):
-    """The logic of sring BEFORE your optimization (The 'Slow' Path)"""
-    single = False
-    if not isinstance(exprs, (list, tuple)):
-        exprs, single = [exprs], True
-    exprs = list(map(sympify, exprs))
-    
-    # OLD LOGIC: Always used _parallel_dict_from_expr first
-    opt = build_options(symbols, options)
-    reps, opt = _parallel_dict_from_expr(exprs, opt)
-    
-    if opt.domain is None:
-        # Construct domain from dictionary coefficients
-        coeffs = sum([list(rep.values()) for rep in reps], [])
-        opt.domain, coeffs_dom = construct_domain(coeffs, opt=opt)
-        coeff_map = dict(zip(coeffs, coeffs_dom))
-        reps = [{m: coeff_map[c] for m, c in rep.items()} for rep in reps]
-    
-    _ring = PolyRing(opt.gens, opt.domain, opt.order)
-    polys = list(map(_ring.from_dict, reps))
-    
-    if single: return (_ring, polys[0])
-    return (_ring, polys)
-
 def _parse_symbols(
     symbols: str | Expr | Sequence[str] | Sequence[Expr],
 ) -> Sequence[Expr]:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -212,7 +212,7 @@ def sring(exprs, *symbols, **options):
         if not opt_fast.gens:
             symbols = set()
             for expr in exprs:
-                symbols.update(expr.free_symbols)
+                symbols.update({s for s in expr.free_symbols if s.is_commutative})
             opt_fast.gens = tuple(sorted(symbols, key=default_sort_key))
 
         if opt_fast.domain is None:
@@ -242,6 +242,29 @@ def sring(exprs, *symbols, **options):
     else:
         return (_ring, polys)
 
+def sring_old(exprs, *symbols, **options):
+    """The logic of sring BEFORE your optimization (The 'Slow' Path)"""
+    single = False
+    if not isinstance(exprs, (list, tuple)):
+        exprs, single = [exprs], True
+    exprs = list(map(sympify, exprs))
+    
+    # OLD LOGIC: Always used _parallel_dict_from_expr first
+    opt = build_options(symbols, options)
+    reps, opt = _parallel_dict_from_expr(exprs, opt)
+    
+    if opt.domain is None:
+        # Construct domain from dictionary coefficients
+        coeffs = sum([list(rep.values()) for rep in reps], [])
+        opt.domain, coeffs_dom = construct_domain(coeffs, opt=opt)
+        coeff_map = dict(zip(coeffs, coeffs_dom))
+        reps = [{m: coeff_map[c] for m, c in rep.items()} for rep in reps]
+    
+    _ring = PolyRing(opt.gens, opt.domain, opt.order)
+    polys = list(map(_ring.from_dict, reps))
+    
+    if single: return (_ring, polys[0])
+    return (_ring, polys)
 
 def _parse_symbols(
     symbols: str | Expr | Sequence[str] | Sequence[Expr],

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -24,6 +24,8 @@ from sympy.core.expr import Expr
 from sympy.core.intfunc import igcd
 from sympy.core.symbol import Symbol, symbols as _symbols
 from sympy.core.sympify import CantSympify, sympify
+from sympy.core.numbers import Number
+from sympy.core.sorting import default_sort_key
 from sympy.ntheory.multinomial import multinomial_coefficients
 from sympy.polys.compatibility import IPolys
 from sympy.polys.constructor import construct_domain
@@ -40,6 +42,7 @@ from sympy.polys.polyerrors import (
     GeneratorsError,
     ExactQuotientFailed,
     MultivariatePolynomialError,
+    BasePolynomialError
 )
 from sympy.polys.polyoptions import (
     Domain as DomainOpt,
@@ -204,20 +207,35 @@ def sring(exprs, *symbols, **options):
 
     exprs = list(map(sympify, exprs))
     opt = build_options(symbols, options)
+    opt_fast = opt.clone()
+    try:
+        if not opt_fast.gens:
+            symbols = set()
+            for expr in exprs:
+                symbols.update(expr.free_symbols)
+            opt_fast.gens = tuple(sorted(symbols, key=default_sort_key))
 
-    # TODO: rewrite this so that it doesn't use expand() (see poly()).
-    reps, opt = _parallel_dict_from_expr(exprs, opt)
+        if opt_fast.domain is None:
+            numbers = []
+            for expr in exprs:
+                numbers.extend(expr.atoms(Number))
+            opt_fast.domain, coeffs_dom = construct_domain(numbers, opt=opt_fast)
 
-    if opt.domain is None:
-        coeffs = sum([list(rep.values()) for rep in reps], [])
+        _ring = PolyRing(opt_fast.gens, opt_fast.domain, opt_fast.order)
+        polys = [_ring.from_expr(expr) for expr in exprs]
+    except (ValueError, BasePolynomialError, NotImplementedError):
+        reps, opt = _parallel_dict_from_expr(exprs, opt)
 
-        opt.domain, coeffs_dom = construct_domain(coeffs, opt=opt)
+        if opt.domain is None:
+            coeffs = sum([list(rep.values()) for rep in reps], [])
 
-        coeff_map = dict(zip(coeffs, coeffs_dom))
-        reps = [{m: coeff_map[c] for m, c in rep.items()} for rep in reps]
+            opt.domain, coeffs_dom = construct_domain(coeffs, opt=opt)
 
-    _ring = PolyRing(opt.gens, opt.domain, opt.order)
-    polys = list(map(_ring.from_dict, reps))
+            coeff_map = dict(zip(coeffs, coeffs_dom))
+            reps = [{m: coeff_map[c] for m, c in rep.items()} for rep in reps]
+
+        _ring = PolyRing(opt.gens, opt.domain, opt.order)
+        polys = list(map(_ring.from_dict, reps))
 
     if single:
         return (_ring, polys[0])

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3524,7 +3524,7 @@ def test_cancel():
     # issue 7022
     A = Symbol('A', commutative=False)
     p1 = Piecewise((A*(x**2 - 1)/(x + 1), x > 1), ((x + 2)/(x**2 + 2*x), True))
-    p2 = Piecewise((A*(x - 1), x > 1), (1/x, True))
+    p2 = Piecewise((A*x - A, x > 1), (1/x, True))
     assert cancel(p1) == p2
     assert cancel(2*p1) == 2*p2
     assert cancel(1 + p1) == 1 + p2

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3524,7 +3524,7 @@ def test_cancel():
     # issue 7022
     A = Symbol('A', commutative=False)
     p1 = Piecewise((A*(x**2 - 1)/(x + 1), x > 1), ((x + 2)/(x**2 + 2*x), True))
-    p2 = Piecewise((A*x - A, x > 1), (1/x, True))
+    p2 = Piecewise((A*(x - 1), x > 1), (1/x, True))
     assert cancel(p1) == p2
     assert cancel(2*p1) == 2*p2
     assert cancel(1 + p1) == 1 + p2
@@ -4264,3 +4264,28 @@ def test_schur_conditions():
 
     assert any(c <= 0 for c in p6.set_domain(QQ).schur_conditions())
     assert any(c <= 0 for c in p6.set_domain(EXRAW).schur_conditions())
+
+
+def test_cancel_noncommutative():
+    x, y = symbols('x y') 
+    A = symbols('A', commutative=False)
+    B = symbols('B', commutative=False)
+    
+    expr1 = A * (x**2 - 1)/(x + 1) * B
+    assert cancel(expr1) == (x - 1) * A * B
+    
+    expr2 = (x**2 - 1)/(x + 1) * A * B
+    expr3 = (x**2 - 1)/(x + 1) * B * A
+    assert cancel(expr2) == (x - 1) * A * B
+    assert cancel(expr3) == (x - 1) * B * A
+    
+    # 3. Two scalar variables
+    expr4 = A * (x**2 - y**2)/(x + y) * B
+    # Note: Depending on canonicalization, y*A*B might be A*B*y. 
+    # Just ensure coeff is correct and A is left of B.
+    res4 = cancel(expr4)
+    assert res4 == (x - y) * A * B
+
+    # 4. False Cancellation (Safety check)
+    expr5 = (A**2 - B**2)/(A + B)
+    assert cancel(expr5) == expr5 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -4267,25 +4267,23 @@ def test_schur_conditions():
 
 
 def test_cancel_noncommutative():
-    x, y = symbols('x y') 
+    x, y = symbols('x y')
     A = symbols('A', commutative=False)
     B = symbols('B', commutative=False)
-    
+
     expr1 = A * (x**2 - 1)/(x + 1) * B
     assert cancel(expr1) == (x - 1) * A * B
-    
+
     expr2 = (x**2 - 1)/(x + 1) * A * B
     expr3 = (x**2 - 1)/(x + 1) * B * A
     assert cancel(expr2) == (x - 1) * A * B
     assert cancel(expr3) == (x - 1) * B * A
-    
+
     # 3. Two scalar variables
     expr4 = A * (x**2 - y**2)/(x + y) * B
-    # Note: Depending on canonicalization, y*A*B might be A*B*y. 
-    # Just ensure coeff is correct and A is left of B.
     res4 = cancel(expr4)
     assert res4 == (x - y) * A * B
 
     # 4. False Cancellation (Safety check)
     expr5 = (A**2 - B**2)/(A + B)
-    assert cancel(expr5) == expr5 
+    assert cancel(expr5) == expr5

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1932,7 +1932,7 @@ class NthOrderReducible(SingleODESolver):
     >>> eq = Eq(x*f(x).diff(x)**2 + f(x).diff(x, 2), 0)
     >>> dsolve(eq, f(x), hint='nth_order_reducible')
     ... # doctest: +NORMALIZE_WHITESPACE
-    Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
+    Eq(f(x), C1 + sqrt(1/C2)*log(-C2*sqrt(1/C2) + x) - sqrt(1/C2)*log(C2*sqrt(1/C2) + x))
 
     """
     hint = "nth_order_reducible"

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -523,7 +523,7 @@ def test_solve_ics():
         {Eq(f(x), 0), Eq(f(x), C2*x + x**3/6)}
 
     K, r, f0 = symbols('K r f0')
-    sol = Eq(f(x), K*f0*exp(r*x)/((-K + f0)*(f0*exp(r*x)/(-K + f0) - 1)))
+    sol = Eq(f(x), -K*f0*exp(r*x)/((K - f0)*(-f0*exp(r*x)/(K - f0) - 1)))
     assert (dsolve(Eq(f(x).diff(x), r * f(x) * (1 - f(x) / K)), f(x), ics={f(0): f0})) == sol
 
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1316,8 +1316,8 @@ def _get_examples_ode_sol_nth_order_reducible():
             'examples':{
     'reducible_01': {
         'eq': Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2), 0),
-        'sol': [Eq(f(x),C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) +
-        sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))],
+        'sol': [Eq(f(x),C1 + sqrt(1/C2)*log(-C2*sqrt(-1/C2) + x) -
+        sqrt(1/C2)*log(C2*sqrt(-1/C2) + x))],
         'slow': True,
     },
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Add tests for checking fidelity between Density objects and removed the TODO: test for invalid arguments

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
