### PR TITLE
Added type annotations to sympy/utlities/decorator.py

### DIFF
--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
 from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
-
+F = TypeVar("F",bound=Callable[...,Any])
 
 T = TypeVar('T')
 """A generic type"""
 
 
-def threaded_factory(func: Callable[..., Any], use_add: bool) -> Callable[..., Any]:
+def threaded_factory(func: F, use_add: bool):
     """A factory for ``threaded`` decorators. """
     from sympy.core import sympify
     from sympy.matrices import MatrixBase
@@ -51,7 +51,7 @@ def threaded_factory(func: Callable[..., Any], use_add: bool) -> Callable[..., A
     return threaded_func
 
 
-def threaded(func: Callable[..., Any]) -> Callable[..., Any]:
+def threaded(func: F) -> F:
     """Apply ``func`` to sub--elements of an object, including :class:`~.Add`.
 
     This decorator is intended to make it uniformly possible to apply a
@@ -71,7 +71,7 @@ def threaded(func: Callable[..., Any]) -> Callable[..., Any]:
     return threaded_factory(func, True)
 
 
-def xthreaded(func: Callable[..., Any]) -> Callable[..., Any]:
+def xthreaded(func: F) -> F:
     """Apply ``func`` to sub--elements of an object, excluding :class:`~.Add`.
 
     This decorator is intended to make it uniformly possible to apply a

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -94,7 +94,7 @@ class no_attrs_in_subclass(Generic[C]):
     cls: type[C]
     f: Any
 
-    def __init__(self, cls: type, f: F) -> None:
+    def __init__(self, cls: type[C], f: F) -> None:
         self.cls = cls
         self.f = f
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -1,22 +1,27 @@
 """Useful utility decorators. """
 
-from typing import TypeVar
+from __future__ import annotations
+
 import sys
 import types
 import inspect
 from functools import wraps
+from typing import TypeVar, TYPE_CHECKING, Callable, Any, Generic
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # Keep this import for backwards compatibility:
 from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
-
-
+F = TypeVar("F", bound=Callable[..., Any])
+C = TypeVar("C")
 T = TypeVar('T')
 """A generic type"""
 
 
-def threaded_factory(func, use_add):
+def threaded_factory(func: F, use_add: bool):
     """A factory for ``threaded`` decorators. """
     from sympy.core import sympify
     from sympy.matrices import MatrixBase
@@ -45,7 +50,7 @@ def threaded_factory(func, use_add):
     return threaded_func
 
 
-def threaded(func):
+def threaded(func: F) -> F:
     """Apply ``func`` to sub--elements of an object, including :class:`~.Add`.
 
     This decorator is intended to make it uniformly possible to apply a
@@ -65,7 +70,7 @@ def threaded(func):
     return threaded_factory(func, True)
 
 
-def xthreaded(func):
+def xthreaded(func: F) -> F:
     """Apply ``func`` to sub--elements of an object, excluding :class:`~.Add`.
 
     This decorator is intended to make it uniformly possible to apply a
@@ -85,7 +90,7 @@ def xthreaded(func):
     return threaded_factory(func, False)
 
 
-class no_attrs_in_subclass:
+class no_attrs_in_subclass(Generic[C]):
     """Don't 'inherit' certain attributes from a base class
 
     >>> from sympy.utilities.decorator import no_attrs_in_subclass
@@ -104,11 +109,13 @@ class no_attrs_in_subclass:
     False
 
     """
-    def __init__(self, cls, f):
+    cls: type[C]
+    f: object
+    def __init__(self, cls: type[C], f: object) -> None:
         self.cls = cls
         self.f = f
 
-    def __get__(self, instance, owner=None):
+    def __get__(self, instance: object | None, owner: type | None = None) -> Any:
         if owner == self.cls:
             if hasattr(self.f, '__get__'):
                 return self.f.__get__(instance, owner)
@@ -116,8 +123,13 @@ class no_attrs_in_subclass:
         raise AttributeError
 
 
-def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
-                       python_version=None, ground_types=None):
+def doctest_depends_on(
+    exe: Iterable[str] | str | None = None,
+    modules: Iterable[str] | str | None = None,
+    disable_viewers: Iterable[str] | str | None = None,
+    python_version: tuple[int, ...] | None = None,
+    ground_types: Iterable[str] | str | None = None,
+) -> Callable[[T], T]:
     """
     Adds metadata about the dependencies which need to be met for doctesting
     the docstrings of the decorated objects.
@@ -131,7 +143,7 @@ def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
     ``python_version`` should be the minimum Python version required, as a tuple
     (like ``(3, 0)``)
     """
-    dependencies = {}
+    dependencies: dict[str, Any] = {}
     if exe is not None:
         dependencies['executables'] = exe
     if modules is not None:
