### PR TITLE
core: evaluate is_integer to None for rat_nonint raised to irrational…

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -476,7 +476,7 @@ class Pow(Expr):
     def _eval_is_integer(self):
         b, e = self.args
         if b.is_rational:
-            if b.is_integer is False and e.is_positive:
+            if b.is_integer is False and e.is_positive and e.is_rational:
                 return False  # rat**nonneg
         if b.is_integer and e.is_integer:
             if b is S.NegativeOne:


### PR DESCRIPTION
#### References to other Issues or PRs

see #29380

#### Brief description of what is fixed or changed

This PR fixes an incorrect assumption evaluation in `Power._eval_is_integer`.  
Previously, when a rational non-integer base was raised to a positive exponent, the
expression could incorrectly be evaluated as strictly non-integer.

The fix updates the logic in `_eval_is_integer` to include an additional constraint
checking that the exponent is rational (`e.is_rational`). This prevents invalid
assumption deductions and preserves mathematical invariants.

After the fix, expressions such as `(a/b)**log(a/b, c)` no longer violate the
identity `(a/b)^(log_{a/b}(c)) = c` in the assumptions system.

#### Other comments

The change was implemented in `sympy/core/power.py` by modifying the logic inside
`Power._eval_is_integer`. The SymPy test suite, including tests in
`sympy/core/tests/test_assumptions.py`, passes successfully after the fix.

#### AI Generation Disclosure

I used an LLM to help me understand the codebase and review the logic change.
The actual modification to the code and verification of the fix were done by me.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * Fixed incorrect assumption evaluation for rational non-integer bases raised
    to positive exponents in `Power._eval_is_integer`.

<!-- END RELEASE NOTES -->