### PR TITLE
assumption: Fix `NonZeroPredicate` for `Pow` function

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -188,7 +188,9 @@ def _(expr, assumptions):
 
 @NonZeroPredicate.register(Pow)
 def _(expr, assumptions):
-    return ask(Q.nonzero(expr.base), assumptions)
+    return fuzzy_and([
+        ask(Q.nonzero(expr.base), assumptions), ask(Q.real(expr), assumptions)
+    ])
 
 @NonZeroPredicate.register(Abs)
 def _(expr, assumptions):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -189,7 +189,11 @@ def _(expr, assumptions):
 @NonZeroPredicate.register(Pow)
 def _(expr, assumptions):
     return fuzzy_and([
-        ask(Q.nonzero(expr.base), assumptions), ask(Q.real(expr), assumptions)
+        fuzzy_or([
+            ask(Q.nonzero(expr.base), assumptions),
+            ask(Q.zero(expr.exp), assumptions)
+        ]),
+        ask(Q.real(expr), assumptions)
     ])
 
 @NonZeroPredicate.register(Abs)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1757,7 +1757,12 @@ def test_nonzero():
     assert ask(Q.nonzero(x*y), Q.nonzero(x)) is None
     assert ask(Q.nonzero(x*y), Q.nonzero(x) & Q.nonzero(y)) is True
 
-    assert ask(Q.nonzero(x**y), Q.nonzero(x)) is True
+    assert ask(Q.nonzero(Pow(x, y), Q.nonzero(x))) is None
+    assert ask(Q.nonzero(Pow(x, y)), Q.positive(x) & Q.real(y)) is True
+    assert ask(Q.nonzero(Pow(5, 2*I*n*pi)), Q.integer(n)) is False
+    assert ask(Q.nonzero(Pow(0, x)), Q.positive(x)) is False
+    assert ask(Q.nonzero(Pow(5, I*n), Q.integer(n))) is None
+    assert ask(Q.nonzero(Pow(-1, x)), Q.real(x)) is None
 
     assert ask(Q.nonzero(Abs(x))) is None
     assert ask(Q.nonzero(Abs(x)), Q.nonzero(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1757,12 +1757,15 @@ def test_nonzero():
     assert ask(Q.nonzero(x*y), Q.nonzero(x)) is None
     assert ask(Q.nonzero(x*y), Q.nonzero(x) & Q.nonzero(y)) is True
 
+    # https://github.com/sympy/sympy/pull/29225
     assert ask(Q.nonzero(Pow(x, y), Q.nonzero(x))) is None
     assert ask(Q.nonzero(Pow(x, y)), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.nonzero(Pow(5, 2*I*n*pi)), Q.integer(n)) is False
     assert ask(Q.nonzero(Pow(0, x)), Q.positive(x)) is False
     assert ask(Q.nonzero(Pow(5, I*n), Q.integer(n))) is None
     assert ask(Q.nonzero(Pow(-1, x)), Q.real(x)) is None
+    assert ask(Q.nonzero(Pow(x, x)), Q.zero(x)) is True
+    assert ask(Q.nonzero(Pow(I, x)), Q.zero(x)) is True
 
     assert ask(Q.nonzero(Abs(x))) is None
     assert ask(Q.nonzero(Abs(x)), Q.nonzero(x)) is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Original Issue Comment : https://github.com/sympy/sympy/pull/29146#discussion_r2838384677

#### Brief description of what is fixed or changed
The handler of `NonZeroPredicate` for `Pow` was buggy only checking the base of the `Pow` function. Completely ignoring the the exponent part.

One example where it failed is
```python
print(ask(Q.nonzero(Pow(5, 2*I*n*pi)), Q.zero(n-1)))
```
The `expr` evaluates to a complex number, but completely ignoring the exponent, earlier it outputted `True`.

The handler has been fixed via this PR and tests have been added and one test has been rectified in `test_query.py`.  

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  assumptions
   * Fix bug where `ask(Q.nonzero(...), ...)` wrongly gave `True` in some cases.
<!-- END RELEASE NOTES -->
