### PR TITLE
integrals: Improve Piecewise handling in manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1890,9 +1890,9 @@ def quadratic_denom_rule(integral):
         pieces = []
         # skips degenerate case if b != 0 or if b = 0 would cause null denominator
         if not _if_zero_implies_zero(b, c):
-                substituted = integrand.subs(b, 0)
-                substep = integral_steps(substituted, symbol)
-                pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
+            substituted = integrand.subs(b, 0)
+            substep = integral_steps(substituted, symbol)
+            pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
         if not _if_zero_implies_zero(c, b):
             substituted = integrand.subs(c, 0)
             substep = integral_steps(substituted, symbol)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -86,8 +86,8 @@ def _is_zero_if_zero(P, Q):
     if not P.free_symbols:
         return True
 
-    factors_P = set(f for f, p in factor_list(P)[1])
-    factors_Q = set(f for f, p in factor_list(Q)[1])
+    factors_P = {f for f, p in factor_list(P)[1]}
+    factors_Q = {f for f, p in factor_list(Q)[1]}
 
     return factors_P.issubset(factors_Q)
 
@@ -2468,6 +2468,8 @@ def substitution_rule(integral):
     if substitutions:
         debug("List of Substitution Rules")
         ways = []
+        factored_integrand = integrand.factor()
+        _, denom_integrand = factored_integrand.as_numer_denom()
         for u_func, c, substituted in substitutions:
             subrule = integral_steps(substituted, u_var)
             count = count + 1
@@ -2477,27 +2479,22 @@ def substitution_rule(integral):
                 continue
 
             if simplify(c - 1) != 0:
-                _, denom = c.as_numer_denom()
+                _, denom_c = c.as_numer_denom()
                 if subrule:
                     subrule = ConstantTimesRule(c * substituted, u_var, c, substituted, subrule)
 
-                if denom.free_symbols:
+                if denom_c.free_symbols:
                     piecewise = []
-                    could_be_zero = []
-
-                    if isinstance(denom, Mul):
-                        could_be_zero = denom.args
-                    else:
-                        could_be_zero.append(denom)
-
-                    for expr in could_be_zero:
-                        if not fuzzy_not(expr.is_zero):
-                            substep = integral_steps(manual_subs(integrand, expr, 0), symbol)
+                    factors_denom_c = factor_list(denom_c)[1]
+                    for pole, _ in factors_denom_c:
+                        # only substitute poles introduced by the constant c if they were not already poles of the original integrand
+                        if not fuzzy_not(pole.is_zero) and not _is_zero_if_zero(pole, denom_integrand):
+                            substep = integral_steps(manual_subs(factored_integrand, pole, 0), symbol)
 
                             if substep:
                                 piecewise.append((
                                     substep,
-                                    Eq(expr, 0)
+                                    Eq(pole, 0)
                                 ))
                     piecewise.append((subrule, True))
                     subrule = PiecewiseRule(substituted, symbol, piecewise)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1889,6 +1889,15 @@ def quadratic_denom_rule(integral):
     if match:
         a, b, c = match[a], match[b], match[c]
         general_rule = ArctanRule(integrand, symbol, a, b, c)
+        pieces = []
+        if b.is_zero is not S.false and c.is_zero is not S.true and not _is_zero_if_zero(b, c):
+                substituted = integrand.subs(b, 0)
+                substep = integral_steps(substituted, symbol)
+                pieces.append( (RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)) )
+        if c.is_zero is not S.false and b.is_zero is not S.true and not _is_zero_if_zero(c, b):
+            substituted = integrand.subs(c, 0)
+            substep = integral_steps(substituted, symbol)
+            pieces.append( (RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)) )
         if b.is_extended_real and c.is_extended_real:
             positive_cond = c/b > 0
             if positive_cond is S.true:
@@ -1906,14 +1915,14 @@ def quadratic_denom_rule(integral):
                 negative_step = ConstantTimesRule(rewritten, symbol, coeff, sub, negative_step)
             negative_step = RewriteRule(integrand, symbol, rewritten, negative_step)
             if positive_cond is S.false:
-                return negative_step
-            return PiecewiseRule(integrand, symbol, [(general_rule, positive_cond), (negative_step, S.true)])
+                pieces.append((negative_step, S.true))
+                return PiecewiseRule(integrand, symbol, pieces)
+            else:
+                pieces.append((negative_step, c / b < 0))
+                
+        pieces.append((general_rule, S.true))
+        return PiecewiseRule(integrand, symbol, pieces)    
 
-        power = PowerRule(integrand, symbol, symbol, -2)
-        if b != 1:
-            power = ConstantTimesRule(integrand, symbol, 1/b, symbol**-2, power)
-
-        return PiecewiseRule(integrand, symbol, [(general_rule, Ne(c, 0)), (power, True)])
 
     d = Wild('d', exclude=[symbol])
     match2 = integrand.match(a / (b * symbol ** 2 + c * symbol + d))
@@ -2040,7 +2049,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
             simplified_a = integrand.subs(subs_a)
             degenerate_step_a = integral_steps(simplified_a, x)
             pieces.append((degenerate_step_a, S.true if (_is_zero_if_zero(c0, d0) or cond_c0 is S.true) else cond_c0))
-        # c0 can be == 0 and d0 nullity is not implied by c0
+        # c0 can be == 0, d0 is not 0 and d0 nullity is not implied by c0
         if cond_c0 is not S.true and not _is_zero_if_zero(c0, d0):
             const_val = b0 / d0
             subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
@@ -2492,9 +2501,11 @@ def substitution_rule(integral):
                     for pole, _ in factors_denom_c:
                         # only substitute poles introduced by the constant c if they were not already poles of the original integrand
                         if pole.is_zero is None and not _is_zero_if_zero(pole, denom_integrand):
