### PR TITLE
.rank() is now deprecated, use .ndim for N-dim arrays

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -76,7 +76,13 @@ SymPy deprecation warnings.
 
 ## Version 1.15
 
-There are no deprecations yet for SymPy 1.15.
+(ndim-array-rank)=
+### Use .ndim instead of .rank for the number of dimensions of arrays.
+
+N-dimensional arrays have used to method `rank` to return the number of
+dimensions.  Unfortunately this not the proper term and it can be confused with
+the concept of matrix rank.  From now on, please use `.ndim` property or the
+`get_ndim(...)` function instead.
 
 ## Version 1.14
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1909,7 +1909,7 @@ class LatexPrinter(Printer):
 
     def _print_NDimArray(self, expr: NDimArray):
 
-        if expr.rank() == 0:
+        if expr.ndim == 0:
             return self._print(expr[()])
 
         mat_str = self._settings['mat_str']
@@ -1917,7 +1917,7 @@ class LatexPrinter(Printer):
             if self._settings['mode'] == 'inline':
                 mat_str = 'smallmatrix'
             else:
-                if (expr.rank() == 0) or (expr.shape[-1] <= 10):
+                if (expr.ndim == 0) or (expr.shape[-1] <= 10):
                     mat_str = 'matrix'
                 else:
                     mat_str = 'array'
@@ -1932,15 +1932,15 @@ class LatexPrinter(Printer):
             block_str = r'\left' + left_delim + block_str + \
                         r'\right' + right_delim
 
-        if expr.rank() == 0:
+        if expr.ndim == 0:
             return block_str % ""
 
-        level_str: list[list[str]] = [[] for i in range(expr.rank() + 1)]
+        level_str: list[list[str]] = [[] for i in range(expr.ndim + 1)]
         shape_ranges = [list(range(i)) for i in expr.shape]
         for outer_i in itertools.product(*shape_ranges):
             level_str[-1].append(self._print(expr[outer_i]))
             even = True
-            for back_outer_i in range(expr.rank()-1, -1, -1):
+            for back_outer_i in range(expr.ndim-1, -1, -1):
                 if len(level_str[back_outer_i+1]) < expr.shape[back_outer_i]:
                     break
                 if even:
@@ -1957,7 +1957,7 @@ class LatexPrinter(Printer):
 
         out_str = level_str[0][0]
 
-        if expr.rank() % 2 == 1:
+        if expr.ndim % 2 == 1:
             out_str = block_str % out_str
 
         return out_str

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -289,7 +289,7 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
                                  self._print(expr.args[0].tolist()))
 
     def _print_NDimArray(self, expr):
-        if expr.rank() == 0:
+        if expr.ndim == 0:
             func = self._module_format(f'{self._module}.array')
             return f"{func}({self._print(expr[()])})"
         if 0 in expr.shape:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1256,17 +1256,17 @@ class PrettyPrinter(Printer):
     def _print_NDimArray(self, expr):
         from sympy.matrices.immutable import ImmutableMatrix
 
-        if expr.rank() == 0:
+        if expr.ndim == 0:
             return self._print(expr[()])
 
-        level_str = [[]] + [[] for i in range(expr.rank())]
+        level_str = [[]] + [[] for i in range(expr.ndim)]
         shape_ranges = [list(range(i)) for i in expr.shape]
         # leave eventual matrix elements unflattened
         mat = lambda x: ImmutableMatrix(x, evaluate=False)
         for outer_i in itertools.product(*shape_ranges):
             level_str[-1].append(expr[outer_i])
             even = True
-            for back_outer_i in range(expr.rank()-1, -1, -1):
+            for back_outer_i in range(expr.ndim-1, -1, -1):
                 if len(level_str[back_outer_i+1]) < expr.shape[back_outer_i]:
                     break
                 if even:
@@ -1281,7 +1281,7 @@ class PrettyPrinter(Printer):
                 level_str[back_outer_i+1] = []
 
         out_expr = level_str[0][0]
-        if expr.rank() % 2 == 1:
+        if expr.ndim % 2 == 1:
             out_expr = mat([out_expr])
 
         return self._print(out_expr)

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -474,8 +474,10 @@ class ArrayPrinter:
         raise ValueError("out of letters")
 
     def _print_ArrayTensorProduct(self, expr):
+        from sympy.tensor.array.expressions.array_expressions import _get_sub_ndim_list
+
         letters = self._get_letter_generator_for_einsum()
-        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.subranks])
+        contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in _get_sub_ndim_list(expr)])
         return '%s("%s", %s)' % (
                 self._module_format(self._module + "." + self._einsum),
                 contraction_string,
@@ -488,13 +490,14 @@ class ArrayPrinter:
         contraction_indices = expr.contraction_indices
 
         if isinstance(base, ArrayTensorProduct):
+            from sympy.tensor.array.expressions.array_expressions import _get_sub_ndim_list
             elems = ",".join(["%s" % (self._print(arg)) for arg in base.args])
-            ranks = base.subranks
+            ndim_list = _get_sub_ndim_list(base)
         else:
             elems = self._print(base)
-            ranks = [len(base.shape)]
+            ndim_list = [len(base.shape)]
 
-        contraction_string, letters_free, letters_dum = self._get_einsum_string(ranks, contraction_indices)
+        contraction_string, letters_free, letters_dum = self._get_einsum_string(ndim_list, contraction_indices)
 
         if not contraction_indices:
             return self._print(base)
@@ -510,12 +513,14 @@ class ArrayPrinter:
 
     def _print_ArrayDiagonal(self, expr):
         from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
+        from sympy.tensor.array.expressions.array_expressions import _get_sub_ndim_list
+
         diagonal_indices = list(expr.diagonal_indices)
         if isinstance(expr.expr, ArrayTensorProduct):
-            subranks = expr.expr.subranks
+            subranks = _get_sub_ndim_list(expr.expr)
             elems = expr.expr.args
         else:
-            subranks = expr.subranks
+            subranks = _get_sub_ndim_list(expr)
             elems = [expr.expr]
         diagonal_string, letters_free, letters_dum = self._get_einsum_string(subranks, diagonal_indices)
         elems = [self._print(i) for i in elems]

--- a/sympy/tensor/array/__init__.py
+++ b/sympy/tensor/array/__init__.py
@@ -22,7 +22,7 @@ Array construction can detect the shape of nested lists and tuples:
 [[1, 2], [3, 4], [5, 6]]
 >>> a1.shape
 (3, 2)
->>> a1.rank()
+>>> a1.ndim
 2
 >>> from sympy.abc import x, y, z
 >>> a2 = Array([[[x, y], [z, x*z]], [[1, x*y], [1/x, x/y]]])
@@ -30,7 +30,7 @@ Array construction can detect the shape of nested lists and tuples:
 [[[x, y], [z, x*z]], [[1, x*y], [1/x, x/y]]]
 >>> a2.shape
 (2, 2, 2)
->>> a2.rank()
+>>> a2.ndim
 3
 
 Otherwise one could pass a 1-dim array followed by a shape tuple:

--- a/sympy/tensor/array/array_comprehension.py
+++ b/sympy/tensor/array/array_comprehension.py
@@ -5,6 +5,7 @@ from sympy.core import Basic, Tuple
 from sympy.tensor.array import ImmutableDenseNDimArray
 from sympy.core.symbol import Symbol
 from sympy.core.numbers import Integer
+from sympy.utilities.decorator import deprecated
 
 
 class ArrayComprehension(Basic):
@@ -42,7 +43,7 @@ class ArrayComprehension(Basic):
         obj = Basic.__new__(cls, *arglist, **assumptions)
         obj._limits = obj._args[1:]
         obj._shape = cls._calculate_shape_from_limits(obj._limits)
-        obj._rank = len(obj._shape)
+        obj._ndim = len(obj._shape)
         obj._loop_size = cls._calculate_loop_size(obj._shape)
         return obj
 
@@ -184,8 +185,14 @@ class ArrayComprehension(Basic):
                 return False
         return True
 
+    @deprecated("DO NOT USE",
+                deprecated_since_version="1.15", active_deprecations_target="ndim-array-rank")
     def rank(self):
-        """The rank of the expanded array.
+        return self.ndim
+
+    @property
+    def ndim(self):
+        """The number of dimensions of the expanded array.
 
         Examples
         ========
@@ -194,10 +201,10 @@ class ArrayComprehension(Basic):
         >>> from sympy import symbols
         >>> i, j, k = symbols('i j k')
         >>> a = ArrayComprehension(10*i + j, (i, 1, 4), (j, 1, 3))
-        >>> a.rank()
+        >>> a.ndim
         2
         """
-        return self._rank
+        return self._ndim
 
     def __len__(self):
         """
@@ -331,7 +338,7 @@ class ArrayComprehension(Basic):
 
         if not self.is_shape_numeric:
             raise ValueError("A symbolic array cannot be expanded to a matrix")
-        if self._rank != 2:
+        if self._ndim != 2:
             raise ValueError('Dimensions must be of size of 2')
 
         return Matrix(self._expand_array().tomatrix())
@@ -378,7 +385,7 @@ class ArrayComprehensionMap(ArrayComprehension):
         obj = Basic.__new__(cls, *arglist, **assumptions)
         obj._limits = obj._args
         obj._shape = cls._calculate_shape_from_limits(obj._limits)
-        obj._rank = len(obj._shape)
+        obj._ndim = len(obj._shape)
         obj._loop_size = cls._calculate_loop_size(obj._shape)
         obj._lambda = function
         return obj

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -105,14 +105,14 @@ def _util_contraction_diagonal(array, *contraction_or_diagonal_axes):
                 raise ValueError("cannot contract or diagonalize between axes of different dimension")
             taken_dims.add(d)
 
-    rank = array.rank()
+    ndim = array.ndim
 
     remaining_shape = [dim for i, dim in enumerate(array.shape) if i not in taken_dims]
-    cum_shape = [0]*rank
+    cum_shape = [0]*ndim
     _cumul = 1
-    for i in range(rank):
-        cum_shape[rank - i - 1] = _cumul
-        _cumul *= int(array.shape[rank - i - 1])
+    for i in range(ndim):
+        cum_shape[ndim - i - 1] = _cumul
+        _cumul *= int(array.shape[ndim - i - 1])
 
     # DEFINITION: by absolute position it is meant the position along the one
     # dimensional array containing all the tensor components.
@@ -122,7 +122,7 @@ def _util_contraction_diagonal(array, *contraction_or_diagonal_axes):
 
     # Determine absolute positions of the uncontracted indices:
     remaining_indices = [[cum_shape[i]*j for j in range(array.shape[i])]
-                         for i in range(rank) if i not in taken_dims]
+                         for i in range(ndim) if i not in taken_dims]
 
     # Determine absolute positions of the contracted indices:
     summed_deltas = []
