### PR TITLE
combinatorics: Implement Stallings foldings for `FpSubgroup.__contains__`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -444,6 +444,7 @@ Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>
+Boris Bilich <bilichboris1999@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
 Boris Timokhin <qoqenator@gmail.com>
 Bradley Dowling <34559056+btdow@users.noreply.github.com>

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -16,6 +16,7 @@ from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
 from sympy.utilities.magic import pollute
 
+from collections import defaultdict
 from itertools import product
 
 
@@ -565,116 +566,105 @@ class FpSubgroup(DefaultPrinting):
         self.normal = normal
 
     def __contains__(self, g):
+        '''
+        When parent is a FreeGroup, use Stallings folding algorithm described
+        in detail in [1].
+
+        References
+        ==========
+
+        .. [1] Kapovich, I., Myasnikov, A. (2002).
+        Stallings foldings and the subgroup structure of free groups.
+        arXiv preprint math/0202285.
+        '''
 
         if isinstance(self.parent, FreeGroup):
-            if self._min_words is None:
-                # make _min_words - a list of subwords such that
-                # g is in the subgroup if and only if it can be
-                # partitioned into these subwords. Infinite families of
-                # subwords are presented by tuples, e.g. (r, w)
-                # stands for the family of subwords r*w**n*r**-1
+            def _inverse_label(label):
+                return -label
 
-                def _process(w):
-                    # this is to be used before adding new words
-                    # into _min_words; if the word w is not cyclically
-                    # reduced, it will generate an infinite family of
-                    # subwords so should be written as a tuple;
-                    # if it is, w**-1 should be added to the list
-                    # as well
-                    p, r = w.cyclic_reduction(removed=True)
-                    if not r.is_identity:
-                        return [(r, p)]
+            def _add_edge(graph, u, v, label):
+                graph[u][label].add(v)
+                graph[v][_inverse_label(label)].add(u)
+
+            def _add_generator_loop(graph, base, word, next_vertex_id):
+                current = base
+                letters = word.letter_form
+                if not letters:
+                    return next_vertex_id
+                for i, label in enumerate(letters):
+                    if i == len(letters) - 1:
+                        nxt = base
                     else:
-                        return [w, w**-1]
+                        nxt = next_vertex_id
+                        next_vertex_id += 1
+                    _add_edge(graph, current, nxt, label)
+                    current = nxt
+                return next_vertex_id
 
-                # make the initial list
-                gens = []
-                for w in self.generators:
-                    if self.normal:
-                        w = w.cyclic_reduction()
-                    gens.extend(_process(w))
+            def _merge_vertices(graph, u, v):
+                if u == v:
+                    return
+                nodes = list(graph.keys())
+                for node in nodes:
+                    if node == v:
+                        for label, targets in list(graph[v].items()):
+                            for target in list(targets):
+                                if target == v:
+                                    target = u
+                                _add_edge(graph, u, target, label)
+                        if v in graph:
+                            del graph[v]
+                    else:
+                        for label, targets in list(graph[node].items()):
+                            if v in targets:
+                                targets.discard(v)
+                                targets.add(u)
+                                _add_edge(graph, node, u, label)
 
-                for w1 in gens:
-                    for w2 in gens:
-                        # if w1 and w2 are equal or are inverses, continue
-                        if w1 == w2 or (not isinstance(w1, tuple)
-                                                        and w1**-1 == w2):
-                            continue
+            def _fold(graph):
+                folded = False
+                while not folded:
+                    folded = True
+                    for u in list(graph.keys()):
+                        for label, targets in list(graph[u].items()):
+                            if len(targets) > 1:
+                                v1, v2 = sorted(targets)[:2]
+                                keep = min(v1, v2)
+                                discard = max(v1, v2)
+                                _merge_vertices(graph, keep, discard)
+                                folded = False
+                                break
+                        if not folded:
+                            break
 
-                        # if the start of one word is the inverse of the
-                        # end of the other, their multiple should be added
-                        # to _min_words because of cancellation
-                        if isinstance(w1, tuple):
-                            # start, end
-                            s1, s2 = w1[0][0], w1[0][0]**-1
-                        else:
-                            s1, s2 = w1[0], w1[len(w1)-1]
+            def _check_membership(graph, base, word):
+                current = base
+                for label in word.letter_form:
+                    targets = graph[current].get(label)
+                    if not targets:
+                        return False
+                    current = next(iter(targets))
+                return current == base
 