-                            substep = integral_steps(manual_subs(factored_integrand, pole, 0), symbol)
+                            rewritten_integral = manual_subs(factored_integrand, pole, 0)
+                            substep = integral_steps(rewritten_integral, symbol)
 
                             if substep:
+                                substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
                                 piecewise.append((
                                     substep,
                                     Eq(pole, 0)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -77,7 +77,7 @@ def _if_zero_implies_zero(P, Q):
     """
     Check if expression P = 0 implies Q = 0.
 
-    Returns True if P is not zero or if substituting every irreducible 
+    Returns True if P is not zero or if substituting every irreducible
     factor of the numerator of P in the numerator of Q makes Q = 0.
     """
     num_p, _ = P.as_numer_denom()
@@ -1919,7 +1919,7 @@ def quadratic_denom_rule(integral):
                     pieces.append((negative_step, c / b < 0))
         general_rule = ArctanRule(integrand, symbol, a, b, c)
         pieces.append((general_rule, S.true))
-        return PiecewiseRule(integrand, symbol, pieces)    
+        return PiecewiseRule(integrand, symbol, pieces)
 
 
     d = Wild('d', exclude=[symbol])
@@ -2033,7 +2033,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
         det = a0*d0 - b0*c0
         _, base0_denom = base0.as_numer_denom()
         # skips bases where constant value (degenerate case) is not possible (det != 0 or det = 0 implies den = 0)
-        # (eg. (3*x + 2)/(4*x + 3), (3x + b)/(d), (4*x + 3)/(c*x + c)) 
+        # (eg. (3*x + 2)/(4*x + 3), (3x + b)/(d), (4*x + 3)/(c*x + c))
         if not (_if_zero_implies_zero(det, base0_denom)):
             d0_implies_c0 = _if_zero_implies_zero(d0, c0)
             c0_implies_d0 = _if_zero_implies_zero(c0, d0)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -76,21 +76,19 @@ if TYPE_CHECKING:
 def _is_zero_if_zero(P, Q):
     """
     Returns True if the condition (P == 0) mathematically implies (Q == 0).
-    
-    This is verified by checking if all irreducible factors of P are 
+
+    This is verified by checking if all irreducible factors of P are
     present in Q, which ensures that any root of P is also a root of Q.
     """
-    from sympy import factor_list
 
     if P.is_zero:
         return Q.is_zero
-    
     if not P.free_symbols:
         return True
 
     factors_P = set(f for f, p in factor_list(P)[1])
     factors_Q = set(f for f, p in factor_list(Q)[1])
-    
+
     return factors_P.issubset(factors_Q)
 
 class Rule(ABC):
@@ -1908,7 +1906,7 @@ def quadratic_denom_rule(integral):
             if positive_cond is S.false:
                 return negative_step
             return PiecewiseRule(integrand, symbol, [(general_rule, positive_cond), (negative_step, S.true)])
-        
+
         power = PowerRule(integrand, symbol, symbol, -2)
         if b != 1:
             power = ConstantTimesRule(integrand, symbol, 1/b, symbol**-2, power)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -75,19 +75,21 @@ if TYPE_CHECKING:
 
 def _is_zero_if_zero(P, Q):
     """
-    Returns True if the condition (P == 0) mathematically implies (Q == 0).
+    Check if it is possible P = 0 and in that case Q = 0.
 
-    This is verified by checking if all irreducible factors of P are
-    present in Q, which ensures that any root of P is also a root of Q.
+    Returns True if Q is zero or if every irreducible factor of the 
+    numerator of P is also a factor of the numerator of Q.
     """
+    num_p, _ = P.as_numer_denom()
+    num_q, _ = Q.as_numer_denom()
 
-    if P.is_zero:
-        return Q.is_zero
-    if not P.free_symbols:
+    if Q.is_zero:
         return True
 
-    factors_P = {f for f, p in factor_list(P)[1]}
-    factors_Q = {f for f, p in factor_list(Q)[1]}
+    factors_P = {f for f, p in factor_list(num_p)[1]}
+    if not factors_P:
+        return False
+    factors_Q = {f for f, p in factor_list(num_q)[1]}
 
     return factors_P.issubset(factors_Q)
 
@@ -2022,22 +2024,23 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     if not substep.contains_dont_know():
         step: Rule = URule(integrand, x, u, u_x, substep)
         det = a0*d0 - b0*c0
-        # in this case, if determinant is 0 both c0 and d0 would be 0 (null denom), no need of Piecewise
-        if _is_zero_if_zero(det, c0) and _is_zero_if_zero(det, d0):
+        # determinant is not 0 or it is 0 if just both c0 and d0 would be 0 (null denom), no need of Piecewise
+        if det.is_zero is S.false or (_is_zero_if_zero(det, c0) and _is_zero_if_zero(det, d0)):
             if constant_bases_subs:
                 return RewriteRule(integral.integrand, x, integrand, step)
             else:
                 return step
-        # constant value is possible
         generic_cond = Ne(a0*d0 - b0*c0, 0)
         pieces: list[tuple[Rule, Boolean]] = [(step, generic_cond)]
         cond_c0 = Ne(c0, 0)
-        if cond_c0 is not S.false and not _is_zero_if_zero(d0, c0): # ((a*x + b)/(3*c*d*x + d)) takes just b/d as costant value
+        # c0 can be != 0 and his nullity is not implied by d0, ((a*x + b)/(3*c*d*x + d)), just b/d as costant value
+        if cond_c0 is not S.false and not _is_zero_if_zero(d0, c0):
             const_val = a0 / c0
             subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
             simplified_a = integrand.subs(subs_a)
             degenerate_step_a = integral_steps(simplified_a, x)
             pieces.append((degenerate_step_a, S.true if (_is_zero_if_zero(c0, d0) or cond_c0 is S.true) else cond_c0))
+        # c0 can be == 0 and d0 nullity is not implied by c0
         if cond_c0 is not S.true and not _is_zero_if_zero(c0, d0):
             const_val = b0 / d0
             subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
@@ -2488,7 +2491,7 @@ def substitution_rule(integral):
                     factors_denom_c = factor_list(denom_c)[1]
                     for pole, _ in factors_denom_c:
                         # only substitute poles introduced by the constant c if they were not already poles of the original integrand
-                        if not fuzzy_not(pole.is_zero) and not _is_zero_if_zero(pole, denom_integrand):
+                        if pole.is_zero is None and not _is_zero_if_zero(pole, denom_integrand):
                             substep = integral_steps(manual_subs(factored_integrand, pole, 0), symbol)
 
                             if substep:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -73,25 +73,24 @@ from sympy.utilities.misc import debug
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
 
-def _is_zero_if_zero(P, Q):
+def _if_zero_implies_zero(P, Q):
     """
-    Check if it is possible P = 0 and in that case Q = 0.
+    Check if expression P = 0 implies Q = 0.
 
-    Returns True if Q is zero or if every irreducible factor of the 
-    numerator of P is also a factor of the numerator of Q.
+    Returns True if P is not zero or if substituting every irreducible 
+    factor of the numerator of P in the numerator of Q makes Q = 0.
     """
     num_p, _ = P.as_numer_denom()
     num_q, _ = Q.as_numer_denom()
-
-    if Q.is_zero:
-        return True
-
+    if P.is_zero:
+        return Q.is_zero
     factors_P = {f for f, p in factor_list(num_p)[1]}
-    if not factors_P:
-        return False
-    factors_Q = {f for f, p in factor_list(num_q)[1]}
-
-    return factors_P.issubset(factors_Q)
+    # use factor() to help find substitutions (eg. (a**2 - 1) is zero if (a + 1) = 0)
+    factored_num_q = num_q.factor()
+    for factor in factors_P:
+        if factored_num_q.subs(factor, 0) != 0:
+            return False
+    return True
 
 class Rule(ABC):
 
@@ -1880,46 +1879,45 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
 
 def quadratic_denom_rule(integral):
     integrand, symbol = integral
-    a = Wild('a', exclude=[symbol])
-    b = Wild('b', exclude=[symbol])
-    c = Wild('c', exclude=[symbol])
+    a = Wild('a', exclude=[symbol, 0])
+    b = Wild('b', exclude=[symbol, 0])
+    c = Wild('c', exclude=[symbol, 0])
 
     match = integrand.match(a / (b * symbol ** 2 + c))
 
     if match:
         a, b, c = match[a], match[b], match[c]
-        general_rule = ArctanRule(integrand, symbol, a, b, c)
         pieces = []
-        if b.is_zero is not S.false and c.is_zero is not S.true and not _is_zero_if_zero(b, c):
+        # skips degenerate case if b != 0 or if b = 0 would cause null denominator
+        if not _if_zero_implies_zero(b, c):
                 substituted = integrand.subs(b, 0)
                 substep = integral_steps(substituted, symbol)
-                pieces.append( (RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)) )
-        if c.is_zero is not S.false and b.is_zero is not S.true and not _is_zero_if_zero(c, b):
+                pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
+        if not _if_zero_implies_zero(c, b):
             substituted = integrand.subs(c, 0)
             substep = integral_steps(substituted, symbol)
-            pieces.append( (RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)) )
+            pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)))
         if b.is_extended_real and c.is_extended_real:
             positive_cond = c/b > 0
