### PR TITLE
Add type hints to Boolean class interface

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from typing import ClassVar
     from typing_extensions import Self
     from sympy.logic.boolalg import BooleanTrue, BooleanFalse
+    from sympy.sets.sets import Set
 
 
 __all__ = (
@@ -530,7 +531,7 @@ class Relational(Boolean, EvalfMixin):
             )
         )
 
-    def _eval_as_set(self):
+    def _eval_as_set(self) -> Set:
         # self is univariate and periodicity(self, x) in (0, None)
         from sympy.solvers.inequalities import solve_univariate_inequality
         from sympy.sets.conditionset import ConditionSet

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3,7 +3,7 @@ Boolean algebra module for SymPy
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, overload, Any, Callable
+from typing import TYPE_CHECKING, overload, Any, cast
 
 from collections import defaultdict
 from itertools import chain, combinations, product, permutations
@@ -91,6 +91,8 @@ class Boolean(Basic):
 
         @overload # type: ignore
         def subs(self, arg1: Mapping[Basic | complex, Boolean | complex], arg2: None=None) -> Boolean: ...
+        @overload
+        def subs(self, arg1: Mapping[Relational, Relational], arg2: None=None) -> Boolean: ...
         @overload
         def subs(self, arg1: Iterable[tuple[Basic | complex, Boolean | complex]], arg2: None=None, **kwargs: Any) -> Boolean: ...
         @overload
@@ -198,12 +200,12 @@ class Boolean(Basic):
         if len(free) == 1:
             x = free.pop()
             if x.kind is NumberKind:
-                reps: dict[Basic | complex, Boolean | complex] = {}
+                reps = {}
                 for r in self.atoms(Relational):
                     if periodicity(r, x) not in (0, None):
                         s = r._eval_as_set()
                         if s in (S.EmptySet, S.UniversalSet, S.Reals):
-                            reps[r] = s.as_relational(x)
+                            reps[r] = cast(Any, s).as_relational(x)
                             continue
                         raise NotImplementedError(filldedent('''
                             as_set is not implemented for relationals

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -90,11 +90,11 @@ class Boolean(Basic):
             ...
 
         @overload # type: ignore
-        def subs(self, arg1: Mapping[Basic | complex, Boolean | Relational | complex], arg2: None=None) -> Boolean: ...
+        def subs(self, arg1: Mapping[Basic | complex, Boolean | complex], arg2: None=None) -> Boolean: ...
         @overload
-        def subs(self, arg1: Iterable[tuple[Basic | complex, Boolean | Relational | complex]], arg2: None=None, **kwargs: Any) -> Boolean: ...
+        def subs(self, arg1: Iterable[tuple[Basic | complex, Boolean | complex]], arg2: None=None, **kwargs: Any) -> Boolean: ...
         @overload
-        def subs(self, arg1: Boolean | Relational | complex, arg2: Boolean | Relational | complex) -> Boolean: ...
+        def subs(self, arg1: Boolean | complex, arg2: Boolean | complex) -> Boolean: ...
         @overload
         def subs(self, arg1: Mapping[Basic | complex, Basic | complex], arg2: None=None, **kwargs: Any) -> Basic: ...
         @overload
@@ -110,13 +110,13 @@ class Boolean(Basic):
             ...
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __and__(self, other) -> Boolean:
+    def __and__(self, other: Boolean) -> Boolean:
         return And(self, other)
 
     __rand__ = __and__
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __or__(self, other) -> Boolean:
+    def __or__(self, other: Boolean) -> Boolean:
         return Or(self, other)
 
     __ror__ = __or__
@@ -126,18 +126,18 @@ class Boolean(Basic):
         return Not(self)
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __rshift__(self, other) -> Boolean:
+    def __rshift__(self, other: Boolean) -> Boolean:
         return Implies(self, other)
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __lshift__(self, other) -> Boolean:
+    def __lshift__(self, other: Boolean) -> Boolean:
         return Implies(other, self)
 
     __rrshift__ = __lshift__
     __rlshift__ = __rshift__
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __xor__(self, other) -> Boolean:
+    def __xor__(self, other: Boolean) -> Boolean:
         return Xor(self, other)
 
     __rxor__ = __xor__
@@ -198,7 +198,7 @@ class Boolean(Basic):
         if len(free) == 1:
             x = free.pop()
             if x.kind is NumberKind:
-                reps: dict[Basic | complex, Boolean | Relational | complex] = {}
+                reps: dict[Basic | complex, Boolean | complex] = {}
                 for r in self.atoms(Relational):
                     if periodicity(r, x) not in (0, None):
                         s = r._eval_as_set()
@@ -227,7 +227,7 @@ class Boolean(Basic):
         from sympy.core.relational import Eq, Ne
 
         return set().union(*[i.binary_symbols for i in self.args
-                           if isinstance(i, (Boolean, Symbol, Eq, Ne))])
+                           if isinstance(i, (Boolean, Symbol))])
 
     def _eval_refine(self, assumptions) -> Boolean | None:
         from sympy.assumptions import ask

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -83,6 +83,7 @@ class Boolean(Basic):
     kind = BooleanKind
 
     if TYPE_CHECKING:
+        from sympy.sets.sets import Set
 
         def __new__(cls, *args: Basic | complex) -> Boolean:
             ...
@@ -108,34 +109,34 @@ class Boolean(Basic):
             ...
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __and__(self, other):
+    def __and__(self, other) -> "Boolean":
         return And(self, other)
 
     __rand__ = __and__
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __or__(self, other):
+    def __or__(self, other) -> "Boolean":
         return Or(self, other)
 
     __ror__ = __or__
 
-    def __invert__(self):
+    def __invert__(self) -> "Boolean":
         """Overloading for ~"""
         return Not(self)
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __rshift__(self, other):
+    def __rshift__(self, other) -> "Boolean":
         return Implies(self, other)
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __lshift__(self, other):
+    def __lshift__(self, other) -> "Boolean":
         return Implies(other, self)
 
     __rrshift__ = __lshift__
     __rlshift__ = __rshift__
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __xor__(self, other):
+    def __xor__(self, other) -> "Boolean":
         return Xor(self, other)
 
     __rxor__ = __xor__
@@ -170,7 +171,7 @@ class Boolean(Basic):
         # override where necessary
         return self
 
-    def as_set(self):
+    def as_set(self) -> "Set":
         """
         Rewrites Boolean expression in terms of real sets.
 
@@ -207,26 +208,26 @@ class Boolean(Basic):
                             as_set is not implemented for relationals
                             with periodic solutions
                             '''))