@@ -422,8 +422,8 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     from sympy.tensor.array.expressions.array_expressions import _permute_dims
     from sympy.matrices.expressions.matexpr import MatrixSymbol
     from sympy.tensor.array.expressions import PermuteDims
-    from sympy.tensor.array.expressions.array_expressions import get_rank
-    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_rank(expr))
+    from sympy.tensor.array.expressions.array_expressions import get_ndim
+    perm = PermuteDims._get_permutation_from_arguments(perm, index_order_old, index_order_new, get_ndim(expr))
     if isinstance(expr, (_ArrayExpr, _CodegenArrayAbstract, MatrixSymbol)):
         return _permute_dims(expr, perm)
 
@@ -434,7 +434,7 @@ def permutedims(expr, perm=None, index_order_old=None, index_order_new=None):
     if not isinstance(perm, Permutation):
         perm = Permutation(list(perm))
 
-    if perm.size != expr.rank():
+    if perm.size != expr.ndim:
         raise ValueError("wrong permutation size")
 
     # Get the inverse permutation:

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -93,7 +93,7 @@ class DenseNDimArray(NDimArray):
         """
         from sympy.matrices import Matrix
 
-        if self.rank() != 2:
+        if self.ndim != 2:
             raise ValueError('Dimensions must be of size of 2')
 
         return Matrix(self.shape[0], self.shape[1], self._array)
@@ -142,7 +142,7 @@ class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray): # type: ignor
         self = Basic.__new__(cls, flat_list, shape, **kwargs)
         self._shape = shape
         self._array = list(flat_list)
-        self._rank = len(shape)
+        self._ndim = len(shape)
         self._loop_size = functools.reduce(lambda x,y: x*y, shape, 1)
         return self
 
@@ -168,7 +168,7 @@ class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
         self = object.__new__(cls)
         self._shape = shape
         self._array = list(flat_list)
-        self._rank = len(shape)
+        self._ndim = len(shape)
         self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
         return self
 

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -30,11 +30,12 @@ from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.indexed import (Indexed, IndexedBase)
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.tensor.array.expressions.utils import _apply_recursively_over_nested_lists, _sort_contraction_indices, \
-    _get_mapping_from_subranks, _build_push_indices_up_func_transformation, _get_contraction_links, \
+    _get_mapping_from_sub_ndim_list, _build_push_indices_up_func_transformation, _get_contraction_links, \
     _build_push_indices_down_func_transformation
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import _af_invert
 from sympy.core.sympify import _sympify
+from sympy.utilities.decorator import deprecated
 
 
 class _ArrayExpr(Expr):
@@ -215,38 +216,14 @@ class _CodegenArrayAbstract(Expr):
     is_Atom = True
 
     @property
+    @deprecated("DO NOT USE",
+                deprecated_since_version="1.15", active_deprecations_target="ndim-array-rank")
     def subranks(self):
-        """
-        Returns the ranks of the objects in the uppermost tensor product inside
-        the current object.  In case no tensor products are contained, return
-        the atomic ranks.
+        return self._sub_ndim_list[:]
 
