### PR TITLE
fix(polys): Fix canonicalisation of monom in PuiseuxPoly

### DIFF
--- a/sympy/polys/puiseux.py
+++ b/sympy/polys/puiseux.py
@@ -357,7 +357,8 @@ class PuiseuxPoly(Generic[Er]):
         monom: MonI | None,
         ns: MonI | None,
     ) -> tuple[PolyElement[Er], MonI | None, MonI | None]:
-        if monom is None and ns is None:
+
+        if not poly or (monom is None and ns is None):
             return poly, None, None
 
         if monom is not None:
@@ -365,9 +366,10 @@ class PuiseuxPoly(Generic[Er]):
             if all(di >= mi for di, mi in zip(degs, monom)):
                 poly = _div_poly_monom(poly, monom)
                 monom = None
-            elif any(degs):
-                poly = _div_poly_monom(poly, degs)
-                monom = _div_monom(monom, degs)
+            elif any(mi > 0 and di > 0 for di, mi in zip(degs, monom)):
+                monom_gcd = tuple(min(mi, di) for di, mi in zip(degs, monom))
+                poly = _div_poly_monom(poly, monom_gcd)
+                monom = _div_monom(monom, monom_gcd)
 
         if ns is not None:
             factors_d, [poly_d] = poly.deflate()

--- a/sympy/polys/tests/test_puiseux.py
+++ b/sympy/polys/tests/test_puiseux.py
@@ -130,6 +130,14 @@ def test_puiseux_poly_unify():
     assert repr(1/x + x**QQ(1,2)) == 'x**(-1) + x**(1/2)'
 
 
+def test_puiseux_poly_issue_29363():
+    R, e, b = puiseux_ring('e b', QQ)
+    dz = -1 - b*e
+    neg = b/e*dz
+    dp = dz + neg
+    assert dp == -1 - b/e - b*e - b**2
+
+
 def test_puiseux_poly_arit():
     _, x = puiseux_ring('x', QQ)
     _, y = puiseux_ring('y', QQ)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes gh-29363


<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Ensure that the monomial is canonicalised properly when constructing a PuiseuxPolynomial so that the monomial never ends up having negative exponents.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * A bug in PuiseuxPoly was fixed. Previously some operations might fail with an exception.
<!-- END RELEASE NOTES -->
