### PR TITLE
Print prefixes using their names instead of Prefix(...)

### DIFF
--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -71,14 +71,6 @@ class Prefix(Expr):
     def __str__(self):
         return str(self._abbrev)
 
-    def __repr__(self):
-        if self.base == 10:
-            return "Prefix(%r, %r, %r)" % (
-                str(self.name), str(self.abbrev), self._exponent)
-        else:
-            return "Prefix(%r, %r, %r, %r)" % (
-                str(self.name), str(self.abbrev), self._exponent, self.base)
-
     def __mul__(self, other):
         from sympy.physics.units import Quantity
         if not isinstance(other, (Quantity, Prefix)):

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from sympy import srepr, sstr
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
@@ -82,6 +83,9 @@ def test_bases():
     assert kibi.base == 2
 
 
-def test_repr():
-    assert eval(repr(kilo)) == kilo
-    assert eval(repr(kibi)) == kibi
+def test_prefix_printing():
+    assert str(kilo) == "k"
+    assert repr(kilo) == "kilo"
+    assert sstr(kilo) == "kilo"
+    assert sstr(kilo, abbrev=True) == "k"
+    assert srepr(kilo) == "kilo"

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -254,6 +254,9 @@ class ReprPrinter(Printer):
     def _print_Predicate(self, expr):
         return "Q.%s" % expr.name
 
+    def _print_Prefix(self, expr):
+        return str(expr.name)
+
     def _print_AppliedPredicate(self, expr):
         # will be changed to just expr.args when args overriding is removed
         args = expr._args

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -889,6 +889,11 @@ class StrPrinter(Printer):
             return "%s" % expr.abbrev
         return "%s" % expr.name
 
+    def _print_Prefix(self, expr):
+        if self._settings.get("abbrev", False):
+            return "%s" % expr.abbrev
+        return "%s" % expr.name
+
     def _print_Quaternion(self, expr):
         s = [self.parenthesize(i, PRECEDENCE["Mul"], strict=True) for i in expr.args]
         a = [s[0]] + [i+"*"+j for i, j in zip(s[1:], "ijk")]


### PR DESCRIPTION
# Print prefixes using their names like `"kilo"` instead of `Prefix(...)`

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### Brief description of what is fixed or changed

This changes `srepr(kilo)`, `repr(kilo)` and `sstr(kilo)` from returning some variant of `"Prefix('kilo', 'k', 3)"` to just `"kilo"`. This brings the `Prefix` behavior in line with `Quantity`.

#### Other comments

When I looked at why `Quantity` already automatically printed its class name as its `srepr`, whereas `Prefix` needs `_print_Prefix` in `sympy/printing/repr.py`, I noticed that `Prefix` is not an `AtomicExpr`, unlike `Quantity`. That seems a bit odd, at least if I understand the implications correctly -- one probably doesn't usually want to descend into the args of `Prefix(Symbol('kilo'), Symbol('k'), Integer(3), Integer(10))`, and `kilo.free_symbols` being `{kilo, k}` seems unlikely to be useful as well -- but that's for another PR I think.

See also the original PR message preserved below for some nitty gritty details on what prints how.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Some lines written by Codex, but mostly rewritten by me to clean it up.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Print prefixes using their names like `"kilo"` instead of `"Prefix('kilo', 'k', 3)"`.
<!-- END RELEASE NOTES -->

-------------------

# Original Draft PR Message

@oscarbenjamin This is basically an issue with proof of concept code attached. Before I make a proper PR, could I get your input on whether this is a desirable change at all?

## Background

I'm working on a calculator app, and for its test suite, I'm looking at a lot of `srepr` representations. For `Prefixes` like `kilo`, both `srepr(kilo)` and `sstr(kilo)` are very verbose, which makes them particularly hard to read:

```py
>>> from sympy import *
>>> from sympy.physics.units import *
>>> srepr(Mul(kilo, gram))
"Mul(Prefix(Symbol('kilo'), Symbol('k'), Integer(3), Integer(10)), gram)"
>>> sstr(Mul(kilo, gram))
'gram*Prefix(kilo, k, 3, 10)'
```

I was going to make them more compact inside my test suite, but then it occurred to me that this might be worth upstreaming.

## Proposed change

SymPy is already printing `Quantities` using their names, so `sstr(gram)` and `srepr(gram)` simply print as `"gram"`. Should we do the same for `Prefixes`, so `sstr(kilo)` and `srepr(kilo)` print as `"kilo"`?

## Compatibility

The main question I have trouble judging is whether this is acceptable in terms of backwards compatibility.

On the one hand, I could imagine that this might break a few docstring tests. On the other hand, I'm not sure that we're necessarily trying to guarantee that our stringification is completely stable between releases.

## Details

- **`srepr`:** Make `srepr(kilo)` return `"kilo"` instead of `"Prefix(Symbol('kilo'), Symbol('k'), Integer(3), Integer(10))"`, bringing it in line with the behavior of `Quantity` (like `gram`).

  - One potential concern is that `srepr` is generally supposed to roundtrip under `from sympy import *`. But existing `Quantities` like `gram` already assume `from sympy.physics.units import *` as an additional import. So it seems okay to make the same assumption for `Prefix`.

- **`sstr`:** Make `sstr(kilo)` and `repr(kilo)` return `"kilo"` instead of `"Prefix(kilo, k, 3, 10)"`, just like `srepr`.

- Normally `str` and `repr` simply return the `sstr`, but for `Prefix`, the current behavior is slightly different:

  - **`str`:** Outside of the context of the `sstr` printer, `str(kilo)` currently returns `"k"` (the `abbrev`), because `Prefix` [overrides `__str__`](https://github.com/sympy/sympy/blob/135ac5b7c1dca4fb8a5da291cc27f560d73b22f9/sympy/physics/units/prefixes.py#L71-L72). My hunch is to keep this behavior, rather than also changing it to `"kilo"`, since people might be relying on it, and there's not much reason to change it, other than the slight inconsistency.
  
    (By contrast, `str(Mul(kilo, gram))` hits the `sstr` printer, and prints `"gram*kilo"` with this change.)

  - **`repr`:** `repr(kilo)` currently prints something slightly different from `sstr(kilo)`, because `Prefix` [overrides `__repr__`](https://github.com/sympy/sympy/blob/master/sympy/physics/units/prefixes.py#L74-L80):
  
      ```py
      >>> sstr(kilo)
      'Prefix(kilo, k, 3, 10)'
      >>> repr(kilo)
      "Prefix('kilo', 'k', 3)"
      ```
  
    I assume this is unintentional, and with the change I'm proposing it brings the `repr` in line with the `sstr`.
  
- User-defined prefixes: I thought about printing these as `Prefix(...)`. But we're already printing user-defined `Quantities` using just their `name`; for example `sstr(Quantity("furlong"))` and `srepr(Quantity("furlong"))` both print `"furlong"`. So it seems reasonable to do the same for `Prefix`.

## Code

The attached code is mostly vibecoded as a proof of concept. If you think this is a good change, and you're happy with the details, I'll take another pass over the code and send a proper PR.