-            if positive_cond is S.true:
-                return general_rule
-            coeff = a/(2*sqrt(-c)*sqrt(b))
-            constant = sqrt(-c/b)
-            r1 = 1/(symbol-constant)
-            r2 = 1/(symbol+constant)
-            log_steps = [ReciprocalRule(r1, symbol, symbol-constant),
-                         ConstantTimesRule(-r2, symbol, -1, r2, ReciprocalRule(r2, symbol, symbol+constant))]
-            rewritten = sub = r1 - r2
-            negative_step = AddRule(sub, symbol, log_steps)
-            if coeff != 1:
-                rewritten = Mul(coeff, sub, evaluate=False)
-                negative_step = ConstantTimesRule(rewritten, symbol, coeff, sub, negative_step)
-            negative_step = RewriteRule(integrand, symbol, rewritten, negative_step)
-            if positive_cond is S.false:
-                pieces.append((negative_step, S.true))
-                return PiecewiseRule(integrand, symbol, pieces)
-            else:
-                pieces.append((negative_step, c / b < 0))
-                
+            if positive_cond is not S.true:
+                coeff = a/(2*sqrt(-c)*sqrt(b))
+                constant = sqrt(-c/b)
+                r1 = 1/(symbol-constant)
+                r2 = 1/(symbol+constant)
+                log_steps = [ReciprocalRule(r1, symbol, symbol-constant),
+                            ConstantTimesRule(-r2, symbol, -1, r2, ReciprocalRule(r2, symbol, symbol+constant))]
+                rewritten = sub = r1 - r2
+                negative_step = AddRule(sub, symbol, log_steps)
+                if coeff != 1:
+                    rewritten = Mul(coeff, sub, evaluate=False)
+                    negative_step = ConstantTimesRule(rewritten, symbol, coeff, sub, negative_step)
+                negative_step = RewriteRule(integrand, symbol, rewritten, negative_step)
+                if positive_cond is S.false:
+                    pieces.append((negative_step, S.true))
+                    return PiecewiseRule(integrand, symbol, pieces)
+                else:
+                    pieces.append((negative_step, c / b < 0))
+        general_rule = ArctanRule(integrand, symbol, a, b, c)
         pieces.append((general_rule, S.true))
         return PiecewiseRule(integrand, symbol, pieces)    
 
@@ -2031,37 +2029,35 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     substituted = integrand.subs(subs_dict).subs(x, x_u) * dx_u
     substep = integral_steps(substituted, u)
     if not substep.contains_dont_know():
