### PR TITLE
Fix #20435: FCodePrinter and Integer arguments

### DIFF
--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -298,8 +298,9 @@ class FCodePrinter(CodePrinter):
 
     def _print_Function(self, expr):
         # All constant function args are evaluated as floats
+        # except integer-typed arguments, which should remain as integers
         prec =  self._settings['precision']
-        args = [N(a, prec) for a in expr.args]
+        args = [a if (a.is_integer and a.free_symbols) else N(a, prec) for a in expr.args]
         eval_expr = expr.func(*args)
         if not isinstance(eval_expr, Function):
             return self._print(eval_expr)

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -223,6 +223,11 @@ def test_user_functions():
     n = symbols('n', integer=True)
     assert fcode(
         factorial(n), user_functions={"factorial": "fct"}) == "      fct(n)"
+    # Integer arguments should not be converted to floats (issue #20435)
+    x = symbols('x')
+    g = Function('g')
+    assert fcode(
+        g(n + 1, x**2), user_functions={"g": "myfunc"}) == "      myfunc(n + 1, x**2)"
 
 
 def test_inline_function():


### PR DESCRIPTION
Fixes #20435

## Summary
This PR fixes: FCodePrinter and Integer arguments

## Changes
```
sympy/printing/fortran.py            | 3 ++-
 sympy/printing/tests/test_fortran.py | 5 +++++
 2 files changed, 7 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*