### PR TITLE
Optimized space complexity of PowerSet iterator (Fixes #29305)

### DIFF
--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -111,17 +111,16 @@ class PowerSet(Set):
         return 2 ** len(self.arg)
 
     def __iter__(self) -> Iterator[Set]:
-        found = [S.EmptySet]
-        yield S.EmptySet
-
-        for x in self.arg:
-            temp = []
-            x = FiniteSet(x)
-            for y in found:
-                new = x + y
-                yield new
-                temp.append(new)
-            found.extend(temp)
+        elements = list(self.arg)
+        cardinality = len(elements)
+        for i in range(2**cardinality):
+            temp = S.EmptySet
+            for n in range(cardinality):
+                z=2**(cardinality-n)
+                y=i%z
+                if y>=z//2:
+                    temp |= FiniteSet(elements[n])
+            yield temp
 
     @property
     def kind(self):


### PR DESCRIPTION
Updated `__iter__` method in `powerset.py` to improve its space complexity from O(2^n) to O(n).

Refactored version of the `__iter__` method uses a bitmask-style approach to achieve O(n) space complexity and maintain lazy evaluation.

Fixes #29305

* sets
  * Modified `PowerSet.__iter__` to use a memory-efficient generator, reducing space complexity from O(2^n) to O(n).