### PR TITLE
Remove math and numpy imports from autolev parser

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+Rashmi Ranjan Mohapatra <golu993857@gmail.com>

--- a/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
+++ b/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
@@ -87,7 +87,7 @@ The parser can be used as follows::
     >>> print(sympy_code)
     import sympy.physics.mechanics as me
     import sympy as sm
-    import math as m
+    
     import numpy as np
 
     q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')

--- a/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
+++ b/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
@@ -87,7 +87,7 @@ The parser can be used as follows::
     >>> print(sympy_code)
     import sympy.physics.mechanics as me
     import sympy as sm
-    
+  
     import numpy as np
 
     q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')

--- a/sympy/parsing/autolev/__init__.py
+++ b/sympy/parsing/autolev/__init__.py
@@ -50,8 +50,8 @@ def parse_autolev(autolev_code, include_numeric=False):
     >>> print(parse_autolev(my_al_text, include_numeric=True))
     import sympy.physics.mechanics as _me
     import sympy as _sm
-    
-     
+
+
     <BLANKLINE>
     q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')
     q1_d, q2_d, u1_d, u2_d = _me.dynamicsymbols('q1_ q2_ u1_ u2_', 1)

--- a/sympy/parsing/autolev/__init__.py
+++ b/sympy/parsing/autolev/__init__.py
@@ -50,8 +50,8 @@ def parse_autolev(autolev_code, include_numeric=False):
     >>> print(parse_autolev(my_al_text, include_numeric=True))
     import sympy.physics.mechanics as _me
     import sympy as _sm
-    import math as m
-    import numpy as _np
+    
+     
     <BLANKLINE>
     q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')
     q1_d, q2_d, u1_d, u2_d = _me.dynamicsymbols('q1_ q2_ u1_ u2_', 1)

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -441,7 +441,6 @@ if AutolevListener:
             # Write code to import common dependencies.
             self.output_code.append("import sympy.physics.mechanics as _me\n")
             self.output_code.append("import sympy as _sm\n")
-            
             self.output_code.append("\n")
 
             # Just a store for the max degree variable in a line.

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -441,8 +441,7 @@ if AutolevListener:
             # Write code to import common dependencies.
             self.output_code.append("import sympy.physics.mechanics as _me\n")
             self.output_code.append("import sympy as _sm\n")
-            self.output_code.append("import math as m\n")
-            self.output_code.append("import numpy as _np\n")
+            
             self.output_code.append("\n")
 
             # Just a store for the max degree variable in a line.

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 g, lb, w, h = _sm.symbols('g lb w h', real=True)
 theta, phi, omega, alpha = _me.dynamicsymbols('theta phi omega alpha')

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')
 q1_d, q2_d, u1_d, u2_d = _me.dynamicsymbols('q1_ q2_ u1_ u2_', 1)

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 m, k, b, g = _sm.symbols('m k b g', real=True)
 position, speed = _me.dynamicsymbols('position speed')

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 q1, q2 = _me.dynamicsymbols('q1 q2')
 q1_d, q2_d = _me.dynamicsymbols('q1_ q2_', 1)

--- a/sympy/parsing/autolev/test-examples/ruletest1.py
+++ b/sympy/parsing/autolev/test-examples/ruletest1.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 f = _sm.S(3)
 g = _sm.S(9.81)

--- a/sympy/parsing/autolev/test-examples/ruletest10.py
+++ b/sympy/parsing/autolev/test-examples/ruletest10.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')
 a, b = _sm.symbols('a b', real=True)

--- a/sympy/parsing/autolev/test-examples/ruletest11.py
+++ b/sympy/parsing/autolev/test-examples/ruletest11.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')
 a11, a12, a21, a22, b1, b2 = _sm.symbols('a11 a12 a21 a22 b1 b2', real=True)

--- a/sympy/parsing/autolev/test-examples/ruletest12.py
+++ b/sympy/parsing/autolev/test-examples/ruletest12.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')
 a, b, r = _sm.symbols('a b r', real=True)

--- a/sympy/parsing/autolev/test-examples/ruletest2.py
+++ b/sympy/parsing/autolev/test-examples/ruletest2.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 x1, x2 = _me.dynamicsymbols('x1 x2')
 f1 = x1*x2+3*x1**2

--- a/sympy/parsing/autolev/test-examples/ruletest3.py
+++ b/sympy/parsing/autolev/test-examples/ruletest3.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 frame_a = _me.ReferenceFrame('a')
 frame_b = _me.ReferenceFrame('b')

--- a/sympy/parsing/autolev/test-examples/ruletest4.py
+++ b/sympy/parsing/autolev/test-examples/ruletest4.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 frame_a = _me.ReferenceFrame('a')
 frame_b = _me.ReferenceFrame('b')

--- a/sympy/parsing/autolev/test-examples/ruletest5.py
+++ b/sympy/parsing/autolev/test-examples/ruletest5.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')
 x_d, y_d = _me.dynamicsymbols('x_ y_', 1)

--- a/sympy/parsing/autolev/test-examples/ruletest6.py
+++ b/sympy/parsing/autolev/test-examples/ruletest6.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 q1, q2 = _me.dynamicsymbols('q1 q2')
 x, y, z = _me.dynamicsymbols('x y z')

--- a/sympy/parsing/autolev/test-examples/ruletest7.py
+++ b/sympy/parsing/autolev/test-examples/ruletest7.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')
 x_d, y_d = _me.dynamicsymbols('x_ y_', 1)

--- a/sympy/parsing/autolev/test-examples/ruletest8.py
+++ b/sympy/parsing/autolev/test-examples/ruletest8.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 frame_a = _me.ReferenceFrame('a')
 c1, c2, c3 = _sm.symbols('c1 c2 c3', real=True)

--- a/sympy/parsing/autolev/test-examples/ruletest9.py
+++ b/sympy/parsing/autolev/test-examples/ruletest9.py
@@ -1,7 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
-import numpy as _np
 
 frame_n = _me.ReferenceFrame('n')
 frame_a = _me.ReferenceFrame('a')


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #15186

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The autolev parser was unnecessarily adding import math as m and import numpy as _np to the generated output. I removed these append lines from _listener_autolev_antlr.py. I also removed these imports from the expected output files in the test-examples directory so the tests sync up.

#### Other comments
I ran bin/test sympy/parsing/tests/test_autolev.py locally on macOS and all 5 tests pass successfully.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Removed unnecessary math and numpy imports from the autolev parser output.
<!-- END RELEASE NOTES -->
