### PR TITLE
perf: use deque for AndOr_Base.flatten queue

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1881,3 +1881,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Giulio Leone <giulio97.leone@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -704,6 +704,7 @@ Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>
 Gina <Dr-G@users.noreply.github.com>
+Giulio Leone <giulio97.leone@gmail.com>
 Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -9,6 +9,8 @@ this stuff for general purpose.
 
 from __future__ import annotations
 
+from collections import deque
+
 # Type of a fuzzy bool
 FuzzyBool = bool | None
 
@@ -329,14 +331,11 @@ class AndOr_Base(Logic):
     @classmethod
     def flatten(cls, args):
         # quick-n-dirty flattening for And and Or
-        args_queue = list(args)
+        args_queue = deque(args)
         res = []
 
-        while True:
-            try:
-                arg = args_queue.pop(0)
-            except IndexError:
-                break
+        while args_queue:
+            arg = args_queue.popleft()
             if isinstance(arg, Logic):
                 if isinstance(arg, cls):
                     args_queue.extend(arg.args)


### PR DESCRIPTION
#### References to other Issues or PRs
None — performance improvement.

#### Brief description of what is fixed or changed
Replaces `list` with `collections.deque` for the BFS queue in `AndOr_Base.flatten`. The original code uses `args.pop(0)` which is O(n) for a list. Using `deque.popleft()` makes this O(1), improving flatten performance for expressions with many arguments.

#### Other comments
The change is a drop-in replacement — `deque` supports all the methods used: `popleft()`, `extend()`, and truthiness check.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* logic
  * use deque for BFS queue in AndOr_Base.flatten for O(1) popleft
<!-- END RELEASE NOTES -->

#### Generative AI Disclosure
GitHub Copilot was used to assist with identifying the performance issue and suggesting the fix.