### PR TITLE
polys: optimize list construction in subresultants_qq_zz using PERF401

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1002,6 +1002,7 @@ Lucas Wiman <lucas.wiman@gmail.com>
 Lucy Mountain <lucymountain1@icloud.com> LucyMountain <lucymountain1@icloud.com>
 Luis Garcia <ppn.online@me.com>
 Luis Talavera <luisfertalavera15@gmail.com> Luis F. Talavera R <47088091+LuisFerTR@users.noreply.github.com>
+Luka Aladashvili <115102487+llukito@users.noreply.github.com>
 Lukas Molleman <Lukas.Molleman@gmail.com>
 Lukas Zorich <lukas.zorich@gmail.com>
 Luke Peterson <hazelnusse@gmail.com>

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -326,14 +326,10 @@ def sylvester(f, g, x, method = 1):
     # Sylvester's matrix of 1853 (a.k.a sylvester2)
     else:
         if len(fp) < len(gp):
-            h = []
-            for i in range(len(gp) - len(fp)):
-                h.append(0)
+            h = [0 for _ in range(len(gp) - len(fp))]
             fp[ : 0] = h
         else:
-            h = []
-            for i in range(len(fp) - len(gp)):
-                h.append(0)
+            h = [0 for _ in range(len(fp) - len(gp))]
             gp[ : 0] = h
         mx = max(m, n)
         dim = 2*mx
@@ -1127,8 +1123,7 @@ def sturm_amv(p, q, x, method=0):
     # subresultants or modified subresultants?
     if method == 0 and lcf > 1:
         aux_seq = [sturm_seq[0], sturm_seq[1]]
-        for i in range(2, m):
-            aux_seq.append(simplify(sturm_seq[i] * lcf ))
+        aux_seq.extend(simplify(sturm_seq[i] * lcf) for i in range(2, m))
         sturm_seq = aux_seq
 
     return sturm_seq
@@ -1543,8 +1538,7 @@ def modified_subresultants_pg(p, q, x):
     m = len(subres_l)   # list may be shorter now due to deg(gcd ) > 0
     if LC( p ) < 0:
         aux_seq = [subres_l[0], subres_l[1]]
-        for i in range(2, m):
-            aux_seq.append(simplify(subres_l[i] * (-1) ))
+        aux_seq.extend(simplify(subres_l[i] * (-1)) for i in range(2, m))
         subres_l = aux_seq
 
     return  subres_l
@@ -2193,9 +2187,7 @@ def row2poly(row, deg, x):
         k = k + 1
 
     # append the next deg + 1 elements to poly
-    for j in range( deg + 1):
-        if k + j <= leng:
-            poly.append(row[k + j])
+    poly.extend(row[k + j] for j in range(deg + 1) if k + j <= leng)
 
     return Poly(poly, x)
 


### PR DESCRIPTION
## Summary
I'm opening this PR to clean up some list generation in `sympy/polys/subresultants_qq_zz.py` based on the `PERF401` rule. 

## Changes
I swapped out several manual `for` loops that used `.append()` and replaced them with list comprehensions and `.extend()`. 

Specifically:
- `sylvester()`: updated the zero-padding for `fp` and `gp`.
- `sturm_amv()`: swapped a loop for `.extend()` to simplify the sequence.
- `modified_subresultants_pg()`: swapped a loop for `.extend()` for sign modifications.
- `row2poly()`: passed a generator directly into `.extend()`.

## Why?
Using list comprehensions and `.extend()` pushes the iteration down to C-level Python, which makes it slightly faster and a bit easier to read.

## Verification
I ran the specific tests locally and everything passes:
`bin/test sympy/polys/tests/test_subresultants_qq_zz.py`
Result: 25 passed in 3.66s

## AI Disclosure
- [x] I have read the [SymPy AI Policy](https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html).
- **Disclosure:** I wrote the actual Python code changes, checked the formatting, and ran the test suite locally manually. I originally used an AI to help write the first version of this PR description, but after reading the communication policy, I realized that is not allowed. I have now completely rewritten this description myself, in my own words, without any AI.

## Checklist
- [x] I have read the [SymPy Contribution Guidelines](https://docs.sympy.org/dev/contributing/index.html).
- [x] I have added/updated tests for the changes. (N/A - existing tests pass)
- [x] I have formatted my code with `black` and run `flake8`.

<!-- BEGIN RELEASE NOTES -->
* polys
  * optimized list construction in subresultants_qq_zz using PERF401
<!-- END RELEASE NOTES -->