### PR TITLE
Fixed IndexError on unmatched closing paren in implicit_multiplication_assumption

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1868,3 +1868,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Steven Wolfman <wolf@mail.ubc.ca>

--- a/.mailmap
+++ b/.mailmap
@@ -1565,7 +1565,7 @@ Steve Kieffer <sk@skieffer.info>
 Steven Burns <royalstream@hotmail.com>
 Steven Esquea <steven.esquea@irreverente.net>
 Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
-Steven Wolfman <wolf@mail.ubc.ca>
+Steve Wolfman <steven.wolfman@gmail.com>
 Stewart Wadsworth <stewart.wadsworth@gmail.com>
 Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1565,6 +1565,7 @@ Steve Kieffer <sk@skieffer.info>
 Steven Burns <royalstream@hotmail.com>
 Steven Esquea <steven.esquea@irreverente.net>
 Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
+Steven Wolfman <wolf@mail.ubc.ca>
 Stewart Wadsworth <stewart.wadsworth@gmail.com>
 Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>
@@ -1868,4 +1869,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Steven Wolfman <wolf@mail.ubc.ca>

--- a/.mailmap
+++ b/.mailmap
@@ -1562,10 +1562,10 @@ Stephan Seitz <stephan.seitz@fau.de>
 Stephen Loo <shikil@yahoo.com>
 Steve Anton <anxuiz.nx@gmail.com>
 Steve Kieffer <sk@skieffer.info>
+Steve Wolfman <steven.wolfman@gmail.com> <wolf@mail.ubc.ca>
 Steven Burns <royalstream@hotmail.com>
 Steven Esquea <steven.esquea@irreverente.net>
 Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
-Steve Wolfman <steven.wolfman@gmail.com>
 Stewart Wadsworth <stewart.wadsworth@gmail.com>
 Subhash Saurabh <subhashsaurabh419@gmail.com>
 Sudarshan Kamath <sudarshan.kamath97@gmail.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -140,6 +140,8 @@ def _group_parentheses(recursor: TRANS):
                     stacks.append(ParenthesisGroup([]))
                     stacklevel += 1
                 elif token[1] == ')':
+                    if not stacklevel:
+                        raise TokenError("Mismatched parentheses")
                     stacks[-1].append(token)
                     stack = stacks.pop()
 

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -261,6 +261,7 @@ def test_match_parentheses_implicit_multiplication():
     transformations = standard_transformations + \
                       (implicit_multiplication,)
     raises(TokenError, lambda: parse_expr('(1,2),(3,4]',transformations=transformations))
+    raises(TokenError, lambda: parse_expr(')',transformations=transformations))
 
 
 def test_convert_equals_signs():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29166

#### Brief description of what is fixed or changed

Previously, parsing `)` with `implicit_multiplication_assumption` was failing with an `IndexError` (i.e., a builtin, runtime error) instead of producing a `TokenError` indicating mismatched parentheses, as happens with an unmatched open parenthesis.

I have added a similarly styled check for an empty parenthesis stack just before the line causing the `IndexError` that produces the same `TokenError` as a mismatched open parenthesis.

#### Other comments

An existing test checked for a mismatched open parenthesis. I have expanded that test to also check for a mismatched closing parenthesis.

All current uses of `TokenError` in the sympy codebase seem consistent with this new condition under which a `TokenError` can occur.

#### AI Generation Disclosure

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* parsing
  * Improved error reporting on mismatched closing parentheses in `implicit_multiplication_assumption`

<!-- END RELEASE NOTES -->
