### PR TITLE
assumptions: Adds a function to refine basic cases of binomial.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1542,6 +1542,7 @@ Sophia Pustova <tripplezzed@gmail.com>
 Soumendra Ganguly <soumendraganguly@gmail.com>
 Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
 Soumya Dipta Biswas <sdb1323@gmail.com>
+Soumya Sakshi <s1december2005@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
 Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -479,6 +479,20 @@ def refine_sin_cos(expr, assumptions):
     else:
         return ((-1)**((k + 1) / 2)) * sin(rem)
 
+
+def refine_binomial(expr, assumptions):
+    n , k = expr.args
+    if ask(Q.zero(k), assumptions):
+        return S.One
+    if ask(Q.zero(k - 1), assumptions):
+        return n
+    if ask(Q.integer(k), assumptions):
+        if ask(Q.negative(k), assumptions):
+            return S.Zero
+    if ask(Q.integer(n) & Q.nonnegative(n), assumptions) and ask(Q.negative(n - k), assumptions):
+        return S.Zero
+
+
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
@@ -490,4 +504,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'binomial': refine_binomial
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -4,6 +4,7 @@ from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
+from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -283,3 +284,11 @@ def test_sin_cos():
     assert refine(cos(x + n*pi/2 + k*pi/2 + m*pi/2), \
                   Q.odd(n) & Q.odd(k) & Q.integer(m)) == \
         (-1)**((n + k)/2) * cos(x + m*pi/2)
+
+def test_binomial():
+    n = Symbol('n')
+    k = Symbol('k')
+    assert refine(binomial(n, k), Q.integer(n) & Q.zero(k)) == S.One
+    assert refine(binomial(n, 1), Q.integer(n)) == n
+    assert refine(binomial(n, k), Q.integer(n) & Q.negative(k) & Q.integer(k)) == S.Zero
+    assert refine(binomial(n, k), Q.integer(n) & Q.negative(n - k) & Q.nonnegative(n)) == S.Zero


### PR DESCRIPTION
Adds a function to refine basic cases of binomial.

#### References to other Issues or PRs
Fixes part of #27888 


#### Brief description of what is fixed or changed
This PR adds a function with minimal code logic to refine following basic cases of `binomial(n, k)`:
- `k = 0`  returns 1
- `k = 1`  returns n
- `k < 0`  returns 0
- `k > n`  returns 0 ( when n = nonnegative integer)

#### Other comments
Currently the function covers only the above mentioned four cases out of many.
The function will be made exhaustive gradually.
Feedbacks welcomed!

#### AI Generation Disclosure
None of this code or text is AI generated

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added a new function to refine `binomial(n, k)`.
<!-- END RELEASE NOTES -->