-                new = self.subs(reps)
+                new = self.subs(reps)  # type: ignore
                 if new.func != self.func:
                     return new.as_set()  # restart with new obj
                 else:
-                    return new._eval_as_set()
+                    return new._eval_as_set()  # type: ignore
 
-            return self._eval_as_set()
+            return self._eval_as_set()  # type: ignore
         else:
             raise NotImplementedError("Sorry, as_set has not yet been"
                                       " implemented for multivariate"
                                       " expressions")
 
     @property
-    def binary_symbols(self):
+    def binary_symbols(self) -> set[Basic]:
         from sympy.core.relational import Eq, Ne
-        return set().union(*[i.binary_symbols for i in self.args
+        return set().union(*[i.binary_symbols for i in self.args  # type: ignore
                            if i.is_Boolean or i.is_Symbol
                            or isinstance(i, (Eq, Ne))])
 
-    def _eval_refine(self, assumptions):
+    def _eval_refine(self, assumptions) -> "Boolean | None":
         from sympy.assumptions import ask
         ret = ask(self, assumptions)
         if ret is True:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -109,34 +109,34 @@ class Boolean(Basic):
             ...
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __and__(self, other) -> "Boolean":
+    def __and__(self, other) -> Boolean:
         return And(self, other)
 
     __rand__ = __and__
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __or__(self, other) -> "Boolean":
+    def __or__(self, other) -> Boolean:
         return Or(self, other)
 
     __ror__ = __or__
 
-    def __invert__(self) -> "Boolean":
+    def __invert__(self) -> Boolean:
         """Overloading for ~"""
         return Not(self)
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __rshift__(self, other) -> "Boolean":
+    def __rshift__(self, other) -> Boolean:
         return Implies(self, other)
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __lshift__(self, other) -> "Boolean":
+    def __lshift__(self, other) -> Boolean:
         return Implies(other, self)
 
     __rrshift__ = __lshift__
     __rlshift__ = __rshift__
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
-    def __xor__(self, other) -> "Boolean":
+    def __xor__(self, other) -> Boolean:
         return Xor(self, other)
 
     __rxor__ = __xor__
@@ -171,7 +171,7 @@ class Boolean(Basic):
         # override where necessary
         return self
 
-    def as_set(self) -> "Set":
+    def as_set(self) -> Set | Boolean:
         """
         Rewrites Boolean expression in terms of real sets.
 
@@ -227,7 +227,7 @@ class Boolean(Basic):
                            if i.is_Boolean or i.is_Symbol
                            or isinstance(i, (Eq, Ne))])
 
-    def _eval_refine(self, assumptions) -> "Boolean | None":
+    def _eval_refine(self, assumptions) -> Boolean | None:
         from sympy.assumptions import ask
         ret = ask(self, assumptions)
         if ret is True:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -224,7 +224,6 @@ class Boolean(Basic):
     @property
     def binary_symbols(self) -> set[Basic]:
         from sympy.core.symbol import Symbol
-        from sympy.core.relational import Eq, Ne
 
         return set().union(*[i.binary_symbols for i in self.args
                            if isinstance(i, (Boolean, Symbol))])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
MAINT: Add type hints to Boolean class interface

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added PEP 484 type hints to the `Boolean` base class in `sympy/logic/boolalg.py`.

This includes annotating:
- The public `as_set` method.
- Logical dunder methods (`__and__`, `__or__`, `__invert__`, `__xor__`, `__rshift__`, `__lshift__`).
- Structural properties (`binary_symbols`).
- Evaluation methods (`_eval_refine`).

#### Other comments

**Note on strict typing:**

I had to add `# type: ignore` for `_eval_as_set` and `binary_symbols`. Since `Boolean` is a base class, it relies on dynamic dispatch (these attributes exist on the subclasses at runtime but not the parent). The ignores suppress false positives in Mypy, enabling us to enforce strict return types on the public interface.

**Verification:**
- `bin/test sympy/logic/tests/test_boolalg.py`: Passed (85 passed, 1 xfailed).
- `mypy sympy/logic/boolalg.py`: Clean.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * Added type hints to the `Boolean` class interface.
<!-- END RELEASE NOTES -->
