### PR TITLE
Fix nonlinsolve returning wrong results with floor/ceiling

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3615,11 +3615,11 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         continue
                     if isinstance(soln, ConditionSet):
                         if soln.base_set in (S.Reals, S.Complexes):
-                            soln = S.EmptySet
-                            # don't do `continue` we may get soln
-                            # in terms of other symbol(s)
-                            not_solvable = True
-                            total_conditionst += 1
+                            raise NotImplementedError(
+                                f"Cannot solve {eq2} for {sym} - got ConditionSet. "
+                                f"Functions like floor/ceiling/sign can only filter solutions, "
+                                f"not be solved standalone."
+                            )
                         else:
                             soln = soln.base_set
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -15,6 +15,7 @@ from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
     sinh, cosh, tanh, coth, sech, csch, asinh, acosh, atanh, acoth, asech, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
+from sympy.functions import floor, ceiling
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
     TrigonometricFunction, acos, acot, acsc, asec, asin, atan, atan2,
@@ -1878,6 +1879,15 @@ def test_nonlinsolve_sign():
     result = nonlinsolve([sign(x) - 1], [x])
     assert isinstance(result, FiniteSet)
 
+
+def test_nonlinsolve_floor_ceiling():
+    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - 2*x], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 3, y - x - 1], [x, y]))
+    result1 = nonlinsolve([floor(x) - 5], [x])
+    assert isinstance(result1, FiniteSet)
+    result2 = nonlinsolve([ceiling(x) - 3], [x])
+    assert isinstance(result2, FiniteSet)
 
 def test_raise_exception_nonlinsolve():
     raises(IndexError, lambda: nonlinsolve([x**2 -1], []))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1889,6 +1889,7 @@ def test_nonlinsolve_floor_ceiling():
     result2 = nonlinsolve([ceiling(x) - 3], [x])
     assert isinstance(result2, FiniteSet)
 
+
 def test_raise_exception_nonlinsolve():
     raises(IndexError, lambda: nonlinsolve([x**2 -1], []))
     raises(ValueError, lambda: nonlinsolve([x**2 -1]))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29007 

#### Brief description of what is fixed or changed
nonlinsolve previously ignored `ConditionSet` constraints for real/complex base sets, causing incorrect results for systems with floor , ceiling, or sign. This PR fixes the issue by raising `NotImplementedError` in such cases instead of returning invalid solutions.
```python
On running this:-  nonlinsolve([ceiling(x) - 3, y - x - 1], [x, y])
before:- {(y-1,y)}
after:- NotImplementedError
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * nonlinsolve now consistently raises `NotImplementedError` instead of returning incorrect results when it encounters `ConditionSet` (e.g., in systems involving floor, ceiling, or sign.
<!-- END RELEASE NOTES -->