### PR TITLE
Fix Dyadic._pretty() crash with Python int coefficients

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -221,7 +221,7 @@ class Dyadic(Printable, EvalfMixin):
                     p_v2 = mpp._print(v[2])
                     p_dyad = prettyForm(*p_v1.right(bar, p_v2))
 
-                    c = v[0]
+                    c =sympify(v[0])
                     if i == 0:
                         sign = ""
                     else:

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -214,7 +214,14 @@ a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
     assert ascii_vpretty(xx2) == 'n_x|n_y + n_x|n_z'
     assert unicode_vpretty(xx2) == 'n_x⊗n_y + n_x⊗n_z'
 
-
+def test_dyadic_pretty_int_coeff():
+    # Github issue #29434 - Dyadic._pretty() crashed with AttributeError
+    # when coefficients were plain Python ints instead of SymPy types
+    N = ReferenceFrame('N')
+    d = Dyadic([[1, N.x, N.y]])
+    # these should not raise AttributeError
+    assert ascii_vpretty(d) == 'n_x|n_y'
+    assert unicode_vpretty(d) == 'n_x⊗n_y'
 def test_dyadic_latex():
 
     expected = (r'a^{2}\mathbf{\hat{n}_x}\otimes \mathbf{\hat{n}_y} + '


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29434

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
_pretty() in Dyadic was calling as_coeff_Mul() on the coefficient
directly. When the coefficient is a plain Python int (not a SymPy
type), this crashes with AttributeError since ints don't have that
method. Adding sympify() around v[0] fixes this.

#### Other comments
I also checked _latex() - it accesses v[0] directly too but doesn't
call any SymPy-specific methods on it so it seems fine.

#### AI Generation Disclosure
Used Claude (claude.ai) as a learning assistant to understand
the codebase and the bug. The fix and test were written by me
with guidance. Claude helped me understand what sympify does
and why the crash occurs.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Fixed Dyadic._pretty() crash with AttributeError when
    coefficients are plain Python ints instead of SymPy types.

<!-- END RELEASE NOTES -->
