### PR TITLE
Fix missing comma in test_direction_cosine

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1214,6 +1214,7 @@ Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <Pablogsal@gmail.com>
 Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <pablogsal@gmail.com>
 Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
 Pablo Zubieta <pabloferz@yahoo.com.mx>
+Padam Rathi <rathipadamr5@gmail.com>
 Pan Peng <pengpanster@gmail.com>
 Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -474,7 +474,7 @@ def test_direction_cosine():
 
     assert p1.direction_cosine(Point3D(2.4, 2.4, 0)) == [sqrt(2)/2, sqrt(2)/2, 0]
     assert p1.direction_cosine(Point3D(1, 1, 1)) == [sqrt(3) / 3, sqrt(3) / 3, sqrt(3) / 3]
-    assert p1.direction_cosine(Point3D(-12, 0 -15)) == [-4*sqrt(41)/41, -5*sqrt(41)/41, 0]
+    assert p1.direction_cosine(Point3D(-12, 0, -15)) == [-4*sqrt(41)/41, 0, -5*sqrt(41)/41]
 
     assert p2.direction_cosine(Point3D(0, 0, 0)) == [-sqrt(3) / 3, -sqrt(3) / 3, -sqrt(3) / 3]
     assert p2.direction_cosine(Point3D(1, 1, 12)) == [0, 0, 1]


### PR DESCRIPTION
References to other Issues or PRs

Fixes #29070 

Brief description of what is fixed or changed

I fixed a missing comma in sympy/sympy/geometry/tests/test_point.py where in **Point3D(-12, 0 -15)** was missing
comma between 0 and -15 which was then evaluated as **Point3D(-12, -15)**. I corrected it to **Point3D(-12, 0, -15)** and updated the test values to match.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->