### PR TITLE
Add _eval_refine for Piecewise

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -762,6 +762,7 @@ Himanshu Ladia <hladia199811@gmail.com>
 Hiren Chalodiya <hirenchalodiya99@gmail.com>
 Hong Xu <hong@topbug.net>
 Hou-Rui <houruinus@gmail.com> Hou-Rui <13244639785@163.com>
+Hruthika Katta <hruthika.katta@gmail.com>
 Huangduirong <huangduirong@huawei.com> Huangxiaodui <hdrong.42@163.com>
 Hubert Tsang <intsangity@gmail.com>
 Hugo Kerstens <hugo@kerstens.me> Hugo Kerstens <hugokk@hotmail.nl>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -294,7 +294,7 @@ class Piecewise(DefinedFunction):
         x
 
         >>> refine(Piecewise((1/x**2, x != 0), (0, True)), Q.nonzero(x))
-        1/x**2
+        x**(-2)
         """
         from sympy.assumptions.refine import refine
         from sympy.assumptions import ask

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -309,13 +309,13 @@ class Piecewise(DefinedFunction):
 
             if expr_r != expr or cond_r != cond:
                 changed = True
-            
+
             if cond_r is S.true:
                 if not newargs:
                     return expr_r
                 newargs.append((expr_r, cond_r))
                 break
-            
+
             if cond_r is S.false:
                 changed = True
                 continue
@@ -335,10 +335,10 @@ class Piecewise(DefinedFunction):
 
         if not changed:
             return None
-        
+
         if not newargs:
             return S.NaN
-        
+
         return self.func(*newargs)
 
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -259,6 +259,86 @@ class Piecewise(DefinedFunction):
             if cond:
                 return e._eval_is_meromorphic(x, a)
 
+    def _eval_refine(self, assumptions):
+        """
+        Refine a Piecewise expression under the given assumptions.
+
+        Each expression and condition in the Piecewise is refined using
+        ``refine`` with the provided assumptions. Conditions that become
+        False are removed from the Piecewise expression. If a condition
+        becomes True and no earlier branch remains applicable, the
+        corresponding expression is returned directly.
+
+        If the assumptions do not determine any condition, the original
+        Piecewise structure is preserved with the refined expressions
+        and conditions.
+
+        If no part of the expression changes during refinement, ``None``
+        is returned to indicate that no refinement was possible.
+
+        Examples
+        ========
+
+        >>> from sympy import Piecewise, Symbol, Q
+        >>> from sympy.assumptions.refine import refine
+        >>> x = Symbol('x')
+
+        >>> p = Piecewise((1, x > 0), (-1, x < 0), (0, True))
+        >>> refine(p, Q.positive(x))
+        1
+
+        >>> refine(p, Q.negative(x))
+        -1
+
+        >>> refine(Piecewise((x**2, x < 0), (x, True)), Q.positive(x))
+        x
+
+        >>> refine(Piecewise((1/x**2, x != 0), (0, True)), Q.nonzero(x))
+        1/x**2
+        """
+        from sympy.assumptions.refine import refine
+        from sympy.assumptions import ask
+
+        changed = False
+        newargs = []
+
+        for expr, cond in self.args:
+
+            expr_r = refine(expr, assumptions)
+            cond_r = refine(cond, assumptions)
+
+            if expr_r != expr or cond_r != cond:
+                changed = True
+            
+            if cond_r is S.true:
+                if not newargs:
+                    return expr_r
+                newargs.append((expr_r, cond_r))
+                continue
+            
+            if cond_r is S.false:
+                changed = True
+                continue
+
+            truth = ask(cond_r, assumptions)
+            if truth is True:
+                if not newargs:
+                    return expr_r
+                newargs.append((expr_r, cond_r))
+                continue
+
+            if truth is False:
+                changed = True
+                continue
+
+            newargs.append((expr_r , cond_r))
+
+        if not changed:
+            return None
+        
+        return self.func(*newargs)
+
+
     def piecewise_integrate(self, x, **kwargs):
         """Return the Piecewise with each expression being
         replaced with its antiderivative. To obtain a continuous

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -314,7 +314,7 @@ class Piecewise(DefinedFunction):
                 if not newargs:
                     return expr_r
                 newargs.append((expr_r, cond_r))
-                continue
+                break
             
             if cond_r is S.false:
                 changed = True
@@ -325,16 +325,19 @@ class Piecewise(DefinedFunction):
                 if not newargs:
                     return expr_r
                 newargs.append((expr_r, cond_r))
-                continue
+                break
 
             if truth is False:
                 changed = True
                 continue
 
-            newargs.append((expr_r , cond_r))
+            newargs.append((expr_r, cond_r))
 
         if not changed:
             return None
