### PR TITLE
Fix FormalPowerSeries.product to respect ind and xk

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1330,6 +1330,7 @@ Ray Cathcart <github@cathcart.us> <pix2@_nospam_.cathcart.us>
 Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuy.(none)>
 Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuyJr.(none)>
 Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuyJr>
+Rehan Akhtar <rehan.xt5@gmail.com> rehanxt5 <rehan.xt5@gmail.com>
 Rehas Sachdeva <aquannie@gmail.com>
 Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redeboer@gmx.com>
 Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redeboer@outlook.com>
@@ -1865,4 +1866,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Rehan Akhtar <rehan.xt5@gmail.com> rehanxt5 <rehan.xt5@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1865,3 +1865,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Rehan Akhtar <rehan.xt5@gmail.com> rehanxt5 <rehan.xt5@gmail.com>

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -13,7 +13,6 @@ from sympy.sets.sets import Interval
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy, symbols, Symbol
 from sympy.core.sympify import sympify
-from sympy.discrete.convolutions import convolution
 from sympy.functions.combinatorial.factorials import binomial, factorial, rf
 from sympy.functions.combinatorial.numbers import bell
 from sympy.functions.elementary.integers import floor, frac, ceiling
@@ -1599,13 +1598,13 @@ class FormalPowerSeriesProduct(FiniteFormalPowerSeries):
         sympy.series.formal.FormalPowerSeries.product
 
         """
-        coeff1, coeff2 = self.coeff1, self.coeff2
-
-        aks = convolution(coeff1[:n], coeff2[:n])
-
+        ffps, gfps = self.ffps, self.gfps
         terms = []
-        for i in range(0, n):
-            terms.append(aks[i] * self.ffps.xk.coeff(i))
+        for i in range(n):
+            terms.append(Add(*[
+                ffps._eval_term(j) * gfps._eval_term(i - j)
+                for j in range(i + 1)
+            ]))
 
         return Add(*terms)
 

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -550,6 +550,16 @@ def test_fps__product():
     assert f1.product(f3, x)._eval_terms(4) == x - 2*x**3/3
     assert f1.product(f3, x).truncate(4) == x - 2*x**3/3 + O(x**4)
 
+    f4 = fps(log(1 + x))
+    fprod = f4.product(f2, x)
+    assert fprod.truncate(4) == x + x**2/2 + x**3/3 + O(x**4)
+
+    a, b = symbols('a b')
+    fa = fps(a*exp(x), x)
+    fb = fps(b*exp(x), x)
+    assert fa.product(fb, x).polynomial(5).expand() == \
+        (a*b*exp(2*x)).series(x, 0, 5).removeO().expand()
+
 
 def test_fps__compose():
     f1, f2, f3 = fps(exp(x)), fps(sin(x)), fps(cos(x))


### PR DESCRIPTION
## Issue

`FormalPowerSeries.product` produces incorrect results for some valid formal power series.
In particular, the current implementation ignores the index shift (`ind`) and one side’s per-term scaling (`xk`) when forming the product, which can lead to invalid coefficients (`nan` / `zoo`) or incorrect symbolic results.

This shows up, for example, when multiplying `log(1+x)` with `exp(x)`, or when multiplying scaled exponential series.

## Solution 

The issue comes from how `FormalPowerSeriesProduct` builds and evaluates product terms.
Currently, the product logic effectively convolves raw coefficient sequences starting at `k=0` and applies only one operand’s scaling, which breaks the formal series invariant.

The fix updates product evaluation to compute each term using the full per-order contribution of both operands. This is done by forming the Cauchy product directly from each series’ `_eval_term(k)`, which already accounts for index shifts and per-term scaling.

This restores correct behavior without changing the public API or refactoring unrelated code.

## Changes

* Updated `FormalPowerSeriesProduct._eval_terms` so product terms are computed as a Cauchy product of each operand’s full per-order contribution, rather than raw coefficient sequences.
* Added regression coverage to ensure:
  - `log(1+x) * exp(x)` no longer produces `nan` / `zoo` and matches the expected truncated series.
  - Symbolically scaled exponential products (e.g. `a*exp(x) * b*exp(x)`) produce correct results.

I have also added regression tests.

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed ``FormalPowerSeries.product`` to correctly handle index shifts (``ind``) and per-term scaling (``xk``), which previously caused incorrect results for some valid formal power series.
<!-- END RELEASE NOTES -->
