### PR TITLE
raise geometryerror for zero area Polygon.centroid

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -378,7 +378,9 @@ class Polygon(GeometrySet):
         Point2D(31/18, 11/18)
 
         """
-        A = 1/(6*self.area)
+        if area == 0:
+            raise GeometryError("The centroid of a polygon with zero area is undefined.")
+        A = 1/(6*area)
         cx, cy = 0, 0
         args = self.args
         for i in range(len(args)):

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -363,6 +363,14 @@ class Polygon(GeometrySet):
 
         centroid : Point
 
+        Raises
+        ======
+
+        GeometryError
+            When the polygon has zero area. Note that this check only catches
+            the case where the computed area is zero. Not all self-intersecting
+            polygons are detected, only those that reduce to zero area.
+
         See Also
         ========
 
@@ -380,7 +388,7 @@ class Polygon(GeometrySet):
         """
         area = self.area
         if area == 0:
-            raise GeometryError("The centroid of a polygon with zero area is undefined.")
+            raise GeometryError("Centroid is undefined for a polygon with zero area.")
         A = 1/(6*area)
         cx, cy = 0, 0
         args = self.args

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -378,6 +378,7 @@ class Polygon(GeometrySet):
         Point2D(31/18, 11/18)
 
         """
+        area = self.area
         if area == 0:
             raise GeometryError("The centroid of a polygon with zero area is undefined.")
         A = 1/(6*area)

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -680,3 +680,9 @@ def test_do_poly_distance():
     with warns(UserWarning, \
                match="Polygons may intersect producing erroneous output", test_stacklevel=False):
         assert triangle2._do_poly_distance(square1) == 0
+
+
+def test_centroid_zero_area():
+    p = Polygon((0, 2), (2, 2), (0, 0), (2, 0))
+    raises(GeometryError, lambda: p.centroid)
+

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -685,4 +685,3 @@ def test_do_poly_distance():
 def test_centroid_zero_area():
     p = Polygon((0, 2), (2, 2), (0, 0), (2, 0))
     raises(GeometryError, lambda: p.centroid)
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29086 

#### Brief description of what is fixed or changed
Polygon.centroid divides by the polygon's area. For zero-area polygons, this was resulting in nan coordinates.
Added a check to raise GeometryError if the area is 0.

#### Other comments
Added a test.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fixed Polygon.centroid returns nan coordinates for zero area polygon.
<!-- END RELEASE NOTES -->
