### PR TITLE
functions: Fix asec(x) series expansion at x=0

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1869,12 +1869,8 @@ def test_asec_leading_term():
 
 
 def test_asec_series():
-    assert asec(x).series(x, 0, 9) == \
-        I*log(2) - I*log(x) - I*x**2/4 - 3*I*x**4/32 \
-        - 5*I*x**6/96 - 35*I*x**8/1024 + O(x**9)
-    t4 = asec(x).taylor_term(4, x)
-    assert t4 == -3*I*x**4/32
-    assert asec(x).taylor_term(6, x, t4, 0) == -5*I*x**6/96
+    raises(ValueError, lambda: asec(x).series(x, 0, 9))
+
 
 
 def test_acsc():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3233,23 +3233,7 @@ class asec(InverseTrigonometricFunction):
         """
         return sec
 
-    @staticmethod
-    @cacheit
-    def taylor_term(n, x, *previous_terms):
-        if n == 0:
-            return S.ImaginaryUnit*log(2 / x)
-        elif n < 0 or n % 2 == 1:
-            return S.Zero
-        else:
-            x = sympify(x)
-            if len(previous_terms) > 2 and n > 2:
-                p = previous_terms[-2]
-                return p * ((n - 1)*(n-2)) * x**2/(4 * (n//2)**2)
-            else:
-                k = n // 2
-                R = RisingFactorial(S.Half, k) *  n
-                F = factorial(k) * n // 2 * n // 2
-                return -S.ImaginaryUnit * R / F * x**n / 4
+
 
     def _eval_as_leading_term(self, x, logx, cdir):
         arg = self.args[0]
@@ -3277,6 +3261,10 @@ class asec(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx, cdir=0):  # asec
         from sympy.series.order import O
         arg0 = self.args[0].subs(x, 0)
+
+        if arg0 is S.Zero:
+            raise ValueError("asec(x) does not admit a real Taylor series expansion at x=0")
+
         # Handling branch points
         if arg0 is S.One:
             t = Dummy('t', positive=True)


### PR DESCRIPTION
#### Description of changes

This PR modifies `asec._eval_nseries` to raise a `ValueError` when computing the series expansion at `x=0`.

Previously, [asec(x).series(x, 0)](cci:2://file:///c:/Users/aksha/Downloads/gsoc/sympy/sympy/functions/elementary/trigonometric.py:3104:0-3330:31) returned a complex expansion (`I*log(2) - I*log(x) ...`) that corresponded to a specific complex branch but was unexpected for a function that has no real Taylor expansion at 0. This change ensures that an exception is raised instead, alerting the user to the non-existence of a real series.

The [taylor_term](cci:1://file:///c:/Users/aksha/Downloads/gsoc/sympy/sympy/functions/elementary/trigonometric.py:3443:4-3459:57) method for [asec](cci:2://file:///c:/Users/aksha/Downloads/gsoc/sympy/sympy/functions/elementary/trigonometric.py:3104:0-3330:31) (which hardcoded the complex log terms) has been removed to support this change.

#### Issues fixed

Fixes #28963

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug where [asec(x).series(x, 0)](cci:2://file:///c:/Users/aksha/Downloads/gsoc/sympy/sympy/functions/elementary/trigonometric.py:3104:0-3330:31) returned an incorrect complex expansion; it now correctly raises a `ValueError` as no real series exists.
<!-- END RELEASE NOTES -->