### PR TITLE
Fix boundary check in `Permutation.__call__` method

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -444,6 +444,7 @@ Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>
+Boris Bilich <bilichboris1999@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
 Boris Timokhin <qoqenator@gmail.com>
 Bradley Dowling <34559056+btdow@users.noreply.github.com>

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1653,7 +1653,7 @@ class Permutation(Atom):
             i = i[0]
             if not isinstance(i, Iterable):
                 i = as_int(i)
-                if i < 0 or i > self.size:
+                if i < 0 or i >= self.size:
                     raise TypeError(
                         "{} should be an integer between 0 and {}"
                         .format(i, self.size-1))

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -631,7 +631,7 @@ class Permutation(Atom):
     >>> Permutation(1, 2)(3)
     Traceback (most recent call last):
     ...
-    IndexError: list index out of range
+    TypeError: 3 should be an integer between 0 and 2
 
     This is ok: only the call to an out of range singleton is prohibited;
     otherwise the permutation autosizes:

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -28,6 +28,7 @@ def test_Permutation():
     assert list(p(1, 2)) == [0, 2, 1, 3]
     raises(TypeError, lambda: p(-1))
     raises(TypeError, lambda: p(5))
+    raises(TypeError, lambda: p(4))
     # conversion to list
     assert list(p) == list(range(4))
     assert p.copy() == p


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR fixes an off-by-one error in `Permutation.__call__` when applying a permutation to an integer index. Previously, the bounds check used `i > self.size`, which incorrectly permitted `i == self.size` and resulted in an `IndexError` from list indexing. The check is corrected to `i >= self.size` so out-of-range indices consistently raise `TypeError` as intended.

A regression test is added to ensure that calling a permutation with `i == size` raises `TypeError`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed an off-by-one error in `Permutation.__call__` so that applying a permutation to an index equal to its size raises `TypeError` instead of `IndexError`.
<!-- END RELEASE NOTES -->
