### PR TITLE
solvers: remove dead code in reduce_rational_inequalities

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -223,7 +223,6 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
     (-2 < y) & (y < oo)
     """
     exact = True
-    eqs = []
     solution = S.EmptySet  # add pieces for each group
     for _exprs in exprs:
         if not _exprs:
@@ -269,9 +268,6 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
 
         if _eqs:
             _sol &= solve_rational_inequalities([_eqs])
-            exclude = solve_rational_inequalities([[((d, d.one), '==')
-                for i in eqs for ((n, d), _) in i if d.has(gen)]])
-            _sol -= exclude
 
         solution |= _sol
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The exclude block  in reduce_rational_inequalities was dead code - eqs is initialized as [] and never populated, so exclude was always S.EmptySet. Denominator pole exclusion is already handled internally by solve_rational_inequalities via global_interval -= denom_interval.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USED..


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Removed dead code in reduce_rational_inequalities where `exclude` was always `S.EmptySet`.
<!-- END RELEASE NOTES -->