-        Examples
-        ========
-
-        >>> from sympy.tensor.array import tensorproduct, tensorcontraction
-        >>> from sympy import MatrixSymbol
-        >>> M = MatrixSymbol("M", 3, 3)
-        >>> N = MatrixSymbol("N", 3, 3)
-        >>> P = MatrixSymbol("P", 3, 3)
-
-        Important: do not confuse the rank of the matrix with the rank of an array.
-
-        >>> tp = tensorproduct(M, N, P)
-        >>> tp.subranks
-        [2, 2, 2]
-
-        >>> co = tensorcontraction(tp, (1, 2), (3, 4))
-        >>> co.subranks
-        [2, 2, 2]
-        """
-        return self._subranks[:]
-
+    @deprecated("DO NOT USE", deprecated_since_version="1.15", active_deprecations_target="ndim-array-rank")
     def subrank(self):
-        """
-        The sum of ``subranks``.
-        """
-        return sum(self.subranks)
+        return sum(self._sub_ndim_list)
 
     @property
     def shape(self):
@@ -270,10 +247,10 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
 
         canonicalize = kwargs.pop("canonicalize", False)
 
-        ranks = [get_rank(arg) for arg in args]
+        ndims = [get_ndim(arg) for arg in args]
 
         obj = Basic.__new__(cls, *args)
-        obj._subranks = ranks
+        obj._sub_ndim_list = ndims
         shapes = [get_shape(i) for i in args]
 
         if any(i is None for i in shapes):
@@ -288,7 +265,7 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         args = self.args
         args = self._flatten(args)
 
-        ranks = [get_rank(arg) for arg in args]
+        ndim_list = [get_ndim(arg) for arg in args]
 
         # Check if there are nested ArraySum objects:
         array_sums_i = []
@@ -315,10 +292,10 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         for i, arg in enumerate(args):
             if not isinstance(arg, PermuteDims):
                 continue
-            permutation_cycles.extend([[k + sum(ranks[:i]) for k in j] for j in arg.permutation.cyclic_form])
+            permutation_cycles.extend([[k + sum(ndim_list[:i]) for k in j] for j in arg.permutation.cyclic_form])
             args[i] = arg.expr
         if permutation_cycles:
-            return _permute_dims(_array_tensor_product(*args), Permutation(sum(ranks)-1)*Permutation(permutation_cycles))
+            return _permute_dims(_array_tensor_product(*args), Permutation(sum(ndim_list)-1)*Permutation(permutation_cycles))
 
         if len(args) == 1:
             return args[0]
@@ -332,31 +309,31 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         # expression into `ArrayContraction`:
         contractions = {i: arg for i, arg in enumerate(args) if isinstance(arg, ArrayContraction)}
         if contractions:
-            ranks = [_get_subrank(arg) if isinstance(arg, ArrayContraction) else get_rank(arg) for arg in args]
-            cumulative_ranks = list(accumulate([0] + ranks))[:-1]
+            ndim_list = [_get_sub_ndim(arg) if isinstance(arg, ArrayContraction) else get_ndim(arg) for arg in args]
+            cumulative_ndim_list = list(accumulate([0] + ndim_list))[:-1]
             tp = _array_tensor_product(*[arg.expr if isinstance(arg, ArrayContraction) else arg for arg in args])
-            contraction_indices = [tuple(cumulative_ranks[i] + k for k in j) for i, arg in contractions.items() for j in arg.contraction_indices]
+            contraction_indices = [tuple(cumulative_ndim_list[i] + k for k in j) for i, arg in contractions.items() for j in arg.contraction_indices]
             return _array_contraction(tp, *contraction_indices)
 
         diagonals = {i: arg for i, arg in enumerate(args) if isinstance(arg, ArrayDiagonal)}
         if diagonals:
             inverse_permutation = []
             last_perm = []
-            ranks = [get_rank(arg) for arg in args]
-            cumulative_ranks = list(accumulate([0] + ranks))[:-1]
+            ndim_list = [get_ndim(arg) for arg in args]
+            cumulative_ndim_list = list(accumulate([0] + ndim_list))[:-1]
             for i, arg in enumerate(args):
                 if isinstance(arg, ArrayDiagonal):
-                    i1 = get_rank(arg) - len(arg.diagonal_indices)
+                    i1 = get_ndim(arg) - len(arg.diagonal_indices)
                     i2 = len(arg.diagonal_indices)
-                    inverse_permutation.extend([cumulative_ranks[i] + j for j in range(i1)])
-                    last_perm.extend([cumulative_ranks[i] + j for j in range(i1, i1 + i2)])
+                    inverse_permutation.extend([cumulative_ndim_list[i] + j for j in range(i1)])
+                    last_perm.extend([cumulative_ndim_list[i] + j for j in range(i1, i1 + i2)])
                 else:
-                    inverse_permutation.extend([cumulative_ranks[i] + j for j in range(get_rank(arg))])
+                    inverse_permutation.extend([cumulative_ndim_list[i] + j for j in range(get_ndim(arg))])
             inverse_permutation.extend(last_perm)
             tp = _array_tensor_product(*[arg.expr if isinstance(arg, ArrayDiagonal) else arg for arg in args])
-            ranks2 = [_get_subrank(arg) if isinstance(arg, ArrayDiagonal) else get_rank(arg) for arg in args]
-            cumulative_ranks2 = list(accumulate([0] + ranks2))[:-1]
-            diagonal_indices = [tuple(cumulative_ranks2[i] + k for k in j) for i, arg in diagonals.items() for j in arg.diagonal_indices]
+            ndims2 = [_get_sub_ndim(arg) if isinstance(arg, ArrayDiagonal) else get_ndim(arg) for arg in args]
+            cumulative_ndims2 = list(accumulate([0] + ndims2))[:-1]
+            diagonal_indices = [tuple(cumulative_ndims2[i] + k for k in j) for i, arg in diagonals.items() for j in arg.diagonal_indices]
             return _permute_dims(_array_diagonal(tp, *diagonal_indices), _af_invert(inverse_permutation))
 
         return self.func(*args, canonicalize=False)
@@ -377,10 +354,10 @@ class ArrayAdd(_CodegenArrayAbstract):
 
     def __new__(cls, *args, **kwargs):
         args = [_sympify(arg) for arg in args]
-        ranks = [get_rank(arg) for arg in args]
-        ranks = list(set(ranks))
-        if len(ranks) != 1:
-            raise ValueError("summing arrays of different ranks")
+        ndims = [get_ndim(arg) for arg in args]
+        ndims = list(set(ndims))
+        if len(ndims) != 1:
+            raise ValueError("summing arrays of different number of dims")
         shapes = [arg.shape if hasattr(arg, "shape") else () for arg in args]
         if len({i for i in shapes if i is not None}) > 1:
             raise ValueError("mismatching shapes in addition")
@@ -388,7 +365,7 @@ class ArrayAdd(_CodegenArrayAbstract):
         canonicalize = kwargs.pop("canonicalize", False)
 
         obj = Basic.__new__(cls, *args)
-        obj._subranks = ranks
+        obj._sub_ndim_list = ndims
         if any(i is None for i in shapes):
             obj._shape = None
         else:
@@ -506,17 +483,17 @@ class PermuteDims(_CodegenArrayAbstract):
     def __new__(cls, expr, permutation=None, index_order_old=None, index_order_new=None, **kwargs):
         from sympy.combinatorics import Permutation
         expr = _sympify(expr)
-        expr_rank = get_rank(expr)
-        permutation = cls._get_permutation_from_arguments(permutation, index_order_old, index_order_new, expr_rank)
+        expr_ndim = get_ndim(expr)
+        permutation = cls._get_permutation_from_arguments(permutation, index_order_old, index_order_new, expr_ndim)
         permutation = Permutation(permutation)
         permutation_size = permutation.size
-        if permutation_size != expr_rank:
+        if permutation_size != expr_ndim:
             raise ValueError("Permutation size must be the length of the shape of expr")
 
         canonicalize = kwargs.pop("canonicalize", False)
 
         obj = Basic.__new__(cls, expr, permutation)
-        obj._subranks = [get_rank(expr)]
+        obj._sub_ndim_list = [get_ndim(expr)]
         shape = get_shape(expr)
         if shape is None:
             obj._shape = None
@@ -559,7 +536,7 @@ class PermuteDims(_CodegenArrayAbstract):
         perm_image_form = _af_invert(permutation.array_form)
         args = list(expr.args)
         # Starting index global position for every arg:
-        cumul = list(accumulate([0] + expr.subranks))
+        cumul = list(accumulate([0] + _get_sub_ndim_list(expr)))
         # Split `perm_image_form` into a list of list corresponding to the indices
         # of every argument:
         perm_image_form_in_components = [perm_image_form[cumul[i]:cumul[i+1]] for i in range(len(args))]
@@ -585,18 +562,18 @@ class PermuteDims(_CodegenArrayAbstract):
         if not isinstance(expr.expr, ArrayTensorProduct):
             return expr, permutation
         args = expr.expr.args
-        subranks = [get_rank(arg) for arg in expr.expr.args]
+        sub_ndim_list = [get_ndim(arg) for arg in expr.expr.args]
 
         contraction_indices = expr.contraction_indices
         contraction_indices_flat = [j for i in contraction_indices for j in i]
-        cumul = list(accumulate([0] + subranks))
+        cumul = list(accumulate([0] + sub_ndim_list))
 
         # Spread the permutation in its array form across the args in the corresponding
         # tensor-product arguments with free indices:
         permutation_array_blocks_up = []
         image_form = _af_invert(permutation.array_form)
         counter = 0
-        for i in range(len(subranks)):
+        for i in range(len(sub_ndim_list)):
             current = []
             for j in range(cumul[i], cumul[i+1]):
                 if j in contraction_indices_flat:
@@ -606,7 +583,7 @@ class PermuteDims(_CodegenArrayAbstract):
             permutation_array_blocks_up.append(current)
 
         # Get the map of axis repositioning for every argument of tensor-product:
-        index_blocks = [list(range(cumul[i], cumul[i+1])) for i, e in enumerate(expr.subranks)]
+        index_blocks = [list(range(cumul[i], cumul[i+1])) for i, e in enumerate(_get_sub_ndim_list(expr))]
         index_blocks_up = expr._push_indices_up(expr.contraction_indices, index_blocks)
         inverse_permutation = permutation**(-1)
         index_blocks_up_permuted = [[inverse_permutation(j) for j in i if j is not None] for i in index_blocks_up]
@@ -629,9 +606,9 @@ class PermuteDims(_CodegenArrayAbstract):
 
     @classmethod
     def _check_permutation_mapping(cls, expr, permutation):
-        subranks = expr.subranks
-        index2arg = [i for i, arg in enumerate(expr.args) for j in range(expr.subranks[i])]
-        permuted_indices = [permutation(i) for i in range(expr.subrank())]
+        subndim = _get_sub_ndim_list(expr)
+        index2arg = [i for i, arg in enumerate(expr.args) for j in range(_get_sub_ndim_list(expr)[i])]
+        permuted_indices = [permutation(i) for i in range(_get_sub_ndim(expr))]
         new_args = list(expr.args)
         arg_candidate_index = index2arg[permuted_indices[0]]
         current_indices = []
@@ -643,8 +620,8 @@ class PermuteDims(_CodegenArrayAbstract):
                 current_indices = []
                 arg_candidate_index = index2arg[idx]
             current_indices.append(idx)
-            arg_candidate_rank = subranks[arg_candidate_index]
-            if len(current_indices) == arg_candidate_rank:
+            arg_candidate_ndim = subndim[arg_candidate_index]
+            if len(current_indices) == arg_candidate_ndim:
                 new_permutation.extend(sorted(current_indices))
                 local_current_indices = [j - min(current_indices) for j in current_indices]
                 i1 = index2arg[i]
@@ -658,9 +635,9 @@ class PermuteDims(_CodegenArrayAbstract):
         args_positions = list(range(len(new_args)))
         # Get possible shifts:
         maps = {}
-        cumulative_subranks = [0] + list(accumulate(subranks))
-        for i in range(len(subranks)):
-            s = {index2arg[new_permutation[j]] for j in range(cumulative_subranks[i], cumulative_subranks[i+1])}
+        cumulative_sub_ndim_list = [0] + list(accumulate(subndim))
+        for i in range(len(subndim)):
+            s = {index2arg[new_permutation[j]] for j in range(cumulative_sub_ndim_list[i], cumulative_sub_ndim_list[i+1])}
             if len(s) != 1:
                 continue
             elem = next(iter(s))
@@ -690,7 +667,7 @@ class PermuteDims(_CodegenArrayAbstract):
                 args_positions[line[(i + 1) % len(line)]] = e
 
         # TODO: function in order to permute the args:
-        permutation_blocks = [[new_permutation[cumulative_subranks[i] + j] for j in range(e)] for i, e in enumerate(subranks)]
+        permutation_blocks = [[new_permutation[cumulative_sub_ndim_list[i] + j] for j in range(e)] for i, e in enumerate(subndim)]
         new_args = [new_args[i] for i in args_positions]
         new_permutation_blocks = [permutation_blocks[i] for i in args_positions]
         new_permutation2 = [j for i in new_permutation_blocks for j in i]
@@ -699,18 +676,18 @@ class PermuteDims(_CodegenArrayAbstract):
     @classmethod
     def _check_if_there_are_closed_cycles(cls, expr, permutation):
         args = list(expr.args)
-        subranks = expr.subranks
+        sub_ndim_list = _get_sub_ndim_list(expr)
         cyclic_form = permutation.cyclic_form
-        cumulative_subranks = [0] + list(accumulate(subranks))
+        cumulative_sub_ndim_list = [0] + list(accumulate(sub_ndim_list))
         cyclic_min = [min(i) for i in cyclic_form]
         cyclic_max = [max(i) for i in cyclic_form]
         cyclic_keep = []
         for i, cycle in enumerate(cyclic_form):
             flag = True
-            for j in range(len(cumulative_subranks) - 1):
-                if cyclic_min[i] >= cumulative_subranks[j] and cyclic_max[i] < cumulative_subranks[j+1]:
+            for j in range(len(cumulative_sub_ndim_list) - 1):
+                if cyclic_min[i] >= cumulative_sub_ndim_list[j] and cyclic_max[i] < cumulative_sub_ndim_list[j+1]:
                     # Found a sinkable cycle.
-                    args[j] = _permute_dims(args[j], Permutation([[k - cumulative_subranks[j] for k in cycle]]))
+                    args[j] = _permute_dims(args[j], Permutation([[k - cumulative_sub_ndim_list[j] for k in cycle]]))
                     flag = False
                     break
             if flag:
@@ -814,7 +791,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
             return expr
         obj = Basic.__new__(cls, expr, *diagonal_indices)
         obj._positions = positions
-        obj._subranks = _get_subranks(expr)
+        obj._sub_ndim_list = _get_sub_ndim_list(expr)
         obj._shape = shape
         if canonicalize:
             return obj._canonicalize()
@@ -828,20 +805,20 @@ class ArrayDiagonal(_CodegenArrayAbstract):
             trivial_pos = {e[0]: i for i, e in enumerate(diagonal_indices) if len(e) == 1}
             diag_pos = {e: i for i, e in enumerate(diagonal_indices) if len(e) > 1}
             diagonal_indices_short = [i for i in diagonal_indices if len(i) > 1]
-            rank1 = get_rank(self)
-            rank2 = len(diagonal_indices)
-            rank3 = rank1 - rank2
+            ndim1 = get_ndim(self)
+            ndim2 = len(diagonal_indices)
+            ndim3 = ndim1 - ndim2
             inv_permutation = []
             counter1 = 0
-            indices_down = ArrayDiagonal._push_indices_down(diagonal_indices_short, list(range(rank1)), get_rank(expr))
+            indices_down = ArrayDiagonal._push_indices_down(diagonal_indices_short, list(range(ndim1)), get_ndim(expr))
             for i in indices_down:
                 if i in trivial_pos:
-                    inv_permutation.append(rank3 + trivial_pos[i])
+                    inv_permutation.append(ndim3 + trivial_pos[i])
                 elif isinstance(i, (Integer, int)):
                     inv_permutation.append(counter1)
                     counter1 += 1
                 else:
-                    inv_permutation.append(rank3 + diag_pos[i])
+                    inv_permutation.append(ndim3 + diag_pos[i])
             permutation = _af_invert(inv_permutation)
             if len(diagonal_indices_short) > 0:
                 return _permute_dims(_array_diagonal(expr, *diagonal_indices_short), permutation)
@@ -850,7 +827,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
         if isinstance(expr, ArrayAdd):
             return self._ArrayDiagonal_denest_ArrayAdd(expr, *diagonal_indices)
         if isinstance(expr, ArrayDiagonal):
-            return self._ArrayDiagonal_denest_ArrayDiagonal(expr, get_rank(self), *diagonal_indices)
+            return self._ArrayDiagonal_denest_ArrayDiagonal(expr, get_ndim(self), *diagonal_indices)
         if isinstance(expr, PermuteDims):
             return self._ArrayDiagonal_denest_PermuteDims(expr, *diagonal_indices)
         if isinstance(expr, (ZeroArray, ZeroMatrix)):
@@ -887,9 +864,9 @@ class ArrayDiagonal(_CodegenArrayAbstract):
 
     @staticmethod
     def _flatten(expr: ArrayDiagonal, outer_dims, *outer_diagonal_indices):
-        inddown = ArrayDiagonal._push_indices_down(outer_diagonal_indices, list(range(outer_dims)), get_rank(expr))
+        inddown = ArrayDiagonal._push_indices_down(outer_diagonal_indices, list(range(outer_dims)), get_ndim(expr))
         inddown = tuple(i for i in inddown)
-        inddow2 = ArrayDiagonal._push_indices_down(expr.diagonal_indices, inddown, get_rank(expr.expr))
+        inddow2 = ArrayDiagonal._push_indices_down(expr.diagonal_indices, inddown, get_ndim(expr.expr))
         new_diag_indices = []
         for i in inddow2:
             if not isinstance(i, (tuple, Tuple)):
@@ -914,7 +891,7 @@ class ArrayDiagonal(_CodegenArrayAbstract):
     @classmethod
     def _ArrayDiagonal_denest_PermuteDims(cls, expr: PermuteDims, *diagonal_indices):
         back_diagonal_indices = [[expr.permutation(j) for j in i] for i in diagonal_indices]
-        nondiag = [i for i in range(get_rank(expr)) if not any(i in j for j in diagonal_indices)]
+        nondiag = [i for i in range(get_ndim(expr)) if not any(i in j for j in diagonal_indices)]
         back_nondiag = [expr.permutation(i) for i in nondiag]
         remap = {e: i for i, e in enumerate(sorted(back_nondiag))}
         new_permutation1 = [remap[i] for i in back_nondiag]
@@ -943,14 +920,14 @@ class ArrayDiagonal(_CodegenArrayAbstract):
         return _apply_recursively_over_nested_lists(transform, indices)
 
     @classmethod
-    def _push_indices_down(cls, diagonal_indices, indices, rank):
-        positions, shape = cls._get_positions_shape(range(rank), diagonal_indices)
+    def _push_indices_down(cls, diagonal_indices, indices, ndim):
+        positions, shape = cls._get_positions_shape(range(ndim), diagonal_indices)
         transform = lambda x: positions[x] if x < len(positions) else None
         return _apply_recursively_over_nested_lists(transform, indices)
 
     @classmethod
-    def _push_indices_up(cls, diagonal_indices, indices, rank):
-        positions, shape = cls._get_positions_shape(range(rank), diagonal_indices)
+    def _push_indices_up(cls, diagonal_indices, indices, ndim):
+        positions, shape = cls._get_positions_shape(range(ndim), diagonal_indices)
 
         def transform(x):
             for i, e in enumerate(positions):
@@ -985,7 +962,7 @@ class ArrayElementwiseApplyFunc(_CodegenArrayAbstract):
             function = Lambda(d, function(d))
 
         obj = _CodegenArrayAbstract.__new__(cls, function, element)
-        obj._subranks = _get_subranks(element)
+        obj._sub_ndim_list = _get_sub_ndim_list(element)
         return obj
 
     @property
@@ -1066,10 +1043,10 @@ class ArrayContraction(_CodegenArrayAbstract):
         canonicalize = kwargs.get("canonicalize", False)
 
         obj = Basic.__new__(cls, expr, *contraction_indices)
-        obj._subranks = _get_subranks(expr)
-        obj._mapping = _get_mapping_from_subranks(obj._subranks)
+        obj._sub_ndim_list = _get_sub_ndim_list(expr)
+        obj._mapping = _get_mapping_from_sub_ndim_list(obj._sub_ndim_list)
 
-        free_indices_to_position = {i: i for i in range(sum(obj._subranks)) if all(i not in cind for cind in contraction_indices)}
+        free_indices_to_position = {i: i for i in range(sum(obj._sub_ndim_list)) if all(i not in cind for cind in contraction_indices)}
         obj._free_indices_to_position = free_indices_to_position
 
         shape = get_shape(expr)
@@ -1162,8 +1139,8 @@ class ArrayContraction(_CodegenArrayAbstract):
             raise NotImplementedError()
         if not isinstance(expr, ArrayTensorProduct):
             return expr, contraction_indices
-        subranks = expr.subranks
-        cumranks = list(accumulate([0] + subranks))
+        sub_ndim_list = _get_sub_ndim_list(expr)
+        cum_ndim_list = list(accumulate([0] + sub_ndim_list))
         contraction_indices_remaining = []
         contraction_indices_args = [[] for i in expr.args]
         backshift = set()
@@ -1171,16 +1148,16 @@ class ArrayContraction(_CodegenArrayAbstract):
             for j in range(len(expr.args)):
                 if not isinstance(expr.args[j], ArrayAdd):
                     continue
-                if all(cumranks[j] <= k < cumranks[j+1] for k in contraction_group):
-                    contraction_indices_args[j].append([k - cumranks[j] for k in contraction_group])
+                if all(cum_ndim_list[j] <= k < cum_ndim_list[j+1] for k in contraction_group):
+                    contraction_indices_args[j].append([k - cum_ndim_list[j] for k in contraction_group])
                     backshift.update(contraction_group)
                     break
             else:
                 contraction_indices_remaining.append(contraction_group)
         if len(contraction_indices_remaining) == len(contraction_indices):
             return expr, contraction_indices
-        total_rank = get_rank(expr)
-        shifts = list(accumulate([1 if i in backshift else 0 for i in range(total_rank)]))
+        total_ndim = get_ndim(expr)
+        shifts = list(accumulate([1 if i in backshift else 0 for i in range(total_ndim)]))
         contraction_indices_remaining = [Tuple.fromiter(j - shifts[j] for j in i) for i in contraction_indices_remaining]
         ret = _array_tensor_product(*[
             _array_contraction(arg, *contr) for arg, contr in zip(expr.args, contraction_indices_args)
@@ -1346,15 +1323,15 @@ class ArrayContraction(_CodegenArrayAbstract):
         inner_contraction_indices = expr.contraction_indices
         all_inner = [j for i in inner_contraction_indices for j in i]
         all_inner.sort()
-        # TODO: add API for total rank and cumulative rank:
-        total_rank = _get_subrank(expr)
-        inner_rank = len(all_inner)
-        outer_rank = total_rank - inner_rank
-        shifts = [0 for i in range(outer_rank)]
+
+        total_ndim = _get_sub_ndim(expr)
+        inner_ndim = len(all_inner)
+        outer_ndim = total_ndim - inner_ndim
+        shifts = [0 for i in range(outer_ndim)]
         counter = 0
         pointer = 0
-        for i in range(outer_rank):
-            while pointer < inner_rank and counter >= all_inner[pointer]:
+        for i in range(outer_ndim):
+            while pointer < inner_ndim and counter >= all_inner[pointer]:
                 counter += 1
                 pointer += 1
             shifts[i] += pointer
@@ -1403,7 +1380,7 @@ class ArrayContraction(_CodegenArrayAbstract):
     @classmethod
     def _ArrayContraction_denest_ArrayDiagonal(cls, expr: 'ArrayDiagonal', *contraction_indices):
         diagonal_indices = list(expr.diagonal_indices)
-        down_contraction_indices = expr._push_indices_down(expr.diagonal_indices, contraction_indices, get_rank(expr.expr))
+        down_contraction_indices = expr._push_indices_down(expr.diagonal_indices, contraction_indices, get_ndim(expr.expr))
         # Flatten diagonally contracted indices:
         down_contraction_indices = [[k for j in i for k in (j if isinstance(j, (tuple, Tuple)) else [j])] for i in down_contraction_indices]
         new_contraction_indices = []
@@ -1428,7 +1405,7 @@ class ArrayContraction(_CodegenArrayAbstract):
     def _sort_fully_contracted_args(cls, expr, contraction_indices):
         if expr.shape is None:
             return expr, contraction_indices
-        cumul = list(accumulate([0] + expr.subranks))
+        cumul = list(accumulate([0] + _get_sub_ndim_list(expr)))
         index_blocks = [list(range(cumul[i], cumul[i+1])) for i in range(len(expr.args))]
         contraction_indices_flat = {j for i in contraction_indices for j in i}
         fully_contracted = [all(j in contraction_indices_flat for j in range(cumul[i], cumul[i+1])) for i, arg in enumerate(expr.args)]
@@ -1473,10 +1450,9 @@ class ArrayContraction(_CodegenArrayAbstract):
 
     @staticmethod
     def _contraction_tuples_to_contraction_indices(expr, contraction_tuples):
-        # TODO: check that `expr` has `.subranks`:
-        ranks = expr.subranks
-        cumulative_ranks = [0] + list(accumulate(ranks))
-        return [tuple(cumulative_ranks[j]+k for j, k in i) for i in contraction_tuples]
+        sub_ndim_list = _get_sub_ndim_list(expr)
+        cumulative_ndim_list = [0] + list(accumulate(sub_ndim_list))
+        return [tuple(cumulative_ndim_list[j]+k for j, k in i) for i in contraction_tuples]
 
     @property
     def free_indices(self):
@@ -1498,11 +1474,11 @@ class ArrayContraction(_CodegenArrayAbstract):
         expr = self.expr
         if not isinstance(expr, ArrayTensorProduct):
             raise NotImplementedError("only for contractions of tensor products")
-        ranks = expr.subranks
+        ndim_list = _get_sub_ndim_list(expr)
         mapping = {}
         counter = 0
-        for i, rank in enumerate(ranks):
-            for j in range(rank):
+        for i, ndim in enumerate(ndim_list):
+            for j in range(ndim):
                 mapping[counter] = (i, j)
                 counter += 1
         return mapping
@@ -1585,7 +1561,7 @@ class ArrayContraction(_CodegenArrayAbstract):
         `(2, 0)` respectively. `(0, 1)` is the index slot 1 (the 2nd) of
         argument in position 0 (that is, `A_{\ldot j}`), and so on.
         """
