### PR TITLE
assumptions: add refine regression tests for cos(pi*n) parity

### DIFF
--- a/release/notes/29103.misc.rst
+++ b/release/notes/29103.misc.rst
@@ -1,0 +1,1 @@
+* Added regression tests for refining ``cos(pi*n)`` with ``Q.odd(n)`` and ``Q.even(n)``.

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -12,7 +12,7 @@ from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
-from sympy import cos, pi, symbols, Q
+from sympy import symbols
 
 def test_refine_cos_pi_parity():
     n = symbols('n', integer=True)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -12,6 +12,18 @@ from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
+from sympy import cos, pi, symbols, Q
+
+def test_refine_cos_pi_parity():
+    n = symbols('n', integer=True)
+    assert cos(pi*n).refine(Q.even(n)) == 1
+    assert cos(pi*n).refine(Q.odd(n)) == -1
+
+
+def test_refine_cos_pi_parity_without_integer_assumption():
+    n = symbols('n')
+    assert cos(pi*n).refine(Q.even(n)) == 1
+    assert cos(pi*n).refine(Q.odd(n)) == -1
 
 
 def test_Abs():


### PR DESCRIPTION
Adds regression tests to ensure refine(cos(pi*n), Q.odd(n)/Q.even(n)) simplifies to -1/1,
both with and without integer=True on n.

Refs #27888
