### PR TITLE
lint: don't use typing.List etc old-style type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+target-version = "py310"
 # Enable Pyflakes `E` and `F` codes by default.
 lint.select = [
     "B015",  # Useless comparison: a == b rather than a = b.
@@ -61,6 +62,9 @@ lint.select = [
     "TC005",
     "TRY002",
     "BLE001", # except Exception or except BaseException
+    "UP006", # pyupgrade - non-pep585-annotation
+    "UP007", # pyupgrade - non-pep604-annotation-union
+    "UP045", # pyupgrade - non-pep604-annotation-optional
 ]
 
 # Ignore rules that currently fail on the SymPy codebase

--- a/sympy/assumptions/relation/binrel.py
+++ b/sympy/assumptions/relation/binrel.py
@@ -2,7 +2,6 @@
 General binary relations.
 """
 from __future__ import annotations
-from typing import Optional
 
 from sympy.core.singleton import S
 from sympy.assumptions import AppliedPredicate, ask, Predicate, Q  # type: ignore
@@ -75,8 +74,8 @@ class BinaryRelation(Predicate):
     .. [1] https://en.wikipedia.org/wiki/Reflexive_relation
     """
 
-    is_reflexive: Optional[bool] = None
-    is_symmetric: Optional[bool] = None
+    is_reflexive: bool | None = None
+    is_symmetric: bool | None = None
 
     def __call__(self, *args):
         if not len(args) == 2:

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -14,7 +14,7 @@ from .sympify import SympifyError, sympify
 
 
 if TYPE_CHECKING:
-    from typing import Callable, TypeVar, Union
+    from typing import Callable, TypeVar
     T1 = TypeVar('T1')
     T2 = TypeVar('T2')
     T3 = TypeVar('T3')
@@ -112,7 +112,7 @@ def call_highest_priority(method_name: str
         def binary_op_wrapper(self: T1, other: T2) -> T3:
             if hasattr(other, '_op_priority'):
                 if other._op_priority > self._op_priority:  # type: ignore
-                    f: Union[Callable[[T1], T3], None] = getattr(other, method_name, None)
+                    f: Callable[[T1], T3] | None = getattr(other, method_name, None)
                     if f is not None:
                         return f(self)
             return func(self, other)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -3,7 +3,7 @@ Adaptive numerical evaluation of SymPy expressions, using mpmath
 for mathematical functions.
 """
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING, Any, overload, Type
+from typing import Callable, TYPE_CHECKING, Any, overload
 
 import math
 
@@ -1393,7 +1393,7 @@ def evalf_symbol(x: Expr, prec: int, options: OPT_DICT) -> TMP_RES:
         cache[x] = (v, prec)
         return v
 
-evalf_table: dict[Type[Expr], Callable[[Expr, int, OPT_DICT], TMP_RES]] = {}
+evalf_table: dict[type[Expr], Callable[[Expr, int, OPT_DICT], TMP_RES]] = {}
 
 
 def _create_evalf_table():

--- a/sympy/external/pythonmpq.py
+++ b/sympy/external/pythonmpq.py
@@ -35,7 +35,6 @@ from math import gcd
 from decimal import Decimal
 from fractions import Fraction
 import sys
-from typing import Type
 
 
 # Used for __hash__
@@ -331,7 +330,7 @@ class PythonMPQ:
         else:
             return NotImplemented
 
-    _compatible_types: tuple[Type, ...] = ()
+    _compatible_types: tuple[type, ...] = ()
 
 #
 # These are the types that PythonMPQ will interoperate with for operations

--- a/sympy/external/tests/test_pythonmpq.py
+++ b/sympy/external/tests/test_pythonmpq.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from fractions import Fraction
 from decimal import Decimal
 import pickle
-from typing import Callable, List, Tuple, Type
+from typing import Callable
 
 from sympy.testing.pytest import raises
 
@@ -18,7 +18,7 @@ from sympy.external.pythonmpq import PythonMPQ
 # If gmpy2 is installed then run the tests for both mpq and PythonMPQ.
 # That should ensure consistency between the implementation here and mpq.
 #
-rational_types: List[Tuple[Callable, Type, Callable, Type]]
+rational_types: list[tuple[Callable, type, Callable, type]]
 rational_types = [(PythonMPQ, PythonMPQ, int, int)]
 try:
     from gmpy2 import mpq, mpz

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -22,7 +22,7 @@ To enable simple substitutions, add the match to find_substitutions.
 """
 
 from __future__ import annotations
-from typing import NamedTuple, Type, Callable, Sequence, TYPE_CHECKING
+from typing import NamedTuple, Callable, Sequence, TYPE_CHECKING
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Mapping
@@ -1412,7 +1412,7 @@ def orthogonal_poly_rule(integral):
                     return orthogonal_poly_classes[klass](integrand, symbol, *integrand.args[:var_index])
 
 
-_special_function_patterns: list[tuple[Type, Expr, Callable | None, tuple]] = []
+_special_function_patterns: list[tuple[type, Expr, Callable | None, tuple]] = []
 _wilds = []
 _symbol = Dummy('x')
 

--- a/sympy/matrices/expressions/_shape.py
+++ b/sympy/matrices/expressions/_shape.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
+
 from sympy.core.relational import Eq
 from sympy.core.numbers import Integer
 from sympy.logic.boolalg import Boolean, And
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.matrices.exceptions import ShapeError
-from typing import Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
@@ -39,7 +40,7 @@ def is_matadd_valid(*args: MatrixExpr) -> Boolean:
     )
 
 
-def is_matmul_valid(*args: Union[MatrixExpr, Expr]) -> Boolean:
+def is_matmul_valid(*args: MatrixExpr | Expr) -> Boolean:
     """Return the symbolic condition how ``MatMul`` makes sense
 
     Parameters

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Type
+
 from sympy import Interval, numer, Rational, solveset
 from sympy.core.add import Add
 from sympy.core.basic import Basic
@@ -405,7 +405,7 @@ def gain_margin(system):
 class LinearTimeInvariant(Basic, EvalfMixin, ABC):
     """A common class for all the Linear Time-Invariant Dynamical Systems."""
 
-    _clstype: Type
+    _clstype: type
 
     # Users should not directly interact with this class.
     def __new__(cls, *system, **kwargs):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -9,7 +9,6 @@ TODO:
   AntiCommutator, represent, apply_operators.
 """
 from __future__ import annotations
-from typing import Optional
 
 from sympy.core.add import Add
 from sympy.core.expr import Expr
@@ -106,8 +105,8 @@ class Operator(QExpr):
     .. [1] https://en.wikipedia.org/wiki/Operator_%28physics%29
     .. [2] https://en.wikipedia.org/wiki/Observable
     """
-    is_hermitian: Optional[bool] = None
-    is_unitary: Optional[bool] = None
+    is_hermitian: bool | None = None
+    is_unitary: bool | None = None
     @classmethod
     def default_args(self):
         return ("O",)

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -4,7 +4,6 @@ Several methods to simplify expressions involving unit objects.
 from __future__ import annotations
 from functools import reduce
 from collections.abc import Iterable
-from typing import Optional
 
 from sympy import default_sort_key
 from sympy.core.add import Add
@@ -190,7 +189,7 @@ def quantity_simplify(expr, across_dimensions: bool=False, unit_system=None):
         dim_expr = unit_system.get_dimensional_expr(expr)
         dim_deps = dimension_system.get_dimensional_dependencies(dim_expr, mark_dimensionless=True)
 
-        target_dimension: Optional[Dimension] = None
+        target_dimension: Dimension | None = None
         for ds_dim, ds_dim_deps in dimension_system.dimensional_dependencies.items():
             if ds_dim_deps == dim_deps:
                 target_dimension = ds_dim

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, overload, Literal, Any, cast, Callable
+from typing import TYPE_CHECKING, overload, Literal, Any, cast, Callable
 
 from functools import wraps, reduce
 from operator import mul
@@ -6034,7 +6034,7 @@ def lcm_list(seq, *gens, **args):
     """
     seq = sympify(seq)
 
-    def try_non_polynomial_lcm(seq) -> Optional[Expr]:
+    def try_non_polynomial_lcm(seq) -> Expr | None:
         if not gens and not args:
             domain, numbers = construct_domain(seq)
 

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from sympy.external.gmpy import FMPQ_SERIES as fmpq_series
     from sympy.external.gmpy import FMPZ_POLY as fmpz_poly
     from sympy.external.gmpy import FMPZ_SERIES as fmpz_series
+    ZZSeries = fmpz_series | fmpz_poly
+    QQSeries = fmpq_series | fmpq_poly
 elif GROUND_TYPES == "flint":
     from flint import fmpq_poly, fmpq_series, fmpz_poly, fmpz_series, ctx
     from flint.utils.flint_exceptions import DomainError
@@ -32,11 +34,11 @@ elif GROUND_TYPES == "flint":
     _major, _minor, *_ = flint.__version__.split(".")
     if (int(_major), int(_minor)) >= (0, 8):
         _require_flint_version = True
+    ZZSeries = fmpz_series | fmpz_poly
+    QQSeries = fmpq_series | fmpq_poly
 else:
     fmpq_poly = fmpq_series = fmpz_poly = fmpz_series = ctx = None
-
-ZZSeries = fmpz_series | fmpz_poly
-QQSeries = fmpq_series | fmpq_poly
+    ZZSeries = QQSeries = None
 
 
 def _get_series_precision(s: fmpz_series | fmpq_series) -> int:

--- a/sympy/polys/series/ringflint.py
+++ b/sympy/polys/series/ringflint.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Sequence, Union, TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING
 
 from sympy.polys.densebasic import dup, dup_reverse
 from sympy.polys.domains import Domain, QQ, ZZ
@@ -35,8 +35,8 @@ elif GROUND_TYPES == "flint":
 else:
     fmpq_poly = fmpq_series = fmpz_poly = fmpz_series = ctx = None
 
-ZZSeries = Union[fmpz_series, fmpz_poly]
-QQSeries = Union[fmpq_series, fmpq_poly]
+ZZSeries = fmpz_series | fmpz_poly
+QQSeries = fmpq_series | fmpq_poly
 
 
 def _get_series_precision(s: fmpz_series | fmpq_series) -> int:

--- a/sympy/polys/series/ringpython.py
+++ b/sympy/polys/series/ringpython.py
@@ -5,7 +5,7 @@ from typing import Sequence, TYPE_CHECKING
 if TYPE_CHECKING:
     from sympy.polys.domains.field import Field
     from sympy.polys.domains.domain import Er, Ef
-    from typing import TypeAlias, Union
+    from typing import TypeAlias
 
 
 from sympy.polys.densearith import (
@@ -37,7 +37,7 @@ from sympy.external.gmpy import MPZ, MPQ
 from sympy.polys.ring_series import _giant_steps
 
 
-USeries: TypeAlias = "tuple[list[Er], Union[int, None]]"
+USeries: TypeAlias = "tuple[list[Er], int | None]"
 
 
 def _useries(

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -210,7 +210,7 @@ an expression when customizing a printer. Mistakes include:
 
 from __future__ import annotations
 import sys
-from typing import Any, Type
+from typing import Any
 import inspect
 from contextlib import contextmanager
 from functools import cmp_to_key, update_wrapper
@@ -389,7 +389,7 @@ class _PrintFunction:
     """
     Function wrapper to replace ``**settings`` in the signature with printer defaults
     """
-    def __init__(self, f, print_cls: Type[Printer]):
+    def __init__(self, f, print_cls: type[Printer]):
         # find all the non-setting arguments
         params = list(inspect.signature(f).parameters.values())
         assert params.pop(-1).kind == inspect.Parameter.VAR_KEYWORD

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -84,7 +84,7 @@ class SMTLibPrinter(Printer):
 
     symbol_table: dict
 
-    def __init__(self, settings: typing.Optional[dict] = None,
+    def __init__(self, settings: dict | None = None,
                  symbol_table=None):
         settings = settings or {}
         self.symbol_table = symbol_table or {}
@@ -103,7 +103,7 @@ class SMTLibPrinter(Printer):
         if s[0].isnumeric(): return False
         return all(_.isalnum() or _ == '_' for _ in s)
 
-    def _s_expr(self, op: str, args: typing.Union[list, tuple]) -> str:
+    def _s_expr(self, op: str, args: list | tuple) -> str:
         args_str = ' '.join(
             a if isinstance(a, str)
             else self._print(a)
@@ -144,7 +144,7 @@ class SMTLibPrinter(Printer):
             return self._s_expr(not_op, [self._s_expr(eq_op, e.args)])
 
     def _print_Piecewise(self, e: Piecewise):
-        def _print_Piecewise_recursive(args: typing.Union[list, tuple]):
+        def _print_Piecewise_recursive(args: list | tuple):
             e, c = args[0]
             if len(args) == 1:
                 assert (c is True) or isinstance(c, BooleanTrue)
@@ -454,7 +454,7 @@ def smtlib_code(
     ])
 
 
-def _auto_declare_smtlib(sym: typing.Union[Symbol, Function], p: SMTLibPrinter, log_warn: typing.Callable[[str], None]):
+def _auto_declare_smtlib(sym: Symbol | Function, p: SMTLibPrinter, log_warn: typing.Callable[[str], None]):
     if sym.is_Symbol:
         type_signature = p.symbol_table[sym]
         assert isinstance(type_signature, type)
@@ -491,7 +491,7 @@ def _auto_assert_smtlib(e: Expr, p: SMTLibPrinter, log_warn: typing.Callable[[st
 
 def _auto_infer_smtlib_types(
     *exprs: Basic,
-    symbol_table: typing.Optional[dict] = None
+    symbol_table: dict | None = None
 ) -> dict:
     # [TYPE INFERENCE RULES]
     # X is alone in an expr => X is bool

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -27,7 +27,7 @@ class _W(Enum):
 
 @contextlib.contextmanager
 def _check_warns(expected: typing.Iterable[_W]):
-    warns: typing.List[str] = []
+    warns: list[str] = []
     log_warn = warns.append
     yield log_warn
 

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import functools
-from typing import List
 
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
@@ -13,7 +12,7 @@ from sympy.utilities.iterables import flatten
 
 class DenseNDimArray(NDimArray):
 
-    _array: List[Basic]
+    _array: list[Basic]
 
     def __new__(self, *args, **kwargs):
         return ImmutableDenseNDimArray(*args, **kwargs)

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -1699,7 +1699,7 @@ class _EditArrayContraction:
     by calling the ``.to_array_contraction()`` method.
     """
 
-    def __init__(self, base_array: typing.Union[ArrayContraction, ArrayDiagonal, ArrayTensorProduct]):
+    def __init__(self, base_array: ArrayContraction | ArrayDiagonal | ArrayTensorProduct):
 
         expr: Basic
         diagonalized: tuple[tuple[int, ...], ...]
@@ -1933,7 +1933,7 @@ class _EditArrayContraction:
         self._track_permutation[index_destination].extend(self._track_permutation[index_element]) # type: ignore
         self._track_permutation.pop(index_element) # type: ignore
 
-    def get_absolute_free_range(self, arg: _ArgE) -> typing.Tuple[int, int]:
+    def get_absolute_free_range(self, arg: _ArgE) -> tuple[int, int]:
         """
         Return the range of the free indices of the arg as absolute positions
         among all free indices.
@@ -1946,7 +1946,7 @@ class _EditArrayContraction:
             counter += number_free_indices
         raise IndexError("argument not found")
 
-    def get_absolute_range(self, arg: _ArgE) -> typing.Tuple[int, int]:
+    def get_absolute_range(self, arg: _ArgE) -> tuple[int, int]:
         """
         Return the absolute range of indices for arg, disregarding dummy
         indices.

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import itertools
 from collections import defaultdict
-from typing import FrozenSet
 from functools import singledispatch
 from itertools import accumulate
 
@@ -780,7 +779,7 @@ def identify_hadamard_products(expr: ArrayContraction | ArrayDiagonal):
 
     editor: _EditArrayContraction = _EditArrayContraction(expr)
 
-    map_contr_to_args: dict[FrozenSet, list[_ArgE]] = defaultdict(list)
+    map_contr_to_args: dict[frozenset, list[_ArgE]] = defaultdict(list)
     map_ind_to_inds: dict[int | None, int] = defaultdict(int)
     for arg_with_ind in editor.args_with_ind:
         for ind in arg_with_ind.indices:
@@ -789,7 +788,7 @@ def identify_hadamard_products(expr: ArrayContraction | ArrayDiagonal):
             continue
         map_contr_to_args[frozenset(arg_with_ind.indices)].append(arg_with_ind)
 
-    k: FrozenSet[int]
+    k: frozenset[int]
     v: list[_ArgE]
     for k, v in map_contr_to_args.items():
         make_trace: bool = False

--- a/sympy/testing/runtests_pytest.py
+++ b/sympy/testing/runtests_pytest.py
@@ -28,7 +28,6 @@ import os
 import pathlib
 import re
 from fnmatch import fnmatch
-from typing import List, Optional, Tuple
 
 try:
     import pytest
@@ -96,10 +95,10 @@ def sympy_dir() -> pathlib.Path:
 
 
 def update_args_with_paths(
-    paths: List[str],
-    keywords: Optional[Tuple[str]],
-    args: List[str],
-) -> List[str]:
+    paths: list[str],
+    keywords: tuple[str] | None,
+    args: list[str],
+) -> list[str]:
     """Appends valid paths and flags to the args `list` passed to `pytest.main`.
 
     The are three different types of "path" that a user may pass to the `paths`

--- a/sympy/testing/tests/test_runtests_pytest.py
+++ b/sympy/testing/tests/test_runtests_pytest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import pathlib
-from typing import List
 from pathlib import Path
 import pytest
 
@@ -97,7 +96,7 @@ class TestUpdateArgsWithPaths:
             ),
         ]
     )
-    def test_multiple_paths_from_non_root(paths: List[str], expected_paths: List[str]):
+    def test_multiple_paths_from_non_root(paths: list[str], expected_paths: list[str]):
         """Multiple partial paths are matched correctly."""
         args = update_args_with_paths(paths=paths, keywords=None, args=[])
         assert len(args) == len(expected_paths)
@@ -116,7 +115,7 @@ class TestUpdateArgsWithPaths:
             ['sympy/physics/mechanics/tests/test_kane3.py'],
         ]
     )
-    def test_string_as_keyword(paths: List[str]):
+    def test_string_as_keyword(paths: list[str]):
         """String keywords are matched correctly."""
         keywords = ('bicycle', )
         args = update_args_with_paths(paths=paths, keywords=keywords, args=[])
@@ -136,7 +135,7 @@ class TestUpdateArgsWithPaths:
             ['sympy/core/tests/test_sympify.py'],
         ]
     )
