### PR TITLE
Raise NotImplementedError for variables inside floor or ceiling in nonlinsolve

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -34,6 +34,7 @@ from sympy.functions import (log, tan, cot, sin, cos, sec, csc, exp,
                              piecewise_fold, Piecewise)
 from sympy.functions.combinatorial.numbers import totient
 from sympy.functions.elementary.complexes import Abs, arg, re, im
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
                             sinh, cosh, tanh, coth, sech, csch,
                             asinh, acosh, atanh, acoth, asech, acsch)
@@ -3580,6 +3581,11 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                 soln_imageset = {}
                 for sym in unsolved_syms:
                     not_solvable = False
+                    if any(f.args[0].has(sym) for f in eq2.atoms(floor, ceiling)):
+                        not_solvable = True
+                        raise NotImplementedError(
+                            f"nonlinsolve cannot solve equations with {sym} appearing inside floor/ceiling functions"
+                        )
                     try:
                         soln = solver(eq2, sym)
                         total_solvest_call += 1

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -12,6 +12,7 @@ from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign, conjugate)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
     sinh, cosh, tanh, coth, sech, csch, asinh, acosh, atanh, acoth, asech, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
@@ -1871,6 +1872,13 @@ def test_nonlinsolve_abs():
     raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 1, y - 2], x, y))
     raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 2, x + y], x, y))
 
+def test_nonlinsolve_floor_ceiling():
+    # raises NotImplementedError when variable is inside floor/ceiling
+    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 3, y - x], [x, y]))
+
+    # test working cases when variable is outside floor/ceiling
+    assert nonlinsolve([x - floor(y)], [x]) == FiniteSet((floor(y),))
 
 def test_nonlinsolve_sign():
     raises(NotImplementedError, lambda: nonlinsolve([sign(x) - 1, x*y - 4], [x, y]))


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

* solvers
  * `nonlinsolve` now raises `NotImplementedError` when a variable appears inside `floor()` or `ceiling()` in an equation.
  * Added tests in `test_solveset.py` for both invalid and valid cases (thanks @oscarbenjamin @jhaayushkumar) to verify the behavior.

<!-- END RELEASE NOTES -->