### PR TITLE
Fix mutable default argument in GLSLPrinter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1799,6 +1799,7 @@ klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
 leastloris <ivedants05@gmail.com>
+Luka Aladashvili <115102487+llukito@users.noreply.github.com>
 luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
 luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@users.noreply.github.com>
 mao8 <thisisma08@gmail.com>

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -52,7 +52,9 @@ class GLSLPrinter(CodePrinter):
         'contract': True,
     })
 
-    def __init__(self, settings={}):
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})


### PR DESCRIPTION
## Description
This PR addresses a mutable default argument issue in `sympy/printing/glsl.py`.

In the `GLSLPrinter` class, the `__init__` method used a dictionary (`settings={}`) as a default argument. In Python, this dictionary is created once at definition time and shared across all instances of the class, which can lead to unexpected state persistence and side effects.

## Changes
- Updated `GLSLPrinter.__init__` signature to use `settings=None`.
- Added a check to initialize `settings` as a new dictionary if it is `None`.

This change ensures that each instance of `GLSLPrinter` starts with a fresh settings object if none is provided.

* printing
  * Fixed a mutable default argument issue in `GLSLPrinter` where `settings` could persist across instances.