### PR TITLE
Add helper function to ensure consistent IPython session setup and reduce code duplication

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -822,6 +822,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jassem Manita <jasemmanita00@gmail.com> jassem-manita <jasemmanita00@gmail.com>
 Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
 Jatin Gaur <jatingaurchess@gmail.com> <134034110+jatingaur18@users.noreply.github.com>
 Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
@@ -1865,4 +1866,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Jassem Manita <jasemmanita00@gmail.com> jassem-manita <jasemmanita00@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1865,3 +1865,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Jassem Manita <jasemmanita00@gmail.com> jassem-manita <jasemmanita00@gmail.com>

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -2,7 +2,7 @@
 
 from sympy.core import Integer, Rational, Symbol
 from sympy.external import import_module
-from sympy.interactive.session import (
+from sympy.interactive.session import ( 
     enable_automatic_int_sympification, enable_automatic_symbols,
     init_ipython_session)
 from sympy.testing.pytest import raises
@@ -24,10 +24,10 @@ def _setup_ipython_session(setup_formatter=True, import_ipython=False):
     ==========
     setup_formatter : bool, optional, (default is True)
         If True, sets up the IPython instance and display formatter only (import_ipython defaul is False ).
-        If False, skips formatter setup.    
+        If False, skips formatter setup.
     import_ipython : bool, optional, (default is False)
         If True, runs 'import IPython' before formatter setup.
-        If False. Only relevant if setup_formatter is True. 
+        If False. Only relevant if setup_formatter is True.
 
     Examples
     ========
@@ -68,7 +68,6 @@ def test_automatic_symbols():
     # NOTE: Because of the way the hook works, you have to use run_cell(code,
     # True).  This means that the code must have no Out, or it will be printed
     # during the tests.
-    
     app = _setup_ipython_session(setup_formatter=False)
     app.run_cell("from sympy import *")
     enable_automatic_symbols(app)
@@ -259,7 +258,7 @@ def test_builtin_containers():
  [2]  \
 """
         assert app.user_ns['c'][0]['text/latex'] == '$\\displaystyle \\left( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right],\\right)$'
-
+    
 def test_matplotlib_bad_latex():
     app = _setup_ipython_session(import_ipython=True)
     app.run_cell("from sympy import init_printing, Matrix")

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -2,7 +2,7 @@
 
 from sympy.core import Integer, Rational, Symbol
 from sympy.external import import_module
-from sympy.interactive.session import ( 
+from sympy.interactive.session import (
     enable_automatic_int_sympification, enable_automatic_symbols,
     init_ipython_session)
 from sympy.testing.pytest import raises
@@ -96,7 +96,6 @@ def test_int_to_Integer():
     # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
     app = _setup_ipython_session(setup_formatter=False)
     app.run_cell("from sympy import Integer")
-    
     app.run_cell("a = 1")
     assert isinstance(app.user_ns['a'], int)
     enable_automatic_int_sympification(app)
@@ -232,7 +231,6 @@ def test_builtin_containers():
     app.run_cell('import sys')
     app.run_cell('b = format(sys.flags)')
     app.run_cell('c = format((Matrix([1, 2]),))')
-    
     # Deal with API change starting at IPython 1.0
     if int(ipython.__version__.split(".")[0]) < 1:
         assert app.user_ns['a']['text/plain'] ==  '(True, False)'
@@ -258,7 +256,6 @@ def test_builtin_containers():
  [2]  \
 """
         assert app.user_ns['c'][0]['text/latex'] == '$\\displaystyle \\left( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right],\\right)$'
-    
 def test_matplotlib_bad_latex():
     app = _setup_ipython_session(import_ipython=True)
     app.run_cell("from sympy import init_printing, Matrix")


### PR DESCRIPTION
#### References to other Issues or PRs
No related issues


#### Brief description of what is fixed or changed
Added a `_setup_ipython_session()` helper function to centralizes the initialization and configuration of IPython sessions.
It includes optional display formatter setup and IPython import.
Refactored all test functions to use this function.
isort to organize imports.
#### Other comments
The function accepts two parameters:
- `setup_formatter` (default: True) : sets up IPython display formatter
- `import_ipython` (default: False) : imports IPython module
#### AI Generation Disclosure
Copilot was used to refactor the functions after the implementation.
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