@@ -217,7 +229,7 @@ def public(obj: T) -> T:
     return obj
 
 
-def memoize_property(propfunc):
+def memoize_property(propfunc: Callable[..., Any]) -> property:
     """Property decorator that caches the value of potentially expensive
     ``propfunc`` after the first evaluation. The cached value is stored in
     the corresponding property name with an attached underscore."""
@@ -235,8 +247,13 @@ def memoize_property(propfunc):
     return property(accessor)
 
 
-def deprecated(message, *, deprecated_since_version,
-               active_deprecations_target, stacklevel=3):
+def deprecated(
+    message: str,
+    *,
+    deprecated_since_version: str,
+    active_deprecations_target: str,
+    stacklevel: int = 3,
+) -> Callable[[T], T]:
     '''
     Mark a function as deprecated.
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -91,7 +91,6 @@ def xthreaded(func: F) -> F:
 
 
 class no_attrs_in_subclass(Generic[C]):
-<<<<<<< HEAD
     """Don't 'inherit' certain attributes from a base class
 
     >>> from sympy.utilities.decorator import no_attrs_in_subclass
@@ -112,24 +111,15 @@ class no_attrs_in_subclass(Generic[C]):
     """
     cls: type[C]
     f: object
+
     def __init__(self, cls: type[C], f: object) -> None:
         self.cls = cls
         self.f = f
 
-    def __get__(self, instance: object | None, owner: type | None = None) -> Any:
-=======
-    cls: type[C]
-    f: Any
-
-    def __init__(self, cls: type[C], f: F) -> None:
-        self.cls = cls
-        self.f = f
-
-    def __get__(self, instance: Any, owner: type | None = None) -> Any:
->>>>>>> 3988829ec67b68b9c6749da8b553814b20e57587
+    def __get__(self, instance: object | None, owner: type | None = None) -> object:
         if owner == self.cls:
             if hasattr(self.f, '__get__'):
-                return self.f.__get__(instance, owner)
+                return self.f.__get__(instance, owner) # type: ignore[attr-defined]
             return self.f
         raise AttributeError
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -6,7 +6,7 @@ import sys
 import types
 import inspect
 from functools import wraps
-from typing import TypeVar, TYPE_CHECKING, Callable, Any
+from typing import TypeVar, TYPE_CHECKING, Callable, Any, Generic
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
-F = TypeVar("F",bound=Callable[...,Any])
-
+F = TypeVar("F", bound=Callable[..., Any])
+C = TypeVar("C")
 T = TypeVar('T')
 """A generic type"""
 
@@ -90,7 +90,7 @@ def xthreaded(func: F) -> F:
     return threaded_factory(func, False)
 
 
-class no_attrs_in_subclass:
+class no_attrs_in_subclass(Generic[C]):
     """Don't 'inherit' certain attributes from a base class
 
     >>> from sympy.utilities.decorator import no_attrs_in_subclass
@@ -109,10 +109,10 @@ class no_attrs_in_subclass:
     False
 
     """
-    cls: type
+    cls: type[C]
     f: Any
 
-    def __init__(self, cls: type, f: Any) -> None:
+    def __init__(self, cls: type, f: F) -> None:
         self.cls = cls
         self.f = f
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -6,17 +6,16 @@ import sys
 import types
 import inspect
 from functools import wraps
-from typing import TypeVar, TYPE_CHECKING
+from typing import TypeVar, TYPE_CHECKING, Callable, Any
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import Any, Callable
 
 # Keep this import for backwards compatibility:
 from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
-F = TypeVar("F",bound=callable[...,Any])
+F = TypeVar("F",bound=Callable[...,Any])
 
 T = TypeVar('T')
 """A generic type"""

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -1,10 +1,16 @@
 """Useful utility decorators. """
 
-from typing import TypeVar
+from __future__ import annotations
+
 import sys
 import types
 import inspect
 from functools import wraps
+from typing import TypeVar, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any, Callable
 
 # Keep this import for backwards compatibility:
 from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
@@ -16,7 +22,7 @@ T = TypeVar('T')
 """A generic type"""
 
 
-def threaded_factory(func, use_add):
+def threaded_factory(func: Callable[..., Any], use_add: bool) -> Callable[..., Any]:
     """A factory for ``threaded`` decorators. """
     from sympy.core import sympify
     from sympy.matrices import MatrixBase
@@ -45,7 +51,7 @@ def threaded_factory(func, use_add):
     return threaded_func
 
 
-def threaded(func):
+def threaded(func: Callable[..., Any]) -> Callable[..., Any]:
     """Apply ``func`` to sub--elements of an object, including :class:`~.Add`.
 
     This decorator is intended to make it uniformly possible to apply a
@@ -65,7 +71,7 @@ def threaded(func):
     return threaded_factory(func, True)
 
 
-def xthreaded(func):
+def xthreaded(func: Callable[..., Any]) -> Callable[..., Any]:
     """Apply ``func`` to sub--elements of an object, excluding :class:`~.Add`.
 
     This decorator is intended to make it uniformly possible to apply a
@@ -104,11 +110,14 @@ class no_attrs_in_subclass:
     False
 
     """
-    def __init__(self, cls, f):
+    cls: type
+    f: Any
+
+    def __init__(self, cls: type, f: Any) -> None:
         self.cls = cls
         self.f = f
 
-    def __get__(self, instance, owner=None):
+    def __get__(self, instance: Any, owner: type | None = None) -> Any:
         if owner == self.cls:
             if hasattr(self.f, '__get__'):
                 return self.f.__get__(instance, owner)
@@ -116,8 +125,13 @@ class no_attrs_in_subclass:
         raise AttributeError
 
 
-def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
-                       python_version=None, ground_types=None):
+def doctest_depends_on(
+    exe: Iterable[str] | str | None = None,
+    modules: Iterable[str] | str | None = None,
+    disable_viewers: Iterable[str] | str | None = None,
+    python_version: tuple[int, ...] | None = None,
+    ground_types: Iterable[str] | str | None = None,
+) -> Callable[[T], T]:
     """
     Adds metadata about the dependencies which need to be met for doctesting
     the docstrings of the decorated objects.
@@ -131,7 +145,7 @@ def doctest_depends_on(exe=None, modules=None, disable_viewers=None,
     ``python_version`` should be the minimum Python version required, as a tuple
     (like ``(3, 0)``)
     """
-    dependencies = {}
+    dependencies: dict[str, Any] = {}
     if exe is not None:
         dependencies['executables'] = exe
     if modules is not None:
@@ -217,7 +231,7 @@ def public(obj: T) -> T:
     return obj
 
 
-def memoize_property(propfunc):
+def memoize_property(propfunc: Callable[..., Any]) -> property:
     """Property decorator that caches the value of potentially expensive
     ``propfunc`` after the first evaluation. The cached value is stored in
     the corresponding property name with an attached underscore."""
@@ -235,8 +249,13 @@ def memoize_property(propfunc):
     return property(accessor)
 
 
-def deprecated(message, *, deprecated_since_version,
-               active_deprecations_target, stacklevel=3):
+def deprecated(
+    message: str,
+    *,
+    deprecated_since_version: str,
+    active_deprecations_target: str,
+    stacklevel: int = 3,
+) -> Callable[[T], T]:
     '''
     Mark a function as deprecated.
 

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -91,30 +91,8 @@ def xthreaded(func: F) -> F:
 
 
 class no_attrs_in_subclass(Generic[C]):
