### PR TITLE
assumptions: Fix `inconsistent assumptions` in `satask` for `0*irrational`

### DIFF
--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -239,7 +239,8 @@ def _(expr):
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),
             allargs(x, Q.integer(x), expr) >> Q.integer(expr),
-            exactlyonearg(x, ~Q.rational(x), expr) >> ~Q.integer(expr),
+            (~anyarg(x, Q.zero(x), expr) &
+             exactlyonearg(x, ~Q.rational(x), expr)) >> ~Q.integer(expr),
             allargs(x, Q.commutative(x), expr) >> Q.commutative(expr),
             ]
 
@@ -263,7 +264,8 @@ def _(expr):
 def _(expr):
     allargs_real = allargs(x, Q.real(x), expr)
     onearg_irrational = exactlyonearg(x, Q.irrational(x), expr)
-    return Implies(allargs_real, Implies(onearg_irrational, Q.irrational(expr)))
+    return Implies(allargs_real & ~anyarg(x, Q.zero(x), expr),
+                    Implies(onearg_irrational, Q.irrational(expr)))
 
 @class_fact_registry.register(Mul)
 def _(expr):

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -239,7 +239,7 @@ def _(expr):
             allargs(x, Q.real(x), expr) >> Q.real(expr),
             allargs(x, Q.rational(x), expr) >> Q.rational(expr),
             allargs(x, Q.integer(x), expr) >> Q.integer(expr),
-            (~anyarg(x, Q.zero(x), expr) &
+            (allargs(x, ~Q.zero(x), expr) &
              exactlyonearg(x, ~Q.rational(x), expr)) >> ~Q.integer(expr),
             allargs(x, Q.commutative(x), expr) >> Q.commutative(expr),
             ]
@@ -264,7 +264,7 @@ def _(expr):
 def _(expr):
     allargs_real = allargs(x, Q.real(x), expr)
     onearg_irrational = exactlyonearg(x, Q.irrational(x), expr)
-    return Implies(allargs_real & ~anyarg(x, Q.zero(x), expr),
+    return Implies(allargs_real & allargs(x, ~Q.zero(x), expr),
                     Implies(onearg_irrational, Q.irrational(expr)))
 
 @class_fact_registry.register(Mul)

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -156,7 +156,11 @@ def test_rational_irrational():
         Q.rational(z)) is None
     assert satask(Q.irrational(x*y*z), Q.irrational(x) & Q.rational(y) &
         Q.rational(z)) is None
+    assert satask(Q.irrational(x*y*z), Q.irrational(x) & Q.rational(y) &
+        Q.rational(z) & ~Q.zero(y) & ~Q.zero(z)) is True
     assert satask(Q.irrational(pi*x*y), Q.rational(x) & Q.rational(y)) is None
+    assert satask(Q.irrational(pi*x*y), Q.rational(x) & Q.rational(y) &
+                  ~Q.zero(x) & ~Q.zero(y)) is True
 
     assert satask(Q.irrational(x + y + z), Q.irrational(x) & Q.irrational(y) &
         Q.rational(z)) is None
@@ -229,12 +233,18 @@ def test_integer():
 
     assert satask(Q.integer(x*y), Q.integer(x) & ~Q.integer(y)) is None
     assert satask(Q.integer(x*y), Q.integer(x) & ~Q.rational(y)) is None
+    assert satask(Q.integer(x*y), Q.integer(x) & ~Q.rational(y) &
+        ~Q.zero(x)) is False
     assert satask(Q.integer(x*y*z), Q.integer(x) & Q.integer(y) &
         ~Q.rational(z)) is None
+    assert satask(Q.integer(x*y*z), Q.integer(x) & Q.integer(y) &
+        ~Q.rational(z) & ~Q.zero(x) & ~Q.zero(y)) is False
     assert satask(Q.integer(x*y*z), Q.integer(x) & ~Q.rational(y) &
         ~Q.rational(z)) is None
     assert satask(Q.integer(x*y*z), Q.integer(x) & ~Q.rational(y)) is None
     assert satask(Q.integer(x*y), Q.integer(x) & Q.irrational(y)) is None
