### PR TITLE
Assumptions: Adds a function for nonzero predicate to handle log in query.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1540,6 +1540,7 @@ Sophia Pustova <tripplezzed@gmail.com>
 Soumendra Ganguly <soumendraganguly@gmail.com>
 Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
 Soumya Dipta Biswas <sdb1323@gmail.com>
+Soumya Sakshi <s1december2005@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
 Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -200,9 +200,10 @@ def _(expr, assumptions):
 
 @NonZeroPredicate.register(log)
 def _(expr, assumptions):
-    print("log")
-    return ask(Q.positive(expr.args[0]  - 1, assumptions))
-
+    if ask(Q.positive(expr.args[0]), assumptions) is False:
+        return False
+    if ask(Q.positive(expr.args[0]), assumptions) is True:
+        return ask(Q.ne(expr.args[0], 1))
 
 
 # ZeroPredicate

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -200,9 +200,10 @@ def _(expr, assumptions):
 
 @NonZeroPredicate.register(log)
 def _(expr, assumptions):
-    if ask(Q.positive(expr.args[0]), assumptions) is False:
+    r = ask(Q.positive(expr.args[0]), assumptions)
+    if r is False:
         return False
-    if ask(Q.positive(expr.args[0]), assumptions) is True:
+    if r is True:
         return ask(Q.ne(expr.args[0], 1))
 
 

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -204,7 +204,7 @@ def _(expr, assumptions):
     if r is False:
         return False
     else:
-        return ask(Q.ne(expr.args[0], 1))
+        return ask(Q.ne(expr.args[0], 1), assumptions)
 
 
 # ZeroPredicate

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -198,6 +198,12 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return None
 
+@NonZeroPredicate.register(log)
+def _(expr, assumptions):
+    print("log")
+    return ask(Q.positive(expr.args[0]  - 1, assumptions))
+
+
 
 # ZeroPredicate
 

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -203,7 +203,7 @@ def _(expr, assumptions):
     r = ask(Q.positive(expr.args[0]), assumptions)
     if r is False:
         return False
-    else:
+    if ask(Q.positive(expr.args[0]), assumptions):
         return ask(Q.ne(expr.args[0], 1), assumptions)
 
 

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -203,7 +203,7 @@ def _(expr, assumptions):
     r = ask(Q.positive(expr.args[0]), assumptions)
     if r is False:
         return False
-    if r is True:
+    else:
         return ask(Q.ne(expr.args[0], 1))
 
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1766,6 +1766,13 @@ def test_nonzero():
     # that don't evaluate to a zero with precision
     assert ask(Q.nonzero(cos(1)**2 + sin(1)**2 - 1)) is None
 
+    assert ask(Q.nonzero(log(x))) is None
+    assert ask(Q.nonzero(log(x)), Q.real(x)) is None
+    assert ask(Q.nonzero(log(x)), Q.complex(x)) is None
+    assert ask(Q.nonzero(log(x)), Q.positive(x)) is None
+    assert ask(Q.nonzero(log(x)), Q.negative(x)) is False
+    assert ask(Q.nonzero(log(x)), Q.zero(x)) is False
+
 
 def test_zero():
     assert ask(Q.zero(x)) is None


### PR DESCRIPTION
Adds a function for nonzero predicate to handle log in query.

#### References to other Issues or PRs
Fixes #29158

#### Brief description of what is fixed or changed
Earlier nonzero predicate did not have a function to handle log in query.
eg 
```python
>>> from sympy import Symbol, log, Q, ask
>>> y = Symbol('y')
>>> print(ask(Q.nonzero(log(y)), Q.zero(y)))
# gives None except False
```

This PR adds a function for this.

**Here is a breif code logic:**
For log(expr) to be nonzero:
log(expr) should be real + not equal to zero
log(expr) is real when expr is real and positive
log(expr) is not zero when expr != 1

Thus, the function proceeds as:
1. It checks if the expr is positive (positive => real) and stores it in r
3. If r is False, returns False
4. Else, checks if x is not equal to x
5. If yes, returns True
6. If not returns None

#### Other comments
Feedbacks are welcomed!

#### AI Generation Disclosure
None of this code is AI Generated.

#### Release Notes



<!-- BEGIN RELEASE NOTES -->
* assumptions
  * added a new function for logarithmic expression under query in nonzero predicate.
<!-- END RELEASE NOTES -->
