### PR TITLE
Extend kernel computation for non-surjective maps

### DIFF
--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -141,7 +141,9 @@ class GroupHomomorphism:
         G = self.domain
         H = self.codomain
         Ginf = G.order() is S.Infinity
-        if Ginf and isinstance(H, FpGroup):
+        if Ginf and isinstance(H, (FpGroup, FreeGroup)):
+            if isinstance(H, FreeGroup):
+                H = FpGroup(H, [])
             preimages = self._is_surjective_cert()
             if preimages is not None:
                 symbol_to_preimage = {
@@ -169,6 +171,8 @@ class GroupHomomorphism:
                         return PermutationGroup([G.identity])
                     return G.normal_closure(kernel_gens)
                 return FpSubgroup(G, kernel_gens, normal=True)
+            else:
+                return self.factor()[0].kernel()
 
         if Ginf:
             raise NotImplementedError(

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -264,7 +264,7 @@ class GroupHomomorphism:
             try:
                 preimages = {g: self.invert(g) for g in self.codomain.generators}
             except ValueError:
-                preimages = None
+                pass
             self._surjective_cert = preimages
             self._surjective_cert_computed = True
         return self._surjective_cert

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -142,11 +142,7 @@ class GroupHomomorphism:
         H = self.codomain
         Ginf = G.order() is S.Infinity
         if Ginf and isinstance(H, FpGroup):
-            preimages = None
-            try: # surjectivity test
-                preimages = {g: self.invert(g) for g in H.generators}
-            except ValueError:
-                preimages = None
+            preimages = self._is_surjective_cert()
             if preimages is not None:
                 symbol_to_preimage = {
                     g.ext_rep[0]: preimages[g] for g in H.generators
@@ -247,17 +243,26 @@ class GroupHomomorphism:
         '''
         return self.kernel().order() == 1
 
+    def _is_surjective_cert(self):
+        '''
+        Return a certificate of surjectivity, i.e. a dictionary of
+        preimages of the codomain generators, if the homomorphism
+        is surjective. Otherwise, return None.
+
+        '''
+        preimages = None
+        try:
+            preimages = {g: self.invert(g) for g in self.codomain.generators}
+        except ValueError:
+            preimages = None
+        return preimages
+
     def is_surjective(self):
         '''
         Check if the homomorphism is surjective
 
         '''
-        im = self.image().order()
-        oth = self.codomain.order()
-        if im is S.Infinity and oth is S.Infinity:
-            return None
-        else:
-            return im == oth
+        return self._is_surjective_cert() is not None
 
     def is_isomorphism(self):
         '''

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -151,15 +151,23 @@ class GroupHomomorphism:
                 symbol_to_preimage = {
                     g.ext_rep[0]: preimages[g] for g in H.generators
                 }
+
+                def _lift_to_domain(word):
+                    lifted = G.identity
+                    for symbol, power in word.array_form:
+                        lifted = lifted * symbol_to_preimage[symbol]**power
+                    return lifted
+
                 kernel_gens = []
                 for relator in H.relators:
-                    word = G.identity
-                    for symbol, power in relator.array_form:
-                        word = word * symbol_to_preimage[symbol]**power
-                    if isinstance(G, FpGroup):
-                        word = G.reduce(word)
-                    if not word.is_identity:
-                        kernel_gens.append(word)
+                    word = _lift_to_domain(relator)
+                    kernel_gens.append(word)
+
+                for generator in G.generators:
+                    lifted_image = _lift_to_domain(self(generator))
+                    word = generator * lifted_image**-1
+                    kernel_gens.append(word)
+
                 if isinstance(G, PermutationGroup):
                     if not kernel_gens:
                         return PermutationGroup([G.identity])

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -116,6 +116,14 @@ def test_check_homomorphism():
     G = PermutationGroup([a, b])
     raises(ValueError, lambda: homomorphism(G, G, [a], [a]))
 
+def test_is_surjective():
+    F1, x = free_group("x")
+    G = FpGroup(F1, [])
+    T = homomorphism(G, G, [x], [x])
+    assert T.is_surjective() is True
+    T = homomorphism(G, G, [x], [x**2])
+    assert T.is_surjective() is False
+
 def test_fpgroup_kernel_surjective():
     F, a, b = free_group("a, b")
     G = FpGroup(F, [a**2])

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -126,6 +126,14 @@ def test_fpgroup_kernel_surjective():
     assert b**3 in kernel
     assert (a*b)**2 in kernel
 
+    F, a, b = free_group('a, b')
+    Z, c = free_group('c')
+    G = FpGroup(Z, [])
+    T = homomorphism(F, G, [a, b], [c, c])
+    kernel = T.kernel()
+    assert kernel.normal
+    assert b*a**-1 in kernel
+
     F, a, b = free_group("a, b")
     H = FpGroup(F, [a**2, b**3, (a*b)**2])
     T = homomorphism(F, H, F.generators, H.generators)

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -124,7 +124,7 @@ def test_is_surjective():
     T = homomorphism(G, G, [x], [x**2])
     assert T.is_surjective() is False
 
-def test_fpgroup_kernel_surjective():
+def test_fpgroup_kernel():
     F, a, b = free_group("a, b")
     G = FpGroup(F, [a**2])
     H = FpGroup(F, [a**2, b**3, (a*b)**2])
@@ -150,6 +150,15 @@ def test_fpgroup_kernel_surjective():
     assert a**2 in kernel
     assert b**3 in kernel
     assert (a*b)**2 in kernel
+
+    F, a, b = free_group("a, b")
+    E, x, y = free_group("x, y")
+    H = FpGroup(E, [y**2, y*x*y*x])
+    T = homomorphism(F, H, [a, b], [x, x])
+    assert T.is_surjective() is False
+    kernel = T.kernel()
+    assert kernel.normal
+    assert b*a**-1 in kernel
 
 def test_homomorphism_factor():
     F, a, b = free_group("a, b")

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -151,6 +151,26 @@ def test_fpgroup_kernel_surjective():
     assert b**3 in kernel
     assert (a*b)**2 in kernel
 
+def test_homomorphism_factor():
+    F, a, b = free_group("a, b")
+    H = FpGroup(F, [a**2, b**2, (a*b)**2])
+    T = homomorphism(F, H, [a, b], [a, a])
+
+    surj, inj = T.factor()
+
+    assert surj.is_surjective()
+    assert inj.is_injective()
+    assert H.equals(inj(surj(a*b*a**-1)), T(a*b*a**-1))
+
+    F, a, b = free_group("a, b")
+    E, x, y = free_group("x, y")
+    T = homomorphism(F, E, [a, b], [x, y])
+
+    surj, inj = T.factor()
+
+    assert surj.is_surjective()
+    assert inj(surj(a*b**2*a**-1)) == T(a*b**2*a**-1)
+
 def test_fpgroup_isomorphism():
 
     # S3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- Added `GroupHomomorphism.factor()` to factor a homomorphism as (injection into codomain)∘(surjection onto image) .
- Made `is_surjective()` work for some infinite groups. This also improved performance.
- Implemented `kernel()` computation for homomorphisms with image of finite index.
- Fixed some wrong results of `kernel()` for surjective homomorphisms, which I overlooked in #29093.

#### Other comments


#### AI Generation Disclosure
Some code is writen by codex, inspected and edited by me.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Implemented `GroupHomomorphism.kernel` for homomorphisms to `FpGroup` with image of finite index.
  * Added `GroupHomomorphism.factor` method, which produces a factorization into injective and surjective homomorphisms.
  * Implemented `GroupHomomorphism.is_surjective` for infinite groups.
<!-- END RELEASE NOTES -->
