### PR TITLE
Fix TODO: Support dynamicsymbols in Autolev Taylor expansion

### DIFF
--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -803,8 +803,8 @@ if AutolevListener:
                     child = ch.expr(index)
                     v = self.getValue(child.getChild(0))
                     a = self.getValue(child.getChild(2))
-                    if v in self.type.keys() and self.type[v] in ("variable", "motionvariable", "motionvariable'", "specified"):
-                        l.append(".subs(" + v + ", _sm.Symbol('" + v + "_dummy')).series(_sm.Symbol('" + v + "_dummy'), " + a + ", " + order + ").removeO().subs(_sm.Symbol('" + v + "_dummy'), " + v + ")")
+                if v in self.type.keys() and self.type[v] in ("motionvariable", "motionvariable'") or v in self.q_ind + self.q_dep + self.u_ind + self.u_dep:
+                    l.append(".subs(" + v + ", _sm.Symbol('" + v + "_dummy')).series(_sm.Symbol('" + v + "_dummy'), " + a + ", " + order + ").removeO().subs(_sm.Symbol('" + v + "_dummy'), " + v + ")")
                     else:
                         l.append(".series(" + v + ", " + a + ", " + order + ").removeO()")
                 self.setValue(ctx, "(" + exp + ")" + "".join(l))

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -803,8 +803,8 @@ if AutolevListener:
                     child = ch.expr(index)
                     v = self.getValue(child.getChild(0))
                     a = self.getValue(child.getChild(2))
-                if v in self.type.keys() and self.type[v] in ("motionvariable", "motionvariable'") or v in self.q_ind + self.q_dep + self.u_ind + self.u_dep:
-                    l.append(".subs(" + v + ", _sm.Symbol('" + v + "_dummy')).series(_sm.Symbol('" + v + "_dummy'), " + a + ", " + order + ").removeO().subs(_sm.Symbol('" + v + "_dummy'), " + v + ")")
+                    if v in self.type.keys() and self.type[v] in ("motionvariable", "motionvariable'") or v in self.q_ind + self.q_dep + self.u_ind + self.u_dep:
+                        l.append(".subs(" + v + ", _sm.Symbol('" + v + "_dummy')).series(_sm.Symbol('" + v + "_dummy'), " + a + ", " + order + ").removeO().subs(_sm.Symbol('" + v + "_dummy'), " + v + ")")
                     else:
                         l.append(".series(" + v + ", " + a + ", " + order + ").removeO()")
                 self.setValue(ctx, "(" + exp + ")" + "".join(l))

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -792,8 +792,7 @@ if AutolevListener:
                 else:
                     self.setValue(ctx, expr)
 
-            # Taylor(y, 0:2, w=a, x=0)
-            # TODO: Currently only works with symbols. Make it work for dynamicsymbols.
+           # Taylor(y, 0:2, w=a, x=0)
             elif func_name == "taylor":
                 exp = self.getValue(ch.expr(0))
                 order = self.getValue(ch.expr(1).expr(1))
@@ -802,9 +801,12 @@ if AutolevListener:
                 for i in range(x):
                     index = 2 + i
                     child = ch.expr(index)
-                    l.append(".series(" + self.getValue(child.getChild(0)) +
-                             ", " + self.getValue(child.getChild(2)) +
-                             ", " + order + ").removeO()")
+                    v = self.getValue(child.getChild(0))
+                    a = self.getValue(child.getChild(2))
+                    if v in self.type.keys() and self.type[v] in ("variable", "motionvariable", "motionvariable'", "specified"):
+                        l.append(".subs(" + v + ", _sm.Symbol('" + v + "_dummy')).series(_sm.Symbol('" + v + "_dummy'), " + a + ", " + order + ").removeO().subs(_sm.Symbol('" + v + "_dummy'), " + v + ")")
+                    else:
+                        l.append(".series(" + v + ", " + a + ", " + order + ").removeO()")
                 self.setValue(ctx, "(" + exp + ")" + "".join(l))
 
             # Evaluate(y, a=x, b=2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The Autolev parser's Taylor function generator previously only worked with standard symbol. There was an inline TODO: Currently only works with symbols. Make it work for dynamicsymbols.

This PR introduces logic to check if a parsed variable is registerd in self.type as a time-dependent dynamicsymbol (e.g., variable, motionvariable, specified). If it is, the generated code now temporarily substitutes a dummy static symbol ` (_sm.Symbol('v_dummy')) ` , computes the series expansion and then safely substitutes the original dynamicsymbol back into the expression. If it is a standard symbol, it falls back to the original .series() behavior.

#### Other comments
Tested locally using python3 bin/test sympy/parsing/. All available parsing tests passed successfully.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing

    * Supported dynamicsymbols in the Autolev parser's Taylor expansion function.
<!-- END RELEASE NOTES -->
