### PR TITLE
Handle nested And/Or inequalities using DNF and recursion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -491,6 +491,7 @@ Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@us
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chidroopakanaparthy <chidroopak007@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -946,6 +946,17 @@ def reduce_inequalities(inequalities, symbols=[]):
         inequalities = [inequalities]
     inequalities = [sympify(i) for i in inequalities]
 
+    # Flatten And/Or boolean expressions into individual args so that
+    # e.g. (x > 0) & (x < 1) is treated the same as [x > 0, x < 1].
+    from sympy.logic.boolalg import And as BoolAnd, Or as BoolOr
+    flat = []
+    for i in inequalities:
+        if isinstance(i, (BoolAnd, BoolOr)):
+            flat.extend(i.args)
+        else:
+            flat.append(i)
+    inequalities = flat
+
     gens = set().union(*[i.free_symbols for i in inequalities])
 
     if not iterable(symbols):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -942,20 +942,35 @@ def reduce_inequalities(inequalities, symbols=[]):
     >>> reduce_inequalities(0 <= x + y*2 - 1, [x])
     (x < oo) & (x >= 1 - 2*y)
     """
+    from sympy.logic.boolalg import And as BoolAnd, Or as BoolOr, to_dnf, BooleanAtom
+
     if not iterable(inequalities):
         inequalities = [inequalities]
     inequalities = [sympify(i) for i in inequalities]
 
-    # Flatten And/Or boolean expressions into individual args so that
-    # e.g. (x > 0) & (x < 1) is treated the same as [x > 0, x < 1].
-    from sympy.logic.boolalg import And as BoolAnd, Or as BoolOr
-    flat = []
+    normalized = []
     for i in inequalities:
-        if isinstance(i, (BoolAnd, BoolOr)):
-            flat.extend(i.args)
+        if isinstance(i, (Relational, BoolAnd, BoolOr, BooleanAtom)):
+            normalized.append(i)
         else:
-            flat.append(i)
-    inequalities = flat
+            normalized.append(Eq(i, 0))
+    inequalities = normalized
+
+    if len(inequalities) == 1:
+        expr = inequalities[0]
+    else:
+        expr = BoolAnd(*inequalities)
+
+    if isinstance(expr, BoolOr):
+        return BoolOr(*[reduce_inequalities(arg, symbols) for arg in expr.args])
+
+    if isinstance(expr, BoolAnd) and any(arg.has(BoolOr) for arg in expr.args):
+        return reduce_inequalities(to_dnf(expr), symbols)
+
+    if isinstance(expr, BoolAnd):
+        inequalities = list(expr.args)
+    else:
+        inequalities = [expr]
 
     gens = set().union(*[i.free_symbols for i in inequalities])
 

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -221,6 +221,14 @@ def test_reduce_inequalities_boolean():
     assert reduce_inequalities([Eq(x**2, 0), False]) == False
     assert reduce_inequalities(x**2 >= 0) is S.true  # issue 10196
 
+    # issue 23953: And/Or boolean expressions should be flattened
+    assert reduce_inequalities((x > 0) & (x < 1), x) == \
+        reduce_inequalities([x > 0, x < 1], x)
+    assert reduce_inequalities((x > 0) & Eq(x, 3)) == Eq(x, 3)
+    assert reduce_inequalities((x >= -1) & (x <= 1) & (x > 0), x) == \
+        reduce_inequalities([x >= -1, x <= 1, x > 0], x)
+
+
 
 def test_reduce_inequalities_multivariate():
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == And(

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -229,7 +229,6 @@ def test_reduce_inequalities_boolean():
         reduce_inequalities([x >= -1, x <= 1, x > 0], x)
 
 
-
 def test_reduce_inequalities_multivariate():
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == And(
         Or(And(Le(S.One, x), Lt(x, oo)), And(Le(x, -1), Lt(-oo, x))),


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #23953
Improves #29428

#### Brief description of what is fixed or changed

In my previous attempt at this issue, i made a logical error by treating both And and Or as equal, which incorrectly turned disjunctions into conjunctions. This pr now operats on a linked tree in place of a list. For nested cases i have added a to_dnf pass which ensures the branches are expanded and solved correctly. I have also added recursion for each branch if the input is in BoolOr.

#### Other comments

### Verification
one of the examples this code solved:
Input: (x > 0) & ((x > 10) | (x < 2)) which gave the output
Result: ((0 < x) & (x < 2)) | ((10 < x) & (x < oo))

#### AI Generation Disclosure

I used a LLM to properly understand the error i made in my previous attempt as corrected by the maintainer, and to check the correctness of my code this time.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* solvers
   * Fixed a regression in reduce_inequalities where And and Or expressions were not correctly handled.

<!-- END RELEASE NOTES -->
