### PR TITLE
Ensure that a `FreeGroupElement` is stored in reduced form

### DIFF
--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -362,7 +362,11 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
                 array_form.append((-letter, -1))
         return _reduce_array_form(array_form)
 
-    def __new__(cls, init=(), *, reduced=False, boundary_index=None):
+    def __new__(cls, init=()):
+        return cls._new(init)
+
+    @classmethod
+    def _new(cls, init=(), *, reduced=False, boundary_index=None):
         if not init:
             return tuple.__new__(cls, ())
         if boundary_index is not None:
@@ -372,10 +376,11 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
             return tuple.__new__(cls, tuple(init))
         return tuple.__new__(cls, _reduce_array_form(init))
 
-    def new(self, init):
+    @classmethod
+    def new(cls, init):
         if isinstance(init, FreeGroupElement):
-            return self.__class__(init, reduced=True)
-        return self.__class__(init)
+            return cls._new(init, reduced=True)
+        return cls._new(init)
 
     _hash = None
 
@@ -553,7 +558,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         if other.is_identity:
             return self
         r = self.array_form + other.array_form
-        return group.dtype(r, boundary_index=len(self.array_form) - 1)
+        return group.dtype._new(r, boundary_index=len(self.array_form) - 1)
 
     def __truediv__(self, other):
         group = self.group
@@ -589,7 +594,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         """
         group = self.group
         r = tuple((i, -j) for i, j in self.array_form[::-1])
-        return group.dtype(r, reduced=True)
+        return group.dtype._new(r, reduced=True)
 
     def order(self):
         """Find the order of a ``FreeGroupElement``.
@@ -925,7 +930,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         else:
             letter_form = self.letter_form[from_i: to_j]
             array_form = self._array_form_from_letter_form(letter_form)
-            return group.dtype(array_form, reduced=True)
+            return group.dtype._new(array_form, reduced=True)
 
     def subword_index(self, word, start = 0):
         '''
@@ -1026,7 +1031,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         period2 = int(to_j/l) - 1
         word += letter_form*period2 + letter_form[:diff-l+from_i-l*period2]
         array_form = self._array_form_from_letter_form(word)
-        return group.dtype(array_form, reduced=True)
+        return group.dtype._new(array_form, reduced=True)
 
     def cyclic_conjugates(self):
         """Returns a words which are cyclic to the word `self`.

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -363,24 +363,19 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         return _reduce_array_form(array_form)
 
     def __new__(cls, init=()):
-        return cls._new(init)
-
-    @classmethod
-    def _new(cls, init=(), *, reduced=False, boundary_index=None):
-        if not init:
-            return tuple.__new__(cls, ())
-        if boundary_index is not None:
-            init = _reduce_array_form(init, boundary_index=boundary_index)
-            return tuple.__new__(cls, init)
-        if reduced:
-            return tuple.__new__(cls, tuple(init))
-        return tuple.__new__(cls, _reduce_array_form(init))
-
-    @classmethod
-    def new(cls, init):
         if isinstance(init, FreeGroupElement):
-            return cls._new(init, reduced=True)
-        return cls._new(init)
+            return cls._new(tuple(init))
+        return cls._new(_reduce_array_form(init))
+
+    @classmethod
+    def _new(cls, array_form=()):
+        return tuple.__new__(cls, array_form)
+
+    @classmethod
+    def _new_reduce_at_boundary(cls, array_form, boundary_index):
+        array_form = _reduce_array_form(array_form,
+                                        boundary_index=boundary_index)
+        return cls._new(array_form)
 
     _hash = None
 
@@ -391,7 +386,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         return _hash
 
     def copy(self):
-        return self.new(self)
+        return self._new(tuple(self))
 
     @property
     def is_identity(self):
@@ -558,7 +553,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         if other.is_identity:
             return self
         r = self.array_form + other.array_form
-        return group.dtype._new(r, boundary_index=len(self.array_form) - 1)
+        return group.dtype._new_reduce_at_boundary(r, len(self.array_form) - 1)
 
     def __truediv__(self, other):
         group = self.group
@@ -594,7 +589,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         """
         group = self.group
         r = tuple((i, -j) for i, j in self.array_form[::-1])
-        return group.dtype._new(r, reduced=True)
+        return group.dtype._new(r)
 
     def order(self):
         """Find the order of a ``FreeGroupElement``.
@@ -930,7 +925,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         else:
             letter_form = self.letter_form[from_i: to_j]
             array_form = self._array_form_from_letter_form(letter_form)
-            return group.dtype._new(array_form, reduced=True)
+            return group.dtype._new(array_form)
 
     def subword_index(self, word, start = 0):
         '''
@@ -1031,7 +1026,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         period2 = int(to_j/l) - 1
         word += letter_form*period2 + letter_form[:diff-l+from_i-l*period2]
         array_form = self._array_form_from_letter_form(word)
-        return group.dtype._new(array_form, reduced=True)
+        return group.dtype._new(array_form)
 
     def cyclic_conjugates(self):
         """Returns a words which are cyclic to the word `self`.

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -224,3 +224,10 @@ def test_FreeGroupElm_words():
 
     assert w.substituted_word(0, 7, y**-1) == y**-1*x*y**-4*x
     assert w.substituted_word(0, 7, y**2*x) == y**2*x**2*y**-4*x
+
+
+def test_FreeGroupElm_cyclic_subword_reduction():
+    _, x, y = free_group("x y")
+    w = x*y*x**-1
+    rot = w.cyclic_subword(1, 1 + len(w))
+    assert rot == y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR ensures that when an element of a free group is created, it is stored as a reduced word. Among other things, this makes `==` correspond to equality of group elements. 

Fixes #29020

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Ensure that a `FreeGroupElement` is stored in reduced form

<!-- END RELEASE NOTES -->
