### PR TITLE
assumptions: add refine handler for tan and cot

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1612,6 +1612,7 @@ Tejaswini Sanapathi <sastejaswini2002@gmail.com>
 Temiloluwa Yusuf ytemiloluwa@gmail.com Temi <ytemiloluwa@gmail.com>
 Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com> Sibi <85477603+t-sibiraj@users.noreply.github.com>
+Tharupahan Jayawardana <tharupahanjayawardana@gmail.com> tharu-jwd <tharupahanjayawardana@gmail.com>
 Theodore Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -512,18 +512,14 @@ def refine_tan_cot(expr, assumptions):
     >>> from sympy.abc import x, n
     >>> refine_tan_cot(tan(n*pi), Q.integer(n))
     0
-    >>> refine_tan_cot(cot(n*pi/2), Q.odd(n))
-    0
     >>> refine_tan_cot(tan(x + n*pi), Q.integer(n))
     tan(x)
-    >>> refine_tan_cot(cot(x + n*pi), Q.integer(n))
-    cot(x)
+    >>> refine_tan_cot(tan(x + n*pi/2), Q.even(n))
+    tan(x)
     >>> refine_tan_cot(tan(x + n*pi/2), Q.odd(n))
     -cot(x)
     >>> refine_tan_cot(cot(x + n*pi/2), Q.odd(n))
     -tan(x)
-    >>> refine_tan_cot(tan(x + n*pi/2), Q.even(n))
-    tan(x)
 
     """
     from sympy.functions.elementary.trigonometric import tan, cot

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -533,17 +533,10 @@ def refine_tan_cot(expr, assumptions):
     _, sum_of_parity_known_coeffs_is_even, rem = result
 
     if sum_of_parity_known_coeffs_is_even:
-        # Even total of pi/2 shifts: tan(rem + k*pi) = tan(rem) (period pi)
-        if isinstance(expr, tan):
-            return tan(rem)
-        else:
-            return cot(rem)
+        return expr.func(rem)
     else:
-        # Odd total: tan(rem + pi/2) = -cot(rem), cot(rem + pi/2) = -tan(rem)
-        if isinstance(expr, tan):
-            return -cot(rem)
-        else:
-            return -tan(rem)
+        co_func = cot if isinstance(expr, tan) else tan
+        return -co_func(rem)
 
 
 def refine_floor_ceiling(expr, assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -532,6 +532,13 @@ def refine_tan_cot(expr, assumptions):
         return expr
     _, sum_of_parity_known_coeffs_is_even, rem = result
 
+    # If k is even (k*pi/2 is an integer multiple of pi):
+    #    `tan(rem + k*pi/2)` -> `tan(rem)`
+    #    `cot(rem + k*pi/2)` -> `cot(rem)`
+    #
+    # If k is odd:
+    #    `tan(rem + k*pi/2)` -> `-cot(rem)`
+    #    `cot(rem + k*pi/2)` -> `-tan(rem)`
     if sum_of_parity_known_coeffs_is_even:
         return expr.func(rem)
     else:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -461,9 +461,8 @@ def refine_sin_cos(expr, assumptions):
     ========
 
     >>> from sympy.assumptions.refine import refine_sin_cos
-    >>> from sympy import Symbol, Q, sin, cos, pi
-    >>> from sympy.abc import x, y
-    >>> n = Symbol('n')
+    >>> from sympy import Q, sin, cos, pi
+    >>> from sympy.abc import x, y, n
     >>> refine_sin_cos(cos(n*pi), Q.even(n))
     (-1)**n
     >>> refine_sin_cos(sin(n*pi/2), Q.odd(n) & Q.odd((n-1)/2))

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -508,9 +508,8 @@ def refine_tan_cot(expr, assumptions):
     ========
 
     >>> from sympy.assumptions.refine import refine_tan_cot
-    >>> from sympy import Symbol, Q, tan, cot, pi
-    >>> from sympy.abc import x
-    >>> n = Symbol('n')
+    >>> from sympy import Q, tan, cot, pi
+    >>> from sympy.abc import x, n
     >>> refine_tan_cot(tan(n*pi), Q.integer(n))
     0
     >>> refine_tan_cot(cot(n*pi/2), Q.odd(n))

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -504,13 +504,6 @@ def refine_tan_cot(expr, assumptions):
     """
     Handler for the tan and cot functions.
 
