### PR TITLE
Raise NotImplementedError for symbolic expressions inside floor or ceiling in nonlinsolve

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -343,7 +343,7 @@ Anjul Kumar Tyagi <anjul.ten@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Ankit Kumar Singh <ankitdiswar10@gmail.com>
 Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
-Annamalai N <srirammount@gmail.com> Annamalai <91740832+RaMathuZen@users.noreply.github.com> 
+Annamalai N <srirammount@gmail.com> Annamalai <91740832+RaMathuZen@users.noreply.github.com>
 Annamalai N <srirammount@gmail.com> ramathuzen <srirammount@gmail.com>
 Ansh Mishra <anshmishra471@gmail.com>
 Anshul Sharma <anshulsharma4605@gmail.com>
@@ -1381,6 +1381,7 @@ Robert Pollak <robert.pollak@posteo.net> Robert Pollak <robert.pollak@jku.at>
 Robert Schwarz <lethargo@googlemail.com> lethargo <devnull@localhost>
 Roberto Colistete, Jr. <roberto.colistete@gmail.com>
 Roberto Díaz Pérez <r.r.1994a@gmail.com>
+Roberto Hogas Goras <robertohogas@gmail.com>
 Roberto Nobrega <rwnobrega@gmail.com>
 Robin Neatherway <robin.neatherway@gmail.com>
 Robin Richard <raisin@ecomail.fr> Nornort <francois.lalleve@laposte.net>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -34,6 +34,7 @@ from sympy.functions import (log, tan, cot, sin, cos, sec, csc, exp,
                              piecewise_fold, Piecewise)
 from sympy.functions.combinatorial.numbers import totient
 from sympy.functions.elementary.complexes import Abs, arg, re, im
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
                             sinh, cosh, tanh, coth, sech, csch,
                             asinh, acosh, atanh, acoth, asech, acsch)
@@ -3580,6 +3581,11 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                 soln_imageset = {}
                 for sym in unsolved_syms:
                     not_solvable = False
+                    if any(f.args[0].has(sym) for f in eq2.atoms(floor, ceiling)):
+                        not_solvable = True
+                        raise NotImplementedError(
+                            f"nonlinsolve cannot solve equations with {sym} appearing inside floor/ceiling functions"
+                        )
                     try:
                         soln = solver(eq2, sym)
                         total_solvest_call += 1

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -12,6 +12,7 @@ from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign, conjugate)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
     sinh, cosh, tanh, coth, sech, csch, asinh, acosh, atanh, acoth, asech, acsch)
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
@@ -1871,6 +1872,13 @@ def test_nonlinsolve_abs():
     raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 1, y - 2], x, y))
     raises(NotImplementedError, lambda: nonlinsolve([Abs(x) - 2, x + y], x, y))
 
+def test_nonlinsolve_floor_ceiling():
+    # raises NotImplementedError when variable is inside floor/ceiling
+    raises(NotImplementedError, lambda: nonlinsolve([floor(x) - 5, y - x - 1], [x, y]))
+    raises(NotImplementedError, lambda: nonlinsolve([ceiling(x) - 3, y - x], [x, y]))
+
+    # test working cases when variable is outside floor/ceiling
+    assert nonlinsolve([x - floor(y)], [x]) == FiniteSet((floor(y),))
 
 def test_nonlinsolve_sign():
     raises(NotImplementedError, lambda: nonlinsolve([sign(x) - 1, x*y - 4], [x, y]))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #29026 

#### Brief description of what is fixed or changed

`nonlinsolve([floor(x) - 5, y - x - 1], [x, y])` previously returned parametric solutions like `{(y - 1, y)}`. Now, `nonlinsolve` raises `NotImplementedError` for equations containing `floor` or `ceiling` with symbolic expressions inside.

#### Other comments

Tested locally with pytest. All new tests pass. Uses symbolic floor/ceiling cases as described in issue #29026.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed nonlinsolve returning incorrect parametric solutions for systems containing `floor` or `ceiling` with symbolic expressions inside. Now correctly raises `NotImplementedError` in these cases.
<!-- END RELEASE NOTES -->