### PR TITLE
Fix ask returning None for Q.negative(log(x)) when 0 < x < 1

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -130,6 +130,23 @@ def _(expr, assumptions):
         return False
     raise MDNotImplementedError
 
+@NegativePredicate.register(log)
+def _(expr, assumptions):
+    r = ask(Q.real(expr.args[0]), assumptions)
+    if r is not True:
+        return r
+    # log(x) < 0 iff 0 < x < 1
+    # Check using relational predicates (handles Q.gt/Q.lt assumptions)
+    # and also using positivity of arg-1 (handles symbolic expressions)
+    if ask(Q.gt(expr.args[0], 0) & Q.lt(expr.args[0], 1), assumptions):
+        return True
+    if ask(Q.positive(expr.args[0]) & Q.negative(expr.args[0] - 1), assumptions):
+        return True
+    if ask(Q.ge(expr.args[0], 1), assumptions):
+        return False
+    if ask(Q.nonnegative(expr.args[0] - 1), assumptions):
+        return False
+
 
 # NonNegativePredicate
 
@@ -341,8 +358,16 @@ def _(expr, assumptions):
     r = ask(Q.real(expr.args[0]), assumptions)
     if r is not True:
         return r
+    # log(x) > 0 iff x > 1
+    # Check using relational predicates (handles Q.gt assumptions)
+    # and also using positivity of arg-1 (handles symbolic expressions)
+    if ask(Q.gt(expr.args[0], 1), assumptions):
+        return True
     if ask(Q.positive(expr.args[0] - 1), assumptions):
         return True
+    # log(x) <= 0 iff x <= 1 (includes x < 0, x = 0, 0 < x <= 1)
+    if ask(Q.lt(expr.args[0], 1), assumptions):
+        return False
     if ask(Q.negative(expr.args[0] - 1), assumptions):
         return False
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2583,3 +2583,20 @@ def test_issue_28127():
     assert ask(Q.gt(y,x), Q.lt(x,y)) is True
     assert ask(Q.lt(y,x), Q.gt(x,y)) is True
     assert ask(Q.le(y,x), Q.ge(x,y)) is True
+
+
+def test_issue_29186():
+    # ask should return True for Q.negative(log(x)) when 0 < x < 1 and x is real
+    x = Symbol('x')
+    # Test cases from the issue report
+    assert ask(Q.negative(log(x)), Q.real(x) & Q.lt(x, 1) & Q.gt(x, 0)) is True
+    assert ask(Q.negative(log(x)), Q.real(x) & Q.positive(x) & Q.lt(x, 1)) is True
+
+    x_real = Symbol('x_real', real=True)
+    assert ask(Q.negative(log(x_real)), Q.lt(x_real, 1) & Q.gt(x_real, 0)) is True
+    assert ask(Q.negative(log(x_real)), Q.positive(x_real) & Q.lt(x_real, 1)) is True
+
+    # Regression: log(x) should be positive when x > 1
+    assert ask(Q.positive(log(x)), Q.real(x) & Q.gt(x, 1)) is True
+    # log(x) with non-real arg should not be negative
+    assert ask(Q.negative(log(x)), Q.imaginary(x)) is False


### PR DESCRIPTION
Fix ask returning None for Q.negative(log(x)) when 0 < x < 1

#### References to other Issues or PRs

Fixes #29186

#### Brief description of what is fixed or changed

`ask(Q.negative(log(x)), Q.real(x) & Q.lt(x, 1) & Q.gt(x, 0))` incorrectly
returned `None` instead of `True`.

Two bugs caused this:

1. **Missing handler** — No `NegativePredicate.register(log)` existed. Calls to
   `ask(Q.negative(log(x)), ...)` fell through to the generic `Expr` handler,
   which called `expr.is_negative` and returned `None` for symbolic expressions.

2. **Incomplete positive handler** — `PositivePredicate.register(log)` used
   `ask(Q.positive(arg - 1))` and `ask(Q.negative(arg - 1))` to infer the sign
   of `log`. These work when assumptions use symbolic propagation (e.g.
   `Q.positive(x)` implies `Q.positive(x+1)`), but fail when assumptions are
   given as relational predicates (`Q.gt(x, 0)`, `Q.lt(x, 1)`), which the
   SAT/LRA solver handles separately.

The fix adds a `NegativePredicate.register(log)` handler and updates
`PositivePredicate.register(log)` to try both approaches in combination:
- Relational predicates (`Q.gt(arg, 1)`, `Q.lt(arg, 1)`, `Q.gt(arg, 0)`) —
  handles assumptions like `Q.lt(x, 1) & Q.gt(x, 0)`
- Positivity of shifted arg (`Q.positive(arg - 1)`, `Q.negative(arg - 1)`) —
  handles assumptions like `Q.positive(x)` with symbolic expressions like
  `log(x + 2)`

#### Other comments

All four cases from the issue report now return `True` as expected:

```python
>>> from sympy import Symbol, ask, Q, log
>>> x = Symbol('x')
>>> ask(Q.negative(log(x)), Q.real(x) & Q.lt(x, 1) & Q.gt(x, 0))
True
>>> ask(Q.negative(log(x)), Q.real(x) & Q.positive(x) & Q.lt(x, 1))
True
>>> x = Symbol('x', real=True)
>>> ask(Q.negative(log(x)), Q.lt(x, 1) & Q.gt(x, 0))
True
>>> ask(Q.negative(log(x)), Q.positive(x) & Q.lt(x, 1))
True
```

#### AI Generation Disclosure


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `ask(Q.negative(log(x)), ...)` returning `None` instead of `True`
    when `0 < x < 1` and `x` is real (issue #29186). Added a `NegativePredicate`
    handler for `log` and updated the `PositivePredicate` handler to work with
    both relational (`Q.gt`/`Q.lt`) and symbolic (`Q.positive`/`Q.negative`)
    assumption styles.
<!-- END RELEASE NOTES -->
