### PR TITLE
Snapshot testing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,3 +18,6 @@ include AUTHORS
 include README.md
 include bin/isympy
 exclude MANIFEST.in
+include bin/snapshot
+include snapshot_test.md
+include sympy/testing/tests/test_solving_guidance.md

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -26,8 +26,8 @@ options, args = parser.parse_known_args()
 ok = run_snapshot_tests(options, args)
 
 if ok:
-    print(f"All okay.")
+    print("All okay.")
     sys.exit(0)
 else:
-    print(f"All not okay.")
+    print("All not okay.")
     sys.exit(1)

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -7,158 +7,12 @@ from get_sympy import path_hack
 path_hack()
 
 from argparse import ArgumentParser
-import doctest as pdoctest
-import os
+from sympy.testing.snapshot import run_snapshot_tests
 import sys
-
-from sympy.testing.runtests import (
-    SymPyDocTestRunner,
-    SymPyOutputChecker,
-    SymPyTestResults,
-)
-
-
-class SymPySnapshotRunner(SymPyDocTestRunner):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.snapshot_mismatches = []
-
-    def report_failure(self, out, test, example, got):
-        # Record mismatches
-        self.snapshot_mismatches.append({
-            "filename": test.filename,
-            "lineno": example.lineno,
-            "source": example.source,
-            "want": example.want,
-            "got": got,
-        })
-
-        self._fakeout.truncate(0)
-        self._fakeout.seek(0)
-
-
-# Monkeypatch name-mangled methods for SnapshotRunner
-monkeypatched_snapshot_methods = [
-    'report_failure',
-]
-
-for method in monkeypatched_snapshot_methods:
-    oldname = '_DocTestRunner__' + method
-    newname = '_SymPySnapshotRunner__' + method
-    setattr(SymPySnapshotRunner, newname, getattr(SymPySnapshotRunner, method))
-
-
-def apply_snapshot_updates(filename, mismatches):
-    with open(filename, "r", encoding="utf-8") as f:
-        lines = f.readlines()
-
-    for m in reversed(mismatches):
-        lineno = m["lineno"] - 1
-        source_lines = m["source"].count("\n") + 1
-
-        out_start = lineno + source_lines
-        out_end = out_start
-
-        # go through old expected output
-        while out_end < len(lines):
-            line = lines[out_end]
-            if line.lstrip().startswith(">>>") or line.lstrip().startswith("```"):
-                break
-            out_end += 1
-
-        new_output = m["got"].rstrip("\n").splitlines(keepends=True)
-        new_output = [l + "\n" for l in new_output]
-
-        # replace it with new output
-        lines[out_start:out_end] = new_output
-
-    with open(filename, "w", encoding="utf-8") as f:
-        f.writelines(lines)
-
-
-# This function is same as sympytestfile, with minor changes adapted to snapshot testing.
-def snapshot_testfile(filename, module_relative=True, name=None, package=None,
-             globs=None, verbose=None, report=True, optionflags=0,
-             extraglobs=None, raise_on_error=False,
-             parser=pdoctest.DocTestParser(), encoding=None, update=False):
-
-    if package and not module_relative:
-        raise ValueError("Package may only be specified for module-"
-                         "relative paths.")
-
-    # Relativize the path
-    text, filename = pdoctest._load_testfile(
-        filename, package, module_relative, encoding)
-
-    # If no name was given, then use the file's name.
-    if name is None:
-        name = os.path.basename(filename)
-
-    # Assemble the globals.
-    if globs is None:
-        globs = {}
-    else:
-        globs = globs.copy()
-    if extraglobs is not None:
-        globs.update(extraglobs)
-    if '__name__' not in globs:
-        globs['__name__'] = '__main__'
-
-    if raise_on_error:
-        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
-    else:
-        runner = SymPySnapshotRunner(verbose=verbose, optionflags=optionflags)
-        runner._checker = SymPyOutputChecker()
-
-    # Read the file, convert it to a test, and run it.
-    test = parser.get_doctest(text, globs, name, filename, 0)
-    print(f"{filename}: {len(test.examples)} examples")
-    runner.run(test)
-
-    print(f"Tried: {runner.tries}")
-    print(f"Snapshot mismatches: {len(runner.snapshot_mismatches)}")
-
-    if report:
-        runner.summarize()
-
-    if pdoctest.master is None:
-        pdoctest.master = runner
-    else:
-        pdoctest.master.merge(runner)
-
-    if hasattr(runner, "snapshot_mismatches"):
-        for m in runner.snapshot_mismatches:
-            print(f"Snapshot mismatch in {m['filename']}:{m['lineno']}")
-            print(m["source"].rstrip())
-            print("--- expected")
-            print(m["want"].rstrip())
-            print("+++ got")
-            print(m["got"].rstrip())
-
-    mismatches = getattr(runner, "snapshot_mismatches", [])
-
-    if update and mismatches:
-        apply_snapshot_updates(filename, mismatches)
-        return SymPyTestResults(0, runner.tries)
-
-    return SymPyTestResults(len(mismatches), runner.tries)
-
-
-def iter_markdown_files(paths):
-    for path in paths:
-        if os.path.isdir(path):
-            for root, _, files in os.walk(path):
-                for f in files:
-                    if f.endswith(".md"):
-                        yield os.path.join(root, f)
-        else:
-            if path.endswith(".md"):
-                yield path
 
 
 epilog = """
 "options" are any of the options above.
-If no file arguments are given, all snapshot tests will be run.
 This program executes or updates the snapshot tests.
 """
 
