### PR TITLE
fix nonlinsolve handling of floor functions

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -34,6 +34,7 @@ from sympy.functions import (log, tan, cot, sin, cos, sec, csc, exp,
                              piecewise_fold, Piecewise)
 from sympy.functions.combinatorial.numbers import totient
 from sympy.functions.elementary.complexes import Abs, arg, re, im
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
                             sinh, cosh, tanh, coth, sech, csch,
                             asinh, acosh, atanh, acoth, asech, acsch)
@@ -3587,6 +3588,10 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                     # complex domain
                     raise NotImplementedError(
                         "nonlinsolve cannot solve equations with Abs in the complex domain"
+                    )
+                if depen1.has(floor) or depen2.has(floor) or depen1.has(ceiling) or depen2.has(ceiling):
+                    raise NotImplementedError(
+                        "nonlinsolve cannot solve equations with floor or ceiling functions"
                     )
                 soln_imageset = {}
                 for sym in unsolved_syms:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3591,11 +3591,12 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                     )
                 soln_imageset = {}
                 for sym in unsolved_syms:
+                    not_solvable = False
                     if any(f.args[0].has(sym) for f in eq2.atoms(floor, ceiling)):
+                        not_solvable = True
                         raise NotImplementedError(
                             "nonlinsolve cannot solve equations with floor or ceiling functions"
                         )
-                    not_solvable = False
                     try:
                         soln = solver(eq2, sym)
                         total_solvest_call += 1

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -4094,7 +4094,7 @@ def nonlinsolve(system, *symbols):
         raise IndexError(filldedent(msg))
 
     symbols = list(map(_sympify, symbols))
-    sys,tem = [_sympify(eq) for eq in system]
+    system = [_sympify(eq) for eq in system]
     system, symbols, swap = recast_to_symbols(system, symbols)
     if swap:
         soln = nonlinsolve(system, symbols)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3589,12 +3589,12 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                     raise NotImplementedError(
                         "nonlinsolve cannot solve equations with Abs in the complex domain"
                     )
-                if depen1.has(floor) or depen2.has(floor) or depen1.has(ceiling) or depen2.has(ceiling):
-                    raise NotImplementedError(
-                        "nonlinsolve cannot solve equations with floor or ceiling functions"
-                    )
                 soln_imageset = {}
                 for sym in unsolved_syms:
+                    if any(f.args[0].has(sym) for f in eq2.atoms(floor, ceiling)):
+                        raise NotImplementedError(
+                            "nonlinsolve cannot solve equations with floor or ceiling functions"
+                        )
                     not_solvable = False
                     try:
                         soln = solver(eq2, sym)
@@ -4094,7 +4094,7 @@ def nonlinsolve(system, *symbols):
         raise IndexError(filldedent(msg))
 
     symbols = list(map(_sympify, symbols))
-    system = [_sympify(eq) for eq in system]
+    sys,tem = [_sympify(eq) for eq in system]
     system, symbols, swap = recast_to_symbols(system, symbols)
     if swap:
         soln = nonlinsolve(system, symbols)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2397,12 +2397,8 @@ def test_nonlinsolve_conditionset():
 
 def test_nonlinsolve_floor_ceiling():
     raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
-    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 5, y - 2], [x, y]))
-    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 3], [x]))
-    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 3], [x]))
-    raises(NotImplementedError, lambda: nonlinsolve([x + floor(x) - 5], [x]))
+    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 3, y - x], [x, y]))
     assert nonlinsolve([x - floor(y)], [x]) == FiniteSet((floor(y),))
-    assert nonlinsolve([x - ceiling(y)], [x]) == FiniteSet((ceiling(y),))
 
 
 def test_substitution_basic():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -14,6 +14,7 @@ from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign, conjug
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
     sinh, cosh, tanh, coth, sech, csch, asinh, acosh, atanh, acoth, asech, acsch)
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
@@ -2392,6 +2393,11 @@ def test_nonlinsolve_conditionset():
         intermediate_system,
         S.Complexes**2)
     assert nonlinsolve([f1, f2], [x, y]) == soln
+
+
+def test_nonlinsolve_floor():
+    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 5, y - 2], [x, y]))
 
 
 def test_substitution_basic():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2395,7 +2395,7 @@ def test_nonlinsolve_conditionset():
     assert nonlinsolve([f1, f2], [x, y]) == soln
 
 
-def test_nonlinsolve_floor():
+def test_nonlinsolve_floor_ceiling():
     raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
     raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 5, y - 2], [x, y]))
     raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 3], [x]))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2398,6 +2398,11 @@ def test_nonlinsolve_conditionset():
 def test_nonlinsolve_floor():
     raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
     raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 5, y - 2], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 3], [x]))
+    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 3], [x]))
+    raises(NotImplementedError, lambda: nonlinsolve([x + floor(x) - 5], [x]))
+    assert nonlinsolve([x - floor(y)], [x]) == FiniteSet((floor(y),))
+    assert nonlinsolve([x - ceiling(y)], [x]) == FiniteSet((ceiling(y),))
 
 
 def test_substitution_basic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29026 
similar to #28773 (similar fix used)
#### Brief description of what is fixed or changed
nonlinsolve`([floor(x) - 5, y - x - 1], [x, y])` was incorrectly returning parametric solution `{(y - 1, y)}` instead of raising an exception. nonlinsolve now raises `NotImplementedError` when encountering equations with `floor` or `ceiling` functions, as it cannot properly solve these discrete step functions symbolically.
This fix follows the same approach as #28773, which fixed the same issue for `Abs` functions. When nonlinsolve encounters functions it cannot solve, it raises an error rather than returning incorrect partial solutions.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed nonlinsolve returning incorrect parametric solutions for systems containing `floor` or `ceiling` functions. Now correctly raises `NotImplementedError` when these functions are present.
<!-- END RELEASE NOTES -->
