### PR TITLE
Greatly improve nsimplify behavior for large values and integer-valued floats

### DIFF
--- a/doc/src/modules/evalf.rst
+++ b/doc/src/modules/evalf.rst
@@ -424,3 +424,8 @@ Here are several more advanced examples:
     >>> nsimplify(gamma('1/4')*gamma('3/4'), [pi])
       ___
     \/ 2 *pi
+    >>> nsimplify((100*sqrt(7)/30*pi*E*log(2)).evalf(), [pi,E,log(2)], full=true)
+         ___
+    10*\/ 7 *e*pi*log(2)
+    --------------------
+             3

--- a/doc/src/modules/evalf.rst
+++ b/doc/src/modules/evalf.rst
@@ -380,7 +380,7 @@ and a minimum numerical tolerance. Here are some elementary examples:
     635
     ---
     504
-    >>> nsimplify(2.0**(1/3.), tolerance=0.001, full=True)
+    >>> nsimplify(2.0**(1/3.))
     3 ___
     \/ 2
 

--- a/sympy/polys/numberfields/tests/test_minpoly.py
+++ b/sympy/polys/numberfields/tests/test_minpoly.py
@@ -2,6 +2,7 @@
 
 from sympy.core.function import expand
 from sympy.core import (GoldenRatio, TribonacciConstant)
+from sympy.core import sympify
 from sympy.core.numbers import (AlgebraicNumber, I, Rational, oo, pi)
 from sympy.core.power import Pow
 from sympy.core.singleton import S
@@ -328,9 +329,13 @@ def test_minpoly_compose():
 
 
 def test_minpoly_issue_7113():
-    # see discussion in https://github.com/sympy/sympy/pull/2234
+    # see discussion in
+    #   https://github.com/sympy/sympy/pull/2234
+    #   https://github.com/sympy/sympy/pull/2288
+    #   https://github.com/sympy/sympy/pull/29101
     from sympy.simplify.simplify import nsimplify
-    r = nsimplify(pi, tolerance=0.000000001)
+    r = nsimplify(pi, tolerance=0.000000001, full=True, magnitude_offsets=False)
+    assert r == sympify("2*2**(22/109)*3**(42/109)*5**(90/109)*7**(71/109)/15")
     mp = minimal_polynomial(r, x)
     assert mp == 1768292677839237920489538677417507171630859375*x**109 - \
     2734577732179183863586489182929671773182898498218854181690460140337930774573792597743853652058046464

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1401,7 +1401,7 @@ def nthroot(expr, n, max_len=4, prec=15):
 
 
 def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
-    rational_conversion='base10', magnitude_offsets=None):
+    rational_conversion='base10', shortcut_integers=True, magnitude_offsets=None):
     """
     Find a simple representation for a number or, if there are free symbols or
     if ``rational=True``, then replace Floats with their Rational equivalents. If
@@ -1466,7 +1466,7 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
 
     """
     expr = sympify(expr)
