### PR TITLE
Add curvature tensor examples to tensor documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -231,6 +231,7 @@ Addison Cugini <ajcugini@gmail.com> <addisonc@pcp065368pcs.dhcp.calpoly.edu>
 Aditya Jindal <jaditya8889@gmail.com>
 Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
 Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141@gmail.com>
+Aditya Prakash <prakashaditya2709@gmail.com>
 Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>

--- a/doc/src/modules/tensor/index.rst
+++ b/doc/src/modules/tensor/index.rst
@@ -18,3 +18,4 @@ Contents
    index_methods.rst
    tensor.rst
    toperators.rst
+   riemannian_geometry.rst

--- a/doc/src/modules/tensor/riemannian_geometry.rst
+++ b/doc/src/modules/tensor/riemannian_geometry.rst
@@ -38,7 +38,7 @@ We verify this by computing the scalar curvature:
    >>> g = diag(1, r**2)
    >>> coords = [r, th]
    >>> Gamma = metric_to_Christoffel_2nd(g, coords)
-    >>> Gamma[0, 1, 1]
+   >>> Gamma[0, 1, 1]
    r
    >>> Riem = riemann_tensor(Gamma, coords)
    >>> Ric = ricci_tensor(Riem, coords)

--- a/doc/src/modules/tensor/riemannian_geometry.rst
+++ b/doc/src/modules/tensor/riemannian_geometry.rst
@@ -27,26 +27,19 @@ describes flat Euclidean space, so the Ricci tensor and scalar curvature should
 be zero.
 
 We verify this by computing the scalar curvature:
-.. doctest::
+.. code-block:: pycon
 
-   >>> from sympy import symbols, diag, simplify
-   >>> from sympy.diffgeom.riemannian_geometry import (
-   ...     metric_to_Christoffel_2nd, riemann_tensor,
-   ...     ricci_tensor, scalar_curvature
-   ... )
-   >>> r, th = symbols('r th', positive=True, real=True)
-   >>> g = diag(1, r**2)
-   >>> coords = [r, th]
-   >>> Gamma = metric_to_Christoffel_2nd(g, coords)
-   >>> Gamma[0, 1, 1]
-   r
-   >>> Riem = riemann_tensor(Gamma, coords)
-   >>> Ric = ricci_tensor(Riem, coords)
-   >>> Scal = scalar_curvature(Ric, g, coords)
-   >>> all(simplify(c) == 0 for row in Ric for c in row)
-   True
-   >>> simplify(Scal)
-   0
+   >>> from sympy.diffgeom import TensorProduct, metric_to_Christoffel_2nd, metric_to_Ricci_components
+   >>> from sympy.diffgeom.rn import R2_p
+   >>> TP = TensorProduct
+   >>> g = TP(R2_p.dr, R2_p.dr) + R2_p.r**2*TP(R2_p.dtheta, R2_p.dtheta)
+   >>> Gamma = metric_to_Christoffel_2nd(g)
+   >>> Gamma[0][1][1]
+   -rho
+   >>> Ric = metric_to_Ricci_components(g)
+   >>> Ric
+   [[0, 0], [0, 0]]
+
 
 Unit 2-sphere
 =============
@@ -62,20 +55,17 @@ has constant positive curvature. For the unit sphere, the scalar curvature is 2
 
 .. code-block:: pycon
 
