### PR TITLE
Fix logic error in geometry validation checks

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -201,7 +201,7 @@ class LinearEntity(GeometrySet):
         >>> l1.smallest_angle_between(l2)
         acos(sqrt(2)/3)
         """
-        if not isinstance(l1, LinearEntity) and not isinstance(l2, LinearEntity):
+        if not isinstance(l1, LinearEntity) or not isinstance(l2, LinearEntity):
             raise TypeError('Must pass only LinearEntity objects')
 
         v1, v2 = l1.direction, l2.direction
@@ -236,7 +236,7 @@ class LinearEntity(GeometrySet):
 
         angle_between, is_perpendicular, Ray2D.closing_angle
         """
-        if not isinstance(l1, LinearEntity) and not isinstance(l2, LinearEntity):
+        if not isinstance(l1, LinearEntity) or not isinstance(l2, LinearEntity):
             raise TypeError('Must pass only LinearEntity objects')
 
         v1, v2 = l1.direction, l2.direction
@@ -613,7 +613,7 @@ class LinearEntity(GeometrySet):
         False
 
         """
-        if not isinstance(l1, LinearEntity) and not isinstance(l2, LinearEntity):
+        if not isinstance(l1, LinearEntity) or not isinstance(l2, LinearEntity):
             raise TypeError('Must pass only LinearEntity objects')
 
         return l1.direction.is_scalar_multiple(l2.direction)
@@ -661,7 +661,7 @@ class LinearEntity(GeometrySet):
         False
 
         """
-        if not isinstance(l1, LinearEntity) and not isinstance(l2, LinearEntity):
+        if not isinstance(l1, LinearEntity) or not isinstance(l2, LinearEntity):
             raise TypeError('Must pass only LinearEntity objects')
 
         return S.Zero.equals(l1.direction.dot(l2.direction))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -678,6 +678,24 @@ def test_is_perpendicular():
                                    Line3D(Point3D(x1, x1, x1), Point3D(y1, y1, y1))) is False
 
 
+def test_validation_for_linear_entity_methods():
+    p1 = Point(0, 0)
+    p2 = Point(1, 1)
+    l1 = Line(p1, p2)
+
+    raises(TypeError, lambda: Line.is_parallel(p1, l1))
+    raises(TypeError, lambda: Line.is_parallel(l1, p1))
+
+    raises(TypeError, lambda: Line.is_perpendicular(p1, l1))
+    raises(TypeError, lambda: Line.is_perpendicular(l1, p1))
+
+    raises(TypeError, lambda: Line.angle_between(p1, l1))
+    raises(TypeError, lambda: Line.angle_between(l1, p1))
+
+    raises(TypeError, lambda: Line.smallest_angle_between(p1, l1))
+    raises(TypeError, lambda: Line.smallest_angle_between(l1, p1))
+
+
 def test_is_similar():
     p1 = Point(2000, 2000)
     p2 = p1.scale(2, 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29031 


#### Brief description of what is fixed or changed
Passed an invalid argument (like a `Point` object) to `Line.is_parallel` causes an `AttributeError` crash instead of raising a proper `TypeError`.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fixed `Line.is_parallel`, `Line.is_perpendicular`, `Line.angle_between`, and `Line.smallest_angle_between` raising `AttributeError` instead of `TypeError` when passed invalid arguments.
<!-- END RELEASE NOTES -->
