### PR TITLE
Fixed how several operations of FreeGroupElement treat identity

### DIFF
--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -677,6 +677,8 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         """
         if by is None:
             by = self.group.identity
+        if not gen:
+            raise ValueError("gen must be a non-empty word")
         if self.is_independent(gen) or gen == by:
             return self
         if gen == self:

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -1016,6 +1016,8 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
     def cyclic_subword(self, from_i, to_j):
         group = self.group
         l = len(self)
+        if l == 0:
+            return group.identity
         letter_form = self.letter_form
         period1 = int(from_i/l)
         if from_i >= l:
@@ -1049,7 +1051,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         .. [1] https://planetmath.org/cyclicpermutation
 
         """
-        return {self.cyclic_subword(i, i+len(self)) for i in range(len(self))}
+        return {self, *(self.cyclic_subword(i, i+len(self)) for i in range(1,len(self)))}
 
     def is_cyclic_conjugate(self, w):
         """

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -114,6 +114,7 @@ def test_FreeGroupElm_eliminate_word():
     assert w3.eliminate_word(y, x**-1) == x**-3
     assert w3.eliminate_word(x, y*z) == y*z*y*z*y**3*z**-1
     assert (y**-3).eliminate_word(y, x**-1*z**-1) == z*x*z*x*z*x
+    raises(ValueError, lambda: w.eliminate_word(F.identity, x))
     #assert w3.eliminate_word(x, y*x) == y*x*y*x**2*y*x*y*x*y*x*z**3
     #assert w3.eliminate_word(x, x*y) == x*y*x**2*y*x*y*x*y*x*y*z**3
 

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -229,8 +229,15 @@ def test_FreeGroupElm_words():
     assert w.substituted_word(0, 7, y**2*x) == y**2*x**2*y**-4*x
 
 
-def test_FreeGroupElm_cyclic_subword_reduction():
-    _, x, y = free_group("x y")
+def test_FreeGroupElm_cyclic():
+    F, x, y = free_group("x y")
     w = x*y*x**-1
     rot = w.cyclic_subword(1, 1 + len(w))
     assert rot == y
+    identity = F.identity
+    assert identity.cyclic_subword(3, 7) == identity
+    assert identity.cyclic_conjugates() == {identity}
+    assert x.is_cyclic_conjugate(identity) is False
+    assert identity.is_cyclic_conjugate(x * x**-1)
+    v = x*y*x*y*x
+    assert v.cyclic_conjugates() == {x*y*x**2*y, x**2*y*x*y, y*x*y*x**2, y*x**2*y*x, x*y*x*y*x}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed
`FreeGroupElement.cyclic_subword` crashed on identity input and `.cyclic_conjugates`, `.is_cyclic_conjugate` had wrong output. Fixed that.


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed how cyclic operations of `FreeGroupElement` treat identity
<!-- END RELEASE NOTES -->
