### PR TITLE
Fix: ask(Q.real(sqrt(x)), Q.real(x)) should return None

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -339,15 +339,12 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
-            if ask(Q.zero(expr.base), assumptions) is not False:
-                if ask(Q.positive(expr.exp), assumptions):
-                    return True
-                return
             if expr.exp.is_Rational and \
                     ask(Q.even(expr.exp.q), assumptions):
                 return ask(Q.positive(expr.base), assumptions)
             elif ask(Q.integer(expr.exp), assumptions):
-                return True
+                is_not_real = ask_all(Q.zero(expr.base), Q.negative(expr.exp), assumptions=assumptions)
+                return fuzzy_not(is_not_real)
             elif ask(Q.positive(expr.base), assumptions):
                 return True
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -7,7 +7,7 @@ from sympy.core import Add, Basic, Expr, Mul, Pow, S
 from sympy.core.numbers import (AlgebraicNumber, ComplexInfinity, Exp1, Float,
     GoldenRatio, ImaginaryUnit, Infinity, Integer, NaN, NegativeInfinity,
     Number, NumberSymbol, Pi, pi, Rational, TribonacciConstant, E)
-from sympy.core.logic import fuzzy_bool, fuzzy_not
+from sympy.core.logic import fuzzy_bool, fuzzy_not, fuzzy_and
 from sympy.functions import (Abs, acos, acot, asin, atan, cos, cot, exp, im,
     log, re, sin, tan)
 from sympy.core.numbers import I
@@ -339,11 +339,13 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
-            if expr.exp.is_Rational and \
-                    ask(Q.even(expr.exp.q), assumptions):
-                return ask(Q.positive(expr.base), assumptions)
-            elif ask(Q.integer(expr.exp), assumptions):
-                is_not_real = ask_all(Q.zero(expr.base), Q.negative(expr.exp), assumptions=assumptions)
+            if (expr.exp.is_Rational and
+                    ask(Q.even(expr.exp.q), assumptions)):
+                return ask(Q.nonnegative(expr.base), assumptions)
+            base_is_zero = ask(Q.zero(expr.base), assumptions)
+            if base_is_zero or ask(Q.integer(expr.exp), assumptions):
+                is_not_real = fuzzy_and([base_is_zero,
+                                ask(Q.negative(expr.exp), assumptions)])
                 return fuzzy_not(is_not_real)
             elif ask(Q.positive(expr.base), assumptions):
                 return True

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -346,9 +346,9 @@ def _(expr, assumptions):
             if base_is_zero or ask(Q.integer(expr.exp), assumptions):
                 # Division by zero : If the base is 0 and the exponent
                 # is negative, ``expr`` evaluates to complex infinity.
