### PR TITLE
BUG: correct nonlinsolve result

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -350,6 +350,7 @@ Annamalai N <srirammount@gmail.com> Annamalai <91740832+RaMathuZen@users.noreply
 Annamalai N <srirammount@gmail.com> ramathuzen <srirammount@gmail.com>
 Ansh Mishra <anshmishra471@gmail.com>
 Anshul Sharma <anshulsharma4605@gmail.com>
+Antareep Sarkar <206247917+antareepsarkar@users.noreply.github.com>
 Anthony Scopatz <scopatz@gmail.com>
 Anthony Sottile <asottile@umich.edu>
 Anton Akhmerov <anton.akhmerov@gmail.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3531,6 +3531,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
 
         # sort equations so the one with the fewest potential
         # symbols appears first
+
         for index, eq in enumerate(eqs_in_better_order):
             newresult = []
             # if imageset, expr is used to solve for other symbol
@@ -3603,7 +3604,22 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # one symbol's real soln, another symbol may have
                             # corresponding complex soln.
                             if not isinstance(soln, (ImageSet, ConditionSet)):
-                                soln += solveset_complex(eq2, sym)  # might give ValueError with Abs
+                                to_append = solveset_complex(eq2, sym)
+                                if isinstance(to_append, ConditionSet) and to_append.base_set in (S.Reals, S.Complexes):
+                                    to_append = S.EmptySet
+                                elif isinstance(to_append, ConditionSet):
+                                    to_append = to_append.base_set
+                                modified = Union()
+                                if isinstance(to_append, Union):
+                                    for s in to_append.args:
+                                        if isinstance(s, ConditionSet):
+                                            if s.base_set not in (S.Reals, S.Complexes):
+                                                modified += s.base_set
+                                            elif s.base_set == S.Complexes:
+                                                modified += FiniteSet(S.Complexes)
+                                            else:
+                                                modified += s
+                                soln += modified if isinstance(to_append, Union) else to_append  # might give ValueError with Abs
 
                         if not isinstance(soln, (FiniteSet, ImageSet, ConditionSet, Union)) and soln is not S.EmptySet:
                             raise NotImplementedError(
@@ -3614,6 +3630,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         # If solveset is not able to solve equation `eq2`. Next
                         # time we may get soln using next equation `eq2`
                         continue
+
                     if isinstance(soln, ConditionSet):
                         if soln.base_set in (S.Reals, S.Complexes):
                             soln = S.EmptySet

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -332,6 +332,9 @@ def test_issue_21047():
     assert solveset(f, x, S.Reals) == FiniteSet(
         S.Half - sqrt(2*sqrt(2) + 5)/2, S.Half + sqrt(2*sqrt(2) + 5)/2)
 
+def test_issue_29315():
+    x, y = symbols("x y")
+    assert nonlinsolve([x+y-4, 2**x+2**y-10], x, y) == {(1, 3), (3, 1), (4 - y, S.Complexes)}
 
 def test_is_function_class_equation():
     assert _is_function_class_equation(TrigonometricFunction,
@@ -3545,7 +3548,7 @@ def test_issue_23318():
 
 def test_issue_19814():
     assert nonlinsolve([ 2**m - 2**(2*n), 4*2**m - 2**(4*n)], m, n
-                      ) == FiniteSet((log(2**(2*n))/log(2), S.Complexes))
+                      ) == FiniteSet((log(4)/log(2), 1), (log(2**(2*n))/log(2), S.Complexes))
 
 
 def test_issue_22058():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29315 


#### Brief description of what is fixed or changed
Just patched a part of the `substitution` function so that it adds two sets by adding elements & keeping the previous ones.  

#### Other Comments
I'm not sure whether this requires a release note.

#### AI Generation Disclosure
No part of this PR was generated by or made with the help of AI or any bot. 
Even the language(comments, description, etc.) of the PR is written by me.   

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Make `sympy.nonlinsolve` return both real and complex answers in case of  equations containing exponents. 
<!-- END RELEASE NOTES -->
