### PR TITLE
Fix diff(nan, x) returning 0 by propagating NaN

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1531,6 +1531,7 @@ Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
 Shubham Maheshwari <rmaheshwari05@gmail.com>
 Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
 Shubham Tibra <shubh.tibra@gmail.com>
+Shubhankar Joshi <shubhankarjoshi2489@gmail.com> Shubhankar-Joshi2489 <shubhankarjoshi2489@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -63,8 +63,6 @@ from sympy.utilities.misc import as_int, filldedent, func_name
 import mpmath
 from sympy.external.mpmath import (prec_to_dps, mpf, mpc, mp, workprec, diff as
                                    mpmath_diff)
-from sympy.core.singleton import S
-
 import inspect
 from collections import Counter
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -63,6 +63,7 @@ from sympy.utilities.misc import as_int, filldedent, func_name
 import mpmath
 from sympy.external.mpmath import (prec_to_dps, mpf, mpc, mp, workprec, diff as
                                    mpmath_diff)
+from sympy.core.singleton import S
 
 import inspect
 from collections import Counter
@@ -1374,7 +1375,6 @@ class Derivative(Expr):
         # good way to unambiguously print this.
         if len(variable_count) == 0:
             return expr
-        from sympy import S
         if expr.has(S.NaN):
             return S.NaN
         evaluate = kwargs.get('evaluate', False)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1374,9 +1374,10 @@ class Derivative(Expr):
         # good way to unambiguously print this.
         if len(variable_count) == 0:
             return expr
-
+        from sympy import S
+        if expr.has(S.NaN):
+            return S.NaN
         evaluate = kwargs.get('evaluate', False)
-
         if evaluate:
             if isinstance(expr, Derivative):
                 expr = expr.canonical

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -16,9 +16,12 @@ from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
 from sympy import nan,diff
+
 def test_nan_derivative():
     x = Symbol('x')
-    assert diff(nan, x) == nan   
+    assert diff(nan, x)==nan
+
+
 def test_diff():
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from sympy.concrete.summations import Sum
 from sympy.core.expr import Expr
-from sympy.core.function import (Derivative, Function, diff, Subs)
+from sympy.core.function import (Derivative, Function, Subs)
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -15,10 +15,10 @@ from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
-from sympy import Symbol, nan, diff
+from sympy import nan,diff
 def test_nan_derivative():
     x = Symbol('x')
-    assert diff(nan, x) is nan
+    assert diff(nan, x) == nan
 def test_diff():
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -16,12 +16,9 @@ from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
 from sympy import nan,diff
-
 def test_nan_derivative():
     x = Symbol('x')
-    assert diff(nan, x) == nan
-
-    
+    assert diff(nan, x) == nan   
 def test_diff():
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -15,10 +15,13 @@ from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
+
 from sympy import nan,diff
 def test_nan_derivative():
     x = Symbol('x')
     assert diff(nan, x) == nan
+
+    
 def test_diff():
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -15,8 +15,8 @@ from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
-from sympy import nan,diff
 
+from sympy import nan,diff
 def test_nan_derivative():
     x = Symbol('x')
     assert diff(nan, x)==nan

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -15,7 +15,10 @@ from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
-
+from sympy import Symbol, nan, diff
+def test_nan_derivative():
+    x = Symbol('x')
+    assert diff(nan, x) is nan
 def test_diff():
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -15,8 +15,8 @@ from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises
 from sympy.abc import a, b, c, x, y, z
-
 from sympy import nan,diff
+
 def test_nan_derivative():
     x = Symbol('x')
     assert diff(nan, x) == nan


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29296
#### Brief description of what is fixed or changed

Currently diff(nan, x) returns 0 due to a quick-exit optimization in
Derivative.__new__() that checks if the differentiation variable
appears in expr.free_symbols.

Since nan.free_symbols is empty, the code incorrectly treats the
expression as constant and returns 0.

However, NaN should propagate through differentiation, so the
correct result is NaN.

Example:

    from sympy import Symbol, nan, diff
    x = Symbol('x')
    diff(nan, x)

Current output:
    0

Expected output:
    nan

This patch adds a guard before the zero-check optimization to ensure
NaN propagates correctly. 
#### Other comments
Additional test case added in sympy/core/tests/test_diff.py.

#### AI Generation Disclosure
ChatGPT was used for assistance with debugging ideas and drafting the PR description.
All code changes and tests were implemented and verified manually.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.


DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed diff(nan, x) incorrectly returning 0 instead of nan.
<!-- END RELEASE NOTES -->
