### PR TITLE
Add: Added a variable to display all old assumptions.

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -3,7 +3,8 @@
 
 from .sympify import sympify, SympifyError
 from .cache import cacheit
-from .assumptions import assumptions, check_assumptions, failing_assumptions, common_assumptions, all_assumptions
+from .assumptions import (assumptions, check_assumptions, failing_assumptions, 
+                          common_assumptions, all_assumptions)
 from .basic import Basic, Atom
 from .singleton import S
 from .expr import Expr, AtomicExpr, UnevaluatedExpr

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -3,7 +3,7 @@
 
 from .sympify import sympify, SympifyError
 from .cache import cacheit
-from .assumptions import assumptions, check_assumptions, failing_assumptions, common_assumptions
+from .assumptions import assumptions, check_assumptions, failing_assumptions, common_assumptions, all_assumptions
 from .basic import Basic, Atom
 from .singleton import S
 from .expr import Expr, AtomicExpr, UnevaluatedExpr
@@ -45,7 +45,7 @@ __all__ = [
     'cacheit',
 
     'assumptions', 'check_assumptions', 'failing_assumptions',
-    'common_assumptions',
+    'common_assumptions', 'all_assumptions',
 
     'Basic', 'Atom',
 

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -3,7 +3,7 @@
 
 from .sympify import sympify, SympifyError
 from .cache import cacheit
-from .assumptions import (assumptions, check_assumptions, failing_assumptions, 
+from .assumptions import (assumptions, check_assumptions, failing_assumptions,
                           common_assumptions, all_assumptions)
 from .basic import Basic, Atom
 from .singleton import S

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -292,7 +292,7 @@ _assume_rules = _load_pre_generated_assumption_rules()
 _assume_defined = _assume_rules.defined_facts.copy()
 _assume_defined.add('polar')
 _assume_defined = frozenset(_assume_defined)
-
+all_assumptions = _assume_defined
 
 def assumptions(expr, _check=None):
     """return the T/F assumptions of ``expr``"""

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -155,6 +155,20 @@ can be obtained as follows:
     False, 'prime': False, 'rational': False, 'real': False, 'zero':
     False}
 
+To access the set of all defined assumption names, you can use ``all_assumptions``
+which can be obtained as follows:
+
+    >>> from sympy.core import all_assumptions
+    >>> 'real' in all_assumptions
+    True
+    >>> all_assumptions
+    frozenset({'negative', 'zero', 'commutative', 'extended_real',
+    'real', 'infinite', 'algebraic', 'complex', 'even', 'polar',
+    'imaginary', 'composite', 'finite', 'extended_negative', 'positive',
+    'extended_nonnegative', 'nonpositive', 'extended_nonpositive', 'odd',
+    'nonzero', 'noninteger', 'integer', 'irrational', 'nonnegative', 'rational',
+    'extended_positive', 'transcendental', 'prime', 'extended_nonzero'})
+
 Developers Notes
 ================
 
@@ -293,6 +307,7 @@ _assume_defined = _assume_rules.defined_facts.copy()
 _assume_defined.add('polar')
 _assume_defined = frozenset(_assume_defined)
 all_assumptions = _assume_defined
+
 
 def assumptions(expr, _check=None):
     """return the T/F assumptions of ``expr``"""

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -159,15 +159,15 @@ To access the set of all defined assumption names, you can use ``all_assumptions
 which can be obtained as follows:
 
     >>> from sympy.core import all_assumptions
+    >>> all_assumptions
+    frozenset({'algebraic', 'commutative', 'complex', 'composite', 'even',
+    'extended_negative', 'extended_nonnegative', 'extended_nonpositive',
+    'extended_nonzero', 'extended_positive', 'extended_real', 'finite', 'imaginary',
+    'infinite', 'integer', 'irrational', 'negative', 'noninteger', 'nonnegative',
+    'nonpositive', 'nonzero', 'odd', 'polar', 'positive', 'prime', 'rational',
+    'real', 'transcendental', 'zero'})
     >>> 'real' in all_assumptions
     True
-    >>> all_assumptions
-    frozenset({'negative', 'zero', 'commutative', 'extended_real',
-    'real', 'infinite', 'algebraic', 'complex', 'even', 'polar',
-    'imaginary', 'composite', 'finite', 'extended_negative', 'positive',
-    'extended_nonnegative', 'nonpositive', 'extended_nonpositive', 'odd',
-    'nonzero', 'noninteger', 'integer', 'irrational', 'nonnegative', 'rational',
-    'extended_positive', 'transcendental', 'prime', 'extended_nonzero'})
 
 Developers Notes
 ================


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes: #11539

#### Brief description of what is fixed or changed
Added a non private variable displaying all old assumptions in `core/assumptions.py`. It just takes the value from `_assume_defined` a private variable.

```python
from sympy.core import all_assumptions
print(all_assumptions) 
 # frozenset({'extended_nonnegative', 'composite', 'transcendental', 'infinite', 'polar', 'extended_nonzero', 'complex', 'imaginary', 'zero', 'nonpositive', 'finite', 'nonnegative', 'extended_positive', 'extended_nonpositive', 'odd', 'irrational', 'real', 'commutative', 'extended_negative', 'integer', 'rational', 'noninteger', 'nonzero', 'extended_real', 'positive', 'algebraic', 'prime', 'negative', 'even'})
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Added a non private variable (`all_assumptions`) that exposes the full list of asumptions predicates in the core assumptions.
<!-- END RELEASE NOTES -->
