### PR TITLE
combinatorics: Add type hints to graycode.py

### DIFF
--- a/doc/src/modules/combinatorics/graycode.rst
+++ b/doc/src/modules/combinatorics/graycode.rst
@@ -17,3 +17,5 @@ Gray Code
 .. automethod:: sympy.combinatorics.graycode.get_subset_from_bitstring
 
 .. automethod:: sympy.combinatorics.graycode.graycode_subsets
+
+.. autodata:: sympy.combinatorics.graycode.T

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -4,7 +4,7 @@ from sympy.core import Basic, Integer
 
 import random
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 class GrayCode(Basic):
     """
@@ -384,7 +384,7 @@ def bin_to_gray(bin_list: str) -> str:
     return ''.join(b)
 
 
-def get_subset_from_bitstring(super_set: list[T], bitstring: str) -> list[T]:
+def get_subset_from_bitstring(super_set: list[_T], bitstring: str) -> list[_T]:
     """
     Gets the subset defined by the bitstring.
 
@@ -408,7 +408,7 @@ def get_subset_from_bitstring(super_set: list[T], bitstring: str) -> list[T]:
             if bitstring[i] == '1']
 
 
-def graycode_subsets(gray_code_set: list[T]) -> Iterator[list[T]]:
+def graycode_subsets(gray_code_set: list[_T]) -> Iterator[list[_T]]:
     """
     Generates the subsets as enumerated by a Gray code.
 

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from typing import Iterator, Any, TypeVar
+from typing import Iterator, Any
 from sympy.core import Basic, Integer
 
 import random
 
-_T = TypeVar("_T")
 
 class GrayCode(Basic):
     """
@@ -384,7 +383,7 @@ def bin_to_gray(bin_list: str) -> str:
     return ''.join(b)
 
 
-def get_subset_from_bitstring(super_set: list[_T], bitstring: str) -> list[_T]:
+def get_subset_from_bitstring(super_set: list[Any], bitstring: str) -> list[Any]:
     """
     Gets the subset defined by the bitstring.
 
@@ -408,7 +407,7 @@ def get_subset_from_bitstring(super_set: list[_T], bitstring: str) -> list[_T]:
             if bitstring[i] == '1']
 
 
-def graycode_subsets(gray_code_set: list[_T]) -> Iterator[list[_T]]:
+def graycode_subsets(gray_code_set: list[Any]) -> Iterator[list[Any]]:
     """
     Generates the subsets as enumerated by a Gray code.
 

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,3 +1,4 @@
+from typing import Iterator, List, Any, Type
 from sympy.core import Basic, Integer
 
 import random
@@ -51,7 +52,7 @@ class GrayCode(Basic):
     _current = 0
     _rank = None
 
-    def __new__(cls, n, *args, **kw_args):
+    def __new__(cls: Type["GrayCode"], n: int, *args: Any, **kw_args: Any) -> "GrayCode":
         """
         Default constructor.
 
@@ -99,7 +100,7 @@ class GrayCode(Basic):
             obj._current = obj.unrank(n, obj._rank)
         return obj
 
-    def next(self, delta=1):
+    def next(self, delta: int = 1) -> "GrayCode":
         """
         Returns the Gray code a distance ``delta`` (default = 1) from the
         current value in canonical order.
@@ -147,7 +148,7 @@ class GrayCode(Basic):
         """
         return self.args[0]
 
-    def generate_gray(self, **hints):
+    def generate_gray(self, **hints: Any) -> Iterator[str]:
         """
         Generates the sequence of bit vectors of a Gray Code.
 
@@ -286,7 +287,7 @@ class GrayCode(Basic):
         return rv.rjust(self.n, '0')
 
     @classmethod
-    def unrank(self, n, rank):
+    def unrank(cls, n: int, rank: int) -> str:
         """
         Unranks an n-bit sized Gray code of rank k. This method exists
         so that a derivative GrayCode class can define its own code of
@@ -319,7 +320,7 @@ class GrayCode(Basic):
         return _unrank(rank, n)
 
 
-def random_bitstring(n):
+def random_bitstring(n: int) -> str:
     """
     Generates a random bitlist of length n.
 
@@ -333,7 +334,7 @@ def random_bitstring(n):
     return ''.join([random.choice('01') for i in range(n)])
 
 
-def gray_to_bin(bin_list):
+def gray_to_bin(bin_list: str) -> str:
     """
     Convert from Gray coding to binary coding.
 
@@ -357,7 +358,7 @@ def gray_to_bin(bin_list):
     return ''.join(b)
 
 
-def bin_to_gray(bin_list):
+def bin_to_gray(bin_list: str) -> str:
     """
     Convert from binary coding to gray coding.
 
