### PR TITLE
Docs fix custom printer example

### DIFF
--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -83,15 +83,16 @@ in a shorter form.
 
     from sympy.core.symbol import Symbol
     from sympy.printing.latex import LatexPrinter, print_latex
-    from sympy.core.function import UndefinedFunction, Function
+    from sympy.core.function import AppliedUndef, Function
 
 
     class MyLatexPrinter(LatexPrinter):
         \"\"\"Print derivative of a function of symbols in a shorter form.
         \"\"\"
         def _print_Derivative(self, expr):
-            function, *vars = expr.args
-            if not isinstance(type(function), UndefinedFunction) or \\
+            function = expr.expr
+            vars = expr.variables
+            if not isinstance(function, AppliedUndef) or \\
                not all(isinstance(i, Symbol) for i in vars):
                 return super()._print_Derivative(expr)
 

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -113,6 +113,10 @@ class JointPSpace(ProductPSpace):
         rvs = rvs or syms
         if not any(i in rvs for i in syms):
             return expr
+        if hasattr(self.distribution, "_compute_expectation"):
+            res = self.distribution._compute_expectation(expr, syms, rvs=rvs, **kwargs)
+            if res is not None:
+                return res
         expr = expr*self.pdf
         for rv in rvs:
             if isinstance(rv, Indexed):

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -64,6 +64,9 @@ class JointPSpace(ProductPSpace):
 
     @property
     def component_count(self):
+        dim = getattr(self.distribution, 'dimension', None)
+        if dim is not None:
+            return S(dim)
         _set = self.distribution.set
         if isinstance(_set, ProductSet):
             return S(len(_set.args))

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -14,7 +14,6 @@ from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.bessel import besselk
-from sympy.functions.special.delta_functions import DiracDelta
 from sympy.functions.special.gamma_functions import gamma
 from sympy.matrices.dense import (Matrix, ones)
 from sympy.sets.fancysets import Range

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -14,6 +14,7 @@ from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.bessel import besselk
+from sympy.functions.special.delta_functions import DiracDelta
 from sympy.functions.special.gamma_functions import gamma
 from sympy.matrices.dense import (Matrix, ones)
 from sympy.sets.fancysets import Range
@@ -501,7 +502,26 @@ class MultivariateBetaDistribution(JointDistribution):
     def pdf(self, *syms):
         alpha = self.alpha
         B = Mul.fromiter(map(gamma, alpha))/gamma(Add(*alpha))
