### PR TITLE
printing: add LaTeX printer for PuiseuxPoly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -690,8 +690,8 @@ Gaurav Dhingra <gauravdhingra.gxyd@gmail.com> <axyd0000@gmail.com>
 Gaurav Dhingra <gauravdhingra.gxyd@gmail.com> <igauravdhingra@protonmail.com>
 Gaurav Jain <gjain369@gmail.com> Gaurav Jain <72644006+gjain-7@users.noreply.github.com>
 Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com>
-Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <GauravDeshmukh <gauravgdeshmukh5225@gmail.com>>
 Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <Gaurav23-bit <gauravgdeshmukh5225@gmail.com>>
+Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <GauravDeshmukh <gauravgdeshmukh5225@gmail.com>>
 Gautam Menghani <gum3ng@protonmail.com> gautammenghani <gautammenghani14@gmail.com>
 Gautam Menghani <gum3ng@protonmail.com> gum3ng <78410304+gum3ng@users.noreply.github.com>
 Gautam Menghani <gum3ng@protonmail.com> gum3ng <gum3ng@protonmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -689,6 +689,9 @@ Gaurav Dhingra <gauravdhingra.gxyd@gmail.com>
 Gaurav Dhingra <gauravdhingra.gxyd@gmail.com> <axyd0000@gmail.com>
 Gaurav Dhingra <gauravdhingra.gxyd@gmail.com> <igauravdhingra@protonmail.com>
 Gaurav Jain <gjain369@gmail.com> Gaurav Jain <72644006+gjain-7@users.noreply.github.com>
+Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com>
+Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <GauravDeshmukh <gauravgdeshmukh5225@gmail.com>>
+Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <Gaurav23-bit <gauravgdeshmukh5225@gmail.com>>
 Gautam Menghani <gum3ng@protonmail.com> gautammenghani <gautammenghani14@gmail.com>
 Gautam Menghani <gum3ng@protonmail.com> gum3ng <78410304+gum3ng@users.noreply.github.com>
 Gautam Menghani <gum3ng@protonmail.com> gum3ng <gum3ng@protonmail.com>
@@ -1886,4 +1889,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <Gaurav23-bit <gauravgdeshmukh5225@gmail.com>>

--- a/.mailmap
+++ b/.mailmap
@@ -1886,3 +1886,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Gaurav Sambhaji Deshmukh <gauravgdeshmukh5225@gmail.com> <Gaurav23-bit <gauravgdeshmukh5225@gmail.com>>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2574,7 +2574,7 @@ class LatexPrinter(Printer):
     def _print_PolyElement(self, poly):
         mul_symbol = self._settings['mul_symbol_latex']
         return poly.str(self, PRECEDENCE, "{%s}^{%d}", mul_symbol)
-    
+
     def _print_PuiseuxPoly(self, poly):
         return self._print(poly.as_expr())
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2574,6 +2574,9 @@ class LatexPrinter(Printer):
     def _print_PolyElement(self, poly):
         mul_symbol = self._settings['mul_symbol_latex']
         return poly.str(self, PRECEDENCE, "{%s}^{%d}", mul_symbol)
+    
+    def _print_PuiseuxPoly(self, poly):
+        return self._print(poly.as_expr())
 
     def _print_FracElement(self, frac):
         if frac.denom == 1:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See #20487


#### Brief description of what is fixed or changed

Adds `_print_PuiseuxPoly` to the LaTeX printer.

As noted by @oscarbenjamin in the closure of #20487, `PuiseuxPoly` lacked a dedicated LaTeX printer and fell back to a raw string representation wrapped in `\mathtt`. This patch intercepts `PuiseuxPoly` and routes it through `.as_expr()` so fractional exponents are formatted properly.

Before: `\mathtt{\text{x**(3/2)}}`
After: `x^{\frac{3}{2}}`

#### Other comments

Tested locally against `sympy/printing/tests/test_latex.py` and it passes all checks.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Added LaTeX printer for PuiseuxPoly.

<!-- END RELEASE NOTES -->
