### PR TITLE
docs: add AccumulationBounds documentation to render on Calculas docs page

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1542,6 +1542,7 @@ Sophia Pustova <tripplezzed@gmail.com>
 Soumendra Ganguly <soumendraganguly@gmail.com>
 Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
 Soumya Dipta Biswas <sdb1323@gmail.com>
+Soumya Sakshi <s1december2005@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
 Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>

--- a/doc/src/modules/calculus/index.rst
+++ b/doc/src/modules/calculus/index.rst
@@ -17,3 +17,6 @@ Calculus
 
 .. automodule:: sympy.calculus.util
     :members:
+
+.. automodule:: sympy.calculus.accumulationbounds
+    :members:


### PR DESCRIPTION
docs: add accumulationbounds documentation to render on Calculas docs page

#### References to other Issues or PRs
Fixes #29190 

#### Brief description of what is fixed or changed
Adds the documentation of accumulationbounds in the Calculus module.

- Issue
The AccumulationBounds class in the Calculus Module, had it's documentation written, but it did not render in the HTML docs for Calculus.
Although, AccumulationBounds had it's documentation, but there was no reference (directive) in `modules/calculus/index.rst` to include this during the HTML build.

- Causes
The Sphinx (documentation generator based on given instructions/directives in `.rst` files), only includes classes or functions in the documentation if they are explicitly mentioned in the module's `.rst` files.  


- Fix
Added the directive (intructions for Sphinx) to include AccumulationBounds, during the HTML build of Calculus Module.
For this:
`.. automodule:: sympy.calculus.accumulationbounds` was included in `doc/src/modules/calculus/index.rst`



#### Other comments


#### AI Generation Disclosure
None of this code is AI generated


#### Release Notes



<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
