### PR TITLE
NonZeroPredicate for exp

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -823,6 +823,7 @@ Jason Ross <jasonross1024@gmail.com>
 Jason Siefken <siefkenj@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com>
 Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jassem Manita <jasemmanita00@gmail.com> jassem-manita <jasemmanita00@gmail.com>
 Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
 Jatin Gaur <jatingaurchess@gmail.com> <134034110+jatingaur18@users.noreply.github.com>
 Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -152,6 +152,12 @@ def _(expr, assumptions):
 
 # NonZeroPredicate
 
+@NonZeroPredicate.register(exp)
+def _(expr, assumptions):
+    # exp is always nonzero
+    return True
+
+
 @NonZeroPredicate.register(Expr)
 def _(expr, assumptions):
     ret = expr.is_nonzero

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1761,6 +1761,11 @@ def test_nonzero():
     assert ask(Q.nonzero(Abs(x))) is None
     assert ask(Q.nonzero(Abs(x)), Q.nonzero(x)) is True
 
+    # exp tests
+    assert ask(Q.nonzero(exp(x)), Q.real(x)) is True
+    assert ask(Q.nonzero(exp(x)), Q.positive(x)) is True
+    assert ask(Q.nonzero(exp(x)), Q.negative(x)) is True
+
     assert ask(Q.nonzero(log(exp(2*I)))) is False
     # although this could be False, it is representative of expressions
     # that don't evaluate to a zero with precision


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
issue #29144
#### Brief description of what is fixed or changed
There was no NonZeroPredicate handler for exp that's why it returned None
#### Other comments

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
None

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
