### PR TITLE
Add type annotations to functions in sympy/ntheory/factor_.py

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2,7 +2,7 @@
 Integer factorization
 """
 from __future__ import annotations
-from typing import SupportsIndex
+from typing import Any, Iterator, Literal, overload, SupportsIndex
 from bisect import bisect_left
 from collections import defaultdict, OrderedDict
 from collections.abc import MutableMapping
@@ -1710,7 +1710,12 @@ def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         return Mul(*args, evaluate=False)
 
 
-def primefactors(n, limit=None, verbose=False, **kwargs):
+def primefactors(
+    n: int,
+    limit: int | None = None,
+    verbose: bool = False,
+    **kwargs: Any
+) -> list[int]:
     """Return a sorted list of n's prime factors, ignoring multiplicity
     and any composite factor that remains if the limit was set too low
     for complete factorization. Unlike factorint(), primefactors() does
@@ -1769,7 +1774,7 @@ def primefactors(n, limit=None, verbose=False, **kwargs):
     return s
 
 
-def _divisors(n, proper=False):
+def _divisors(n: int, proper: bool = False) -> Iterator[int]:
     """Helper function for divisors which generates the divisors.
 
     Parameters
@@ -1803,8 +1808,30 @@ def _divisors(n, proper=False):
     else:
         yield from rec_gen()
 
+@overload
+def divisors(
+    n: int,
+    generator: Literal[True],
+    proper: bool = False
+) -> Iterator[int]: ...
+@overload
+def divisors(
+    n: int,
+    generator: Literal[False] = False,
+    proper: bool = False
+) -> list[int]: ...
+@overload
+def divisors(
+    n: int,
+    generator: bool = False,
+    proper: bool = False
+) -> Iterator[int] | list[int]: ...
 
-def divisors(n, generator=False, proper=False):
+def divisors(
+    n: int,
+    generator: bool = False,
+    proper: bool = False
+) -> Iterator[int] | list[int]:
     r"""
     Return all divisors of n sorted from 1..n by default.
     If generator is ``True`` an unordered generator is returned.
@@ -1840,7 +1867,7 @@ def divisors(n, generator=False, proper=False):
     return rv if generator else sorted(rv)
 
 
-def divisor_count(n, modulus=1, proper=False):
+def divisor_count(n: int, modulus: int = 1, proper: bool = False) -> int:
     """
     Return the number of divisors of ``n``. If ``modulus`` is not 1 then only
     those that are divisible by ``modulus`` are counted. If ``proper`` is True
@@ -1872,13 +1899,19 @@ def divisor_count(n, modulus=1, proper=False):
             return 0
     if n == 0:
         return 0
-    n = Mul(*[v + 1 for k, v in factorint(n).items() if k > 1])
+    n = math.prod([v + 1 for k, v in factorint(n).items() if k > 1], start=1)
     if n and proper:
         n -= 1
     return n
 
+@overload
+def proper_divisors(n: int, generator: Literal[True]) -> Iterator[int]: ...
+@overload
+def proper_divisors(n: int, generator: Literal[False] = False) -> list[int]: ...
+@overload
+def proper_divisors( n: int, generator: bool = False) -> Iterator[int] | list[int]: ...
 
-def proper_divisors(n, generator=False):
+def proper_divisors(n: int, generator: bool = False) -> Iterator[int] | list[int]:
     """
     Return all divisors of n except n, sorted by default.
     If generator is ``True`` an unordered generator is returned.
@@ -1903,7 +1936,7 @@ def proper_divisors(n, generator=False):
     return divisors(n, generator=generator, proper=True)
 
 
-def proper_divisor_count(n, modulus=1):
+def proper_divisor_count(n: int, modulus: int = 1) -> int:
     """
     Return the number of proper divisors of ``n``.
 
@@ -1925,7 +1958,7 @@ def proper_divisor_count(n, modulus=1):
     return divisor_count(n, modulus=modulus, proper=True)
 
 
-def _udivisors(n):
+def _udivisors(n: int)-> Iterator[int]:
     """Helper function for udivisors which generates the unitary divisors.
 
     Parameters
@@ -1951,8 +1984,14 @@ def _udivisors(n):
             i >>= 1
         yield d
 
+@overload
+def udivisors(n: int, generator: Literal[True]) -> Iterator[int]: ...
+@overload
+def udivisors(n: int, generator: Literal[False] = False) -> list[int]: ...
+@overload
+def udivisors(n: int, generator: bool = False) -> Iterator[int] | list[int]: ...
 
-def udivisors(n, generator=False):
+def udivisors(n: int, generator: bool = False) -> Iterator[int] | list[int]:
     r"""
     Return all unitary divisors of n sorted from 1..n by default.
     If generator is ``True`` an unordered generator is returned.
@@ -1989,7 +2028,7 @@ def udivisors(n, generator=False):
     return rv if generator else sorted(rv)
 
 
-def udivisor_count(n):
+def udivisor_count(n: int) -> int:
     """
     Return the number of unitary divisors of ``n``.
 
@@ -2022,7 +2061,7 @@ def udivisor_count(n):
     return 2**len([p for p in factorint(n) if p > 1])
 
 
-def _antidivisors(n):
+def _antidivisors(n: int) -> Iterator[int]:
     """Helper function for antidivisors which generates the antidivisors.
 
     Parameters
@@ -2045,8 +2084,14 @@ def _antidivisors(n):
         if n > d >= 2 and n % d:
             yield d
 
+@overload
+def antidivisors(n: int, generator: Literal[True]) -> Iterator[int]: ...
+@overload
+def antidivisors(n: int, generator: Literal[False] = False) -> list[int]: ...
+@overload
+def antidivisors(n: int, generator: bool = False) -> Iterator[int] | list[int]: ...
 
-def antidivisors(n, generator=False):
+def antidivisors(n: int, generator: bool = False) -> Iterator[int] | list[int]:
     r"""
     Return all antidivisors of n sorted from 1..n by default.
 


### PR DESCRIPTION



<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Relates to #28806
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added type annotations to functions in sympy/ntheory/factor_.py including primefactors, _divisors, divisors, divisor_count, proper_divisors, proper_divisor_count, _udivisors, udivisors, udivisor_count, _antidivisors, antidivisors. Changes include specifying int, bool, None, Any, list[int] and Iterator[int] where appropriate. 




<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->

#### Other comments

#### AI Generation Disclosure
OpenAI's ChatGPT was used for better understanding the existing codebase and documentation and for learning more about available type annotations. The actual changes were written by human. The types were verified at runtime as described in the issue instructions.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
