### PR TITLE
Fix TableForm LaTeX to use math-mode array instead of text-mode tabular

### DIFF
--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -24,11 +24,11 @@ class TableForm:
     format (ascii, latex, html, ...).
 
     >>> print(t.as_latex())
-    \begin{tabular}{l l}
-    $5$ & $7$ \\
-    $4$ & $2$ \\
-    $10$ & $3$ \\
-    \end{tabular}
+    \begin{array}{l l}
+    5 & 7 \\
+    4 & 2 \\
+    10 & 3 \\
+    \end{array}
 
     """
 
@@ -332,7 +332,7 @@ class TableForm:
             alignments = [self._head_align]
         alignments.extend(self._alignments)
 
-        s = r"\begin{tabular}{" + " ".join(alignments) + "}\n"
+        s = r"\begin{array}{" + " ".join(alignments) + "}\n"
 
         if self._headings[1]:
             d = self._headings[1]
@@ -358,9 +358,9 @@ class TableForm:
                     d.append(v)
                 else:
                     v = printer._print(x)
-                    d.append("$%s$" % v)
+                    d.append(v)
             if self._headings[0]:
                 d = [self._headings[0][i]] + d
             s += " & ".join(d) + r" \\" + "\n"
-        s += r"\end{tabular}"
+        s += r"\end{array}"
         return s

--- a/sympy/printing/tests/test_tableform.py
+++ b/sympy/printing/tests/test_tableform.py
@@ -104,57 +104,57 @@ def test_TableForm_latex():
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 &   & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 &   & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic"), alignments='l'))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 &   & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 &   & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic"), alignments='l'*3))
     assert s == (
-        '\\begin{tabular}{l l l}\n'
+        '\\begin{array}{l l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 &   & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 &   & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 & $a$ & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 & a & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             formats=['(%s)', None], headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 & (a) & $x^{3}$ \\\\\n'
-        '2 & (c) & $\\frac{1}{4}$ \\\\\n'
-        '3 & (sqrt(x)) & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 & (a) & x^{3} \\\\\n'
+        '2 & (c) & \\frac{1}{4} \\\\\n'
+        '3 & (sqrt(x)) & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
 
     def neg_in_paren(x, i, j):
@@ -165,18 +165,18 @@ def test_TableForm_latex():
     s = latex(TableForm([[-1, 2], [-3, 4]],
             formats=[neg_in_paren]*2, headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
         '1 & -1 & 2 \\\\\n'
         '2 & (-3) & 4 \\\\\n'
-        '\\end{tabular}'
+        '\\end{array}'
     )
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]]))
     assert s == (
-        '\\begin{tabular}{l l}\n'
-        '$a$ & $x^{3}$ \\\\\n'
-        '$c$ & $\\frac{1}{4}$ \\\\\n'
-        '$\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '\\begin{array}{l l}\n'
+        'a & x^{3} \\\\\n'
+        'c & \\frac{1}{4} \\\\\n'
+        '\\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )


### PR DESCRIPTION
## Summary

`TableForm._latex()` was returning `\begin{tabular}` which is a text-mode LaTeX environment, but the contract of `_latex` requires math-mode output. This caused invalid LaTeX when:

- A `TableForm` is nested inside another expression (e.g. `latex([t])` produces `\left[ \begin{tabular}...` which is illegal since `\left` is math-mode only)
- Using `mode='equation'` or `mode='inline'` wraps the output in math delimiters, causing nested `$` signs

**Fix:** Switch from `\begin{tabular}` to `\begin{array}`, which is the math-mode equivalent. Also remove the `$...$` wrapping around individual cell values since `array` already operates in math mode.

**Before:**
```latex
\left[ \begin{tabular}{l l}
$1$ & $2$ \\
\end{tabular}\right]
```

**After:**
```latex
\left[ \begin{array}{l l}
1 & 2 \\
\end{array}\right]
```

Fixes #20063

## Changes

- `sympy/printing/tableform.py`: `_latex` method uses `array` environment instead of `tabular`, drops `$...$` cell wrapping
- `sympy/printing/tests/test_tableform.py`: Updated expected output in `test_TableForm_latex`
- Updated docstring example to match new output

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed `TableForm._latex()` to use math-mode `array` environment instead of text-mode `tabular`, allowing correct LaTeX output when nested inside other expressions or used with equation modes.
<!-- END RELEASE NOTES -->