### PR TITLE
Fix UnboundLocalError in centroid() for mixed geometry types

### DIFF
--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -93,6 +93,7 @@ def test_centroid():
     assert centroid(p, q) == Point(1, -sqrt(2) + 2)
     assert centroid(Point(0, 0), Point(2, 0)) == Point(2, 0)/2
     assert centroid(Point(0, 0), Point(0, 0), Point(2, 0)) == Point(2, 0)/3
+    assert centroid(Point(0, 0), Segment((0, 0), (1, 1))) is None
 
 
 def test_farthest_points_closest_points():

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -276,6 +276,8 @@ def centroid(*args):
                 c += g.centroid*a
                 A += a
             den = A
+        else:
+            return None
         c /= den
         return c.func(*[i.simplify() for i in c.args])
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29076


#### Brief description of what is fixed or changed
Fixed UnboundLocalError in centroid() by handling mixed geometry type inputs (e.g. Points and Segments) gracefully. The function now returns None for such inputs, as specified in the documentation, instead of crashing.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fixed `UnboundLocalError` in centroid() when processing mixed geometry types (e.g. Points and Segments together).

<!-- END RELEASE NOTES -->
