### PR TITLE
Fix incorrect is_integer assumptions in Pow, Mul, and Add

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1283,6 +1283,7 @@ Pradyumna <pradyu1993@gmail.com>
 Prafullkumar P. Tale <hector1618@gmail.com> <Hector1618@gmail.com>
 Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
 Prajwal Pathade <prajwalpathade7@gmail.com> Prajwal <prajwalpathade7@gmail.com>
+Prakash Kalwaniya <kalwaniyaprakash1@gmail.com>
 Pramod Ch <pramodch14@gmail.com>
 Pranjal Tale <pranjaltale16@gmail.com>
 Prashant Tandon <102211549+PT-10@users.noreply.github.com>\

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -634,8 +634,35 @@ class Add(Expr, AssocOp):
         (a.is_finite for a in self.args), quick_exit=True)
     _eval_is_hermitian = lambda self: _fuzzy_group(
         (a.is_hermitian for a in self.args), quick_exit=True)
-    _eval_is_integer = lambda self: _fuzzy_group(
-        (a.is_integer for a in self.args), quick_exit=True)
+    def _eval_is_integer(self):
+        non_ints = 0
+        ints = 0
+        unknown_ints = 0
+        for a in self.args:
+            if a.is_integer:
+                ints += 1
+            elif a.is_integer is False:
+                non_ints += 1
+            elif a.is_Mul:
+                a_non_int_nonrat = 0
+                a_unknown = 0
+                for f in a.args:
+                    if f.is_integer is False:
+                        if f.is_rational is False:
+                            a_non_int_nonrat += 1
+                    elif f.is_integer is None:
+                        a_unknown += 1
+                if a_non_int_nonrat == 1 and a_unknown == 0:
+                    non_ints += 1
+                else:
+                    unknown_ints += 1
+            else:
+                unknown_ints += 1
+
+        if non_ints == 1 and unknown_ints == 0:
+            return False
+
+        return _fuzzy_group((a.is_integer for a in self.args), quick_exit=True)
     _eval_is_rational = lambda self: _fuzzy_group(
         (a.is_rational for a in self.args), quick_exit=True)
     _eval_is_algebraic = lambda self: _fuzzy_group(
@@ -689,6 +716,37 @@ class Add(Expr, AssocOp):
             # issue 10528: there is no way to know if a nc symbol
             # is zero or not
             return
+
+        # An integer cannot cancel out a non-integer
+        # If there is exactly one non-integer, and all others are integers,
+        # the sum cannot be zero.
+        non_ints = 0
+        ints = 0
+        unknown_ints = 0
+        for a in self.args:
+            if a.is_integer:
+                ints += 1
+            elif a.is_integer is False:
+                non_ints += 1
+            elif a.is_Mul:
+                a_non_int_nonrat = 0
+                a_unknown = 0
+                for f in a.args:
+                    if f.is_integer is False:
+                        if f.is_rational is False:
+                            a_non_int_nonrat += 1
+                    elif f.is_integer is None:
+                        a_unknown += 1
+                if a_non_int_nonrat == 1 and a_unknown == 0:
+                    non_ints += 1
+                else:
+                    unknown_ints += 1
+            else:
+                unknown_ints += 1
+
+        if non_ints == 1 and unknown_ints == 0:
+            return False
+
         nz = []
         z = 0
         im_or_z = False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1454,6 +1454,15 @@ class Mul(Expr, AssocOp):
                     # x**2, 2**x, or x**y with x and y int-unknown -> unknown
                     return
             else:
+                # If this arg is non-integer and all other args are integers
+                # whose product is +/-1, the whole product is non-integer.
+                if a.is_integer is False:
+                    others_int = all(
+                        o.is_integer for o in self.args if o is not a)
+                    if others_int:
+                        coeff = Mul(*[o for o in self.args if o is not a])
+                        if abs(coeff) is S.One:
+                            return False
                 return
 
         if not denominators and not unknown:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -476,8 +476,8 @@ class Pow(Expr):
     def _eval_is_integer(self):
         b, e = self.args
         if b.is_rational:
-            if b.is_integer is False and e.is_positive:
-                return False  # rat**nonneg
+            if b.is_integer is False and e.is_positive and e.is_rational:
+                return False  # rat**pos_rat
         if b.is_integer and e.is_integer:
             if b is S.NegativeOne:
                 return True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -446,7 +446,7 @@ def test_Add_Mul_is_integer():
     nr = Symbol('nr', rational=False)
     nz = Symbol('nz', integer=True, zero=False)
 
-    assert (-nk).is_integer is None
+    assert (-nk).is_integer is False
     assert (-nr).is_integer is False
     assert (2*k).is_integer is True
     assert (-k).is_integer is True


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29349

#### Brief description of what is fixed or changed

This PR fixes incorrect behavior in integer evaluation logic for `Pow`, `Mul`, and `Add`.

- In `Pow._eval_is_integer`, a guard for `e.is_rational` was added so that returning `False` only applies when the exponent is rational. Irrational exponents may still produce integer results.
- In `Mul._eval_is_integer`, handling was added for the case where a non-integer factor is multiplied only by integer factors whose absolute product is `±1`, ensuring expressions like `(-ni)` correctly evaluate as non-integer.
- In `Add._eval_is_integer` and `Add._eval_is_zero`, the inner `Mul` decomposition was corrected so the non-integer factor must also be non-rational. This prevents expressions like `n/3` from being incorrectly classified as definitively non-integer.

A related test assertion in `test_arit.py` was updated (`is None` → `is False`). All tests in `test_arit.py` pass (`101 passed`, `2 xfailed`).

#### Other comments
No additional changes.

#### AI Generation Disclosure
AI assistance was used for drafting the PR description only. 
The code changes and debugging were done manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * Fixed incorrect integer evaluation in `Pow._eval_is_integer`, `Mul._eval_is_integer`, and `Add._eval_is_integer`.

<!-- END RELEASE NOTES -->