### PR TITLE
Fix show linprog sympify error

### DIFF
--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -965,7 +965,7 @@ def linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("A and b must both be given")
         # the governing equations will be simple constraints
         # on variables
-        A, b = zeros(0, C.cols), zeros(0, 1)  # FIX: was zeros(C.cols, 1) which is truthy and caused ValueError in _simplex
+        A, b = zeros(0, C.cols), zeros(C.cols, 1)
     else:
         A, b = [Matrix(i) for i in (A, b)]
 
@@ -1032,7 +1032,7 @@ def show_linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("A and b must both be given")
         # the governing equations will be simple constraints
         # on variables
-        A, b = zeros(0, C.cols), zeros(C.cols, 1)
+        A, b = zeros(0, C.cols), zeros(0, 1)
     else:
         A, b = [Matrix(i) for i in (A, b)]
 
@@ -1066,8 +1066,8 @@ def show_linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("unexpected bounds %s" % bounds)
 
     x = Matrix(symbols('x1:%s' % (A.cols+1)))
-    eq_constraints = [Eq(i, j) for i, j in zip(A_eq*x, b_eq)] if A_eq is not None else []
-    f, c = (C*x)[0], [i<=j for i, j in zip(A*x, b)] + eq_constraints
+    eq_constraints = [Eq(i,j) for i,j in zip(A_eq*x, b_eq)] if A_eq is not None else []
+    f,c = (C*x)[0], [i<=j for i,j in zip(A*x, b)] + eq_constraints
     if bounds is not None:
         for i, (lo, hi) in enumerate(bounds):
             if lo is not None:

--- a/sympy/solvers/simplex.py
+++ b/sympy/solvers/simplex.py
@@ -965,7 +965,7 @@ def linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("A and b must both be given")
         # the governing equations will be simple constraints
         # on variables
-        A, b = zeros(0, C.cols), zeros(C.cols, 1)
+        A, b = zeros(0, C.cols), zeros(0, 1)  # FIX: was zeros(C.cols, 1) which is truthy and caused ValueError in _simplex
     else:
         A, b = [Matrix(i) for i in (A, b)]
 
@@ -1066,10 +1066,12 @@ def show_linprog(c, A=None, b=None, A_eq=None, b_eq=None, bounds=None):
             raise ValueError("unexpected bounds %s" % bounds)
 
     x = Matrix(symbols('x1:%s' % (A.cols+1)))
-    f,c = (C*x)[0], [i<=j for i,j in zip(A*x, b)] + [Eq(i,j) for i,j in zip(A_eq*x,b_eq)]
-    for i, (lo, hi) in enumerate(bounds):
-        if lo is not None:
-            c.append(x[i]>=lo)
-        if hi is not None:
-            c.append(x[i]<=hi)
+    eq_constraints = [Eq(i, j) for i, j in zip(A_eq*x, b_eq)] if A_eq is not None else []
+    f, c = (C*x)[0], [i<=j for i, j in zip(A*x, b)] + eq_constraints
+    if bounds is not None:
+        for i, (lo, hi) in enumerate(bounds):
+            if lo is not None:
+                c.append(x[i]>=lo)
+            if hi is not None:
+                c.append(x[i]<=hi)
     return f,c


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29382 


#### Brief description of what is fixed or changed
Fixed `show_linprog` raising `SympifyError: None` when called without `A_eq` by guarding the equality constraints computation with `if A_eq is not None else []`. Also fixed `zeros(C.cols, 1)` to `zeros(0, 1)` to keep empty constraint matrices consistently falsy, and guarded the `bounds` iteration with `if bounds is not None`.

#### Other comments

#### AI Generation Disclosure
NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed `show_linprog` raising `SympifyError: None` instead of correct behavior when called without `A_eq`.
<!-- END RELEASE NOTES -->