### PR TITLE
logic: Fix LRA confilct clause generation bug when distinct literals have the same encoding

### DIFF
--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -366,9 +366,11 @@ class LRASolver():
             var.lower = LRARational(-float("inf"), 0)
             var.lower_from_eq = False
             var.lower_from_neg = False
+            var.lower_lit = None
             var.upper = LRARational(float("inf"), 0)
             var.upper_from_eq = False
             var.upper_from_neg = False
+            var.upper_lit = None
             var.assign = LRARational(0, 0)
 
     def assert_lit(self, enc_constraint):
@@ -416,16 +418,16 @@ class LRASolver():
             c = LRARational(c, 0)
 
         if boundary.equality:
-            res1 = self._assert_lower(sym, c, from_equality=True, from_neg=negated)
+            res1 = self._assert_lower(sym, c, enc_constraint, from_equality=True, from_neg=negated)
             if res1 and res1[0] == False:
                 res = res1
             else:
-                res2 = self._assert_upper(sym, c, from_equality=True, from_neg=negated)
+                res2 = self._assert_upper(sym, c, enc_constraint, from_equality=True, from_neg=negated)
                 res =  res2
         elif upper:
-            res = self._assert_upper(sym, c, from_neg=negated)
+            res = self._assert_upper(sym, c, enc_constraint, from_neg=negated)
         else:
-            res = self._assert_lower(sym, c, from_neg=negated)
+            res = self._assert_lower(sym, c, enc_constraint, from_neg=negated)
 
         if self.is_sat and sym not in self.slack_set:
             self.is_sat = res is None
@@ -434,7 +436,7 @@ class LRASolver():
 
         return res
 
-    def _assert_upper(self, xi, ci, from_equality=False, from_neg=False):
+    def _assert_upper(self, xi, ci, lit, from_equality=False, from_neg=False):
         """
         Adjusts the upper bound on variable xi if the new upper bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -449,22 +451,13 @@ class LRASolver():
         if ci >= xi.upper:
             return None
         if ci < xi.lower:
-            assert (xi.lower[1] >= 0) is True
-            assert (ci[1] <= 0) is True
-
-            lit1, neg1 = Boundary.from_lower(xi)
-
-            lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=True, equality=from_equality)
-            if from_neg:
-                lit2 = lit2.get_negated()
-            neg2 = -1 if from_neg else 1
-
-            conflict = [-neg1*self.boundary_to_enc[lit1], -neg2*self.boundary_to_enc[lit2]]
+            conflict = [-xi.lower_lit, -lit]
             self.result = False, conflict
             return self.result
         xi.upper = ci
         xi.upper_from_eq = from_equality
         xi.upper_from_neg = from_neg
+        xi.upper_lit = lit
         if xi in self.nonslack and xi.assign > ci:
             self._update(xi, ci)
 
@@ -476,7 +469,7 @@ class LRASolver():
 
         return None
 
-    def _assert_lower(self, xi, ci, from_equality=False, from_neg=False):
+    def _assert_lower(self, xi, ci, lit, from_equality=False, from_neg=False):
         """
         Adjusts the lower bound on variable xi if the new lower bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -491,22 +484,13 @@ class LRASolver():
         if ci <= xi.lower:
             return None
         if ci > xi.upper:
-            assert (xi.upper[1] <= 0) is True
-            assert (ci[1] >= 0) is True
-
-            lit1, neg1 = Boundary.from_upper(xi)
-
-            lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=False, equality=from_equality)
-            if from_neg:
-                lit2 = lit2.get_negated()
-            neg2 = -1 if from_neg else 1
-
-            conflict = [-neg1*self.boundary_to_enc[lit1],-neg2*self.boundary_to_enc[lit2]]
+            conflict = [-xi.upper_lit, -lit]
             self.result = False, conflict
             return self.result
         xi.lower = ci
         xi.lower_from_eq = from_equality
         xi.lower_from_neg = from_neg
+        xi.lower_lit = lit
         if xi in self.nonslack and xi.assign < ci:
             self._update(xi, ci)
 
