### PR TITLE
Fix casus irreducibilis crash.

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -267,7 +267,13 @@ def function_range(f, symbol, domain):
                         'Infinite number of critical points for {}'.format(f))
 
             for critical_point in critical_points:
-                vals += FiniteSet(f.subs(symbol, critical_point))
+                from sympy import RootOf
+                if isinstance(critical_point, RootOf):
+                    numeric_val = critical_point.n()
+                    val = f.subs(symbol, numeric_val)
+                else:
+                    val = f.subs(symbol, critical_point)
+                vals += FiniteSet(val)
 
             left_open, right_open = False, False
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1025,6 +1025,17 @@ def _solve_as_poly(f, symbol, domain=S.Complexes):
     """
     result = None
     if f.is_polynomial(symbol):
+        poly = Poly(f, symbol)
+        deg = poly.degree()
+        if deg == 3:
+            from sympy import discriminant
+            disc = discriminant(poly)
+            if disc.is_number and disc.is_real and disc > 0:
+                all_roots = poly.all_roots()
+                filtered_roots = [r for r in all_roots if r.is_real and (domain.contains(r))]
+
+                return FiniteSet(*filtered_roots)
+
         solns = roots(f, symbol, cubics=True, quartics=True,
                       quintics=True, domain='EX')
         num_roots = sum(solns.values())

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -614,23 +614,11 @@ def test_solve_sqrt_3():
     R = Symbol('R')
     eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
     sol = solveset_complex(eq, R)
-    fset = [Rational(5, 3) + 4*sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3,
-            -sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3 +
-            40*re(1/((Rational(-1, 2) - sqrt(3)*I/2)*(Rational(251, 27) + sqrt(111)*I/9)**Rational(1, 3)))/9 +
-            sqrt(30)*sin(atan(3*sqrt(111)/251)/3)/3 + Rational(5, 3) +
-            I*(-sqrt(30)*cos(atan(3*sqrt(111)/251)/3)/3 -
-               sqrt(10)*sin(atan(3*sqrt(111)/251)/3)/3 +
-               40*im(1/((Rational(-1, 2) - sqrt(3)*I/2)*(Rational(251, 27) + sqrt(111)*I/9)**Rational(1, 3)))/9)]
-    cset = [40*re(1/((Rational(-1, 2) + sqrt(3)*I/2)*(Rational(251, 27) + sqrt(111)*I/9)**Rational(1, 3)))/9 -
-            sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3 - sqrt(30)*sin(atan(3*sqrt(111)/251)/3)/3 +
-            Rational(5, 3) +
-            I*(40*im(1/((Rational(-1, 2) + sqrt(3)*I/2)*(Rational(251, 27) + sqrt(111)*I/9)**Rational(1, 3)))/9 -
-               sqrt(10)*sin(atan(3*sqrt(111)/251)/3)/3 +
-               sqrt(30)*cos(atan(3*sqrt(111)/251)/3)/3)]
-
-    fs = FiniteSet(*fset)
-    cs = ConditionSet(R, Eq(eq, 0), FiniteSet(*cset))
-    assert sol == (fs - {-1}) | (cs - {-1})
+    expected = FiniteSet(
+        CRootOf(R**3 - 5*R**2 - 5*R - 1, 1),
+        CRootOf(R**3 - 5*R**2 - 5*R - 1, 2)
+    )
+    assert sol == expected
 
     # the number of real roots will depend on the value of m: for m=1 there are 4
     # and for m=-1 there are none.
@@ -2446,14 +2434,11 @@ def test_substitution_incorrect():
 
 
 def test_substitution_redundant():
-    # the third and fourth solutions are redundant in the test below
     assert substitution([x**2 - y**2, z - 1], [x, z]) == \
            {(-y, 1), (y, 1), (-sqrt(y**2), 1), (sqrt(y**2), 1)}
 
-    # the system below has three solutions. Two of the solutions
-    # returned by substitution are redundant.
     res = substitution([x - y, y**3 - 3*y**2 + 1], [x, y])
-    assert len(res) == 5
+    assert len(res) == 3
 
 
 def test_issue_5132_substitution():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -899,7 +899,7 @@ def test_M2():
     # The roots of this equation should all be real. Note that this
     # doesn't test that they are correct.
     sol = solveset(3*x**3 - 18*x**2 + 33*x - 19, x)
-    assert all(s.expand(complex=True).is_real for s in sol)
+    assert all(s.is_real for s in sol)
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#23873 

#### Brief description of what is fixed or changed
* Solveset returns CRootOf objects for cubic polynomials.
* CRootOf objects contains distinct roots, so I have updated test_substition_reduntant to robustly deal with distinct roots. Earlier it was dealing with 5 roots which was just different algebraically but mathematically and logically same.
* Added corresponding RootOf Object handler in calculus/utils.py.
* test_M2 now deals with CRootOf object, so relevant changes were made. Actually, just the method is updated to check if solutions are real or not. 
* test_solve_sqrt_3 - Earlier it was expecting 3 solution for the modified cubic polynomial we got from the original one, but one among these was not satisfying the original one but did not exclude it becuase it did not verify it on orignal polynomial. However, CRootOf approach resolves this issues, it further filters out the false root.

#### Other comments
* This resolved the casus irreducibilis issue keeping rest of the functionality and final output intact.
* I have cross checked the maximum and minimum value of the concerned polynomial graphically in desmos.

#### AI Generation Disclosure
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * solveset returns CRootOf object for cubic (casus irreducibilis)  polynomials.
* calculus
  * util.py have additional RootOf object handler.
<!-- END RELEASE NOTES -->
