### PR TITLE
Add type annotations to sympy/utilities/source.py

### DIFF
--- a/sympy/utilities/source.py
+++ b/sympy/utilities/source.py
@@ -2,8 +2,10 @@
 This module adds several functions for interactive source code inspection.
 """
 
+from typing import Any
 
-def get_class(lookup_view):
+
+def get_class(lookup_view: str | Any) -> Any:
     """
     Convert a string version of a class name to the object.
 
@@ -21,7 +23,7 @@ def get_class(lookup_view):
     return lookup_view
 
 
-def get_mod_func(callback):
+def get_mod_func(callback: str) -> tuple[str, str]:
     """
     splits the string path to a class into a string path to the module
     and the name of the class.


### PR DESCRIPTION
Add type annotations for `get_class` and `get_mod_func` functions in the source inspection module.

- `get_class(lookup_view: str | Any) -> Any`
- `get_mod_func(callback: str) -> tuple[str, str]`

Passes pyright strict mode with 0 errors. All existing tests pass.

Issue: gh-28806