+        
+        if not newargs:
+            return S.NaN
         
         return self.func(*newargs)
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1639,6 +1639,7 @@ def test_piecewise__eval_is_meromorphic():
     assert f.is_meromorphic(x, Symbol('a')) is None
     assert f.is_meromorphic(x, Symbol('a', real=True)) is None
 
+
 def test_refine():
     from sympy.assumptions.refine import refine
     from sympy.assumptions import Q
@@ -1655,10 +1656,8 @@ def test_refine():
 
     # Relational condition simplified using assumptions
     assert refine(Piecewise((1/x**2, x != 0), (0, True)), Q.nonzero(x)) == 1/x**2
-    
+
     # Undecidable conditions preserve the Piecewise expression
     p = Piecewise((1, x > 0), (2, x < -5), (3, True))
     assert refine(p, Q.real(x)) == p
     assert refine(Piecewise((1, x > 0), (0, True)), Q.real(x)) == Piecewise((1, x > 0), (0, True))
-    
-

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1651,11 +1651,11 @@ def test_refine():
     # First condition becomes False and the next branch is selected
     assert refine(Piecewise((1, x > 0), (2, True)), Q.negative(x)) == 2
 
-     # Condition becomes False through refinement
+    # Condition becomes False through refinement
     assert refine(Piecewise((x**2, x < 0), (x, True)), Q.positive(x)) == x
 
     # Relational condition simplified using assumptions
-    assert refine(Piecewise((x**(-2), x != 0), (0, True)), Q.nonzero(x)) == x**(-2)
+    assert refine(Piecewise((1/x**2, x != 0), (0, True)), Q.nonzero(x)) == 1/x**2
 
     # Undecidable conditions preserve the Piecewise expression
     p = Piecewise((1, x > 0), (2, x < -5), (3, True))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1655,7 +1655,7 @@ def test_refine():
     assert refine(Piecewise((x**2, x < 0), (x, True)), Q.positive(x)) == x
 
     # Relational condition simplified using assumptions
-    assert refine(Piecewise((1/x**2, x != 0), (0, True)), Q.nonzero(x)) == 1/x**2
+    assert refine(Piecewise((x**(-2), x != 0), (0, True)), Q.nonzero(x)) == x**(-2)
 
     # Undecidable conditions preserve the Piecewise expression
     p = Piecewise((1, x > 0), (2, x < -5), (3, True))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1638,3 +1638,27 @@ def test_piecewise__eval_is_meromorphic():
     assert f.is_meromorphic(x, 2) == True
     assert f.is_meromorphic(x, Symbol('a')) is None
     assert f.is_meromorphic(x, Symbol('a', real=True)) is None
+
+def test_refine():
+    from sympy.assumptions.refine import refine
+    from sympy.assumptions import Q
+
+    x = symbols('x')
+    # Condition becomes True under the assumptions
+    assert refine(Piecewise((1, x > 0), (-1, x < 0), (0, True)), Q.positive(x)) == 1
+
+    # First condition becomes False and the next branch is selected
+    assert refine(Piecewise((1, x > 0), (2, True)), Q.negative(x)) == 2
+
+     # Condition becomes False through refinement
+    assert refine(Piecewise((x**2, x < 0), (x, True)), Q.positive(x)) == x
+
+    # Relational condition simplified using assumptions
+    assert refine(Piecewise((1/x**2, x != 0), (0, True)), Q.nonzero(x)) == 1/x**2
+    
+    # Undecidable conditions preserve the Piecewise expression
+    p = Piecewise((1, x > 0), (2, x < -5), (3, True))
+    assert refine(p, Q.real(x)) == p
+    assert refine(Piecewise((1, x > 0), (0, True)), Q.real(x)) == Piecewise((1, x > 0), (0, True))
+    
+

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1661,3 +1661,4 @@ def test_refine():
     p = Piecewise((1, x > 0), (2, x < -5), (3, True))
     assert refine(p, Q.real(x)) == p
     assert refine(Piecewise((1, x > 0), (0, True)), Q.real(x)) == Piecewise((1, x > 0), (0, True))
+

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1661,4 +1661,3 @@ def test_refine():
     p = Piecewise((1, x > 0), (2, x < -5), (3, True))
     assert refine(p, Q.real(x)) == p
     assert refine(Piecewise((1, x > 0), (0, True)), Q.real(x)) == Piecewise((1, x > 0), (0, True))
-


### PR DESCRIPTION

#### References to other Issues or PRs

Fixes #24183 
Related to #27888


#### Brief description of what is fixed or changed

This PR adds an implementation of the  `_eval_refine`  method for  `Piecewise`. 

This method refines each branch expression and condition in the Piecewise using the given assumptions. Branches whose conditions evaluate to `False` are removed. If a condition evaluates to `True` and no earlier branch remains applicable, the corresponding expression is returned. Otherwise, the Piecewise expression is returned unchanged. 

Tests were added for Piecewise refinement behaviour.


#### Other comments

None

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