@@ -168,36 +22,8 @@ parser.add_argument(
     help="Update snapshot outputs.")
 
 options, args = parser.parse_known_args()
-all_files = list(iter_markdown_files(args))
-ok = True
 
-if not all_files:
-    print("No markdown files found.")
-    sys.exit(0)
-
-for filename in all_files:
-    print(f"Running snapshot tests: {filename}")
-    try:
-        failures, attempted = snapshot_testfile(
-            filename=filename,
-            module_relative=False,
-            encoding="utf-8",
-            optionflags=(
-                pdoctest.ELLIPSIS |
-                pdoctest.NORMALIZE_WHITESPACE |
-                pdoctest.IGNORE_EXCEPTION_DETAIL
-            ),
-            update=options.update
-        )
-    except Exception as e:
-        print(f"Error while testing {filename}: {e}")
-        ok = False
-        continue
-
-    if failures and not options.update:
-        ok = False
-    else:
-        print(f"Succesfully tested {filename}.")
+ok = run_snapshot_tests(options, args)
 
 if ok:
     print(f"All okay.")

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+"""
+Program to execute or update the snapshot tests.
+"""
+
+from get_sympy import path_hack
+path_hack()
+
+from argparse import ArgumentParser
+import doctest as pdoctest
+import os
+import sys
+
+from sympy.testing.runtests import (
+    SymPyDocTestRunner,
+    SymPyOutputChecker,
+    SymPyTestResults,
+)
+
+
+class SymPySnapshotRunner(SymPyDocTestRunner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.snapshot_mismatches = []
+
+    def report_failure(self, out, test, example, got):
+        # Record mismatches
+        self.snapshot_mismatches.append({
+            "filename": test.filename,
+            "lineno": example.lineno,
+            "source": example.source,
+            "want": example.want,
+            "got": got,
+        })
+
+        self._fakeout.truncate(0)
+        self._fakeout.seek(0)
+
+
+# Monkeypatch name-mangled methods for SnapshotRunner
+monkeypatched_snapshot_methods = [
+    'report_failure',
+]
+
+for method in monkeypatched_snapshot_methods:
+    oldname = '_DocTestRunner__' + method
+    newname = '_SymPySnapshotRunner__' + method
+    setattr(SymPySnapshotRunner, newname, getattr(SymPySnapshotRunner, method))
+
+
+def apply_snapshot_updates(filename, mismatches):
+    with open(filename, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for m in reversed(mismatches):
+        lineno = m["lineno"] - 1
+        source_lines = m["source"].count("\n") + 1
+
+        out_start = lineno + source_lines
+        out_end = out_start
+
+        # go through old expected output
+        while out_end < len(lines):
+            line = lines[out_end]
+            if line.lstrip().startswith(">>>") or line.lstrip().startswith("```"):
+                break
+            out_end += 1
+
+        new_output = m["got"].rstrip("\n").splitlines(keepends=True)
+        new_output = [l + "\n" for l in new_output]
+
+        # replace it with new output
+        lines[out_start:out_end] = new_output
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+# This function is same as sympytestfile, with minor changes adapted to snapshot testing.
+def snapshot_testfile(filename, module_relative=True, name=None, package=None,
+             globs=None, verbose=None, report=True, optionflags=0,
+             extraglobs=None, raise_on_error=False,
+             parser=pdoctest.DocTestParser(), encoding=None, update=False):
+
+    if package and not module_relative:
+        raise ValueError("Package may only be specified for module-"
+                         "relative paths.")
+
+    # Relativize the path
+    text, filename = pdoctest._load_testfile(
+        filename, package, module_relative, encoding)
+
+    # If no name was given, then use the file's name.
+    if name is None:
+        name = os.path.basename(filename)
+
+    # Assemble the globals.
+    if globs is None:
+        globs = {}
+    else:
+        globs = globs.copy()
+    if extraglobs is not None:
+        globs.update(extraglobs)
+    if '__name__' not in globs:
+        globs['__name__'] = '__main__'
+
+    if raise_on_error:
+        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
+    else:
+        runner = SymPySnapshotRunner(verbose=verbose, optionflags=optionflags)
+        runner._checker = SymPyOutputChecker()
+
+    # Read the file, convert it to a test, and run it.
+    test = parser.get_doctest(text, globs, name, filename, 0)
+    print(f"{filename}: {len(test.examples)} examples")
+    runner.run(test)
+
+    print(f"Tried: {runner.tries}")
+    print(f"Snapshot mismatches: {len(runner.snapshot_mismatches)}")
+
+    if report:
+        runner.summarize()
+
+    if pdoctest.master is None:
+        pdoctest.master = runner
+    else:
+        pdoctest.master.merge(runner)
+
+    if hasattr(runner, "snapshot_mismatches"):
+        for m in runner.snapshot_mismatches:
+            print(f"Snapshot mismatch in {m['filename']}:{m['lineno']}")
+            print(m["source"].rstrip())
+            print("--- expected")
+            print(m["want"].rstrip())
+            print("+++ got")
+            print(m["got"].rstrip())
+
+    mismatches = getattr(runner, "snapshot_mismatches", [])
+
+    if update and mismatches:
+        apply_snapshot_updates(filename, mismatches)
+        return SymPyTestResults(0, runner.tries)
+
+    return SymPyTestResults(len(mismatches), runner.tries)
+
+
+def iter_markdown_files(paths):
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for f in files:
+                    if f.endswith(".md"):
+                        yield os.path.join(root, f)
+        else:
+            if path.endswith(".md"):
+                yield path
+
+
+epilog = """
+"options" are any of the options above.
+If no file arguments are given, all snapshot tests will be run.
+This program executes or updates the snapshot tests.
+"""
+
+parser = ArgumentParser(epilog=epilog)
+parser.add_argument(
+    "-u", "--update", action="store_true", dest="update", default=False,
+    help="Update snapshot outputs.")
+
+options, args = parser.parse_known_args()
+all_files = list(iter_markdown_files(args))
+ok = True
+
+if not all_files:
+    print("No markdown files found.")
+    sys.exit(0)
+
+for filename in all_files:
+    print(f"Running snapshot tests: {filename}")
+    try:
+        failures, attempted = snapshot_testfile(
+            filename=filename,
+            module_relative=False,
+            encoding="utf-8",
+            optionflags=(
+                pdoctest.ELLIPSIS |
+                pdoctest.NORMALIZE_WHITESPACE |
+                pdoctest.IGNORE_EXCEPTION_DETAIL
+            ),
+            update=options.update
+        )
+    except Exception as e:
+        print(f"Error while testing {filename}: {e}")
+        ok = False
+        continue
+
+    if failures and not options.update:
+        ok = False
+    else:
+        print(f"Succesfully tested {filename}.")
+
+if ok:
+    print(f"All okay.")
+    sys.exit(0)
+else:
+    print(f"All not okay.")
+    sys.exit(1)

--- a/snapshot_test.md
+++ b/snapshot_test.md
@@ -1,13 +1,31 @@
+# preamble section for setup
 ```py
->>> from sympy import symbols, cancel, simplify
+>>> from sympy import symbols, simplify, integrate, cancel
 >>> x = symbols('x')
+```
+
+# testing the simplify function
+```py
 >>> simplify(x * (x + 1))
 x*(x + 1)
 >>> simplify(x - x)
 100
 >>> simplify(x * (1 - x) + x * (x - 1))
-10
->>> cancel((x ** 2 - 1) / (x - 1))
+67
+```
+
+# testing the cancel function
+```py
+>>> cancel((x ** 2 - 1)/(x - 1))
 x + 1
 >>> cancel((x + 1 - 1)/x)
-(x + 1)/x
+x
+```
+
+# testing the integration capabilities of sympy
+```py
+>>> integrate(x)
+x**2/2
+>>> integrate(2 * x)
+x**3
+```

--- a/snapshot_test.md
+++ b/snapshot_test.md
@@ -1,31 +1,50 @@
 # preamble section for setup
+This section can be used as the preamble.
+I setup the commonly used symbol x, and import functions I need.
 ```py
 >>> from sympy import symbols, simplify, integrate, cancel
 >>> x = symbols('x')
 ```
 
 # testing the simplify function
+These are basic tests of calling simplify with polynomial expressions.
+The expected behaviour is not necessarily that it will call factor.
 ```py
 >>> simplify(x * (x + 1))
 x*(x + 1)
 >>> simplify(x - x)
-100
+0
 >>> simplify(x * (1 - x) + x * (x - 1))
-67
+0
 ```
 
 # testing the cancel function
+cancel function can be used for rational functions to remove the common factors
 ```py
 >>> cancel((x ** 2 - 1)/(x - 1))
 x + 1
 >>> cancel((x + 1 - 1)/x)
-x
+1
 ```
 
 # testing the integration capabilities of sympy
+this performs indefinite integration wrt x
 ```py
 >>> integrate(x)
 x**2/2
 >>> integrate(2 * x)
-x**3
+x**2
+```
+
+
+# testing basic exceptions in python
+```py
+>>> 1 / 0
+11
+```
+
+# testing some other errors
+```py
+>>> 1 + "sympy"
+11
 ```

--- a/snapshot_test.md
+++ b/snapshot_test.md
@@ -1,0 +1,13 @@
+```py
+>>> from sympy import symbols, cancel, simplify
+>>> x = symbols('x')
+>>> simplify(x * (x + 1))
+x*(x + 1)
+>>> simplify(x - x)
+100
+>>> simplify(x * (1 - x) + x * (x - 1))
+10
+>>> cancel((x ** 2 - 1) / (x - 1))
+x + 1
+>>> cancel((x + 1 - 1)/x)
+(x + 1)/x

--- a/sympy/testing/snapshot.py
+++ b/sympy/testing/snapshot.py
@@ -1,0 +1,182 @@
+import doctest as pdoctest
+import os
+import sys
+
+from sympy.testing.runtests import (
+    SymPyDocTestRunner,
+    SymPyOutputChecker,
+    SymPyTestResults,
+)
+
+
+class SymPySnapshotRunner(SymPyDocTestRunner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.snapshot_mismatches = []
+
+    def report_failure(self, out, test, example, got):
+        # Record mismatches
+        self.snapshot_mismatches.append({
+            "filename": test.filename,
+            "lineno": example.lineno,
+            "source": example.source,
+            "want": example.want,
+            "got": got,
+        })
+
+        self._fakeout.truncate(0)
+        self._fakeout.seek(0)
+
+
+# Monkeypatch name-mangled methods for SnapshotRunner
+monkeypatched_snapshot_methods = [
+    'report_failure',
+]
+
+for method in monkeypatched_snapshot_methods:
+    oldname = '_DocTestRunner__' + method
+    newname = '_SymPySnapshotRunner__' + method
+    setattr(SymPySnapshotRunner, newname, getattr(SymPySnapshotRunner, method))
+
+
+def apply_snapshot_updates(filename, mismatches):
+    with open(filename, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for m in reversed(mismatches):
+        lineno = m["lineno"] - 1
+        source_lines = m["source"].count("\n") + 1
+
+        out_start = lineno + source_lines
+        out_end = out_start
+
+        # go through old expected output
+        while out_end < len(lines):
+            line = lines[out_end]
+            if line.lstrip().startswith(">>>") or line.lstrip().startswith("```"):
+                break
+            out_end += 1
+
+        new_output = m["got"].rstrip("\n").splitlines(keepends=True)
+        new_output = [l + "\n" for l in new_output]
+
+        # replace it with new output
+        lines[out_start:out_end] = new_output
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+# This function is same as sympytestfile, with minor changes adapted to snapshot testing.
+def snapshot_testfile(filename, module_relative=True, name=None, package=None,
+             globs=None, verbose=None, report=True, optionflags=0,
+             extraglobs=None, raise_on_error=False,
+             parser=pdoctest.DocTestParser(), encoding=None, update=False):
+
+    if package and not module_relative:
+        raise ValueError("Package may only be specified for module-"
+                         "relative paths.")
+
+    # Relativize the path
+    text, filename = pdoctest._load_testfile(
+        filename, package, module_relative, encoding)
+
+    # If no name was given, then use the file's name.
+    if name is None:
+        name = os.path.basename(filename)
+
+    # Assemble the globals.
+    if globs is None:
+        globs = {}
+    else:
+        globs = globs.copy()
+    if extraglobs is not None:
+        globs.update(extraglobs)
+    if '__name__' not in globs:
+        globs['__name__'] = '__main__'
+
+    if raise_on_error:
+        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
+    else:
+        runner = SymPySnapshotRunner(verbose=verbose, optionflags=optionflags)
+        runner._checker = SymPyOutputChecker()
+
+    # Read the file, convert it to a test, and run it.
+    test = parser.get_doctest(text, globs, name, filename, 0)
+    print(f"{filename}: {len(test.examples)} examples")
+    runner.run(test)
+
+    print(f"Tried: {runner.tries}")
+    print(f"Snapshot mismatches: {len(runner.snapshot_mismatches)}")
+
+    if report:
+        runner.summarize()
+
+    if pdoctest.master is None:
+        pdoctest.master = runner
+    else:
+        pdoctest.master.merge(runner)
+
+    if hasattr(runner, "snapshot_mismatches"):
+        for m in runner.snapshot_mismatches:
+            print(f"Snapshot mismatch in {m['filename']}:{m['lineno']}")
+            print(m["source"].rstrip())
+            print("--- expected")
+            print(m["want"].rstrip())
+            print("+++ got")
+            print(m["got"].rstrip())
+
+    mismatches = getattr(runner, "snapshot_mismatches", [])
+
+    if update and mismatches:
+        apply_snapshot_updates(filename, mismatches)
+        return SymPyTestResults(0, runner.tries)
+
+    return SymPyTestResults(len(mismatches), runner.tries)
+
+
+def iter_markdown_files(paths):
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for f in files:
+                    if f.endswith(".md"):
+                        yield os.path.join(root, f)
+        else:
+            if path.endswith(".md"):
+                yield path
+
+
+def run_snapshot_tests(options, args):
+    all_files = list(iter_markdown_files(args))
+    ok = True
+
+    if not all_files:
+        print("No markdown files found.")
+        sys.exit(0)
+
+    for filename in all_files:
+        print(f"Running snapshot tests: {filename}")
+        try:
+            failures, attempted = snapshot_testfile(
+                filename=filename,
+                module_relative=False,
+                encoding="utf-8",
+                optionflags=(
+                    pdoctest.ELLIPSIS |
+                    pdoctest.NORMALIZE_WHITESPACE |
+                    pdoctest.IGNORE_EXCEPTION_DETAIL
+                ),
+                update=options.update
+            )
+        except Exception as e:
+            print(f"Error while testing {filename}: {e}")
+            ok = False
+            continue
+
+        if failures and not options.update:
+            ok = False
+        else:
+            print(f"Succesfully tested {filename}.")
+
+    return ok

--- a/sympy/testing/snapshot.py
+++ b/sympy/testing/snapshot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Classes and functions for carrying out snapshot testing in sympy.
 Ideas and code borrowed from pre-existing doctest framework.

--- a/sympy/testing/snapshot.py
+++ b/sympy/testing/snapshot.py
@@ -316,7 +316,7 @@ def run_snapshot_tests(options, args):
                 ),
                 update=options.update
             )
