### PR TITLE
Fix #28806: Add type annotations to conftest.py pytest hooks

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -24,7 +24,7 @@ except ImportError:
 sp = re.compile(r"([0-9]+)/([1-9][0-9]*)")
 
 
-def process_split(config, items):
+def process_split(config: "pytest.Config", items: "list[pytest.Item]") -> None:
     split = config.getoption("--split")
     if not split:
         return
@@ -41,14 +41,12 @@ def process_split(config, items):
         del items[end:]
     del items[:start]
 
-
-def pytest_report_header(config):
+def pytest_report_header(config: "pytest.Config") -> str:
     s = "architecture: %s\n" % ARCH
-    s += "cache:        %s\n" % USE_CACHE
+    s += "cache:         %s\n" % USE_CACHE
     version = ""
     if GROUND_TYPES == "gmpy":
         import gmpy2
-
         version = gmpy2.version()
     elif GROUND_TYPES == "flint":
         try:
@@ -60,15 +58,13 @@ def pytest_report_header(config):
     s += "ground types: %s %s\n" % (GROUND_TYPES, version)
     return s
 
-
-def pytest_terminal_summary(terminalreporter):
+def pytest_terminal_summary(terminalreporter: "pytest.TerminalReporter") -> None:
     if terminalreporter.stats.get("error", None) or terminalreporter.stats.get(
         "failed", None
     ):
         terminalreporter.write_sep(" ", "DO *NOT* COMMIT!", red=True, bold=True)
 
-
-def pytest_addoption(parser):
+def pytest_addoption(parser: "pytest.Parser") -> None:
     parser.addoption("--split", action="store", default="", help="split tests")
 
 


### PR DESCRIPTION
Fixes #28806

Added type hints to pytest functions in conftest.py:
- process_split(): pytest.Config → None  
- pytest_report_header(): pytest.Config → str
- pytest_terminal_summary(): pytest.TerminalReporter → None
- pytest_addoption(): pytest.Parser → None

First SymPy contribution! Interested in GSoC 2026 
Wrapping Geometries project.
