### PR TITLE
Add test for solving polynomial system with rational conversion 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1099,6 +1099,7 @@ Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
+Meer Patel <meerpatel1314@gmail.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1100,6 +1101,8 @@ Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
 Meer Patel <meerpatel1314@gmail.com>
+Meer Patel <meerpatel1314@gmail.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
@@ -1887,6 +1890,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Meer Patel <meerpatel1314@gmail.com>
-Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
-

--- a/.mailmap
+++ b/.mailmap
@@ -1886,3 +1886,6 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Meer Patel <meerpatel1314@gmail.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
+

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -24,9 +24,8 @@ from sympy.polys.polytools import parallel_poly_from_expr
 from sympy.testing.pytest import raises
 from sympy.core.relational import Eq
 from sympy.functions.elementary.trigonometric import sin, cos
-
 from sympy.functions.elementary.exponential import exp
-
+from sympy import nsimplify
 
 def test_solve_poly_system():
     assert solve_poly_system([x - 1], x) == [(S.One,)]
@@ -461,3 +460,26 @@ def test_factor_sets():
     for _ in range(100):
         system = generate_random_system()
         assert _factor_sets(system) == _factor_sets_slow(system)
+
+
+def test_issue_non_zero_dimensional():
+    x, y, lam, a0, conc = symbols('x y lam a0 conc')
+
+    eqs = [
+        lam + 2*y - a0*(1 - x/2)*x - 0.005*x/2*x,
+        a0*(1 - x/2)*x - y - 0.743436700916726*y,
+        x + y - conc
+    ]
+
+    reqs = [nsimplify(e, rational=True) for e in eqs]
+
+    sol = solve(reqs, [x, y, a0])
+
+    assert sol is not None
+    assert len(sol) >= 1
+
+    vars = [x, y, a0]
+
+    for s in sol:
+        sol_dict = dict(zip(vars, s))
+        assert all(eq.subs(sol_dict).simplify() == 0 for eq in reqs)


### PR DESCRIPTION
#### References to other Issues or PRs

N/A

#### Brief description of what is fixed or changed

This PR adds a test for a system of polynomial equations that requires converting the expressions to rational form before solving.
The test checks that **solve()** is able to return solutions for this system and then verifies them by substituting the results back into the original equations. Since the solutions are returned as tuples, they are first converted into dictionaries so that substitution can be applied correctly.

#### Other comments

N/A

#### AI Generation Disclosure

AI tools were used for general guidance during the process, but the final code and test were written and refined manually.

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added a test for solving a polynomial system with rational conversion, ensuring that solutions returned by solve() are valid.
<!-- END RELEASE NOTES -->