### PR TITLE
physics/mechanics: enforce @property in _Methods ABC abstractmethods

### DIFF
--- a/sympy/physics/mechanics/method.py
+++ b/sympy/physics/mechanics/method.py
@@ -3,37 +3,53 @@ from abc import ABC, abstractmethod
 class _Methods(ABC):
     """Abstract Base Class for all methods."""
 
+    @property
     @abstractmethod
     def q(self):
-        pass
+        """Generalized coordinates of the system."""
+        ...
 
+    @property
     @abstractmethod
     def u(self):
-        pass
+        """Generalized speeds of the system."""
+        ...
 
+    @property
     @abstractmethod
     def bodies(self):
-        pass
+        """Bodies in the system."""
+        ...
 
+    @property
     @abstractmethod
     def loads(self):
-        pass
+        """Loads applied to the system."""
+        ...
 
+    @property
     @abstractmethod
     def mass_matrix(self):
-        pass
+        """The mass matrix of the system."""
+        ...
 
+    @property
     @abstractmethod
     def forcing(self):
-        pass
+        """The forcing vector of the system."""
+        ...
 
+    @property
     @abstractmethod
     def mass_matrix_full(self):
-        pass
+        """The mass matrix of the system, augmented by the kinematic equations."""
+        ...
 
+    @property
     @abstractmethod
     def forcing_full(self):
-        pass
+        """The forcing vector of the system, augmented by the kinematic equations."""
+        ...
 
     def _form_eoms(self):
         raise NotImplementedError("Subclasses must implement this.")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

No related issue. 

#### Brief description of what is fixed or changed

`_Methods` is the abstract base class for `KanesMethod` and `LagrangesMethod`.
Both concrete classes expose the following attributes as `@property`:

- `q`, `u`, `bodies`, `loads`
- `mass_matrix`, `mass_matrix_full`
- `forcing`, `forcing_full`

However, `_Methods` declared all of these as plain `@abstractmethod` functions.
Python silently allows a `@property` in a subclass to satisfy a plain
`@abstractmethod`, so no error was raised, but the interface contract was
unenforced. A future subclass could implement `q()` as a regular callable
method, pass ABC checks without error, and introduce subtle access-pattern
bugs downstream.

Fix: stack `@property` above `@abstractmethod` for all eight attributes.
`@property` must be the outer decorator for correct behaviour. Bare `pass`
bodies are replaced with `...` and one-line docstrings are added to each
stub, following SymPy conventions.

Verified with ABC introspection, all eight members now show
`@property=True @abstractmethod=True`. `KanesMethod` and `LagrangesMethod`
still instantiate correctly. Attempting to instantiate `_Methods` directly
correctly raises `TypeError`.

#### Other comments

Only `sympy/physics/mechanics/method.py` is modified. No public API changes,
no behaviour changes for existing users.
```
515 passed, 2 deselected
```

All 515 existing `sympy/physics/mechanics/tests/` pass unchanged. The 2
deselected are slow/optional tests excluded by the `-q` flag, not failures.

#### AI Generation Disclosure

I used Claude as an assistive tool to help identify this
inconsistency when i was exploring the codebase of `sympy/physics/mechanics/`. The fix
was written and verified by me. I reviewed every line of the diff, ran the
full mechanics test suite locally (515 tests pass), performed ABC
introspection to confirm the fix is correct, and understand the change fully
before submitting.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->