### PR TITLE
Raise error on symbol clash in Plane.equation

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -334,6 +334,13 @@ class Plane(GeometryEntity):
 
 
     def equation(self, x=None, y=None, z=None):
+
+        coords = {x, y, z} - {None}
+        if coords & self.free_symbols:
+            raise ValueError(
+                "Plane.equation(): provided symbols clash with symbols used to define the plane."
+            )
+
         """The equation of the Plane.
 
         Examples

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -6,6 +6,7 @@ from sympy.functions.elementary.trigonometric import (asin, cos, sin)
 from sympy.geometry import Line, Point, Ray, Segment, Point3D, Line3D, Ray3D, Segment3D, Plane, Circle
 from sympy.geometry.util import are_coplanar
 from sympy.testing.pytest import raises
+import pytest
 
 
 def test_plane():
@@ -272,3 +273,12 @@ def test_parameter_value():
     raises(ValueError, lambda: p.parameter_value((1, 0, 0), t))
     raises(ValueError, lambda: p.parameter_value(Line(Point(0, 0), Point(1, 1)), t))
     raises(ValueError, lambda: p.parameter_value((0, -3, 2), t, 1))
+
+
+def test_plane_equation_symbol_clash():
+    x, y, z, u, v, w = symbols('x y z u v w')
+
+    p = Plane(Point3D(x, y, z), normal_vector=(u, v, w))
+
+    with pytest.raises(ValueError, match = "clash"):
+        p.equation(x, y, z)


### PR DESCRIPTION
Fixes a symbol-name clash in Plane.equation where passing symbols already used
to define the plane could silently return zero.

This PR adds a regression test and ensures such cases are handled explicitly.

Fixes #25228

<!-- BEGIN RELEASE NOTES -->

* geometry
  * Prevent Plane.equation from silently returning zero when provided symbols clash with symbols used to define the plane.

<!-- END RELEASE NOTES -->