-    if isinstance(expr, Integer):
+    if shortcut_integers and isinstance(expr, Integer):
         return expr
     expr = expr.xreplace({
         Float('inf'): S.Infinity,
@@ -1565,6 +1565,9 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
         """
         if not x:  # nothing to do for 0
             return x
+        # only offer integer shortcutting within tolerance
+        if shortcut_integers and x < (1/tolerance) and ctx.isint(x):
+            return Integer(int(x))
         if not magnitude_offsets:  # offsetting disabled (False)
             return nsimplify_real(ctx, x)
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1503,7 +1503,7 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     elif not isinstance(magnitude_offsets, (list, tuple, set)):
         # NOTE decimal offsets are not explicitly blocked here as they might be useful to somebody
         #   though it might make sense to warn for silly offsets
-        raise TypeError(f"magnitude_offsets must be False (disabled), or a list/tuple/set of None or integers")
+        raise TypeError("magnitude_offsets must be False (disabled), or a list/tuple/set of None or integers")
 
     constants_sym = []
     constants_dict = {}
@@ -1598,7 +1598,6 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
 
         # get the base order of magnitude
         magnitude = int(log(abs(x), 10).evalf())
-        # try the range containing 2 orders of magnitide on either side
         trials = []
         # TODO should prec or tolerance be rescaled?
         for offset in magnitude_offsets:  # try to identify with a window of orders of magnitude

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1476,12 +1476,14 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     prec = 30
     bprec = int(prec*3.33)
 
+    constants_sym = []
     constants_dict = {}
     for constant in constants:
         constant = sympify(constant)
         v = constant.evalf(prec)
         if not v.is_Float:
             raise ValueError("constants must be real-valued")
+        constants_sym.append(constant)
         constants_dict[str(constant)] = v._to_mpmath(bprec)
 
     exprval = expr.evalf(prec, chop=True)
@@ -1490,6 +1492,10 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     # safety check to make sure that this evaluated to a number
     if not (re.is_Number and im.is_Number):
         return expr
+
+    def count_constants(expr):
+        # TODO is this any better/worse than `sum(expr.count(s) for s in constants_sym)`?
+        return expr.subs({s: Dummy() for s in constants_sym}).count(Dummy)
 
     def nsimplify_real(x):
         xv = x._to_mpmath(bprec)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1446,7 +1446,7 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     Examples
     ========
 
-    >>> from sympy import nsimplify, sqrt, GoldenRatio, exp, I, pi
+    >>> from sympy import nsimplify, N, sqrt, GoldenRatio, exp, I, pi
     >>> nsimplify(4/(1+sqrt(5)), [GoldenRatio])
     -2 + 2*GoldenRatio
     >>> nsimplify((1/(exp(3*pi*I/5)+1)))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1594,7 +1594,7 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
         # by a large scaling factor
         # users can increase the tolerance to change this behavior or call
         # `mpmath.isint()` themselves
-        if shortcut_integers and abs(x) < (.1/tolerance) and ctx.isint(x):
+        if shortcut_integers and tolerance != 0 and abs(x) < (.1/tolerance) and ctx.isint(x):
             return Integer(int(x))
         if not magnitude_offsets:  # offsetting disabled (False)
             return nsimplify_real(ctx, x)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1462,9 +1462,11 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     1/3
 
     >>> nsimplify(N(10**20*sqrt(2)), magnitude_offsets=False)
-    141421356237309509632
+    141421356237310000000
     >>> nsimplify(N(10**20*sqrt(2)), magnitude_offsets=[0])
     100000000000000000000*sqrt(2)
+    >>> nsimplify(N(10**20*sqrt(2)), tolerance=10**-22)  # detects as Integer
+    141421356237309509632
 
     See Also
     ========

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1494,12 +1494,6 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
     def nsimplify_real(x):
         xv = x._to_mpmath(bprec)
         with local_workprec(prec) as ctx:
-            # We'll be happy with low precision if a simple fraction
-            if not (tolerance or full):
-                ctx.dps = 15
-                rat = ctx.pslq([xv, 1])
-                if rat is not None:
-                    return Rational(-int(rat[1]), int(rat[0]))
             ctx.dps = prec
             newexpr = ctx.identify(xv, constants=constants_dict,
                 tol=tolerance, full=full)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1481,7 +1481,7 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
         Float('inf'): S.Infinity,
         Float('-inf'): S.NegativeInfinity,
     })
-    if expr is S.Infinity or expr is S.NegativeInfinity:
+    if expr is S.Infinity or expr is S.NegativeInfinity or expr is S.NaN:
         return expr
     if rational or expr.free_symbols:
         return _real_to_rational(expr, tolerance, rational_conversion)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1617,8 +1617,8 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
                 # constant count: more total constant members are preferred
                 -count_constants(expr),
                 # Float component: sort later and by-count
-                # NOTE constants can be Float, skip for x<0 which may expect a Float result
-                None if magnitude < 0 else expr.count(Float),
+                # NOTE constants can be Float
+                expr.count(Float),
                 # complexity: less complexity sorts earlier, but beware Floats vs Rationals
                 # for example C(.3)=1, but C(3/10)=2 so this should come after Float check
                 expr.count_ops(),

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1496,10 +1496,11 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
 
     if magnitude_offsets is None:  # use default
         magnitude_offsets = [None,0,-1,1,2]  # None means no normalization
+    elif isinstance(magnitude_offsets, int) and not isinstance(magnitude_offsets, bool):
+        # pass in a list like `[offset]` to omit default
+        magnitude_offsets = [magnitude_offsets, None]
     elif not magnitude_offsets:  # False or empty collection: disabled
          magnitude_offsets = False
-    elif isinstance(magnitude_offsets, int):  # pass in a list like `[offset]` to omit default
-        magnitude_offsets = [magnitude_offsets, None]
     elif not isinstance(magnitude_offsets, (list, tuple, set)):
         # NOTE decimal offsets are not explicitly blocked here as they might be useful to somebody
         #   though it might make sense to warn for silly offsets

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1566,7 +1566,7 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
         if not x:  # nothing to do for 0
             return x
         # only offer integer shortcutting within tolerance
-        if shortcut_integers and x < (1/tolerance) and ctx.isint(x):
+        if shortcut_integers and abs(x) < (.1/tolerance) and ctx.isint(x):
             return Integer(int(x))
         if not magnitude_offsets:  # offsetting disabled (False)
             return nsimplify_real(ctx, x)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -390,8 +390,7 @@ def test_nsimplify():
     assert nsimplify(pi, tolerance=0.001) == Rational(355, 113)
     assert nsimplify(0.33333, tolerance=1e-4) == Rational(1, 3)
     assert nsimplify(2.0**(1/3.), tolerance=0.001) == Rational(635, 504)
-    assert nsimplify(2.0**(1/3.), tolerance=0.001, full=True) == \
-        2**Rational(1, 3)
+    assert nsimplify(2.0**(1/3.)) == 2**Rational(1, 3)
     assert nsimplify(x + .5, rational=True) == S.Half + x
     assert nsimplify(1/.3 + x, rational=True) == Rational(10, 3) + x
     assert nsimplify(log(3).n(), rational=True) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #23822

#### Brief description of what is fixed or changed

Greatly improves `nsimplify()` behavior for large values and integer-valued float inputs
* adds a heuristic/dynamic complexity analysis for `nsimplify_real()`
* attempts to `nsimplify_real()` several times, additionally normalizing values around 1 and then searching the close magnitudes before restoring the value, and choosing the best result

Greatly improved integer-valued float detection, especially through cautious use of `mpmath.isint()`

Both shortcuts for Integers and the new magnitude offsetting are optional/controllable via new arguments `shortcut_integers` and `magnitude_offsets` respectively

#### Other comments

I've written a test tool which does a huge number of trials on forms like `N(factor/divisor*scale*constant)`, then checks for the presence of the constant after simplifying  `return str(self.constant) in str(r) and abs(r).count_ops() < 5`  but it's not ready to show off yet as it's both extraordinarily slow and doesn't have a nice output format.. however I still wanted to show these early results and get some comments to chew on in the meantime!
* before: ran 198450, while 156757 needed hint and 147147 failed (Python 3.13.1, SymPy 1.14.0)
* mine: ran 198450, while 66732 needed hint and 1201 failed (Python 3.12.3, branch HEAD)

I suspect the failed values may all have the higher tolerance setting, but should probably still work or be understood!

"hinting" here means that the user needed to provide `constants=[constant]` to `nsimplify()`

lightly touched-up snippet

```python
class Trial:
    ...
    def check(self, r):
        return str(self.constant) in str(r) and abs(r).count_ops() < 5
    def simplify(self):
        self.expr = parse_expr(self.base)
        test_decimal = N(self.expr)
        self.n = test_decimal
        if self.constant is not I:  # FIXME lazy
            assert isinstance(test_decimal, Float), f"failed: {self.base} -> {test_decimal}"
        if self.constant is not pi:  # pi is never a default
            self.simplified = nsimplify(test_decimal, tolerance=self.tolerance)
            self.solved = self.check(self.simplified)
            if self.solved:
                self.hinted = False
                return
        self.hinted = True
        self.simplified = nsimplify(test_decimal, [self.constant], tolerance=self.tolerance)
        self.solved = self.check(self.simplified)
    ...

    for power in range(-20,55):
        for tolerance in [None, 10**-10, 10**-18]:  # None means 10**-15 default
            for factor in range(-5,10):
                if factor == 0: continue  # FIXME somewhat lazy
                for divisor in range(1, 10):
                    for constant in [
                        sqrt(2),
                        sqrt(3),
                        sqrt(5),
                        sqrt(7),
                        pi,  # NOTE never a default constant
                        E,
                        I,  # not really a constant, but should behave the same
                    ]:
                        jobs.append((factor, divisor, power, constant, tolerance))
```

My updated version takes around 3x as long as current for trials of this form (but appears to work much better!) and is also _much_ faster for integer-valued floats!

existing
```python
>>> t = time.time() ; print([a for a in range(2000) if nsimplify(float(a)) != a]) ; time.time() - t
[1093, 1164, 1298, 1358, 1455, 1552, 1615, 1691, 1807, 1940, 1947]
42.112919092178345
```

updated (note range contains 500x as many values..)

```python
>>> t = time.time() ; print([a for a in range(10**6) if nsimplify(float(a)) != a]) ; time.time() - t
[]
186.15378642082214
```

Additionally, I believe this is able to demonstrate all the examples from #23822 and the docs
```python
>>> nsimplify(4678.), nsimplify(23591.)
(4678, 23591)
>>> nsimplify(N(Rational(4033,2))), nsimplify(N(Rational(4093,2)))
(4033/2, 4093/2)
```

docs examples https://docs.sympy.org/latest/modules/evalf.html

```python
>>> nsimplify(0.1)
1/10
>>> nsimplify(6.28, [pi], tolerance=0.01)
2⋅π
>>> nsimplify(pi, tolerance=0.01)
22/7
>>> nsimplify(pi, tolerance=0.001)
355
───
113
>>> nsimplify(0.33333, tolerance=1e-4)
1/3
>>> nsimplify(2.0**(1/3.), tolerance=0.001)
635
───
504
>>> nsimplify(2.0**(1/3.), tolerance=0.001, full=True)  # differs, but still can be solved
160
───
127
>>> nsimplify(2.0**(1/3.), tolerance=0.001, constants=[cbrt(2)])
3 ___
╲╱ 2 
>>> nsimplify(2.0**(1/3.))  # actually this works fine in the existing version
3 ___
╲╱ 2 
```

```python
>>> nsimplify(Float('0.130198866629986772369127970337',30), [pi, E])
    1    
─────────
5⋅π      
─── + 2⋅ℯ
 7       
>>> nsimplify(cos(atan('1/3')))
3⋅√10
─────
 10  
>>> nsimplify(4/(1+sqrt(5)), [GoldenRatio])
-2 + 2⋅φ
>>> nsimplify(2 + exp(2*atan('1/4')*I))
49   8⋅ⅈ
── + ───
17   17 
>>> nsimplify((1/(exp(3*pi*I/5)+1)))
          ________
1        ╱ √5   1 
─ - ⅈ⋅  ╱  ── + ─ 
2     ╲╱   10   4 
>>> nsimplify(I**I, [pi])
 -π 
 ───
  2 
ℯ   
>>> n = Symbol('n')
>>> nsimplify(Sum(1/n**2, (n, 1, oo)), [pi])
 2
π 
──
6 
>>> nsimplify(gamma('1/4')*gamma('3/4'), [pi])
√2⋅π
```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* simplify
  * integer-valued floats passed to `nsimplify()`, such as `23591.` should now be simplified correctly, this can be controlled by setting a new argument `shortcut_integers` which defaults to True (enabled)
  * reals are tried as-is, but additionally normalized in the internal `nsimplify_real()` close to 1 by dividing off their order of magnitude before attempting simplification (and then multiplying it back on), then the best result is chosen from amongst the trials, this can be controlled by setting a new argument `magnitude_offsets`, or by setting `magnitude_offsets=False` to disable the feature

<!-- END RELEASE NOTES -->
