### PR TITLE
bin/test: Improve ergonomics

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -104,8 +104,8 @@ parser.add_argument(
     'tests', nargs='*', metavar='tests',
     help='0 or more glob strings of tests to run. If no test arguments are given, all tests will be run.')
 
-options, args = parser.parse_known_args()
-tests = options.tests + args
+options = parser.parse_args()
+tests = options.tests
 
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'

--- a/bin/test
+++ b/bin/test
@@ -38,8 +38,6 @@ path_hack()
 
 epilog = """
 "options" are any of the options above.
-"tests" are 0 or more glob strings of tests to run.
-If no test arguments are given, all tests will be run.
 """
 
 parser = ArgumentParser(
@@ -108,8 +106,12 @@ parser.add_argument(
     '--store-durations', action='store_true', dest='store_durations',
     default=False, help='Update the `.test_durations` file, which helps '
     'pytest-split partition tests into even-sized groups.')
+parser.add_argument(
+    'tests', nargs='*', metavar='tests',
+    help='0 or more glob strings of tests to run. If no test arguments are given, all tests will be run.')
 
 options, args = parser.parse_known_args()
+tests = options.tests + args
 
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
@@ -118,7 +120,7 @@ if options.types:
 
 import sympy
 
-exit_code = sympy.test(*args, verbose=options.verbose, kw=options.kw,
+exit_code = sympy.test(*tests, verbose=options.verbose, kw=options.kw,
     tb=options.tb, pdb=options.pdb, colors=options.colors,
     force_colors=options.force_colors, sort=options.sort,
     seed=options.seed, slow=options.slow, timeout=options.timeout,

--- a/bin/test
+++ b/bin/test
@@ -36,13 +36,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from get_sympy import path_hack
 path_hack()
 
-epilog = """
-"options" are any of the options above.
-"""
-
-parser = ArgumentParser(
-    epilog=epilog,
-    formatter_class=ArgumentDefaultsHelpFormatter)
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument(
     '-s', '--use-sympy-runner', action='store_true', dest='use_sympy_runner',
     default=False, help='Use the SymPy test runner instead of pytest. This is '

--- a/bin/test_optional_dependencies.py
+++ b/bin/test_optional_dependencies.py
@@ -56,9 +56,11 @@ test_list = [
 
     # codegen
     'sympy/codegen/',
-    'sympy/utilities/tests/test_codegen',
-    'sympy/utilities/_compilation/tests/test_compilation',
-    'sympy/external/tests/test_codegen.py',
+    # Match sympy/utilities/tests/test_codegen*.py and
+    # sympy/external/tests/test_codegen.py. (The pattern matching code currently
+    # only lets us match globs as a basename, so we can't spell out the directories.)
+    'test_codegen*.py',
+    'sympy/utilities/_compilation/tests/test_compilation.py',
 
     # cloudpickle
     'pickling',

--- a/sympy/testing/runtests_pytest.py
+++ b/sympy/testing/runtests_pytest.py
@@ -137,17 +137,23 @@ def update_args_with_paths(
             else:
                 partial_path_file_patterns.append(f'test*{partial_path}*.py')
         matches = []
-        for testpath in valid_testpaths_default:
-            for path, dirs, files in os.walk(testpath, topdown=True):
-                zipped = zip(partial_paths, partial_path_file_patterns)
-                for (partial_path, partial_path_file) in zipped:
+        zipped = zip(partial_paths, partial_path_file_patterns)
+        for partial_path, partial_path_file in zipped:
+            did_match_partial_path = False
+            for testpath in valid_testpaths_default:
+                for path, dirs, files in os.walk(testpath, topdown=True):
                     if fnmatch(path, f'*{partial_path}*'):
                         matches.append(str(pathlib.Path(path)))
+                        did_match_partial_path = True
                         dirs[:] = []
                     else:
                         for file in files:
                             if fnmatch(file, partial_path_file):
                                 matches.append(str(pathlib.Path(path, file)))
+                                did_match_partial_path = True
+            if not did_match_partial_path:
+                msg = f'No test paths matched: {partial_path!r}'
+                raise FileNotFoundError(msg)
         return matches
 
     def is_tests_file(filepath: str) -> bool:

--- a/sympy/testing/tests/test_runtests_pytest.py
+++ b/sympy/testing/tests/test_runtests_pytest.py
@@ -81,6 +81,27 @@ class TestUpdateArgsWithPaths:
         assert args == expected
 
     @staticmethod
+    def test_nonexistent_path_raises_error():
+        with pytest.raises(FileNotFoundError, match='doesnotexist'):
+            update_args_with_paths(paths=['doesnotexist'], keywords=None, args=[])
+
+    @staticmethod
+    def test_missing_path_with_other_valid_paths_raises_error():
+        paths = ['sympy/core/tests/test_basic.py', 'doesnotexist']
+        with pytest.raises(FileNotFoundError, match='doesnotexist'):
+            update_args_with_paths(paths=paths, keywords=None, args=[])
+
+    @staticmethod
+    def test_multiple_nested_paths_do_not_raise_error():
+        # Ensure that directory pruning on sympy/core does not cause the second
+        # pattern to fail
+        paths = ['/core', 'test_sympify.py']
+        args = update_args_with_paths(paths=paths, keywords=None, args=[])
+        expected_paths = ['sympy/core', 'sympy/core/tests/test_sympify.py']
+        for expected in expected_paths:
+            assert any(expected in Path(arg).as_posix() for arg in args)
+
+    @staticmethod
     @pytest.mark.parametrize(
         'paths, expected_paths',
         [


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### Brief description of what is fixed or changed

`bin/test` now fails when you pass `--badopt` or `nonexistent_test`. This also improves the `bin/test --help` text; here's the output diff:

```diff
--- "bin/test --help"
+++ "bin/test --help"
@@ -3,6 +3,12 @@
             [-t {gmpy,gmpy1,python}] [-C] [--timeout TIMEOUT] [--slow]
             [--no-subprocess] [-E] [--split SPLIT] [--rerun RERUN]
             [--parallel] [--store-durations]
+            [tests ...]
+
+positional arguments:
+  tests                 0 or more glob strings of tests to run. If no test
+                        arguments are given, all tests will be run. (default:
+                        None)

 options:
   -h, --help            show this help message and exit
@@ -43,6 +49,3 @@
   --store-durations     Update the `.test_durations` file, which helps pytest-
                         split partition tests into even-sized groups.
                         (default: False)
-
-"options" are any of the options above. "tests" are 0 or more glob strings of
-tests to run. If no test arguments are given, all tests will be run.
```

#### Other comments

See individual commit messages for notes.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Most lines written by Codex (codex-5.3 high), with multiple revisions.  I made minor manual changes and carefully reviewed and tested the code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
