### PR TITLE
Fixed iteration bug in MarginalDistribution.pdf

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1669,6 +1669,7 @@ Victor Immanuel <chrollolucilfer1402@gmail.com> victor immanuel <89346667+victor
 Victoria Koval <bictoriakoval16@gmail.com> vicoolchik <bictoriakoval16@gmail.com>
 Victoria Koval <bictoriakoval16@gmail.com> viktoria_koval <78905683+vicoolchik@users.noreply.github.com>
 Victory Omole <vtomole2@gmail.com>
+Vidhi Singh <vidhiii0909@gmail.com>
 Vighnesh Shenoy <vighneshq@gmail.com>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijair <vijair@umich.edu>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijairam20 <vijairamg@gmail.com>

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -389,7 +389,7 @@ class MarginalDistribution(Distribution):
         if isinstance(expr, JointDistribution):
             count = len(expr.domain.args)
             x = Dummy('x', real=True)
-            syms = tuple(Indexed(x, i) for i in count)
+            syms = tuple(Indexed(x, i) for i in range(count))
             expr = expr.pdf(syms)
         else:
             syms = tuple(rv.pspace.symbol if isinstance(rv, RandomSymbol) else rv.args[0] for rv in rvs)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -440,5 +440,14 @@ def test_issue_20286():
     assert eq.dummy_eq(H(B))
 
 def test_marginal_distribution_pdf_joint():
+    from sympy import simplify
     X = Normal('X', 0, 1)
-    assert density(X).pdf(0) is not None
+    Y = Normal('Y', 0, 1)
+
+    joint = density(X, Y)
+
+    marginal_X = joint.pdf(0, 0).integrate((Y, -oo, oo))
+
+    expected = density(X).pdf(0)
+
+    assert simplify(marginal_X - expected) == 0

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -15,8 +15,8 @@ from sympy.logic.boolalg import (And, Or)
 from sympy.matrices.dense import Matrix
 from sympy.sets.sets import Interval
 from sympy.tensor.indexed import Indexed
-from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
-        density, given, independent, dependent, where, pspace, GaussianUnitaryEnsemble,
+from sympy.stats import (Die,Normal, Exponential, FiniteRV, P, E, H, variance,density,
+         given, independent, dependent, where, pspace, GaussianUnitaryEnsemble,
         random_symbols, sample, Geometric, factorial_moment, Binomial, Hypergeometric,
         DiscreteUniform, Poisson, characteristic_function, moment_generating_function,
         BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance, cmoment,
@@ -438,3 +438,7 @@ def test_issue_20286():
     k = Dummy('k', integer = True)
     eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
     assert eq.dummy_eq(H(B))
+
+def test_marginal_distribution_pdf_joint():
+    X = Normal('X', 0, 1)
+    assert density(X).pdf(0) is not None


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
### References to other Issues or PRs

Fixes #15859

### Brief description of what is fixed or changed

The marginal distribution of a joint PDF did not iterate correctly, leading to incorrect results in certain cases when computing marginal PDFs from joint distributions.

This PR fixes the iteration logic used in MarginalDistribution.pdf and adds a regression test to ensure correct behavior when marginalizing joint probability density functions.

### Other comments

N/A

### Release Notes

* stats
  * Fixed incorrect marginal PDF computation for joint distributions.

<!-- END RELEASE NOTES -->
