### PR TITLE
SDM: Optimization for 1x3, 3x1, and 3x3 matrix multiplication in matmul function

### DIFF
--- a/sympy/physics/quantum/circuitutils.py
+++ b/sympy/physics/quantum/circuitutils.py
@@ -1,6 +1,6 @@
 """Primitive circuit operations on quantum circuits."""
 
-from functools import reduce
+from functools import reduce as _reduce
 
 from sympy.core.sorting import default_sort_key
 from sympy.core.containers import Tuple
@@ -483,6 +483,6 @@ def random_insert(circuit, choices, seed=None):
 def flatten_ids(ids):
     collapse = lambda acc, an_id: acc + sorted(an_id.equivalent_ids,
                                         key=default_sort_key)
-    ids = reduce(collapse, ids, [])
+    ids = _reduce(collapse, ids, [])
     ids.sort(key=default_sort_key)
     return ids

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -5,7 +5,7 @@ Authors:
 * Matt Curry
 """
 
-from functools import reduce
+from functools import reduce as _reduce
 
 from sympy.core.basic import Basic
 from sympy.core.singleton import S
@@ -383,7 +383,7 @@ class TensorProductHilbertSpace(HilbertSpace):
         if S.Infinity in arg_list:
             return S.Infinity
         else:
-            return reduce(lambda x, y: x*y, arg_list)
+            return _reduce(lambda x, y: x*y, arg_list)
 
     @property
     def spaces(self):
@@ -502,7 +502,7 @@ class DirectSumHilbertSpace(HilbertSpace):
         if S.Infinity in arg_list:
             return S.Infinity
         else:
-            return reduce(lambda x, y: x + y, arg_list)
+            return _reduce(lambda x, y: x + y, arg_list)
 
     @property
     def spaces(self):

--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -266,7 +266,6 @@ def test_fidelity():
     assert abs(fidelity(d1, d2) - 0.996) < 1e-3
     assert abs(fidelity(d1, d2) - fidelity(d2, d1)) < 1e-3
 
-    #TODO: test for invalid arguments
     # non-square matrix
     mat1 = [[0, 0],
             [0, 0],
@@ -287,3 +286,10 @@ def test_fidelity():
     # unsupported data-type
     x, y = 1, 2  # random values that is not a matrix
     raises(ValueError, lambda: fidelity(x, y))
+
+    # check density objs of different sizes
+    d1 = Density([Qubit('0'), 1])
+    d2 = Density([Qubit('00'), 1])
+    raises(ValueError, lambda: fidelity(d1, d2))
+
+    raises(ValueError, lambda: fidelity(d1, 123))

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -815,7 +815,74 @@ class SDM(dict):
             raise DMDomainError
         m, n = A.shape
         n2, o = B.shape
-        if n != n2:
+        K = A.domain
+        zero = K.zero
+        if m == 1 and n == 3 and n2 == 3 and o == 3:
+            C = {}
+            A_row = [A.get(0, {}).get(i, zero) for i in range(3)]
+            
+            for j in range(3):
+                val_b0 = B.get(0, {}).get(j, zero)
+                val_b1 = B.get(1, {}).get(j, zero)
+                val_b2 = B.get(2, {}).get(j, zero)
+
+                t1 = K.mul(A_row[0], val_b0)
+                t2 = K.mul(A_row[1], val_b1)
+                t3 = K.mul(A_row[2], val_b2)
+                
+                c = K.add(K.add(t1, t2), t3)
+                
+                if c != zero:
+                    C[j] = c
+
+            if not C:
+                return A.new({}, (m, o), A.domain)
+            return A.new({0: C}, (m, o), A.domain)
+
+        elif m == 3 and n == 3 and n2 == 3 and o == 1:
+            C = {}
+            B_col = [B.get(i, {}).get(0, zero) for i in range(3)]
+            
+            for j in range(3):
+                val_a0 = A.get(j, {}).get(0, zero)
+                val_a1 = A.get(j, {}).get(1, zero)
+                val_a2 = A.get(j, {}).get(2, zero)
+                t1 = K.mul(val_a0, B_col[0])
+                t2 = K.mul(val_a1, B_col[1])
+                t3 = K.mul(val_a2, B_col[2])
+                c = K.add(K.add(t1, t2), t3)
+                
+                if c != zero:
+                    C[j] = {0: c}
+
+            if not C:
+                return A.new({}, (m, o), A.domain)
+            return A.new({0: C}, (m, o), A.domain)
+        elif m == 3 and n == 3 and n2 == 3 and o == 3:
+            C = {}
+            
+            for i in range(3):
+                T = {}
+                A_row = [A.get(i, {}).get(k, zero) for k in range(3)]
+                
+                for j in range(3):
+                    val_b0 = B.get(0, {}).get(j, zero)
+                    val_b1 = B.get(1, {}).get(j, zero)
+                    val_b2 = B.get(2, {}).get(j, zero)
+                    t1 = K.mul(A_row[0], val_b0)
+                    t2 = K.mul(A_row[1], val_b1)
+                    t3 = K.mul(A_row[2], val_b2)
+                    c = K.add(K.add(t1, t2), t3)
+                    
+                    if c != zero:
+                        T[j] = c
+                
+                if T:
+                    C[i] = T
+            if not C:
+                return A.new({}, (m, o), A.domain)
+            return A.new({0: C}, (m, o), A.domain)       
+        elif n != n2:
             raise DMShapeError
         C = sdm_matmul(A, B, A.domain, m, o)
         return A.new(C, (m, o), A.domain)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
issue #28481

#### Brief description of what is fixed or changed
Added optimizations for 1x3, 3x1 and 3x3 matrix multiplications inside of matmul

#### Other comments
The changes achieve a 2x speedup in vector.dot calculations

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Optimized `SDM` matrix multiplication for small fixed sizes (1x3, 3x1, 3x3).
<!-- END RELEASE NOTES -->