@@ -381,7 +382,7 @@ def bin_to_gray(bin_list):
     return ''.join(b)
 
 
-def get_subset_from_bitstring(super_set, bitstring):
+def get_subset_from_bitstring(super_set: List[Any], bitstring: str) -> List[Any]:
     """
     Gets the subset defined by the bitstring.
 
@@ -405,7 +406,7 @@ def get_subset_from_bitstring(super_set, bitstring):
             if bitstring[i] == '1']
 
 
-def graycode_subsets(gray_code_set):
+def graycode_subsets(gray_code_set: List[Any]) -> Iterator[List[Any]]:
     """
     Generates the subsets as enumerated by a Gray code.
 

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
-from typing import Iterator, Any
+from typing import Iterator, Any, TypeVar
 from sympy.core import Basic, Integer
 
 import random
 
+T = TypeVar('T')
 
 class GrayCode(Basic):
     """
@@ -383,7 +384,7 @@ def bin_to_gray(bin_list: str) -> str:
     return ''.join(b)
 
 
-def get_subset_from_bitstring(super_set: list[Any], bitstring: str) -> list[Any]:
+def get_subset_from_bitstring(super_set: list[T], bitstring: str) -> list[T]:
     """
     Gets the subset defined by the bitstring.
 
@@ -407,7 +408,7 @@ def get_subset_from_bitstring(super_set: list[Any], bitstring: str) -> list[Any]
             if bitstring[i] == '1']
 
 
-def graycode_subsets(gray_code_set: list[Any]) -> Iterator[list[Any]]:
+def graycode_subsets(gray_code_set: list[T]) -> Iterator[list[T]]:
     """
     Generates the subsets as enumerated by a Gray code.
 

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,8 +1,10 @@
-from typing import Iterator, List, Any, Type
+from __future__ import annotations
+from typing import Iterator, Any, TypeVar
 from sympy.core import Basic, Integer
 
 import random
 
+T = TypeVar("T")
 
 class GrayCode(Basic):
     """
@@ -52,7 +54,7 @@ class GrayCode(Basic):
     _current = 0
     _rank = None
 
-    def __new__(cls: Type["GrayCode"], n: int, *args: Any, **kw_args: Any) -> "GrayCode":
+    def __new__(cls: type[GrayCode], n: int, *args: Any, **kw_args: Any) -> GrayCode:
         """
         Default constructor.
 
@@ -100,7 +102,7 @@ class GrayCode(Basic):
             obj._current = obj.unrank(n, obj._rank)
         return obj
 
-    def next(self, delta: int = 1) -> "GrayCode":
+    def next(self, delta: int = 1) -> GrayCode:
         """
         Returns the Gray code a distance ``delta`` (default = 1) from the
         current value in canonical order.
@@ -287,7 +289,7 @@ class GrayCode(Basic):
         return rv.rjust(self.n, '0')
 
     @classmethod
-    def unrank(cls, n: int, rank: int) -> str:
+    def unrank(cls, n: int | Basic, rank: int) -> str:
         """
         Unranks an n-bit sized Gray code of rank k. This method exists
         so that a derivative GrayCode class can define its own code of
@@ -382,7 +384,7 @@ def bin_to_gray(bin_list: str) -> str:
     return ''.join(b)
 
 
-def get_subset_from_bitstring(super_set: List[Any], bitstring: str) -> List[Any]:
+def get_subset_from_bitstring(super_set: list[T], bitstring: str) -> list[T]:
     """
     Gets the subset defined by the bitstring.
 
@@ -406,7 +408,7 @@ def get_subset_from_bitstring(super_set: List[Any], bitstring: str) -> List[Any]
             if bitstring[i] == '1']
 
 
-def graycode_subsets(gray_code_set: List[Any]) -> Iterator[List[Any]]:
+def graycode_subsets(gray_code_set: list[T]) -> Iterator[list[T]]:
     """
     Generates the subsets as enumerated by a Gray code.
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
part of #28806


#### Brief description of what is fixed or changed
Added type anotations to the `GrayCode` class and helper functions in `sympy/combinatorics/graycode.py`. 

Changes include:
- Added parameter and return types .
- Added type hints to helper functions.
- Imported necessary types (`Iterator`, `List`, `Any`, `Type`) from `typing`.

#### Other comments
all tests passed

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
