### PR TITLE
Fix IndexError in beam.py solve_for_reaction_loads for inconsistent systems

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -491,6 +491,7 @@ Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@us
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chidroopakanaparthy <chidroopak007@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1027,8 +1027,14 @@ class Beam:
             eqs = deflection_curve.subs(x, position) - value
             deflection_eqs.append(eqs)
         total_supports = tuple(set(applied_supports + reactions))
-        solution = list((linsolve([shear_curve, moment_curve] + shear_force_eqs + bending_moment_eqs + slope_eqs
-                            + deflection_eqs, (C3, C4) + total_supports + rotation_jumps + deflection_jumps).args)[0])
+        system_solution = linsolve([shear_curve, moment_curve] + shear_force_eqs + bending_moment_eqs + slope_eqs
+                            + deflection_eqs, (C3, C4) + total_supports + rotation_jumps + deflection_jumps)
+        if system_solution == S.EmptySet:
+            raise ValueError(
+                "The system of applied loads and boundary conditions is inconsistent."
+                "No solution for the reaction loads exists."
+            )
+        solution = list((system_solution.args)[0])
         reaction_index = 2+len(total_supports)
         rotation_index = reaction_index + len(rotation_jumps)
         reaction_solution = solution[2:reaction_index]

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -286,6 +286,68 @@ def test_insufficient_bconditions():
     assert p == q/(E*I)
 
 
+def test_for_inconsistent_reaction_loads():
+    E, I, P = symbols('E I P')
+    Q = Symbol('Q')
+
+    # Rotation hinge at the load point of a simply supported beam, no unique set of static reaction forces exists.
+    b1 = Beam(10, E, I)
+    r1 = b1.apply_support(0, 'pin')
+    r2 = b1.apply_support(10, 'roller')
+    b1.apply_rotation_hinge(4)
+    b1.apply_load(-P, 4, -1)
+    raises(ValueError, lambda: b1.solve_for_reaction_loads(r1, r2))
+
+    # Two internal rotation hinges in a simply supported beam produce more internal releases than the supports can restrain, resulting in a kinematic mechanism
+    b2 = Beam(15, E, I)
+    b2.apply_rotation_hinge(5)
+    b2.apply_rotation_hinge(10)
+    r0 = b2.apply_support(0, 'pin')
+    r15 = b2.apply_support(15, 'roller')
+    b2.apply_load(-Q, 0, 0, end=15)
+    raises(ValueError, lambda: b2.solve_for_reaction_loads(r0, r15))
+
+    # Roller support with a sliding hinge. Only vertical reaction is available,
+    # but the sliding hinge releases the shear constraint, leaving the beam free to translate
+    b3 = Beam(8, E, I)
+    R1_3 = b3.apply_support(0, 'roller')
+    b3.apply_sliding_hinge(4)
+    b3.apply_load(5, 8, -1)
+    raises(ValueError, lambda: b3.solve_for_reaction_loads(R1_3))
+
+    # Two rotation hinges with multiple symbolic point loads on a simply supported beam
+    b4 = Beam(12, E, I)
+    b4.apply_rotation_hinge(3)
+    b4.apply_rotation_hinge(8)
+    r1_4 = b4.apply_support(0, 'pin')
+    r2_4 = b4.apply_support(12, 'roller')
+    b4.apply_load(-P, 6, -1)
+    b4.apply_load(Q, 9, -1)
+    raises(ValueError, lambda: b4.solve_for_reaction_loads(r1_4, r2_4))
+
+    # Contradicting Conditions : Pin support enforces zero deflection at x=0,
+    # but an additional boundary condition prescribes unit deflection at the same point
+    b5 = Beam(10, E, I)
+    b5.apply_support(0, type='pin')
+    b5.bc_deflection.append((0, 1))
+    raises(ValueError, lambda: b5.solve_for_reaction_loads())
+
+    # Single pin support can't satisfy moment equilibrium when an external point load acts at a different location
+    b6 = Beam(10, E, I)
+    R1_6 = b6.apply_support(0, 'pin')
+    b6.apply_load(10, 10, -1)
+    raises(ValueError, lambda: b6.solve_for_reaction_loads(R1_6))
+
+    # Parametric load configuration that violates global static equilibrium
+    M_sym = symbols('M')
+    b7 = Beam(10, E, I)
+    R1_7 = symbols('R1')
+    b7.apply_load(R1_7, 0, -1)
+    b7.apply_load(M_sym, 5, -2)
+    b7.bc_deflection = [(0, 0)]
+    raises(ValueError, lambda: b7.solve_for_reaction_loads(R1_7))
+
+
 def test_statically_indeterminate():
     E = Symbol('E')
     I = Symbol('I')


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #28346
Supersedes #28113 and #28453

#### Brief description of what is fixed or changed

This PR fixes an `IndexError` in `Beam.solve_for_reaction_loads` that occurs when the system of equations is inconsistent or over-determined. Earlier, if `linsolve` returned `S.EmptySet`, the code would attempt to access `.args[0]`, resulting in an `IndexError`.

Explicitly checks for `S.EmptySet` have been added that now raises a descriptive `ValueError` with a clear message, making it easier for the user to debug unstable or over-constrained beam setups.

#### Other comments

Added new test cases to `sympy/physics/continuum_mechanics/tests/test_beam.py` to verify:
* Numerical inconsistency 
* Symbolic inconsistency (e.g., parameters that cannot satisfy equilibrium).

#### AI Generation Disclosure

I used Antigravity to help debug the `linsolve` interaction and draft the initial test cases. I've since refactored the logic and verified the new tests locally to make sure the physics holds up.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.continuum_mechanics
   * Fixed an IndexError in `solve_for_reaction_loads` by adding validation for inconsistent/over-determined beam systems.

<!-- END RELEASE NOTES -->
