### PR TITLE
added NaN guard before the zero-check

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1384,6 +1384,9 @@ class Derivative(Expr):
                 (v.canonical if isinstance(v, Derivative) else v, c)
                 for v, c in variable_count]
 
+            if expr is S.NaN:
+                return S.NaN
+
             # Look for a quick exit if there are symbols that don't appear in
             # expression at all. Note, this cannot check non-symbols like
             # Derivatives as those can be created by intermediate


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29296 

#### Brief description of what is fixed or changed
`diff(nan, x)` was returning 0 instead of `nan`. The quick-exit optimization in `Derivative.__new__()` checks if the differentiation variable appears in `expr.free_symbols` .Since `nan` has no free symbols, it concludes that derivative is zero.I fixed it by adding a NaN check before that block .

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `diff(nan, x)` returning 0 instead of `nan`
<!-- END RELEASE NOTES -->
