### PR TITLE
fix diophantine() KeyError

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1329,8 +1329,8 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
                     'syms should be given as a sequence, e.g. a list')
             syms = [i for i in syms if i in var]
             if syms != var:
-                dict_sym_index = dict(zip(syms, range(len(syms))))
-                return {tuple([t[dict_sym_index[i]] for i in var])
+                dict_sym_index = dict(zip(var, range(len(var))))
+                return {tuple([t[dict_sym_index[i]] for i in syms])
                             for t in diophantine(eq, param, permute=permute)}
         n, d = eq.as_numer_denom()
         if n.is_number:

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1327,7 +1327,8 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
             if not is_sequence(syms):
                 raise TypeError(
                     'syms should be given as a sequence, e.g. a list')
-            syms = [i for i in syms if i in var]
+            if set(syms) != set(var):
+                raise ValueError("syms must contain all free symbols of the equation")
             if syms != var:
                 dict_sym_index = dict(zip(var, range(len(var))))
                 return {tuple([t[dict_sym_index[i]] for i in syms])

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -978,6 +978,10 @@ def test_issue_9538():
     raises(TypeError, lambda: diophantine(eq, syms={y, x}))
 
 
+def test_issue_29269():
+    assert diophantine(x + y + z - 3, syms=[x, y])
+
+
 def test_ternary_quadratic():
     # solution with 3 parameters
     s = diophantine(2*x**2 + y**2 - 2*z**2)

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -979,7 +979,8 @@ def test_issue_9538():
 
 
 def test_issue_29269():
-    assert diophantine(x + y + z - 3, syms=[x, y])
+    assert diophantine(x + y + z - 3, syms=[x, y]) == {(t_0, t_0 + t_1)}
+    assert diophantine(x + y + z - 3, syms=[y, x]) == {(t_0 + t_1, t_0)}
 
 
 def test_ternary_quadratic():

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -979,8 +979,8 @@ def test_issue_9538():
 
 
 def test_issue_29269():
-    assert diophantine(x + y + z - 3, syms=[x, y]) == {(t_0, t_0 + t_1)}
-    assert diophantine(x + y + z - 3, syms=[y, x]) == {(t_0 + t_1, t_0)}
+    raises(ValueError, lambda: diophantine(x + y + z - 3, syms=[x, y]))
+    raises(ValueError, lambda: diophantine(x + y + z - 3, syms=[y, x]))
 
 
 def test_ternary_quadratic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29269 

#### Brief description of what is fixed or changed
Following the maintainer's feedback, `diophantine()` is not intended to solve for a subset of variables while treating the missing ones as symbolic parameters.

Now it raises a `ValueError` if the provided `syms` list does not contain all the free symbols of the equation. 
#### Other comments
Added a test case

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
I used AI(gemini) to understand why the test was incorrect and how it could be fixed.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `diophantine()` now raises a `ValueError` if the `syms` argument does not include all free symbols, preventing a `KeyError` and incorrect partial solutions.
<!-- END RELEASE NOTES -->