-        return Mul.fromiter(sym**(a_k - 1) for a_k, sym in zip(alpha, syms))/B
+        return Mul.fromiter(sym ** (a_k - 1) for a_k, sym in zip(alpha, syms)) / B
+
+    def _compute_expectation(self, expr, syms, rvs=None, **kwargs):
+        alpha = self.alpha
+        A = Add(*alpha)
+        means = {}
+        for rv in syms:
+            if not isinstance(rv, Indexed):
+                return None
+            i = rv.args[1]
+            means[rv] = alpha[i] / A
+        const_part = expr
+        for rv in syms:
+            const_part -= expr.coeff(rv) * rv
+        if any(const_part.has(rv) for rv in syms):
+            return None
+        result = const_part
+        for rv in syms:
+            result += expr.coeff(rv) * means[rv]
+        return result
 
 def MultivariateBeta(syms, *alpha):
     """

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -573,7 +573,7 @@ def MultivariateBeta(syms, *alpha):
     >>> density(B)(x, y)
     x**(a1 - 1)*y**(a2 - 1)*gamma(a1 + a2)/(gamma(a1)*gamma(a2))
     >>> marginal_distribution(C, C[0])(x)
-    x**(a1 - 1)*gamma(a1 + a2)/(a2*gamma(a1)*gamma(a2))
+    x**(a1 - 1)*(1 - x)**(a2 - 1)*gamma(a1 + a2)/(gamma(a1)*gamma(a2))
 
     References
     ==========

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -5,7 +5,8 @@ from sympy.core.function import Lambda
 from sympy.core.mul import Mul
 from sympy.core.numbers import (Integer, Rational, pi)
 from sympy.core.power import Pow
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ge
+from sympy.logic.boolalg import And
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
@@ -18,6 +19,7 @@ from sympy.functions.special.gamma_functions import gamma
 from sympy.matrices.dense import (Matrix, ones)
 from sympy.sets.fancysets import Range
 from sympy.sets.sets import (Intersection, Interval)
+from sympy.sets.conditionset import ConditionSet
 from sympy.tensor.indexed import (Indexed, IndexedBase)
 from sympy.matrices import ImmutableMatrix, MatrixSymbol
 from sympy.matrices.expressions.determinant import det
@@ -494,14 +496,31 @@ class MultivariateBetaDistribution(JointDistribution):
                                             " should be positive.")
 
     @property
+    def dimension(self):
+        return len(self.alpha)
+
+    @property
     def set(self):
         k = len(self.alpha)
-        return Interval(0, 1)**k
+        xs = tuple(Symbol(f'_x{i}', real=True) for i in range(k))
+        cond = And(*[Ge(x, 0) for x in xs], Eq(Add(*xs), 1))
+        return ConditionSet(xs, cond, S.Reals ** k)
 
     def pdf(self, *syms):
         alpha = self.alpha
         B = Mul.fromiter(map(gamma, alpha))/gamma(Add(*alpha))
         return Mul.fromiter(sym ** (a_k - 1) for a_k, sym in zip(alpha, syms)) / B
+
+    def _marginal_distribution(self, indices, sym):
+        if len(indices) != 1:
+            return None
+        i = indices[0]
+        alpha = self.alpha
+        A = Add(*alpha)
+        ai = alpha[i]
+        bi = A - ai
+        x = Symbol(f"{sym}[{i}]", real=True)
+        return Lambda(x, gamma(A) / (gamma(ai) * gamma(bi)) * x ** (ai - 1) * (1 - x) ** (bi - 1))
 
     def _compute_expectation(self, expr, syms, rvs=None, **kwargs):
         alpha = self.alpha

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -194,6 +194,9 @@ def test_MultivariateBeta():
     a1_f, a2_f = symbols('a1, a2', positive=False, real=True)
     mb = MultivariateBeta('B', [a1, a2])
     mb_c = MultivariateBeta('C', a1, a2)
+    X = MultivariateBeta('X', [1, 1, 1])
+    assert E(X[0]) == Rational(1, 3)
+    assert E(X[0] + X[1] + X[2]) == 1
     assert density(mb)(1, 2) == S(2)**(a2 - 1)*gamma(a1 + a2)/\
                                 (gamma(a1)*gamma(a2))
     assert marginal_distribution(mb_c, 0)(3) == S(3)**(a1 - 1)*gamma(a1 + a2)/\

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -35,6 +35,7 @@ from sympy.testing.pytest import raises, XFAIL, skip, slow
 from sympy.external import import_module
 
 from sympy.abc import x, y
+import numpy as np
 
 def _is_simplex_sample(vec, tol=1e-12):
     return all(float(v) >= -tol for v in vec) and abs(sum(float(v) for v in vec) - 1.0) <= tol
@@ -384,7 +385,12 @@ def test_sample_pymc():
         for X in distribs_pymc:
             samps = sample(X, size=size, library='pymc')
             for sam in samps:
-                assert tuple(sam.flatten()) in X.pspace.distribution.set
+                flat = np.asarray(sam).reshape(-1)
+                if X.pspace.distribution.__class__.__name__ == "MultivariateBetaDistribution":
+                    assert np.all(flat >= 0)
+                    assert np.isclose(flat.sum(), 1.0, rtol=0, atol=1e-12)
+                else:
+                    assert tuple(sam.flatten()) in X.pspace.distribution.set
         N_c = NegativeMultinomial('N', 3, 0.1, 0.1, 0.1)
         raises(NotImplementedError, lambda: sample(N_c, library='pymc'))
 

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,7 +1,8 @@
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
+from sympy.core.add import Add
 from sympy.core.numbers import (Rational, oo, pi)
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ge
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.combinatorial.factorials import (RisingFactorial, factorial)
@@ -13,9 +14,11 @@ from sympy.functions.special.bessel import besselk
 from sympy.functions.special.gamma_functions import gamma
 from sympy.matrices.dense import eye
 from sympy.matrices.expressions.determinant import Determinant
+from sympy.sets.conditionset import ConditionSet
 from sympy.sets.fancysets import Range
 from sympy.sets.sets import (Interval, ProductSet)
 from sympy.simplify.simplify import simplify
+from sympy.stats.joint_rv_types import MultivariateBetaDistribution
 from sympy.tensor.indexed import (Indexed, IndexedBase)
 from sympy.core.numbers import comp
 from sympy.integrals.integrals import integrate
@@ -33,7 +36,8 @@ from sympy.external import import_module
 
 from sympy.abc import x, y
 
-
+def _is_simplex_sample(vec, tol=1e-12):
+    return all(float(v) >= -tol for v in vec) and abs(sum(float(v) for v in vec) - 1.0) <= tol
 
 def test_Normal():
     m = Normal('A', [1, 2], [[1, 0], [0, 1]])
@@ -197,15 +201,21 @@ def test_MultivariateBeta():
     X = MultivariateBeta('X', [1, 1, 1])
     assert E(X[0]) == Rational(1, 3)
     assert E(X[0] + X[1] + X[2]) == 1
-    assert density(mb)(1, 2) == S(2)**(a2 - 1)*gamma(a1 + a2)/\
-                                (gamma(a1)*gamma(a2))
-    assert marginal_distribution(mb_c, 0)(3) == S(3)**(a1 - 1)*gamma(a1 + a2)/\
-                                                (a2*gamma(a1)*gamma(a2))
+    t = Rational(1, 3)
+    expected = t ** (a1 - 1) * (1 - t) ** (a2 - 1) * gamma(a1 + a2) / (gamma(a1) * gamma(a2))
+    assert density(mb)(t, 1 - t) == expected
+    assert marginal_distribution(mb_c, 0)(t) == expected
     raises(ValueError, lambda: MultivariateBeta('b1', [a1_f, a2]))
     raises(ValueError, lambda: MultivariateBeta('b2', [a1, a2_f]))
     raises(ValueError, lambda: MultivariateBeta('b3', [0, 0]))
     raises(ValueError, lambda: MultivariateBeta('b4', [a1_f, a2_f]))
-    assert mb.pspace.distribution.set == ProductSet(Interval(0, 1), Interval(0, 1))
+    support = mb.pspace.distribution.set
+    assert isinstance(support, ConditionSet)
+    xs = support.sym
+    cond = support.condition
+    for x_i in xs:
+        assert cond.has(Ge(x_i, 0))
+    assert cond.has(Eq(Add(*xs), 1))
 
 
 def test_MultivariateEwens():
@@ -322,7 +332,10 @@ def test_sample_numpy():
         for X in distribs_numpy:
             samps = sample(X, size=size, library='numpy')
             for sam in samps:
-                assert tuple(sam) in X.pspace.distribution.set
+                if isinstance(X.pspace.distribution, MultivariateBetaDistribution):
+                    assert _is_simplex_sample(sam)
+                else:
+                    assert tuple(sam) in X.pspace.distribution.set
         N_c = NegativeMultinomial('N', 3, 0.1, 0.1, 0.1)
         raises(NotImplementedError, lambda: sample(N_c, library='numpy'))
 
@@ -343,10 +356,16 @@ def test_sample_scipy():
             samps = sample(X, size=size)
             samps2 = sample(X, size=(2, 2))
             for sam in samps:
-                assert tuple(sam) in X.pspace.distribution.set
+                if isinstance(X.pspace.distribution, MultivariateBetaDistribution):
+                    assert _is_simplex_sample(sam)
+                else:
+                    assert tuple(sam) in X.pspace.distribution.set
             for i in range(2):
                 for j in range(2):
-                    assert tuple(samps2[i][j]) in X.pspace.distribution.set
+                    if isinstance(X.pspace.distribution, MultivariateBetaDistribution):
+                        assert _is_simplex_sample(samps2[i][j])
+                    else:
+                        assert tuple(samps2[i][j]) in X.pspace.distribution.set
         N_c = NegativeMultinomial('N', 3, 0.1, 0.1, 0.1)
         raises(NotImplementedError, lambda: sample(N_c))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29282

#### Brief description of what is fixed or changed
The example assumes that `expr.args` returns only `Symbol` objects.
However, `Derivative` variables can now be `(Symbol, order)` tuples.
Using `expr.expr` and `expr.variables` ensures the example works with the current API.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
