### PR TITLE
core: fix Add._eval_is_extended_real for oo + (-oo) case

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1833,6 +1833,7 @@ pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 phipf <phipf@online.de>
 platypus <platypus.computerchip@gmail.com>
+prakash-kalwaniya <kalwaniyaprakash1@gmail.com>
 prshnt19 <prashant.rawat216@gmail.com>
 rahil-amin <rahilamin201@gmail.com>
 rahuldan <rahul02013@gmail.com>

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -624,8 +624,27 @@ class Add(Expr, AssocOp):
     # assumption methods
     _eval_is_real = lambda self: _fuzzy_group(
         (a.is_real for a in self.args), quick_exit=True)
-    _eval_is_extended_real = lambda self: _fuzzy_group(
-        (a.is_extended_real for a in self.args), quick_exit=True)
+    def _eval_is_extended_real(self):
+        rv = _fuzzy_group(
+            (a.is_extended_real for a in self.args), quick_exit=True)
+        if rv is True:
+            # oo + (-oo) is nan which is not extended_real. We only need
+            # to worry when two *different* args could produce opposite-
+            # sign infinities that cancel.  A single arg with unknown
+            # sign cannot cause oo - oo by itself.
+            could_pos = []  # indices of args that could be +oo
+            could_neg = []  # indices of args that could be -oo
+            for i, a in enumerate(self.args):
+                if a.is_infinite is True:
+                    if a.is_extended_nonpositive is not True:
+                        could_pos.append(i)
+                    if a.is_extended_nonnegative is not True:
+                        could_neg.append(i)
+            if could_pos and could_neg:
+                # need at least two different args involved
+                if set(could_pos) != set(could_neg) or len(could_pos) > 1:
+                    return None
+        return rv
     _eval_is_complex = lambda self: _fuzzy_group(
         (a.is_complex for a in self.args), quick_exit=True)
     _eval_is_antihermitian = lambda self: _fuzzy_group(


### PR DESCRIPTION
#### References to other Issues or PRs
See #29352
 <!-- Replace with the relevant issue if applicable -->

#### Brief description of what is fixed or changed
Fixed the `_eval_is_extended_real` method in `Add` to correctly handle the `oo + (-oo)` case, ensuring proper extended real evaluation.

#### Other comments
This improves the correctness of assumption evaluations in expressions involving positive and negative infinity.

#### AI Generation Disclosure
AI-assisted for drafting parts of this PR; all implementation checked manually.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `Add._eval_is_extended_real` to handle `oo + (-oo)` case correctly.
<!-- END RELEASE NOTES -->
