### PR TITLE
Add return type annotation to timed()

### DIFF
--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -10,7 +10,9 @@ _scales = [1e0, 1e3, 1e6, 1e9]
 _units = ['s', 'ms', '\N{GREEK SMALL LETTER MU}s', 'ns']
 
 
-def timed(func, setup="pass", limit=None):
+def timed(
+    func: Callable[[], object], setup: str = "pass", limit: int | None = None
+) -> tuple[int, float, float, str]:
     """Adaptively measure execution time of a function. """
     timer = timeit.Timer(func, setup=setup)
     repeat, number = 3, 1


### PR DESCRIPTION
#### References to other Issues or PRs
Related to #28806.

#### Brief description of what is fixed or changed
This PR adds basic type annotations to the `timed` function in
`sympy/utilities/timeutils.py`.

The change is purely for typing, improves readability and static analysis,
and does not affect runtime behavior.

#### Other comments
None.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->