### PR TITLE
Escape leading underscores in latex() output

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1783,6 +1783,7 @@ faizan2700 <syedfaizan824@gmail.com>
 fazledyn-or <ataf@openrefactory.com>
 foice <foice.news@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>
+graphpilled <graphpilled@protonmail.com>
 gregmedlock <gmedlo@gmail.com>
 helo9 <helo9@users.noreply.github.com>
 hm <hacman0@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1661,6 +1661,9 @@ class LatexPrinter(Printer):
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]
+        if name and name[0] == '_':
+            i = len(name) - len(name.lstrip('_'))
+            name = r'\_' * i + name[i:]
         return (name, supers, subs)
 
     def _deal_with_super_sub(self, string: str, style='plain') -> str:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1661,7 +1661,7 @@ class LatexPrinter(Printer):
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]
-        if name and name[0] == '_':
+        if name and name.startswith('_'):
             i = len(name) - len(name.lstrip('_'))
             name = r'\_' * i + name[i:]
         return (name, supers, subs)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1658,12 +1658,15 @@ class LatexPrinter(Printer):
             name, supers, subs = (name.replace('_', '\\_').replace('^', '\\^'), [], [])
         else:
             name, supers, subs = split_super_sub(name)
+        prefix = ''
+        if name and name.startswith('_'):
+            i = len(name) - len(name.lstrip('_'))
+            prefix = r'\_' * i
+            name = name[i:]
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]
-        if name and name.startswith('_'):
-            i = len(name) - len(name.lstrip('_'))
-            name = r'\_' * i + name[i:]
+        name = prefix + name
         return (name, supers, subs)
 
     def _deal_with_super_sub(self, string: str, style='plain') -> str:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -433,7 +433,7 @@ def test_latex_symbols():
     assert latex(Symbol('_x')) == r"\_x"
     assert latex(Symbol('__x')) == r"\_\_x"
     assert latex(2 * Symbol('_x')) == r"2 \_x"
-    assert latex(Symbol('_alpha')) == r"\_alpha"
+    assert latex(Symbol('_alpha')) == r"\_\alpha"
     assert latex(Symbol('_x_1')) == r"\_x_{1}"
     assert latex(Symbol('_')) == r"\_"
     assert latex(Symbol('__')) == r"\_\_"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -430,6 +430,13 @@ def test_latex_symbols():
     assert latex(Symbol('e^Alpha')) == r"e^{\mathrm{A}}"
     assert latex(Symbol('omega_alpha^beta')) == r"\omega^{\beta}_{\alpha}"
     assert latex(Symbol('omega') ** Symbol('beta')) == r"\omega^{\beta}"
+    assert latex(Symbol('_x')) == r"\_x"
+    assert latex(Symbol('__x')) == r"\_\_x"
+    assert latex(2 * Symbol('_x')) == r"2 \_x"
+    assert latex(Symbol('_alpha')) == r"\_alpha"
+    assert latex(Symbol('_x_1')) == r"\_x_{1}"
+    assert latex(Symbol('_')) == r"\_"
+    assert latex(Symbol('__')) == r"\_\_"
 
 
 @XFAIL


### PR DESCRIPTION
Symbols with leading underscores produced invalid LaTeX since _ is a special character. Now they are escaped as \_.
Fixes #14718
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
#### References to other Issues or PRs

Fixes #14718
Related: #15939 (attempted a broader fix but has been stalled for 7 years with merge conflicts)

#### Brief description of what is fixed or changed

Fix latex rendering of symbols with leading underscores by escaping them as \_ to prevent invalid LaTeX output. Add corresponding regression tests.

#### Other comments

#### AI Generation Disclosure

Used Claude Code to explore the codebase and generate an initial draft of the fix in _split_super_sub and the test assertions. I rewrote the implementation and tested it on my own.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed `latex()` to escape leading underscores in symbol names, producing valid LaTeX output.
<!-- END RELEASE NOTES -->