### PR TITLE
assumptions: add refine handler for Heaviside

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1612,6 +1612,7 @@ Tejaswini Sanapathi <sastejaswini2002@gmail.com>
 Temiloluwa Yusuf ytemiloluwa@gmail.com Temi <ytemiloluwa@gmail.com>
 Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
 Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com> Sibi <85477603+t-sibiraj@users.noreply.github.com>
+Tharupahan Jayawardana <tharupahanjayawardana@gmail.com> tharu-jwd <tharupahanjayawardana@gmail.com>
 Theodore Dias <theodore.dias@hotmail.co.uk>
 Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
 Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -480,6 +480,34 @@ def refine_sin_cos(expr, assumptions):
         return ((-1)**((k + 1) / 2)) * sin(rem)
 
 
+def refine_Heaviside(expr, assumptions):
+    """
+    Handler for the Heaviside step function.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_Heaviside
+    >>> from sympy import Q, Heaviside
+    >>> from sympy.abc import x
+    >>> refine_Heaviside(Heaviside(x), Q.positive(x))
+    1
+    >>> refine_Heaviside(Heaviside(x), Q.negative(x))
+    0
+    >>> refine_Heaviside(Heaviside(x), Q.zero(x))
+    1/2
+
+    """
+    arg, H0 = expr.args
+    if ask(Q.positive(arg), assumptions):
+        return S.One
+    if ask(Q.negative(arg), assumptions):
+        return S.Zero
+    if ask(Q.zero(arg), assumptions):
+        return H0
+    return expr
+
+
 def refine_floor_ceiling(expr, assumptions):
     """
     Handler for the floor and ceiling functions
@@ -531,6 +559,7 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -14,6 +14,7 @@ from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.functions.elementary.integers import floor, ceiling
+from sympy.functions.special.delta_functions import Heaviside
 
 
 def test_Abs():
@@ -305,3 +306,17 @@ def test_floor_ceiling():
 
     assert refine(floor(floor(x)+ floor(y))) == floor(x) + floor(y)
     assert refine(ceiling(ceiling(x) - ceiling(y))) == ceiling(x) - ceiling(y)
+
+
+def test_Heaviside():
+    assert refine(Heaviside(x), Q.positive(x)) == 1
+    assert refine(Heaviside(x), Q.negative(x)) == 0
+    assert refine(Heaviside(x), Q.zero(x)) == S.Half
+    assert refine(Heaviside(x), Q.nonnegative(x)) == Heaviside(x)
+    assert refine(Heaviside(x), Q.nonpositive(x)) == Heaviside(x)
+    assert refine(Heaviside(x), True) == Heaviside(x)
+
+    # custom H0 value
+    assert refine(Heaviside(x, 1), Q.zero(x)) == 1
+    assert refine(Heaviside(x, 1), Q.positive(x)) == 1
+    assert refine(Heaviside(x, 1), Q.negative(x)) == 0


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Part of #12682.

#### Brief description of what is fixed or changed

Adds a `refine_Heaviside` handler to `sympy/assumptions/refine.py` so that
`refine` can simplify the Heaviside step function under the new assumptions
system.

**Before:**
```python
>>> refine(Heaviside(x), Q.positive(x))
Heaviside(x)
>>> refine(Heaviside(x), Q.negative(x))
Heaviside(x)
>>> refine(Heaviside(x), Q.zero(x))
Heaviside(x)
```

**After:**
```python
>>> refine(Heaviside(x), Q.positive(x))
1
>>> refine(Heaviside(x), Q.negative(x))
0
>>> refine(Heaviside(x), Q.zero(x))
1/2
```

The handler also respects the optional second argument that controls the
value at zero:
```python
>>> refine(Heaviside(x, 1), Q.zero(x))
1
```

#### Other comments

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added `refine` support for `Heaviside`.
<!-- END RELEASE NOTES -->