-    Explanation
-    ===========
-
-    Simplifies ``tan`` and ``cot`` by removing integer multiples of ``pi``
-    from their arguments (using the period-``pi`` identity) and converting
-    between ``tan`` and ``cot`` when an odd multiple of ``pi/2`` is present.
-
     Examples
     ========
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -404,6 +404,47 @@ def refine_matrixelement(expr, assumptions):
         return MatrixElement(matrix, j, i)
 
 
+def _trig_pi_half_shift(arg, assumptions):
+    """Parse a trig argument for integer multiples of pi/2 and compute parity.
+
+    Returns ``None`` if no simplification is possible, otherwise returns
+    ``(sum_of_parity_known_coeffs, sum_of_parity_known_coeffs_is_even, rem)``
+    where ``rem`` is the argument with all integer-pi/2 terms removed.
+    """
+    integer_coeffs_of_pi_half = []
+    remaining_terms = []
+
+    terms = arg.args if arg.is_Add else (arg,)
+    for term in terms:
+        coeff_of_pi = term.coeff(S.Pi)
+        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
+            integer_coeffs_of_pi_half.append(2 * coeff_of_pi)
+        else:
+            remaining_terms.append(term)
+
+    if not integer_coeffs_of_pi_half:
+        return None
+
+    sum_of_parity_known_coeffs = 0
+    sum_of_parity_unknown_coeffs = 0
+    sum_of_parity_known_coeffs_is_even = True
+    for coeff in integer_coeffs_of_pi_half:
+        coeff_is_even = ask(Q.even(coeff), assumptions)
+        if coeff_is_even is None:
+            sum_of_parity_unknown_coeffs += coeff
+        else:
+            sum_of_parity_known_coeffs += coeff
+            sum_of_parity_known_coeffs_is_even = (
+                sum_of_parity_known_coeffs_is_even == coeff_is_even
+            )
+
+    if sum_of_parity_known_coeffs == 0:
+        return None
+
+    rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
+    return sum_of_parity_known_coeffs, sum_of_parity_known_coeffs_is_even, rem
+
+
 def refine_sin_cos(expr, assumptions):
     """
     Handler for sin and cos functions.
@@ -427,38 +468,10 @@ def refine_sin_cos(expr, assumptions):
     (-1)**(2*n)*cos(x + y)
     """
     from sympy.functions.elementary.trigonometric import sin, cos
-    arg = expr.args[0]
-
-    integer_coeffs_of_pi_half = []
-    remaining_terms = []
-
-    terms = arg.args if arg.is_Add else (arg,)
-    for term in terms:
-        coeff_of_pi = term.coeff(S.Pi)
-        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
-            coeff_of_pi_half = 2 * coeff_of_pi
-            integer_coeffs_of_pi_half.append(coeff_of_pi_half)
-        else:
-            remaining_terms.append(term)
-
-    if not integer_coeffs_of_pi_half:
+    result = _trig_pi_half_shift(expr.args[0], assumptions)
+    if result is None:
         return expr
-
-    sum_of_parity_known_coeffs = 0
-    sum_of_parity_unknown_coeffs = 0
-    sum_of_parity_known_coeffs_is_even = True
-    for coeff in integer_coeffs_of_pi_half:
-        coeff_is_even = ask(Q.even(coeff), assumptions)
-        if coeff_is_even is None:
-            sum_of_parity_unknown_coeffs += coeff
-        else:
-            sum_of_parity_known_coeffs += coeff
-            sum_of_parity_known_coeffs_is_even = (
-                sum_of_parity_known_coeffs_is_even == coeff_is_even
-            )
-
-    if sum_of_parity_known_coeffs == 0:
-        return expr
+    sum_of_parity_known_coeffs, sum_of_parity_known_coeffs_is_even, rem = result
 
     # Treat sin as a phase-shifted cosine so a single logic path can handle both.
     if isinstance(expr, sin):
