### PR TITLE
Fix float pickling 19988

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -385,6 +385,8 @@ Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Asish Panda <asishrocks95@gmail.com>
 Atharva Khare <khareatharva@gmail.com>
+Athul Das <createwithathuldas@gmail.com>
+Athul Das <createwithathuldas@gmail.com> <134342370+createwithathuldas@users.noreply.github.com>
 Atul Bisht <me.atulbisht@gmail.com>
 Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2331,17 +2331,8 @@ def test_issue_28222():
 def test_issue_19988():
     import pickle
     from sympy import Float
-    
-    # Create a float with 20 decimal digits of precision
     t = Float('1.123456789123456789', dps=20)
-    
-    # Pickle and Unpickle
     serialized = pickle.dumps(t)
     deserialized = pickle.loads(serialized)
-    
-    # 1. Check if the values are equal
     assert t == deserialized
-    
-    # 2. Check if the internal binary precision (_prec) was preserved
-    # This was the specific part that used to fail!
     assert t._prec == deserialized._prec

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2327,3 +2327,21 @@ def test_issue_28222():
     assert Mod(2 + 3*I, 10) == Mod(2 + 3*I, 10)
     assert Mod(I, exp(1)) == Mod(I, exp(1))
     assert Mod(I, S(1.5)) == Mod(I, S(1.5))
+
+def test_issue_19988():
+    import pickle
+    from sympy import Float
+    
+    # Create a float with 20 decimal digits of precision
+    t = Float('1.123456789123456789', dps=20)
+    
+    # Pickle and Unpickle
+    serialized = pickle.dumps(t)
+    deserialized = pickle.loads(serialized)
+    
+    # 1. Check if the values are equal
+    assert t == deserialized
+    
+    # 2. Check if the internal binary precision (_prec) was preserved
+    # This was the specific part that used to fail!
+    assert t._prec == deserialized._prec


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #19988
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added a regression test in sympy/core/tests/test_numbers.py to ensure that Float objects with high decimal precision (dps) correctly preserve their value and internal binary precision (._prec) after undergoing a round-trip of pickle.dumps() and pickle.loads().


#### Other comments
The test verifies both equality of value and equality of the underlying precision attribute to prevent future regressions where pickling might default back to standard hardware float precision.


#### AI Generation Disclosure
I used Gemini (an AI collaborator) to help guide me through the SymPy development environment setup (to know directory structure) and to help draft the initial structure of the regression test and this description.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
+ core 
   + Added a regression test to ensure high-precision Float objects maintain precision when pickled.

<!-- END RELEASE NOTES -->