-                expr_is_not_real = fuzzy_and([base_is_zero,
+                expr_is_complex_infinity = fuzzy_and([base_is_zero,
                                 ask(Q.negative(expr.exp), assumptions)])
-                return fuzzy_not(expr_is_not_real)
+                return fuzzy_not(expr_is_complex_infinity)
             elif ask(Q.positive(expr.base), assumptions):
                 return True
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -344,9 +344,11 @@ def _(expr, assumptions):
                 return ask(Q.nonnegative(expr.base), assumptions)
             base_is_zero = ask(Q.zero(expr.base), assumptions)
             if base_is_zero or ask(Q.integer(expr.exp), assumptions):
-                is_not_real = fuzzy_and([base_is_zero,
+                # Division by zero : If the base is 0 and the exponent
+                # is negative, ``expr`` evaluates to complex infinity.
+                expr_is_not_real = fuzzy_and([base_is_zero,
                                 ask(Q.negative(expr.exp), assumptions)])
-                return fuzzy_not(is_not_real)
+                return fuzzy_not(expr_is_not_real)
             elif ask(Q.positive(expr.base), assumptions):
                 return True
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -9,6 +9,7 @@ from sympy.assumptions.handlers import AskHandler
 from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)
 from sympy.core.add import Add
+from sympy.core.mul import Mul
 from sympy.core.numbers import (I, Integer, Rational, oo, zoo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
@@ -2071,6 +2072,7 @@ def test_real_pow():
     assert ask(Q.real(x**two_thirds), Q.zero(x)) is True
     assert ask(Q.real(x**pi), Q.zero(x)) is True
     assert ask(Q.real(x**sqrt(2)), Q.zero(x)) is True
+    assert ask(Q.real(x**Rational(1/2)), Q.zero(x)) is True
 
 
 @_both_exp_pow

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2062,16 +2062,16 @@ def test_real_pow():
     # https://github.com/sympy/sympy/issues/28142
     from sympy.core import Mul, Pow
     assert ask(Q.real(sqrt(x)), Q.real(x)) is None
-    one_half = Mul((S.One / 2), 1, evaluate=False)
+    one_half = Mul(S.Half, 1, evaluate=False)
     assert ask(Q.real(x ** one_half), Q.real(x)) is None
-    zero = symbols("zero", zero=True)
-    assert ask(Q.real(Pow(zero, 1, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, zero, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, -1, evaluate=False))) is False
+    assert ask(Q.real(Pow(x, 1, evaluate=False)), Q.zero(x)) is True
+    assert ask(Q.real(x**x), Q.zero(x)) is True
+    assert ask(Q.real(Pow(x, -1, evaluate=False)), Q.zero(x)) is False
     two_thirds = Rational(2, 3)
-    assert ask(Q.real(Pow(zero, two_thirds, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, pi, evaluate=False))) is True
-    assert ask(Q.real(Pow(zero, sqrt(2), evaluate=False))) is True
+    assert ask(Q.real(x**two_thirds), Q.zero(x)) is True
+    assert ask(Q.real(x**pi), Q.zero(x)) is True
+    assert ask(Q.real(x**sqrt(2)), Q.zero(x)) is True
+
 
 @_both_exp_pow
 def test_real_functions():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2059,6 +2059,16 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.zero(x) & Q.real(y)) is None
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
+    # https://github.com/sympy/sympy/issues/28142
+    from sympy.core import Mul, Pow
+    assert ask(Q.real(sqrt(x)), Q.real(x)) is None
+    one_half = Mul((S.One / 2), 1, evaluate=False)
+    assert ask(Q.real(x ** one_half), Q.real(x)) is None
+    zero = symbols("zero", zero=True)
+    assert ask(Q.real(Pow(zero, 1, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, zero, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, -1, evaluate=False))) is False
+
 
 @_both_exp_pow
 def test_real_functions():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2068,7 +2068,10 @@ def test_real_pow():
     assert ask(Q.real(Pow(zero, 1, evaluate=False))) is True
     assert ask(Q.real(Pow(zero, zero, evaluate=False))) is True
     assert ask(Q.real(Pow(zero, -1, evaluate=False))) is False
-
+    two_thirds = Rational(2, 3)
+    assert ask(Q.real(Pow(zero, two_thirds, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, pi, evaluate=False))) is True
+    assert ask(Q.real(Pow(zero, sqrt(2), evaluate=False))) is True
 
 @_both_exp_pow
 def test_real_functions():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2061,7 +2061,6 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.zero(x) & Q.positive(y)) is True
 
     # https://github.com/sympy/sympy/issues/28142
-    from sympy.core import Mul, Pow
     assert ask(Q.real(sqrt(x)), Q.real(x)) is None
     one_half = Mul(S.Half, 1, evaluate=False)
     assert ask(Q.real(x ** one_half), Q.real(x)) is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Completes/Continues: #28149 
Fixes: #28142

#### Brief description of what is fixed or changed
Corrected the `RealPredicate` handler for `Pow` function to give `None` instead of `True` for `ask(Q.real(sqrt(x)), Q.real(x))`

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Correct `ask(Q.real(sqrt(x)), Q.real(x))` into giving `None` instead of `True`.
<!-- END RELEASE NOTES -->