-        args, dlinks = _get_contraction_links([self], self.subranks, *self.contraction_indices)
+        args, dlinks = _get_contraction_links([self], _get_sub_ndim_list(self), *self.contraction_indices)
         return dlinks
 
     def as_explicit(self):
@@ -1679,7 +1655,7 @@ class _ArgE:
     def __init__(self, element, indices: list[int | None] | None = None):
         self.element = element
         if indices is None:
-            self.indices = [None for i in range(get_rank(element))]
+            self.indices = [None for i in range(get_ndim(element))]
         else:
             self.indices = indices
 
@@ -1729,14 +1705,14 @@ class _EditArrayContraction:
         diagonalized: tuple[tuple[int, ...], ...]
         contraction_indices: list[tuple[int]]
         if isinstance(base_array, ArrayContraction):
-            mapping = _get_mapping_from_subranks(base_array.subranks)
+            mapping = _get_mapping_from_sub_ndim_list(_get_sub_ndim_list(base_array))
             expr = base_array.expr
             contraction_indices = base_array.contraction_indices
             diagonalized = ()
         elif isinstance(base_array, ArrayDiagonal):
 
             if isinstance(base_array.expr, ArrayContraction):
-                mapping = _get_mapping_from_subranks(base_array.expr.subranks)
+                mapping = _get_mapping_from_sub_ndim_list(_get_sub_ndim_list(base_array.expr))
                 expr = base_array.expr.expr
                 diagonalized = ArrayContraction._push_indices_down(base_array.expr.contraction_indices, base_array.diagonal_indices)
                 contraction_indices = base_array.expr.contraction_indices
