### PR TITLE
Fix solveset for Piecewise with conditions not involving the symbol

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1912,3 +1912,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Aditya Prakash <prakashaditya2709@gmail.com>
+

--- a/.mailmap
+++ b/.mailmap
@@ -1913,4 +1913,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
 Aditya Prakash <prakashaditya2709@gmail.com>
-

--- a/.mailmap
+++ b/.mailmap
@@ -1912,4 +1912,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Aditya Prakash <prakashaditya2709@gmail.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1307,7 +1307,7 @@ def _solveset(f, symbol, domain, _check=False):
             else:
                 try:
                     in_set = cond_eff.as_set()
-                except Exception:
+                except (TypeError, ValueError):
                     solns = solver(expr, symbol, domain)
                     result += ConditionSet(symbol, cond_eff, solns)
                 else:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1291,12 +1291,30 @@ def _solveset(f, symbol, domain, _check=False):
         result = Intersection(_solveset(re(a) > 0, symbol, domain),
                               _solveset(im(a), symbol, domain))
     elif f.is_Piecewise:
-        expr_set_pairs = f.as_expr_set_pairs(domain)
-        for (expr, in_set) in expr_set_pairs:
-            if in_set.is_Relational:
-                in_set = in_set.as_set()
-            solns = solver(expr, symbol, in_set)
-            result += solns
+
+        remaining = S.true
+        for expr, cond in f.args:
+            cond_eff = cond & remaining
+            if cond_eff is S.false:
+                remaining = remaining & ~cond
+                continue
+            if cond_eff is S.true:
+                result += solver(expr, symbol, domain)
+                break
+            if not cond_eff.has(symbol):
+                solns = solver(expr, symbol, domain)
+                result += ConditionSet(symbol, cond_eff, solns)
+            else:
+                try:
+                    in_set = cond_eff.as_set()
+                except Exception:
+                    solns = solver(expr, symbol, domain)
+                    result += ConditionSet(symbol, cond_eff, solns)
+                else:
+                    solns = solver(expr, symbol, in_set)
+                    result += solns
+            remaining = remaining & ~cond
+
     elif isinstance(f, Eq):
         result = solver(Add(f.lhs, -f.rhs, evaluate=False), symbol, domain)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1293,7 +1293,10 @@ def _solveset(f, symbol, domain, _check=False):
     elif f.is_Piecewise:
         if not domain.is_subset(S.Reals):
             for _, cond in f.args:
-                if cond is not True and cond.has(Relational):
+                if cond is True:
+                    continue
+                rels = cond.atoms(Relational)
+                if any(getattr(r, "rel_op", None) in ("<", "<=", ">", ">=") for r in rels):
                     raise ValueError(
                         "Inequalities in Piecewise require an ordered domain."
                     )

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1291,6 +1291,12 @@ def _solveset(f, symbol, domain, _check=False):
         result = Intersection(_solveset(re(a) > 0, symbol, domain),
                               _solveset(im(a), symbol, domain))
     elif f.is_Piecewise:
+        if not domain.is_subset(S.Reals):
+            for _, cond in f.args:
+                if cond is not True and cond.has(Relational):
+                    raise ValueError(
+                        "Inequalities in Piecewise require an ordered domain."
+                    )
 
         remaining = S.true
         for expr, cond in f.args:
@@ -1312,6 +1318,7 @@ def _solveset(f, symbol, domain, _check=False):
                     result += ConditionSet(symbol, cond_eff, solns)
                 else:
                     solns = solver(expr, symbol, in_set)
+                    solns = Intersection(solns, domain)
                     result += solns
             remaining = remaining & ~cond
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1310,7 +1310,7 @@ def _solveset(f, symbol, domain, _check=False):
             if cond_eff is S.true:
                 result += solver(expr, symbol, domain)
                 break
-            if not cond_eff.has(symbol):
+            if not cond_eff.has_free(symbol):
                 solns = solver(expr, symbol, domain)
                 result += ConditionSet(symbol, cond_eff, solns)
             else:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1293,7 +1293,7 @@ def _solveset(f, symbol, domain, _check=False):
     elif f.is_Piecewise:
         if not domain.is_subset(S.Reals):
             for _, cond in f.args:
-                if cond is True:
+                if cond is S.true:
                     continue
                 rels = cond.atoms(Relational)
                 if any(getattr(r, "rel_op", None) in ("<", "<=", ">", ">=") for r in rels):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1589,6 +1589,16 @@ def test_solvify_piecewise():
     assert solvify(p4, x, S.Reals) == [pi]
 
 
+def test_solveset_piecewise_condition_not_in_symbol():
+    x, y = symbols('x y', real=True)
+    f = Piecewise((x**2 - 4, y < 5), (x**2 - 36, True))
+    sol = solveset(f, x, S.Reals)
+
+    assert sol == Union(
+        ConditionSet(x, y >= 5, FiniteSet(-6, 6)),
+        ConditionSet(x, y < 5, FiniteSet(-2, 2)),
+    )
+
 def test_abs_invert_solvify():
 
     x = Symbol('x',positive=True)


### PR DESCRIPTION
### Fix solveset for Piecewise with conditions not involving the symbol

#### References to other Issues or PRs

Fixes #10534


#### Brief description of what is fixed or changed

Fixes `solveset` handling of `Piecewise` expressions when branch conditions do not
involve the symbol of interest. Previously, such cases could incorrectly collapse
conditional branches into an unconditional `FiniteSet` (for example `{ -2, 2, 6 }`).

This change ensures that conditional solutions are returned using `ConditionSet`
and adds a regression test to prevent future regressions.


#### Other comments

None.


#### AI Generation Disclosure

This pull request was written by the author with interactive assistance from ChatGPT
for debugging guidance and drafting the regression test. All code changes were
implemented and reviewed manually me.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* solvers
  * Fixed `solveset` for `Piecewise` expressions with conditions that do not depend
    on the solved symbol, returning conditional solutions instead of collapsing to
    an unconditional `FiniteSet`.

<!-- END RELEASE NOTES -->
