### PR TITLE
fix: resolve KeyError in diophantine() when syms is a subset

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1329,8 +1329,8 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
                     'syms should be given as a sequence, e.g. a list')
             syms = [i for i in syms if i in var]
             if syms != var:
-                dict_sym_index = dict(zip(syms, range(len(syms))))
-                return {tuple([t[dict_sym_index[i]] for i in var])
+                dict_var_index = dict(zip(var, range(len(var))))
+                return {tuple(t[dict_var_index[i]] for i in syms)
                             for t in diophantine(eq, param, permute=permute)}
         n, d = eq.as_numer_denom()
         if n.is_number:

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -1070,3 +1070,10 @@ def test_issue_18628():
     eq2 = 2*x**2 - 9*x + 4*y**2 - 8*y + 14
     sol = diophantine(eq2)
     assert sol == {(2, 1)}
+
+
+def test_diophantine_syms_subset():
+    x, y, z = symbols('x y z', integer=True)
+    # This should not raise KeyError
+    # It confirms that diophantine() handles syms being a subset of equation symbols.
+    assert diophantine(x + y + z - 3, syms=[x, y]) == {(t_0, t_0 + t_1)}


### PR DESCRIPTION
Fixes #29269

## Summary
- Fixed a `KeyError` in `diophantine()` that occurred when the `syms` parameter was a subset of the equation's free symbols.
- Corrected the index remapping logic in `sympy/solvers/diophantine/diophantine.py` to correctly map from full variables (`var`) to the user-requested symbols (`syms`).
- Added a regression test `test_diophantine_syms_subset` to ensure the fix is verified and prevent regressions.

## Test Plan
- Run `pytest sympy/solvers/diophantine/tests/test_diophantine.py -k test_diophantine_syms_subset` (Passes)
- Run full module tests (All 49 relevant tests pass, 2 pre-existing xfails)
- Verified with reproduction script from issue #29269.

<!-- BEGIN RELEASE NOTES -->
- solvers
  - Fixed a KeyError in diophantine() when syms is a subset of the equation's free symbols.
<!-- END RELEASE NOTES -->