### PR TITLE
Improve __hash__ docstring by adding a simple example

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1242,6 +1242,7 @@ Paul Scott <paul.scott@nicta.com.au>
 Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
 Paul Strickland <p.e.strickland@gmail.com>
 Pauli Virtanen <pav@iki.fi>
+Pavana K V <pavanakv557@gmail.com>
 Pavel Fedotov <fedotovp@gmail.com>
 Pavel Tkachenko <paveltkachenko@email.com>
 Pearu Peterson <pearu.peterson@gmail.com> pearu.peterson <devnull@localhost>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -319,6 +319,16 @@ class Basic(Printable):
         return super().__reduce_ex__(protocol)
 
     def __hash__(self) -> int:
+        """
+        Return the hash of the SymPy object.
+
+        Examples
+        ========
+        >>> from sympy import Symbol
+        >>> x = Symbol('x')
+        >>> isinstance(hash(x), int)
+        True
+        """
         # hash cannot be cached using cache_it because infinite recurrence
         # occurs as hash is needed for setting cache dictionary keys
         h = self._mhash


### PR DESCRIPTION
<!--
Please do not remove this template.
-->

This PR improves documentation clarity by adding a small usage example
to the __hash__ method in Basic. No functional changes are made.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->