### PR TITLE
Fixed improper printing of UnevaluatedExpr objects

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -6,7 +6,8 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import itertools
 
-from sympy.core import Add, Float, Mod, Mul, Number, S, Symbol, Expr
+from sympy.core import (
+    Add, Float, Mod, Mul, Number, S, Symbol, Expr, UnevaluatedExpr)
 from sympy.core.alphabets import greeks
 from sympy.core.containers import Tuple
 from sympy.core.function import Function, AppliedUndef, Derivative
@@ -322,6 +323,10 @@ class LatexPrinter(Printer):
         from sympy.concrete.summations import Sum
         from sympy.integrals.integrals import Integral
 
+        if isinstance(expr, UnevaluatedExpr):
+            e = expr.args[0]
+            if e.is_Mul and e.could_extract_minus_sign():
+                return True
         if expr.is_Mul:
             if not first and expr.could_extract_minus_sign():
                 return True
@@ -345,6 +350,9 @@ class LatexPrinter(Printer):
         printed as part of an Add, False otherwise.  This is False for most
         things.
         """
+        if isinstance(expr, UnevaluatedExpr):
+            if expr.args[0].is_Add:
+                return True
         if expr.is_Relational:
             return True
         if any(expr.has(x) for x in (Mod,)):
@@ -521,8 +529,13 @@ class LatexPrinter(Printer):
         separator: str = self._settings['mul_symbol_latex']
         numbersep: str = self._settings['mul_symbol_latex_numbers']
 
+        is_Add = lambda e: (e.is_Add or (
+            isinstance(e, UnevaluatedExpr) and e.args[0].is_Add))
+        is_Mul = lambda e: (e.is_Mul or (
+            isinstance(e, UnevaluatedExpr) and e.args[0].is_Mul))
+
         def convert(expr) -> str:
-            if not expr.is_Mul:
+            if not is_Mul(expr):
                 return str(self._print(expr))
             else:
                 if self.order not in ('old', 'none'):
@@ -574,8 +587,9 @@ class LatexPrinter(Printer):
         if expr.could_extract_minus_sign():
             expr = -expr
             tex = "- "
-            if expr.is_Add:
-                tex += "("
+            if is_Add(expr) or (isinstance(expr, UnevaluatedExpr) \
+                    and expr.args[0].is_Number and expr.args[0].is_negative):
+                tex += r"\left("
                 include_parens = True
         else:
             tex = ""
@@ -628,7 +642,7 @@ class LatexPrinter(Printer):
                 tex += r"\frac{%s}{%s}" % (snumer, sdenom)
 
         if include_parens:
-            tex += ")"
+            tex += r"\right)"
         return tex
 
     def _print_AlgebraicNumber(self, expr):

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -65,6 +65,10 @@ def precedence_Mul(item):
            arg.precedence < PRECEDENCE["Mul"] for arg in item.args):
         return PRECEDENCE["Mul"]
 
+    from sympy.core.expr import UnevaluatedExpr
+    if any(isinstance(a, UnevaluatedExpr) for a in item.args):
+        return PRECEDENCE["Mul"]
+
     if item.could_extract_minus_sign():
         return PRECEDENCE["Add"]
     return PRECEDENCE["Mul"]

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import itertools
 
-from sympy.core import S
+from sympy.core import S, UnevaluatedExpr
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.function import Function
@@ -1979,7 +1979,10 @@ class PrettyPrinter(Printer):
             elif term.is_Number and term < 0:
                 pform = self._print(-term)
                 pforms.append(pretty_negative(pform, i))
-            elif term.is_Relational:
+            elif (
+                term.is_Relational
+                or (isinstance(term, UnevaluatedExpr) and term.args[0].is_Add)
+            ):
                 pforms.append(prettyForm(*self._print(term).parens()))
             else:
                 pforms.append(self._print(term))
@@ -2059,9 +2062,20 @@ class PrettyPrinter(Printer):
             else:
                 a.append(item)
 
-        # Convert to pretty forms. Parentheses are added by `__mul__`.
-        a = [self._print(ai) for ai in a]
-        b = [self._print(bi) for bi in b]
+        # TODO: this should probably be moved into prettyForm.__mul__
+        def add_parens(expr):
+            if isinstance(expr, UnevaluatedExpr):
+                c, e = expr.args[0].as_coeff_Mul()
+                if c < 0:
+                    return True
+            return False
+
+        # Convert to pretty forms.
+        # Parentheses are added by `__mul__`, except for UnevaluatedExpr
+        a = [prettyForm(*self._print(ai).parens()) if add_parens(ai)
+            else self._print(ai) for ai in a]
+        b = [prettyForm(*self._print(bi).parens()) if add_parens(bi)
+            else self._print(bi) for bi in b]
 
         # Construct a pretty form
         if len(b) == 0:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7242,6 +7242,189 @@ x⋅─\n\
 ''')
     assert upretty(x*he) == ucode_str
 
+    ue1 = UnevaluatedExpr(-2*x**2 - 9*x + 5)
+
+    ucode_str = \
+"""\
+    ⎛     2          ⎞\n\
+1 + ⎝- 2⋅x  - 9⋅x + 5⎠\
+"""
+    assert upretty(1 + ue1) == ucode_str
+
+    ucode_str = \
+"""\
+    ⎛     2          ⎞\n\
+1 - ⎝- 2⋅x  - 9⋅x + 5⎠\
+"""
+    assert upretty(1 - ue1) == ucode_str
+
+    ue2 = UnevaluatedExpr(-2*x**2 + 3*x + 2)
+    ue3 = UnevaluatedExpr(-5*x**2 + 6*x - 7)
+
+    ucode_str = \
+"""\
+⎛     2          ⎞   ⎛     2          ⎞\n\
+⎝- 5⋅x  + 6⋅x - 7⎠ + ⎝- 2⋅x  + 3⋅x + 2⎠\
+"""
+    assert upretty(ue2 + ue3) == ucode_str
+
+    ucode_str = \
+"""\
+  ⎛     2          ⎞   ⎛     2          ⎞\n\
+- ⎝- 5⋅x  + 6⋅x - 7⎠ + ⎝- 2⋅x  + 3⋅x + 2⎠\
+"""
+    assert upretty(ue2 - ue3) == ucode_str
+
+    u = UnevaluatedExpr(2)
+    assert upretty(u) == "2"
+    assert upretty(-u) == "-2"
+    assert upretty(2 * u) == "2⋅2"
+    assert upretty(-2 * u) == "-2⋅2"
+    assert upretty(x**2 * u) == """\
+ 2  \n\
+x ⋅2\
+"""
+    assert upretty(-x**2 * u) == """\
+  2  \n\
+-x ⋅2\
+"""
+
+    u = UnevaluatedExpr(-2)
+    assert upretty(u) == "-2"
+    assert upretty(-u) == "-(-2)"
+    assert upretty(2 * u) == "2⋅(-2)"
+    assert upretty(-2 * u) == "-2⋅(-2)"
+    assert upretty(x**2 * u) == """\
+ 2     \n\
+x ⋅(-2)\
+"""
+    assert upretty(-x**2 * u) == """\
+  2     \n\
+-x ⋅(-2)\
+"""
+
+    u = UnevaluatedExpr(x)
+    assert upretty(u) == "x"
+    assert upretty(-u) == "-x"
+    assert upretty(2 * u) == "2⋅x"
+    assert upretty(-2 * u) == "-2⋅x"
+    assert upretty(x**2 * u) == """\
+ 2  \n\
+x ⋅x\
+"""
+    assert upretty(-x**2 * u) == """\
+  2  \n\
+-x ⋅x\
+"""
+
+    u = UnevaluatedExpr(-x)
+    assert upretty(u) == "-x"
+    assert upretty(-u) == "-(-x)"
+    assert upretty(2 * u) == "2⋅(-x)"
+    assert upretty(-2 * u) == "-2⋅(-x)"
+    assert upretty(x**2 * u) == """\
+ 2     \n\
+x ⋅(-x)\
+"""
+    assert upretty(-x**2 * u) == """\
+  2     \n\
+-x ⋅(-x)\
+"""
+
+    u = UnevaluatedExpr(x**2)
+    assert upretty(u) == """\
+ 2\n\
+x \
+"""
+    assert upretty(-u) == """\
+  2\n\
+-x \
+"""
+    assert upretty(2 * u) == """\
+   2\n\
+2⋅x \
+"""
+    assert upretty(-2 * u) == """\
+    2\n\
+-2⋅x \
+"""
+    assert upretty(x**2 * u) == """\
+ 2  2\n\
+x ⋅x \
+"""
+    assert upretty(-x**2 * u) == """\
+  2  2\n\
+-x ⋅x \
+"""
+
+    u = UnevaluatedExpr(-x**2)
+    assert upretty(u) == """\
+  2\n\
+-x \
+"""
+    assert upretty(-u) == """\
+ ⎛  2⎞\n\
+-⎝-x ⎠\
+"""
+    assert upretty(2 * u) == """\
+  ⎛  2⎞\n\
+2⋅⎝-x ⎠\
+"""
+    assert upretty(-2 * u) == """\
+   ⎛  2⎞\n\
+-2⋅⎝-x ⎠\
+"""
+    assert upretty(x**2 * u) == """\
+ 2 ⎛  2⎞\n\
+x ⋅⎝-x ⎠\
+"""
+    assert upretty(-x**2 * u) == """\
+  2 ⎛  2⎞\n\
+-x ⋅⎝-x ⎠\
+"""
+
+    u = UnevaluatedExpr(x * (x + 2))
+    assert upretty(u) == "x⋅(x + 2)"
+    assert upretty(-u) == "-x⋅(x + 2)"
+    assert upretty(2 * u) == "2⋅x⋅(x + 2)"
+    assert upretty(-2 * u) == "-2⋅x⋅(x + 2)"
+    assert upretty(x**2 * u) == """\
+ 2          \n\
+x ⋅x⋅(x + 2)\
+"""
+    assert upretty(-x**2 * u) == """\
+  2          \n\
+-x ⋅x⋅(x + 2)\
+"""
+
+    u = UnevaluatedExpr(-x * (x + 2))
+    assert upretty(u) == "-x⋅(x + 2)"
+    assert upretty(-u) == "-(-x⋅(x + 2))"
+    assert upretty(2 * u) == "2⋅(-x⋅(x + 2))"
+    assert upretty(-2 * u) == "-2⋅(-x⋅(x + 2))"
+    assert upretty(x**2 * u) == """\
+ 2             \n\
+x ⋅(-x⋅(x + 2))\
+"""
+    assert upretty(-x**2 * u) == """\
+  2             \n\
+-x ⋅(-x⋅(x + 2))\
+"""
+
+    u = UnevaluatedExpr(x + 2)
+    assert upretty(u) == "x + 2"
+    assert upretty(-1 * u) == "-(x + 2)"
+    assert upretty(3 * u) == "3⋅(x + 2)"
+    assert upretty(-3 * u) == "-3⋅(x + 2)"
+    assert upretty(x**2 * u) == """\
+ 2        \n\
+x ⋅(x + 2)\
+"""
+    assert upretty(-x**2 * u) == """\
+  2        \n\
+-x ⋅(x + 2)\
+"""
+
 
 def test_issue_10472():
     M = (Matrix([[0, 0], [0, 0]]), Matrix([0, 0]))

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -5,7 +5,7 @@ A Printer for generating readable representation of most SymPy classes.
 from __future__ import annotations
 from typing import Any
 
-from sympy.core import S, Rational, Pow, Basic, Mul, Number
+from sympy.core import S, Rational, Pow, Basic, Mul, Number, UnevaluatedExpr
 from sympy.core.function import Lambda
 from sympy.core.mul import _keep_coeff
 from sympy.core.numbers import Integer
@@ -57,16 +57,19 @@ class StrPrinter(Printer):
     def _print_Add(self, expr, order=None):
         terms = self._as_ordered_terms(expr, order=order)
 
+        is_Add = lambda e: e.is_Add or (
+            isinstance(e, UnevaluatedExpr) and e.args[0].is_Add)
+
         prec = precedence(expr)
         l = []
         for term in terms:
             t = self._print(term)
-            if t.startswith('-') and not term.is_Add:
+            if t.startswith('-') and not is_Add(term):
                 sign = "-"
                 t = t[1:]
             else:
                 sign = "+"
-            if precedence(term) < prec or term.is_Add:
+            if precedence(term) < prec or is_Add(term):
                 l.extend([sign, "(%s)" % t])
             else:
                 l.extend([sign, t])
@@ -265,7 +268,6 @@ class StrPrinter(Printer):
         return expr.name
 
     def _print_Mul(self, expr):
-
         prec = precedence(expr)
 
         # Check for unevaluated Mul. In this case we need to make sure the
@@ -345,6 +347,7 @@ class StrPrinter(Printer):
             if isinstance(i, Pow):
                 return i.func(b, e, evaluate=False)
             return i.func(e, evaluate=False)
+
         for item in args:
             if (item.is_commutative and
                     isinstance(item, Pow) and

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1157,7 +1157,7 @@ def test_latex_commutator():
     A = Operator('A')
     B = Operator('B')
     comm = Commutator(B, A)
-    assert latex(comm.doit()) == r"- (A B - B A)"
+    assert latex(comm.doit()) == r"- \left(A B - B A\right)"
 
 
 def test_latex_union():
@@ -2574,7 +2574,92 @@ def test_latex_UnevaluatedExpr():
     assert latex(he) == latex(1/x) == r"\frac{1}{x}"
     assert latex(he**2) == r"\left(\frac{1}{x}\right)^{2}"
     assert latex(he + 1) == r"1 + \frac{1}{x}"
+    assert latex(he - 1) == r"-1 + \frac{1}{x}"
+    assert latex(-he + 1) == r"1 - \frac{1}{x}"
     assert latex(x*he) == r"x \frac{1}{x}"
+
+    ue1 = UnevaluatedExpr(-2*x**2 - 9*x + 5)
+    assert latex(1 + ue1) == r"1 + \left(- 2 x^{2} - 9 x + 5\right)"
+    assert latex(1 - ue1) == r"1 - \left(- 2 x^{2} - 9 x + 5\right)"
+
+    ue2 = UnevaluatedExpr(-2*x**2 + 3*x + 2)
+    ue3 = UnevaluatedExpr(-5*x**2 + 6*x - 7)
+    assert latex(ue2 + ue3) == \
+        r"\left(- 5 x^{2} + 6 x - 7\right) + \left(- 2 x^{2} + 3 x + 2\right)"
+    assert latex(ue2 - ue3) == \
+        r"- \left(- 5 x^{2} + 6 x - 7\right) + \left(- 2 x^{2} + 3 x + 2\right)"
+
+    u = UnevaluatedExpr(2)
+    assert latex(u) == "2"
+    assert latex(-u) == "- 2"
+    assert latex(2 * u) == r"2 \cdot 2"
+    assert latex(-2 * u) == r"- 2 \cdot 2"
+    assert latex(x**2 * u) == r"x^{2} \cdot 2"
+    assert latex(-x**2 * u) == r"- x^{2} \cdot 2"
+
+    u = UnevaluatedExpr(-2)
+    assert latex(u) == "-2"
+    assert latex(-u) == r"- \left(-2\right)"
+    assert latex(2 * u) == r"2 \left(-2\right)"
+    assert latex(-2 * u) == r"- 2 \left(-2\right)"
+    assert latex(x**2 * u) == r"x^{2} \left(-2\right)"
+    assert latex(-x**2 * u) == r"- x^{2} \left(-2\right)"
+
+    u = UnevaluatedExpr(x)
+    assert latex(u) == r"x"
+    assert latex(-u) == r"- x"
+    assert latex(2 * u) == r"2 x"
+    assert latex(-2 * u) == r"- 2 x"
+    assert latex(x**2 * u) == r"x^{2} x"
+    assert latex(-x**2 * u) == r"- x^{2} x"
+
+    u = UnevaluatedExpr(-x)
+    assert latex(u) == "- x"
+    assert latex(-u) == r"- \left(- x\right)"
+    assert latex(2 * u) == r"2 \left(- x\right)"
+    assert latex(-2 * u) == r"- 2 \left(- x\right)"
+    assert latex(x**2 * u) == r"x^{2} \left(- x\right)"
+    assert latex(-x**2 * u) == r"- x^{2} \left(- x\right)"
+
+    u = UnevaluatedExpr(x**2)
+    assert latex(u) == r"x^{2}"
+    assert latex(-u) == r"- x^{2}"
+    assert latex(2 * u) == r"2 x^{2}"
+    assert latex(-2 * u) == r"- 2 x^{2}"
+    assert latex(x**2 * u) == r"x^{2} x^{2}"
+    assert latex(-x**2 * u) == r"- x^{2} x^{2}"
+
+    u = UnevaluatedExpr(-x**2)
+    assert latex(u) == r"- x^{2}"
+    assert latex(-u) == r"- \left(- x^{2}\right)"
+    assert latex(2 * u) == r"2 \left(- x^{2}\right)"
+    assert latex(-2 * u) == r"- 2 \left(- x^{2}\right)"
+    assert latex(x**2 * u) == r"x^{2} \left(- x^{2}\right)"
+    assert latex(-x**2 * u) == r"- x^{2} \left(- x^{2}\right)"
+
+    u = UnevaluatedExpr(x * (x + 2))
+    assert latex(u) == r"x \left(x + 2\right)"
+    assert latex(-u) == r"- x \left(x + 2\right)"
+    assert latex(2 * u) == r"2 x \left(x + 2\right)"
+    assert latex(-2 * u) == r"- 2 x \left(x + 2\right)"
+    assert latex(x**2 * u) == r"x^{2} x \left(x + 2\right)"
+    assert latex(-x**2 * u) == r"- x^{2} x \left(x + 2\right)"
+
+    u = UnevaluatedExpr(-x * (x + 2))
+    assert latex(u) == r"- x \left(x + 2\right)"
+    assert latex(-u) == r"- \left(- x \left(x + 2\right)\right)"
+    assert latex(2 * u) == r"2 \left(- x \left(x + 2\right)\right)"
+    assert latex(-2 * u) == r"- 2 \left(- x \left(x + 2\right)\right)"
+    assert latex(x**2 * u) == r"x^{2} \left(- x \left(x + 2\right)\right)"
+    assert latex(-x**2 * u) == r"- x^{2} \left(- x \left(x + 2\right)\right)"
+
+    u = UnevaluatedExpr(x + 2)
+    assert latex(u) == "x + 2"
+    assert latex(-1 * u) == r"- \left(x + 2\right)"
+    assert latex(3 * u) == r"3 \left(x + 2\right)"
+    assert latex(-3 * u) == r"- 3 \left(x + 2\right)"
+    assert latex(x**2 * u) == r"x^{2} \left(x + 2\right)"
+    assert latex(-x**2 * u) == r"- x^{2} \left(x + 2\right)"
 
 
 def test_MatrixElement_printing():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1060,6 +1060,88 @@ def test_UnevaluatedExpr():
     expr1 = 2*UnevaluatedExpr(a+b)
     assert str(expr1) == "2*(a + b)"
 
+    x = symbols("x")
+    ue1 = UnevaluatedExpr(-2*x**2 - 9*x + 5)
+    assert str(1 + ue1) == "1 + (-2*x**2 - 9*x + 5)"
+    assert str(1 - ue1) == "1 - (-2*x**2 - 9*x + 5)"
+
+    ue2 = UnevaluatedExpr(-2*x**2 + 3*x + 2)
+    ue3 = UnevaluatedExpr(-5*x**2 + 6*x - 7)
+    assert str(ue2 + ue3) == "(-5*x**2 + 6*x - 7) + (-2*x**2 + 3*x + 2)"
+    assert str(ue2 - ue3) == "-(-5*x**2 + 6*x - 7) + (-2*x**2 + 3*x + 2)"
+
+    u = UnevaluatedExpr(2)
+    assert str(u) == "2"
+    assert str(-u) == "-2"
+    assert str(2 * u) == "2*2"
+    assert str(-2 * u) == "-2*2"
+    assert str(x**2 * u) == "x**2*2"
+    assert str(-x**2 * u) == "-x**2*2"
+
+    u = UnevaluatedExpr(-2)
+    assert str(u) == "-2"
+    assert str(-u) == "-(-2)"
+    assert str(2 * u) == "2*(-2)"
+    assert str(-2 * u) == "-2*(-2)"
+    assert str(x**2 * u) == "x**2*(-2)"
+    assert str(-x**2 * u) == "-x**2*(-2)"
+
+    u = UnevaluatedExpr(x)
+    assert str(u) == "x"
+    assert str(-u) == "-x"
+    assert str(2 * u) == "2*x"
+    assert str(-2 * u) == "-2*x"
+    assert str(x**2 * u) == "x**2*x"
+    assert str(-x**2 * u) == "-x**2*x"
+
+    u = UnevaluatedExpr(-x)
+    assert str(u) == "-x"
+    assert str(-u) == "-(-x)"
+    assert str(2 * u) == "2*(-x)"
+    assert str(-2 * u) == "-2*(-x)"
+    assert str(x**2 * u) == "x**2*(-x)"
+    assert str(-x**2 * u) == "-x**2*(-x)"
+
+    u = UnevaluatedExpr(x**2)
+    assert str(u) == "x**2"
+    assert str(-u) == "-x**2"
+    assert str(2 * u) == "2*x**2"
+    assert str(-2 * u) == "-2*x**2"
+    assert str(x**2 * u) == "x**2*x**2"
+    assert str(-x**2 * u) == "-x**2*x**2"
+
+    u = UnevaluatedExpr(-x**2)
+    assert str(u) == "-x**2"
+    assert str(-u) == "-(-x**2)"
+    assert str(2 * u) == "2*(-x**2)"
+    assert str(-2 * u) == "-2*(-x**2)"
+    assert str(x**2 * u) == "x**2*(-x**2)"
+    assert str(-x**2 * u) == "-x**2*(-x**2)"
+
+    u = UnevaluatedExpr(x * (x + 2))
+    assert str(u) == "x*(x + 2)"
+    assert str(-u) == "-(x*(x + 2))"
+    assert str(2 * u) == "2*(x*(x + 2))"
+    assert str(-2 * u) == "-2*(x*(x + 2))"
+    assert str(x**2 * u) == "x**2*(x*(x + 2))"
+    assert str(-x**2 * u) == "-x**2*(x*(x + 2))"
+
+    u = UnevaluatedExpr(-x * (x + 2))
+    assert str(u) == "-x*(x + 2)"
+    assert str(-u) == "-(-x*(x + 2))"
+    assert str(2 * u) == "2*(-x*(x + 2))"
+    assert str(-2 * u) == "-2*(-x*(x + 2))"
+    assert str(x**2 * u) == "x**2*(-x*(x + 2))"
+    assert str(-x**2 * u) == "-x**2*(-x*(x + 2))"
+
+    u = UnevaluatedExpr(x + 2)
+    assert str(u) == "x + 2"
+    assert str(-1 * u) == "-(x + 2)"
+    assert str(3 * u) == "3*(x + 2)"
+    assert str(-3 * u) == "-3*(x + 2)"
+    assert str(x**2 * u) == "x**2*(x + 2)"
+    assert str(-x**2 * u) == "-x**2*(x + 2)"
+
 
 def test_MatrixElement_printing():
     # test cases for issue #11821


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29392


#### Brief description of what is fixed or changed

Updated logic to deal with objects of type `UnevaluatedExpr` in the following printers: `LatexPrinter, PrettyPrinter, StrPrinter`


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Fixed improper printing of UnevaluatedExpr objects.

<!-- END RELEASE NOTES -->
