### PR TITLE
assumptions: Add helper function to improve order predicates for `Add`.

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -21,7 +21,7 @@ from ..predicates.order import (NegativePredicate, NonNegativePredicate,
 
 def _determine_definite_strict_sign_of_add(expr, assumptions):
     """
-    Analyzes an Add expression to determine if it is 
+    Analyzes an Add expression to determine if it is
     definitively strictly positive or negative.
 
     Parameters

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -43,6 +43,8 @@ def _determine_definite_strict_sign_of_add(expr, assumptions):
     =======
 
     >>> from sympy import Symbol, Q
+    >>> from sympy.assumptions.handlers.order import (
+    ...     _determine_definite_strict_sign_of_add)
     >>> x = Symbol('x')
     >>> _determine_definite_strict_sign_of_add(x + 1, Q.positive(x))
     (True, False)

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -19,7 +19,36 @@ from ..predicates.order import (NegativePredicate, NonNegativePredicate,
     ExtendedPositivePredicate,)
 
 
-def _helper_add_sign(expr, assumptions):
+def _determine_definite_strict_sign_of_add(expr, assumptions):
+    """
+    Analyzes an Add expression to determine if it is 
+    definitively strictly positive or negative.
+
+    Parameters
+    ==========
+
+    expr : Add
+        The ``Add`` expression to analyse.
+
+    assumptions : Boolean
+        The assumptions given to ``expr``.
+
+    Returns
+    =======
+
+    tuple(bool, bool)
+        A tuple of (is_strictly_positive, is_strictly_negative)
+
+    Examples
+    =======
+
+    >>> from sympy import Symbol, Q
+    >>> x = Symbol('x')
+    >>> _determine_definite_strict_sign_of_add(x + 1, Q.positive(x))
+    (True, False)
+    >>> _determine_definite_strict_sign_of_add(-x - 3, Q.positive(x))
+    (False, True)
+    """
     can_be_pos = True
     can_be_neg = True
     strict_pos = False
@@ -52,6 +81,10 @@ def _helper_add_sign(expr, assumptions):
             if is_pos is not False:
                 can_be_neg = False
 
+    # is_definitely_positive is True only if:
+    # 1) There are no negative terms (can_be_pos -> True)
+    # 2) Atleast one term is > 0 (strict_pos -> True)
+    # Similar logic for is_definitely_negative
     is_definitely_positive = can_be_pos and strict_pos
     is_definitely_negative = can_be_neg and strict_neg
 
@@ -108,7 +141,8 @@ def _(expr, assumptions):
     if r is not True:
         return r
 
-    is_pos, is_neg = _helper_add_sign(expr, assumptions)
+    # determine the definite sign of the expr.
+    is_pos, is_neg = _determine_definite_strict_sign_of_add(expr, assumptions)
 
     if is_neg:
         return True
@@ -330,7 +364,8 @@ def _(expr, assumptions):
     if r is not True:
         return r
 
-    is_pos, is_neg = _helper_add_sign(expr, assumptions)
+    # determine the definite sign of the expr.
+    is_pos, is_neg = _determine_definite_strict_sign_of_add(expr, assumptions)
 
     if is_pos:
         return True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2584,6 +2584,7 @@ def test_issue_28127():
     assert ask(Q.lt(y,x), Q.gt(x,y)) is True
     assert ask(Q.le(y,x), Q.ge(x,y)) is True
 
+
 def test_issue_29096():
     assert ask(x > -1, Q.positive(x)) is True
     assert ask(x < 1, Q.negative(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1713,6 +1713,10 @@ def test_negative():
     assert ask(Q.negative(x + y), Q.negative(x)) is None
     assert ask(Q.negative(x + y), Q.negative(x) & Q.negative(y)) is True
     assert ask(Q.negative(x + y), Q.negative(x) & Q.nonpositive(y)) is True
+    assert ask(Q.negative(x + 1), Q.positive(x)) is False
+    assert ask(Q.negative(-1 - x), Q.positive(x)) is True
+    assert ask(Q.negative(1 - x), Q.negative(x)) is False
+    assert ask(Q.negative(x + y), Q.positive(x) & Q.negative(y)) is None
     assert ask(Q.negative(2 + I)) is False
     # although this could be False, it is representative of expressions
     # that don't evaluate to a zero with precision
@@ -1930,6 +1934,11 @@ def test_positive():
     assert ask(Q.positive(x + y), Q.positive(x) & Q.nonnegative(y)) is True
     assert ask(Q.positive(x + y), Q.positive(x) & Q.negative(y)) is None
     assert ask(Q.positive(x + y), Q.positive(x) & Q.imaginary(y)) is False
+    assert ask(Q.positive(x + 1), Q.positive(x)) is True
+    assert ask(Q.positive(x - 1), Q.positive(x)) is None
+    assert ask(Q.positive(x + y), Q.positive(x)) is None
+    assert ask(Q.positive(x+1), Q.real(x)) is None
+    assert ask(Q.positive(x+1)) is None
 
     assert ask(Q.positive(2*x), Q.positive(x)) is True
     assumptions = Q.positive(x) & Q.negative(y) & Q.negative(z) & Q.positive(w)
@@ -2588,10 +2597,3 @@ def test_issue_28127():
 def test_issue_29096():
     assert ask(x > -1, Q.positive(x)) is True
     assert ask(x < 1, Q.negative(x)) is True
-    assert ask(Q.positive(x + 1), Q.positive(x)) is True
-    assert ask(Q.negative(x + 1), Q.positive(x)) is False
-    assert ask(Q.negative(-1 - x), Q.positive(x)) is True
-    assert ask(Q.negative(1 - x), Q.negative(x)) is False
-    assert ask(Q.positive(x - 1), Q.positive(x)) is None
-    assert ask(Q.negative(x + y), Q.positive(x) & Q.negative(y)) is None
-    assert ask(Q.positive(x + y), Q.positive(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2583,3 +2583,14 @@ def test_issue_28127():
     assert ask(Q.gt(y,x), Q.lt(x,y)) is True
     assert ask(Q.lt(y,x), Q.gt(x,y)) is True
     assert ask(Q.le(y,x), Q.ge(x,y)) is True
+
+def test_issue_29096():
+    assert ask(x > -1, Q.positive(x)) is True
+    assert ask(x < 1, Q.negative(x)) is True
+    assert ask(Q.positive(x + 1), Q.positive(x)) is True
+    assert ask(Q.negative(x + 1), Q.positive(x)) is False
+    assert ask(Q.negative(-1 - x), Q.positive(x)) is True
+    assert ask(Q.negative(1 - x), Q.negative(x)) is False
+    assert ask(Q.positive(x - 1), Q.positive(x)) is None
+    assert ask(Q.negative(x + y), Q.positive(x) & Q.negative(y)) is None
+    assert ask(Q.positive(x + y), Q.positive(x)) is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes: #29096

#### Brief description of what is fixed or changed
This PR revamps the `PositivePredicate` and `NegativePredicate` handlers for `Add` expressions in `assumptions/handlers/order.py`. Added a helper function (`_helper_add_sign`) to unify both `Predicate`.

Earlier `PositivePredicate` would just identify if an `expr` is Positive and else return `None`, which would be an issue if `expr` is Negative and should have returned `False`.

I have also added tests for the same in `test_query.py`

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed issue where the sign of addition expressions was not correctly deduced by ``ask``.
<!-- END RELEASE NOTES -->
