### PR TITLE
Optimise degree() using iterative postorder traversal

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4926,15 +4926,17 @@ def _mul_profiles (dict_1, dict_2): # add keys, multiply values
 
 
 def _add_profiles (dict_1, dict_2): # keep keys the same, add values
-    result = dict(dict_1)
+    result            = dict(dict_1)
+    cancellation_flag = False
     
     for deg, coeff in dict_2.items():
         result[deg] = result.get(deg, 0) + coeff
         
         if result[deg] == 0:
+            cancellation_flag = True
             del result[deg]
             
-    return result
+    return result, cancellation_flag
 
 
 def _pow_profile (dict_, exponent):
@@ -4959,12 +4961,12 @@ def __degree_it (f, gen):
     if isinstance(f, Poly):
         f = f.as_expr()
     
-    profiles_stack = []
+    profiles_stack    = []
     
     for expr in postorder_traversal(f):
         
         if expr == 0:
-            return S.NegativeInfinity
+            profiles_stack.append({})
         
         elif not expr.has(gen): 
             profile = {0 : expr}
@@ -4996,7 +4998,10 @@ def __degree_it (f, gen):
             for i in range(0, len(part)):
                 if i + 1 == len(part):
                     break
-                part[i+1] = _add_profiles(part[i], part[i+1])
+                part[i+1], cancellation_flag = _add_profiles(part[i], part[i+1])
+                
+                if cancellation_flag:
+                    return None
                 
             final = part[-1]
             
@@ -5015,7 +5020,7 @@ def __degree_it (f, gen):
             exponent = exponent_profile[0]
 
             if not exponent.is_Integer or not exponent.is_nonnegative:
-                return None
+                return None 
             
             profiles_stack.append(_pow_profile(base_profile, int(exponent)))
         else:
@@ -5112,7 +5117,7 @@ def degree(f, gen=0):
     
     if not isinstance(f, Poly) or gen not in f.gens:
         d = __degree_it(f, gen)
-        if d == S.NegativeInfinity or d == None or d == 0:
+        if d == None:
             f = poly_from_expr(f, gen)[0]
             return _degree(f.degree(gen))
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4916,11 +4916,11 @@ def _update_args(args, key, value):
 def _mul_profiles (dict_1, dict_2): # add keys, multiply values
     result = {}
     for k, v in dict_1.items():
-         for k_, v_ in dict_2.items():
-             result[k + k_] = result.get(k + k_, 0) + v * v_
+        for k_, v_ in dict_2.items():
+            result[k + k_] = result.get(k + k_, 0) + v * v_
              
-             if result[k + k_] == 0:
-                 del result[k + k_]
+            if result[k + k_] == 0:
+                del result[k + k_]
     
     return result
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4939,7 +4939,7 @@ def _add_profiles (dict_1, dict_2): # keep keys the same, add values
     return result, cancellation_flag
 
 
-def _pow_profile (dict_, exponent, cutoff=50):
+def _pow_profile (dict_, exponent, cutoff=550):
     
     if exponent == 0:
         return {0 : 1}

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4913,6 +4913,125 @@ def _update_args(args, key, value):
     return args
 
 
