### PR TITLE
core: improve finiteness inference for x**x when base equals exponent

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1466,6 +1466,7 @@ Samyak Jain <samyak.jain2016a@vitstudent.ac.in> Samyak Jain <samtan106@gmail.com
 Sandeep Murthy <smurthy@protonmail.ch>
 Sandeep Veethu <sandeep.veethu@gmail.com>
 Sanket Agarwal <sanket@sanketagarwal.com>
+Sanskar Mittal <sanskarmrt@gmail.com>
 Sanya Khurana <sanya@monica.in>
 Saptarshi Mandal <sapta.iitkgp@gmail.com>
 Saroj Adhikari <adh.saroj@gmail.com>

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -643,7 +643,7 @@ class Pow(Expr):
         if c2 is None:
             return
         if c1 and c2:
-            if(self.base == self.exp):
+            if(self.base == self.exp and self.base.is_complex):
                 return True
             if self.exp.is_nonnegative or fuzzy_not(self.base.is_zero):
                 return True

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -643,6 +643,8 @@ class Pow(Expr):
         if c2 is None:
             return
         if c1 and c2:
+            if(self.base == self.exp):
+                return True
             if self.exp.is_nonnegative or fuzzy_not(self.base.is_zero):
                 return True
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1174,6 +1174,7 @@ def test_real_Pow():
 def test_Pow_is_finite():
     xe = Symbol('xe', extended_real=True)
     xr = Symbol('xr', real=True)
+    xc = Symbol('xc', complex=True)
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)
     i = Symbol('i', integer=True)
@@ -1185,6 +1186,7 @@ def test_Pow_is_finite():
     assert (xr**xe).is_finite is None
     assert (xe**xr).is_finite is None
     assert (xr**xr).is_finite is True
+    assert (xc**xc).is_finite is True
 
     assert (p**xe).is_finite is None
     assert (p**xr).is_finite is True
@@ -1211,11 +1213,6 @@ def test_Pow_is_finite():
     assert (1/S.Pi).is_finite is True
 
     assert (1/(i-1)).is_finite is None
-
-def test_Pow_is_finite_same_base_exponent_complex():
-    xc = Symbol('xc', complex=True)
-
-    assert (xc**xc).is_finite is True
 
 
 def test_Pow_is_even_odd():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1184,9 +1184,8 @@ def test_Pow_is_finite():
     assert (xe**xe).is_finite is None
     assert (xr**xe).is_finite is None
     assert (xe**xr).is_finite is None
-    # FIXME: The line below should be True rather than None
-    # assert (xr**xr).is_finite is True
-    assert (xr**xr).is_finite is None
+    
+    assert (xr**xr).is_finite is True
 
     assert (p**xe).is_finite is None
     assert (p**xr).is_finite is True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1184,7 +1184,6 @@ def test_Pow_is_finite():
     assert (xe**xe).is_finite is None
     assert (xr**xe).is_finite is None
     assert (xe**xr).is_finite is None
-    
     assert (xr**xr).is_finite is True
 
     assert (p**xe).is_finite is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1212,6 +1212,11 @@ def test_Pow_is_finite():
 
     assert (1/(i-1)).is_finite is None
 
+def test_Pow_is_finite_same_base_exponent_complex():
+    xc = Symbol('xc', complex=True)
+
+    assert (xc**xc).is_finite is True
+
 
 def test_Pow_is_even_odd():
     x = Symbol('x')

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1175,6 +1175,7 @@ def test_Pow_is_finite():
     xe = Symbol('xe', extended_real=True)
     xr = Symbol('xr', real=True)
     xc = Symbol('xc', complex=True)
+    x = Symbol('x')
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)
     i = Symbol('i', integer=True)
@@ -1187,6 +1188,7 @@ def test_Pow_is_finite():
     assert (xe**xr).is_finite is None
     assert (xr**xr).is_finite is True
     assert (xc**xc).is_finite is True
+    assert (x**x).is_finite is None
 
     assert (p**xe).is_finite is None
     assert (p**xr).is_finite is True


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

NONE


#### Brief description of what is fixed or changed

Fix finiteness inference for expressions like `x**x` when the base and exponent are same and finite.

Previously `(xr**xr).is_finite` returned `None`, even though the result should always be finite.

This adds a small shortcut in `_eval_is_finite` and updates the corresponding test in `test_arit.py`.

#### Other comments

tests pass locally with:

python bin/test sympy/core/tests/test_arit.py


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USED IN ANY CODE OR TEST


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Improve finiteness inference for x**x when the base is known to be complex.
<!-- END RELEASE NOTES -->