### PR TITLE
fix for fourier_series on constants

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1236,6 +1236,7 @@ Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>
 Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
+Parth Chavan <parthc1729@gmail.com>
 Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>
 Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
 Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@gmail.com>

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -551,7 +551,9 @@ class FiniteFourierSeries(FourierSeries):
     @property
     def interval(self):
         _length = 1 if self.a0 else 0
-        _length += max(set(self.an.keys()).union(set(self.bn.keys()))) + 1
+        _keys = set(self.an.keys()).union(set(self.bn.keys()))
+        if _keys:
+            _length += max(_keys) + 1
         return Interval(0, _length)
 
     @property
@@ -784,9 +786,6 @@ def fourier_series(f, limits=None, finite=True):
 
     limits = _process_limits(f, limits)
     x = limits[0]
-
-    if x not in f.free_symbols:
-        return f
 
     if finite:
         L = abs(limits[2] - limits[1]) / 2

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -25,7 +25,8 @@ def _get_examples():
 def test_FourierSeries():
     fo, fe, fp = _get_examples()
 
-    assert fourier_series(1, (-pi, pi)) == 1
+    assert isinstance(fourier_series(1, (-pi, pi)), FourierSeries)
+    assert fourier_series(1, (-pi, pi)).truncate() == 1
     assert (Piecewise((0, x < 0), (pi, True)).
             fourier_series((x, -pi, pi)).truncate()) == fp.truncate()
     assert isinstance(fo, FourierSeries)
@@ -164,3 +165,16 @@ def test_FourierSeries_finite():
     assert fourier_series(cos(pi*x), (x, -1, 1)).truncate(oo) == cos(pi*x)
     assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y), (x, -1, 1)).truncate(oo) == -log(pi*y)*sin(4*pi*x)\
            - sin(4)*sin(3*pi*x) + cos(4)*cos(3*pi*x)
+
+
+def test_fourier_series_constant():
+    #https://github.com/sympy/sympy/issues/29336
+    s = fourier_series(3, (x, -pi, pi))
+    assert isinstance(s, FourierSeries)
+    assert s.a0 == 3
+    assert s.truncate() == 3
+
+    s0 = fourier_series(S.Zero, (x, -pi, pi))
+    assert isinstance(s0, FourierSeries)
+    assert s0.a0 == 0
+    assert s0.truncate() == 0


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #29336 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

On constant inputs, 'fourier_series()' was returning Integer type objects instead of 'FourierSeries' type. So it caused errors on methods like 'truncate()' and 'shift()'. This was caused by an early return `if x not in f.free_symbols: return f` as it bypassed`FourierSeries` construction. Removed this part of the code. The previous test file had `assert fourier_series(1, (-pi, pi)) == 1` which incorrectly asserting the buggy behaviour. Changed this and added a regression test.

Also, 'FiniteFourierSeries.interval' crashed with 'ValueError' when 'an={}' and 'bn={}' due to calling 'max()' on an empty set. Added a guard to prevent this. 

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE


#### Release Notes

NO NOTES

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
