### PR TITLE
Add support for \circ in lark LaTeX parsing

### DIFF
--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -86,6 +86,7 @@ CMD_RANGLE: "\\rangle"
 CMD_MATHIT: "\\mathit"
 
 CMD_INFTY: "\\infty"
+CMD_CIRC: "\\circ"
 
 BANG: "!"
 BAR: "|"
@@ -276,6 +277,8 @@ product: FUNC_PROD group_curly_parentheses_special _expression
 
 superscript: _expression_func CARET (_expression_power | CMD_PRIME | CMD_ASTERISK)
     | _expression_func CARET L_BRACE (PRIMES | STARS | PRIMES_VIA_CMD | STARS_VIA_CMD) R_BRACE
+    | _expression_func CARET L_BRACE CMD_CIRC R_BRACE -> degree
+    | _expression_func CARET CMD_CIRC -> degree
 
 matrix_prime: (matrix | group_round_parentheses) PRIMES
 

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -265,6 +265,10 @@ class TransformToSymPyExpr(Transformer):
 
         return sympy.Pow(base, sup)
 
+    def degree(self, args):
+        base = args[0]
+        return base * (sympy.pi / 180)
+
     def matrix_prime(self, tokens):
         base = tokens[0]
         primes = tokens[1].value

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -20,7 +20,7 @@ from sympy.functions.elementary.trigonometric import asin, cos, csc, sec, sin, t
 from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 from sympy import Matrix, MatAdd, MatMul, Transpose, Trace
-from sympy import I
+from sympy import I, pi
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum import Bra, Ket, InnerProduct
@@ -253,7 +253,10 @@ UNEVALUATED_POWER_EXPRESSION_PAIRS = [
     (r"x^\frac{1}{2}", _Pow(x, _Mul(1, _Pow(2, -1)))),
     (r"x^{3 + 1}", x ** _Add(3, 1)),
     (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
-    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0))))
+    (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
+    (r"x^\circ", _Mul(x, _Mul(pi, _Pow(180, -1)))),
+    (r"x^{\circ}", _Mul(x, _Mul(pi, _Pow(180, -1)))),
+    (r"180^\circ", _Mul(180, _Mul(pi, _Pow(180, -1))))
 ]
 
 EVALUATED_POWER_EXPRESSION_PAIRS = [
@@ -261,7 +264,10 @@ EVALUATED_POWER_EXPRESSION_PAIRS = [
     (r"x^\frac{1}{2}", sqrt(x)),
     (r"x^{3 + 1}", x ** 4),
     (r"\pi^{|xy|}", Symbol('pi') ** _Abs(x * y)),
-    (r"5^0 - 4^0", 0)
+    (r"5^0 - 4^0", 0),
+    (r"x^\circ", pi*x/180),
+    (r"x^{\circ}", pi*x/180),
+    (r"180^\circ", pi)
 ]
 
 UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This PR adds support for parsing the degree symbol (`^{\circ}`) in the new Lark-based LaTeX parser. Previously, encountering degrees would raise an `UnexpectedCharacters` exception.

##### Changes made:
1. Implemented `degree()` in `TransformToSymPyExpr` to convert degree input into radians `(base * pi / 180)`.
2. Grammar was updated to recognize `\circ` (`CMD_CIRC`) in superscripts.
3. Added regression tests.

#### Other comments


#### AI Generation Disclosure
Used Codex (GPT-5.3) to identify the relevant location for adding tests in `sympy\parsing\tests\test_latex_lark.py`

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Added support for `circ` in Lark LaTeX parsing.

<!-- END RELEASE NOTES -->
