### PR TITLE
Reduce coefficient explosion in smith_normal_decomp by improving pivot selection (#29139)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1678,6 +1678,7 @@ Victory Omole <vtomole2@gmail.com>
 Vighnesh Shenoy <vighneshq@gmail.com>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijair <vijair@umich.edu>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijairam20 <vijairamg@gmail.com>
+Vikash Kumar <vikashsio793@gmail.com>
 Vikrant Malik <vikrantmalik051@gmail.com> Vikrant <vikrant@Vikrant.local>
 Vikrant Malik <vikrantmalik051@gmail.com> Vikrant <vikrantmalik051@gmail.com>
 Vinay Kumar <gnulinooks@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1678,7 +1678,7 @@ Victory Omole <vtomole2@gmail.com>
 Vighnesh Shenoy <vighneshq@gmail.com>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijair <vijair@umich.edu>
 Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijairam20 <vijairamg@gmail.com>
-Vikash Kumar <vikashsio793@gmail.com>
+Vikash Kumar <vikashsio793@gmail.com> <163628932+Vikash-Kumar-23@users.noreply.github.com>
 Vikrant Malik <vikrantmalik051@gmail.com> Vikrant <vikrant@Vikrant.local>
 Vikrant Malik <vikrantmalik051@gmail.com> Vikrant <vikrantmalik051@gmail.com>
 Vinay Kumar <gnulinooks@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+Vikash Kumar <vikashsio793@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,4 +1457,3 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
-Vikash Kumar <vikashsio793@gmail.com>

--- a/sympy/polys/matrices/tests/test_normalforms.py
+++ b/sympy/polys/matrices/tests/test_normalforms.py
@@ -53,14 +53,14 @@ def test_smith_normal():
 
     s = DM([
         [0, 1, -1, 0],
-        [1, -4, 0, 0],
-        [0, -2, 3, 0],
+        [1, -6, 3, 0],
+        [3, -16, 6, 0],
         [-2, 2, -1, 1]], ZZ)
 
     t = DM([
-        [1, 1, 10, 0],
-        [0, -1, -2, 0],
-        [0, 1, 3, -2],
+        [1, 8, -7, 0],
+        [0, 0, -1, 0],
+        [0, 1, 0, -2],
         [0, 0, 0, 1]], ZZ)
 
     assert smith_normal_form(m).to_dense() == smf
@@ -106,10 +106,15 @@ def test_smith_normal():
         DM([[2], [0]], ZZ), DM([[0, -1], [1, 0]], ZZ), DM([[1]], ZZ)
     )
 
+    # Verify the decomposition is valid (s*m*t == snf) for these small cases
+    for mm in [DM([[0, -2]], ZZ), DM([[0], [-2]], ZZ)]:
+        snf_mm, s_mm, t_mm = smith_normal_decomp(mm)
+        assert snf_mm == s_mm * mm * t_mm
+
     m =   DM([[3, 0, 0, 0], [0, 0, 0, 0], [0, 0, 2, 0]], ZZ)
     snf = DM([[1, 0, 0, 0], [0, 6, 0, 0], [0, 0, 0, 0]], ZZ)
-    s = DM([[1, 0, 1], [2, 0, 3], [0, 1, 0]], ZZ)
-    t = DM([[1, -2, 0, 0], [0, 0, 0, 1], [-1, 3, 0, 0], [0, 0, 1, 0]], ZZ)
+    s = DM([[1, 0, -1], [2, 0, -3], [0, 1, 0]], ZZ)
+    t = DM([[1, -2, 0, 0], [0, 0, 0, 1], [1, -3, 0, 0], [0, 0, 1, 0]], ZZ)
 
     assert smith_normal_form(m).to_dense() == snf
     assert smith_normal_decomp(m) == (snf, s, t)
@@ -117,6 +122,59 @@ def test_smith_normal():
     assert snf == s * m * t
 
     raises(ValueError, lambda: smith_normal_form(DM([[1]], ZZ[x])))