@@ -1772,7 +1748,7 @@ class _EditArrayContraction:
         self.number_of_contraction_indices: int = len(contraction_indices)
         self._track_permutation: list[list[int]] | None = None
 
-        mapping = _get_mapping_from_subranks(base_array.subranks)
+        mapping = _get_mapping_from_sub_ndim_list(_get_sub_ndim_list(base_array))
 
         # Trick: add diagonalized indices as negative indices into the editor object:
         for i, e in enumerate(diagonalized):
@@ -1814,7 +1790,7 @@ class _EditArrayContraction:
 
     def to_array_contraction(self):
 
-        # Count the ranks of the arguments:
+        # Count the N-dims of the arguments:
         counter = 0
         # Create a collector for the new diagonal indices:
         diag_indices = defaultdict(list)
@@ -1984,13 +1960,13 @@ class _EditArrayContraction:
         raise IndexError("argument not found")
 
 
-def get_rank(expr):
+def get_ndim(expr):
     if isinstance(expr, (MatrixExpr, MatrixElement)):
         return 2
     if isinstance(expr, _CodegenArrayAbstract):
         return len(expr.shape)
     if isinstance(expr, NDimArray):
-        return expr.rank()
+        return expr.ndim
     if isinstance(expr, Indexed):
         return expr.rank
     if isinstance(expr, IndexedBase):