@@ -594,15 +578,14 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict = []
-                    conflict += [Boundary.from_upper(nb) for nb in N_plus]
-                    conflict += [Boundary.from_lower(nb) for nb in N_minus]
-                    conflict.append(Boundary.from_lower(xi))
-                    conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
+                    conflict += [-nb.upper_lit for nb in N_plus]
+                    conflict += [-nb.lower_lit for nb in N_minus]
+                    conflict.append(-xi.lower_lit)
                     return False, conflict
                 xj = min(cand, key=str)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
 
-            if xi.assign > xi.upper:
+            elif xi.assign > xi.upper:
                 cand = [nb for nb in nonbasic
                         if (M[i, nb.col_idx] < 0 and nb.assign < nb.upper)
                         or (M[i, nb.col_idx] > 0 and nb.assign > nb.lower)]
@@ -612,11 +595,10 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict = []
-                    conflict += [Boundary.from_upper(nb) for nb in N_minus]
-                    conflict += [Boundary.from_lower(nb) for nb in N_plus]
-                    conflict.append(Boundary.from_upper(xi))
+                    conflict += [-nb.upper_lit for nb in N_minus]
+                    conflict += [-nb.lower_lit for nb in N_plus]
+                    conflict.append(-xi.upper_lit)
 
-                    conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
@@ -894,9 +876,11 @@ class LRAVariable():
         self.upper = LRARational(float("inf"), 0)
         self.upper_from_eq = False
         self.upper_from_neg = False
+        self.upper_lit = None
         self.lower = LRARational(-float("inf"), 0)
         self.lower_from_eq = False
         self.lower_from_neg = False
+        self.lower_lit = None
         self.assign = LRARational(0,0)
         self.var = var
         self.col_idx = None

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -1,28 +1,39 @@
 from __future__ import annotations
-from sympy.core.numbers import Rational, I, oo
-from sympy.core.relational import Eq
-from sympy.core.symbol import symbols
-from sympy.core.singleton import S
-from sympy.matrices.dense import Matrix
-from sympy.matrices.dense import randMatrix
-from sympy.assumptions.ask import Q
-from sympy.logic.boolalg import And
-from sympy.abc import x, y, z
-from sympy.assumptions.cnf import CNF, EncodedCNF
-from sympy.functions.elementary.trigonometric import cos
-from sympy.external import import_module
 
-from sympy.logic.algorithms.lra_theory import LRASolver, UnhandledInput, LRARational, HANDLE_NEGATION
-from sympy.core.random import random, choice, randint
-from sympy.core.sympify import sympify
-from sympy.ntheory.generate import randprime
-from sympy.core.relational import StrictLessThan, StrictGreaterThan
 import itertools
 
-from sympy.testing.pytest import raises, XFAIL, skip
+from sympy.abc import x, y, z
+from sympy.assumptions.ask import Q
+from sympy.assumptions.cnf import CNF, EncodedCNF
+from sympy.core.numbers import I, Rational, oo
+from sympy.core.random import choice, randint, random
+from sympy.core.relational import Eq, StrictGreaterThan, StrictLessThan
+from sympy.core.singleton import S
+from sympy.core.symbol import symbols
+from sympy.core.sympify import sympify
+from sympy.external import import_module
+from sympy.functions.elementary.trigonometric import cos
+from sympy.logic.algorithms.lra_theory import (
+    HANDLE_NEGATION,
+    LRARational,
+    LRASolver,
+    UnhandledInput,
+)
+from sympy.logic.boolalg import And
+from sympy.matrices.dense import Matrix, randMatrix
+from sympy.ntheory.generate import randprime
+from sympy.testing.pytest import XFAIL, raises, skip
 
-def make_random_problem(num_variables=2, num_constraints=2, sparsity=.1, rational=True,
-                        disable_strict = False, disable_nonstrict=False, disable_equality=False):
+
+def make_random_problem(
+    num_variables=2,
+    num_constraints=2,
+    sparsity=0.1,
+    rational=True,
+    disable_strict=False,
+    disable_nonstrict=False,
+    disable_equality=False,
+):
     def rand(sparsity=sparsity):
         if random() < sparsity:
             return sympify(0)
