### PR TITLE
assumptions: refine sin/cos with further simplification using assumpt…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -487,6 +487,7 @@ Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@us
 Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>
 Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@users.noreply.github.com>
+Charlie Lam <888lamcharlie@gmail.com>
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -475,9 +475,13 @@ def refine_sin_cos(expr, assumptions):
     #    `cos(rem + k*pi/2)` -> `(-1)^((k+1)/2) * sin(rem)`
     rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
     if k_is_even:
-        return refine(((-1)**(k / 2)) * cos(rem), assumptions)
+        pow_expr = (-1)**(k / 2)
+        refined_pow = refine_Pow(pow_expr, assumptions)
+        return (pow_expr if refined_pow is None else refined_pow) * cos(rem)
     else:
-        return refine(((-1)**((k + 1) / 2)) * sin(rem), assumptions)
+        pow_expr = (-1)**((k + 1) / 2)
+        refined_pow = refine_Pow(pow_expr, assumptions)
+        return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
 
 def refine_floor_ceiling(expr, assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -416,15 +416,15 @@ def refine_sin_cos(expr, assumptions):
     >>> from sympy.abc import x, y
     >>> n = Symbol('n')
     >>> refine_sin_cos(cos(n*pi), Q.even(n))
-    (-1)**n
+    1
     >>> refine_sin_cos(sin(n*pi/2), Q.odd(n) & Q.odd((n-1)/2))
-    (-1)**(n/2 - 1/2)
+    -1
     >>> refine_sin_cos(sin(x + n*pi/2), Q.odd(n))
-    (-1)**(n/2 - 1/2)*cos(x)
+    (-1)**(n/2 + 3/2)*cos(x)
     >>> refine_sin_cos(cos(x + n*pi/2), Q.even(n))
     (-1)**(n/2)*cos(x)
     >>> refine_sin_cos(cos(x + y + 2*n*pi), Q.integer(n))
-    (-1)**(2*n)*cos(x + y)
+    cos(x + y)
     """
     from sympy.functions.elementary.trigonometric import sin, cos
     arg = expr.args[0]

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -475,9 +475,9 @@ def refine_sin_cos(expr, assumptions):
     #    `cos(rem + k*pi/2)` -> `(-1)^((k+1)/2) * sin(rem)`
     rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
     if k_is_even:
-        return ((-1)**(k / 2)) * cos(rem)
+        return refine(((-1)**(k / 2)) * cos(rem), assumptions)
     else:
-        return ((-1)**((k + 1) / 2)) * sin(rem)
+        return refine(((-1)**((k + 1) / 2)) * sin(rem), assumptions)
 
 
 def refine_floor_ceiling(expr, assumptions):


### PR DESCRIPTION
assumptions: refine sin/cos applies further simplification using assumptions

#### References to other Issues or PRs
Fixes part of #27888

#### Brief description of what is fixed or changed
refine_sin_cos was returning expressions like (-1)**n without further 
simplifying using the given assumptions. Wrapping the return value in 
refine() allows assumptions like Q.odd(n) and Q.even(n) to be applied, 
so cos(n*pi) now correctly returns -1 or 1 respectively.

#### Other comments

#### AI Generation Disclosure


#### Release Notes
<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->