### PR TITLE
Fix Solvers to handle `None` return from unrad in `_solve_radical`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -492,6 +492,7 @@ Charlie Lam <888lamcharlie@gmail.com>
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chidroopakanaparthy <chidroopak007@gmail.com> Chidroopa Kanaparthy <chidroopak007@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2231,3 +2231,11 @@ def test_issue_15566():
     assert isinstance(result, Piecewise)
 
     assert result.has(erf)
+
+
+def test_issue_19639():
+    r, a, b = symbols('r a b', real=True)
+    f = sqrt(1 - r**2)*(a*r**3 + b*r**4)
+    ans = integrate(f, (r, 0, 1))
+    expected = Rational(2, 15)*a + pi*b/32
+    assert ans == expected


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #19639

#### Brief description of what is fixed or changed

This PR fixes a TypeError which cannot unpack non-iterable `NoneType` object in `solveset.py`. The crash occurs in `_solve_radical` when the unrad helper function fails to simplify a radical expression and returns `None` instead of a tuple.

#### The Bug:

When evaluating the continuity of certain expressions, SymPy calls` _solve_radica`l. The implementation assumes unrad(f) will always return a tuple (eq, cov). For complex radical expressions like sqrt(1 - r**2)*(a*r**3 + b*r**4), unrad returns `None`, leading to an unpacking failure.

#### Other comments

This issue was identified during a workflow involving integration of radical expressions where the continuity check triggered a cascading failure in solveset. By adding this defensive check, the solver can now fail gracefully or fall back to other methods rather than halting the entire process with a TypeError.

### Verification:

Manual Test: Verified that integrate(sqrt(1 - r**2)*(a*r**3 + b*r**4), (r, 0, 1)) now evaluates correctly to 2*a/15 + pi*b/32 instead of crashing.
Test Suite: Ran sympy/solvers/tests/test_solveset.py (191 passed, 13 xfailed as expected).
Code Quality: Passed bin/test_code_quality.py.

#### AI Generation Disclosure

Tool Used: Gemini 
Assistance by LLM  was used for the initial diagnosis of the `TypeError` traceback and for identifying the specific defensive check required in `_solve_radical` within `sympy/solvers/solveset.py`. I also consulted the tool for the structure of the regression test and to verify the correctness of logic. All code and text were reviewed, modified, and verified locally by me to ensure full compatibility with the existing SymPy test suite.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* solvers

   * Fixed a TypeError in solveset where _solve_radical would fail to unpack when unrad returned None.

<!-- END RELEASE NOTES -->
