### PR TITLE
Fix 27662

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -399,6 +399,7 @@ Avanish Salunke <avanishsalunke16@gmail.com> AvanishSalunke <avanishsalunke16@gm
 Avasam <samuel.06@hotmail.com>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>
 Avichal Dayal <avichal.dayal@gmail.com>
+Avijit Dutta <avijitdutta1230000@gmail.com> Avi123410 <abhijitdutta12340000@email.com>
 Ayden Alvarez <Aydenalv6282@gmail.com>
 Ayodeji Ige <ayodeji18@outlook.com>
 Ayush Aryan <ayush.aryan71@gmail.com> Ayush aryan <75092320+ayush3781@users.noreply.github.com>

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -78,14 +78,20 @@ def satask(proposition, assumptions=True, context=global_assumptions,
         use_known_facts=use_known_facts, iterations=iterations)
     sat.add_from_cnf(assumptions)
 
-    # Check if assumptions themselves are contradictory
+   # Check if assumptions themselves are contradictory
     if not satisfiable(sat.copy()):
-        raise ValueError("Inconsistent assumptions")
+        raise ValueError("Contradictory assumptions")
     if context:
         sat.add_from_cnf(context_cnf)
 
     return check_satisfiability(props, _props, sat)
-
+    if result is None:
+        # Check if both proposition and negation are unsatisfiable (indeterminate)
+        pos = check_satisfiability(props, _props, sat)
+        neg = check_satisfiability(~props, _props, sat)
+        if pos is None and neg is None:
+            return None
+    return result
 
 def check_satisfiability(prop, _prop, factbase):
     sat_true = factbase.copy()
@@ -105,9 +111,7 @@ def check_satisfiability(prop, _prop, factbase):
         return False
 
     if not can_be_true and not can_be_false:
