### PR TITLE
Fix #20063: sympy.TableForm produces invalid math-mode latex

### DIFF
--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -24,11 +24,11 @@ class TableForm:
     format (ascii, latex, html, ...).
 
     >>> print(t.as_latex())
-    \begin{tabular}{l l}
-    $5$ & $7$ \\
-    $4$ & $2$ \\
-    $10$ & $3$ \\
-    \end{tabular}
+    \begin{array}{l l}
+    5 & 7 \\
+    4 & 2 \\
+    10 & 3 \\
+    \end{array}
 
     """
 
@@ -332,7 +332,7 @@ class TableForm:
             alignments = [self._head_align]
         alignments.extend(self._alignments)
 
-        s = r"\begin{tabular}{" + " ".join(alignments) + "}\n"
+        s = r"\begin{array}{" + " ".join(alignments) + "}\n"
 
         if self._headings[1]:
             d = self._headings[1]
@@ -358,9 +358,9 @@ class TableForm:
                     d.append(v)
                 else:
                     v = printer._print(x)
-                    d.append("$%s$" % v)
+                    d.append(v)
             if self._headings[0]:
                 d = [self._headings[0][i]] + d
             s += " & ".join(d) + r" \\" + "\n"
-        s += r"\end{tabular}"
+        s += r"\end{array}"
         return s

--- a/sympy/printing/tests/test_tableform.py
+++ b/sympy/printing/tests/test_tableform.py
@@ -104,57 +104,57 @@ def test_TableForm_latex():
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 &   & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 &   & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic"), alignments='l'))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 &   & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 &   & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic"), alignments='l'*3))
     assert s == (
-        '\\begin{tabular}{l l l}\n'
+        '\\begin{array}{l l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 &   & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 &   & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 & $a$ & $x^{3}$ \\\\\n'
-        '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 & a & x^{3} \\\\\n'
+        '2 & c & \\frac{1}{4} \\\\\n'
+        '3 & \\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             formats=['(%s)', None], headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
-        '1 & (a) & $x^{3}$ \\\\\n'
-        '2 & (c) & $\\frac{1}{4}$ \\\\\n'
-        '3 & (sqrt(x)) & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '1 & (a) & x^{3} \\\\\n'
+        '2 & (c) & \\frac{1}{4} \\\\\n'
+        '3 & (sqrt(x)) & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
 
     def neg_in_paren(x, i, j):
@@ -165,18 +165,24 @@ def test_TableForm_latex():
     s = latex(TableForm([[-1, 2], [-3, 4]],
             formats=[neg_in_paren]*2, headings=("automatic", "automatic")))
     assert s == (
-        '\\begin{tabular}{r l l}\n'
+        '\\begin{array}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
         '1 & -1 & 2 \\\\\n'
         '2 & (-3) & 4 \\\\\n'
-        '\\end{tabular}'
+        '\\end{array}'
     )
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]]))
     assert s == (
-        '\\begin{tabular}{l l}\n'
-        '$a$ & $x^{3}$ \\\\\n'
-        '$c$ & $\\frac{1}{4}$ \\\\\n'
-        '$\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
-        '\\end{tabular}'
+        '\\begin{array}{l l}\n'
+        'a & x^{3} \\\\\n'
+        'c & \\frac{1}{4} \\\\\n'
+        '\\sqrt{x} & \\sin{\\left(x^{2} \\right)} \\\\\n'
+        '\\end{array}'
     )
+    # Verify that the output is valid math-mode LaTeX (issue #20063):
+    # latex([t]) should produce valid nested LaTeX
+    t = TableForm([[1, 2]])
+    s = latex([t])
+    assert '\\begin{array}' in s
+    assert '\\begin{tabular}' not in s


### PR DESCRIPTION
Fixes #20063

## Summary
This PR fixes: sympy.TableForm produces invalid math-mode latex

## Changes
```
sympy/printing/tableform.py            | 16 ++++----
 sympy/printing/tests/test_tableform.py | 70 ++++++++++++++++++----------------
 2 files changed, 46 insertions(+), 40 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed TableForm LaTeX printing to produce valid math-mode output.
<!-- END RELEASE NOTES -->