+    assert satask(Q.integer(x*y), Q.integer(x) & Q.irrational(y) &
+        ~Q.zero(x)) is False
 
 
 def test_abs():

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
 from sympy.assumptions.assume import assuming
-from sympy.core.numbers import (I, pi)
+from sympy.core.numbers import (I, pi, E)
 from sympy.core.relational import (Eq, Gt)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Dummy
@@ -155,8 +155,8 @@ def test_rational_irrational():
     assert satask(Q.irrational(x*y*z), Q.irrational(x) & Q.irrational(y) &
         Q.rational(z)) is None
     assert satask(Q.irrational(x*y*z), Q.irrational(x) & Q.rational(y) &
-        Q.rational(z)) is True
-    assert satask(Q.irrational(pi*x*y), Q.rational(x) & Q.rational(y)) is True
+        Q.rational(z)) is None
+    assert satask(Q.irrational(pi*x*y), Q.rational(x) & Q.rational(y)) is None
 
     assert satask(Q.irrational(x + y + z), Q.irrational(x) & Q.irrational(y) &
         Q.rational(z)) is None
@@ -228,13 +228,13 @@ def test_integer():
     assert satask(Q.integer(x*y), Q.integer(x)) is None
 
     assert satask(Q.integer(x*y), Q.integer(x) & ~Q.integer(y)) is None
-    assert satask(Q.integer(x*y), Q.integer(x) & ~Q.rational(y)) is False
+    assert satask(Q.integer(x*y), Q.integer(x) & ~Q.rational(y)) is None
     assert satask(Q.integer(x*y*z), Q.integer(x) & Q.integer(y) &
-        ~Q.rational(z)) is False
+        ~Q.rational(z)) is None
     assert satask(Q.integer(x*y*z), Q.integer(x) & ~Q.rational(y) &
         ~Q.rational(z)) is None
     assert satask(Q.integer(x*y*z), Q.integer(x) & ~Q.rational(y)) is None
-    assert satask(Q.integer(x*y), Q.integer(x) & Q.irrational(y)) is False
+    assert satask(Q.integer(x*y), Q.integer(x) & Q.irrational(y)) is None
 
 
 def test_abs():
@@ -376,3 +376,11 @@ def test_get_relevant_clsfacts():
 def test_issue_27467():
     s = sum(Dummy() for _ in range(10))
     assert all(len(CNF.to_CNF(f).clauses) < 1000 for f in class_fact_registry(s))
+
+def test_issue_29433():
+    assert satask(Q.infinite(x+y*pi), Q.zero(y)) is None
+    assert satask(Q.rational(x + y*E), Q.zero(y)) is None
+    assert satask(Q.integer(x + y*pi), Q.zero(y)) is None
+    assert satask(Q.even(x + y*(3**0.5)), Q.zero(y)) is None
+    assert satask(Q.odd(x + y*(3**0.5)), Q.zero(y)) is None
+    assert satask(Q.positive(x + y*pi), Q.zero(y)) is None


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes: #29433

#### Brief description of what is fixed or changed
Earlier, `ask(Q.infinite(x+n*pi), Q.zero(n))` used to raise a ValueError `Inconsistent assumptions` instead of `None`. While evaluating for `can_be_true` and `can_be_false` in `check_satisfiability`, both end up being `False`.

The issue was with `sathandlers.py` where for `Mul` handler, to claim an `expr` is not an `integer` it used to follow this logic, `exactlyonearg(x, ~Q.rational(x), expr) >> ~Q.integer(expr)`, but it never checks if any of the variables in the `expr` is 0, if any one is 0, then the `expr` is just 0 (which is an `integer`)


```python
from sympy import *
n = Symbol('n')

print(ask(Q.infinite(x+n*pi), Q.zero(n))) # Now correctly returns None instead of raising ValueError
```

`sathandlers.py` has been updated accordingly with correct logic and tests have been updated as well as added for this particular bug.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `ask` wrongly raising `inconsistent assumptions` when evaluating expressions multiplied by zero (e.g. `0*pi`)
<!-- END RELEASE NOTES -->
