### PR TITLE
Fix hash collision of `FreeGroupElements`

### DIFF
--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -382,7 +382,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
     def __hash__(self):
         _hash = self._hash
         if _hash is None:
-            self._hash = _hash = hash((self.group, frozenset(tuple(self))))
+            self._hash = _hash = hash((self.group, tuple(self)))
         return _hash
 
     def copy(self):

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -69,6 +69,9 @@ def test_FreeGroup__getitem__():
 
 def test_FreeGroupElm__hash__():
     assert hash(x*y*z)
+    assert hash(x * y) != hash(y * x)
+    assert hash(x * y * x) != hash(x * y)
+    assert hash(x**2 * y) == hash(x * x * y)
 
 
 def test_FreeGroupElm_copy():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Hash function of `FreeGroupElement` converted `tuple` to `frozenset` for no apparant reason. This created tons of hash collisions as simple as `hash(x*y)==hash(y*x)`.
This PR fixes this and adds two tests which failed before.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed hash collisions for elements of free groups.
<!-- END RELEASE NOTES -->