-        step: Rule = URule(integrand, x, u, u_x, substep)
+        pieces = []
         det = a0*d0 - b0*c0
-        # determinant is not 0 or it is 0 if just both c0 and d0 would be 0 (null denom), no need of Piecewise
-        if det.is_zero is S.false or (_is_zero_if_zero(det, c0) and _is_zero_if_zero(det, d0)):
-            if constant_bases_subs:
-                return RewriteRule(integral.integrand, x, integrand, step)
-            else:
-                return step
-        generic_cond = Ne(a0*d0 - b0*c0, 0)
-        pieces: list[tuple[Rule, Boolean]] = [(step, generic_cond)]
-        cond_c0 = Ne(c0, 0)
-        # c0 can be != 0 and his nullity is not implied by d0, ((a*x + b)/(3*c*d*x + d)), just b/d as costant value
-        if cond_c0 is not S.false and not _is_zero_if_zero(d0, c0):
-            const_val = a0 / c0
-            subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
-            simplified_a = integrand.subs(subs_a)
-            degenerate_step_a = integral_steps(simplified_a, x)
-            pieces.append((degenerate_step_a, S.true if (_is_zero_if_zero(c0, d0) or cond_c0 is S.true) else cond_c0))
-        # c0 can be == 0, d0 is not 0 and d0 nullity is not implied by c0
-        if cond_c0 is not S.true and not _is_zero_if_zero(c0, d0):
-            const_val = b0 / d0
-            subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
-            simplified_b = integrand.subs(subs_b)
-            simplified_b.subs({a0: 0, c0: 0}) # if det=0 and c0=0 and d0!=0, a0=0
-            degenerate_step_b = integral_steps(simplified_b, x)
-            pieces.append((degenerate_step_b, S.true))
+        _, base0_denom = base0.as_numer_denom()
+        # skips bases where constant value (degenerate case) is not possible (det != 0 or det = 0 implies den = 0)
+        # (eg. (3*x + 2)/(4*x + 3), (3x + b)/(d), (4*x + 3)/(c*x + c)) 
+        if not (_if_zero_implies_zero(det, base0_denom)):
+            d0_implies_c0 = _if_zero_implies_zero(d0, c0)
+            c0_implies_d0 = _if_zero_implies_zero(c0, d0)
+            # skips constant value a/c if d != 0 or d = 0 implies c = 0 (eg. (3*x + 2)/(c*d*x + d), (3*x + 2)/(c*x + 4))
+            # takes a/c if they both imply each other (eg. (a*x + b)/3*x + 4)) (taking b/d would be the same)
+            if not d0_implies_c0 or (c0_implies_d0 and d0_implies_c0):
+                const_val = a0 / c0
+                subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
+                simplified_a = integrand.subs(subs_a)
+                degenerate_step_a = integral_steps(simplified_a, x)
+                pieces.append((degenerate_step_a, (And(Eq(det, 0), Ne(c0, 0)))))
+            if not c0_implies_d0:
+                const_val = b0 / d0
+                subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
+                simplified_b = integrand.subs(subs_b)
+                simplified_b = simplified_b.subs({a0: 0, c0: 0}) # if det = 0, c = 0 and d != 0, a must be 0
+                degenerate_step_b = integral_steps(simplified_b, x)
+                pieces.append((degenerate_step_b, (And(Eq(det, 0), Eq(c0, 0)))))
+        step = URule(integrand, x, u, u_x, substep)
+        pieces.append((step, S.true))
         step = PiecewiseRule(integrand, x, pieces)
         if constant_bases_subs:
             return RewriteRule(integral.integrand, x, integrand, step)
-        else:
-            return step
+        return step
     return None
 
 
@@ -2500,7 +2496,7 @@ def substitution_rule(integral):
                     factors_denom_c = factor_list(denom_c)[1]
                     for pole, _ in factors_denom_c:
                         # only substitute poles introduced by the constant c if they were not already poles of the original integrand
-                        if pole.is_zero is None and not _is_zero_if_zero(pole, denom_integrand):
+                        if not _if_zero_implies_zero(pole, denom_integrand):
                             rewritten_integral = manual_subs(factored_integrand, pole, 0)
                             substep = integral_steps(rewritten_integral, symbol)
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1918,8 +1918,10 @@ def quadratic_denom_rule(integral):
                 else:
                     pieces.append((negative_step, c / b < 0))
         general_rule = ArctanRule(integrand, symbol, a, b, c)
-        pieces.append((general_rule, S.true))
-        return PiecewiseRule(integrand, symbol, pieces)
+        if pieces:
+            pieces.append((general_rule, S.true))
+            return PiecewiseRule(integrand, symbol, pieces)
+        return general_rule
 
 
     d = Wild('d', exclude=[symbol])
@@ -2029,7 +2031,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     substituted = integrand.subs(subs_dict).subs(x, x_u) * dx_u
     substep = integral_steps(substituted, u)
     if not substep.contains_dont_know():
-        pieces = []
+        pieces: list[tuple[Rule, Boolean]] = []
         det = a0*d0 - b0*c0
         _, base0_denom = base0.as_numer_denom()
         # skips bases where constant value (degenerate case) is not possible (det != 0 or det = 0 implies den = 0)
@@ -2052,9 +2054,10 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
                 simplified_b = simplified_b.subs({a0: 0, c0: 0}) # if det = 0, c = 0 and d != 0, a must be 0
                 degenerate_step_b = integral_steps(simplified_b, x)
                 pieces.append((degenerate_step_b, (And(Eq(det, 0), Eq(c0, 0)))))
-        step = URule(integrand, x, u, u_x, substep)
-        pieces.append((step, S.true))
-        step = PiecewiseRule(integrand, x, pieces)
+        step: Rule = URule(integrand, x, u, u_x, substep)
+        if pieces:
+            pieces.append((step, S.true))
+            step = PiecewiseRule(integrand, x, pieces)
         if constant_bases_subs:
             return RewriteRule(integral.integrand, x, integrand, step)
         return step