-        except Exception as e:
+        except OSError as e:
             print(f"Error while testing {filename}: {e}")
             ok = False
             continue

--- a/sympy/testing/tests/test_solving_guidance.md
+++ b/sympy/testing/tests/test_solving_guidance.md
@@ -1,0 +1,33 @@
+# preamble
+```
+>>> from sympy import *
+>>> from sympy.abc import x
+```
+
+# test_no_closed_form_solution
+```
+>>> from sympy import solve, cos
+>>> from sympy.abc import x
+>>> solve(cos(x) - x, x, dict=True)
+Traceback (most recent call last):
+    ...
+NotImplementedError: multiple generators [x, cos(x)]
+No algorithms are implemented to solve equation -x + cos(x)
+```
+
+# test_nsolve
+```
+>>> from sympy import nsolve, cos
+>>> from sympy.abc import x
+>>> nsolve(cos(x) - x, x, 2)
+0.739085133215161
+```
+
+# test_polynomial_roots
+```
+>>> from sympy import solve
+>>> from sympy.abc import x
+>>> solutions = solve(x**5 - x - 1, x, dict=True)
+>>> [solution[x].evalf(3) for solution in solutions]
+[1.17, -0.765 - 0.352*I, -0.765 + 0.352*I, 0.181 - 1.08*I, 0.181 + 1.08*I]
+```


### PR DESCRIPTION
Add snapshot tests for solving guidance examples
#### References to other Issues or PRs
Fixes #25610
References #29094

#### Brief description of what is fixed or changed
Added a snapshot test file `sympy/testing/tests/test_solving_guidance.md`
as part of the snapshot testing framework introduced in #29094.

The file contains structured snapshot tests for solving-related examples
from the SymPy documentation, including:
- `test_no_closed_form_solution` — verifies NotImplementedError for unsolvable equations
- `test_nsolve` — verifies numerical solving output
- `test_polynomial_roots` — verifies all 5 roots (including complex) of x**5 - x - 1

A mismatch was found and corrected using `bin/snapshot --update`: the expected
output was missing complex roots and has been updated to the correct full output.

#### Other comments
This PR builds on the snapshot testing framework from #29094.
The snapshot tests can be run using:
    python bin/snapshot sympy/testing/tests/test_solving_guidance.md
And updated using:
    python bin/snapshot --update sympy/testing/tests/test_solving_guidance.md

#### AI Generation Disclosure


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* testing
  * Added snapshot test file for solving guidance examples using the
    new snapshot testing framework.
<!-- END RELEASE NOTES -->
