### PR TITLE
Fix IndexError in euler_equations when no functions are passed

### DIFF
--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -78,6 +78,9 @@ def euler_equations(L, funcs=(), vars=()):
             if not isinstance(f, Function):
                 raise TypeError('Function expected, got: %s' % f)
 
+    if not funcs:
+        raise ValueError("euler_equations requires at least one Function to compute derivatives.")
+
     vars = tuple(vars) if iterable(vars) else (vars,)
 
     if not vars:

--- a/sympy/calculus/tests/test_euler.py
+++ b/sympy/calculus/tests/test_euler.py
@@ -11,6 +11,7 @@ def test_euler_interface():
     y = Symbol('y')
     t = Symbol('t')
     raises(TypeError, lambda: euler())
+    raises(ValueError, lambda: euler(y**2))
     raises(TypeError, lambda: euler(D(x(t), t)*y(t), [x(t), y]))
     raises(ValueError, lambda: euler(D(x(t), t)*x(y), [x(t), x(y)]))
     raises(TypeError, lambda: euler(D(x(t), t)**2, x(0)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29123

#### Brief description of what is fixed or changed
Fixed `euler_equations()` which now raise a `ValueError` instead of `IndexError` when the Lagrangian contains no Function.

#### Other comments
Added a test case

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixed `euler_equations` to raise `ValueError` instead of `IndexError` when no Function terms are found in the Lagrangian.
<!-- END RELEASE NOTES -->
