### PR TITLE
Fix how QR decomposition handles rank of matrix with symbols

### DIFF
--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1363,17 +1363,24 @@ def _QRdecomposition_optional(M, normalize=True):
 
     for j in range(A.cols):
         for i in range(j):
-            if Q[:, i].is_zero_matrix:
+            z = Q[:, i].is_zero_matrix
+            if z is True:
                 continue
 
-            R[i, j] = dot(Q[:, i], Q[:, j]) / dot(Q[:, i], Q[:, i])
+            norm = dps(dot(Q[:, i], Q[:, i]))
+            if z is None and norm.equals(0):
+                continue
+
+            R[i, j] = dot(Q[:, i], Q[:, j]) / norm
             R[i, j] = dps(R[i, j])
             Q[:, j] -= Q[:, i] * R[i, j]
 
         Q[:, j] = dps(Q[:, j])
-        if Q[:, j].is_zero_matrix is not True:
-            ranked.append(j)
-            R[j, j] = M.one
+        z = Q[:, j].is_zero_matrix
+        if z is True or dps(dot(Q[:, j], Q[:, j])).equals(0):
+            continue
+        ranked.append(j)
+        R[j, j] = M.one
 
     Q = Q.extract(range(Q.rows), ranked)
     R = R.extract(ranked, range(R.cols))

--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -276,6 +276,20 @@ def test_QR_trivial():
     assert A == Q*R
 
 
+def test_QR_symbolic_dependent_columns():
+    a = Symbol('a', real=True)
+    b = Symbol('b', real=True)
+    k = Symbol('k', real=True)
+    A = Matrix([[a, k*a],
+                [b, k*b]])
+    Q, R = A.QRdecomposition()
+    assert A.rank() == 1
+    assert Q.cols == A.rank()
+    QQ = (Q.H * Q).applyfunc(simplify)
+    assert not QQ.has(S.NaN)
+    assert (Q*R - A).applyfunc(simplify) == zeros(2, 2)
+
+
 def test_QR_float():
     A = Matrix([[1, 1], [1, 1.01]])
     Q, R = A.QRdecomposition()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`QRdecomposition` docs claim that 

>     For matrices which are not square or are rank-deficient, it is
>     sufficient to return a column orthogonal matrix because augmenting
>     them may introduce redundant computations.
>     And an another advantage of this is that you can easily inspect the
>     matrix rank by counting the number of columns of $Q$.

However, this did not work well for matrices with symbols. Of course, in this case the rank is usually undefined, but there is always a "maximal possible" rank like in the following example.
```python
a, b, k = symbols('a b k', real=True)
A = Matrix([[a, k*a],
            [b, k*b]])  # rank is <= 1
Q, R = A.QRdecomposition()
print(A.rank()) # 1
print(Q.cols) # 2
print(sp.simplify(Q) * sp.simplify(R)) # Matrix([[nan, nan], [nan, nan]])
```
This PR fixes this behavior by adding an additional condition.

#### Other comments

#### AI Generation Disclosure

The code was written by codex and then edited by a human.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. --!>


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Fix how QR decomposition handles rank of matrix with symbols

<!-- END RELEASE NOTES -->
