### PR TITLE
feat(core): Add Piecewise rewrite for nth derivatives of x**m and log(x)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1514,6 +1514,8 @@ Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
 Shubham Maheshwari <rmaheshwari05@gmail.com>
 Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
 Shubham Tibra <shubh.tibra@gmail.com>
+Shuvro Bhattacharjee <shuvrobhatt11@gmail.com> Shuvro <shuvrobhatt11@gmail.com>
+Shuvro Bhattacharjee <shuvrobhatt11@gmail.com> Shuvro-git <shuvrobhatt11@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -468,6 +468,7 @@ Guo Xingjian <Seeker1995@gmail.com>
 Sandeep Veethu <sandeep.veethu@gmail.com>
 Archit Verma <architv07@gmail.com>
 Shubham Tibra <shubh.tibra@gmail.com>
+Shuvro Bhattacharjee <shuvrobhatt11@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>
 Michael S. Hansen <michael.hansen@nih.gov>
 Anish Shah <shah.anish07@gmail.com>

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1159,6 +1159,33 @@ def test_Derivative_as_finite_difference():
     ref2 = f(xm, ym) + f(xp, yp) - f(xp, ym) - f(xm, yp)
     assert (d2fdxdy.as_finite_difference() - ref2).simplify() == 0
 
+def test_derivative_rewrite_as_piecewise():
+    """Test Derivative.rewrite(Piecewise) for x**m and log(x)."""
+    from sympy import Derivative, symbols, log, Piecewise, simplify, gamma, factorial
+
+    x, m, n = symbols('x m n')
+
+    # Test 1: x**m returns Piecewise with formula
+    expr1 = Derivative(x**m, (x, n))
+    result1 = expr1.rewrite(Piecewise)
+
+    # Check it's a Piecewise (not the original Derivative)
+    assert isinstance(result1, Piecewise)
+
+    # Check the formula is in the Piecewise
+    expected_formula = x**(m - n)*gamma(m + 1)/gamma(m - n + 1)
+    assert result1.has(expected_formula)
+
+    # Test 2: log(x) returns correct formula
+    expr2 = Derivative(log(x), (x, n))
+    result2 = expr2.rewrite(Piecewise)
+    assert result2 == (-1)**(n - 1)*factorial(n - 1)/x**n
+
+    # Test 3: Concrete cases
+    assert simplify(Derivative(x**3, (x, 5)).rewrite(Piecewise)) == 0
+    assert simplify(Derivative(x**5, (x, 3)).rewrite(Piecewise)) == 60*x**2
+    assert Derivative(log(x), (x, 3)).rewrite(Piecewise) == 2/x**3
+
 
 def test_issue_11159():
     # Tests Application._eval_subs


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29102


#### Brief description of what is fixed or changed
- Added `_eval_rewrite_as_Piecewise` method to the `Derivative` class
- `Derivative(x**m, (x, n)).rewrite(Piecewise)` now returns a piecewise expression
- `Derivative(log(x), (x, n)).rewrite(Piecewise)` now returns an explicit formula
- The implementation handles the case where the result is zero (when `n > m` and `m` is a nonnegative integer)

#### Examples
C:\Users\Shuvra AKA (A.A.C.)\sympy>python sympy_test.py
Test 1: Derivative(x^m, (x, n)).rewrite(Piecewise)
Piecewise((0, (m >= 0) & (m < n) & Eq(m, floor(m))), (x**(m - n)*gamma(m + 1)/gamma(m - n + 1), True))

Test 2: Derivative(log(x), (x, n)).rewrite(Piecewise)
(-1)**(n - 1)*factorial(n - 1)/x**n

Test 3: Derivative(x^3, (x, 5)).rewrite(Piecewise)
0
Simplified: 0

Test 4: Derivative(x^5, (x, 3)).rewrite(Piecewise)
60*x**2
Simplified: 60*x**2

Test 5: 3rd derivative of log(x)
Rewrite as Piecewise: 2/x**3

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added `_eval_rewrite_as_Piecewise` method to the `Derivative` class
  * `Derivative(x**m, (x, n)).rewrite(Piecewise)` now returns a piecewise expression with the gamma function formula
  * `Derivative(log(x), (x, n)).rewrite(Piecewise)` now returns the explicit formula `(-1)**(n - 1)*factorial(n - 1)/x**n`

<!-- END RELEASE NOTES -->
