### PR TITLE
Fix FCodePrinter converting integer function args to floats

### DIFF
--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -299,7 +299,7 @@ class FCodePrinter(CodePrinter):
     def _print_Function(self, expr):
         # All constant function args are evaluated as floats
         prec =  self._settings['precision']
-        args = [N(a, prec) for a in expr.args]
+        args = [a if a.is_integer and not a.is_number else N(a, prec) for a in expr.args]
         eval_expr = expr.func(*args)
         if not isinstance(eval_expr, Function):
             return self._print(eval_expr)

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -14,6 +14,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (atan2, cos, sin)
 from sympy.functions.special.gamma_functions import gamma
+from sympy.functions.special.bessel import besselj
 from sympy.integrals.integrals import Integral
 from sympy.sets.fancysets import Range
 
@@ -223,6 +224,21 @@ def test_user_functions():
     n = symbols('n', integer=True)
     assert fcode(
         factorial(n), user_functions={"factorial": "fct"}) == "      fct(n)"
+
+
+def test_fcode_integer_args_not_converted_to_floats():
+    # issue 20435
+    n = symbols('n', integer=True)
+    x = symbols('x')
+    p = FCodePrinter({'user_functions': {'besselj': 'BESJN'}})
+    # integer-typed arguments should not be converted to floats
+    assert p.doprint(besselj(n + 1, x**2)) == '      BESJN(n + 1, x**2)'
+    assert p.doprint(besselj(n, x)) == '      BESJN(n, x)'
+    # non-integer constant arguments should still be evaluated
+    m = symbols('m', integer=True)
+    result = p.doprint(besselj(m + 2, pi))
+    assert 'm + 2' in result
+    assert '3.14159' in result
 
 
 def test_inline_function():


### PR DESCRIPTION
## Summary

Fixes #20435

`FCodePrinter._print_Function` unconditionally passes all function arguments through `N(a, prec)`, which converts integer-typed arguments to floats. This causes expressions like `besselj(n+1, x**2)` (where `n` is declared `integer=True`) to render as `BESJN(n + 1.0d0, x**2)` instead of `BESJN(n + 1, x**2)`, breaking Fortran compilation since intrinsics like `BESJN` expect their first argument to be `INTEGER`.

The fix skips the `N()` evaluation for arguments whose `is_integer` property is `True` and that aren't pure numeric constants (`is_number` is `False`). This preserves integer semantics for symbolic integer expressions while still allowing constant folding for cases like `log(10)` where the integer `10` needs to be evaluated to produce a numeric result.

## Changes

- `sympy/printing/fortran.py`: In `_print_Function`, skip `N()` conversion for integer-typed non-numeric arguments
- `sympy/printing/tests/test_fortran.py`: Add regression test for #20435 covering integer args with user functions

## Test plan

- [x] All 44 existing + new Fortran printer tests pass
- [x] `besselj(n+1, x**2)` with `n` integer renders as `BESJN(n + 1, x**2)` (no `1.0d0`)
- [x] `besselj(n, x)` with `n` integer renders as `BESJN(n, x)`
- [x] `log(10)` still constant-folds correctly (pure integer constants still get N'd)
- [x] `besselj(m+2, pi)` correctly preserves `m + 2` as integer and evaluates `pi` to float

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed `FCodePrinter` to preserve integer types for symbolic integer arguments in function calls, preventing incorrect float conversion that broke Fortran intrinsics like `BESJN`.
<!-- END RELEASE NOTES -->