-    """Don't 'inherit' certain attributes from a base class
-
-    >>> from sympy.utilities.decorator import no_attrs_in_subclass
-
-    >>> class A(object):
-    ...     x = 'test'
-
-    >>> A.x = no_attrs_in_subclass(A, A.x)
-
-    >>> class B(A):
-    ...     pass
-
-    >>> hasattr(A, 'x')
-    True
-    >>> hasattr(B, 'x')
-    False
-
-    """
     cls: type[C]
-<<<<<<< HEAD
     f: Any
-=======
-    f: F
->>>>>>> 0495a2c96c90648fe8512af53f083abea6cc81b8
 
     def __init__(self, cls: type, f: F) -> None:
         self.cls = cls

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -109,8 +109,8 @@ class no_attrs_in_subclass:
     False
 
     """
-    cls: type
-    f: Any
+    cls: type[C]
+    f: F
 
     def __init__(self, cls: type, f: Any) -> None:
         self.cls = cls

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 from sympy.external.mpmath import conserve_mpmath_dps # noqa: F401
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
-F = TypeVar("F",bound=Callable[...,Any])
+F = TypeVar("F",bound=callable[...,Any])
 
 T = TypeVar('T')
 """A generic type"""


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #28806
#### Brief description of what is fixed or changed
Added type annotations to sympy/utilities/decorator.py.

This change introduces static typing information for functions in this module without modifying the runtime behavior. The TYPE_CHECKING imports are used where appropriate to avoid introducing runtime dependencies.
#### Other comments
mypy sympy/utilities/decorator.py reports no issues.

Local tests were executed for sympy/utilities. One unrelated failure in test_mathml.py occurred on Windows due to a known lxml file URI issue.

#### AI Generation Disclosure
AI tools were used for limited assistance when drafting some type annotations.

All the changes were verified manually and tested locally before submission.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
