### PR TITLE
Fix reduce_inequalities returning False for And/Or inputs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -491,6 +491,7 @@ Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@us
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chidroopakanaparthy <chidroopak007@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -946,6 +946,17 @@ def reduce_inequalities(inequalities, symbols=[]):
         inequalities = [inequalities]
     inequalities = [sympify(i) for i in inequalities]
 
+    # Flatten And/Or boolean expressions into individual args so that
+    # e.g. (x > 0) & (x < 1) is treated the same as [x > 0, x < 1].
+    from sympy.logic.boolalg import And as BoolAnd, Or as BoolOr
+    flat = []
+    for i in inequalities:
+        if isinstance(i, (BoolAnd, BoolOr)):
+            flat.extend(i.args)
+        else:
+            flat.append(i)
+    inequalities = flat
+
     gens = set().union(*[i.free_symbols for i in inequalities])
 
     if not iterable(symbols):

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -221,6 +221,14 @@ def test_reduce_inequalities_boolean():
     assert reduce_inequalities([Eq(x**2, 0), False]) == False
     assert reduce_inequalities(x**2 >= 0) is S.true  # issue 10196
 
+    # issue 23953: And/Or boolean expressions should be flattened
+    assert reduce_inequalities((x > 0) & (x < 1), x) == \
+        reduce_inequalities([x > 0, x < 1], x)
+    assert reduce_inequalities((x > 0) & Eq(x, 3)) == Eq(x, 3)
+    assert reduce_inequalities((x >= -1) & (x <= 1) & (x > 0), x) == \
+        reduce_inequalities([x >= -1, x <= 1, x > 0], x)
+
+
 
 def test_reduce_inequalities_multivariate():
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == And(

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -229,7 +229,6 @@ def test_reduce_inequalities_boolean():
         reduce_inequalities([x >= -1, x <= 1, x > 0], x)
 
 
-
 def test_reduce_inequalities_multivariate():
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == And(
         Or(And(Le(S.One, x), Lt(x, oo)), And(Le(x, -1), Lt(-oo, x))),


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #23953

#### Brief description of what is fixed or changed

In order to properly handle And and Or boolean expressions, the reduce_inequalities method has been changed to flatten them into separate relational arguments. This guarantees that list inputs like [x > 0, x < 1] are handled similarly to inputs like (x > 0) & (x < 1).

#### Other comments

The problem stemmed from And objects' inability to be iterated. Any non-iterable input that wasn't a boolean or a Relational was wrapped in an Eq(expr, 0) call in the reduce_inequalities prefilter. This produced Eq(And(...), 0) for And expressions, which evaluated to False and led the function to output S.false prematurely.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* solvers
      * Fixed a bug in reduce_inequalities where it fails to handle And/Or expressions correctly.
      
<!-- END RELEASE NOTES -->