### PR TITLE
Ambiguous generator selection

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1121,6 +1121,7 @@ Mohak Malviya <mohakmalviya2000@gmail.com> Senku <mohakmalviya2000@gmail.com>
 Mohamed Rezk <mohrizq895@gmail.com>
 Mohammad Sadeq Dousti <msdousti@gmail.com>
 Mohammed Bilal <r.mohammedbilal@gmail.com>
+Mohammed Umar <mdumr4@gmail.com>
 Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohit Balwani <44258119+Mohitbalwani26@users.noreply.github.com>
 Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohitbalwani26 <44258119+Mohitbalwani26@users.noreply.github.com>
 Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohitbalwani26 <mohitbalwani.ict17@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1456,3 +1456,4 @@ Avanish Salunke <avanishsalunke16@gmail.com>
 Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
+Mohammed Umar <mdumr4@gmail.com>

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4962,18 +4962,18 @@ def degree(f, gen=0):
             return S.NegativeInfinity if f.is_zero else S.Zero
         try:
             p = Poly(f, expand=False)
-        except GeneratorsNeeded:
-            p = Poly(f, Dummy())
+        except GeneratorsNeeded:  # e.g. f = (1+I)**2/2
+            gens = ()  # do not guess what the user intended
         else:
             gens = p.gens
-            free = f.free_symbols
-            if not (gen == 0 and len(gens) == 1 and len(free) < 2 and f.is_polynomial(
-                    gen := next(iter(gens))) and # <-- assigns gen
-                    gen.is_Atom):  # e.g. x or pi
-                raise TypeError(filldedent('''
-                    To avoid ambiguity, this expression requires either
-                    a symbol (not int) generator or a Poly (which identifies
-                    the generators).'''))
+        free = f.free_symbols
+        if not (gen == 0 and len(gens) == 1 and len(free) < 2 and f.is_polynomial(
+                gen := next(iter(gens))) and # <-- assigns gen
+                gen.is_Atom):  # e.g. x or pi
+            raise TypeError(filldedent('''
+                To avoid ambiguity, this expression requires either
+                a symbol (not int) generator or a Poly (which identifies
+                the generators).'''))
         return p.degree(gen)
 
     gen = sympify(gen, strict=True)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1335,6 +1335,7 @@ def test_Poly_degree():
     assert degree(x*y**2, z) == 0
 
     assert degree(pi) == 1
+    raises(TypeError, lambda: degree(I))  # Poly sees a number but no gen -> needs gen
     raises(TypeError, lambda: degree(y**2 + x**3))
     raises(TypeError, lambda: degree(y**2 + x**3, 1))
     raises(PolynomialError, lambda: degree(x**2/(x**3 + 1), x))

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1334,7 +1334,7 @@ def test_Poly_degree():
     assert degree(x*y**2, y) == 2
     assert degree(x*y**2, z) == 0
 
-    assert degree(pi) == 1
+    raises(TypeError, lambda: degree(pi))  # no guessing for non-Number expressions
 
     raises(TypeError, lambda: degree(y**2 + x**3))
     raises(TypeError, lambda: degree(y**2 + x**3, 1))
@@ -1347,6 +1347,11 @@ def test_Poly_degree():
     assert degree(Poly(y**2 + x**3, y, x), 1) == 3
     assert degree(Poly(y**2 + x**3, x), z) == 0
     assert degree(Poly(y**2 + x**3 + z**4, x), z) == 4
+
+    # Regression test for Issue 29090
+    assert degree(x**2) == 2
+    raises(TypeError, lambda: degree(x*(1/x + 1)))  # no help for gen=0
+    raises(TypeError, lambda: degree(x + 1/x))  # no guessing for gen=0
 
 def test_Poly_degree_list():
     assert Poly(0, x).degree_list() == (-oo,)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -72,7 +72,7 @@ from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.hyperbolic import tanh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import sin
+from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.matrices.dense import Matrix
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.polys.rootoftools import rootof
@@ -1334,11 +1334,9 @@ def test_Poly_degree():
     assert degree(x*y**2, y) == 2
     assert degree(x*y**2, z) == 0
 
-    raises(TypeError, lambda: degree(pi))  # no guessing for non-Number expressions
-
+    assert degree(pi) == 1
     raises(TypeError, lambda: degree(y**2 + x**3))
     raises(TypeError, lambda: degree(y**2 + x**3, 1))
-    raises(PolynomialError, lambda: degree(x, 1.1))
     raises(PolynomialError, lambda: degree(x**2/(x**3 + 1), x))
 
     assert degree(Poly(0,x),z) is -oo
@@ -1348,10 +1346,39 @@ def test_Poly_degree():
     assert degree(Poly(y**2 + x**3, x), z) == 0
     assert degree(Poly(y**2 + x**3 + z**4, x), z) == 4
 
-    # Regression test for Issue 29090
-    assert degree(x**2) == 2
-    raises(TypeError, lambda: degree(x*(1/x + 1)))  # no help for gen=0
-    raises(TypeError, lambda: degree(x + 1/x))  # no guessing for gen=0
+
+    # optimization
+    big = 2  # make this number 1000 when full expansion can be avoided
+
+    assert degree((x + 1)**big, x) == big  # Large power (fast-path, no expansion)
+    assert degree((x + 1)**big + x**(big-1), x) == big  # Addition without cancellation
+    assert degree((x + 1)**2 - x**2, x) == 1  # Addition with cancellation (fallback required)
+    assert degree(x*(x + 1)**big, x) == big + 1  # Nested multiplication
+    assert degree(y*(x + 1)**big, x) == big  # Generator independence
+
+    # checking 0 detection
+    Z = pi*(1/pi + 1) - 1 - pi
+    assert degree(Z**big, x) is S.NegativeInfinity
+    assert degree(Z**big, pi) is S.NegativeInfinity
+    Z = Add(0, Mul(0, x, evaluate=False), evaluate=False)
+    assert degree(Z, x) is S.NegativeInfinity
+    assert degree(cos(1)**2 + sin(1)**2 - 1, x) == 0  # should be -oo
+
+    # /!\ user was warned; anything could change as Poly is improved-#
+    eq = x + 1/x**2                                                  #
+    raises(PolynomialError, lambda: degree(eq**big, x))              #
+    assert degree(eq**big, 1/x) == 2*big                             #
+                                                                     #
+    eq = exp(x) + 1/exp(2*x)                                         #
+    assert degree(eq, exp(x)) == 1                                   #
+    assert degree(eq, exp(-x)) == 2                                  #
+                                                                     #
+    one = Pow(x, 0, evaluate=False)                                  #
+    raises(PolynomialError, lambda: degree(one, one))                #
+    assert degree(x, 1.1) == degree(x, pi) == 0                      #
+    assert degree(0, 1.1) == -oo                                     #
+    # end of zoo of warnings-----------------------------------------#
+
 
 def test_Poly_degree_list():
     assert Poly(0, x).degree_list() == (-oo,)


### PR DESCRIPTION
polys: Fix ambiguous generator selection in degree()

Fixes #29090


Release Notes
<!-- BEGIN RELEASE NOTES -->
* polys
  * degree() function only allows gen to be an int if f is a Poly or is a polynomial expression expressed in a single Atom
<!-- END RELEASE NOTES -->