### PR TITLE
Fix `PermutationGroup` crash with multiple identities and `dups=False`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -444,6 +444,7 @@ Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>
+Boris Bilich <bilichboris1999@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
 Boris Timokhin <qoqenator@gmail.com>
 Bradley Dowling <34559056+btdow@users.noreply.github.com>

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -143,7 +143,8 @@ class PermutationGroup(Basic):
         if dups:
             args = list(uniq([_af_new(list(a)) for a in args]))
         if len(args) > 1:
-            args = [g for g in args if not g.is_identity]
+            non_identity = [g for g in args if not g.is_identity]
+            args = non_identity if non_identity else [args[0]]
         return Basic.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -67,6 +67,14 @@ def test_order():
     assert PermutationGroup().order() == 1
 
 
+def test_identity_generators_dups_false():
+    identity = Permutation(3)
+    G = PermutationGroup(identity, identity, dups=False)
+    assert len(G.generators) == 1
+    assert G.generators[0].is_identity
+    assert G.order() == 1
+
+
 def test_equality():
     p_1 = Permutation(0, 1, 3)
     p_2 = Permutation(0, 2, 3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This PR fixes a bug in `PermutationGroup.__new__`. When initializing a `PermutationGroup` with multiple identity permutations and `dups=False`, the previous logic removed *all* identity elements if the number of arguments was greater than 1. This resulted in an empty `args` list being passed to `__init__`, causing an `IndexError: list index out of range` when attempting to access `self._generators[0]` to determine the degree.

The fix ensures that if the filtering process removes all generators (because they were all identity permutations), at least one identity permutation is retained, allowing the trivial group to be created successfully.

A regression test `test_identity_generators_dups_false` has been added to `sympy/combinatorics/tests/test_perm_groups.py`.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* combinatorics
  * Fixed `PermutationGroup` initialization to correctly handle multiple identity generators when `dups=False`.

<!-- END RELEASE NOTES -->
