### PR TITLE
Typing egypt greedy

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1654,9 +1654,9 @@ Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
-Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
-Utkarsh Sahu <utkarsh.m.sahu@gmail.com> Utksahu <utkarsh.m.sahu@gmail.com>
 Utkarsh Sahu <utkarsh.m.sahu@gmail.com> utksahu <utkarsh.m.sahu@gmail.com>
+Utkarsh Sahu <utkarsh.m.sahu@gmail.com> Utksahu <utkarsh.m.sahu@gmail.com>
+Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1655,7 +1655,6 @@ Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
 Utkarsh Sahu <utkarsh.m.sahu@gmail.com> utksahu <utkarsh.m.sahu@gmail.com>
-Utkarsh Sahu <utkarsh.m.sahu@gmail.com> Utksahu <utkarsh.m.sahu@gmail.com>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1655,6 +1655,8 @@ Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
+Utkarsh Sahu <utkarsh.m.sahu@gmail.com> Utksahu <utkarsh.m.sahu@gmail.com>
+Utkarsh Sahu <utkarsh.m.sahu@gmail.com> utksahu <utkarsh.m.sahu@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ file is generated automatically by running `./bin/authors_update.py`.
 
 There are a total of 1450 authors.
 
+Utkarsh Sahu <utkarsh.m.sahu@gmail.com>
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
 Jurjen N.E. Bos <jnebos@gmail.com>

--- a/sympy/ntheory/egyptian_fraction.py
+++ b/sympy/ntheory/egyptian_fraction.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sympy.core.containers import Tuple
 from sympy.core.numbers import (Integer, Rational)
 from sympy.core.singleton import S
@@ -139,8 +140,7 @@ def egyptian_fraction(r, algorithm="Greedy"):
     return prefix + [Integer(i) for i in postfix]
 
 
-def egypt_greedy(x, y):
-    # assumes gcd(x, y) == 1
+def egypt_greedy(x: int, y: int) -> list[int]:    # assumes gcd(x, y) == 1
     if x == 1:
         return [y]
     else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
None

#### Brief description of what is fixed or changed
Added type annotations to `egypt_greedy` in `sympy/ntheory/egyptian_fraction.py`.

#### Other comments
First contribution.

#### AI Generation Disclosure
Used ChatGPT for guidance.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. -->

<!-- BEGIN RELEASE NOTES -->

* ntheory
  * Added type annotations to egypt_greedy.

<!-- END RELEASE NOTES -->