### PR TITLE
Add type annotations to misc utility functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1016,6 +1016,7 @@ Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.n
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
+Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com>
 Manoj Babu K. <manoj.babu2378@gmail.com>
 Manoj Kumar <manojkumarsivaraj334@gmail.com>
 Marcel Stimberg <marcel.stimberg@ens.fr> <marcel.stimberg@inserm.fr>
@@ -1862,4 +1863,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1016,7 +1016,7 @@ Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.n
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
-Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com> <22610394+mannatjain1146-netizen@users.noreply.github.com>
+Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com> Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com>
 Manoj Babu K. <manoj.babu2378@gmail.com>
 Manoj Kumar <manojkumarsivaraj334@gmail.com>
 Marcel Stimberg <marcel.stimberg@ens.fr> <marcel.stimberg@inserm.fr>

--- a/.mailmap
+++ b/.mailmap
@@ -1016,7 +1016,7 @@ Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.n
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
-Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com> Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com>
+Mannat Jain <22610394+mannatjain11465-netizen@users.noreply.github.com>
 Manoj Babu K. <manoj.babu2378@gmail.com>
 Manoj Kumar <manojkumarsivaraj334@gmail.com>
 Marcel Stimberg <marcel.stimberg@ens.fr> <marcel.stimberg@inserm.fr>

--- a/.mailmap
+++ b/.mailmap
@@ -1016,7 +1016,7 @@ Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.n
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
-Mannat Jain <22610394+mannatjain11465-netizen@users.noreply.github.com>
+Mannat Jain <226103934+mannatjain11465-netizen@users.noreply.github.com> <226103934+mannatjain11465-netizen@users.noreply.github.com>
 Manoj Babu K. <manoj.babu2378@gmail.com>
 Manoj Kumar <manojkumarsivaraj334@gmail.com>
 Marcel Stimberg <marcel.stimberg@ens.fr> <marcel.stimberg@inserm.fr>

--- a/.mailmap
+++ b/.mailmap
@@ -1862,3 +1862,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1016,7 +1016,7 @@ Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.n
 Manish Gill <gill.manish90@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
 Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
-Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com>
+Mannat Jain <22610394+mannatjain1146-netizen@users.noreply.github.com> <22610394+mannatjain1146-netizen@users.noreply.github.com>
 Manoj Babu K. <manoj.babu2378@gmail.com>
 Manoj Kumar <manojkumarsivaraj334@gmail.com>
 Marcel Stimberg <marcel.stimberg@ens.fr> <marcel.stimberg@inserm.fr>

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Tuple, List, Optional
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -72,7 +72,7 @@ def strlines(s: str, c: int = 64, short: bool = False) -> str:
     if '\n' in s:
         return rawlines(s)
     q_char = '"' if repr(s).startswith('"') else "'"
-    q: Tuple[str, str] = (q_char, q_char)
+    q = (q_char, q_char)
     if '\\' in s:  # use r-string
         m = '(\nr%s%%s%s\n)' % q
         j = '%s\nr%s' % q
@@ -81,7 +81,7 @@ def strlines(s: str, c: int = 64, short: bool = False) -> str:
         m = '(\n%s%%s%s\n)' % q
         j = '%s\n%s' % q
         c -= 2
-    out = []
+    out: list[str] = []
     while s:
         out.append(s[:c])
         s = s[c:]
@@ -155,7 +155,7 @@ def rawlines(s: str) -> str:
         return repr(lines[0])
     triple = ["'''" in s, '"""' in s]
     if any(li.endswith(' ') for li in lines) or '\\' in s or all(triple):
-        rv: List[str] = []
+        rv: list[str] = []
         # add on the newlines
         trailing = s.endswith('\n')
         last = len(lines) - 1
@@ -166,11 +166,11 @@ def rawlines(s: str) -> str:
                 rv.append(repr(li))
         return '(\n    %s\n)' % '\n    '.join(rv)
     else:
-        rv = '\n    '.join(lines)
+        rv_str = '\n    '.join(lines)
         if triple[0]:
-            return 'dedent("""\\\n    %s""")' % rv
+            return 'dedent("""\\\n    %s""")' % rv_str
         else:
-            return "dedent('''\\\n    %s''')" % rv
+            return "dedent('''\\\n    %s''')" % rv_str
 
 ARCH = str(struct.calcsize('P') * 8) + "-bit"
 
@@ -260,7 +260,7 @@ def debugf(string: str, args: object) -> None:
     if SYMPY_DEBUG:
         print(string%args, file=sys.stderr)
 