@@ -2492,7 +2495,7 @@ def substitution_rule(integral):
                     subrule = ConstantTimesRule(c * substituted, u_var, c, substituted, subrule)
 
                 if denom_c.free_symbols:
-                    piecewise = []
+                    pieces = []
                     factors_denom_c = factor_list(denom_c)[1]
                     for pole, _ in factors_denom_c:
                         # only substitute poles introduced by the constant c if they were not already poles of the original integrand
@@ -2502,12 +2505,13 @@ def substitution_rule(integral):
 
                             if substep:
                                 substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
-                                piecewise.append((
+                                pieces.append((
                                     substep,
                                     Eq(pole, 0)
                                 ))
-                    piecewise.append((subrule, True))
-                    subrule = PiecewiseRule(substituted, symbol, piecewise)
+                    if pieces:
+                        pieces.append((subrule, True))
+                        subrule = PiecewiseRule(substituted, symbol, pieces)
 
             ways.append(URule(integrand, symbol, u_var, u_func, subrule))
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -61,7 +61,7 @@ from sympy.functions.special.zeta_functions import polylog
 from .integrals import Integral
 from sympy.logic.boolalg import And, Boolean
 from sympy.ntheory.factor_ import primefactors
-from sympy.polys.polytools import degree, lcm_list, gcd_list, Poly
+from sympy.polys.polytools import degree, factor_list, lcm_list, gcd_list, Poly
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.simplify.powsimp import powsimp
@@ -73,6 +73,25 @@ from sympy.utilities.misc import debug
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
 
+def _is_zero_if_zero(P, Q):
+    """
+    Returns True if the condition (P == 0) mathematically implies (Q == 0).
+    
+    This is verified by checking if all irreducible factors of P are 
+    present in Q, which ensures that any root of P is also a root of Q.
+    """
+    from sympy import factor_list
+
+    if P.is_zero:
+        return Q.is_zero
+    
+    if not P.free_symbols:
+        return True
+
+    factors_P = set(f for f, p in factor_list(P)[1])
+    factors_Q = set(f for f, p in factor_list(Q)[1])
+    
+    return factors_P.issubset(factors_Q)
 
 class Rule(ABC):
 
@@ -1889,7 +1908,7 @@ def quadratic_denom_rule(integral):
             if positive_cond is S.false:
                 return negative_step
             return PiecewiseRule(integrand, symbol, [(general_rule, positive_cond), (negative_step, S.true)])
-
+        
         power = PowerRule(integrand, symbol, symbol, -2)
         if b != 1:
             power = ConstantTimesRule(integrand, symbol, 1/b, symbol**-2, power)
@@ -2004,30 +2023,31 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     substep = integral_steps(substituted, u)
     if not substep.contains_dont_know():
         step: Rule = URule(integrand, x, u, u_x, substep)
-        # in these cases, deteminant would be 0 only if both c0 and d0 were 0 (null denom), no need of Piecewise
-        if (c0.is_zero and (a0.is_zero is False)) or (d0.is_zero and (b0.is_zero is False)):
+        det = a0*d0 - b0*c0
+        # in this case, if determinant is 0 both c0 and d0 would be 0 (null denom), no need of Piecewise
+        if _is_zero_if_zero(det, c0) and _is_zero_if_zero(det, d0):
             if constant_bases_subs:
                 return RewriteRule(integral.integrand, x, integrand, step)
             else:
                 return step
+        # constant value is possible
         generic_cond = Ne(a0*d0 - b0*c0, 0)
-        if generic_cond is not S.true:
-            pieces: list[tuple[Rule, Boolean]] = [(step, generic_cond)]
-            cond_c0 = Ne(c0, 0)
-            if cond_c0 is not S.false:
-                const_val = a0 / c0
-                subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
-                simplified_a = integrand.subs(subs_a)
-                degenerate_step_a = integral_steps(simplified_a, x)
-                pieces.append((degenerate_step_a, cond_c0))
-            if cond_c0 is not S.true:
-                const_val = b0 / d0
-                subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
-                simplified_b = integrand.subs(subs_b)
-                simplified_b.subs({a0: 0, c0: 0}) # if det=0 and c0=0 and d0!=0, a0=0
-                degenerate_step_b = integral_steps(simplified_b, x)
-                pieces.append((degenerate_step_b, S.true))
-            step = PiecewiseRule(integrand, x, pieces)
+        pieces: list[tuple[Rule, Boolean]] = [(step, generic_cond)]
+        cond_c0 = Ne(c0, 0)
+        if cond_c0 is not S.false and not _is_zero_if_zero(d0, c0): # ((a*x + b)/(3*c*d*x + d)) takes just b/d as costant value
+            const_val = a0 / c0
+            subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
+            simplified_a = integrand.subs(subs_a)
+            degenerate_step_a = integral_steps(simplified_a, x)
+            pieces.append((degenerate_step_a, S.true if (_is_zero_if_zero(c0, d0) or cond_c0 is S.true) else cond_c0))
+        if cond_c0 is not S.true and not _is_zero_if_zero(c0, d0):
+            const_val = b0 / d0
+            subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
+            simplified_b = integrand.subs(subs_b)
+            simplified_b.subs({a0: 0, c0: 0}) # if det=0 and c0=0 and d0!=0, a0=0
+            degenerate_step_b = integral_steps(simplified_b, x)
+            pieces.append((degenerate_step_b, S.true))
+        step = PiecewiseRule(integrand, x, pieces)
         if constant_bases_subs:
             return RewriteRule(integral.integrand, x, integrand, step)
         else:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2031,6 +2031,7 @@ def test_sqrt_quadratic():
     assert integrate(1/sqrt(a+b*x+c*x**2), x) == \
         Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(c, 0) & Ne(a - b**2/(4*c), 0)),
                   ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), Ne(c, 0)),