@@ -2004,17 +1980,47 @@ def get_rank(expr):
     return 0
 
 
-def _get_subrank(expr):
-    if isinstance(expr, _CodegenArrayAbstract):
-        return expr.subrank()
-    return get_rank(expr)
+@deprecated("use get_ndim(...) instead", deprecated_since_version="1.15", active_deprecations_target="ndim-array-rank")
+def get_rank(expr):
+    return get_ndim(expr)
 
 
-def _get_subranks(expr):
+def _get_sub_ndim(expr):
     if isinstance(expr, _CodegenArrayAbstract):
-        return expr.subranks
+        return sum(expr._sub_ndim_list)
+    return get_ndim(expr)
+
+
+def _get_sub_ndim_list(expr):
+    """
+    Returns the N-dims of the objects in the uppermost tensor product inside
+    the current object.  In case no tensor products are contained, return
+    the atomic ranks.
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.array import tensorproduct, tensorcontraction
+    >>> from sympy.tensor.array.expressions.array_expressions import _get_sub_ndim_list
+    >>> from sympy import MatrixSymbol
+    >>> M = MatrixSymbol("M", 3, 3)
+    >>> N = MatrixSymbol("N", 3, 3)
+    >>> P = MatrixSymbol("P", 3, 3)
+
+    Important: do not confuse the rank of the matrix with the rank of an array.
+
+    >>> tp = tensorproduct(M, N, P)
+    >>> _get_sub_ndim_list(tp)
+    [2, 2, 2]
+
+    >>> co = tensorcontraction(tp, (1, 2), (3, 4))
+    >>> _get_sub_ndim_list(co)
+    [2, 2, 2]
+    """
+    if isinstance(expr, _CodegenArrayAbstract):
+        return expr._sub_ndim_list
     else:
-        return [get_rank(expr)]
+        return [get_ndim(expr)]
 
 
 def get_shape(expr):

--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -14,7 +14,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.tensor.array.expressions.array_expressions import (
     _ArrayExpr, ZeroArray, ArraySymbol, ArrayTensorProduct, ArrayAdd,
-    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_rank,
+    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, get_ndim,
     get_shape, ArrayContraction, _array_tensor_product, _array_contraction,
     _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum)
 from sympy.tensor.array.expressions.from_matrix_to_array import convert_matrix_to_array
@@ -150,8 +150,8 @@ def _(expr: Inverse, x: Expr):
 
 @array_derive.register(ElementwiseApplyFunction)
 def _(expr: ElementwiseApplyFunction, x: Expr):
-    assert get_rank(expr) == 2
-    assert get_rank(x) == 2
+    assert get_ndim(expr) == 2
+    assert get_ndim(x) == 2
     fdiff = expr._get_function_fdiff()
     dexpr = array_derive(expr.expr, x)
     tp = _array_tensor_product(
@@ -173,8 +173,8 @@ def _(expr: ArrayElementwiseApplyFunc, x: Expr):
         dsubexpr,
         ArrayElementwiseApplyFunc(fdiff, subexpr)
     )
-    b = get_rank(x)
-    c = get_rank(expr)
+    b = get_ndim(x)
+    c = get_ndim(expr)
     diag_indices = [(b + i, b + c + i) for i in range(c)]
     return _array_diagonal(tp, *diag_indices)
 

--- a/sympy/tensor/array/expressions/from_array_to_indexed.py
+++ b/sympy/tensor/array/expressions/from_array_to_indexed.py
@@ -4,7 +4,7 @@ from itertools import accumulate
 
 from sympy import Mul, Sum, Dummy, Add
 from sympy.tensor.array.expressions import PermuteDims, ArrayAdd, ArrayElementwiseApplyFunc, Reshape
-from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, get_rank, ArrayContraction, \
+from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, get_ndim, ArrayContraction, \
     ArrayDiagonal, get_shape, _get_array_element_or_slice, _ArrayExpr
 from sympy.tensor.array.expressions.utils import _apply_permutation_to_list
 
@@ -20,11 +20,11 @@ class _ConvertArrayToIndexed:
 
     def do_convert(self, expr, indices):
         if isinstance(expr, ArrayTensorProduct):
-            cumul = list(accumulate([0] + [get_rank(arg) for arg in expr.args]))
+            cumul = list(accumulate([0] + [get_ndim(arg) for arg in expr.args]))
             indices_grp = [indices[cumul[i]:cumul[i+1]] for i in range(len(expr.args))]
             return Mul.fromiter(self.do_convert(arg, ind) for arg, ind in zip(expr.args, indices_grp))
         if isinstance(expr, ArrayContraction):
-            new_indices = [None for i in range(get_rank(expr.expr))]
+            new_indices = [None for i in range(get_ndim(expr.expr))]
             limits = []
             bottom_shape = get_shape(expr.expr)
             for contraction_index_grp in expr.contraction_indices:
@@ -42,8 +42,8 @@ class _ConvertArrayToIndexed:
             newexpr = self.do_convert(expr.expr, new_indices)
             return Sum(newexpr, *limits)
         if isinstance(expr, ArrayDiagonal):
-            new_indices = [None for i in range(get_rank(expr.expr))]
-            ind_pos = expr._push_indices_down(expr.diagonal_indices, list(range(len(indices))), get_rank(expr))
+            new_indices = [None for i in range(get_ndim(expr.expr))]
+            ind_pos = expr._push_indices_down(expr.diagonal_indices, list(range(len(indices))), get_ndim(expr))
             for i, index in zip(ind_pos, indices):
                 if isinstance(i, collections.abc.Iterable):
                     for j in i:

--- a/sympy/tensor/array/expressions/utils.py
+++ b/sympy/tensor/array/expressions/utils.py
@@ -6,18 +6,18 @@ from sympy.core.containers import Tuple
 from sympy.core.numbers import Integer
 
 
-def _get_mapping_from_subranks(subranks):
+def _get_mapping_from_sub_ndim_list(sub_ndim_list):
     mapping = {}
     counter = 0
-    for i, rank in enumerate(subranks):
+    for i, rank in enumerate(sub_ndim_list):
         for j in range(rank):
             mapping[counter] = (i, j)
             counter += 1
     return mapping
 
 
-def _get_contraction_links(args, subranks, *contraction_indices):
-    mapping = _get_mapping_from_subranks(subranks)
+def _get_contraction_links(args, sub_ndim_list, *contraction_indices):
+    mapping = _get_mapping_from_sub_ndim_list(sub_ndim_list)
     contraction_tuples = [[mapping[j] for j in i] for i in contraction_indices]
     dlinks = defaultdict(dict)
     for links in contraction_tuples:

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -11,6 +11,8 @@ from sympy.printing.defaults import Printable
 import itertools
 from collections.abc import Iterable
 
+from sympy.utilities.decorator import deprecated
+
 
 class ArrayKind(Kind):
     """
@@ -155,12 +157,12 @@ class NDimArray(Printable):
         if self._loop_size == 0:
             raise ValueError("Index not valid with an empty array")
 
-        if len(index) != self._rank:
+        if len(index) != self._ndim:
             raise ValueError('Wrong number of array axes')
 
         real_index = 0
         # check if input index can exist in current indexing
-        for i in range(self._rank):
+        for i in range(self._ndim):
             if (index[i] >= self.shape[i]) or (index[i] < -self.shape[i]):
                 raise ValueError('Index ' + str(index) + ' out of border')
             if index[i] < 0:
@@ -291,20 +293,25 @@ class NDimArray(Printable):
         """
         return self._shape
 
