### PR TITLE
fix: handle ruff 0.15.0 changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,7 @@ lint.ignore = [
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "E741",  # Ambiguous variable name: `<VARIABLE>`
     "E743",  # Ambiguous function name: `<FUNCTION>`
-    # Rules from the stable "FURB" set that are ignored. See #27897
-    # Just to be safe, we'll ignore FURB161 until we drop support for Python 3.9
-    "FURB161",  # Use of `bin({existing}).count('1')`
+    "FURB110",  # Replace ternary `if` expression with `or` operator
     "FURB187",  # Use of assignment of `reversed` on list `{name}`
 ]
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -259,7 +259,7 @@ def test_Lambda():
     eq = Lambda(x, 2*x) + Lambda(y, 2*y)
     assert eq != 2*Lambda(x, 2*x)
     assert eq.as_dummy() == 2*Lambda(x, 2*x).as_dummy()
-    assert Lambda(x, 2*x) not in [ Lambda(x, x) ]
+    assert Lambda(x, 2*x) != Lambda(x, x)
     raises(BadSignatureError, lambda: Lambda(1, x))
     assert Lambda(x, 1)(1) is S.One
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -171,7 +171,7 @@ class factorial(CombinatorialFunction):
                         result = _gmpy.fac(n)
 
                     else:
-                        bits = bin(n).count('1')
+                        bits = n.bit_count()
                         result = cls._recursive(n)*2**(n - bits)
 
                     return Integer(result)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -232,7 +232,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         plaintext_formatter.for_type(cls, _print_plain)
 
     svg_formatter = ip.display_formatter.formatters['image/svg+xml']
-    if use_latex in ('svg', ):
+    if use_latex == 'svg':
         debug("init_printing: using svg formatter")
         for cls in printable_types:
             svg_formatter.for_type(cls, _print_latex_svg)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3,7 +3,7 @@ Boolean algebra module for SymPy
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, overload, Any, Callable
+from typing import TYPE_CHECKING, overload, Any
 
 from collections import defaultdict
 from itertools import chain, combinations, product, permutations
@@ -25,12 +25,6 @@ from sympy.utilities.misc import filldedent
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
-
-
-try:  # sys.version_info >= (3, 10)
-    _bit_count: Callable[[int], int] = int.bit_count
-except AttributeError:
-    _bit_count = lambda i: bin(i).count("1")
 
 
 def as_Boolean(e):
@@ -2224,7 +2218,7 @@ def _get_odd_parity_terms(n):
     with an odd number of ones.
     """
     return [[1 if (mask >> i) & 1 else 0 for i in range(n)]
-            for mask in range(1 << n) if _bit_count(mask) % 2 == 1]
+            for mask in range(1 << n) if mask.bit_count() % 2 == 1]
 
 
 def _get_even_parity_terms(n):
@@ -2233,7 +2227,7 @@ def _get_even_parity_terms(n):
     with an even number of ones.
     """
     return [[1 if (mask >> i) & 1 else 0 for i in range(n)]
-            for mask in range(1 << n) if _bit_count(mask) % 2 == 0]
+            for mask in range(1 << n) if mask.bit_count() % 2 == 0]
 
 
 def _simplified_pairs(terms):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1241,7 +1241,7 @@ def test_issue_3950():
     a = Matrix([1, 2, 3])
     b = Matrix([2, 2, 3])
     assert not (m in [])
-    assert not (m in [1])
+    assert not (m == 1)
     assert m != 1
     assert m == a
     assert m != b

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -2042,7 +2042,7 @@ def test_issue_3950():
     a = Matrix([1, 2, 3])
     b = Matrix([2, 2, 3])
     assert not (m in [])
-    assert not (m in [1])
+    assert not (m == 1)
     assert m != 1
     assert m == a
     assert m != b

--- a/sympy/physics/biomechanics/_mixin.py
+++ b/sympy/physics/biomechanics/_mixin.py
@@ -44,7 +44,7 @@ class _NamedMixin:
                 f'{type(name)}, must be {str}.'
             )
             raise TypeError(msg)
-        if name in {''}:
+        if name == '':
             msg = (
                 f'Name {repr(name)} is invalid, must be a nonzero length '
                 f'{type(str)}.'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