+                  (x/sqrt(a), Eq(b, 0)),
                   (2*sqrt(a + b*x)/b, Ne(b, 0)), (x/sqrt(a), True))
 
     assert integrate((7*x+6)/sqrt(3*x**2+4*x+5)) == \
@@ -2044,6 +2045,7 @@ def test_sqrt_quadratic():
                    Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(a - b**2/(4*c), 0)),
                              ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), True)) +
                    e*sqrt(a + b*x + c*x**2)/c, Ne(c, 0)),
+                   ((d*x + e*x**2/2)/sqrt(a), Eq(b, 0)),
                   (2*((d*sqrt(a + b*x) - e*(a*sqrt(a + b*x) - (a + b*x)**(S(3)/2)/3)/b)/b), Ne(b, 0)),
                   ((d*x + e*x**2/2)/sqrt(a), True))
 
@@ -2058,6 +2060,7 @@ def test_sqrt_quadratic():
                    Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(a - b**2/(4*c), 0)),
                              ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), True)) +
                    (b/(4*c) + x/2)*sqrt(a + b*x + c*x**2), Ne(c, 0)),
+                   (sqrt(a)*x, Eq(b, 0)),
                   (2*(a + b*x)**(S(3)/2)/(3*b), Ne(b, 0)),
                   (sqrt(a)*x, True))
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from sympy.core.function import (Derivative, Function, diff, expand)
 from sympy.core.numbers import (I, Rational, pi)
-from sympy.core.relational import Ne
+from sympy.core.relational import Ne, Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import (exp, log)
@@ -149,18 +149,20 @@ def test_manualintegrate_inversetrig():
     ra = Symbol('a', real=True)
     rb = Symbol('b', real=True)
     assert manualintegrate(1/(ra + rb*x**2), x) == \
-        Piecewise((atan(x/sqrt(ra/rb))/(rb*sqrt(ra/rb)), ra/rb > 0),
-                  ((log(x - sqrt(-ra/rb)) - log(x + sqrt(-ra/rb)))/(2*sqrt(rb)*sqrt(-ra)), True))
+        Piecewise((x/ra, Eq(rb, 0)), (-1/(rb*x), Eq(ra, 0)),
+                  ((log(x - sqrt(-ra/rb)) - log(x + sqrt(-ra/rb)))/(2*sqrt(rb)*sqrt(-ra)), ra/rb < 0),
+                  (atan(x/sqrt(ra/rb))/(rb*sqrt(ra/rb)), True))
     assert manualintegrate(1/(4 + rb*x**2), x) == \
-        Piecewise((atan(x/(2*sqrt(1/rb)))/(2*rb*sqrt(1/rb)), 1/rb > 0),
-                  (-I*(log(x - 2*sqrt(-1/rb)) - log(x + 2*sqrt(-1/rb)))/(4*sqrt(rb)), True))
+        Piecewise((x/4, Eq(rb, 0)), (-I*(log(x - 2*sqrt(-1/rb)) - log(x + 2*sqrt(-1/rb)))/(4*sqrt(rb)), 1/rb < 0),
+                   (atan(x/(2*sqrt(1/rb)))/(2*rb*sqrt(1/rb)), True))
     assert manualintegrate(1/(ra + 4*x**2), x) == \
-        Piecewise((atan(2*x/sqrt(ra))/(2*sqrt(ra)), ra > 0),
-                  ((log(x - sqrt(-ra)/2) - log(x + sqrt(-ra)/2))/(4*sqrt(-ra)), True))
+        Piecewise((-1/(4*x), Eq(ra, 0)), ((log(x - sqrt(-ra)/2) - log(x + sqrt(-ra)/2))/(4*sqrt(-ra)), ra < 0),
+                (atan(2*x/sqrt(ra))/(2*sqrt(ra)), True))
+
     assert manualintegrate(1/(4 + 4*x**2), x) == atan(x) / 4
 
-    assert manualintegrate(1/(a + b*x**2), x) == Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), Ne(a, 0)),
-                                                           (-1/(b*x), True))
+    assert manualintegrate(1/(a + b*x**2), x) == Piecewise((x/a, Eq(b, 0)), (-1/(b*x), Eq(a, 0)),
+                                                           (atan(x/sqrt(a/b))/(b*sqrt(a/b)), True))
 
     # asin
     assert manualintegrate(1/sqrt(1-x**2), x) == asin(x)
