### PR TITLE
Add rule for integrating 1/(sin(x)*cos(x)) in manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2563,6 +2563,18 @@ def rewrites_rule(integral):
         rewritten = integrand.subs(1/cos(symbol), sec(symbol))
         return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
 
+def sin_cos_product_rule(integral):
+    integrand, symbol = integral
+
+    # detect 1/(sin(x)*cos(x))
+    if integrand == 1/(sin(symbol)*cos(symbol)):
+        rewritten = 2*csc(2*symbol)
+
+        substep = integral_steps(rewritten, symbol)
+
+        if substep and not isinstance(substep, DontKnowRule):
+            return RewriteRule(integrand, symbol, rewritten, substep)        
+
 def fallback_rule(integral):
     return DontKnowRule(*integral)
 
@@ -2677,6 +2689,7 @@ def integral_steps(integrand, symbol, **options):
             null_safe(trig_rule),
             null_safe(hyperbolic_rule),
             null_safe(alternatives(
+                sin_cos_product_rule,
                 rewrites_rule,
                 substitution_rule,
                 condition(

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -867,3 +867,7 @@ def test_mul_pow_derivative():
     assert_is_integral_of(x**3*Derivative(f(x), (x, 4)),
                           x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) +
                           6*x*Derivative(f(x), x) - 6*f(x))
+    
+def test_sin_cos_product():
+    x = symbols('x')
+    assert manualintegrate(1/(sin(x)*cos(x)), x) == -log(cot(2*x) + csc(2*x))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

None. I found this issue while testing manualintegrate on trigonometric integrals.

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

manualintegrate used to give up when trying to integrate 1/(sin(x)*cos(x)) and just return the integral as it is. I found this while testing and wanted it to actually solve. 

This PR adds a new rule called sin_cos_product_rule that only checks for this exact 1/(sin(x)*cos(x)) form and rewrites it as 2*csc(2*x). Then the normal integration rules handle it and give the right answer, -log(cot(2*x) + csc(2*x)). 

I also added a small test in test_manual.py to make sure it works. This fix is only for this one case, other trigonometric products are not touched.


#### Other comments

This PR only fixes the 1/(sin(x)*cos(x)) case. I tried to make a more general rule for all reciprocal trigonometric products, but it got too complicated and caused infinite loops, so I kept it simple and safe. Everything added is tested and shouldn’t break anything else.


#### AI Generation Disclosure

This PR used AI tools (ChatGPT and Claude) to generate and suggest code for handling 1/(sin(x)*cos(x)). 
I reviewed every line, tested it, and confirmed it works correctly. I understand how it integrates with manualintegrate. 
AI was used as a coding assistant; I take full responsibility for the final code.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
  * Added a rule to `manualintegrate` for `1/(sin(x)*cos(x))`.

<!-- END RELEASE NOTES -->
