### PR TITLE
Fix: ask(Q.real(sqrt(x)), Q.real(x)) should return None

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -7,7 +7,7 @@ from sympy.core import Add, Basic, Expr, Mul, Pow, S
 from sympy.core.numbers import (AlgebraicNumber, ComplexInfinity, Exp1, Float,
     GoldenRatio, ImaginaryUnit, Infinity, Integer, NaN, NegativeInfinity,
     Number, NumberSymbol, Pi, pi, Rational, TribonacciConstant, E)
-from sympy.core.logic import fuzzy_bool, fuzzy_not
+from sympy.core.logic import fuzzy_bool, fuzzy_not, fuzzy_and
 from sympy.functions import (Abs, acos, acot, asin, atan, cos, cot, exp, im,
     log, re, sin, tan)
 from sympy.core.numbers import I
@@ -342,9 +342,10 @@ def _(expr, assumptions):
             if (expr.exp.is_Rational and
                     ask(Q.even(expr.exp.q), assumptions)):
                 return ask(Q.nonnegative(expr.base), assumptions)
-            elif ask(Q.integer(expr.exp), assumptions) or ask(Q.zero(expr.base), assumptions):
-                is_not_real = (ask_all(Q.zero(expr.base),
-                            Q.negative(expr.exp), assumptions=assumptions))
+            base_is_zero = ask(Q.zero(expr.base), assumptions)
+            if (ask(Q.integer(expr.exp), assumptions) or base_is_zero):
+                is_not_real = fuzzy_and([base_is_zero,
+                                ask(Q.negative(expr.exp), assumptions)])
                 return fuzzy_not(is_not_real)
             elif ask(Q.positive(expr.base), assumptions):
                 return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -339,15 +339,13 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
-            if ask(Q.zero(expr.base), assumptions) is not False:
-                if ask(Q.positive(expr.exp), assumptions):
-                    return True
-                return
-            if expr.exp.is_Rational and \
-                    ask(Q.even(expr.exp.q), assumptions):
-                return ask(Q.positive(expr.base), assumptions)
-            elif ask(Q.integer(expr.exp), assumptions):
-                return True
+            if (expr.exp.is_Rational and
+                    ask(Q.even(expr.exp.q), assumptions)):
+                return ask(Q.nonnegative(expr.base), assumptions)
+            elif ask(Q.integer(expr.exp), assumptions) or ask(Q.zero(expr.base), assumptions):
+                is_not_real = (ask_all(Q.zero(expr.base),
+                            Q.negative(expr.exp), assumptions=assumptions))
+                return fuzzy_not(is_not_real)
             elif ask(Q.positive(expr.base), assumptions):
                 return True
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2071,6 +2071,7 @@ def test_real_pow():
     assert ask(Q.real(x**two_thirds), Q.zero(x)) is True
     assert ask(Q.real(x**pi), Q.zero(x)) is True
     assert ask(Q.real(x**sqrt(2)), Q.zero(x)) is True
+    assert ask(Q.real(x**Rational(1/2)), Q.zero(x)) is True
 
 
 @_both_exp_pow

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -9,6 +9,7 @@ from sympy.assumptions.handlers import AskHandler
 from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)
 from sympy.core.add import Add
+from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer, Rational, oo, zoo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
@@ -2058,6 +2059,18 @@ def test_real_pow():
     assert ask(Q.real(1/Abs(x))) is None
     assert ask(Q.real(x**y), Q.zero(x) & Q.real(y)) is None
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
+
+    # https://github.com/sympy/sympy/issues/28142
+    assert ask(Q.real(sqrt(x)), Q.real(x)) is None
+    one_half = Mul(S.Half, 1, evaluate=False)
+    assert ask(Q.real(x ** one_half), Q.real(x)) is None
+    assert ask(Q.real(Pow(x, 1, evaluate=False)), Q.zero(x)) is True
+    assert ask(Q.real(x**x), Q.zero(x)) is True
+    assert ask(Q.real(Pow(x, -1, evaluate=False)), Q.zero(x)) is False
+    two_thirds = Rational(2, 3)
+    assert ask(Q.real(x**two_thirds), Q.zero(x)) is True
+    assert ask(Q.real(x**pi), Q.zero(x)) is True
+    assert ask(Q.real(x**sqrt(2)), Q.zero(x)) is True
 
 
 @_both_exp_pow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Completes/Continues: #28149 
Fixes: #28142

#### Brief description of what is fixed or changed
Corrected the `RealPredicate` handler for `Pow` function to give `None` instead of `True` for `ask(Q.real(sqrt(x)), Q.real(x))`

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Correct `ask(Q.real(sqrt(x)), Q.real(x))` into giving `None` instead of `True`.
<!-- END RELEASE NOTES -->