@@ -210,7 +212,8 @@ def test_manualintegrate_inversetrig():
     # atan
     assert manualintegrate(atan(x), x) == x*atan(x) - log(x**2 + 1)/2
     assert manualintegrate(atan(a*x), x) == Piecewise(((a*x*atan(a*x) - log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (0, True))
-    assert manualintegrate(x*atan(a*x), x) == -a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*atan(a*x)/2
+    assert manualintegrate(x*atan(a*x), x) == -a*(x/a**2 - Piecewise((x, Eq(a**2, 0)),
+                                            (atan(x/sqrt(a**(-2)))/(a**2*sqrt(a**(-2))), True))/a**2)/2 + x**2*atan(a*x)/2
     # acsc
     assert manualintegrate(acsc(x), x) == x*acsc(x) + Integral(1/(x*sqrt(1 - 1/x**2)), x)
     assert manualintegrate(acsc(a*x), x) == x*acsc(a*x) + Integral(1/(x*sqrt(1 - 1/(a**2*x**2))), x)/a
@@ -222,7 +225,8 @@ def test_manualintegrate_inversetrig():
     # acot
     assert manualintegrate(acot(x), x) == x*acot(x) + log(x**2 + 1)/2
     assert manualintegrate(acot(a*x), x) == Piecewise(((a*x*acot(a*x) + log(a**2*x**2 + 1)/2)/a, Ne(a, 0)), (pi*x/2, True))
-    assert manualintegrate(x*acot(a*x), x) == a*(x/a**2 - atan(x/sqrt(a**(-2)))/(a**4*sqrt(a**(-2))))/2 + x**2*acot(a*x)/2
+    assert manualintegrate(x*acot(a*x), x) == a*(x/a**2 - Piecewise((x, Eq(a**2, 0)),
+                                            (atan(x/sqrt(a**(-2)))/(a**2*sqrt(a**(-2))), True))/a**2)/2 + x**2*acot(a*x)/2
 
     # piecewise
     assert manualintegrate(1/sqrt(ra-rb*x**2), x) == \
@@ -499,7 +503,8 @@ def test_issue_6746():
         (y + 1)**(n*x)/(n*log(y + 1))
     a = Symbol('a', negative=True)
     b = Symbol('b')
-    assert manualintegrate(1/(a + b*x**2), x) == atan(x/sqrt(a/b))/(b*sqrt(a/b))
+    assert manualintegrate(1/(a + b*x**2), x) == Piecewise(
+        (atan(x/sqrt(a/b))/(b*sqrt(a/b)), Ne(b, 0)), (x/a, True))
     b = Symbol('b', negative=True)
     assert manualintegrate(1/(a + b*x**2), x) == \
         atan(x/(sqrt(-a)*sqrt(-1/b)))/(b*sqrt(-a)*sqrt(-1/b))
@@ -551,55 +556,50 @@ def test_issue_10847_slow():
 def test_issue_10847():
 
     assert manualintegrate(x**2 / (x**2 - c), x) == \
-        c*Piecewise((atan(x/sqrt(-c))/sqrt(-c), Ne(c, 0)), (-1/x, True)) + x
+            c*Piecewise((-1/x, Eq(c, 0)), (atan(x/sqrt(-c))/sqrt(-c), True)) + x
 
     rc = Symbol('c', real=True)
     assert manualintegrate(x**2 / (x**2 - rc), x) == \
-        rc*Piecewise((atan(x/sqrt(-rc))/sqrt(-rc), rc < 0),
-                     ((log(-sqrt(rc) + x) - log(sqrt(rc) + x))/(2*sqrt(rc)), True)) + x
+        rc*Piecewise(((-1/x, Eq(rc, 0))), ((log(-sqrt(rc) + x) - log(sqrt(rc) + x))/(2*sqrt(rc)), rc > 0),
+                     (atan(x/sqrt(-rc))/sqrt(-rc), True)) + x
 
     assert manualintegrate(sqrt(x - y) * log(z / x), x) == \
-        4*y**2*Piecewise((atan(sqrt(x - y)/sqrt(y))/sqrt(y), Ne(y, 0)),
-                         (-1/sqrt(x - y), True))/3 - 4*y*sqrt(x - y)/3 + \
+        4*y**2*Piecewise((-1/sqrt(x - y), Eq(y, 0)),
+                         (atan(sqrt(x - y)/sqrt(y))/sqrt(y), True))/3 - 4*y*sqrt(x - y)/3 + \
         2*(x - y)**Rational(3, 2)*log(z/x)/3 + 4*(x - y)**Rational(3, 2)/9
     ry = Symbol('y', real=True)
     rz = Symbol('z', real=True)
     assert manualintegrate(sqrt(x - ry) * log(rz / x), x) == \
-        4*ry**2*Piecewise((atan(sqrt(x - ry)/sqrt(ry))/sqrt(ry), ry > 0),
-                         ((log(-sqrt(-ry) + sqrt(x - ry)) - log(sqrt(-ry) + sqrt(x - ry)))/(2*sqrt(-ry)), True))/3 \
-                         - 4*ry*sqrt(x - ry)/3 + 2*(x - ry)**Rational(3, 2)*log(rz/x)/3 \
-                         + 4*(x - ry)**Rational(3, 2)/9
+        4*ry**2*Piecewise((-1/sqrt(x - ry), Eq(ry, 0)), ((log(-sqrt(-ry) + sqrt(x - ry)) - log(sqrt(-ry) + sqrt(x - ry)))/(2*sqrt(-ry)), ry < 0),
+                          (atan(sqrt(x - ry)/sqrt(ry))/sqrt(ry), True))/3 - 4*ry*sqrt(x - ry)/3 + 2*(x - ry)**(Rational(3, 2))*log(rz/x)/3 + 4*(x - ry)**(Rational(3, 2))/9
 
     assert manualintegrate(sqrt(x) * log(x), x) == 2*x**Rational(3, 2)*log(x)/3 - 4*x**Rational(3, 2)/9
 
     result = manualintegrate(sqrt(a*x + b) / x, x)
-    assert result == Piecewise((-2*b*Piecewise(
-        (-atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b), Ne(b, 0)),
-        (1/sqrt(a*x + b), True)) + 2*sqrt(a*x + b), Ne(a, 0)),
-        (sqrt(b)*log(x), True))
-    assert piecewise_fold(result) == Piecewise(
-        (2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0) & Ne(b, 0)),
-        (-2*b/sqrt(a*x + b) + 2*sqrt(a*x + b), Ne(a, 0)),
-        (sqrt(b)*log(x), True))
+    assert result == Piecewise((-2*b*Piecewise((1/sqrt(a*x + b), Eq(b, 0)), (-atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b), True)) + 2*sqrt(a*x + b), Ne(a, 0)),
+                                (sqrt(b)*log(x), True))
+
+    assert piecewise_fold(result) == Piecewise((-2*b/sqrt(a*x + b) + 2*sqrt(a*x + b), Eq(b, 0) & Ne(a, 0)),
+                   (2*b*atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b) + 2*sqrt(a*x + b), Ne(a, 0)), (sqrt(b)*log(x), True))
 
     ra = Symbol('a', real=True)
     rb = Symbol('b', real=True)
     assert manualintegrate(sqrt(ra*x + rb) / x, x) == \
