### PR TITLE
Remove AskHandler (Deprecated since SymPy 1.8)

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1226,43 +1226,6 @@ into a new project called [Aesara](https://github.com/aesara-devs/aesara). The
 been renamed (e.g., `theano_code` has been renamed to {func}`~.aesara_code`,
 `TheanoPrinter` has been renamed to {class}`~.AesaraPrinter`, and so on).
 
-(deprecated-askhandler)=
-### `sympy.assumptions.handlers.AskHandler` and related methods
-
-`Predicate` has experienced a big design change. Previously, its handler was a
-list of `AskHandler` classes and registration was done by `add_handler()` and
-`remove_handler()` functions. Now, its handler is a multipledispatch instance
-and registration is done by `register()` or `register_many()` methods. Users
-must define a predicate class to introduce a new one.
-
-Previously, handlers were defined and registered this way:
-
-```python
-class AskPrimeHandler(AskHandler):
-    @staticmethod
-    def Integer(expr, assumptions):
-        return expr.is_prime
-
-register_handler('prime', AskPrimeHandler)
-```
-
-It should be changed to this:
-
-```python
-# Predicate definition.
-# Not needed if you are registering the handler to existing predicate.
-class PrimePredicate(Predicate):
-    name = 'prime'
-Q.prime = PrimePredicate()
-
-# Handler registration
-@Q.prime.register(Integer)
-def _(expr, assumptions):
-    return expr.is_prime
-```
-
-See GitHub issue [#20209](https://github.com/sympy/sympy/issues/20209).
-
 ## Version 1.7.1
 
 (deprecated-distribution-randomindexedsymbol)=

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -72,7 +72,7 @@ from .logic import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor,
         true, false, satisfiable)
 
 from .assumptions import (AppliedPredicate, Predicate, AssumptionsContext,
-        assuming, Q, ask, register_handler, remove_handler, refine)
+        assuming, Q, ask, refine)
 
 from .polys import (Poly, PurePoly, poly_from_expr, parallel_poly_from_expr,
         degree, total_degree, degree_list, LC, LM, LT, pdiv, prem, pquo,
@@ -291,7 +291,7 @@ __all__ = [
 
     # sympy.assumptions
     'AppliedPredicate', 'Predicate', 'AssumptionsContext', 'assuming', 'Q',
-    'ask', 'register_handler', 'remove_handler', 'refine',
+    'ask',  'refine',
 
     # sympy.polys
     'Poly', 'PurePoly', 'poly_from_expr', 'parallel_poly_from_expr', 'degree',

--- a/sympy/assumptions/__init__.py
+++ b/sympy/assumptions/__init__.py
@@ -6,13 +6,13 @@ from .assume import (
     AppliedPredicate, Predicate, AssumptionsContext, assuming,
     global_assumptions
 )
-from .ask import Q, ask, register_handler, remove_handler
+from .ask import Q, ask
 from .refine import refine
 from .relation import BinaryRelation, AppliedBinaryRelation
 
 __all__ = [
     'AppliedPredicate', 'Predicate', 'AssumptionsContext', 'assuming',
-    'global_assumptions', 'Q', 'ask', 'register_handler', 'remove_handler',
+    'global_assumptions', 'Q', 'ask',
     'refine',
     'BinaryRelation', 'AppliedBinaryRelation'
 ]

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -8,9 +8,6 @@ from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
-from sympy.utilities.exceptions import (sympy_deprecation_warning,
-                                        SymPyDeprecationWarning,
-                                        ignore_warnings)
 
 
 # Memoization is necessary for the properties of AssumptionKeys to

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -639,54 +639,5 @@ def _ask_single_fact(key, local_facts):
     return None
 
 
-def register_handler(key, handler):
-    """
-    Register a handler in the ask system. key must be a string and handler a
-    class inheriting from AskHandler.
-
-    .. deprecated:: 1.8.
-        Use multipledispatch handler instead. See :obj:`~.Predicate`.
-
-    """
-    sympy_deprecation_warning(
-        """
-        The AskHandler system is deprecated. The register_handler() function
-        should be replaced with the multipledispatch handler of Predicate.
-        """,
-        deprecated_since_version="1.8",
-        active_deprecations_target='deprecated-askhandler',
-    )
-    if isinstance(key, Predicate):
-        key = key.name.name
-    Qkey = getattr(Q, key, None)
-    if Qkey is not None:
-        Qkey.add_handler(handler)
-    else:
-        setattr(Q, key, Predicate(key, handlers=[handler]))
-
-
-def remove_handler(key, handler):
-    """
-    Removes a handler from the ask system.
-
-    .. deprecated:: 1.8.
-        Use multipledispatch handler instead. See :obj:`~.Predicate`.
-
-    """
-    sympy_deprecation_warning(
-        """
-        The AskHandler system is deprecated. The remove_handler() function
-        should be replaced with the multipledispatch handler of Predicate.
-        """,
-        deprecated_since_version="1.8",
-        active_deprecations_target='deprecated-askhandler',
-    )
-    if isinstance(key, Predicate):
-        key = key.name.name
-    # Don't show the same warning again recursively
-    with ignore_warnings(SymPyDeprecationWarning):
-        getattr(Q, key).remove_handler(handler)
-
-
 from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -1,14 +1,11 @@
 """A module which implements predicates and assumption context."""
 
 from contextlib import contextmanager
-import inspect
 from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import Boolean, false, true
 from sympy.multipledispatch.dispatcher import Dispatcher, str_signature
-from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
-from sympy.utilities.source import get_class
 
 
 class AssumptionsContext(set):

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -401,63 +401,8 @@ class UndefinedPredicate(Predicate):
     def __call__(self, expr):
         return AppliedPredicate(self, expr)
 
-    def add_handler(self, handler):
-        sympy_deprecation_warning(
-            """
-            The AskHandler system is deprecated. Predicate.add_handler()
-            should be replaced with the multipledispatch handler of Predicate.
-            """,
-            deprecated_since_version="1.8",
-            active_deprecations_target='deprecated-askhandler',
-        )
-        self.handlers.append(handler)
-
-    def remove_handler(self, handler):
-        sympy_deprecation_warning(
-            """
-            The AskHandler system is deprecated. Predicate.remove_handler()
-            should be replaced with the multipledispatch handler of Predicate.
-            """,
-            deprecated_since_version="1.8",
-            active_deprecations_target='deprecated-askhandler',
-        )
-        self.handlers.remove(handler)
-
     def eval(self, args, assumptions=True):
-        # Support for deprecated design
-        # When old design is removed, this will always return None
-        sympy_deprecation_warning(
-            """
-            The AskHandler system is deprecated. Evaluating UndefinedPredicate
-            objects should be replaced with the multipledispatch handler of
-            Predicate.
-            """,
-            deprecated_since_version="1.8",
-            active_deprecations_target='deprecated-askhandler',
-            stacklevel=5,
-        )
-        expr, = args
-        res, _res = None, None
-        mro = inspect.getmro(type(expr))
-        for handler in self.handlers:
-            cls = get_class(handler)
-            for subclass in mro:
-                eval_ = getattr(cls, subclass.__name__, None)
-                if eval_ is None:
-                    continue
-                res = eval_(expr, assumptions)
-                # Do not stop if value returned is None
-                # Try to check for higher classes
-                if res is None:
-                    continue
-                if _res is None:
-                    _res = res
-                else:
-                    # only check consistency if both resolutors have concluded
-                    if _res != res:
-                        raise ValueError('incompatible resolutors')
-                break
-        return res
+        return None
 
 
 @contextmanager

--- a/sympy/assumptions/handlers/__init__.py
+++ b/sympy/assumptions/handlers/__init__.py
@@ -4,10 +4,8 @@ Handlers in this module are not directly imported to other modules in
 order to avoid circular import problem.
 """
 
-from .common import (AskHandler, CommonHandler,
-    test_closed_group)
+from .common import test_closed_group
 
 __all__ = [
-    'AskHandler', 'CommonHandler',
     'test_closed_group'
 ]

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -9,7 +9,6 @@ from sympy.core.logic import _fuzzy_group, fuzzy_and, fuzzy_or
 from sympy.core.numbers import NaN, Number
 from sympy.logic.boolalg import (And, BooleanTrue, BooleanFalse, conjuncts,
     Equivalent, Implies, Not, Or)
-from sympy.utilities.exceptions import sympy_deprecation_warning
 
 from ..predicates.common import CommutativePredicate, IsTruePredicate
 

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -14,39 +14,6 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from ..predicates.common import CommutativePredicate, IsTruePredicate
 
 
-class AskHandler:
-    """Base class that all Ask Handlers must inherit."""
-    def __new__(cls, *args, **kwargs):
-        sympy_deprecation_warning(
-            """
-            The AskHandler system is deprecated. The AskHandler class should
-            be replaced with the multipledispatch handler of Predicate
-            """,
-            deprecated_since_version="1.8",
-            active_deprecations_target='deprecated-askhandler',
-        )
-        return super().__new__(cls, *args, **kwargs)
-
-
-class CommonHandler(AskHandler):
-    # Deprecated
-    """Defines some useful methods common to most Handlers. """
-
-    @staticmethod
-    def AlwaysTrue(expr, assumptions):
-        return True
-
-    @staticmethod
-    def AlwaysFalse(expr, assumptions):
-        return False
-
-    @staticmethod
-    def AlwaysNone(expr, assumptions):
-        return None
-
-    NaN = AlwaysFalse
-
-
 # CommutativePredicate
 
 @CommutativePredicate.register(Symbol)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,11 +1,9 @@
 from sympy.abc import t, w, x, y, z, n, k, m, p, i
-from sympy.assumptions import (ask, AssumptionsContext, Q, register_handler,
-        remove_handler)
+from sympy.assumptions import (ask, AssumptionsContext, Q)
 from sympy.assumptions.assume import assuming, global_assumptions, Predicate
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.facts import (single_fact_lookup,
     get_known_facts, generate_known_facts_dict, get_known_facts_keys)
-from sympy.assumptions.handlers import AskHandler
 from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)
 from sympy.core.add import Add
@@ -2237,26 +2235,6 @@ def test_key_extensibility():
     # make sure the key is not defined
     raises(AttributeError, lambda: ask(Q.my_key(x)))
 
-    # Old handler system
-    class MyAskHandler(AskHandler):
-        @staticmethod
-        def Symbol(expr, assumptions):
-            return True
-    try:
-        with warns_deprecated_sympy():
-            register_handler('my_key', MyAskHandler)
-        with warns_deprecated_sympy():
-            assert ask(Q.my_key(x)) is True
-        with warns_deprecated_sympy():
-            assert ask(Q.my_key(x + 1)) is None
-    finally:
-        # We have to disable the stacklevel testing here because this raises
-        # the warning twice from two different places
-        with warns_deprecated_sympy():
-            remove_handler('my_key', MyAskHandler)
-        del Q.my_key
-    raises(AttributeError, lambda: ask(Q.my_key(x)))
-
     # New handler system
     class MyPredicate(Predicate):
         pass
@@ -2480,28 +2458,6 @@ def test_autosimp_used_to_fail():
 def test_custom_AskHandler():
     from sympy.logic.boolalg import conjuncts
 
-    # Old handler system
-    class MersenneHandler(AskHandler):
-        @staticmethod
-        def Integer(expr, assumptions):
-            if ask(Q.integer(log(expr + 1, 2))):
-                return True
-        @staticmethod
-        def Symbol(expr, assumptions):
-            if expr in conjuncts(assumptions):
-                return True
-    try:
-        with warns_deprecated_sympy():
-            register_handler('mersenne', MersenneHandler)
-        n = Symbol('n', integer=True)
-        with warns_deprecated_sympy():
-            assert ask(Q.mersenne(7))
-        with warns_deprecated_sympy():
-            assert ask(Q.mersenne(n), Q.mersenne(n))
-    finally:
-        del Q.mersenne
-
-    # New handler system
     class MersennePredicate(Predicate):
         pass
     try:

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -19,8 +19,7 @@ from sympy.functions.elementary.trigonometric import (
     acos, acot, asin, atan, cos, cot, sin, tan)
 from sympy.logic.boolalg import Equivalent, Implies, Xor, And, to_cnf
 from sympy.matrices import Matrix, SparseMatrix
-from sympy.testing.pytest import (XFAIL, slow, raises, warns_deprecated_sympy,
-    _both_exp_pow)
+from sympy.testing.pytest import XFAIL, slow, raises,  _both_exp_pow
 import math
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/20837

#### Other comments 

This needs to be merged first before https://github.com/sympy/sympy/pull/29078 can be merged.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions 
  *  **BREAKING CHANGE**: The deprecated `AskHandler` class and the `add_handler()`/`remove_handler()` functions have been removed. Custom predicates must now be defined by subclassing `Predicate` and registered using the `@Q.predicate.register(Type)` decorator. See the second example in the [documentation page for the Predicate class](https://docs.sympy.org/latest/modules/assumptions/index.html#predicate) for more information for how to define custom predicates the new way.

<!-- END RELEASE NOTES -->
