### PR TITLE
Fix custom printer example for Derivative variables

### DIFF
--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -83,15 +83,16 @@ in a shorter form.
 
     from sympy.core.symbol import Symbol
     from sympy.printing.latex import LatexPrinter, print_latex
-    from sympy.core.function import UndefinedFunction, Function
+    from sympy.core.function import AppliedUndef, Function
 
 
     class MyLatexPrinter(LatexPrinter):
         \"\"\"Print derivative of a function of symbols in a shorter form.
         \"\"\"
         def _print_Derivative(self, expr):
-            function, *vars = expr.args
-            if not isinstance(type(function), UndefinedFunction) or \\
+            function = expr.expr
+            vars = expr.variables
+            if not isinstance(function, AppliedUndef) or \\
                not all(isinstance(i, Symbol) for i in vars):
                 return super()._print_Derivative(expr)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29282

#### Brief description of what is fixed or changed
The example assumes that `expr.args` returns only `Symbol` objects.
However, `Derivative` variables can now be `(Symbol, order)` tuples.
Using `expr.expr` and `expr.variables` ensures the example works with the current API.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
