### PR TITLE
docs: expose LLVMPrinter and llvm_callable in printing docs

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -128,8 +128,27 @@ Usage::
 LLVM JIT Code Printing
 ----------------------
 
-.. automodule:: sympy.printing.llvmjitcode
+This module provides LLVM-based JIT compilation utilities for SymPy
+expressions.
+
+.. module:: sympy.printing.llvmjitcode
+
+LLVMPrinter
+^^^^^^^^^^^
+
+The ``LLVMPrinter`` class converts SymPy expressions into LLVM IR.
+
+.. autoclass:: sympy.printing.llvmjitcode.LLVMPrinter
    :members:
+   :show-inheritance:
+
+llvm_callable
+^^^^^^^^^^^^^
+
+The ``llvm_callable`` function creates a callable LLVM-compiled function
+from a SymPy expression.
+
+.. autofunction:: sympy.printing.llvmjitcode.llvm_callable
 
 RCodePrinter
 ------------


### PR DESCRIPTION
### References
Fixes #28470

### What is changed
This PR exposes the `LLVMPrinter` class and the `llvm_callable` function in the
Sphinx documentation.

The printing documentation previously only included a generic `automodule`
directive, which did not clearly document these public APIs. This change adds
explicit sections with `autoclass` and `autofunction` directives so that they
appear correctly on the documentation site.

### Why this is needed
The LLVM JIT printing utilities are part of the public API, but they were not
discoverable in the generated documentation. Making them visible improves
usability and aligns the docs with the actual functionality.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->