+    @deprecated("Use .ndim instead", deprecated_since_version="1.15", active_deprecations_target="ndim-array-rank")
     def rank(self):
+        return self.ndim
+
+    @property
+    def ndim(self):
         """
-        Returns rank of array.
+        Returns number of dimensions of array.
 
         Examples
         ========
 
         >>> from sympy import MutableDenseNDimArray
         >>> a = MutableDenseNDimArray.zeros(3,4,5,6,3)
-        >>> a.rank()
+        >>> a.ndim
         5
 
         """
-        return self._rank
+        return self._ndim
 
     def diff(self, *args, **kwargs):
         """
@@ -360,7 +367,7 @@ class NDimArray(Printable):
             sh //= shape_left[0]
             return "[" + ", ".join([f(sh, shape_left[1:], i+e*sh, i+(e+1)*sh) for e in range(shape_left[0])]) + "]" # + "\n"*len(shape_left)
 
-        if self.rank() == 0:
+        if self.ndim == 0:
             return printer._print(self[()])
         if 0 in self.shape:
             return f"{self.__class__.__name__}([], {self.shape})"
@@ -526,7 +533,7 @@ class NDimArray(Printable):
         return not self == other
 
     def _eval_transpose(self):
-        if self.rank() != 2:
+        if self.ndim != 2:
             raise ValueError("array rank not 2")
         from .arrayop import permutedims
         return permutedims(self, (1, 0))
@@ -578,11 +585,11 @@ class NDimArray(Printable):
         if isinstance(index, (SYMPY_INTS, Integer, slice)):
             index = (index,)
 
-        if len(index) < self.rank():
+        if len(index) < self.ndim:
             index = tuple(index) + \
-                          tuple(slice(None) for i in range(len(index), self.rank()))
+                          tuple(slice(None) for i in range(len(index), self.ndim))
 
-        if len(index) > self.rank():
+        if len(index) > self.ndim:
             raise ValueError('Dimension of index greater than rank of array')
 
         return index

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -85,7 +85,7 @@ class SparseNDimArray(NDimArray):
         [1, 1, 1]])
         """
         from sympy.matrices import SparseMatrix
-        if self.rank() != 2:
+        if self.ndim != 2:
             raise ValueError('Dimensions must be of size of 2')
 
         mat_sparse = {}
@@ -122,7 +122,7 @@ class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray): # type: ign
 
         self = Basic.__new__(cls, sparse_array, shape, **kwargs)
         self._shape = shape
-        self._rank = len(shape)
+        self._ndim = len(shape)
         self._loop_size = loop_size
         self._sparse_array = sparse_array
 
@@ -141,7 +141,7 @@ class MutableSparseNDimArray(MutableNDimArray, SparseNDimArray):
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         self = object.__new__(cls)
         self._shape = shape
-        self._rank = len(shape)
+        self._ndim = len(shape)
         self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
 
         # Sparse array:

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -25,7 +25,7 @@ def test_array_comprehension():
     assert b.subs(j, 3) == ArrayComprehension(i, (i, 1, 4))
     assert b.free_symbols == {j}
     assert b.shape == (j + 1,)
-    assert b.rank() == 1
+    assert b.ndim == 1
     assert b.is_shape_numeric == False
     assert c.free_symbols == set()
     assert c.function == i + j + k + l

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -176,7 +176,7 @@ def test_array_permutedims():
         raises(ValueError, lambda: po.transpose())
         raises(ValueError, lambda: po.adjoint())
 
