### PR TITLE
Fix interval return type in `RecursiveSeq`

### DIFF
--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -896,7 +896,7 @@ class RecursiveSeq(SeqBase):
     @property
     def interval(self):
         """Interval on which sequence is defined."""
-        return (self.start, S.Infinity)
+        return Interval(self.start, S.Infinity)
 
     def _eval_coeff(self, index):
         if index - self.start < len(self.cache):

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -310,3 +310,4 @@ def test_RecursiveSeq():
     n = Symbol('n')
     fib = RecursiveSeq(y(n - 1) + y(n - 2), y(n), n, [0, 1])
     assert fib.coeff(3) == 2
+    assert (fib + fib).coeff(3) == 4


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`RecursiveSeq.interval` was a tuple instead of `Interval`. This made the following elementary snippet to raise `TypeError`:

```python
import sympy as sp
from sympy.series.sequences import RecursiveSeq

y = sp.Function('y')
n = sp.Symbol('n')
fib = RecursiveSeq(y(n-1) + y(n-2), y(n), n, [0, 1])
fibs = fib + fib
```
Fixed the interval definition.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* series
  * Fixed the type of `RecursiveSeq.interval`

<!-- END RELEASE NOTES -->
