### PR TITLE
Fix euler_equations to raise ValueError instead of IndexError

### DIFF
--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -78,6 +78,9 @@ def euler_equations(L, funcs=(), vars=()):
             if not isinstance(f, Function):
                 raise TypeError('Function expected, got: %s' % f)
 
+    if not funcs:
+        raise ValueError('No functions found in Lagrangian')
+
     vars = tuple(vars) if iterable(vars) else (vars,)
 
     if not vars:

--- a/sympy/calculus/tests/test_euler.py
+++ b/sympy/calculus/tests/test_euler.py
@@ -15,6 +15,7 @@ def test_euler_interface():
     raises(ValueError, lambda: euler(D(x(t), t)*x(y), [x(t), x(y)]))
     raises(TypeError, lambda: euler(D(x(t), t)**2, x(0)))
     raises(TypeError, lambda: euler(D(x(t), t)*y(t), [t]))
+    raises(ValueError, lambda: euler(y**2))  # Lagrangian with no Function terms
     assert euler(D(x(t), t)**2/2, {x(t)}) == [Eq(-D(x(t), t, t), 0)]
     assert euler(D(x(t), t)**2/2, x(t), {t}) == [Eq(-D(x(t), t, t), 0)]
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29123

#### Brief description of what is fixed or changed

When `euler_equations()` is called with a Lagrangian that contains no Function terms, it now raises a `ValueError` with a clear error message instead of raising an `IndexError`.

This commit adds a check after extracting functions from the Lagrangian to verify that at least one function was found. If no functions are found, a `ValueError` is raised with the message "No functions found in Lagrangian".

A test case has been added to `test_euler_interface()` to verify this behavior.

#### Other comments

Before this fix:
```python
from sympy import Symbol, euler_equations
L = Symbol('x')**2  # Lagrangian with no Function terms
euler_equations(L)  # IndexError: tuple index out of range
```

After this fix:
```python
euler_equations(L)  # ValueError: No functions found in Lagrangian
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixed `euler_equations()` to raise `ValueError` instead of `IndexError` when the Lagrangian contains no Function terms.
<!-- END RELEASE NOTES -->