### PR TITLE
Clarify that eigenvects() returns a basis, not orthonormal eigenvectors

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -459,6 +459,17 @@ def _eigenvects(
 
     eigenvals
     MatrixBase.nullspace
+
+    Notes
+    =====
+
+    The eigenvectors returned form a basis of the eigenspace.
+    They are not guaranteed to be orthogonal or normalized,
+    even in the case of repeated eigenvalues.
+    If orthonormal eigenvectors are required, an additional
+    orthogonalization step (for example, Gram–Schmidt)
+    must be applied by the user.
+
     """
     primitive = simplify is not False
 


### PR DESCRIPTION
Clarify that eigenvects() returns a basis, not orthonormal eigenvectors

## Description

This PR clarifies that eigenvects() returns a basis of the eigenspace and does not guarantee orthogonal or normalized eigenvectors. The purpose of this PR is to avoid confusion for users who expect orthonormal eigenvectors (e.g., in physical applications involving mass matrices).
To be noted, no functional changes are introduced.

## Changes

Added a docstring stating what is expected from the code

## Reference to issue

Closes #29137 

## RELEASE NOTES 

* Clarified in documentation that eigenvects() returns a basis and does not guarantee orthonormal eigenvectors
