### PR TITLE
docs: fix LLVM JIT Code Printing module directive

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -128,8 +128,12 @@ Usage::
 LLVM JIT Code Printing
 ----------------------
 
-.. automodule:: sympy.printing.llvmjitcode
+.. module:: sympy.printing.llvmjitcode
+
+.. autoclass:: LLVMJitCodePrinter
    :members:
+
+.. autofunction:: llvm_callable
 
 RCodePrinter
 ------------


### PR DESCRIPTION
### What is changed
This PR fixes the Sphinx documentation for LLVM JIT code printing by replacing
an incorrect `automodule` directive with explicit `autoclass` and
`autofunction` directives.

### Why this is needed
Using `automodule` caused private/internal members to be exposed, which led
to Sphinx and doctest failures. Restricting the documentation to the public
API fixes the documentation build.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->