### PR TITLE
Fix broken link in Introductory Tutorial

### DIFF
--- a/doc/src/tutorials/intro-tutorial/preliminaries.rst
+++ b/doc/src/tutorials/intro-tutorial/preliminaries.rst
@@ -26,6 +26,6 @@ Exercises
 
 This tutorial was the basis for a tutorial given at the 2013 SciPy conference
 in Austin, TX.  The website for that tutorial is `here
-<https://certik.github.io/scipy-2013-tutorial/html/index.html>`_. It has links
+<https://docs.sympy.org/latest/tutorials/intro-tutorial/preliminaries.html>`_. It has links
 to videos, materials, and IPython notebook exercises.  The IPython notebook
 exercises in particular are recommended to anyone going through this tutorial.


### PR DESCRIPTION
Fixes #29023

This PR updates the outdated external link in the Introductory Tutorial to the current SymPy documentation.

<!-- BEGIN RELEASE NOTES -->

- Fixed a broken external link in the Introductory Tutorial documentation.

<!-- END RELEASE NOTES -->