### PR TITLE
Add test for solving polynomial system with rational conversion 

### DIFF
--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -461,3 +461,28 @@ def test_factor_sets():
     for _ in range(100):
         system = generate_random_system()
         assert _factor_sets(system) == _factor_sets_slow(system)
+
+
+from sympy import symbols, solve, nsimplify
+
+def test_issue_non_zero_dimensional():
+    x, y, lam, a0, conc = symbols('x y lam a0 conc')
+
+    eqs = [
+        lam + 2*y - a0*(1 - x/2)*x - 0.005*x/2*x,
+        a0*(1 - x/2)*x - y - 0.743436700916726*y,
+        x + y - conc
+    ]
+
+    reqs = [nsimplify(e, rational=True) for e in eqs]
+
+    sol = solve(reqs, [x, y, a0])
+
+    assert sol is not None
+    assert len(sol) >= 1
+
+    vars = [x, y, a0]
+
+    for s in sol:
+        sol_dict = dict(zip(vars, s))
+        assert all(eq.subs(sol_dict).simplify() == 0 for eq in reqs)


### PR DESCRIPTION
#### References to other Issues or PRs

N/A

#### Brief description of what is fixed or changed

This PR adds a test for a system of polynomial equations that requires converting the expressions to rational form before solving.
The test checks that **solve()** is able to return solutions for this system and then verifies them by substituting the results back into the original equations. Since the solutions are returned as tuples, they are first converted into dictionaries so that substitution can be applied correctly.

#### Other comments

N/A

#### AI Generation Disclosure

AI tools were used for general guidance during the process, but the final code and test were written and refined manually.

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added a test for solving a polynomial system with rational conversion, ensuring that solutions returned by solve() are valid.
<!-- END RELEASE NOTES -->