### PR TITLE
fix __len__ for powerset to handle nested finite sets and pass all tests

### DIFF
--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -106,7 +106,7 @@ class PowerSet(Set):
         if isinstance(other, PowerSet):
             return self.arg.is_subset(other.arg)
         return None
-    
+
     def __len__(self) -> int:
         if isinstance(self.arg, PowerSet):
             return 2 ** len(self.arg)  # recursively compute length

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -106,8 +106,12 @@ class PowerSet(Set):
         if isinstance(other, PowerSet):
             return self.arg.is_subset(other.arg)
         return None
-
+    
     def __len__(self) -> int:
+        if isinstance(self.arg, PowerSet):
+            return 2 ** len(self.arg)  # recursively compute length
+        if not self.arg.is_FiniteSet:
+            raise TypeError("PowerSet of infinite set has no finite length")
         return 2 ** len(self.arg)
 
     def __iter__(self) -> Iterator[Set]:

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -135,3 +135,12 @@ def test_is_subset():
     assert subset.is_subset(pset)
     # assert "bad_set" is subset of pset == False
     assert not pset.is_subset(bad_set)
+
+def test_powerset_len_infinite():
+    import pytest
+    from sympy import PowerSet, S, FiniteSet
+
+    with pytest.raises(TypeError):
+        len(PowerSet(S.Naturals))
+
+    assert len(PowerSet(FiniteSet(1,2,3))) == 8


### PR DESCRIPTION
#### Brief description of what is fixed or changed

`PowerSet.__len__` method originally worked only for simple finite sets, for nested finite power sets like `PowerSet(PowerSet(EmptySet))`, it raised a `TypeError` because sympy treated nested powersets as non fiinite, this broke tests that expected the length to be computed

updated ` __len__ ` to compute length recursively for nested powersets while still raising `TypeError` for truly infinite sets

**Before**
```python
def __len__(self) -> int:
    if not self.arg.is_FiniteSet:
        raise TypeError("PowerSet of infinite set has no finite length")
    return 2 ** len(self.arg)
```
**After**
```python
def __len__(self) -> int:
    if isinstance(self.arg, PowerSet):
        return 2 ** len(self.arg) 
    if not self.arg.is_FiniteSet:
        raise TypeError("PowerSet of infinite set has no finite length")
    return 2 ** len(self.arg)
```

also already ran pytest on test_powerset.py. all tests passed
#### AI Generation Disclosure
ChatGPT was used for understanding the workflow of code only

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
