### PR TITLE
Fix #29086: Raise GeometryError for zero-area polygon centroid

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1543,6 +1543,7 @@ Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Arun Yeragudipati <ysarun1999
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Srinivasa Arun Yeragudipati <38272686+arun-y99@users.noreply.github.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> arun <ysarun1999@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> arun-y99 <ysarun1999@gmail.com>
+Sriram Varun Kumar <sriramvarunkumar@gmail.com> varunkumar-22 <sriramvarunkumar@gmail.com>
 Stan Schymanski <stan.schymanski@env.ethz.ch>
 Stas Kelvich <stanconn@gmail.com>
 Stefan Behnle <84378403+behnle@users.noreply.github.com>

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -378,7 +378,11 @@ class Polygon(GeometrySet):
         Point2D(31/18, 11/18)
 
         """
-        A = 1/(6*self.area)
+        area = self.area
+        if area == 0:
+            raise GeometryError(
+                "Cannot compute centroid of a zero-area polygon")
+        A = 1/(6*area)
         cx, cy = 0, 0
         args = self.args
         for i in range(len(args)):

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -133,6 +133,7 @@ def test_polygon():
         Point(x, 0), Point(0, y), Point(x, y)).arbitrary_point('x'))
     assert p6.intersection(r) == [Point(-9, Rational(-84, 13)), Point(-9, Rational(33, 5))]
     assert p10.area == 0
+    raises(GeometryError, lambda: p10.centroid)
     assert p11 == RegularPolygon(Point(0, 0), 1, 3, 0)
     assert p11 == p12
     assert p11.vertices[0] == Point(1, 0)


### PR DESCRIPTION
Polygon.centroid now raises GeometryError instead of returning Point2D(nan, zoo) when called on a zero-area polygon. The centroid formula divides by area, causing division by zero for polygons with self-intersecting sides where areas cancel out.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29086

#### Brief description of what is fixed or changed
`Polygon.centroid `now raises `GeometryError` instead of returning `Point2D(nan, zoo)` when called on a zero-area polygon.
The centroid formula divides by area without checking for zero, causing division by zero for polygons with self-intersecting sides where positive and negative areas cancel out (e.g., Z-shaped polygons).

### Before:
```python
>>> Polygon((0, 2), (2, 2), (0, 0), (2, 0)).centroid
Point2D(nan, zoo)
```
### After:
```python
>>> Polygon((0, 2), (2, 2), (0, 0), (2, 0)).centroid
GeometryError: Cannot compute centroid of a zero-area polygon
```

#### Other comments
Added corresponding test case in `test_polygon.py`


#### AI Generation Disclosure
This fix was developed without any AI assistance

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* geometry
    * `Polygon.centroid `now raises `GeometryError` for zero-area polygons instead of returning `Point2D(nan, zoo).`
<!-- END RELEASE NOTES -->
