### PR TITLE
Fix negative base symbolic rational exponent realness handling

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -340,6 +340,10 @@ def _(expr, assumptions):
 
     if ask(Q.real(expr.base), assumptions):
         if ask(Q.real(expr.exp), assumptions):
+            if ask(Q.negative(expr.base), assumptions) and \
+                ask(Q.rational(expr.exp), assumptions) and \
+                ask(~Q.integer(expr.exp), assumptions):
+                return False
             if (expr.exp.is_Rational and
                     ask(Q.even(expr.exp.q), assumptions)):
                 return ask(Q.nonnegative(expr.base), assumptions)
@@ -388,7 +392,14 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return True
 
-@ExtendedRealPredicate.register_many(Add, Mul, Pow) # type:ignore
+@ExtendedRealPredicate.register(Pow)
+def _(expr, assumptions):
+    ret = expr.is_extended_real
+    if ret is not None:
+        return ret
+    raise MDNotImplementedError
+
+@ExtendedRealPredicate.register_many(Add, Mul) # type:ignore
 def _(expr, assumptions):
     return test_closed_group(expr, assumptions, Q.extended_real)
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2045,7 +2045,6 @@ def test_real_pow():
     assert ask(Q.real(x**y), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.real(x**y), Q.real(x) & Q.rational(y)) is None
 
-    # https://github.com/sympy/sympy/issues/29335
     nneg = Symbol('nneg', negative=True)
     q = Symbol('q', rational=True, integer=False)
     r = Symbol('r', rational=True)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2044,6 +2044,27 @@ def test_real_pow():
     assert ask(Q.real(x**0), Q.imaginary(x)) is True
     assert ask(Q.real(x**y), Q.positive(x) & Q.real(y)) is True
     assert ask(Q.real(x**y), Q.real(x) & Q.rational(y)) is None
+
+    # https://github.com/sympy/sympy/issues/29335
+    nneg = Symbol('nneg', negative=True)
+    q = Symbol('q', rational=True, integer=False)
+    r = Symbol('r', rational=True)
+    kint = Symbol('kint', integer=True)
+    ppos = Symbol('ppos', positive=True)
+    assert (nneg ** q).is_real is False
+    assert (nneg ** q).is_extended_real is False
+    assert ask(Q.real(nneg ** q)) is False
+    assert ask(Q.extended_real(nneg ** q)) is False
+    assert (nneg ** r).is_real is None
+    assert ask(Q.real(nneg ** r)) is None
+    assert ask(Q.extended_real(nneg ** r)) is None
+    assert (nneg ** kint).is_real is True
+    assert ask(Q.real(nneg ** kint)) is True
+    assert ask(Q.extended_real(nneg ** kint)) is True
+    assert (ppos ** q).is_real is True
+    assert ask(Q.real(ppos ** q)) is True
+    assert ask(Q.extended_real(ppos ** q)) is True
+
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.integer(y)) is None
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.odd(y)) is False
     assert ask(Q.real(x**y), Q.imaginary(x) & Q.even(y)) is True

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -522,7 +522,7 @@ class Pow(Expr):
             elif self.exp.is_integer and self.exp.is_nonnegative:
                 return True
             elif self.base.is_extended_negative:
-                if self.exp.is_Rational:
+                if self.exp.is_rational and self.exp.is_integer is False:
                     return False
         if real_e and self.exp.is_extended_negative and self.base.is_zero is False:
             return Pow(self.base, -self.exp).is_extended_real


### PR DESCRIPTION
- Fix Pow._eval_is_extended_real for symbolic rational non-integer exponents
- Ensure consistency with assumptions handlers
- Add regression tests for issue #29335

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29335

#### Brief description of what is fixed or changed
**The Problem**
`Pow._eval_is_extended_real` currently returns `None` for a symbolic rational number with a negative base. The problem lies in the fact that the function checks `self.exp.is_Rational` instead of `self.exp.is_rational`.

**Example**
```python
n = Symbol('n', negative=True)
q = Symbol('q', rational=True, integer=False)
(n**q).is_extended_real  # -> None (expected: False)
```

**Key Fixes**

- **Modified Core Logic**:
In `Pow._eval_is_extended_real`, the check `self.exp.is_Rational` is replaced with `self.exp.is_rational` to bridge the gap between concrete numbers and symbolic symbols.

- **Tri-valued Logic Implementation**:
In the `Pow` function, I have added an explicit check for `self.exp.is_integer` to be False to respect the tri-valued logic system.

- **Assumptions Handler Integration**: 
Registered the handler for the ExtendedRealPredicate for the Pow class. This guarantees that ask(Q.extended_real(expr)) is consistent with the .is_extended_real property.

- **Regression Testing**: 
Implemented a test suitable for negative bases with symbolic rational, integer, and rational exponents to ensure that
regressions will not occur in the future.

### Before
(n**q).is_extended_real -> None
ask(Q.real(n**q)) -> None

### After
(n**q).is_extended_real -> False
ask(Q.real(n**q)) -> False

#### Other comments

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
ChatGPT was used to test the ideas during the debugging process, all logic and code implementation was done by me.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- assumptions
    - Fixed incorrect realness detection for symbolic rational exponents with negative bases in Pow._eval_is_extended_real.
<!-- END RELEASE NOTES -->
