### PR TITLE
Add docstring to MutableDenseMatrix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -913,6 +913,7 @@ Ka Yi <chua.kayi@yahoo.com.sg>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
+Kanan Talreja <kantalreja48@gmail.com> kanan <kantalreja48@gmail.com>
 Kanan Talreja <kantalreja48@gmail.com> 29kanan <166933633+29kanan@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -913,8 +913,8 @@ Ka Yi <chua.kayi@yahoo.com.sg>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
-Kanan Talreja <kantalreja48@gmail.com> kanan <kantalreja48@gmail.com>
 Kanan Talreja <kantalreja48@gmail.com> 29kanan <166933633+29kanan@users.noreply.github.com>
+Kanan Talreja <kantalreja48@gmail.com> kanan <kantalreja48@gmail.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
 Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -913,6 +913,7 @@ Ka Yi <chua.kayi@yahoo.com.sg>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
+Kanan Talreja <kantalreja48@gmail.com> 29kanan <166933633+29kanan@users.noreply.github.com>
 Karan <grgkaran03@gmail.com>
 Karan <grgkaran03@gmail.com>
 Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -122,6 +122,65 @@ def _force_mutable(x):
 
 class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
 
+    """A mutable matrix class represents a mathematical matrix whose entries can 
+    be modified after creation. Entries can be any SymPy expression, including 
+    symbols, numbers, and mathematical functions.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+
+    Create a matrix from a nested iterable:
+    >>> Matrix([[1, 2], [3, 4]])
+    Matrix([
+    [1, 2],
+    [3, 4]])
+
+    A 1D iterable can be used to create a column vector matrix:
+    >>> Matrix([1, 2, 3])
+    Matrix([
+    [1],
+    [2],
+    [3]])
+
+    Another way to create a matrix is by specifying the number of rows and columns 
+    along with the 1D iterable of values:
+    >>> Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    Matrix([
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9]])
+
+    A lambda function can be used to generate matrix entries that follow a 
+    pattern or rule:
+    >>> Matrix(2, 2, lambda i, j: i+j)
+    Matrix([
+    [0, 1],
+    [1, 2]])
+
+    For example, to create an identity matrix:
+    >>> Matrix(3, 3, lambda i, j: 1 if i == j else 0)
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    An empty matrix can be created with no arguments:
+    >>> Matrix()
+    Matrix(0, 0, [])
+
+    Notes
+    =====
+    Users should use Matrix or ImmutableMatrix directly. The base 
+    classes such as MatrixBase, DenseMatrix and MutableRepMatrix are for 
+    internal use only.
+
+    See Also
+    ========
+    ImmutableMatrix
+    """
+
     # The simplify method for mutable mattrices is inconsistent with the
     # one for immutable matrices.
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -122,8 +122,8 @@ def _force_mutable(x):
 
 class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
 
-    """A mutable matrix class represents a mathematical matrix whose entries can 
-    be modified after creation. Entries can be any SymPy expression, including 
+    """A mutable matrix class represents a mathematical matrix whose entries can
+    be modified after creation. Entries can be any SymPy expression, including
     symbols, numbers, and mathematical functions.
 
     Examples
@@ -144,7 +144,7 @@ class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
     [2],
     [3]])
 
-    Another way to create a matrix is by specifying the number of rows and columns 
+    Another way to create a matrix is by specifying the number of rows and columns
     along with the 1D iterable of values:
     >>> Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     Matrix([
@@ -152,7 +152,7 @@ class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
     [4, 5, 6],
     [7, 8, 9]])
 
-    A lambda function can be used to generate matrix entries that follow a 
+    A lambda function can be used to generate matrix entries that follow a
     pattern or rule:
     >>> Matrix(2, 2, lambda i, j: i+j)
     Matrix([
@@ -172,8 +172,8 @@ class MutableDenseMatrix(DenseMatrix, MutableRepMatrix):
 
     Notes
     =====
-    Users should use Matrix or ImmutableMatrix directly. The base 
-    classes such as MatrixBase, DenseMatrix and MutableRepMatrix are for 
+    Users should use Matrix or ImmutableMatrix directly. The base
+    classes such as MatrixBase, DenseMatrix and MutableRepMatrix are for
     internal use only.
 
     See Also


### PR DESCRIPTION
Adds a docstring to the MutableDenseMatrix class in sympy/matrices/dense.py. 

#### References to other Issues or PRs

Fixes #24917

#### Brief description of what is fixed or changed
Currently, help(Matrix) shows no useful information about how to create a matrix. This PR adds a detailed docstring to the MutableDenseMatrix class that covers:
* Various ways to create a matrix with examples.
* Difference between user-facing classes and internal classes.

#### Other comments


#### AI Generation Disclosure


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