-        # If both can't be true and can't be false, the assumptions are contradictory
-        raise ValueError("Contradictory assumptions")
-
+        raise ValueError("Inconsistent assumptions")
 def extract_predargs(proposition, assumptions=None, context=None):
     """
     Extract every expression in the argument of predicates from *proposition*,

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -101,11 +101,8 @@ def check_satisfiability(prop, _prop, factbase):
         return False
 
     if not can_be_true and not can_be_false:
-        # If both can't be true and can't be false, return None
-        # This happens when the proposition is indeterminate (e.g., inf*0)
-        # or when assumptions on different variables create no valid model
-        return None
-
+        # If both can't be true and can't be false, the assumptions are contradictory
+        raise ValueError("Contradictory assumptions")
 
 def extract_predargs(proposition, assumptions=None, context=None):
     """

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -74,25 +74,30 @@ def satask(proposition, assumptions=True, context=global_assumptions,
     if context:
         context_cnf = context_cnf.extend(context)
 
+    # Check assumptions for contradiction using known facts but a neutral proposition
+    contradiction_check = get_all_relevant_facts(props, assumptions, context_cnf,
+        use_known_facts=use_known_facts, iterations=iterations)
+    contradiction_check.add_from_cnf(assumptions)
+    if context:
+        contradiction_check.add_from_cnf(context_cnf)
+    if not satisfiable(contradiction_check):
+        # Only raise if assumptions alone are contradictory, not the proposition
+        assumptions_only = get_all_relevant_facts(assumptions, assumptions, context_cnf,
+            use_known_facts=use_known_facts, iterations=iterations)
+        assumptions_only.add_from_cnf(assumptions)
+        if context:
+            assumptions_only.add_from_cnf(context_cnf)
+        if not satisfiable(assumptions_only):
+            raise ValueError("Contradictory assumptions")
+
     sat = get_all_relevant_facts(props, assumptions, context_cnf,
         use_known_facts=use_known_facts, iterations=iterations)
     sat.add_from_cnf(assumptions)
-
-   # Check if assumptions themselves are contradictory
-    if not satisfiable(sat.copy()):
-        raise ValueError("Contradictory assumptions")
     if context:
         sat.add_from_cnf(context_cnf)
 
-    return check_satisfiability(props, _props, sat)
-    if result is None:
-        # Check if both proposition and negation are unsatisfiable (indeterminate)
-        pos = check_satisfiability(props, _props, sat)
-        neg = check_satisfiability(~props, _props, sat)
-        if pos is None and neg is None:
-            return None
+    result = check_satisfiability(props, _props, sat)
     return result
-
 def check_satisfiability(prop, _prop, factbase):
     sat_true = factbase.copy()
     sat_false = factbase.copy()
@@ -111,7 +116,7 @@ def check_satisfiability(prop, _prop, factbase):
         return False
 
     if not can_be_true and not can_be_false:
-        raise ValueError("Inconsistent assumptions")
+        return None
 def extract_predargs(proposition, assumptions=None, context=None):
     """
     Extract every expression in the argument of predicates from *proposition*,

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -101,10 +101,10 @@ def check_satisfiability(prop, _prop, factbase):
         return False
 
     if not can_be_true and not can_be_false:
-        # TODO: Run additional checks to see which combination of the
-        # assumptions, global_assumptions, and relevant_facts are
-        # inconsistent.
-        raise ValueError("Inconsistent assumptions")
+        # If both can't be true and can't be false, return None
+        # This happens when the proposition is indeterminate (e.g., inf*0)
+        # or when assumptions on different variables create no valid model
+        return None
 
 
 def extract_predargs(proposition, assumptions=None, context=None):

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -77,6 +77,10 @@ def satask(proposition, assumptions=True, context=global_assumptions,
     sat = get_all_relevant_facts(props, assumptions, context_cnf,
         use_known_facts=use_known_facts, iterations=iterations)
     sat.add_from_cnf(assumptions)
+
+    # Check if assumptions themselves are contradictory
+    if not satisfiable(sat.copy()):
+        raise ValueError("Inconsistent assumptions")
     if context:
         sat.add_from_cnf(context_cnf)
 

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -376,3 +376,22 @@ def test_get_relevant_clsfacts():
 def test_issue_27467():
     s = sum(Dummy() for _ in range(10))
     assert all(len(CNF.to_CNF(f).clauses) < 1000 for f in class_fact_registry(s))
+
+def test_satask_indeterminate_issue_27662():
+    """Regression test for issue #27662.
+    satask() should return None for indeterminate cases, not raise ValueError.
+    """
+    x, y = symbols('x y')
+
+    # Core regression: inf * 0 is indeterminate, should return None
+    assert satask(Q.finite(x*y), Q.infinite(x) & Q.zero(y)) is None
+
+    # Genuinely contradictory assumptions should still raise ValueError
+    raises(ValueError, lambda: satask(Q.positive(x), Q.positive(x) & Q.negative(x)))
+
+    # Correct False result should still work
+    assert satask(Q.finite(x) & Q.zero(y), Q.infinite(x) & Q.zero(y)) == False
+
+    # Normal cases unaffected
+    assert satask(Q.positive(x), Q.positive(x)) == True
+    assert satask(Q.negative(x), Q.positive(x)) == False

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -26,7 +26,7 @@ from sympy.utilities.misc import as_int, filldedent
 from .ecm import _ecm_one_factor
 
 
-def smoothness(n: int) -> tuple[int, int]:
+def smoothness(n: SupportsIndex) -> tuple[int, int]:
     """
     Return the B-smooth and B-power smooth values of n.
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -26,7 +26,7 @@ from sympy.utilities.misc import as_int, filldedent
 from .ecm import _ecm_one_factor
 
 
-def smoothness(n):
+def smoothness(n: int) -> tuple[int, int]:
     """
     Return the B-smooth and B-power smooth values of n.
 


### PR DESCRIPTION
assumptions: fix satask() raising ValueError for indeterminate cases instead of returning None


 #### References to other Issues or PRs
Fixes #27662
#### Brief description of what is fixed or changed
`satask()` was raising `ValueError("Contradictory assumptions")` for
indeterminate cases like `satask(Q.finite(x*y), Q.infinite(x) & Q.zero(y))`
instead of returning `None`.

The contradiction check was running after `get_all_relevant_facts()` had
already loaded derived facts about the query proposition. When the fact system
reasoned about `x*y` given `infinite(x) & zero(y)`, it derived a contradiction
— but that contradiction belongs to the query, not the assumptions themselves.
`Q.infinite(x) & Q.zero(y)` are perfectly consistent assumptions; `x` and `y`
are independent symbols. The expression `x*y` is simply indeterminate (∞ * 0
is undefined), so `None` is the correct return value.

Fixed with a two-stage contradiction check:
1. Check using proposition facts — catches genuine contradictions like
   `Q.positive(x) & Q.negative(x)` which need the known fact system to detect
2. Tiebreaker using assumptions as their own proposition — if stage 1 says
   unsatisfiable, recheck in isolation without the query influencing which facts
   load. Indeterminate cases pass this check; genuine contradictions fail both.
#### Other comments
The key insight is that `get_all_relevant_facts()` loads different facts
depending on what proposition is passed. Passing the query proposition loads
facts about compound expressions like `x*y`, which can make valid assumptions
appear contradictory. Passing the assumptions themselves as the proposition
only loads facts about the symbols in the assumptions, which correctly
distinguishes the two cases.
#### AI Generation Disclosure
Yes I used Claude for better understanding the bug.
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `satask()` to return `None` for indeterminate cases (e.g.,
    `satask(Q.finite(x*y), Q.infinite(x) & Q.zero(y))`) instead of
    incorrectly raising `ValueError("Contradictory assumptions")`.
<!-- END RELEASE NOTES -->