-        assert permutedims(po, reversed(range(po.rank()))) == ArrayType(
+        assert permutedims(po, reversed(range(po.ndim))) == ArrayType(
             [[[[[[sa[0], sa[72]], [sa[36], sa[108]]], [[sa[12], sa[84]], [sa[48], sa[120]]], [[sa[24],
                                                                                                sa[96]], [sa[60], sa[132]]]],
                [[[sa[4], sa[76]], [sa[40], sa[112]]], [[sa[16],

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -16,7 +16,7 @@ from sympy.testing.pytest import raises
 def test_ndim_array_initiation():
     arr_with_no_elements = ImmutableDenseNDimArray([], shape=(0,))
     assert len(arr_with_no_elements) == 0
-    assert arr_with_no_elements.rank() == 1
+    assert arr_with_no_elements.ndim == 1
 
     raises(ValueError, lambda: ImmutableDenseNDimArray([0], shape=(0,)))
     raises(ValueError, lambda: ImmutableDenseNDimArray([1, 2, 3], shape=(0,)))
@@ -30,42 +30,42 @@ def test_ndim_array_initiation():
     assert len(arr_with_one_element) == 1
     assert arr_with_one_element[0] == 23
     assert arr_with_one_element[:] == ImmutableDenseNDimArray([23])
-    assert arr_with_one_element.rank() == 1
+    assert arr_with_one_element.ndim == 1
 
     arr_with_symbol_element = ImmutableDenseNDimArray([Symbol('x')])
     assert len(arr_with_symbol_element) == 1
     assert arr_with_symbol_element[0] == Symbol('x')
     assert arr_with_symbol_element[:] == ImmutableDenseNDimArray([Symbol('x')])
-    assert arr_with_symbol_element.rank() == 1
+    assert arr_with_symbol_element.ndim == 1
 
     number5 = 5
     vector = ImmutableDenseNDimArray.zeros(number5)
     assert len(vector) == number5
     assert vector.shape == (number5,)
-    assert vector.rank() == 1
+    assert vector.ndim == 1
 
     vector = ImmutableSparseNDimArray.zeros(number5)
     assert len(vector) == number5
     assert vector.shape == (number5,)
     assert vector._sparse_array == Dict()
-    assert vector.rank() == 1
+    assert vector.ndim == 1
 
     n_dim_array = ImmutableDenseNDimArray(range(3**4), (3, 3, 3, 3,))
     assert len(n_dim_array) == 3 * 3 * 3 * 3
     assert n_dim_array.shape == (3, 3, 3, 3)
-    assert n_dim_array.rank() == 4
+    assert n_dim_array.ndim == 4
 
     array_shape = (3, 3, 3, 3)
     sparse_array = ImmutableSparseNDimArray.zeros(*array_shape)
     assert len(sparse_array._sparse_array) == 0
     assert len(sparse_array) == 3 * 3 * 3 * 3
     assert n_dim_array.shape == array_shape
-    assert n_dim_array.rank() == 4
+    assert n_dim_array.ndim == 4
 
     one_dim_array = ImmutableDenseNDimArray([2, 3, 1])
     assert len(one_dim_array) == 3
     assert one_dim_array.shape == (3,)
-    assert one_dim_array.rank() == 1
+    assert one_dim_array.ndim == 1
     assert one_dim_array.tolist() == [2, 3, 1]
 
     shape = (3, 3)
@@ -73,19 +73,19 @@ def test_ndim_array_initiation():
     assert len(array_with_many_args) == 3 * 3
     assert array_with_many_args.shape == shape
     assert array_with_many_args[0, 0] == 0
-    assert array_with_many_args.rank() == 2
+    assert array_with_many_args.ndim == 2
 
     shape = (int(3), int(3))
     array_with_long_shape = ImmutableSparseNDimArray.zeros(*shape)
     assert len(array_with_long_shape) == 3 * 3
     assert array_with_long_shape.shape == shape
     assert array_with_long_shape[int(0), int(0)] == 0
-    assert array_with_long_shape.rank() == 2
+    assert array_with_long_shape.ndim == 2
 
     vector_with_long_shape = ImmutableDenseNDimArray(range(5), int(5))
     assert len(vector_with_long_shape) == 5
     assert vector_with_long_shape.shape == (int(5),)
-    assert vector_with_long_shape.rank() == 1
+    assert vector_with_long_shape.ndim == 1
     raises(ValueError, lambda: vector_with_long_shape[int(5)])
 
     from sympy.abc import x
@@ -93,7 +93,7 @@ def test_ndim_array_initiation():
         rank_zero_array = ArrayType(x)
         assert len(rank_zero_array) == 1
         assert rank_zero_array.shape == ()
-        assert rank_zero_array.rank() == 0
+        assert rank_zero_array.ndim == 0
         assert rank_zero_array[()] == x
         raises(ValueError, lambda: rank_zero_array[0])
 
@@ -101,12 +101,17 @@ def test_ndim_array_initiation():
 def test_reshape():
     array = ImmutableDenseNDimArray(range(50), 50)
     assert array.shape == (50,)
-    assert array.rank() == 1
+    assert array.ndim == 1
 
     array = array.reshape(5, 5, 2)
     assert array.shape == (5, 5, 2)
-    assert array.rank() == 3
+    assert array.ndim == 3
     assert len(array) == 50
+
+    from sympy.testing.pytest import warns_deprecated_sympy
+
+    with warns_deprecated_sympy():
+        assert array.rank() == 3
 
 
 def test_getitem():
@@ -445,6 +450,6 @@ def test_zeros_without_shape():
 
 def test_issue_21870():
     a0 = ImmutableDenseNDimArray(0)
-    assert a0.rank() == 0
+    assert a0.ndim == 0
     a1 = ImmutableDenseNDimArray(a0)
-    assert a1.rank() == 0
+    assert a1.ndim == 0

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -16,31 +16,31 @@ def test_ndim_array_initiation():
     arr_with_one_element = MutableDenseNDimArray([23])
     assert len(arr_with_one_element) == 1
     assert arr_with_one_element[0] == 23
-    assert arr_with_one_element.rank() == 1
+    assert arr_with_one_element.ndim == 1
     raises(ValueError, lambda: arr_with_one_element[1])
 
     arr_with_symbol_element = MutableDenseNDimArray([Symbol('x')])
     assert len(arr_with_symbol_element) == 1
     assert arr_with_symbol_element[0] == Symbol('x')
-    assert arr_with_symbol_element.rank() == 1
+    assert arr_with_symbol_element.ndim == 1
 
     number5 = 5
     vector = MutableDenseNDimArray.zeros(number5)
     assert len(vector) == number5
     assert vector.shape == (number5,)
-    assert vector.rank() == 1
+    assert vector.ndim == 1
     raises(ValueError, lambda: arr_with_one_element[5])
 
     vector = MutableSparseNDimArray.zeros(number5)
     assert len(vector) == number5
     assert vector.shape == (number5,)
     assert vector._sparse_array == {}
-    assert vector.rank() == 1
+    assert vector.ndim == 1
 
     n_dim_array = MutableDenseNDimArray(range(3**4), (3, 3, 3, 3,))
     assert len(n_dim_array) == 3 * 3 * 3 * 3
     assert n_dim_array.shape == (3, 3, 3, 3)
-    assert n_dim_array.rank() == 4
+    assert n_dim_array.ndim == 4
     raises(ValueError, lambda: n_dim_array[0, 0, 0, 3])
     raises(ValueError, lambda: n_dim_array[3, 0, 0, 0])
     raises(ValueError, lambda: n_dim_array[3**4])
@@ -50,12 +50,12 @@ def test_ndim_array_initiation():
     assert len(sparse_array._sparse_array) == 0
     assert len(sparse_array) == 3 * 3 * 3 * 3
     assert n_dim_array.shape == array_shape
-    assert n_dim_array.rank() == 4
+    assert n_dim_array.ndim == 4
 
     one_dim_array = MutableDenseNDimArray([2, 3, 1])
     assert len(one_dim_array) == 3
     assert one_dim_array.shape == (3,)
-    assert one_dim_array.rank() == 1
+    assert one_dim_array.ndim == 1
     assert one_dim_array.tolist() == [2, 3, 1]
 
     shape = (3, 3)
@@ -63,19 +63,19 @@ def test_ndim_array_initiation():
     assert len(array_with_many_args) == 3 * 3
     assert array_with_many_args.shape == shape
     assert array_with_many_args[0, 0] == 0
-    assert array_with_many_args.rank() == 2
+    assert array_with_many_args.ndim == 2
 
     shape = (int(3), int(3))
     array_with_long_shape = MutableSparseNDimArray.zeros(*shape)
     assert len(array_with_long_shape) == 3 * 3
     assert array_with_long_shape.shape == shape
     assert array_with_long_shape[int(0), int(0)] == 0
-    assert array_with_long_shape.rank() == 2
+    assert array_with_long_shape.ndim == 2
 
     vector_with_long_shape = MutableDenseNDimArray(range(5), int(5))
     assert len(vector_with_long_shape) == 5
     assert vector_with_long_shape.shape == (int(5),)
-    assert vector_with_long_shape.rank() == 1
+    assert vector_with_long_shape.ndim == 1
     raises(ValueError, lambda: vector_with_long_shape[int(5)])
 
     from sympy.abc import x
@@ -83,7 +83,7 @@ def test_ndim_array_initiation():
         rank_zero_array = ArrayType(x)
         assert len(rank_zero_array) == 1
         assert rank_zero_array.shape == ()
-        assert rank_zero_array.rank() == 0
+        assert rank_zero_array.ndim == 0
         assert rank_zero_array[()] == x
         raises(ValueError, lambda: rank_zero_array[0])
 
@@ -98,12 +98,17 @@ def test_sympify():
 def test_reshape():
     array = MutableDenseNDimArray(range(50), 50)
     assert array.shape == (50,)
-    assert array.rank() == 1
+    assert array.ndim == 1
 
     array = array.reshape(5, 5, 2)
     assert array.shape == (5, 5, 2)
-    assert array.rank() == 3
+    assert array.ndim == 3
     assert len(array) == 50
+
+    from sympy.testing.pytest import warns_deprecated_sympy
+
+    with warns_deprecated_sympy():
+        assert array.rank() == 3
 
 
 def test_iterator():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -444,9 +444,9 @@ class _TensorDataLazyEvaluator(CantSympify):
         if not isinstance(dat, NDimArray):
             return dat
 
-        if dat.rank() == 0:
+        if dat.ndim == 0:
             return dat[()]
-        elif dat.rank() == 1 and len(dat) == 1:
+        elif dat.ndim == 1 and len(dat) == 1:
             return dat[0]
         return dat
 
@@ -685,8 +685,8 @@ class _TensorDataLazyEvaluator(CantSympify):
     def _flip_index_by_metric(data, metric, pos):
         from .array import tensorproduct, tensorcontraction
 
-        mdim = metric.rank()
-        ddim = data.rank()
+        mdim = metric.ndim
+        ddim = data.ndim
 
         if pos == 0:
             data = tensorcontraction(
@@ -1174,9 +1174,9 @@ class TensorIndexType(Basic):
         from .array import MutableDenseNDimArray
 
         data = _TensorDataLazyEvaluator.parse_data(data)
-        if data.rank() > 2:
+        if data.ndim > 2:
             raise ValueError("data have to be of rank 1 (diagonal metric) or 2.")
-        if data.rank() == 1:
+        if data.ndim == 1:
             if self.dim.is_number:
                 nda_dim = data.shape[0]
                 if nda_dim != self.dim:
@@ -1917,7 +1917,7 @@ class TensorHead(Basic):
             metrics = [_.data for _ in self.index_types]
 
             marray = self.data
-            marraydim = marray.rank()
+            marraydim = marray.ndim
             for metric in metrics:
                 marray = tensorproduct(marray, metric, marray)
                 marray = tensorcontraction(marray, (0, marraydim), (marraydim+1, marraydim+2))
@@ -2079,7 +2079,7 @@ class TensExpr(Expr, ABC):
             from .array import tensorproduct, tensorcontraction
             free = self.free
             marray = self.data
-            mdim = marray.rank()
+            mdim = marray.ndim
             for metric in free:
                 marray = tensorcontraction(
                     tensorproduct(
@@ -2278,7 +2278,7 @@ class TensExpr(Expr, ABC):
             permutation = TensExpr._get_indices_permutation(free_ind2, free_ind1)
             array = permutedims(array, permutation)
 
-        if hasattr(array, "rank") and array.rank() == 0:
+        if hasattr(array, "ndim") and array.ndim == 0:
             array = array[()]
 
         return free_ind2, array
@@ -2368,7 +2368,7 @@ class TensExpr(Expr, ABC):
                 expected_shape = [tensor.dim for i in range(2)]
             else:
                 expected_shape = [index_type.dim for index_type in tensor.index_types]
-            if len(expected_shape) != array.rank() or (not all(dim1 == dim2 if
+            if len(expected_shape) != array.ndim or (not all(dim1 == dim2 if
                 dim1.is_number else True for dim1, dim2 in zip(expected_shape,
                 array.shape))):
                 raise ValueError(f"shapes for tensor {tensor} expected to be {expected_shape}, "\


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/28848


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