+def _mul_profiles (dict_1, dict_2): # add keys, multiply values
+    result = {}
+    for k, v in dict_1.items():
+         for k_, v_ in dict_2.items():
+             result[k + k_] = result.get(k + k_, 0) + v * v_
+             
+             if result[k + k_] == 0:
+                 del result[k + k_]
+    
+    return result
+
+
+def _add_profiles (dict_1, dict_2): # keep keys the same, add values
+    result = dict(dict_1)
+    
+    for deg, coeff in dict_2.items():
+        result[deg] = result.get(deg, 0) + coeff
+        
+        if result[deg] == 0:
+            del result[deg]
+            
+    return result
+
+
+def _pow_profile (dict_, exponent):
+    
+    if exponent == 0:
+        return {0 : 1}
+    
+    result = {}
+    for deg, coeff in dict_.items():
+        k, v = deg*exponent, coeff**exponent
+        result[k] = result.get(k, 0) + v
+        
+    return result
+
+from sympy import postorder_traversal
+
+def __degree_it (f, gen):
+    
+    f   = sympify(f)
+    gen = sympify(gen)
+    
+    if isinstance(f, Poly):
+        f = f.as_expr()
+    
+    profiles_stack = []
+    
+    for expr in postorder_traversal(f):
+        
+        if expr == 0:
+            return S.NegativeInfinity
+        
+        elif not expr.has(gen): 
+            profile = {0 : expr}
+            profiles_stack.append(profile)
+        
+        elif expr == gen: 
+            profile = {1 : 1}
+            profiles_stack.append(profile)
+            
+        # stack "unfolding" cases
+        elif expr.is_Mul:
+            num_factors = len(expr.args)
+            parts       = profiles_stack[-num_factors:]
+            
+            total = {0 : 1}
+            for p in parts:
+                total = _mul_profiles(total, p)
+            
+            del profiles_stack[-num_factors:]
+            del parts
+            
+            profiles_stack.append(total)
+        
+        elif expr.is_Add:
+            num_terms = len(expr.args) 
+            part      = profiles_stack[-num_terms:]
+            final = {}
+            
+            for i in range(0, len(part)):
+                if i + 1 == len(part):
+                    break
+                part[i+1] = _add_profiles(part[i], part[i+1])
+                
+            final = part[-1]
+            
+            del profiles_stack[-num_terms:]
+            del part
+            
+            profiles_stack.append(final)
+            
+        elif expr.is_Pow: 
+            exponent_profile    = profiles_stack.pop()
+            base_profile        = profiles_stack.pop()
+            
+            if len(exponent_profile) != 1 or 0 not in exponent_profile:
+                return None
+            
+            exponent = exponent_profile[0]
+
+            if not exponent.is_Integer or not exponent.is_nonnegative:
+                return None
+            
+            profiles_stack.append(_pow_profile(base_profile, int(exponent)))
+        else:
+            return None
+        
+    if len(profiles_stack) != 1:
+        return None
+    
+    final_profile = profiles_stack[0]
+    
+    if not final_profile:
+        return S.NegativeInfinity
+    
+    return max(final_profile)
+
+
 @public
 def degree(f, gen=0):
     """
@@ -4988,9 +5107,16 @@ def degree(f, gen=0):
         return p.degree(gen)
 
     gen = sympify(gen, strict=True)
+    if isinstance(f, Poly) and gen in f.gens:
+        return _degree(f.degree(gen))
+    
     if not isinstance(f, Poly) or gen not in f.gens:
-        f = poly_from_expr(f, gen)[0]
-    return _degree(f.degree(gen))
+        d = __degree_it(f, gen)
+        if d == S.NegativeInfinity or d == None or d == 0:
+            f = poly_from_expr(f, gen)[0]
+            return _degree(f.degree(gen))
+        else:
+            return _degree(d)
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5124,7 +5124,7 @@ def degree(f, gen=0):
 
     if not isinstance(f, Poly) or gen not in f.gens:
         d = __degree_it(f, gen)
-        if d == None:
+        if d is None:
             f = poly_from_expr(f, gen)[0]
             return _degree(f.degree(gen))
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4939,17 +4939,24 @@ def _add_profiles (dict_1, dict_2): # keep keys the same, add values
     return result, cancellation_flag
 
 
-def _pow_profile (dict_, exponent):
+def _pow_profile (dict_, exponent, cutoff=50):
     
     if exponent == 0:
         return {0 : 1}
+    elif exponent == 1:
+        return dict_
     
-    result = {}
-    for deg, coeff in dict_.items():
-        k, v = deg*exponent, coeff**exponent
-        result[k] = result.get(k, 0) + v
-        
-    return result
+    if exponent > cutoff:
+        result = {}
+        for deg, coeff in dict_.items():
+            k, v = deg*exponent, coeff**exponent
+            result[k] = result.get(k, 0) + v
+        return result
+    else:
+        result = {0 : 1}
+        for _ in range(int(exponent)):
+            result = _mul_profiles(result, dict_)
+        return result
 
 from sympy import postorder_traversal
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4918,34 +4918,34 @@ def _mul_profiles (dict_1, dict_2): # add keys, multiply values
     for k, v in dict_1.items():
         for k_, v_ in dict_2.items():
             result[k + k_] = result.get(k + k_, 0) + v * v_
-             
+
             if result[k + k_] == 0:
                 del result[k + k_]
-    
+
     return result
 
 
 def _add_profiles (dict_1, dict_2): # keep keys the same, add values
     result            = dict(dict_1)
     cancellation_flag = False
-    
+
     for deg, coeff in dict_2.items():
         result[deg] = result.get(deg, 0) + coeff
-        
+
         if result[deg] == 0:
             cancellation_flag = True
             del result[deg]
-            
+
     return result, cancellation_flag
 
 
 def _pow_profile (dict_, exponent, cutoff=550):
-    
+
     if exponent == 0:
         return {0 : 1}
     elif exponent == 1:
         return dict_
-    
+
     if exponent > cutoff:
         result = {}
         for deg, coeff in dict_.items():
@@ -4961,86 +4961,86 @@ def _pow_profile (dict_, exponent, cutoff=550):
 from sympy import postorder_traversal
 
 def __degree_it (f, gen):
-    
+
     f   = sympify(f)
     gen = sympify(gen)
-    
+
     if isinstance(f, Poly):
         f = f.as_expr()
-    
+
     profiles_stack    = []
-    
+
     for expr in postorder_traversal(f):
-        
+
         if expr == 0:
             profiles_stack.append({})
-        
-        elif not expr.has(gen): 
+
+        elif not expr.has(gen):
             profile = {0 : expr}
             profiles_stack.append(profile)
-        
-        elif expr == gen: 
+
+        elif expr == gen:
             profile = {1 : 1}
             profiles_stack.append(profile)
-            
+
         # stack "unfolding" cases
         elif expr.is_Mul:
             num_factors = len(expr.args)
             parts       = profiles_stack[-num_factors:]
-            
+
             total = {0 : 1}
             for p in parts:
                 total = _mul_profiles(total, p)
-            
+
             del profiles_stack[-num_factors:]
             del parts
-            
+
             profiles_stack.append(total)
-        
+
         elif expr.is_Add:
-            num_terms = len(expr.args) 
+            num_terms = len(expr.args)
             part      = profiles_stack[-num_terms:]
             final = {}
-            
+
             for i in range(0, len(part)):
                 if i + 1 == len(part):
                     break
                 part[i+1], cancellation_flag = _add_profiles(part[i], part[i+1])
-                
+
                 if cancellation_flag:
                     return None
-                
+
             final = part[-1]
-            
+
             del profiles_stack[-num_terms:]
             del part
-            
+
             profiles_stack.append(final)
-            
-        elif expr.is_Pow: 
+
+        elif expr.is_Pow:
             exponent_profile    = profiles_stack.pop()
             base_profile        = profiles_stack.pop()
-            
+
             if len(exponent_profile) != 1 or 0 not in exponent_profile:
                 return None
-            
+
             exponent = exponent_profile[0]
 
             if not exponent.is_Integer or not exponent.is_nonnegative:
-                return None 
-            
+                return None
+
             profiles_stack.append(_pow_profile(base_profile, int(exponent)))
         else:
             return None
-        
+
     if len(profiles_stack) != 1:
         return None
-    
+
     final_profile = profiles_stack[0]
-    
+
     if not final_profile:
         return S.NegativeInfinity
-    
+
     return max(final_profile)
 
 
@@ -5121,7 +5121,7 @@ def degree(f, gen=0):
     gen = sympify(gen, strict=True)
     if isinstance(f, Poly) and gen in f.gens:
         return _degree(f.degree(gen))
-    
+
     if not isinstance(f, Poly) or gen not in f.gens:
         d = __degree_it(f, gen)
         if d == None:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #6322
Alternative approach to #29051

#### Brief description of what is fixed or changed
This PR implements an iterative approach for `degree()`, using `postorder_traversal` on the input expression. It avoids unnecessary expansion for certain factored polynomial cases, like `(x + 1)**10000`, and falls back to the existing method when the fast path (`__degree_it()`) cannot safely determine the degree (mainly on cancelling terms).

#### Other comments
- Passes `sympy/polys/tests` locally
- Benchmarked on `(x + 1)**10000`, `x*(x + 1)**5000`, `(x + 1)**2 - x**2`, `x*(x + 1) - x**2 - x`, `y*(x + 1)**10000`

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->