+
+
+def test_smith_normal_decomp_coefficient_growth():
+    """Regression test for sympy/sympy#29139.
+
+    The 16x16 integer matrix from the issue previously caused the
+    transformation matrices S and T to contain entries on the order of
+    10**52, making floating-point determinant checks fail.  With the
+    minabs pivot strategy the entries stay within a reasonable range
+    and the decomposition remains correct and unimodular.
+    """
+    m = DM([
+        [ 16,  24,   8,  16,   8,  16, 0,  0, -16,  0,   0,  0, 16, 16, 0, 0],
+        [  0,   0,   0,   0,   8,   0, 0,  0,   0,  0,   0,  0,  0,  0, 0, 0],
+        [  8,   8,   0,   0,   0,   0, 0,  0,   0,  0,   0,  0,  0,  0, 0, 0],
+        [  0,   0,   0,   0,   8,   0, 0,  0,   0,  0,  16,  0,  0,  0, 0, 0],
+        [ -8,  -8,   8,  16,   8,   0, 0,  0,  16, 16,   0,  0,  0,  0, 0, 0],
+        [  4,  -8,   0,   0, -16,   0, 0,  0,   8,  0,  -8,  8, -8, -8, 0, 0],
+        [  4,   0,  -4,  -8,  -8,   0, 0,  0,  -8, -8,   0,  0,  0,  0, 0, 0],
+        [-12, -16,  -4,  -8, -12,   0, 8, -8,   8,  0,  -8,  0, -8, -8, 0, 0],
+        [ -4,  -8,   0,  -4, -12,   0, 0,  0,   0,  0,  -8,  0, -8,  0, 0, 0],
+        [  8,   8,   4,  -8,  -8,   0, 0,  8,  -8, -8,  -8,  0,  0,  0, 0, 0],
+        [-12, -12, -12, -16, -12,  -8, 0, -8,   0, -8,   0,  0, -8, -8, 0, 0],
+        [-12, -16,  -4,  -4,  -8,  -8, 0,  0,   8,  0,  -8,  0, -8, -8, 0, 0],
+        [  4,   8,   0,  -4,  -8,   0, 0,  0,  -8, -8,  -8,  0,  0,  8, 0, 0],
+        [ -8,  -8,  -4, -12, -16,  -8, 0,  0,   8, -8,  -8,  0, -8, -8, 0, 0],
+        [-16, -16,  -8, -24,   4, -16, 0,  0,   0, -8,   0, -8, -8, -8, 8, 0],
+        [  8,  -8, -12,  -4, -12,   0, 0,  0,  -8, -8, -16,  8,  0, -8, 0, 8],
+    ], ZZ)
+
+    snf, s, t = smith_normal_decomp(m)
+
+    # Decomposition must be correct
+    assert snf == s * m * t
+
+    # S and T must be unimodular (det = +/-1)
+    from sympy import Matrix
+    det_s = Matrix(s.to_list()).det()
+    det_t = Matrix(t.to_list()).det()
+    assert abs(det_s) == 1
+    assert abs(det_t) == 1
+
+    # The result must be in Smith Normal Form
+    assert is_smith_normal_form(snf)
+
+    # Coefficient growth guard: entries in S and T must stay reasonable.
+    # Before the fix these reached ~10**52; with minabs pivoting they
+    # should stay well below 10**15.
+    threshold = 10**15
+    max_s = max(abs(x) for row in s.to_list() for x in row)
+    max_t = max(abs(x) for row in t.to_list() for x in row)
+    assert max_s < threshold, f"max |S_ij| = {max_s} exceeds {threshold}"
+    assert max_t < threshold, f"max |T_ij| = {max_t} exceeds {threshold}"
 
 
 def test_hermite_normal():


### PR DESCRIPTION
Reduce coefficient growth in smith_normal_decomp by improving pivot selection

Fixes #29139

#### Brief description of what is fixed or changed

This PR fixes excessive coefficient growth in `smith_normal_decomp` over the Integer domain (`ZZ`).

Previously, the algorithm chose the first non-zero entry as the pivot. While correct, this led to very large intermediate values in the transformation matrices `S` and `T`. For the 16×16 example from the issue, entries grew to around 10^52, causing overflow and incorrect results when used with NumPy’s float64 backend.

This change introduces a minimum-absolute-value pivot strategy for the `ZZ` domain. At each recursion step, the smallest non-zero entry in the active submatrix is selected and moved to the pivot position using row and column swaps. The transformation matrices are updated to preserve the invariant

    S * M * T = SNF

and maintain unimodularity.

With this change, coefficient growth is significantly reduced (max entry drops from ~10^52 to ~10^8 for the reported example), while preserving exact correctness.

#### Other comments

The change is limited to the `ZZ` domain and does not affect other domains.


#### AI Generation Disclosure
I used an AI assistant to research the root cause of the coefficient growth in smith_normal_decomp and to understand the numerical implications of the reported issue in detail. The implementation of the global minabs pivoting strategy, the logic for maintaining transformation matrix invariants, and the new regression tests were developed and verified manually to ensure the fix correctly addresses issue #29139.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Reduced coefficient growth in `smith_normal_decomp` over the Integer domain by improving pivot selection.

<!-- END RELEASE NOTES -->