### PR TITLE
functions: fix polygamma leading term at poles and Mul integer assumption

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1836,6 +1836,7 @@ pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 phipf <phipf@online.de>
 platypus <platypus.computerchip@gmail.com>
+prakash-kalwaniya <kalwaniyaprakash1@gmail.com>
 prshnt19 <prashant.rawat216@gmail.com>
 rahil-amin <rahilamin201@gmail.com>
 rahuldan <rahul02013@gmail.com>

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1426,6 +1426,7 @@ class Mul(Expr, AssocOp):
         numerators = []
         denominators = []
         unknown = False
+        non_integers = []
         for a in self.args:
             hit = False
             if a.is_integer:
@@ -1453,8 +1454,15 @@ class Mul(Expr, AssocOp):
                 else:
                     # x**2, 2**x, or x**y with x and y int-unknown -> unknown
                     return
+            elif a.is_integer is False:
+                non_integers.append(a)
             else:
                 return
+
+        if non_integers:
+            if len(non_integers) == 1 and not numerators and not denominators and not unknown:
+                return False
+            return
 
         if not denominators and not unknown:
             return True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -446,7 +446,7 @@ def test_Add_Mul_is_integer():
     nr = Symbol('nr', rational=False)
     nz = Symbol('nz', integer=True, zero=False)
 
-    assert (-nk).is_integer is None
+    assert (-nk).is_integer is False
     assert (-nr).is_integer is False
     assert (2*k).is_integer is True
     assert (-k).is_integer is True

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -794,6 +794,10 @@ class polygamma(DefinedFunction):
         if n == 0 and o.contains(1/x):
             logx = log(x) if logx is None else logx
             return o.getn() * logx
+        elif not o.contains(S.One) and n.is_integer and n.is_nonnegative:
+            # z -> 0: pole of order (n+1), leading Laurent term:
+            # polygamma(n, z) ~ (-1)^(n+1) * n! / z^(n+1)
+            return S.NegativeOne**(n + 1) * factorial(n) / z**(n + 1)
         else:
             return self.func(n, z)
 


### PR DESCRIPTION
#### References to other Issues or PRs

No related issue exists for this bug.

#### Brief description of what is fixed or changed

Fixed two correctness bugs:

1. `polygamma._eval_as_leading_term` in `gamma_functions.py` was returning
   unevaluated `polygamma(n, z)` when the argument approaches zero, instead
   of the correct Laurent series leading term `(-1)^(n+1) * n! / z^(n+1)`.
   This caused `limit(polygamma(n, x), x, 0, '+')` to return `zoo` instead
   of the correct signed infinity `±oo`. The fix adds a branch that detects
   the z→0 case and returns the proper dominant singular term.

2. `Mul._eval_is_integer` in `mul.py` was returning `None` (unknown) for
   products like `-nk` where `nk` is a symbol with `integer=False`, even
   though multiplying a non-integer by ±1 always gives a non-integer.
   The fix collects known-non-integer factors and returns `False` when the
   product is a single non-integer times only ±1 terms.

Before:
```python
>>> limit(polygamma(0, x), x, 0, '+')
zoo
>>> nk = Symbol('nk', integer=False)
>>> (-nk).is_integer is None
True
```

After:
```python
>>> limit(polygamma(0, x), x, 0, '+')
-oo
>>> (-nk).is_integer is False
True
```

#### Other comments

The Laurent expansion used for the polygamma pole fix is the standard identity:
`polygamma(n, z) ~ (-1)^(n+1) * n! / z^(n+1)` as z → 0,
which is numerically verified (`polygamma(0, 0.001) ≈ -1001`).

#### AI Generation Disclosure

This contribution was primarily completed by me through manual analysis and
coding. I only used AI tools for minor assistance such as improving wording and
organizing explanations. The bug investigation, reasoning, and final code changes
were done manually by me.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `polygamma(n, x).as_leading_term(x)` at poles. Previously,
    `limit(polygamma(n, x), x, 0, '+')` incorrectly returned `zoo`; it now
    returns the correct signed infinity (`-oo` for even `n`, `oo` for odd `n`).

* core
  * Fixed `Mul._eval_is_integer` to return `False` (instead of `None`) for
    products like `-nk` where `nk` is a symbol with `integer=False`.
<!-- END RELEASE NOTES -->
