### PR TITLE
Add type annotations to sympy/ntheory/bbp_pi.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -293,6 +293,7 @@ Alexey Pakhocmhik <cool.Bakov@yandex.ru>
 Alexey Subach <alexey.subach@gmail.com>
 Alexey U. Gudchenko <proga@goodok.ru>
 Alexis Schotte <alexis.schotte@gmail.com> AlexisSchotte <32765319+AlexisSchotte@users.noreply.github.com>
+Alfiya Patil <patilalfiya1@gmail.com>
 Alhussein Ashraf <alhusseinashraf55@gmail.com> Alhussein Ashraf <63222279+huss11ein@users.noreply.github.com>
 Alhussein Ashraf <alhusseinashraf55@gmail.com> huss11ein <alhusseinashraf55@gmail.com>
 Ali Raza Syed <arsyed@gmail.com>

--- a/sympy/ntheory/bbp_pi.py
+++ b/sympy/ntheory/bbp_pi.py
@@ -70,11 +70,12 @@ calculated for the given precision.
 array (perhaps just a matter of preference).
 
 '''
+from __future__ import annotations
 
 from sympy.utilities.misc import as_int
 
 
-def _series(j, n, prec=14):
+def _series(j: int, n: int, prec: int = 14) -> int:
 
     # Left sum from the bbp algorithm
     s = 0
@@ -106,7 +107,7 @@ def _series(j, n, prec=14):
     return total
 
 
-def pi_hex_digits(n, prec=14):
+def pi_hex_digits(n: int, prec: int = 14) -> str:
     """Returns a string containing ``prec`` (default 14) digits
     starting at the nth digit of pi in hex. Counting of digits
     starts at 0 and the decimal is not counted, so for n = 0 the
@@ -179,7 +180,7 @@ def pi_hex_digits(n, prec=14):
     return s
 
 
-def _dn(n, prec):
+def _dn(n: int, prec: int) -> int:
     # controller for n dependence on precision
     # n = starting digit index
     # prec = the number of total digits to compute


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Related to #28806


#### Brief description of what is fixed or changed

This PR adds explicit type annotations to the `bbp_pi` implementation
in `sympy/ntheory/bbp_pi.py`.

The changes improve type clarity and assist static type checking.
No runtime behavior has been modified.


#### Other comments

This PR replaces the previously closed submission (#29201)
and includes the required PR template.


#### AI Generation Disclosure

This PR was primarily authored by me. AI assistance was used
for guidance on type annotation syntax, but all code was
reviewed and verified manually.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->