### PR TITLE
Fix ValueError in linprog when no constraints are provided

### DIFF
--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -965,7 +965,7 @@ def linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("A and b must both be given")
         # the governing equations will be simple constraints
         # on variables
-        A, b = zeros(0, C.cols), zeros(C.cols, 1)
+        A, b = zeros(0, C.cols), zeros(0, 1)  # FIX: was zeros(C.cols, 1) which is truthy and caused ValueError in _simplex
     else:
         A, b = [Matrix(i) for i in (A, b)]
 
@@ -1066,10 +1066,12 @@ def show_linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("unexpected bounds %s" % bounds)
 
     x = Matrix(symbols('x1:%s' % (A.cols+1)))
-    f,c = (C*x)[0], [i<=j for i,j in zip(A*x, b)] + [Eq(i,j) for i,j in zip(A_eq*x,b_eq)]
-    for i, (lo, hi) in enumerate(bounds):
-        if lo is not None:
-            c.append(x[i]>=lo)
-        if hi is not None:
-            c.append(x[i]<=hi)
+    eq_constraints = [Eq(i, j) for i, j in zip(A_eq*x, b_eq)] if A_eq is not None else []
+    f, c = (C*x)[0], [i<=j for i, j in zip(A*x, b)] + eq_constraints
+    if bounds is not None:
+        for i, (lo, hi) in enumerate(bounds):
+            if lo is not None:
+                c.append(x[i]>=lo)
+            if hi is not None:
+                c.append(x[i]<=hi)
     return f,c


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29368 

#### Brief description of what is fixed or changed
Fixed `linprog(c)` raising `ValueError` when called without `A` and `B` by changing `zeros(C.cols, 1)` to `zeros(0, 1)`.

#### Other comments

#### AI Generation Disclosure
NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed `linprog(c)` raising `ValueError: must give A and B` instead of correct behavior when called without `A` and `B`.
<!-- END RELEASE NOTES -->