### PR TITLE
Preserve autograd for torch lambdify Matrix outputs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1608,6 +1608,8 @@ Tanu Hari Dixit <tokencolour@gmail.com>
 Tarang Patel <tarangrockr@gmail.com> <tarang@ubuntu.ubuntu-domain>
 Tarun Gaba <tarun.gaba7@gmail.com>
 Tasha Kim <jae_young_kim@brown.edu>
+Tatsuya Mori <tatsuya.mori@turing-motors.com> tmori <tatsuya.mori@turing-motors.com>
+Tatsuya Mori <tatsuya.mori@turing-motors.com> tmparticle <33801591+tmparticle@users.noreply.github.com>
 Taylan Sahin <info@taylansahin.net>
 Ted Dokos <tdokos@gmail.com> <t.dokos@gmail.com>
 Ted Horst <ted.horst@earthlink.net>

--- a/sympy/printing/pytorch.py
+++ b/sympy/printing/pytorch.py
@@ -14,6 +14,29 @@ import sympy
 torch = import_module('torch')
 
 
+def _torch_tensor(data, *, dtype=None, requires_grad=False):
+    """Build nested torch tensors without detaching existing tensor leaves.
+
+    ``torch.tensor([...])`` reconstructs tensors from values and severs autograd
+    history when elements already require grad. This helper preserves tensor
+    leaves by recursively combining them with ``torch.stack`` while still
+    materializing scalar constants as tensors.
+    """
+
+    if isinstance(data, (list, tuple)):
+        return torch.stack([
+            _torch_tensor(item, dtype=dtype, requires_grad=requires_grad)
+            for item in data
+        ])
+
+    if isinstance(data, torch.Tensor):
+        if dtype is not None and data.dtype != dtype:
+            return data.to(dtype=dtype)
+        return data
+
+    return torch.tensor(data, dtype=dtype, requires_grad=requires_grad)
+
+
 class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
 
     printmethod = "_torchcode"
@@ -229,7 +252,7 @@ class TorchPrinter(ArrayPrinter, AbstractPythonCodePrinter):
             params.append("requires_grad=True")
 
         return "{}({})".format(
-            self._module_format("torch.tensor"),
+            "_torch_tensor",
             ", ".join(params)
         )
 

--- a/sympy/printing/tests/test_torch.py
+++ b/sympy/printing/tests/test_torch.py
@@ -394,6 +394,24 @@ def test_requires_grad():
     assert abs(y_val.grad.item() - float(-sin(2.0).evalf())) < 1e-6
 
 
+def test_matrix_lambdify_preserves_autograd_graph():
+    if not torch:
+        skip("PyTorch not installed")
+
+    expr = Matrix([[x, sin(y)], [1, 2]])
+    f = lambdify([x, y], expr, 'torch')
+
+    x_val = torch.tensor(1.0, dtype=torch.float64, requires_grad=True)
+    y_val = torch.tensor(2.0, dtype=torch.float64, requires_grad=True)
+    result = f(x_val, y_val)
+
+    assert result.requires_grad
+    result.sum().backward()
+
+    assert abs(x_val.grad.item() - 1.0) < 1e-6
+    assert abs(y_val.grad.item() - float(cos(2.0).evalf())) < 1e-6
+
+
 def test_torch_multi_variable_derivatives():
     if not torch:
         skip("PyTorch not installed")

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -138,7 +138,7 @@ MODULES = {
     "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "jax": (JAX, JAX_DEFAULT, JAX_TRANSLATIONS, ("import jax",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
-    "torch": (TORCH, TORCH_DEFAULT, TORCH_TRANSLATIONS, ("import torch",)),
+    "torch": (TORCH, TORCH_DEFAULT, TORCH_TRANSLATIONS, ("import torch", "from sympy.printing.pytorch import _torch_tensor")),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",
         "from sympy.matrices import *",


### PR DESCRIPTION
## Summary

Preserve autograd connectivity for explicit matrix outputs in `lambdify(..., "torch")`.

## What changed

- Add `_torch_tensor(...)` in `sympy.printing.pytorch`
- Use `_torch_tensor(...)` instead of `torch.tensor(...)` in `_print_MatrixBase`
- Import `_torch_tensor` into the `"torch"` lambdify namespace
- Add a regression test showing that a matrix-valued lambdified function keeps gradients flowing

## Why

`torch.tensor([...])` reconstructs tensors from values. If any matrix entry is already a tensor that requires grad, the resulting matrix loses its autograd graph.

Using recursive `torch.stack(...)` preserves existing tensor leaves while still handling scalar constants cleanly.

## Reproducer

```python
import torch
from sympy import Matrix, symbols, sin
from sympy.utilities.lambdify import lambdify

x, y = symbols("x y")
expr = Matrix([[x, sin(y)], [1, 2]])
f = lambdify([x, y], expr, "torch")

x_val = torch.tensor(1.0, dtype=torch.float64, requires_grad=True)
y_val = torch.tensor(2.0, dtype=torch.float64, requires_grad=True)
result = f(x_val, y_val)
result.sum().backward()
```

After this patch, `result.requires_grad` is true and gradients flow back to both inputs.

## Validation

- Minimal local reproducer:
  - `result.requires_grad == True`
  - `result.grad_fn` is `StackBackward0`
  - `x_val.grad == 1.0`
  - `y_val.grad == cos(2.0)`
- Targeted pytest:
  - `MPLCONFIGDIR=/tmp/mpl PYTHONPATH=/tmp/sympy-test-deps:/tmp/sympy-torch-stack-pr /Users/tmori/work/tmpmono/.venv/bin/python -m pytest sympy/printing/tests/test_torch.py -q`
  - `16 passed in 1.06s`

#### AI Generation Disclosure

OpenAI Codex assisted with drafting the patch and PR text. The code changes were reviewed and validated locally before submission.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* printing
  * Fixed `lambdify(..., "torch")` so matrix-valued outputs preserve PyTorch autograd connectivity.

<!-- END RELEASE NOTES -->

Closes #29464
