### PR TITLE
assumptions: add refine handler for tan and cot

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1612,6 +1612,7 @@ Tejaswini Sanapathi <sastejaswini2002@gmail.com>
 Temiloluwa Yusuf ytemiloluwa@gmail.com Temi <ytemiloluwa@gmail.com>
 Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com> Sibi <85477603+t-sibiraj@users.noreply.github.com>
+Tharupahan Jayawardana <tharupahanjayawardana@gmail.com> tharu-jwd <tharupahanjayawardana@gmail.com>
 Theodore Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -480,6 +480,90 @@ def refine_sin_cos(expr, assumptions):
         return ((-1)**((k + 1) / 2)) * sin(rem)
 
 
+def refine_tan_cot(expr, assumptions):
+    """
+    Handler for the tan and cot functions.
+
+    Explanation
+    ===========
+
+    Simplifies ``tan`` and ``cot`` by removing integer multiples of ``pi``
+    from their arguments (using the period-``pi`` identity) and converting
+    between ``tan`` and ``cot`` when an odd multiple of ``pi/2`` is present.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_tan_cot
+    >>> from sympy import Symbol, Q, tan, cot, pi
+    >>> from sympy.abc import x
+    >>> n = Symbol('n')
+    >>> refine_tan_cot(tan(n*pi), Q.integer(n))
+    0
+    >>> refine_tan_cot(cot(n*pi/2), Q.odd(n))
+    0
+    >>> refine_tan_cot(tan(x + n*pi), Q.integer(n))
+    tan(x)
+    >>> refine_tan_cot(cot(x + n*pi), Q.integer(n))
+    cot(x)
+    >>> refine_tan_cot(tan(x + n*pi/2), Q.odd(n))
+    -cot(x)
+    >>> refine_tan_cot(cot(x + n*pi/2), Q.odd(n))
+    -tan(x)
+    >>> refine_tan_cot(tan(x + n*pi/2), Q.even(n))
+    tan(x)
+
+    """
+    from sympy.functions.elementary.trigonometric import tan, cot
+    arg = expr.args[0]
+
+    integer_coeffs_of_pi_half = []
+    remaining_terms = []
+
+    terms = arg.args if arg.is_Add else (arg,)
+    for term in terms:
+        coeff_of_pi = term.coeff(S.Pi)
+        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
+            integer_coeffs_of_pi_half.append(2 * coeff_of_pi)
+        else:
+            remaining_terms.append(term)
+
+    if not integer_coeffs_of_pi_half:
+        return expr
+
+    sum_of_parity_known_coeffs = 0
+    sum_of_parity_unknown_coeffs = 0
+    sum_of_parity_known_coeffs_is_even = True
+
+    for coeff in integer_coeffs_of_pi_half:
+        coeff_is_even = ask(Q.even(coeff), assumptions)
+        if coeff_is_even is None:
+            sum_of_parity_unknown_coeffs += coeff
+        else:
+            sum_of_parity_known_coeffs += coeff
+            sum_of_parity_known_coeffs_is_even = (
+                sum_of_parity_known_coeffs_is_even == coeff_is_even
+            )
+
+    if sum_of_parity_known_coeffs == 0:
+        return expr
+
+    rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
+
+    if sum_of_parity_known_coeffs_is_even:
+        # Even total of pi/2 shifts: tan(rem + k*pi) = tan(rem) (period pi)
+        if isinstance(expr, tan):
+            return tan(rem)
+        else:
+            return cot(rem)
+    else:
+        # Odd total: tan(rem + pi/2) = -cot(rem), cot(rem + pi/2) = -tan(rem)
+        if isinstance(expr, tan):
+            return -cot(rem)
+        else:
+            return -tan(rem)
+
+
 def refine_floor_ceiling(expr, assumptions):
     """
     Handler for the floor and ceiling functions
@@ -531,6 +615,8 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'tan': refine_tan_cot,
+    'cot': refine_tan_cot,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 from sympy.assumptions.ask import Q
 from sympy.assumptions.refine import refine
 from sympy.core.expr import Expr
-from sympy.core.numbers import (I, Rational, nan, pi)
+from sympy.core.numbers import (I, Rational, nan, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, cot, sin, tan)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -305,3 +305,53 @@ def test_floor_ceiling():
 
     assert refine(floor(floor(x)+ floor(y))) == floor(x) + floor(y)
     assert refine(ceiling(ceiling(x) - ceiling(y))) == ceiling(x) - ceiling(y)
+
+
+def test_tan_cot():
+    n = Symbol('n')
+    m = Symbol('m')
+
+    # tan with integer multiples of pi (period pi -> 0)
+    assert refine(tan(n*pi), Q.integer(n)) == 0
+    assert refine(tan(n*pi), Q.even(n)) == 0
+    assert refine(tan(n*pi), Q.odd(n)) == 0
+
+    # tan with even multiples of pi/2 (equivalent to integer multiples of pi)
+    assert refine(tan(n*pi/2), Q.even(n)) == 0
+
+    # tan with odd multiples of pi/2 (undefined -> zoo)
+    assert refine(tan(n*pi/2), Q.odd(n)) == zoo
+
+    # tan: remove integer-pi shifts from argument
+    assert refine(tan(x + n*pi), Q.integer(n)) == tan(x)
+    assert refine(tan(x + n*pi), Q.even(n)) == tan(x)
+    assert refine(tan(x + n*pi), Q.odd(n)) == tan(x)
+
+    # tan: remove even pi/2 shifts
+    assert refine(tan(x + n*pi/2), Q.even(n)) == tan(x)
+
+    # tan: odd pi/2 shift converts tan -> -cot
+    assert refine(tan(x + n*pi/2), Q.odd(n)) == -cot(x)
+
+    # cot with odd multiples of pi/2 (cot(pi/2) = 0)
+    assert refine(cot(n*pi/2), Q.odd(n)) == 0
+
+    # cot: remove integer-pi shifts from argument
+    assert refine(cot(x + n*pi), Q.integer(n)) == cot(x)
+    assert refine(cot(x + n*pi), Q.even(n)) == cot(x)
+    assert refine(cot(x + n*pi), Q.odd(n)) == cot(x)
+
+    # cot: remove even pi/2 shifts
+    assert refine(cot(x + n*pi/2), Q.even(n)) == cot(x)
+
+    # cot: odd pi/2 shift converts cot -> -tan
+    assert refine(cot(x + n*pi/2), Q.odd(n)) == -tan(x)
+
+    # mixed: integer n*pi and integer m*pi/2 with unknown parity of m
+    assert refine(tan(x + n*pi + m*pi/2), Q.integer(n) & Q.integer(m)) == tan(x + m*pi/2)
+    assert refine(tan(x + n*pi + m*pi/2), Q.integer(n) & Q.even(m)) == tan(x)
+    assert refine(tan(x + n*pi + m*pi/2), Q.integer(n) & Q.odd(m)) == -cot(x)
+
+    # no simplification when parity is unknown
+    assert refine(tan(x + n*pi/2), Q.integer(n)) == tan(x + n*pi/2)
+    assert refine(cot(x + n*pi/2), Q.integer(n)) == cot(x + n*pi/2)


### PR DESCRIPTION
Part of #27888.

Adds a `refine_tan_cot` handler for `tan` and `cot`, similar to the existing `refine_sin_cos` handler.

**Before:**
```python
>>> refine(tan(n*pi), Q.integer(n))
tan(pi*n)
>>> refine(tan(x + n*pi/2), Q.odd(n))
tan(pi*n/2 + x)
>>> refine(cot(x + n*pi/2), Q.odd(n))
cot(pi*n/2 + x)
```

**After:**
```python
>>> refine(tan(n*pi), Q.integer(n))
0
>>> refine(tan(x + n*pi/2), Q.odd(n))
-cot(x)
>>> refine(cot(x + n*pi/2), Q.odd(n))
-tan(x)
```

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added `refine` support for `tan` and `cot` under integer, even, and odd assumptions.
<!-- END RELEASE NOTES -->