### PR TITLE
[WIP] Implement snapshot testing

### DIFF
--- a/bin/snapshot
+++ b/bin/snapshot
@@ -26,8 +26,8 @@ options, args = parser.parse_known_args()
 ok = run_snapshot_tests(options, args)
 
 if ok:
-    print(f"All okay.")
+    print("All okay.")
     sys.exit(0)
 else:
-    print(f"All not okay.")
+    print("All not okay.")
     sys.exit(1)

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -7,158 +7,12 @@ from get_sympy import path_hack
 path_hack()
 
 from argparse import ArgumentParser
-import doctest as pdoctest
-import os
+from sympy.testing.snapshot import run_snapshot_tests
 import sys
-
-from sympy.testing.runtests import (
-    SymPyDocTestRunner,
-    SymPyOutputChecker,
-    SymPyTestResults,
-)
-
-
-class SymPySnapshotRunner(SymPyDocTestRunner):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.snapshot_mismatches = []
-
-    def report_failure(self, out, test, example, got):
-        # Record mismatches
-        self.snapshot_mismatches.append({
-            "filename": test.filename,
-            "lineno": example.lineno,
-            "source": example.source,
-            "want": example.want,
-            "got": got,
-        })
-
-        self._fakeout.truncate(0)
-        self._fakeout.seek(0)
-
-
-# Monkeypatch name-mangled methods for SnapshotRunner
-monkeypatched_snapshot_methods = [
-    'report_failure',
-]
-
-for method in monkeypatched_snapshot_methods:
-    oldname = '_DocTestRunner__' + method
-    newname = '_SymPySnapshotRunner__' + method
-    setattr(SymPySnapshotRunner, newname, getattr(SymPySnapshotRunner, method))
-
-
-def apply_snapshot_updates(filename, mismatches):
-    with open(filename, "r", encoding="utf-8") as f:
-        lines = f.readlines()
-
-    for m in reversed(mismatches):
-        lineno = m["lineno"] - 1
-        source_lines = m["source"].count("\n") + 1
-
-        out_start = lineno + source_lines
-        out_end = out_start
-
-        # go through old expected output
-        while out_end < len(lines):
-            line = lines[out_end]
-            if line.lstrip().startswith(">>>") or line.lstrip().startswith("```"):
-                break
-            out_end += 1
-
-        new_output = m["got"].rstrip("\n").splitlines(keepends=True)
-        new_output = [l + "\n" for l in new_output]
-
-        # replace it with new output
-        lines[out_start:out_end] = new_output
-
-    with open(filename, "w", encoding="utf-8") as f:
-        f.writelines(lines)
-
-
-# This function is same as sympytestfile, with minor changes adapted to snapshot testing.
-def snapshot_testfile(filename, module_relative=True, name=None, package=None,
-             globs=None, verbose=None, report=True, optionflags=0,
-             extraglobs=None, raise_on_error=False,
-             parser=pdoctest.DocTestParser(), encoding=None, update=False):
-
-    if package and not module_relative:
-        raise ValueError("Package may only be specified for module-"
-                         "relative paths.")
-
-    # Relativize the path
-    text, filename = pdoctest._load_testfile(
-        filename, package, module_relative, encoding)
-
-    # If no name was given, then use the file's name.
-    if name is None:
-        name = os.path.basename(filename)
-
-    # Assemble the globals.
-    if globs is None:
-        globs = {}
-    else:
-        globs = globs.copy()
-    if extraglobs is not None:
-        globs.update(extraglobs)
-    if '__name__' not in globs:
-        globs['__name__'] = '__main__'
-
-    if raise_on_error:
-        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
-    else:
-        runner = SymPySnapshotRunner(verbose=verbose, optionflags=optionflags)
-        runner._checker = SymPyOutputChecker()
-
-    # Read the file, convert it to a test, and run it.
-    test = parser.get_doctest(text, globs, name, filename, 0)
-    print(f"{filename}: {len(test.examples)} examples")
-    runner.run(test)
-
-    print(f"Tried: {runner.tries}")
-    print(f"Snapshot mismatches: {len(runner.snapshot_mismatches)}")
-
-    if report:
-        runner.summarize()
-
-    if pdoctest.master is None:
-        pdoctest.master = runner
-    else:
-        pdoctest.master.merge(runner)
-
-    if hasattr(runner, "snapshot_mismatches"):
-        for m in runner.snapshot_mismatches:
-            print(f"Snapshot mismatch in {m['filename']}:{m['lineno']}")
-            print(m["source"].rstrip())
-            print("--- expected")
-            print(m["want"].rstrip())
-            print("+++ got")
-            print(m["got"].rstrip())
-
-    mismatches = getattr(runner, "snapshot_mismatches", [])
-
-    if update and mismatches:
-        apply_snapshot_updates(filename, mismatches)
-        return SymPyTestResults(0, runner.tries)
-
-    return SymPyTestResults(len(mismatches), runner.tries)
-
-
-def iter_markdown_files(paths):
-    for path in paths:
-        if os.path.isdir(path):
-            for root, _, files in os.walk(path):
-                for f in files:
-                    if f.endswith(".md"):
-                        yield os.path.join(root, f)
-        else:
-            if path.endswith(".md"):
-                yield path
 
 
 epilog = """
 "options" are any of the options above.
-If no file arguments are given, all snapshot tests will be run.
 This program executes or updates the snapshot tests.
 """
 
