### PR TITLE
utilities: add type annotations to warning helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ sample.tex
 # Ignore hypothesis files
 .hypothesis
 
+sympy-env/

--- a/.mailmap
+++ b/.mailmap
@@ -856,6 +856,7 @@ Jerry Li <jerry@jerryli.ca>
 Jezreel Ng <jezreel@gmail.com>
 Jiaxing Liang <liangjiaxing57@gmail.com>
 Jiaxing Liang <liangjiaxing57@gmail.com> <jiaxingl@CS-DEAL-03.cs.sfu.ca>
+JienWeng <laijienweng@gmail.com>
 Jim Crist <crist042@umn.edu>
 Jim Zhang <Hyriodula@gmail.com>
 Jiri Kuncar <jiri.kuncar@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -856,7 +856,6 @@ Jerry Li <jerry@jerryli.ca>
 Jezreel Ng <jezreel@gmail.com>
 Jiaxing Liang <liangjiaxing57@gmail.com>
 Jiaxing Liang <liangjiaxing57@gmail.com> <jiaxingl@CS-DEAL-03.cs.sfu.ca>
-JienWeng <laijienweng@gmail.com>
 Jim Crist <crist042@umn.edu>
 Jim Zhang <Hyriodula@gmail.com>
 Jiri Kuncar <jiri.kuncar@gmail.com>
@@ -971,6 +970,8 @@ Kunal Singh <ksingh19136@gmail.com> kunal singh <ksingh19136@gmail.com>
 Kundan Kumar <kundankumar18581@gmail.com>
 Kyle McDaniel <mcdanie5@illinois.edu> <mcdaniel221@gmail.com>
 Lagaras Stelios <stel.lag@hotmail.com> lagamura <stel.lag@hotmail.com>
+Lai Jien Weng <laijienweng@gmail.com> Jien Weng <reallyhat@gmail.com>
+Lai Jien Weng <laijienweng@gmail.com> JienWeng <laijienweng@gmail.com>
 Lakshya Agrawal <zeeshan.lakshya@gmail.com>
 Langston Barrett <langston.barrett@gmail.com>
 Lars Buitinck <larsmans@gmail.com>

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -8,7 +8,7 @@ import contextlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import collections.abc as _abc
+    from collections.abc import Callable, Iterator
 
 from textwrap import dedent
 
@@ -108,7 +108,7 @@ will be removed in a future version of SymPy.
     def __reduce__(
         self,
     ) -> tuple[
-        _abc.Callable[[str, str, str], SymPyDeprecationWarning],
+        Callable[[str, str, str], SymPyDeprecationWarning],
         tuple[str, str, str],
     ]:
         return (self._new, (self.message, self.deprecated_since_version, self.active_deprecations_target))
@@ -233,7 +233,7 @@ def sympy_deprecation_warning(
 
 
 @contextlib.contextmanager
-def ignore_warnings(warningcls: type[Warning]) -> _abc.Iterator[None]:
+def ignore_warnings(warningcls: type[Warning]) -> Iterator[None]:
     '''
     Context manager to suppress warnings during tests.
 

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import warnings
 import contextlib
+import collections.abc as _abc  # noqa: TC003
 
 from textwrap import dedent
 
@@ -51,7 +52,13 @@ class SymPyDeprecationWarning(DeprecationWarning):
     sympy.testing.pytest.warns_deprecated_sympy
 
     """
-    def __init__(self, message, *, deprecated_since_version, active_deprecations_target):
+    def __init__(
+        self,
+        message: str,
+        *,
+        deprecated_since_version: str,
+        active_deprecations_target: str,
+    ) -> None:
 
         super().__init__(message, deprecated_since_version,
                      active_deprecations_target)
@@ -74,31 +81,45 @@ This has been deprecated since SymPy version {deprecated_since_version}. It
 will be removed in a future version of SymPy.
 """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.full_message
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.message!r}, deprecated_since_version={self.deprecated_since_version!r}, active_deprecations_target={self.active_deprecations_target!r})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, SymPyDeprecationWarning) and self.args == other.args
 
     # Make pickling work. The by default, it tries to recreate the expression
     # from its args, but this doesn't work because of our keyword-only
     # arguments.
     @classmethod
-    def _new(cls, message, deprecated_since_version,
-              active_deprecations_target):
+    def _new(
+        cls,
+        message: str,
+        deprecated_since_version: str,
+        active_deprecations_target: str,
+    ) -> SymPyDeprecationWarning:
         return cls(message, deprecated_since_version=deprecated_since_version, active_deprecations_target=active_deprecations_target)
 
-    def __reduce__(self):
+    def __reduce__(
+        self,
+    ) -> tuple[
+        _abc.Callable[[str, str, str], SymPyDeprecationWarning],
+        tuple[str, str, str],
+    ]:
         return (self._new, (self.message, self.deprecated_since_version, self.active_deprecations_target))
 
 # Python by default hides DeprecationWarnings, which we do not want.
 warnings.simplefilter("once", SymPyDeprecationWarning)
 
-def sympy_deprecation_warning(message, *, deprecated_since_version,
-                              active_deprecations_target, stacklevel=3):
+def sympy_deprecation_warning(
+    message: str,
+    *,
+    deprecated_since_version: str,
+    active_deprecations_target: str,
+    stacklevel: int = 3,
+) -> None:
     r'''
     Warn that a feature is deprecated in SymPy.
 
@@ -209,7 +230,7 @@ def sympy_deprecation_warning(message, *, deprecated_since_version,
 
 
 @contextlib.contextmanager
-def ignore_warnings(warningcls):
+def ignore_warnings(warningcls: type[Warning]) -> _abc.Iterator[None]:
     '''
     Context manager to suppress warnings during tests.
 

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import warnings
 import contextlib
-import collections.abc as _abc  # noqa: TC003
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import collections.abc as _abc
 
 from textwrap import dedent
 


### PR DESCRIPTION
#### References to other Issues or PRs

See #28806

#### Brief description of what is fixed or changed

Add type annotations to the warning helper APIs in `sympy.utilities.exceptions`.
This covers `SymPyDeprecationWarning`, `sympy_deprecation_warning`, and
`ignore_warnings` without changing runtime behavior.

#### Other comments

Tested locally with:
- `python -m mypy sympy`
- `python -m pytest sympy/utilities/tests/test_exceptions.py -q`
- `python -m pytest sympy/testing/tests/test_pytest.py -q`
- `python -m pytest sympy/utilities/tests/test_pickling.py -q`
- `ruff check sympy/utilities/exceptions.py`

#### AI Generation Disclosure

AI assistance was used to help draft the type annotations in
`sympy/utilities/exceptions.py` and to run the local verification workflow.
The final patch was reviewed manually before submission.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->