### PR TITLE
Fix system-dependent kinetic energy test in physics.mechanics

### DIFF
--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -53,10 +53,8 @@ def test_particle():
     assert p.angular_momentum(O, N) == m2 * r * (v3 * N.x - v1 * N.z)
     p.potential_energy = m * g * h
     assert p.potential_energy == m * g * h
-    # TODO make the result not be system-dependent
-    assert p.kinetic_energy(
-        N) in [m2 * (v1 ** 2 + v2 ** 2 + v3 ** 2) / 2,
-               m2 * v1 ** 2 / 2 + m2 * v2 ** 2 / 2 + m2 * v3 ** 2 / 2]
+    expected_kinetic_energy = m2 * (v1 ** 2 + v2 ** 2 + v3 ** 2) / 2
+    assert (p.kinetic_energy(N) - expected_kinetic_energy).expand() == 0
 
 
 def test_parallel_axis():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR resolves a TODO in `sympy/physics/mechanics/tests/test_particle.py`

Previously, we had a check where we check against the two possible evaluated expressions for `p.kinetic_energy`

Changes made:
* It now uses `.expand()` to check the mathematical correctness of the expression instead of a hardcoded check.
#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
