### PR TITLE
Fix refine_sin_cos to handle Q.odd assumption for cos(n*pi)

### DIFF
--- a/sympy/.mailmap
+++ b/sympy/.mailmap
@@ -1,0 +1,1 @@
+Saloni Mathur <mathursaloni2287@gmail.com>

--- a/sympy/AUTHORS
+++ b/sympy/AUTHORS
@@ -1,0 +1,1 @@
+Saloni Mathur <mathursaloni2287@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -449,13 +449,18 @@ def refine_sin_cos(expr, assumptions):
     sum_of_parity_known_coeffs_is_even = True
     for coeff in integer_coeffs_of_pi_half:
         coeff_is_even = ask(Q.even(coeff), assumptions)
+#fix
         if coeff_is_even is None:
-            sum_of_parity_unknown_coeffs += coeff
-        else:
-            sum_of_parity_known_coeffs += coeff
-            sum_of_parity_known_coeffs_is_even = (
-                sum_of_parity_known_coeffs_is_even == coeff_is_even
-            )
+            coeff_is_odd = ask(Q.odd(coeff), assumptions)
+            if coeff_is_odd:
+                coeff_is_even = False  # odd matlab even nahi!
+                if coeff_is_even is None:
+                    sum_of_parity_unknown_coeffs += coeff
+                else:
+                    sum_of_parity_known_coeffs += coeff
+                    sum_of_parity_known_coeffs_is_even = (
+                        sum_of_parity_known_coeffs_is_even == coeff_is_even
+                    )
 
     if sum_of_parity_known_coeffs == 0:
         return expr


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

#27888

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The given code was not taking care of the case where n is odd, so modified the code to consider that case as well.

#### Other comments


#### AI Generation Disclosure

No use of AI

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Fixed ``refine_sin_cos`` to correctly simplify ``cos(n*pi)`` when
    ``n`` is assumed odd via ``Q.odd``. Previously the expression was
    left unevaluated.

<!-- END RELEASE NOTES -->