@@ -473,7 +486,6 @@ def refine_sin_cos(expr, assumptions):
     #
     # If k is odd:
     #    `cos(rem + k*pi/2)` -> `(-1)^((k+1)/2) * sin(rem)`
-    rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
     if k_is_even:
         return ((-1)**(k / 2)) * cos(rem)
     else:
@@ -515,40 +527,10 @@ def refine_tan_cot(expr, assumptions):
 
     """
     from sympy.functions.elementary.trigonometric import tan, cot
-    arg = expr.args[0]
-
-    integer_coeffs_of_pi_half = []
-    remaining_terms = []
-
-    terms = arg.args if arg.is_Add else (arg,)
-    for term in terms:
-        coeff_of_pi = term.coeff(S.Pi)
-        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
-            integer_coeffs_of_pi_half.append(2 * coeff_of_pi)
-        else:
-            remaining_terms.append(term)
-
-    if not integer_coeffs_of_pi_half:
+    result = _trig_pi_half_shift(expr.args[0], assumptions)
+    if result is None:
         return expr
-
-    sum_of_parity_known_coeffs = 0
-    sum_of_parity_unknown_coeffs = 0
-    sum_of_parity_known_coeffs_is_even = True
-
-    for coeff in integer_coeffs_of_pi_half:
-        coeff_is_even = ask(Q.even(coeff), assumptions)
-        if coeff_is_even is None:
-            sum_of_parity_unknown_coeffs += coeff
-        else:
-            sum_of_parity_known_coeffs += coeff
-            sum_of_parity_known_coeffs_is_even = (
-                sum_of_parity_known_coeffs_is_even == coeff_is_even
-            )
-
-    if sum_of_parity_known_coeffs == 0:
-        return expr
-
-    rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
+    _, sum_of_parity_known_coeffs_is_even, rem = result
 
     if sum_of_parity_known_coeffs_is_even:
         # Even total of pi/2 shifts: tan(rem + k*pi) = tan(rem) (period pi)

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -405,11 +405,19 @@ def refine_matrixelement(expr, assumptions):
 
 
 def _trig_pi_half_shift(arg, assumptions):
-    """Parse a trig argument for integer multiples of pi/2 and compute parity.
+    """Extract integer multiples of ``pi/2`` from a trig argument and determine parity.
 
-    Returns ``None`` if no simplification is possible, otherwise returns
-    ``(sum_of_parity_known_coeffs, sum_of_parity_known_coeffs_is_even, rem)``
-    where ``rem`` is the argument with all integer-pi/2 terms removed.
+    Splits ``arg`` into terms that are provably integer multiples of ``pi/2``
+    and a remainder. Returns ``None`` if no such term exists.
+
+    Otherwise returns ``(k, k_is_even, rem)`` where ``k`` is the total integer
+    coefficient (of ``pi/2``) whose parity is known, ``k_is_even`` is ``True``
+    if ``k`` is even and ``False`` if odd, and ``rem`` is the rest of the
+    argument (including any ``pi/2`` terms whose parity could not be determined).
+
+    For example, given ``n*pi`` with ``Q.integer(n)``, returns ``(2*n, True, 0)``
+    since ``2*n`` is always even. Given ``x + n*pi/2`` with ``Q.odd(n)``, returns
+    ``(n, False, x)`` since ``n`` is odd.
     """
     integer_coeffs_of_pi_half = []
     remaining_terms = []

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -480,6 +480,90 @@ def refine_sin_cos(expr, assumptions):
         return ((-1)**((k + 1) / 2)) * sin(rem)
 
 
