### PR TITLE
Fix odd predicate behavior under negation

### DIFF
--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -48,3 +48,13 @@ def test_exactlyonearg():
         Or((Q.positive(x) | Q.negative(x)) &
         ~(Q.positive(y) | Q.negative(y)), (Q.positive(y) | Q.negative(y)) &
         ~(Q.positive(x) | Q.negative(x)))
+
+
+def test_odd_negation_symmetry():
+    from sympy import symbols
+    from sympy.assumptions.ask import Q, ask
+
+    n = symbols('n', integer=True)
+
+    assert ask(Q.odd(-n), Q.odd(n)) is True
+    assert ask(Q.odd(n), Q.odd(-n)) is True


### PR DESCRIPTION
This PR fixes inference of odd predicates under negation.

Previously, assumptions involving Q.odd(n) and Q.odd(-n) were not inferred symmetrically.
This change ensures correct behavior in both directions.

A regression test is added to cover this case.

Examples:
ask(Q.odd(-n), Q.odd(n)) -> True
ask(Q.odd(n), Q.odd(-n)) -> True
