### PR TITLE
Add matrix derivative of determinant

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -340,6 +340,8 @@ Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
 Angadh Nanjangud <angadh.n@gmail.com>
 Angus Griffith <16sn6uv@gmail.com>
 Anibal M. Medina-Mardones <ammedmar@gmail.com>
+Anika Thakur <athakur6@terpmail.umd.edu>
+Anika Thakur <69318995+anikat2@users.noreply.github.com>
 Animesh Sinha <animeshsinha1309@gmail.com>
 Anish Shah <shah.anish07@gmail.com>
 Anjul Kumar Tyagi <anjul.ten@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -340,8 +340,8 @@ Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
 Angadh Nanjangud <angadh.n@gmail.com>
 Angus Griffith <16sn6uv@gmail.com>
 Anibal M. Medina-Mardones <ammedmar@gmail.com>
-Anika Thakur <athakur6@terpmail.umd.edu>
 Anika Thakur <69318995+anikat2@users.noreply.github.com>
+Anika Thakur <athakur6@terpmail.umd.edu>
 Animesh Sinha <animeshsinha1309@gmail.com>
 Anish Shah <shah.anish07@gmail.com>
 Anjul Kumar Tyagi <anjul.ten@gmail.com>

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -54,7 +54,6 @@ class Determinant(Expr):
         return self
 
     def _eval_derivative(self, x):
-        from sympy.matrices.expressions.inverse import Inverse
         A = self.args[0]
         return self * A.T.inv()
 

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -54,9 +54,9 @@ class Determinant(Expr):
         return self
 
     def _eval_derivative(self, x):
-        # Derivative currently implements `hasattr(..., "_eval_derivative")` to proceed:
-        return None
-
+        from sympy.matrices.expressions.inverse import Inverse
+        A = self.args[0]
+        return self * A.T.inv()
 
 def det(matexpr):
     """ Matrix Determinant

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -11,7 +11,8 @@ from sympy.abc import x, y, z
 from sympy.testing.pytest import raises
 from sympy.matrices.exceptions import NonSquareMatrixError
 from sympy.functions.combinatorial.factorials import factorial, subfactorial
-
+from sympy import Symbol, diff
+from sympy.matrices.expressions import MatrixSymbol, det
 
 @pytest.mark.parametrize("method", [
     # Evaluating these directly because they are never reached via M.det()
@@ -128,7 +129,7 @@ def test_legacy_det(method, M, sol):
 def test_det_derivative():
     n = Symbol('n', integer=True, positive=True)
     A = MatrixSymbol('A', n, n)
-    result = diff(det(A), A)
+    assert diff(det(A), A) == det(A) * A.T.inv()
 
 def eye_Determinant(n):
     return Matrix(n, n, lambda i, j: int(i == j))

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -11,7 +11,7 @@ from sympy.abc import x, y, z
 from sympy.testing.pytest import raises
 from sympy.matrices.exceptions import NonSquareMatrixError
 from sympy.functions.combinatorial.factorials import factorial, subfactorial
-from sympy import Symbol, diff
+from sympy import diff
 from sympy.matrices.expressions import MatrixSymbol, det
 
 @pytest.mark.parametrize("method", [

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -125,6 +125,10 @@ def test_legacy_det(method, M, sol):
     # Partially copied from test_determinant()
     assert M.det(method=method) == sol
 
+def test_det_derivative():
+    n = Symbol('n', integer=True, positive=True)
+    A = MatrixSymbol('A', n, n)
+    result = diff(det(A), A)
 
 def eye_Determinant(n):
     return Matrix(n, n, lambda i, j: int(i == j))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29355
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

#### Brief description of what is fixed or changed
Now supports matrix derivative of the determinant for MatrixSymbol

#### Other comments


#### AI Generation Disclosure
NO AI USE

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * ``diff(det(A), A)`` now returns ``det(A) * A.T.inv()`` for a ``MatrixSymbol`` ``A``, instead of an unevaluated expression.
<!-- END RELEASE NOTES -->
