### PR TITLE
Enhance monomial operations to handle mismatched lengths

### DIFF
--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-from itertools import combinations_with_replacement, product
+from itertools import combinations_with_replacement, product, zip_longest
 from textwrap import dedent
 
 from sympy.core.cache import cacheit
@@ -195,7 +195,7 @@ def monomial_mul(A, B):
     which gives `x**4*y**5*z`.
 
     """
-    return tuple([ a + b for a, b in zip(A, B) ])
+    return tuple([ a + b for a, b in zip_longest(A, B, fillvalue=0) ])
 
 def monomial_div(A: monom, B: monom) -> monom | None:
     """
@@ -248,7 +248,7 @@ def monomial_ldiv(A: monom, B: monom) -> monom:
     which gives `x**2*y**2*z**-1`.
 
     """
-    return tuple([ a - b for a, b in zip(A, B) ])
+    return tuple([ a - b for a, b in zip_longest(A, B, fillvalue=0) ])
 
 def monomial_pow(A, n):
     """Return the n-th pow of the monomial. """
@@ -271,7 +271,7 @@ def monomial_gcd(A, B):
     which gives `x*y**2`.
 
     """
-    return tuple([ min(a, b) for a, b in zip(A, B) ])
+    return tuple([ min(a, b) for a, b in zip_longest(A, B, fillvalue=0) ])
 
 def monomial_lcm(A, B):
     """
@@ -290,7 +290,7 @@ def monomial_lcm(A, B):
     which gives `x**3*y**4*z`.
 
     """
-    return tuple([ max(a, b) for a, b in zip(A, B) ])
+    return tuple([ max(a, b) for a, b in zip_longest(A, B, fillvalue=0) ])
 
 def monomial_divides(A, B):
     """
@@ -305,7 +305,7 @@ def monomial_divides(A, B):
     >>> monomial_divides((1, 2), (0, 2))
     False
     """
-    return all(a <= b for a, b in zip(A, B))
+    return all(a <= b for a, b in zip_longest(A, B, fillvalue=0))
 
 def monomial_max(*monoms):
     """

--- a/sympy/polys/tests/test_monomials.py
+++ b/sympy/polys/tests/test_monomials.py
@@ -202,6 +202,13 @@ def test_monomial_divides():
     assert monomial_divides((1, 2, 3), (4, 5, 6)) is True
     assert monomial_divides((1, 2, 3), (0, 5, 6)) is False
 
+def test_monomial_mismatched_lengths():
+    assert monomial_mul((1,), (1, 2)) == (2, 2)
+    assert monomial_div((1,), (1, 2)) is None
+    assert monomial_gcd((1,), (1, 2)) == (1, 0)
+    assert monomial_lcm((1,), (1, 2)) == (1, 2)
+    assert monomial_divides((1,), (1, 2)) is True
+
 def test_Monomial():
     m = Monomial((3, 4, 1), (x, y, z))
     n = Monomial((1, 2, 0), (x, y, z))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed that monomial operations incorrectly truncated longer monomials on inputs with mismatched lengths.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed that monomial operations incorrectly truncated longer monomials on inputs with mismatched lengths.
<!-- END RELEASE NOTES -->
