### PR TITLE
linprog: fix phantom b matrix when A is omitted (fixes #29368)

### DIFF
--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -964,7 +964,7 @@ def linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("A and b must both be given")
         # the governing equations will be simple constraints
         # on variables
-        A, b = zeros(0, C.cols), zeros(C.cols, 1)
+        A, b = zeros(0, C.cols), zeros(0, 1)
     else:
         A, b = [Matrix(i) for i in (A, b)]
 

--- a/sympy/solvers/tests/test_simplex.py
+++ b/sympy/solvers/tests/test_simplex.py
@@ -262,3 +262,11 @@ def test_28104():
     val, var = lpmax(0, [x >= 0, y >= 0])
     assert var[y] is S.Zero
     assert var[x] is S.Zero
+
+
+def test_29368():
+    assert linprog([1]) == (0, [0])
+    assert linprog([1, 1]) == (0, [0, 0])
+    raises(UnboundedLPError, lambda: linprog([-1]))
+    assert linprog([1], bounds=(0, None)) == (0, [0])
+    raises(UnboundedLPError, lambda: linprog([-1], bounds=(0, None)))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29368

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Fixed linprog(c) raising `ValueError` when called without `A` and `B` by changing `zeros(C.cols, 1)` to `zeros(0, 1)`.



#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed linprog(c) raising ValueError: must give A and B instead of correct behavior when called without A and B.

<!-- END RELEASE NOTES -->