@@ -168,36 +22,8 @@ parser.add_argument(
     help="Update snapshot outputs.")
 
 options, args = parser.parse_known_args()
-all_files = list(iter_markdown_files(args))
-ok = True
 
-if not all_files:
-    print("No markdown files found.")
-    sys.exit(0)
-
-for filename in all_files:
-    print(f"Running snapshot tests: {filename}")
-    try:
-        failures, attempted = snapshot_testfile(
-            filename=filename,
-            module_relative=False,
-            encoding="utf-8",
-            optionflags=(
-                pdoctest.ELLIPSIS |
-                pdoctest.NORMALIZE_WHITESPACE |
-                pdoctest.IGNORE_EXCEPTION_DETAIL
-            ),
-            update=options.update
-        )
-    except Exception as e:
-        print(f"Error while testing {filename}: {e}")
-        ok = False
-        continue
-
-    if failures and not options.update:
-        ok = False
-    else:
-        print(f"Succesfully tested {filename}.")
+ok = run_snapshot_tests(options, args)
 
 if ok:
     print(f"All okay.")

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+"""
+Program to execute or update the snapshot tests.
+"""
+
+from get_sympy import path_hack
+path_hack()
+
+from argparse import ArgumentParser
+import doctest as pdoctest
+import os
+import sys
+
+from sympy.testing.runtests import (
+    SymPyDocTestRunner,
+    SymPyOutputChecker,
+    SymPyTestResults,
+)
+
+
+class SymPySnapshotRunner(SymPyDocTestRunner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.snapshot_mismatches = []
+
+    def report_failure(self, out, test, example, got):
+        # Record mismatches
+        self.snapshot_mismatches.append({
+            "filename": test.filename,
+            "lineno": example.lineno,
+            "source": example.source,
+            "want": example.want,
+            "got": got,
+        })
+
+        self._fakeout.truncate(0)
+        self._fakeout.seek(0)
+
+
+# Monkeypatch name-mangled methods for SnapshotRunner
+monkeypatched_snapshot_methods = [
+    'report_failure',
+]
+
+for method in monkeypatched_snapshot_methods:
+    oldname = '_DocTestRunner__' + method
+    newname = '_SymPySnapshotRunner__' + method
+    setattr(SymPySnapshotRunner, newname, getattr(SymPySnapshotRunner, method))
+
+
+def apply_snapshot_updates(filename, mismatches):
+    with open(filename, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for m in reversed(mismatches):
+        lineno = m["lineno"] - 1
+        source_lines = m["source"].count("\n") + 1
+
+        out_start = lineno + source_lines
+        out_end = out_start
+
+        # go through old expected output
+        while out_end < len(lines):
+            line = lines[out_end]
+            if line.lstrip().startswith(">>>") or line.lstrip().startswith("```"):
+                break
+            out_end += 1
+
+        new_output = m["got"].rstrip("\n").splitlines(keepends=True)
+        new_output = [l + "\n" for l in new_output]
+
+        # replace it with new output
+        lines[out_start:out_end] = new_output
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+# This function is same as sympytestfile, with minor changes adapted to snapshot testing.
+def snapshot_testfile(filename, module_relative=True, name=None, package=None,
+             globs=None, verbose=None, report=True, optionflags=0,
+             extraglobs=None, raise_on_error=False,
+             parser=pdoctest.DocTestParser(), encoding=None, update=False):
+
+    if package and not module_relative:
+        raise ValueError("Package may only be specified for module-"
+                         "relative paths.")
+
+    # Relativize the path
+    text, filename = pdoctest._load_testfile(
+        filename, package, module_relative, encoding)
+
+    # If no name was given, then use the file's name.
+    if name is None:
+        name = os.path.basename(filename)
+
+    # Assemble the globals.
+    if globs is None:
+        globs = {}
+    else:
+        globs = globs.copy()
+    if extraglobs is not None:
+        globs.update(extraglobs)
+    if '__name__' not in globs:
+        globs['__name__'] = '__main__'
+
+    if raise_on_error:
+        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
+    else:
+        runner = SymPySnapshotRunner(verbose=verbose, optionflags=optionflags)
+        runner._checker = SymPyOutputChecker()
+
+    # Read the file, convert it to a test, and run it.
+    test = parser.get_doctest(text, globs, name, filename, 0)
+    print(f"{filename}: {len(test.examples)} examples")
+    runner.run(test)
+
+    print(f"Tried: {runner.tries}")
+    print(f"Snapshot mismatches: {len(runner.snapshot_mismatches)}")
+
+    if report:
+        runner.summarize()
+
+    if pdoctest.master is None:
+        pdoctest.master = runner
+    else:
+        pdoctest.master.merge(runner)
+
+    if hasattr(runner, "snapshot_mismatches"):
+        for m in runner.snapshot_mismatches:
+            print(f"Snapshot mismatch in {m['filename']}:{m['lineno']}")
+            print(m["source"].rstrip())
+            print("--- expected")
+            print(m["want"].rstrip())
+            print("+++ got")
+            print(m["got"].rstrip())
+
+    mismatches = getattr(runner, "snapshot_mismatches", [])
+
+    if update and mismatches:
+        apply_snapshot_updates(filename, mismatches)
+        return SymPyTestResults(0, runner.tries)
+
+    return SymPyTestResults(len(mismatches), runner.tries)
+
+
+def iter_markdown_files(paths):
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for f in files:
+                    if f.endswith(".md"):
+                        yield os.path.join(root, f)
+        else:
+            if path.endswith(".md"):
+                yield path
+
+
+epilog = """
+"options" are any of the options above.
+If no file arguments are given, all snapshot tests will be run.
+This program executes or updates the snapshot tests.
+"""
+
+parser = ArgumentParser(epilog=epilog)
+parser.add_argument(
+    "-u", "--update", action="store_true", dest="update", default=False,
+    help="Update snapshot outputs.")
+
+options, args = parser.parse_known_args()
+all_files = list(iter_markdown_files(args))
+ok = True
+
+if not all_files:
+    print("No markdown files found.")
+    sys.exit(0)
+
+for filename in all_files:
+    print(f"Running snapshot tests: {filename}")
+    try:
+        failures, attempted = snapshot_testfile(
+            filename=filename,
+            module_relative=False,
+            encoding="utf-8",
+            optionflags=(
+                pdoctest.ELLIPSIS |
+                pdoctest.NORMALIZE_WHITESPACE |
+                pdoctest.IGNORE_EXCEPTION_DETAIL
+            ),
+            update=options.update
+        )
+    except Exception as e:
+        print(f"Error while testing {filename}: {e}")
+        ok = False
+        continue
+
+    if failures and not options.update:
+        ok = False
+    else:
+        print(f"Succesfully tested {filename}.")
+
+if ok:
+    print(f"All okay.")
+    sys.exit(0)
+else:
+    print(f"All not okay.")
+    sys.exit(1)

--- a/snapshot_test.md
+++ b/snapshot_test.md
@@ -1,13 +1,31 @@
+# preamble section for setup
 ```py
->>> from sympy import symbols, cancel, simplify
+>>> from sympy import symbols, simplify, integrate, cancel
 >>> x = symbols('x')
+```
+
+# testing the simplify function
+```py
 >>> simplify(x * (x + 1))
 x*(x + 1)
 >>> simplify(x - x)
 100
 >>> simplify(x * (1 - x) + x * (x - 1))
-10
->>> cancel((x ** 2 - 1) / (x - 1))
+67
+```
+
+# testing the cancel function
+```py
+>>> cancel((x ** 2 - 1)/(x - 1))
 x + 1
 >>> cancel((x + 1 - 1)/x)
-(x + 1)/x
+x
+```
+
+# testing the integration capabilities of sympy
+```py
+>>> integrate(x)
+x**2/2
+>>> integrate(2 * x)
+x**3
+```

--- a/snapshot_test.md
+++ b/snapshot_test.md
@@ -1,31 +1,50 @@
 # preamble section for setup
+This section can be used as the preamble.
+I setup the commonly used symbol x, and import functions I need.
 ```py
 >>> from sympy import symbols, simplify, integrate, cancel
 >>> x = symbols('x')
 ```
 
 # testing the simplify function
+These are basic tests of calling simplify with polynomial expressions.
+The expected behaviour is not necessarily that it will call factor.
 ```py
 >>> simplify(x * (x + 1))
 x*(x + 1)
 >>> simplify(x - x)
-100
+0
 >>> simplify(x * (1 - x) + x * (x - 1))
-67
+0
 ```
 
 # testing the cancel function
+cancel function can be used for rational functions to remove the common factors
 ```py
 >>> cancel((x ** 2 - 1)/(x - 1))
 x + 1
 >>> cancel((x + 1 - 1)/x)
-x
+1
 ```
 
 # testing the integration capabilities of sympy
+this performs indefinite integration wrt x
 ```py
 >>> integrate(x)
 x**2/2
 >>> integrate(2 * x)
-x**3
+x**2
+```
+
+
+# testing basic exceptions in python
+```py
+>>> 1 / 0
+11
+```
+
+# testing some other errors
+```py
+>>> 1 + "sympy"
+11
 ```

--- a/snapshot_test.md
+++ b/snapshot_test.md
@@ -1,0 +1,13 @@
+```py
+>>> from sympy import symbols, cancel, simplify
+>>> x = symbols('x')
+>>> simplify(x * (x + 1))
+x*(x + 1)
+>>> simplify(x - x)
+100
+>>> simplify(x * (1 - x) + x * (x - 1))
+10
+>>> cancel((x ** 2 - 1) / (x - 1))
+x + 1
+>>> cancel((x + 1 - 1)/x)
+(x + 1)/x

--- a/sympy/testing/snapshot.py
+++ b/sympy/testing/snapshot.py
@@ -1,0 +1,182 @@
+import doctest as pdoctest
+import os
+import sys
+
+from sympy.testing.runtests import (
+    SymPyDocTestRunner,
+    SymPyOutputChecker,
+    SymPyTestResults,
+)
+
+
+class SymPySnapshotRunner(SymPyDocTestRunner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.snapshot_mismatches = []
+
+    def report_failure(self, out, test, example, got):
+        # Record mismatches
+        self.snapshot_mismatches.append({
+            "filename": test.filename,
+            "lineno": example.lineno,
+            "source": example.source,
+            "want": example.want,
+            "got": got,
+        })
+
+        self._fakeout.truncate(0)
+        self._fakeout.seek(0)
+
+
+# Monkeypatch name-mangled methods for SnapshotRunner
+monkeypatched_snapshot_methods = [
+    'report_failure',
+]
+
+for method in monkeypatched_snapshot_methods:
+    oldname = '_DocTestRunner__' + method
+    newname = '_SymPySnapshotRunner__' + method
+    setattr(SymPySnapshotRunner, newname, getattr(SymPySnapshotRunner, method))
+
+
+def apply_snapshot_updates(filename, mismatches):
+    with open(filename, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for m in reversed(mismatches):
+        lineno = m["lineno"] - 1
+        source_lines = m["source"].count("\n") + 1
+
+        out_start = lineno + source_lines
+        out_end = out_start
+
+        # go through old expected output
+        while out_end < len(lines):
+            line = lines[out_end]
+            if line.lstrip().startswith(">>>") or line.lstrip().startswith("```"):
+                break
+            out_end += 1
+
+        new_output = m["got"].rstrip("\n").splitlines(keepends=True)
+        new_output = [l + "\n" for l in new_output]
+
+        # replace it with new output
+        lines[out_start:out_end] = new_output
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+# This function is same as sympytestfile, with minor changes adapted to snapshot testing.
+def snapshot_testfile(filename, module_relative=True, name=None, package=None,
+             globs=None, verbose=None, report=True, optionflags=0,
+             extraglobs=None, raise_on_error=False,
+             parser=pdoctest.DocTestParser(), encoding=None, update=False):
+
+    if package and not module_relative:
+        raise ValueError("Package may only be specified for module-"
+                         "relative paths.")
+
+    # Relativize the path
+    text, filename = pdoctest._load_testfile(
+        filename, package, module_relative, encoding)
+
+    # If no name was given, then use the file's name.
+    if name is None:
+        name = os.path.basename(filename)
+
+    # Assemble the globals.
+    if globs is None:
+        globs = {}
+    else:
+        globs = globs.copy()
+    if extraglobs is not None:
+        globs.update(extraglobs)
+    if '__name__' not in globs:
+        globs['__name__'] = '__main__'
+
+    if raise_on_error:
+        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
+    else:
+        runner = SymPySnapshotRunner(verbose=verbose, optionflags=optionflags)
+        runner._checker = SymPyOutputChecker()
+
+    # Read the file, convert it to a test, and run it.
+    test = parser.get_doctest(text, globs, name, filename, 0)
+    print(f"{filename}: {len(test.examples)} examples")
+    runner.run(test)
+
+    print(f"Tried: {runner.tries}")
+    print(f"Snapshot mismatches: {len(runner.snapshot_mismatches)}")
+
+    if report:
+        runner.summarize()
+
+    if pdoctest.master is None:
+        pdoctest.master = runner
+    else:
+        pdoctest.master.merge(runner)
+
+    if hasattr(runner, "snapshot_mismatches"):
+        for m in runner.snapshot_mismatches:
+            print(f"Snapshot mismatch in {m['filename']}:{m['lineno']}")
+            print(m["source"].rstrip())
+            print("--- expected")
+            print(m["want"].rstrip())
+            print("+++ got")
+            print(m["got"].rstrip())
+
+    mismatches = getattr(runner, "snapshot_mismatches", [])
+
+    if update and mismatches:
+        apply_snapshot_updates(filename, mismatches)
+        return SymPyTestResults(0, runner.tries)
+
+    return SymPyTestResults(len(mismatches), runner.tries)
+
+
+def iter_markdown_files(paths):
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for f in files:
+                    if f.endswith(".md"):
+                        yield os.path.join(root, f)
+        else:
+            if path.endswith(".md"):
+                yield path
+
+
+def run_snapshot_tests(options, args):
+    all_files = list(iter_markdown_files(args))
+    ok = True
+
+    if not all_files:
+        print("No markdown files found.")
+        sys.exit(0)
+
+    for filename in all_files:
+        print(f"Running snapshot tests: {filename}")
+        try:
+            failures, attempted = snapshot_testfile(
+                filename=filename,
+                module_relative=False,
+                encoding="utf-8",
+                optionflags=(
+                    pdoctest.ELLIPSIS |
+                    pdoctest.NORMALIZE_WHITESPACE |
+                    pdoctest.IGNORE_EXCEPTION_DETAIL
+                ),
+                update=options.update
+            )
+        except Exception as e:
+            print(f"Error while testing {filename}: {e}")
+            ok = False
+            continue
+
+        if failures and not options.update:
+            ok = False
+        else:
+            print(f"Succesfully tested {filename}.")
+
+    return ok


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25610

#### Brief description of what is fixed or changed
This PR is currently work in progress. Right now I have implemented a wrapper script `bin/snapshot` which takes in 2 arguments, a list of files/directories and an optional `--update` (or `-u`) flag, which will manually update the markdown files with the actual output received. Without the flag, the script will execute the tests and report what is wrong. The actual logic for this lives in `sympy/testing/snapshot.py`. 

Current issues which I have come across:
```bash
Snapshot mismatch in doc/src/guides/solving/solving-guidance.md:257
parsed
--- expected
Eq(x**2, y)
+++ got
 2    
x  = y
```
I suspect this is because sympy has multiple printers, what we actually "get" is stored as a string in one format, and what is already typed in the file like a doctest might be in a different format. We could get around this by standardizing what will go into our snapshot markdown files. 

Another issue is line wrapping of large outputs:
```bash
$ bin/snapshot doc/src/guides/solving/solve-matrix-equation.md
...
Snapshot mismatch in doc/src/guides/solving/solve-matrix-equation.md:228
A.det()
--- expected
A₀₀⋅A₁₁⋅A₂₂⋅A₃₃ - A₀₀⋅A₁₁⋅A₂₃⋅A₃₂ - A₀₀⋅A₁₂⋅A₂₁⋅A₃₃ + A₀₀⋅A₁₂⋅A₂₃⋅A₃₁ +
A₀₀⋅A₁₃⋅A₂₁⋅A₃₂ - A₀₀⋅A₁₃⋅A₂₂⋅A₃₁ - A₀₁⋅A₁₀⋅A₂₂⋅A₃₃ + A₀₁⋅A₁₀⋅A₂₃⋅A₃₂ +
A₀₁⋅A₁₂⋅A₂₀⋅A₃₃ - A₀₁⋅A₁₂⋅A₂₃⋅A₃₀ - A₀₁⋅A₁₃⋅A₂₀⋅A₃₂ + A₀₁⋅A₁₃⋅A₂₂⋅A₃₀ +
A₀₂⋅A₁₀⋅A₂₁⋅A₃₃ - A₀₂⋅A₁₀⋅A₂₃⋅A₃₁ - A₀₂⋅A₁₁⋅A₂₀⋅A₃₃ + A₀₂⋅A₁₁⋅A₂₃⋅A₃₀ +
A₀₂⋅A₁₃⋅A₂₀⋅A₃₁ - A₀₂⋅A₁₃⋅A₂₁⋅A₃₀ - A₀₃⋅A₁₀⋅A₂₁⋅A₃₂ + A₀₃⋅A₁₀⋅A₂₂⋅A₃₁ +
A₀₃⋅A₁₁⋅A₂₀⋅A₃₂ - A₀₃⋅A₁₁⋅A₂₂⋅A₃₀ - A₀₃⋅A₁₂⋅A₂₀⋅A₃₁ + A₀₃⋅A₁₂⋅A₂₁⋅A₃₀
+++ got
A₀₀⋅A₁₁⋅A₂₂⋅A₃₃ - A₀₀⋅A₁₁⋅A₂₃⋅A₃₂ - A₀₀⋅A₁₂⋅A₂₁⋅A₃₃ + A₀₀⋅A₁₂⋅A₂₃⋅A₃₁ + A₀₀⋅A₁₃⋅A₂₁⋅A₃₂ - A₀₀⋅A₁₃⋅A₂₂⋅A₃₁ - A₀₁⋅A₁₀⋅A₂₂⋅A ↪

↪ ₃₃ + A₀₁⋅A₁₀⋅A₂₃⋅A₃₂ + A₀₁⋅A₁₂⋅A₂₀⋅A₃₃ - A₀₁⋅A₁₂⋅A₂₃⋅A₃₀ - A₀₁⋅A₁₃⋅A₂₀⋅A₃₂ + A₀₁⋅A₁₃⋅A₂₂⋅A₃₀ + A₀₂⋅A₁₀⋅A₂₁⋅A₃₃ - A₀₂⋅A₁ ↪

↪ ₀⋅A₂₃⋅A₃₁ - A₀₂⋅A₁₁⋅A₂₀⋅A₃₃ + A₀₂⋅A₁₁⋅A₂₃⋅A₃₀ + A₀₂⋅A₁₃⋅A₂₀⋅A₃₁ - A₀₂⋅A₁₃⋅A₂₁⋅A₃₀ - A₀₃⋅A₁₀⋅A₂₁⋅A₃₂ + A₀₃⋅A₁₀⋅A₂₂⋅A₃₁ + ↪

↪  A₀₃⋅A₁₁⋅A₂₀⋅A₃₂ - A₀₃⋅A₁₁⋅A₂₂⋅A₃₀ - A₀₃⋅A₁₂⋅A₂₀⋅A₃₁ + A₀₃⋅A₁₂⋅A₂₁⋅A₃₀
```
This is the only failure in this file, the expected output in the file has manual line breaks, however the pretty printed representation has those little arrows, which obviously do not match when compared like strings. 

#### Other comments

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->

My approach has been to take inspiration from `bin/doctest` and `sympy/testing/runtests.py` and copying some of the code that is needed. I generated the `iter_markdown_files` function and part of the `apply_snapshot_updates` function, but only after carefully describing the logic needed manually. Rest of the code is typed out by me. The tool in question is ChatGPT Go. All the code is reviewed by me by my own eyes. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