-   >>> from sympy import symbols, diag, sin, simplify
-   >>> from sympy.diffgeom.riemannian_geometry import (
-   ...     metric_to_Christoffel_2nd, riemann_tensor,
-   ...     ricci_tensor, scalar_curvature
-   ... )
-   >>> th, ph = symbols('th ph', real=True)
-   >>> g = diag(1, sin(th)**2)
-   >>> coords = [th, ph]
-   >>> Gamma = metric_to_Christoffel_2nd(g, coords)
-   >>> Riem = riemann_tensor(Gamma, coords)
-   >>> Ric = ricci_tensor(Riem, coords)
-   >>> Scal = scalar_curvature(Ric, g, coords)
-   >>> simplify(Scal - 2)
-   0
+   >>> from sympy.diffgeom import TensorProduct, metric_to_Ricci_components
+   >>> from sympy.diffgeom.rn import R2
+   >>> from sympy import simplify
+   >>> TP = TensorProduct
+   >>> g = (1/R2.y**2)*(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
+   >>> Ric = metric_to_Ricci_components(g)
+   >>> Ric
+   [[-1/y**2, 0], [0, -1/y**2]]
+   >>> R = simplify((R2.y**2)*Ric[0][0] + (R2.y**2)*Ric[1][1])
+   >>> R
+   -2
 
 Notes on larger examples
 ========================

--- a/doc/src/modules/tensor/riemannian_geometry.rst
+++ b/doc/src/modules/tensor/riemannian_geometry.rst
@@ -1,0 +1,88 @@
+.. _tensor_riemannian_geometry:
+
+========================================================
+Computing Christoffel Symbols, Riemann and Ricci Tensors
+========================================================
+
+This page demonstrates how to compute curvature tensors from a metric using
+SymPy's tensor/differential-geometry functionality.
+
+The workflow is:
+
+1. Define coordinates and a metric tensor ``g``.
+2. Compute Christoffel symbols.
+3. Compute the Riemann tensor, Ricci tensor, and scalar curvature.
+4. Verify results with lightweight symbolic checks.
+
+Flat space in polar coordinates
+===============================
+
+The 2D polar metric
+
+.. math::
+
+   ds^2 = dr^2 + r^2 d\theta^2
+
+describes flat Euclidean space, so the Ricci tensor and scalar curvature should
+be zero.
+
+We verify this by computing the scalar curvature:
+.. doctest::
+
+   >>> from sympy import symbols, diag, simplify
+   >>> from sympy.diffgeom.riemannian_geometry import (
+   ...     metric_to_Christoffel_2nd, riemann_tensor,
+   ...     ricci_tensor, scalar_curvature
+   ... )
+   >>> r, th = symbols('r th', positive=True, real=True)
+   >>> g = diag(1, r**2)
+   >>> coords = [r, th]
+   >>> Gamma = metric_to_Christoffel_2nd(g, coords)
+    >>> Gamma[0, 1, 1]
+   r
+   >>> Riem = riemann_tensor(Gamma, coords)
+   >>> Ric = ricci_tensor(Riem, coords)
+   >>> Scal = scalar_curvature(Ric, g, coords)
+   >>> all(simplify(c) == 0 for row in Ric for c in row)
+   True
+   >>> simplify(Scal)
+   0
+
+Unit 2-sphere
+=============
+
+The unit 2-sphere metric
+
+.. math::
+
+   ds^2 = d\theta^2 + \sin^2(\theta)\, d\phi^2
+
+has constant positive curvature. For the unit sphere, the scalar curvature is 2
+(with the common convention used here).
+
+.. code-block:: pycon
+
+   >>> from sympy import symbols, diag, sin, simplify
+   >>> from sympy.diffgeom.riemannian_geometry import (
+   ...     metric_to_Christoffel_2nd, riemann_tensor,
+   ...     ricci_tensor, scalar_curvature
+   ... )
+   >>> th, ph = symbols('th ph', real=True)
+   >>> g = diag(1, sin(th)**2)
+   >>> coords = [th, ph]
+   >>> Gamma = metric_to_Christoffel_2nd(g, coords)
+   >>> Riem = riemann_tensor(Gamma, coords)
+   >>> Ric = ricci_tensor(Riem, coords)
+   >>> Scal = scalar_curvature(Ric, g, coords)
+   >>> simplify(Scal - 2)
+   0
+
+Notes on larger examples
+========================
+
+More complicated metrics (e.g. Schwarzschild) can produce very large symbolic
+expressions. If you are working with such metrics, consider:
+
+- applying assumptions (e.g. ``positive=True``) to reduce branch issues,
+- using targeted simplification (e.g. simplifying only selected components),
+- verifying only key identities/components to keep runtime reasonable.


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

* tensor
  * Added examples showing how to compute Christoffel symbols, Riemann tensor, Ricci tensor, and scalar curvature from a metric in the tensor module documentation.

<!-- END RELEASE NOTES -->
