### PR TITLE
Fixed Invalid NaN comparison error

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -720,7 +720,7 @@ class Expr(Basic, EvalfMixin):
             try:
                 a = expr.subs(list(zip(free, [0]*len(free))),
                     simultaneous=True)
-                if a is S.NaN:
+                if a is S.NaN or a.has(S.NaN):
                     # evaluation may succeed when substitution fails
                     a = expr._random(None, 0, 0, 0, 0)
             except ZeroDivisionError:
@@ -729,7 +729,7 @@ class Expr(Basic, EvalfMixin):
                 try:
                     b = expr.subs(list(zip(free, [1]*len(free))),
                         simultaneous=True)
-                    if b is S.NaN:
+                    if b is S.NaN or b.has(S.NaN):
                         # evaluation may succeed when substitution fails
                         b = expr._random(None, 1, 0, 1, 0)
                 except ZeroDivisionError:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1987,7 +1987,7 @@ def test_equals():
 
     # issue 29159
     T = Function('T')
-    assert T(n*log(n)).equals(T(n)) is not True
+    assert T(n*log(n)).equals(T(n)) is None
 
 
 def test_random():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1985,6 +1985,10 @@ def test_equals():
     S(13)/6)/2 - S.One/4)**2 - Rational(1, 3))
     assert z.equals(0)
 
+    # issue 29159
+    T = Function('T')
+    assert T(n*log(n)).equals(T(n)) is not True
+
 
 def test_random():
     from sympy.functions.combinatorial.numbers import lucas


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29159 

#### Brief description of what is fixed or changed
Previously `T(n*log(n)).equals(T(n))` was raising a `TypeError: Invalid NaN comparison` instead of returning `False` or `None`. 

It was happening beacuse of `is_constant()`.When we take`n = 0` in `T(n*log(n)).equals(T(n))`, we get `T(NaN) - T(0)` (0*log(0) is NaN) .

The code was on checing for `NaN` only, not for something like `T(NaN)` that is when NaN is inside a Function.This was the root cause of `TypeError` , so i updated the checks to look for `NaN` in whole expression using `.has(S.NaN)`.
#### Other comments
Added a test case

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  *  Fixed the `TypeError: Invalid NaN comparison` when calls `equals()` on an expression with log.
<!-- END RELEASE NOTES -->
