### PR TITLE
docs: Fix cross-reference syntax

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -512,7 +512,7 @@ class RisingFactorial(CombinatorialFunction):
     more information check "Concrete mathematics" by Graham, pp. 66
     or visit https://mathworld.wolfram.com/RisingFactorial.html page.
 
-    When `x` is a `~.Poly` instance of degree $\ge 1$ with a single variable,
+    When `x` is a :class:`~.Poly` instance of degree $\ge 1$ with a single variable,
     `(x)^k = x(y) \cdot x(y+1) \cdots x(y+k-1)`, where `y` is the
     variable of `x`. This is as described in [2]_.
 
@@ -671,7 +671,7 @@ class FallingFactorial(CombinatorialFunction):
     more information check "Concrete mathematics" by Graham, pp. 66
     or [1]_.
 
-    When `x` is a `~.Poly` instance of degree $\ge 1$ with single variable,
+    When `x` is a :class:`~.Poly` instance of degree $\ge 1$ with single variable,
     `(x)_k = x(y) \cdot x(y-1) \cdots x(y-k+1)`, where `y` is the
     variable of `x`. This is as described in
 

--- a/sympy/physics/mechanics/inertia.py
+++ b/sympy/physics/mechanics/inertia.py
@@ -141,7 +141,7 @@ class Inertia(namedtuple('Inertia', ['dyadic', 'point'])):
         Explanation
         ===========
 
-        This class method uses the :func`~.inertia` to create the Dyadic based
+        This class method uses the :func:`~.inertia` to create the Dyadic based
         on the tensor values.
 
         Parameters

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -3075,8 +3075,8 @@ def latex(expr, **settings):
     order: string, optional
         Any of the supported monomial orderings (currently ``'lex'``,
         ``'grlex'``, or ``'grevlex'``), ``'old'``, and ``'none'``. This
-        parameter does nothing for `~.Mul` objects. Setting order to ``'old'``
-        uses the compatibility ordering for ``~.Add`` defined in Printer. For
+        parameter does nothing for :class:`~.Mul` objects. Setting order to ``'old'``
+        uses the compatibility ordering for :class:`~.Add` defined in Printer. For
         very large expressions, set the ``order`` keyword to ``'none'`` if
         speed is a concern.
     symbol_names : dictionary of strings mapped to symbols, optional
@@ -3086,7 +3086,7 @@ def latex(expr, **settings):
         form. Default is ``True``, to print exponent in root form.
     mat_symbol_style : string, optional
         Can be either ``'plain'`` (default) or ``'bold'``. If set to
-        ``'bold'``, a `~.MatrixSymbol` A will be printed as ``\mathbf{A}``,
+        ``'bold'``, a :class:`~.MatrixSymbol` A will be printed as ``\mathbf{A}``,
         otherwise as ``A``.
     imaginary_unit : string, optional
         String to use for the imaginary unit. Defined options are ``'i'``


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### Brief description of what is fixed or changed

Fix cross-reference syntax.

#### Other comments

It previously rendered like math:

<img width="284" height="18" alt="image" src="https://github.com/user-attachments/assets/21d616cf-0173-4b89-8452-60037633c764" />

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
