### PR TITLE
fixed solve_tringulated valueerror

### DIFF
--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -386,6 +386,13 @@ def solve_triangulated(polys, *gens, **args):
         A List of tuples. Solutions for symbols that satisfy the
         equations listed in polys
 
+    Raises
+    ======
+
+    NotImplementedError
+        If the system is not zero-dimensional, that is it has 
+        infinitely many solutions.
+
     Examples
     ========
 
@@ -460,6 +467,11 @@ def solve_triangulated(polys, *gens, **args):
 
                     if g.degree(var) == h.degree():
                         H.append(h)
+
+            if not H:
+                raise NotImplementedError(
+                    "solve_triangulated only supports zero-dimensional systems "
+                    "(finitely many solutions)")
 
             p = min(H, key=lambda h: h.degree())
             zeros = _solve_univariate(p)

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -390,7 +390,7 @@ def solve_triangulated(polys, *gens, **args):
     ======
 
     NotImplementedError
-        If the system is not zero-dimensional, that is it has 
+        If the system is not zero-dimensional, that is it has
         infinitely many solutions.
 
     Examples

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -177,6 +177,8 @@ def test_solve_triangulated():
     assert solve_triangulated([f_1, f_2, f_3], x, y, z, extension=True) == \
         [(0, 0, 1), (0, 1, 0), (1, 0, 0), (a, a, a), (b, b, b)]
 
+    raises(NotImplementedError, lambda: solve_triangulated([x*y, y**2 - y], x, y))
+
 
 def test_solve_issue_3686():
     roots = solve_poly_system([((x - 5)**2/250000 + (y - Rational(5, 10))**2/250000) - 1, x], x, y)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29268 

#### Brief description of what is fixed or changed
`solve_triangulated` raises `ValueError: min() iterable argument is empty` when given a polynomial system with infinitely many solutions.

Fixed it with a check if `H` is empty and raise `NotImplementedError`.

```python
if not H:
    raise NotImplementedError(
        "solve_triangulated only supports zero-dimensional systems "
        "(finitely many solutions)")
```
#### Other comments
Added a test case

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solve_triangulated` now raises `NotImplementedError` instead of ValueError for systems with infinitely many solutions.
<!-- END RELEASE NOTES -->
