### PR TITLE
Update quaternion.py

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -655,7 +655,7 @@ class Quaternion(Expr):
         return cls(a, b, c, d)
 
     @classmethod
-    def from_rotation_matrix(cls, M):
+    def from_rotation_matrix(cls, M: Matrix) -> Quaternion:
         """Returns the equivalent quaternion of a matrix. The quaternion will be normalized
         only if the matrix is special orthogonal (orthogonal and det(M) = 1).
 
@@ -728,7 +728,7 @@ class Quaternion(Expr):
     def _eval_Integral(self, *args) -> Quaternion:
         return self.integrate(*args)
 
-    def diff(self, *symbols, **kwargs):
+    def diff(self, *symbols, **kwargs) -> Quaternion:
         kwargs.setdefault('evaluate', True)
         a, b, c, d = [arg.diff(*symbols, **kwargs) for arg in self.args]
         return self.func(a, b, c, d)
@@ -1018,7 +1018,7 @@ class Quaternion(Expr):
 
         return Quaternion(a, b, c, d)
 
-    def log(self):
+    def log(self) -> Quaternion:
         r"""Returns the logarithm of the quaternion, given by $\log q$.
 
         Examples


### PR DESCRIPTION
#### References to other Issues or PRs
See #28806


#### Brief description of what is fixed or changed

Added a few missing type annotations in sympy/algebras/quaternion.py.
This change adds return type hints to several simple methods that did not
previously have annotations. No logic changes were made.


#### Other comments

This is a small typing-only change intended to help with the typing work
requested in issue #28806.


#### AI Generation Disclosure

AI assistance was used for guidance on the typing changes, but the final edits
and code modifications were written and reviewed manually.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->