@@ -32,10 +43,13 @@ def make_random_problem(num_variables=2, num_constraints=2, sparsity=.1, rationa
         else:
             return randint(1, 10) * choice([-1, 1])
 
-    variables = symbols('x1:%s' % (num_variables + 1))
+    variables = symbols("x1:%s" % (num_variables + 1))
     constraints = []
     for _ in range(num_constraints):
-        lhs, rhs = sum(rand() * x for x in variables), rand(sparsity=0) # sparsity=0  bc of bug with smtlib_code
+        lhs, rhs = (
+            sum(rand() * x for x in variables),
+            rand(sparsity=0),
+        )  # sparsity=0  bc of bug with smtlib_code
         options = []
         if not disable_equality:
             options += [Eq(lhs, rhs)]
@@ -48,10 +62,12 @@ def make_random_problem(num_variables=2, num_constraints=2, sparsity=.1, rationa
 
     return constraints
 
+
 def check_if_satisfiable_with_z3(constraints):
     from sympy.external.importtools import import_module
-    from sympy.printing.smtlib import smtlib_code
     from sympy.logic.boolalg import And
+    from sympy.printing.smtlib import smtlib_code
+
     boolean_formula = And(*constraints)
     z3 = import_module("z3")
     if z3:
@@ -59,26 +75,30 @@ def check_if_satisfiable_with_z3(constraints):
         s = z3.Solver()
         s.from_string(smtlib_string)
         res = str(s.check())
-        if res == 'sat':
+        if res == "sat":
             return True
-        elif res == 'unsat':
+        elif res == "unsat":
             return False
         else:
-            raise ValueError(f"z3 was not able to check the satisfiability of {boolean_formula}")
+            raise ValueError(
+                f"z3 was not able to check the satisfiability of {boolean_formula}"
+            )
+
 
 def find_rational_assignment(constr, assignment, iter=20):
     eps = sympify(1)
 
     for _ in range(iter):
-        assign = {key: val[0] + val[1]*eps for key, val in assignment.items()}
+        assign = {key: val[0] + val[1] * eps for key, val in assignment.items()}
         try:
             for cons in constr:
                 assert cons.subs(assign) == True
             return assign
         except AssertionError:
-            eps = eps/2
+            eps = eps / 2
 
     return None
+
 
 def boolean_formula_to_encoded_cnf(bf):
     cnf = CNF.from_prop(bf)
@@ -92,24 +112,33 @@ def test_from_encoded_cnf():
 
     # Test preprocessing
     # Example is from section 3 of paper.
-    phi = (x >= 0) & ((x + y <= 2) | (x + 2 * y - z >= 6)) & (Eq(x + y, 2) | (x + 2 * y - z > 4))
+    phi = (
+        (x >= 0)
+        & ((x + y <= 2) | (x + 2 * y - z >= 6))
+        & (Eq(x + y, 2) | (x + 2 * y - z > 4))
+    )
     enc = boolean_formula_to_encoded_cnf(phi)
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (2, 5)
-    assert str(lra.slack) == '[_s1, _s2]'
-    assert str(lra.nonslack) == '[x, y, z]'
-    assert lra.A == Matrix([[ 1,  1, 0, -1,  0],
-                            [-1, -2, 1,  0, -1]])
-    assert {(str(b.var), b.bound, b.upper, b.equality, b.strict) for b in lra.enc_to_boundary.values()} == {('_s1', 2, None, True, False),
-    ('_s1', 2, True, False, False),
-    ('_s2', -4, True, False, True),
-    ('_s2', -6, True, False, False),
-    ('x', 0, False, False, False)}
+    assert str(lra.slack) == "[_s1, _s2]"
+    assert str(lra.nonslack) == "[x, y, z]"
+    assert lra.A == Matrix([[1, 1, 0, -1, 0], [-1, -2, 1, 0, -1]])
+    assert {
+        (str(b.var), b.bound, b.upper, b.equality, b.strict)
+        for b in lra.enc_to_boundary.values()
+    } == {
+        ("_s1", 2, None, True, False),
+        ("_s1", 2, True, False, False),
+        ("_s2", -4, True, False, True),
+        ("_s2", -6, True, False, False),
+        ("x", 0, False, False, False),
+    }
 
 
 def test_problem():
-    from sympy.logic.algorithms.lra_theory import LRASolver
     from sympy.assumptions.cnf import CNF, EncodedCNF
+    from sympy.logic.algorithms.lra_theory import LRASolver
+
     cons = [-2 * x - 2 * y >= 7, -9 * y >= 7, -6 * y >= 5]
     cnf = CNF().from_prop(And(*cons))
     enc = EncodedCNF()
@@ -127,8 +156,11 @@ def test_random_problems():
     if z3 is None:
         skip("z3 is not installed")
 
-    special_cases = []; x1, x2, x3 = symbols("x1 x2 x3")
-    special_cases.append([x1 - 3 * x2 <= -5, 6 * x1 + 4 * x2 <= 0, -7 * x1 + 3 * x2 <= 3])
+    special_cases = []
+    x1, x2, x3 = symbols("x1 x2 x3")
+    special_cases.append(
+        [x1 - 3 * x2 <= -5, 6 * x1 + 4 * x2 <= 0, -7 * x1 + 3 * x2 <= 3]
+    )
     special_cases.append([-3 * x1 >= 3, Eq(4 * x1, -1)])
     special_cases.append([-4 * x1 < 4, 6 * x1 <= -6])
     special_cases.append([-3 * x2 >= 7, 6 * x1 <= -5, -3 * x2 <= -4])
@@ -136,29 +168,66 @@ def test_random_problems():
     special_cases.append([x >= 0, x + y <= 2, x + 2 * y - z >= 6])  # from paper example
     special_cases.append([-2 * x1 - 2 * x2 >= 7, -9 * x1 >= 7, -6 * x1 >= 5])
     special_cases.append([2 * x1 > -3, -9 * x1 < -6, 9 * x1 <= 6])
-    special_cases.append([-2*x1 < -4, 9*x1 > -9])
-    special_cases.append([-6*x1 >= -1, -8*x1 + x2 >= 5, -8*x1 + 7*x2 < 4, x1 > 7])
-    special_cases.append([Eq(x1, 2), Eq(5*x1, -2), Eq(-7*x2, -6), Eq(9*x1 + 10*x2, 9)])
-    special_cases.append([Eq(3*x1, 6), Eq(x1 - 8*x2, -9), Eq(-7*x1 + 5*x2, 3), Eq(3*x2, 7)])
-    special_cases.append([-4*x1 < 4, 6*x1 <= -6])
-    special_cases.append([-3*x1 + 8*x2 >= -8, -10*x2 > 9, 8*x1 - 4*x2 < 8, 10*x1 - 9*x2 >= -9])
-    special_cases.append([x1 + 5*x2 >= -6, 9*x1 - 3*x2 >= -9, 6*x1 + 6*x2 < -10, -3*x1 + 3*x2 < -7])
-    special_cases.append([-9*x1 < 7, -5*x1 - 7*x2 < -1, 3*x1 + 7*x2 > 1, -6*x1 - 6*x2 > 9])
-    special_cases.append([9*x1 - 6*x2 >= -7, 9*x1 + 4*x2 < -8, -7*x2 <= 1, 10*x2 <= -7])
+    special_cases.append([-2 * x1 < -4, 9 * x1 > -9])
+    special_cases.append(
+        [-6 * x1 >= -1, -8 * x1 + x2 >= 5, -8 * x1 + 7 * x2 < 4, x1 > 7]
+    )
+    special_cases.append(
+        [Eq(x1, 2), Eq(5 * x1, -2), Eq(-7 * x2, -6), Eq(9 * x1 + 10 * x2, 9)]
+    )
+    special_cases.append(
+        [Eq(3 * x1, 6), Eq(x1 - 8 * x2, -9), Eq(-7 * x1 + 5 * x2, 3), Eq(3 * x2, 7)]
+    )
+    special_cases.append([-4 * x1 < 4, 6 * x1 <= -6])
+    special_cases.append(
+        [
+            -3 * x1 + 8 * x2 >= -8,
+            -10 * x2 > 9,
+            8 * x1 - 4 * x2 < 8,
+            10 * x1 - 9 * x2 >= -9,
+        ]
+    )
+    special_cases.append(
+        [
+            x1 + 5 * x2 >= -6,
+            9 * x1 - 3 * x2 >= -9,
+            6 * x1 + 6 * x2 < -10,
+            -3 * x1 + 3 * x2 < -7,
+        ]
+    )
+    special_cases.append(
+        [-9 * x1 < 7, -5 * x1 - 7 * x2 < -1, 3 * x1 + 7 * x2 > 1, -6 * x1 - 6 * x2 > 9]
+    )
+    special_cases.append(
+        [9 * x1 - 6 * x2 >= -7, 9 * x1 + 4 * x2 < -8, -7 * x2 <= 1, 10 * x2 <= -7]
+    )
 
     feasible_count = 0
     for i in range(50):
         if i % 8 == 0:
-            constraints = make_random_problem(num_variables=1, num_constraints=2, rational=False)
+            constraints = make_random_problem(
+                num_variables=1, num_constraints=2, rational=False
+            )
         elif i % 8 == 1:
-            constraints = make_random_problem(num_variables=2, num_constraints=4, rational=False, disable_equality=True,
-                                              disable_nonstrict=True)
+            constraints = make_random_problem(
+                num_variables=2,
+                num_constraints=4,
+                rational=False,
+                disable_equality=True,
+                disable_nonstrict=True,
+            )
         elif i % 8 == 2:
-            constraints = make_random_problem(num_variables=2, num_constraints=4, rational=False, disable_strict=True)
+            constraints = make_random_problem(
+                num_variables=2, num_constraints=4, rational=False, disable_strict=True
+            )
         elif i % 8 == 3:
-            constraints = make_random_problem(num_variables=3, num_constraints=12, rational=False)
+            constraints = make_random_problem(
+                num_variables=3, num_constraints=12, rational=False
+            )
         else:
-            constraints = make_random_problem(num_variables=3, num_constraints=6, rational=False)
+            constraints = make_random_problem(
+                num_variables=3, num_constraints=6, rational=False
+            )
 
         if i < len(special_cases):
             constraints = special_cases[i]
@@ -169,7 +238,8 @@ def test_random_problems():
         phi = And(*constraints)
         if phi == False:
             continue
-        cnf = CNF.from_prop(phi); enc = EncodedCNF()
+        cnf = CNF.from_prop(phi)
+        enc = EncodedCNF()
         enc.from_cnf(cnf)
         assert all(0 not in clause for clause in enc.data)
 
@@ -181,7 +251,9 @@ def test_random_problems():
         lits = {lit for clause in enc.data for lit in clause}
 
         bounds = [(lra.enc_to_boundary[l], l) for l in lits if l in lra.enc_to_boundary]
-        bounds = sorted(bounds, key=lambda x: (str(x[0].var), x[0].bound, str(x[0].upper))) # to remove nondeterminism
+        bounds = sorted(
+            bounds, key=lambda x: (str(x[0].var), x[0].bound, str(x[0].upper))
+        )  # to remove nondeterminism
 
         for b, l in bounds:
             if lra.result and lra.result[0] == False:
@@ -195,7 +267,7 @@ def test_random_problems():
             assert check_if_satisfiable_with_z3(constraints) is True
             cons_funcs = [cons.func for cons in constraints]
             assignment = feasible[1]
-            assignment = {key.var : value for key, value in assignment.items()}
+            assignment = {key.var: value for key, value in assignment.items()}
             if not (StrictLessThan in cons_funcs or StrictGreaterThan in cons_funcs):
                 assignment = {key: value[0] for key, value in assignment.items()}
                 for cons in constraints:
@@ -214,7 +286,7 @@ def test_random_problems():
             assert check_if_satisfiable_with_z3(conflict) is False
 
             # check that conflict clause is probably minimal
-            for subset in itertools.combinations(conflict, len(conflict)-1):
+            for subset in itertools.combinations(conflict, len(conflict) - 1):
                 assert check_if_satisfiable_with_z3(subset) is True
 
 
@@ -340,7 +412,7 @@ def test_negation():
     assert len(lra.enc_to_boundary) == 2
     assert lra.check()[0] == False
 
-    bf = ~Q.le(x+y, 2) & ~Q.ge(x-y, 2) & ~Q.ge(y, 0)
+    bf = ~Q.le(x + y, 2) & ~Q.ge(x - y, 2) & ~Q.ge(y, 0)
     enc = boolean_formula_to_encoded_cnf(bf)
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     for clause in enc.data:
@@ -432,13 +504,13 @@ def test_reset_bounds():
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
 
     state_variables = [
-        ('lower', LRARational(10, 0), LRARational(-float("inf"), 0)),
-        ('upper', LRARational(10, 0), LRARational(float("inf"), 0)),
-        ('lower_from_eq', True, False),
-        ('lower_from_neg', True, False),
-        ('upper_from_eq', True, False),
-        ('upper_from_neg', True, False),
-        ('assign', LRARational(10, 0), LRARational(0, 0))
+        ("lower", LRARational(10, 0), LRARational(-float("inf"), 0)),
+        ("upper", LRARational(10, 0), LRARational(float("inf"), 0)),
+        ("lower_from_eq", True, False),
+        ("lower_from_neg", True, False),
+        ("upper_from_eq", True, False),
+        ("upper_from_neg", True, False),
+        ("assign", LRARational(10, 0), LRARational(0, 0)),
     ]
 
     for attr_name, test_value, expected_reset_value in state_variables:
@@ -449,8 +521,9 @@ def test_reset_bounds():
 
         for var in lra.all_var:
             actual_value = getattr(var, attr_name)
-            assert actual_value == expected_reset_value, \
+            assert actual_value == expected_reset_value, (
                 f"Failed to reset {attr_name}: expected {expected_reset_value}, got {actual_value}"
+            )
 
 
 def test_empty_cnf():
@@ -460,3 +533,38 @@ def test_empty_cnf():
     lra, conflict = LRASolver.from_encoded_cnf(enc)
     assert len(conflict) == 0
     assert lra.check() == (True, {})
+
+
+def test_conflict_uses_correct_literals():
+    phi = Q.ge(x, 1) & Q.ge(y, 1) & Q.le(x + y, 1)
+    cnf = CNF.from_prop(phi)
+    enc = EncodedCNF()
+    enc.from_cnf(cnf)
+
+    lra, _ = LRASolver.from_encoded_cnf(enc)
+
+    lx = enc.encoding[Q.ge(x, 1)]
+    ly = enc.encoding[Q.ge(y, 1)]
+    ls = enc.encoding[Q.le(x + y, 1)]
+
+    # Add a redundant literal for one of the boundaries to test tracking
+    redundant_lit = 100
+    lra.enc_to_boundary[redundant_lit] = lra.enc_to_boundary[lx]
+    lra.boundary_to_enc[lra.enc_to_boundary[lx]] = redundant_lit
+
+    lra.assert_lit(lx)
+    lra.assert_lit(ly)
+    res = lra.assert_lit(ls)
+
+    if res is None:
+        res = lra.check()
+
+    assert res[0] == False
+    conflict = res[1]
+
+    # We asserted lx, ly, ls. The conflict must contain the literals we actually used.
+    assert -lx in conflict
+    assert -ly in conflict
+    assert -ls in conflict
+    # It should NOT contain the redundant literal that was not asserted.
+    assert -redundant_lit not in conflict


### PR DESCRIPTION
Previously, when two literals had the same encoding (they represented the same constraint), conflict clauses were generated incorrectly. When generating a conflict clause, the code had no way of tracking which of the literals was asserted. It would just use the last literal added to the `self.boundary_to_enc` dictionary. This resulted in a bug where a tautology like {-1, 1} could be given as a conflict clause. 

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Code was entirely AI generated (including commit message) by Gemini CLI.  The bug this fixes was found using a test file written by zed IDE's AI features using Claude Sonnet 4.5. PR description is entirely human written. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
