### PR TITLE
Fix find_dynamicsymbols to extract dynamic symbols from Derivative ar…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -192,7 +192,6 @@
 2torus <boris.ettinger@gmail.com>
 Aadit Kamat <aadit.k12@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
-AdityaGupta716 <itzaditya.gupta0716@gmail.com>
 Aaron Gokaslan <aaronGokaslan@gmail.com>
 Aaron Meurer <asmeurer@gmail.com>
 Aaron Miller <acmiller273@gmail.com> <78561124+aaron-skydio@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -192,6 +192,7 @@
 2torus <boris.ettinger@gmail.com>
 Aadit Kamat <aadit.k12@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
+AdityaGupta716 <itzaditya.gupta0716@gmail.com>
 Aaron Gokaslan <aaronGokaslan@gmail.com>
 Aaron Meurer <asmeurer@gmail.com>
 Aaron Miller <acmiller273@gmail.com> <78561124+aaron-skydio@users.noreply.github.com>

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -477,7 +477,9 @@ def find_dynamicsymbols(expression, exclude=None, reference_frame=None):
         else:
             expression = expression.to_matrix(reference_frame)
     return {i for i in expression.atoms(AppliedUndef, Derivative) if
-            i.free_symbols == t_set} - exclude_set
+        i.free_symbols == t_set} | {d.args[0] for d in
+        expression.atoms(Derivative) if
+        d.args[0].free_symbols == t_set} - exclude_set
 
 
 def msubs(expr, *sub_dicts, smart=False, **kwargs):


### PR DESCRIPTION
…guments  Fixes #26611  The find_dynamicsymbols function now correctly extracts dynamic symbols from the arguments of Derivative expressions, in addition to extracting AppliedUndef objects directly. This ensures that functions like f(t) in Derivative(f(t), t) are properly identified as dynamic symbols.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->


* physics.mechanics
  * Fixed `find_dynamicsymbols` to correctly extract dynamic symbols from the arguments of `Derivative` expressions.
<!-- END RELEASE NOTES -->
