### PR TITLE
Fix ask() handling of Q.zero substitution in predicate arguments

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1531,6 +1531,7 @@ Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
 Shubham Maheshwari <rmaheshwari05@gmail.com>
 Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
 Shubham Tibra <shubh.tibra@gmail.com>
+Shubhankar Joshi <shubhankarjoshi2489@gmail.com> Shubhankar-Joshi2489 <shubhankarjoshi2489@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -9,6 +9,7 @@ from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
+
 from sympy import Function
 
 # Memoization is necessary for the properties of AssumptionKeys to
@@ -522,6 +523,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
+
     if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")
 
@@ -531,7 +533,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     # Normalize both proposition and assumptions
     proposition = _normalize_expr(proposition)
     assumptions = _normalize_expr(assumptions)
-
 
     if isinstance(proposition, AppliedPredicate):
         key, args = proposition.function, proposition.arguments

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -9,7 +9,7 @@ from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
-
+from sympy import Function
 
 # Memoization is necessary for the properties of AssumptionKeys to
 # ensure that only one object of Predicate objects are created.
@@ -402,6 +402,30 @@ def _normalize_expr(expr):
     expr = _normalize_applied_predicates(expr)
     return expr
 
+def _extract_substitutions(assumptions):
+    subs = {}
+    if isinstance(assumptions, AppliedPredicate):
+        if assumptions.function == Q.zero:
+            subs[assumptions.arguments[0]] = 0
+
+    elif assumptions.func.__name__ == "And":
+        for arg in assumptions.args:
+            if isinstance(arg, AppliedPredicate) and arg.function == Q.zero:
+                subs[arg.arguments[0]] = 0
+
+    return subs
+
+    if isinstance(assumptions, AppliedPredicate):
+        if assumptions.function == Q.zero:
+            subs[assumptions.arguments[0]] = 0
+
+    elif assumptions.func.__name__ == "And":
+        for arg in assumptions.args:
+            if isinstance(arg, AppliedPredicate) and arg.function == Q.zero:
+                subs[arg.arguments[0]] = 0
+
+    return subs
+
 def ask(proposition, assumptions=True, context=global_assumptions):
     """
     Function to evaluate the proposition with assumptions.
@@ -498,7 +522,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
-
+    
     if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")
 
@@ -509,10 +533,16 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     proposition = _normalize_expr(proposition)
     assumptions = _normalize_expr(assumptions)
 
+
     if isinstance(proposition, AppliedPredicate):
         key, args = proposition.function, proposition.arguments
     else:
         key, args = Q.is_true, (proposition,)
+
+    subs = _extract_substitutions(assumptions)
+    args = tuple(a.subs(subs) if not a.has(Function) else a for a in args)
+    if isinstance(proposition, AppliedPredicate):
+        proposition = key(*args)
 
     # convert local and global assumptions to CNF
     assump_cnf = CNF.from_prop(assumptions)

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -522,7 +522,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
-    
     if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -24,9 +24,6 @@ from sympy.matrices import Matrix, SparseMatrix
 from sympy.testing.pytest import XFAIL, slow, raises,  _both_exp_pow
 import math
 
-from sympy import ask, Q, pi,oo # for def test_issue_29433_zero_substitution_infinite():
-from sympy.abc import x, n
-
 def test_int_1():
     z = 1
     assert ask(Q.commutative(z)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1809,8 +1809,8 @@ def test_zero():
 def test_issue_29433_zero_substitution_infinite():
     # Previously raised ValueError due to inconsistent assumptions(issue #29433)
     assert ask(Q.infinite(x + n*pi), Q.zero(n)) is None
-    assert ask(Q.infinite(n*x), Q.zero(n)) is False  #n = 0 ⇒ n*x = 0 ⇒ not infinite
-    assert ask(Q.infinite(oo + n*pi),Q.zero(n)) is True  # oo + 0 ⇒ oo ⇒ infinite
+    assert ask(Q.infinite(n*x), Q.zero(n)) is False  #n = 0 ⇒ n*x = 0 -> not infinite
+    assert ask(Q.infinite(oo + n*pi),Q.zero(n)) is True  # oo + 0 ⇒ oo -> infinite
 
 def test_odd_query():
     assert ask(Q.odd(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -23,7 +23,8 @@ from sympy.logic.boolalg import Equivalent, Implies, Xor, And, to_cnf
 from sympy.matrices import Matrix, SparseMatrix
 from sympy.testing.pytest import XFAIL, slow, raises,  _both_exp_pow
 import math
-
+from sympy import ask, Q, pi,oo # for def test_issue_29433_zero_substitution_infinite():
+from sympy.abc import x, n
 
 def test_int_1():
     z = 1
@@ -1803,6 +1804,12 @@ def test_zero():
     assert ask(Q.zero(x), Q.odd(x)) is False
     assert ask(Q.zero(x) | Q.zero(y), Q.zero(x*y)) is True
 
+
+def test_issue_29433_zero_substitution_infinite():
+    # Previously raised ValueError due to inconsistent assumptions(issue #29433)
+    assert ask(Q.infinite(x + n*pi), Q.zero(n)) is None 
+    assert ask(Q.infinite(n*x), Q.zero(n)) is False  #n = 0 ⇒ n*x = 0 ⇒ not infinite
+    assert ask(Q.infinite(oo + n*pi),Q.zero(n)) is True  # oo + 0 ⇒ oo ⇒ infinite
 
 def test_odd_query():
     assert ask(Q.odd(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1809,8 +1809,8 @@ def test_zero():
 def test_issue_29433_zero_substitution_infinite():
     # Previously raised ValueError due to inconsistent assumptions(issue #29433)
     assert ask(Q.infinite(x + n*pi), Q.zero(n)) is None
-    assert ask(Q.infinite(n*x), Q.zero(n)) is False  #n = 0 ⇒ n*x = 0 -> not infinite
-    assert ask(Q.infinite(oo + n*pi),Q.zero(n)) is True  # oo + 0 ⇒ oo -> infinite
+    assert ask(Q.infinite(n*x), Q.zero(n)) is False# n = 0   n*x=0 not infinite
+    assert ask(Q.infinite(oo + n*pi),Q.zero(n)) is True# oo + 0 = oo   infinite
 
 def test_odd_query():
     assert ask(Q.odd(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -23,6 +23,7 @@ from sympy.logic.boolalg import Equivalent, Implies, Xor, And, to_cnf
 from sympy.matrices import Matrix, SparseMatrix
 from sympy.testing.pytest import XFAIL, slow, raises,  _both_exp_pow
 import math
+
 from sympy import ask, Q, pi,oo # for def test_issue_29433_zero_substitution_infinite():
 from sympy.abc import x, n
 
@@ -1807,7 +1808,7 @@ def test_zero():
 
 def test_issue_29433_zero_substitution_infinite():
     # Previously raised ValueError due to inconsistent assumptions(issue #29433)
-    assert ask(Q.infinite(x + n*pi), Q.zero(n)) is None 
+    assert ask(Q.infinite(x + n*pi), Q.zero(n)) is None
     assert ask(Q.infinite(n*x), Q.zero(n)) is False  #n = 0 ⇒ n*x = 0 ⇒ not infinite
     assert ask(Q.infinite(oo + n*pi),Q.zero(n)) is True  # oo + 0 ⇒ oo ⇒ infinite
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29433

#### Brief description of what is fixed or changed
This PR fixes a case where ask() raises a ValueError for inconsistent assumptions
when evaluating expressions like:

ask(Q.infinite(x + n*pi), Q.zero(n))

The issue occurs because the assumption Q.zero(n) implies n = 0, but this is not
taken into account before performing logical inference.

The fix handles simple substitutions from assumptions (currently Q.zero) and
applies them to predicate arguments. This allows expressions like x + n*pi and
n*x to be simplified before evaluation.

Substitution is only applied to direct predicate arguments and not inside
functions, in order to avoid unintended evaluation (for example, asin(p) should
not become asin(0)).

Logical expressions and SAT-based reasoning are left unchanged.


#### Other comments

Added tests:

ask(Q.infinite(x + n*pi), Q.zero(n)) → None
ask(Q.infinite(n*x), Q.zero(n)) → False
ask(Q.infinite(oo + n*pi), Q.zero(n)) → True


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Portions of this contribution (code structure, debugging approach, and test design)
were assisted by an AI tool. All changes were reviewed, tested, and verified manually
to ensure correctness and compliance with project standards.



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed a bug in ask() where assumptions like Q.zero(n) were not used to
    simplify expressions, which could lead to a ValueError.
<!-- END RELEASE NOTES -->