-        Piecewise(
-            (-2*rb*Piecewise(
-                (-atan(sqrt(ra*x + rb)/sqrt(-rb))/sqrt(-rb), rb < 0),
-                (-I*(log(-sqrt(rb) + sqrt(ra*x + rb)) - log(sqrt(rb) + sqrt(ra*x + rb)))/(2*sqrt(-rb)), True)) +
-             2*sqrt(ra*x + rb), Ne(ra, 0)),
-            (sqrt(rb)*log(x), True))
+        Piecewise((-2*rb * Piecewise(
+            (1/sqrt(ra*x + rb), Eq(rb, 0)),
+            (-I*(log(-sqrt(rb) + sqrt(ra*x + rb)) - log(sqrt(rb) + sqrt(ra*x + rb)))/(2*sqrt(-rb)), rb > 0),
+            (-atan(sqrt(ra*x + rb)/sqrt(-rb))/sqrt(-rb), True)) + 2*sqrt(ra*x + rb), Ne(ra, 0)), (sqrt(rb)*log(x), True))
 
     assert expand(manualintegrate(sqrt(ra*x + rb) / (x + rc), x)) == \
-           Piecewise((-2*ra*rc*Piecewise((atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), ra*rc - rb > 0),
-                                       (log(-sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)) -
-                                        log(sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)), True)) +
-                      2*rb*Piecewise((atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), ra*rc - rb > 0),
-                                    (log(-sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)) -
-                                     log(sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)), True)) +
-                      2*sqrt(ra*x + rb), Ne(ra, 0)), (sqrt(rb)*log(rc + x), True))
+           Piecewise((-2*ra*rc*Piecewise((-1/sqrt(ra*x + rb), Eq(ra*rc - rb, 0)),
+                                         (log(-sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)) -
+                                          log(sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)), ra*rc - rb < 0),
+                                            (atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), True))
+                                        + 2*rb*Piecewise((-1/sqrt(ra*x + rb), Eq(ra*rc - rb, 0)),
+                                        (log(-sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)) -
+                                         log(sqrt(-ra*rc + rb) + sqrt(ra*x + rb))/(2*sqrt(-ra*rc + rb)), ra*rc - rb < 0),
+                                        (atan(sqrt(ra*x + rb)/sqrt(ra*rc - rb))/sqrt(ra*rc - rb), True))
+                                          + 2*sqrt(ra*x + rb), Ne(ra, 0)), (sqrt(rb)*log(rc + x), True))
 
     assert manualintegrate(sqrt(2*x + 3) / (x + 1), x) == 2*sqrt(2*x + 3) - log(sqrt(2*x + 3) + 1) + log(sqrt(2*x + 3) - 1)
     assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**Rational(5, 2)/20 - (2*x + 3)**Rational(3, 2)/4
@@ -776,6 +776,7 @@ def test_manualintegrate_sqrt_quadratic():
     assert manualintegrate(1/sqrt(a+b*x+c*x**2), x) == \
         Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(c, 0) & Ne(a - b**2/(4*c), 0)),
                   ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), Ne(c, 0)),
+                  (x/sqrt(a), Eq(b, 0)),
                   (2*sqrt(a + b*x)/b, Ne(b, 0)), (x/sqrt(a), True))
 
     assert_is_integral_of((7*x+6)/sqrt(3*x**2+4*x+5),
@@ -789,6 +790,7 @@ def test_manualintegrate_sqrt_quadratic():
                    Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(a - b**2/(4*c), 0)),
                              ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), True)) +
                    e*sqrt(a + b*x + c*x**2)/c, Ne(c, 0)),
+                   ((d*x + e*x**2/2)/sqrt(a), Eq(b, 0)),
                   (2*((d*sqrt(a + b*x) - e*(a*sqrt(a + b*x) - (a + b*x)**(S(3)/2)/3)/b)/b), Ne(b, 0)),
                   ((d*x + e*x**2/2)/sqrt(a), True))
 
@@ -807,6 +809,7 @@ def test_manualintegrate_sqrt_quadratic():
                    Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(a - b**2/(4*c), 0)),
                              ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), True)) +
                    (b/(4*c) + x/2)*sqrt(a + b*x + c*x**2), Ne(c, 0)),
+                   (sqrt(a)*x, Eq(b, 0)),
                   (2*(a + b*x)**(S(3)/2)/(3*b), Ne(b, 0)),
                   (sqrt(a)*x, True))
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

See #29327

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR aims to better handle some cases of `Piecewise` in `manualintegrate`.

In particular, I modified the `quadratic_denom_rule`, the `sqrt_fractional_linear_rule`, and the `substitution_rule`. To do this, I wrote a function `_if_zero_implies_zero(P, Q)` that checks if `P = 0` implies `Q = 0`. This is convenient to avoid generating useless `Piecewise` expressions where the denominator would be equal to 0.
 Furthermore, I added some useful degenerate cases where they were previously absent in `quadratic_denom_rule` (I will write the examples in a message below).
I refactored these three rules a bit too.


#### Other comments
I would have liked to use SymPy's native logical expressions instead of writing a custom function. However, this wouldn't have covered certain cases. For example (I'm not sure if I should open a separate issue for this)

```python
In [39]: f = Or(Eq(a**2, 0), Ne(a, 0))

In [40]: f
Out[40]: 
 2            
a  = 0 ∨ a ≠ 0

In [41]: f is S.true
Out[41]: False
```
For this reason, SymPy doesn't automatically deduce that `Eq(a**2, 0)` implies `Eq(a, 0)`, for instance.


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
AI helped to write the `_is_zero_if_zero` function after I provided clear specifications. I had to change it later since it still was not good. It helped for commit messages and to translate the PR description too.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Improved Piecewise handling in manualintegrate to avoid redundant branches and simplify results.

<!-- END RELEASE NOTES -->