-    def test_integer_as_keyword(paths: List[str]):
+    def test_integer_as_keyword(paths: list[str]):
         """Integer keywords are matched correctly."""
         keywords = ('3538', )
         args = update_args_with_paths(paths=paths, keywords=keywords, args=[])

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Optional
+from typing import Callable
 
 from collections import OrderedDict
 import os
@@ -63,7 +63,7 @@ class CompilerRunner:
     standards: tuple[None | str, ...]
 
     # Subclass to dict of binary/formater-callback
-    std_formater: dict[str, Callable[[Optional[str]], str]]
+    std_formater: dict[str, Callable[[str | None], str]]
 
     # subclass to be e.g. {'gcc': 'gnu', ...}
     compiler_name_vendor_mapping: dict[str, str]

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -3,8 +3,9 @@ The objects in this module allow the usage of the MatchPy pattern matching
 library on SymPy expressions.
 """
 from __future__ import annotations
+
 import re
-from typing import List, Callable, NamedTuple, Any, Dict, TYPE_CHECKING
+from typing import Callable, NamedTuple, Any, TYPE_CHECKING
 
 from sympy.core.sympify import _sympify
 from sympy.external import import_module
@@ -266,7 +267,7 @@ class Replacer:
         self._common_constraint = common_constraints
         self._lambdify = lambdify
         self._info = info
-        self._wildcards: Dict[str, Wildcard] = {}
+        self._wildcards: dict[str, Wildcard] = {}
 
     def _get_lambda(self, lambda_str: str) -> Callable[..., Expr]:
         exec("from sympy import *")
@@ -286,8 +287,8 @@ class Replacer:
     def _get_custom_constraint_true(self, constraint_expr: Expr) -> Callable[..., Expr]:
         return self._get_custom_constraint(constraint_expr, "({}) == True")
 
-    def add(self, expr: Expr, replacement, conditions_true: List[Expr] = [],
-            conditions_nonfalse: List[Expr] = [], info: Any = None) -> None:
+    def add(self, expr: Expr, replacement, conditions_true: list[Expr] = [],
+            conditions_nonfalse: list[Expr] = [], info: Any = None) -> None:
         expr = _sympify(expr)
         replacement = _sympify(replacement)
         constraints = self._common_constraint[:]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

There are many typing related PRs at the moment where old-style type annotations are being used like `List[int]` rather than `list[int]`. I think it is particularly prevalent because AI defaults to the older style. It is much easier to solve this with a linter rather than reviewing the same things in many PRs over and over.

#### Brief description of what is fixed or changed

Adds a lint rule requiring that type annotations use the new style like `X | Y` rather than `Union[X, Y]` or `T | None` rather than `Optional[T]` and built in types like `list`, `type` etc rather than `typing.List`, `typing.Type`.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->

No AI was used. Most changes are ruff's automatic fixes.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
