### PR TITLE
Add type annotations to sympy/ntheory/multinomial.py

### DIFF
--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,7 +1,9 @@
+from typing import Iterator, SupportsIndex
+
 from sympy.utilities.misc import as_int
 
 
-def binomial_coefficients(n):
+def binomial_coefficients(n: SupportsIndex) -> dict[tuple[int, int], int]:
     """Return a dictionary containing pairs :math:`{(k1,k2) : C_kn}` where
     :math:`C_kn` are binomial coefficients and :math:`n=k1+k2`.
 
@@ -27,7 +29,7 @@ def binomial_coefficients(n):
     return d
 
 
-def binomial_coefficients_list(n):
+def binomial_coefficients_list(n: SupportsIndex) -> list[int]:
     """ Return a list of binomial coefficients as rows of the Pascal's
     triangle.
 
@@ -52,7 +54,7 @@ def binomial_coefficients_list(n):
     return d
 
 
-def multinomial_coefficients(m, n):
+def multinomial_coefficients(m: SupportsIndex, n: SupportsIndex) -> dict[tuple[int, ...], int]:
     r"""Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
     where ``C_kn`` are multinomial coefficients such that
     ``n=k1+k2+..+km``.
@@ -126,7 +128,7 @@ def multinomial_coefficients(m, n):
     return r
 
 
-def multinomial_coefficients_iterator(m, n, _tuple=tuple):
+def multinomial_coefficients_iterator(m: SupportsIndex, n: SupportsIndex, _tuple: type = tuple) -> Iterator[tuple[tuple[int, ...], int]]:
     """multinomial coefficient iterator
 
     This routine has been optimized for `m` large with respect to `n` by taking


### PR DESCRIPTION
Add type annotations for all public functions in the multinomial module:
- `binomial_coefficients`
- `binomial_coefficients_list`  
- `multinomial_coefficients`
- `multinomial_coefficients_iterator`

Uses `SupportsIndex` for parameters (consistent with `as_int` usage) and precise return types. Passes pyright strict mode with 0 errors.

All existing tests pass.

Issue: gh-28806