### PR TITLE
typing: Add type annotations to logic/inference.py (#28806)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -966,6 +966,7 @@ Lagaras Stelios <stel.lag@hotmail.com> lagamura <stel.lag@hotmail.com>
 Lakshya Agrawal <zeeshan.lakshya@gmail.com>
 Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>
+Larry St <coding2013@evv.bz>
 Laura Domine <temigo@gmx.com>
 Laura Pazini Medeiros <laurapazinimedeiros@gmail.com> Laura Pazini Medeiros <162479440+LauraPaziniMedeiros@users.noreply.github.com>
 Lauren Glattly <laurenglattly@gmail.com>

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -1,12 +1,16 @@
 """Inference in propositional logic"""
 
+from __future__ import annotations
+
+from typing import Any, Generator
+
 from sympy.logic.boolalg import And, Not, conjuncts, to_cnf, BooleanFunction
 from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
 
 
-def literal_symbol(literal):
+def literal_symbol(literal: Any) -> Any:
     """
     The symbol in this literal (without the negation).
 
@@ -30,7 +34,13 @@ def literal_symbol(literal):
         raise ValueError("Argument must be a boolean literal.")
 
 
-def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_theory=False):
+def satisfiable(
+    expr: Any,
+    algorithm: str | None = None,
+    all_models: bool = False,
+    minimal: bool = False,
+    use_lra_theory: bool = False
+) -> Any | Generator[Any | bool, None, None]:
     """
     Check satisfiability of a propositional sentence.
     Returns a model when it succeeds.
@@ -100,10 +110,10 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_t
 
     if algorithm == "dpll":
         from sympy.logic.algorithms.dpll import dpll_satisfiable
-        return dpll_satisfiable(expr)
+        return dpll_satisfiable(expr)  # type: ignore[call-arg]
     elif algorithm == "dpll2":
         from sympy.logic.algorithms.dpll2 import dpll_satisfiable
-        return dpll_satisfiable(expr, all_models, use_lra_theory=use_lra_theory)
+        return dpll_satisfiable(expr, all_models, use_lra_theory=use_lra_theory)  # type: ignore[call-arg]
     elif algorithm == "pycosat":
         from sympy.logic.algorithms.pycosat_wrapper import pycosat_satisfiable
         return pycosat_satisfiable(expr, all_models)


### PR DESCRIPTION
      1 ## Description
      2 
      3 This PR adds type annotations to `sympy/logic/inference.py` as part of the ongoing effort in #28806.
      4 
      5 ## Changes
      6 
      7 - Added `from __future__ import annotations` for modern type hint syntax
      8 - Added type hints to `literal_symbol()` function
      9 - Added type hints to `satisfiable()` function with proper Generator return type
     10 - Added `# type: ignore[call-arg]` for existing untyped function calls
     11 - Added .mailmap entry for Larry St
     12 
     13 ## Testing
     14 
     15 - mypy checks pass on modified file
     16 - mailmap check passes
     17 - Existing tests pass (no functional changes, only type annotations)
     18 
     19 ## Related
     20 
     21 Part of #28806 - Adding more type annotations to the codebase
     22 
     23 <!-- BEGIN RELEASE NOTES -->
     24 * logic
     25   * Added type annotations to `sympy/logic/inference.py` for better IDE support
     26 <!-- END RELEASE NOTES -->