+def refine_tan_cot(expr, assumptions):
+    """
+    Handler for the tan and cot functions.
+
+    Explanation
+    ===========
+
+    Simplifies ``tan`` and ``cot`` by removing integer multiples of ``pi``
+    from their arguments (using the period-``pi`` identity) and converting
+    between ``tan`` and ``cot`` when an odd multiple of ``pi/2`` is present.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_tan_cot
+    >>> from sympy import Symbol, Q, tan, cot, pi
+    >>> from sympy.abc import x
+    >>> n = Symbol('n')
+    >>> refine_tan_cot(tan(n*pi), Q.integer(n))
+    0
+    >>> refine_tan_cot(cot(n*pi/2), Q.odd(n))
+    0
+    >>> refine_tan_cot(tan(x + n*pi), Q.integer(n))
+    tan(x)
+    >>> refine_tan_cot(cot(x + n*pi), Q.integer(n))
+    cot(x)
+    >>> refine_tan_cot(tan(x + n*pi/2), Q.odd(n))
+    -cot(x)
+    >>> refine_tan_cot(cot(x + n*pi/2), Q.odd(n))
+    -tan(x)
+    >>> refine_tan_cot(tan(x + n*pi/2), Q.even(n))
+    tan(x)
+
+    """
+    from sympy.functions.elementary.trigonometric import tan, cot
+    arg = expr.args[0]
+
+    integer_coeffs_of_pi_half = []
+    remaining_terms = []
+
+    terms = arg.args if arg.is_Add else (arg,)
+    for term in terms:
+        coeff_of_pi = term.coeff(S.Pi)
+        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
+            integer_coeffs_of_pi_half.append(2 * coeff_of_pi)
+        else:
+            remaining_terms.append(term)
+
+    if not integer_coeffs_of_pi_half:
+        return expr
+
+    sum_of_parity_known_coeffs = 0
+    sum_of_parity_unknown_coeffs = 0
+    sum_of_parity_known_coeffs_is_even = True
+
+    for coeff in integer_coeffs_of_pi_half:
+        coeff_is_even = ask(Q.even(coeff), assumptions)
+        if coeff_is_even is None:
+            sum_of_parity_unknown_coeffs += coeff
+        else:
+            sum_of_parity_known_coeffs += coeff
+            sum_of_parity_known_coeffs_is_even = (
+                sum_of_parity_known_coeffs_is_even == coeff_is_even
+            )
+
+    if sum_of_parity_known_coeffs == 0:
+        return expr
+
+    rem = sum(remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
+
+    if sum_of_parity_known_coeffs_is_even:
+        # Even total of pi/2 shifts: tan(rem + k*pi) = tan(rem) (period pi)
+        if isinstance(expr, tan):
+            return tan(rem)
+        else:
+            return cot(rem)
+    else:
+        # Odd total: tan(rem + pi/2) = -cot(rem), cot(rem + pi/2) = -tan(rem)
+        if isinstance(expr, tan):
+            return -cot(rem)
+        else:
+            return -tan(rem)
+
+
 def refine_floor_ceiling(expr, assumptions):
     """
     Handler for the floor and ceiling functions
@@ -531,6 +615,8 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'tan': refine_tan_cot,
+    'cot': refine_tan_cot,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 from sympy.assumptions.ask import Q
 from sympy.assumptions.refine import refine
 from sympy.core.expr import Expr
-from sympy.core.numbers import (I, Rational, nan, pi)
+from sympy.core.numbers import (I, Rational, nan, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, cot, sin, tan)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -305,3 +305,53 @@ def test_floor_ceiling():
 
     assert refine(floor(floor(x)+ floor(y))) == floor(x) + floor(y)
     assert refine(ceiling(ceiling(x) - ceiling(y))) == ceiling(x) - ceiling(y)
+
+
+def test_tan_cot():
+    n = Symbol('n')
+    m = Symbol('m')
+
+    # tan with integer multiples of pi (period pi -> 0)
+    assert refine(tan(n*pi), Q.integer(n)) == 0
+    assert refine(tan(n*pi), Q.even(n)) == 0
+    assert refine(tan(n*pi), Q.odd(n)) == 0
+
+    # tan with even multiples of pi/2 (equivalent to integer multiples of pi)
+    assert refine(tan(n*pi/2), Q.even(n)) == 0
+
+    # tan with odd multiples of pi/2 (undefined -> zoo)
+    assert refine(tan(n*pi/2), Q.odd(n)) == zoo
+
+    # tan: remove integer-pi shifts from argument
+    assert refine(tan(x + n*pi), Q.integer(n)) == tan(x)
+    assert refine(tan(x + n*pi), Q.even(n)) == tan(x)
+    assert refine(tan(x + n*pi), Q.odd(n)) == tan(x)
+
+    # tan: remove even pi/2 shifts
+    assert refine(tan(x + n*pi/2), Q.even(n)) == tan(x)
+
+    # tan: odd pi/2 shift converts tan -> -cot
+    assert refine(tan(x + n*pi/2), Q.odd(n)) == -cot(x)
+
+    # cot with odd multiples of pi/2 (cot(pi/2) = 0)
+    assert refine(cot(n*pi/2), Q.odd(n)) == 0
+
+    # cot: remove integer-pi shifts from argument
+    assert refine(cot(x + n*pi), Q.integer(n)) == cot(x)
+    assert refine(cot(x + n*pi), Q.even(n)) == cot(x)
+    assert refine(cot(x + n*pi), Q.odd(n)) == cot(x)
+
+    # cot: remove even pi/2 shifts
+    assert refine(cot(x + n*pi/2), Q.even(n)) == cot(x)
+
+    # cot: odd pi/2 shift converts cot -> -tan
+    assert refine(cot(x + n*pi/2), Q.odd(n)) == -tan(x)
+
+    # mixed: integer n*pi and integer m*pi/2 with unknown parity of m
+    assert refine(tan(x + n*pi + m*pi/2), Q.integer(n) & Q.integer(m)) == tan(x + m*pi/2)
+    assert refine(tan(x + n*pi + m*pi/2), Q.integer(n) & Q.even(m)) == tan(x)
+    assert refine(tan(x + n*pi + m*pi/2), Q.integer(n) & Q.odd(m)) == -cot(x)
+
+    # no simplification when parity is unknown
+    assert refine(tan(x + n*pi/2), Q.integer(n)) == tan(x + n*pi/2)
+    assert refine(cot(x + n*pi/2), Q.integer(n)) == cot(x + n*pi/2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Part of #27888.

#### Brief description of what is fixed or changed

Adds a `refine_tan_cot` handler for `tan` and `cot` in `sympy/assumptions/refine.py`, similar to the existing `refine_sin_cos` handler.

**Before:**
```python
>>> refine(tan(n*pi), Q.integer(n))
tan(pi*n)
>>> refine(tan(x + n*pi/2), Q.odd(n))
tan(pi*n/2 + x)
>>> refine(cot(x + n*pi/2), Q.odd(n))
cot(pi*n/2 + x)
```

**After:**
```python
>>> refine(tan(n*pi), Q.integer(n))
0
>>> refine(tan(x + n*pi/2), Q.odd(n))
-cot(x)
>>> refine(cot(x + n*pi/2), Q.odd(n))
-tan(x)
```

The handler covers:
- `tan(n*pi)` → `0` for integer `n`
- `tan(x + n*pi)` → `tan(x)` for integer `n`
- `tan(x + n*pi/2)` → `tan(x)` for even `n`, `-cot(x)` for odd `n`
- `cot(n*pi/2)` → `0` for odd `n`
- `cot(x + n*pi)` → `cot(x)` for integer `n`
- `cot(x + n*pi/2)` → `cot(x)` for even `n`, `-tan(x)` for odd `n`

#### Other comments

Supersedes the closed PR #29317 (which was missing the PR template).

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added `refine` support for `tan` and `cot` under integer, even, and odd assumptions.
<!-- END RELEASE NOTES -->