### PR TITLE
assumptions: refine sqrt inequalities under real assumptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1132,6 +1132,7 @@ Morten Olsen Lysgaard <morten@lysgaard.no>
 Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
+Mrigank Shekhar Singh <mrigank.11.8@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -283,3 +283,21 @@ def test_sin_cos():
     assert refine(cos(x + n*pi/2 + k*pi/2 + m*pi/2), \
                   Q.odd(n) & Q.odd(k) & Q.integer(m)) == \
         (-1)**((n + k)/2) * cos(x + m*pi/2)
+def test_refine_inequality():
+    """Test refining inequality expressions with assumptions (Issue #27750)."""
+    # sqrt inequalities - the main issue #27750
+    assert refine(sqrt(x) >= 0, Q.real(sqrt(x))) == S.true
+    assert refine(sqrt(x) < 0, Q.real(sqrt(x))) == S.false
+    assert refine(sqrt(x) > 0, Q.positive(sqrt(x))) == S.true
+    assert refine(sqrt(x) <= 0, Q.positive(sqrt(x))) == S.false
+    assert refine(sqrt(x) <= 0, Q.zero(sqrt(x))) == S.true
+    # General inequality refinements
+    assert refine(x >= 0, Q.positive(x)) == S.true
+    assert refine(x < 0, Q.positive(x)) == S.false
+    assert refine(x > 0, Q.positive(x)) == S.true
+    assert refine(x <= 0, Q.negative(x)) == S.true
+    assert refine(x < 0, Q.negative(x)) == S.true
+    assert refine(x >= 0, Q.negative(x)) == S.false
+    # Inequalities that cannot be refined should remain unchanged
+    assert refine(x >= 0, Q.real(x)) == (x >= 0)
+    assert refine(x > 0, Q.real(x)) == (x > 0)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #27750
Related to #27888

#### Brief description of what is fixed or changed

since refine did not simplify inequalities like sqrt(x) >= 0 even under the assumption Q.real(sqrt(x)), I've added a refine_inequality handler which handles relational expressions and applies a case for square roots that if sqrt(x) is known to be real, then sqrt(x) >= 0 is always true.

I've also added some tests: test_refine_inequality() for the same in tests_refine.py

<img width="446" height="149" alt="image" src="https://github.com/user-attachments/assets/c0f45ed5-9f13-4260-b08a-0b5b741a0eb4" />


#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->



