### PR TITLE
Fix nP to raise ValueError for negative k

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -2413,6 +2413,9 @@ def nP(n, k=None, replacement=False):
     .. [1] https://en.wikipedia.org/wiki/Permutation
 
     """
+    if k is not None and k < 0:
+        raise ValueError("k cannot be negative")
+
     try:
         n = as_int(n)
     except ValueError:

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -1252,4 +1252,3 @@ def test_deprecated_ntheory_symbolic_functions():
 
 def test_issue_29117():
     raises(ValueError, lambda: nP(3, -1))
-

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -20,7 +20,8 @@ from sympy.functions import (
     primenu, primeomega, totient, reduced_totient, primepi,
     motzkin, binomial, gamma, sqrt, cbrt, hyper, log, digamma,
     trigamma, polygamma, factorial, sin, cos, cot, polylog, zeta, dirichlet_eta)
-from sympy.functions.combinatorial.numbers import _nT
+from sympy.functions.combinatorial.numbers import _nT, nP
+from sympy.utilities.iterables import multiset
 from sympy.ntheory.factor_ import factorint
 
 from sympy.core.expr import unchanged
@@ -984,7 +985,7 @@ def test_nC_nP_nT():
         multiset_permutations, multiset_combinations, multiset_partitions,
         partitions, subsets, permutations)
     from sympy.functions.combinatorial.numbers import (
-        nP, nC, nT, stirling, _stirling1, _stirling2, _multiset_histogram, _AOP_product)
+        nC, nT, stirling, _stirling1, _stirling2, _multiset_histogram, _AOP_product)
 
     from sympy.combinatorics.permutations import Permutation
     from sympy.core.random import choice
@@ -1248,3 +1249,8 @@ def test_deprecated_ntheory_symbolic_functions():
         assert carmichael.find_carmichael_numbers_in_range(10, 20) == []
     with warns_deprecated_sympy():
         assert carmichael.find_first_n_carmichaels(1)
+
+
+def test_issue_29117():
+    raises(ValueError, lambda: nP(3, -1))
+

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -984,7 +984,7 @@ def test_nC_nP_nT():
         multiset_permutations, multiset_combinations, multiset_partitions,
         partitions, subsets, permutations)
     from sympy.functions.combinatorial.numbers import (
-        nC, nT, stirling, _stirling1, _stirling2, _multiset_histogram, _AOP_product)
+        nP, nC, nT, stirling, _stirling1, _stirling2, _multiset_histogram, _AOP_product)
 
     from sympy.combinatorics.permutations import Permutation
     from sympy.core.random import choice

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -20,8 +20,7 @@ from sympy.functions import (
     primenu, primeomega, totient, reduced_totient, primepi,
     motzkin, binomial, gamma, sqrt, cbrt, hyper, log, digamma,
     trigamma, polygamma, factorial, sin, cos, cot, polylog, zeta, dirichlet_eta)
-from sympy.functions.combinatorial.numbers import _nT, nP
-from sympy.utilities.iterables import multiset
+from sympy.functions.combinatorial.numbers import _nT, nP,nC
 from sympy.ntheory.factor_ import factorint
 
 from sympy.core.expr import unchanged

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -20,7 +20,7 @@ from sympy.functions import (
     primenu, primeomega, totient, reduced_totient, primepi,
     motzkin, binomial, gamma, sqrt, cbrt, hyper, log, digamma,
     trigamma, polygamma, factorial, sin, cos, cot, polylog, zeta, dirichlet_eta)
-from sympy.functions.combinatorial.numbers import _nT, nP,nC
+from sympy.functions.combinatorial.numbers import _nT, nP
 from sympy.ntheory.factor_ import factorint
 
 from sympy.core.expr import unchanged


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29117 


#### Brief description of what is fixed or changed
Fixed `nP()` to raise `ValueError` for negative `k`, making it consistent with `nC()` behavior.



#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * `nP()` now raises `ValueError` for negative `k`, consistent with `nC()` behavior
<!-- END RELEASE NOTES -->

