### PR TITLE
printing: Escape leading/trailing underscores in latex symbols

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -409,6 +409,8 @@ Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.norepl
 Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
+Ayush Singh <9833ayush@gmail.com> Ayush Singh <111645429+Flamki@users.noreply.github.com>
+Ayush Singh <9833ayush@gmail.com> Flamki <9833ayush@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>
 B McG <bmcg0890@gmail.com>
 Baibhav Singh <baibhavsfs@gmail.com> B-CantCode <s.baibhav@op.iitg.ac.in>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1664,7 +1664,21 @@ class LatexPrinter(Printer):
         return (name, supers, subs)
 
     def _deal_with_super_sub(self, string: str, style='plain') -> str:
+        # Treat leading/trailing underscores as literal characters so names
+        # like "_x" or "x_" produce valid LaTeX output.
+        literal_uscore_prefix = ""
+        literal_uscore_suffix = ""
+        if not self._settings["disable_split_super_sub"] and string:
+            leading = len(string) - len(string.lstrip('_'))
+            trailing = len(string) - len(string.rstrip('_'))
+            if leading or trailing:
+                literal_uscore_prefix = r"\_" * leading
+                literal_uscore_suffix = r"\_" * trailing
+                end = len(string) - trailing if trailing else len(string)
+                string = string[leading:end]
+
         name, supers, subs = self._split_super_sub(string)
+        name = literal_uscore_prefix + name + literal_uscore_suffix
 
         # apply the style only to the name
         if style == 'bold':

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -431,6 +431,10 @@ def test_latex_symbols():
     assert latex(Symbol('e^Alpha')) == r"e^{\mathrm{A}}"
     assert latex(Symbol('omega_alpha^beta')) == r"\omega^{\beta}_{\alpha}"
     assert latex(Symbol('omega') ** Symbol('beta')) == r"\omega^{\beta}"
+    assert latex(Symbol('_x')) == r"\_x"
+    assert latex(2*Symbol('_x')) == r"2 \_x"
+    assert latex(Symbol('x_')) == r"x\_"
+    assert latex(Symbol('__x__')) == r"\_\_x\_\_"
 
 
 @XFAIL


### PR DESCRIPTION
﻿#### References to other Issues or PRs
Fixes #14718

#### Brief description of what is fixed or changed
Handle leading and trailing underscores in Symbol names as literal characters in LaTeX output, rather than parsing them as empty sub/superscripts.

This fixes malformed outputs such as:
- `latex(Symbol('_x'))` now gives `\_x`
- `latex(Symbol('x_'))` now gives `x\_`
- `latex(Symbol('__x__'))` now gives `\_\_x\_\_`

Added regression tests in `test_latex_symbols()`.

#### Other comments
Validation run locally:
- `python -m pytest sympy/printing/tests/test_latex.py`
- `python bin/test quality`
- `ruff check sympy/printing/latex.py sympy/printing/tests/test_latex.py`
- `flake8 sympy/printing/latex.py sympy/printing/tests/test_latex.py`

#### AI Generation Disclosure
Substantial AI assistance was used to draft and edit this patch and tests. The final code and test changes were manually reviewed and validated before submission.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->

* printing
  * Fixed LaTeX printing of symbol names with leading/trailing underscores, so names like `_x` and `x_` are emitted with escaped underscores instead of malformed sub/superscripts.

<!-- END RELEASE NOTES -->
