### PR TITLE
Docs: expose AccumulationBounds in calculus documentation

### DIFF
--- a/doc/src/modules/calculus/index.rst
+++ b/doc/src/modules/calculus/index.rst
@@ -10,6 +10,9 @@ Calculus
 .. automodule:: sympy.calculus.singularities
     :members:
 
+.. automodule:: sympy.calculus.accumulationbounds
+   :members:
+
 .. _finite_diff:
 
 .. automodule:: sympy.calculus.finite_diff


### PR DESCRIPTION
Fixes #29190

Adds the AccumulationBounds module to the calculus documentation so that its existing documentation is rendered correctly by Sphinx.