### PR TITLE
Fix RecursionError in GeometryEntity.subs when substituting Points

### DIFF
--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -138,7 +138,7 @@ class GeometryEntity(Basic, EvalfMixin):
             else:
                 old = Point(old)
                 new = Point(new)
-            return  self._subs(old, new)
+            return self.xreplace({old: new})
 
     def _repr_svg_(self):
         """SVG representation of a GeometryEntity suitable for IPython"""

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -132,13 +132,16 @@ class GeometryEntity(Basic, EvalfMixin):
     def _eval_subs(self, old, new):
         from sympy.geometry.point import Point, Point3D
         if is_sequence(old) or is_sequence(new):
+            if isinstance(old, (Point, Point3D)) and isinstance(new, (Point, Point3D)):
+                return None
+
             if isinstance(self, Point3D):
                 old = Point3D(old)
                 new = Point3D(new)
             else:
                 old = Point(old)
                 new = Point(new)
-            return self.xreplace({old: new})
+            return self._subs(old, new)
 
     def _repr_svg_(self):
         """SVG representation of a GeometryEntity suitable for IPython"""

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -2,7 +2,7 @@ from sympy.core.numbers import (Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.geometry import (Circle, Ellipse, Point, Line, Parabola,
-    Polygon, Ray, RegularPolygon, Segment, Triangle, Plane, Curve)
+    Polygon, Ray, RegularPolygon, Segment, Triangle, Plane, Curve, Point3D)
 from sympy.geometry.entity import scale, GeometryEntity
 from sympy.testing.pytest import raises
 
@@ -56,6 +56,12 @@ def test_subs():
         assert 'y' in str(o.subs(x, y))
     assert p.subs({x: 1}) == Point(1, 2)
     assert Point(1, 2).subs(Point(1, 2), Point(3, 4)) == Point(3, 4)
+    # Recursion issue 29043
+    assert Circle(Point(0,0), 5).subs(Point(0,0), Point(1,1)) == Circle(Point(1,1), 5)
+    assert Line(Point(0,0), Point(1,0)).subs(Point(0,0), Point(1,1)) == Line(Point(1,1), Point(1,0))
+    assert Point3D(0,0,0).subs(Point3D(0,0,0), Point3D(1,1,1)) == Point3D(1,1,1)
+    assert Plane(Point3D(0,0,0), (0,0,1)).subs(Point3D(0,0,0), Point3D(1,1,1)) == Plane(Point3D(1,1,1), (0,0,1))
+
     assert Point(1, 2).subs((1, 2), Point(3, 4)) == Point(3, 4)
     assert Point(1, 2).subs(Point(1, 2), Point(3, 4)) == Point(3, 4)
     assert Point(1, 2).subs({(1, 2)}) == Point(2, 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29043


#### Brief description of what is fixed or changed
This PR fixes a RecursionError in GeometryEntity.subs() that occurred when substituting Point objects.


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fix RecursionError in GeometryEntity.subs when substituting Points.
<!-- END RELEASE NOTES -->
