### PR TITLE
Raise error on symbol clash in Plane.equation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -231,6 +231,7 @@ Addison Cugini <ajcugini@gmail.com> <addisonc@pcp065368pcs.dhcp.calpoly.edu>
 Aditya Jindal <jaditya8889@gmail.com>
 Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
 Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141@gmail.com>
+Aditya Prakash <prakashaditya2709@gmail.com>
 Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
 Aditya Rohan <riyuzakiiitk@gmail.com>
 Aditya Shah <adityashah30@gmail.com>

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -348,6 +348,9 @@ class Plane(GeometryEntity):
         6*x + 6*y + 6*z - 42
 
         """
+        coords = {x, y, z} - {None}
+        if coords & self.free_symbols:
+            raise ValueError("Provided symbols clash with symbols used to define the plane")
         x, y, z = [i if i else Symbol(j, real=True) for i, j in zip((x, y, z), 'xyz')]
         a = Point3D(x, y, z)
         b = self.p1.direction_ratio(a)

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -272,3 +272,10 @@ def test_parameter_value():
     raises(ValueError, lambda: p.parameter_value((1, 0, 0), t))
     raises(ValueError, lambda: p.parameter_value(Line(Point(0, 0), Point(1, 1)), t))
     raises(ValueError, lambda: p.parameter_value((0, -3, 2), t, 1))
+
+
+def test_plane_equation_symbol_clash():
+    x, y, z, u, v, w = symbols('x y z u v w')
+
+    p = Plane(Point3D(x, y, z), normal_vector=(u, v, w))
+    raises(ValueError, lambda: p.equation(x, y, z))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #25228


#### Brief description of what is fixed or changed
Raises a clear error when `Plane.equation` would create a symbol clash instead of silently producing an incorrect or ambiguous expression.

Tests run locally: `pytest sympy/geometry/tests/test_plane.py`.

#### Other comments
Re-opening PR after previous closure due to accidental removal of the PR template. Template is now filled correctly.

#### AI Generation Disclosure
ChatGPT assisted with drafting portions of the PR description. All code changes were written and reviewed by me.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Raised an error when `Plane.equation` would create a symbol clash.

<!-- END RELEASE NOTES -->
