### PR TITLE
Remove stray string

### DIFF
--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -253,7 +253,6 @@ _xobj_unicode = {
     '|':                    U('BOX DRAWINGS LIGHT VERTICAL'),
     'Tee':                  U('BOX DRAWINGS LIGHT UP AND HORIZONTAL'),
     'UpTack':               U('BOX DRAWINGS LIGHT DOWN AND HORIZONTAL'),
-    'corner_up_centre'
     '(_ext':                U('LEFT PARENTHESIS EXTENSION'),
     ')_ext':                U('RIGHT PARENTHESIS EXTENSION'),
     '(_lower_hook':         U('LEFT PARENTHESIS LOWER HOOK'),


### PR DESCRIPTION
This concatenated with `(_ext`, but this key is currently unused, so the bug never surfaced.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### Other comments

```
❯ rg -F '(_ext'
sympy/printing/pretty/pretty_symbology.py
256:    '(_ext':                U('LEFT PARENTHESIS EXTENSION'),

❯ rg -F ')_ext'
sympy/printing/pretty/pretty.py
1207:                if xobj(')_ext', 1) in tempstr:   # If scalar is a fraction
1210:                        if tempstr[paren] == xobj(')_ext', 1) and tempstr[paren + 1] == '\n':
1213:                            tempstr = tempstr[:paren] + xobj(')_ext', 1)\

sympy/printing/pretty/pretty_symbology.py
257:    ')_ext':                U('RIGHT PARENTHESIS EXTENSION'),

❯ rg corner_up_centre

❯
```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
