### PR TITLE
Printing: Fix LaTeX printer for sets.ordinals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -429,6 +429,7 @@ Ben Oostendorp <oostben@umich.edu> oostben <oostben@umich.edu>
 Ben Payne <ben.is.located@gmail.com> Ben <ben.is.located@gmail.com>
 Bendik Samseth <b.samseth@gmail.com>
 Benedikt Placke <benedikt.placke@outlook.com>
+Benjamin Dolata <bendolata2@gmail.com> MajesticSlacks <bendolata2@gmail.com>
 Benjamin Fishbein <fishbeinb@gmail.com>
 Benjamin Gudehus <hastebrot@gmail.com>
 Benjamin McDonald <mcdonald.ben@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2543,14 +2543,16 @@ class LatexPrinter(Printer):
 
     def _print_OmegaPower(self, expr):
         exp, mul = expr.args
+        if exp == 0:
+            return f"{mul}"
         if mul != 1:
             if exp != 1:
-                return r"{} \omega^{{{}}}".format(mul, exp)
+                return r"\omega^{{{}}} {}".format(self._print(exp), mul)
             else:
-                return r"{} \omega".format(mul)
+                return r"\omega {}".format(mul)
         else:
             if exp != 1:
-                return r"\omega^{{{}}}".format(exp)
+                return r"\omega^{{{}}}".format(self._print(exp))
             else:
                 return r"\omega"
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1202,9 +1202,11 @@ def test_latex_ordinals():
     w = OrdinalOmega()
     assert latex(w) == r"\omega"
     wp = OmegaPower(2, 3)
-    assert latex(wp) == r'3 \omega^{2}'
-    assert latex(Ordinal(wp, OmegaPower(1, 1))) == r'3 \omega^{2} + \omega'
-    assert latex(Ordinal(OmegaPower(2, 1), OmegaPower(1, 2))) == r'\omega^{2} + 2 \omega'
+    assert latex(wp) == r'\omega^{2} 3'
+    assert latex(Ordinal(wp, OmegaPower(1, 1))) == r'\omega^{2} 3 + \omega'
+    assert latex(Ordinal(OmegaPower(2, 1), OmegaPower(1, 2))) == r'\omega^{2} + \omega 2'
+    assert latex(w**(w + 1) + 1) == r'\omega^{\omega + 1} + 1'
+    assert latex(OmegaPower(0,1)) == '1'
 
 
 def test_set_operators_parenthesis():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29473

#### Brief description of what is fixed or changed
Fix LaTeX printer for `sets.ordinals` to respect non-commutativity of ordinal multiplication, correctly display power towers of ordinal exponentials, and to simplify the display finite ordinals.

#### Other comments
Relevant tests have also been added.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug with the LaTeX printer for ordinals. Previously, `omega*2` incorrectly printed as `2 \omega`.
<!-- END RELEASE NOTES -->
