### PR TITLE
Add type annotation to smoothness function in ntheory/factor_.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -399,6 +399,7 @@ Avanish Salunke <avanishsalunke16@gmail.com> AvanishSalunke <avanishsalunke16@gm
 Avasam <samuel.06@hotmail.com>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>
 Avichal Dayal <avichal.dayal@gmail.com>
+Avijit Dutta <avijitdutta1230000@gmail.com> Avi123410 <abhijitdutta12340000@email.com>
 Ayden Alvarez <Aydenalv6282@gmail.com>
 Ayodeji Ige <ayodeji18@outlook.com>
 Ayush Aryan <ayush.aryan71@gmail.com> Ayush aryan <75092320+ayush3781@users.noreply.github.com>

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -26,7 +26,7 @@ from sympy.utilities.misc import as_int, filldedent
 from .ecm import _ecm_one_factor
 
 
-def smoothness(n):
+def smoothness(n: int) -> tuple[int, int]:
     """
     Return the B-smooth and B-power smooth values of n.
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2,7 +2,7 @@
 Integer factorization
 """
 from __future__ import annotations
-
+from typing import SupportsIndex
 from bisect import bisect_left
 from collections import defaultdict, OrderedDict
 from collections.abc import MutableMapping
@@ -26,7 +26,7 @@ from sympy.utilities.misc import as_int, filldedent
 from .ecm import _ecm_one_factor
 
 
-def smoothness(n: int) -> tuple[int, int]:
+def smoothness(n: SupportsIndex) -> tuple[int, int]:
     """
     Return the B-smooth and B-power smooth values of n.
 


### PR DESCRIPTION
Added type hints to smoothness function in ntheory/factor_.py

#### References to other Issues or PRs
Relates to #28806

#### Brief description of what is fixed or changed
Added type annotations to the `smoothness` function in `sympy/ntheory/factor_.py`:
- Parameter `n`: `int` 
- Return type: `tuple[int, int]`

This is part of the ongoing effort to add type annotations to the SymPy codebase to improve type checking and IDE support.

#### Other comments
The function was tested with `pytest sympy/ntheory/tests/test_factor_.py::test_smoothness_and_smoothness_p` and all tests passed.

#### AI Generation Disclosure
Used Claude AI assistant for guidance on contribution workflow and type annotation syntax. All code changes were written and reviewed by the human contributor.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->