### PR TITLE
Kernel computation for permutation codomain and infinite domain

### DIFF
--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -144,26 +144,44 @@ class GroupHomomorphism:
         G = self.domain
         H = self.codomain
         Ginf = G.order() is S.Infinity
-        if Ginf and isinstance(H, (FpGroup, FreeGroup)):
-            # TODO: Make this work for PermutationGroup codomain by replacing it
-            # with FpGroup using PermutationGroup.presentation()
+        if Ginf and isinstance(H, (FpGroup, FreeGroup, PermutationGroup)):
+            perm_codomain = isinstance(H, PermutationGroup)
             if isinstance(H, FreeGroup):
                 H = FpGroup(H, [])
             preimages = self._is_surjective_cert()
             if preimages is not None:
-                symbol_to_preimage = {
-                    g.ext_rep[0]: preimages[g] for g in H.generators
-                }
+                if perm_codomain:
+                    perm_gens = H.generators
+                    fp_group = H.presentation(eliminate_gens=False)
+                    if isinstance(fp_group, FreeGroup):
+                        return G  # if H is simultaneously a free group and a permutation group, H is trivial
+                    symbol_to_preimage = {
+                        g.ext_rep[0]: preimages[perm_g]
+                        for g, perm_g in zip(fp_group.generators, perm_gens)
+                    }
+                else:
+                    symbol_to_preimage = {
+                        g.ext_rep[0]: preimages[g] for g in H.generators
+                    }
 
                 def _lift_to_domain(word):
                     dtype = type(G.identity)
+                    if perm_codomain and isinstance(word, type(H.identity)):
+                        factors = H.generator_product(
+                            word, original=True)[::-1]
+                        return dtype.prod(
+                            preimages[s] if s in preimages
+                            else preimages[s**-1]**-1
+                            for s in factors if not s.is_identity
+                        )
                     return dtype.prod(
                         symbol_to_preimage[symbol]**power
                         for symbol, power in word.array_form
                     )
 
                 kernel_gens = []
-                for relator in H.relators:
+                relators = fp_group.relators if perm_codomain else H.relators
+                for relator in relators:
                     word = _lift_to_domain(relator)
                     if not word.is_identity:
                         kernel_gens.append(word)

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5059,7 +5059,7 @@ class PermutationGroup(Basic):
             C_p = G_p.coset_enumeration([], strategy="coset_table",
                                 draft=C_p, max_cosets=n, incomplete=True)
 
-        self._fp_presentation = simplify_presentation(G_p)
+        self._fp_presentation = simplify_presentation(G_p, change_gens=eliminate_gens)
         return self._fp_presentation
 
     def polycyclic_group(self):

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -161,6 +161,31 @@ def test_fpgroup_kernel():
     assert kernel.normal
     assert b*a**-1 in kernel
 
+def test_infinite_kernel_with_permutation_codomain():
+    F, a, b = free_group("a, b")
+    c = Permutation(0, 1, 2)
+    C3 = PermutationGroup(c)
+
+    T = homomorphism(F, C3, [a, b], [c, c])
+    kernel = T.kernel()
+    assert kernel.normal
+    assert b*a**-1 in kernel
+    assert a**3 in kernel
+
+    G = FpGroup(F, [a*b*a**-1*b**-1])
+    T = homomorphism(G, C3, G.generators, [c, c])
+    kernel = T.kernel()
+    assert kernel.normal
+    assert b*a**-1 in kernel
+    assert a**3 in kernel
+
+    D4 = PermutationGroup(Permutation(0, 1, 2, 3), Permutation(0, 3)(1, 2))
+    T = homomorphism(F, D4, [a], [Permutation(0, 1, 2, 3)])
+    kernel = T.kernel()
+    assert kernel.normal
+    assert b in kernel
+    assert a**4 in kernel
+
 def test_homomorphism_factor():
     F, a, b = free_group("a, b")
     H = FpGroup(F, [a**2, b**2, (a*b)**2])


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Implemented kernel computation for permutation codomain and infinite domain of any type.
Now kernel works for all homomorphisms with domain of finite index. 

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Used codex to generate initial code, then edited it. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Kernel computation now works for all group homomorphisms with domain of finite index. 
<!-- END RELEASE NOTES -->
