### PR TITLE
printing: add LaTeX printer for PuiseuxPoly

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2574,6 +2574,9 @@ class LatexPrinter(Printer):
     def _print_PolyElement(self, poly):
         mul_symbol = self._settings['mul_symbol_latex']
         return poly.str(self, PRECEDENCE, "{%s}^{%d}", mul_symbol)
+    
+    def _print_PuiseuxPoly(self, poly):
+        return self._print(poly.as_expr())
 
     def _print_FracElement(self, frac):
         if frac.denom == 1:


### PR DESCRIPTION
## Description
This PR adds a missing LaTeX printer method for `PuiseuxPoly`. 

As recently noted by @oscarbenjamin in the closure of #20487, Puiseux polynomials lacked a dedicated LaTeX printer and fell back to a raw string wrapped in `\mathtt`. This patch intercepts `PuiseuxPoly` and routes it through `.as_expr()` to generate properly formatted mathematical fractional exponents.

**Before:**
`\mathtt{\text{x**(3/2)}}`

**After:**
`x^{\frac{3}{2}}`


* printing
  * Added LaTeX printer method for PuiseuxPoly to properly format fractional exponents.