-def find_executable(executable: str, path: Optional[str] = None) -> Optional[str]:
+def find_executable(executable: str, path: str | None = None) -> str | None:
     """Try to find 'executable' in the directories listed in 'path' (a
     string listing directories separated by 'os.pathsep'; defaults to
     os.environ['PATH']).  Returns the complete filename or None if not

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Optional
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Tuple, Union, List, Optional
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -71,8 +71,8 @@ def strlines(s: str, c: int = 64, short: bool = False) -> str:
         raise ValueError('expecting string input')
     if '\n' in s:
         return rawlines(s)
-    q = '"' if repr(s).startswith('"') else "'"
-    q = (q,)*2
+    q_char = '"' if repr(s).startswith('"') else "'"
+    q: Tuple[str, str] = (q_char, q_char)
     if '\\' in s:  # use r-string
         m = '(\nr%s%%s%s\n)' % q
         j = '%s\nr%s' % q
@@ -155,7 +155,7 @@ def rawlines(s: str) -> str:
         return repr(lines[0])
     triple = ["'''" in s, '"""' in s]
     if any(li.endswith(' ') for li in lines) or '\\' in s or all(triple):
-        rv = []
+        rv: List[str] = []
         # add on the newlines
         trailing = s.endswith('\n')
         last = len(lines) - 1
@@ -166,7 +166,7 @@ def rawlines(s: str) -> str:
                 rv.append(repr(li))
         return '(\n    %s\n)' % '\n    '.join(rv)
     else:
-        rv = '\n    '.join(lines)
+        rv_str = '\n    '.join(lines)
         if triple[0]:
             return 'dedent("""\\\n    %s""")' % rv
         else:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Tuple, Union, List, Optional
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Tuple, List, Optional
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -166,7 +166,7 @@ def rawlines(s: str) -> str:
                 rv.append(repr(li))
         return '(\n    %s\n)' % '\n    '.join(rv)
     else:
-        rv_str = '\n    '.join(lines)
+        rv = '\n    '.join(lines)
         if triple[0]:
             return 'dedent("""\\\n    %s""")' % rv
         else:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,7 +8,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any
+from typing import TypeVar, Callable, Literal, SupportsIndex, SupportsInt, overload, Any, Optional
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
 
@@ -38,7 +38,7 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
-def strlines(s, c=64, short=False):
+def strlines(s: str, c: int = 64, short: bool = False) -> str:
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)
@@ -84,13 +84,13 @@ def strlines(s, c=64, short=False):
     out = []
     while s:
         out.append(s[:c])
-        s=s[c:]
+        s = s[c:]
     if short and len(out) == 1:
         return (m % out[0]).splitlines()[1]  # strip bounding (\n...\n)
     return m % j.join(out)
 
 
-def rawlines(s):
+def rawlines(s: str) -> str:
     """Return a cut-and-pastable string that, when printed, is equivalent
     to the input. Use this when there is more than one line in the
     string. The string returned is formatted so it can be indented
@@ -242,7 +242,7 @@ def debug_decorator(func: _CallableT) -> _CallableT:
     return decorated  # type: ignore
 
 
-def debug(*args):
+def debug(*args: object) -> None:
     """
     Print ``*args`` if SYMPY_DEBUG is True, else do nothing.
     """
@@ -251,7 +251,7 @@ def debug(*args):
         print(*args, file=sys.stderr)
 
 
-def debugf(string, args):
+def debugf(string: str, args: object) -> None:
     """
     Print ``string%args`` if SYMPY_DEBUG is True, else do nothing. This is
     intended for debug messages using formatted strings.
@@ -260,8 +260,7 @@ def debugf(string, args):
     if SYMPY_DEBUG:
         print(string%args, file=sys.stderr)
 
-
-def find_executable(executable, path=None):
+def find_executable(executable: str, path: Optional[str] = None) -> Optional[str]:
     """Try to find 'executable' in the directories listed in 'path' (a
     string listing directories separated by 'os.pathsep'; defaults to
     os.environ['PATH']).  Returns the complete filename or None if not


### PR DESCRIPTION
Refs sympy/sympy#28806

Added type annotations to small utility functions in sympy/utilities/misc.py, including:
- strlines
- rawlines
- debug
- debugf
- find_executable

I used ChatGPT for guidance in understanding SymPy style conventions. All code changes were reviewed and verified manually before submission.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->