### PR TITLE
core: fix Mul._eval_is_integer for multiple non-integer factors

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1426,6 +1426,7 @@ class Mul(Expr, AssocOp):
         numerators = []
         denominators = []
         unknown = False
+        noninteger_count = 0
         for a in self.args:
             hit = False
             if a.is_integer:
@@ -1454,10 +1455,19 @@ class Mul(Expr, AssocOp):
                     # x**2, 2**x, or x**y with x and y int-unknown -> unknown
                     return
             else:
-                return
+                if a.is_integer is False:
+                    noninteger_count += 1
+                else:
+                    return
 
-        if not denominators and not unknown:
+        if not denominators and not unknown and noninteger_count == 0:
             return True
+
+        # If we have exactly one noninteger factor (that is not a Rational or Pow)
+        # and no numerators (meaning all integer factors had absolute value 1),
+        # then the product is ±(noninteger) which is noninteger.
+        if noninteger_count == 1 and not denominators and not unknown and not numerators:
+            return False
 
         allodd = lambda x: all(i.is_odd for i in x)
         alleven = lambda x: all(i.is_even for i in x)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -446,7 +446,7 @@ def test_Add_Mul_is_integer():
     nr = Symbol('nr', rational=False)
     nz = Symbol('nz', integer=True, zero=False)
 
-    assert (-nk).is_integer is None
+    assert (-nk).is_integer is False
     assert (-nr).is_integer is False
     assert (2*k).is_integer is True
     assert (-k).is_integer is True

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1105,7 +1105,6 @@ def test_issue_7899():
     assert ((x - I)*(x - 1)).is_real is None
 
 
-@XFAIL
 def test_issue_7993():
     x = Dummy(integer=True)
     y = Dummy(noninteger=True)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `Mul._eval_is_integer` to correctly return `False` for products like [(-y).is_integer](cci:1://file:///d:/sympy/sympy/core/mul.py:2220:4-2225:16) when `y` is noninteger, instead of returning `None`.
<!-- END RELEASE NOTES -->