-                        if isinstance(w2, tuple):
-                            # start, end
-                            r1, r2 = w2[0][0], w2[0][0]**-1
-                        else:
-                            r1, r2 = w2[0], w2[len(w1)-1]
-
-                        # p1 and p2 are w1 and w2 or, in case when
-                        # w1 or w2 is an infinite family, a representative
-                        p1, p2 = w1, w2
-                        if isinstance(w1, tuple):
-                            p1 = w1[0]*w1[1]*w1[0]**-1
-                        if isinstance(w2, tuple):
-                            p2 = w2[0]*w2[1]*w2[0]**-1
-
-                        # add the product of the words to the list is necessary
-                        if r1**-1 == s2 and not (p1*p2).is_identity:
-                            new = _process(p1*p2)
-                            if new not in gens:
-                                gens.extend(new)
-
-                        if r2**-1 == s1 and not (p2*p1).is_identity:
-                            new = _process(p2*p1)
-                            if new not in gens:
-                                gens.extend(new)
-
-                self._min_words = gens
-
-            min_words = self._min_words
-
-            def _is_subword(w):
-                # check if w is a word in _min_words or one of
-                # the infinite families in it
-                w, r = w.cyclic_reduction(removed=True)
-                if r.is_identity or self.normal:
-                    return w in min_words
-                else:
-                    t = [s[1] for s in min_words if isinstance(s, tuple)
-                                                                and s[0] == r]
-                    return [s for s in t if w.power_of(s)] != []
-
-            # store the solution of words for which the result of
-            # _word_break (below) is known
-            known = {}
-
-            def _word_break(w):
-                # check if w can be written as a product of words
-                # in min_words
-                if len(w) == 0:
-                    return True
-                i = 0
-                while i < len(w):
-                    i += 1
-                    prefix = w.subword(0, i)
-                    if not _is_subword(prefix):
-                        continue
-                    rest = w.subword(i, len(w))
-                    if rest not in known:
-                        known[rest] = _word_break(rest)
-                    if known[rest]:
-                        return True
-                return False
+            graph = defaultdict(lambda: defaultdict(set))
+            base_vertex = 0
+            next_vertex_id = 1
 
             if self.normal:
+                # TODO: this is wrong in general and there is no algorithm for
+                # all normal subgroups. There is an algorithm for normal
+                # subgroups of finite index and it should be implemented here.
+                gens = [w.cyclic_reduction() for w in self.generators]
                 g = g.cyclic_reduction()
-            return _word_break(g)
+            else:
+                gens = list(self.generators)
+
+            for gen in gens:
+                next_vertex_id = _add_generator_loop(
+                    graph, base_vertex, gen, next_vertex_id)
+
+            _fold(graph)
+            return _check_membership(graph, base_vertex, g)
         else:
             if self.C is None:
                 C = self.parent.coset_enumeration(self.generators)

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -195,6 +195,21 @@ def test_fp_subgroup():
     S = FpSubgroup(f, H)
     _test_subgroup(K, T, S)
 
+    F, x, y = free_group("x, y")
+    H = FpSubgroup(F, [x*y, x])
+    assert x in H
+
+    F, a, b, c = free_group("a, b, c")
+    w1 = a*b
+    w2 = b**-1 * c * b
+    w3 = b**-1 * c**-1
+    H = FpSubgroup(F, [w1, w2, w3])
+    assert a in H
+
+    F, a, b = free_group("a, b")
+    H = FpSubgroup(F, [b])
+    assert not (a in H)
+
 def test_permutation_methods():
     F, x, y = free_group("x, y")
     # DihedralGroup(8)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Follows discussion in #28994

#### Brief description of what is fixed or changed
This PR completely rewrites `FpSubgroup.__contains__` to use the Stallings foldings algorithm for determining subgroup membership in free groups.

The previous implementation relied on a heuristic involving word breaking and infinite families of subwords (_process and _word_break), which was incorrect for many cases. It failed to correctly identify membership when generators involved cancellations that were not simple subword partitions (e.g., the counter-example discussed in the thread involving a*b, b**-1*c*b, b**-1*c**-1).

The new implementation:

Constructs a labeled directed graph (Stallings graph) representing the subgroup generators.

Iteratively "folds" the graph by merging edges with the same start vertex and label until the graph is deterministic.

Checks membership by tracing the candidate word in the folded graph starting from the base vertex.

#### References

The implementation is based on the algorithm detailed in:

Kapovich, I., Myasnikov, A. (2002). Stallings foldings and the subgroup structure of free groups. arXiv preprint math/0202285.

#### Other comments

The implementation is currently incomplete for normal subgroups. There is no general deciding procedure for finitely generated normal subgroups, but there is one for normal subgroups of finite index.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Rewrote `FpSubgroup.__contains__` using the Stallings foldings algorithm to correctly handle subgroup membership testing in free groups.
<!-- END RELEASE NOTES -->
