### PR TITLE
Optimise degree() function using postorder traversal on input expression

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -668,6 +668,7 @@ Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
 G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>
+Gabriela Stancu <gabstancu@outlook.com>
 Gaetano Guerriero <x.guerriero@tin.it>
 Gagan Mishra <simonsimple305@gmail.com> Gagan Mishra <70949548+GaganMishra305@users.noreply.github.com>
 Gagandeep Singh <Gmadaan450@gmail.com> Gagandeep61 <gmadaan450@gmail.com>
@@ -1886,4 +1887,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Gabriela Stancu <gabstancu@outlook.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1886,3 +1886,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Gabriela Stancu <gabstancu@outlook.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,4 +1457,3 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
-Gabriela Stancu <gabstancu@outlook.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+Gabriela Stancu <gabstancu@outlook.com>

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2,28 +2,29 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload, Literal, Any, cast, Callable
-
-from functools import wraps, reduce
-from operator import mul
 from collections import Counter, defaultdict
+from functools import reduce, wraps
+from operator import mul
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast, overload
 
-from sympy.core import (
-    S, Expr, Add, Tuple
-)
+# Required to avoid errors
+import sympy.polys
+from sympy import postorder_traversal
+from sympy.core import Add, Expr, S, Tuple
 from sympy.core.basic import Basic
 from sympy.core.decorators import _sympifyit
-from sympy.core.exprtools import Factors, factor_nc, factor_terms
 from sympy.core.evalf import (
-    pure_complex, evalf, fastlog, _evalf_with_bounded_error, quad_to_mpmath)
+    _evalf_with_bounded_error, evalf, fastlog, pure_complex, quad_to_mpmath)
+from sympy.core.exprtools import Factors, factor_nc, factor_terms
 from sympy.core.function import Derivative
-from sympy.core.mul import Mul, _keep_coeff
 from sympy.core.intfunc import ilcm
-from sympy.core.numbers import I, Integer, equal_valued, NegativeInfinity
-from sympy.core.relational import Relational, Equality
+from sympy.core.mul import Mul, _keep_coeff
+from sympy.core.numbers import I, Integer, NegativeInfinity, equal_valued
+from sympy.core.relational import Equality, Relational
 from sympy.core.symbol import Dummy, Symbol
-from sympy.core.sympify import sympify, _sympify
-from sympy.core.traversal import preorder_traversal, bottom_up
+from sympy.core.sympify import _sympify, sympify
+from sympy.core.traversal import bottom_up, preorder_traversal
+from sympy.external.mpmath import NoConvergence, local_workdps
 from sympy.logic.boolalg import BooleanAtom
 from sympy.polys import polyoptions as options
 from sympy.polys.constructor import construct_domain
@@ -33,40 +34,26 @@ from sympy.polys.fglmtools import matrix_fglm
 from sympy.polys.groebnertools import groebner as _groebner
 from sympy.polys.monomials import Monomial
 from sympy.polys.orderings import monomial_key
-from sympy.polys.polyclasses import DMP, DMF, ANP
+from sympy.polys.polyclasses import ANP, DMF, DMP
 from sympy.polys.polyerrors import (
-    OperationNotSupported, DomainError,
-    CoercionFailed, UnificationFailed,
-    GeneratorsNeeded, PolynomialError,
-    MultivariatePolynomialError,
-    ExactQuotientFailed,
-    PolificationFailed,
-    ComputationFailed,
-    GeneratorsError,
-)
+    CoercionFailed, ComputationFailed, DomainError, ExactQuotientFailed,
+    GeneratorsError, GeneratorsNeeded, MultivariatePolynomialError,
+    OperationNotSupported, PolificationFailed, PolynomialError,
+    UnificationFailed)
 from sympy.polys.polyutils import (
-    basic_from_dict,
-    _sort_gens,
-    _unify_gens,
-    _dict_reorder,
-    _dict_from_expr,
-    _parallel_dict_from_expr,
-)
+    _dict_from_expr, _dict_reorder, _parallel_dict_from_expr, _sort_gens,
+    _unify_gens, basic_from_dict)
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import dup_isolate_real_roots_list
-from sympy.utilities import group, public, filldedent
+from sympy.utilities import filldedent, group, public
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable, sift
 
-# Required to avoid errors
-import sympy.polys
-from sympy.external.mpmath import local_workdps, NoConvergence
-
-
 if TYPE_CHECKING:
-    from sympy.polys.domains.domain import Domain
     from collections.abc import Iterator
     from typing import Self
+
+    from sympy.polys.domains.domain import Domain
 
 
 def _polifyit(func):
@@ -4155,8 +4142,7 @@ class Poly(Basic):
         from sympy.polys.numberfields.galoisgroups import (
             _galois_group_degree_3, _galois_group_degree_4_lookup,
             _galois_group_degree_5_lookup_ext_factor,
-            _galois_group_degree_6_lookup,
-        )
+            _galois_group_degree_6_lookup)
         if (not f.is_univariate
             or not f.is_irreducible
             or f.domain not in [ZZ, QQ]
@@ -4913,27 +4899,26 @@ def _update_args(args, key, value):
     return args
 
 
-from sympy import postorder_traversal
-
-def __degree_it (f, gen):
-    
-    def _mul_profiles (dict_1, dict_2): 
+def __degree_it(f, gen):
+    def _mul_profiles(profile_1, profile_2):
         result = {}
-        for k, v in dict_1.items():
-            for k_, v_ in dict_2.items():
-                result[k + k_] = result.get(k + k_, 0) + v * v_
 
-                if result[k + k_] == 0:
-                    del result[k + k_]
+        for deg_1, coeff_1 in profile_1.items():
+            for deg_2, coeff_2 in profile_2.items():
+                result[deg_1 + deg_2] = (
+                    result.get(deg_1 + deg_2, 0) + coeff_1 * coeff_2
+                )
+
+                if result[deg_1 + deg_2] == 0:
+                    del result[deg_1 + deg_2]
 
         return result
 
-
-    def _add_profiles (dict_1, dict_2):
-        result            = dict(dict_1)
+    def _add_profiles(profile_1, profile_2):
+        result = dict(profile_1)
         cancellation_flag = False
 
-        for deg, coeff in dict_2.items():
+        for deg, coeff in profile_2.items():
             result[deg] = result.get(deg, 0) + coeff
 
             if result[deg] == 0:
@@ -4942,69 +4927,70 @@ def __degree_it (f, gen):
 
         return result, cancellation_flag
 
-
-    def _pow_profile (dict_, exponent, cutoff=550):
+    def _pow_profile(profile, exponent, cutoff=550):
         if exponent == 0:
-            return {0 : 1}
+            return {0: 1}
         elif exponent == 1:
-            return dict_
+            return profile
 
         if exponent > cutoff:
             result = {}
-            for deg, coeff in dict_.items():
-                k, v = deg*exponent, coeff**exponent
-                result[k] = result.get(k, 0) + v
-            return result
-        else:
-            result = {0 : 1}
-            for _ in range(int(exponent)):
-                result = _mul_profiles(result, dict_)
+
+            for deg, coeff in profile.items():
+                new_deg, new_coeff = deg * exponent, coeff**exponent
+                result[new_deg] = result.get(new_deg, 0) + new_coeff
+
             return result
 
-    f   = sympify(f)
+        result = {0: 1}
+        for _ in range(int(exponent)):
+            result = _mul_profiles(result, profile)
+
+        return result
+
+    f = sympify(f)
     gen = sympify(gen)
 
     if isinstance(f, Poly):
         f = f.as_expr()
 
-    profiles_stack    = []
+    profiles_stack = []
 
     for expr in postorder_traversal(f):
-
         if expr == 0:
             profiles_stack.append({})
 
         elif not expr.has(gen):
-            profile = {0 : expr}
+            profile = {0: expr}
             profiles_stack.append(profile)
 
         elif expr == gen:
-            profile = {1 : 1}
+            profile = {1: 1}
             profiles_stack.append(profile)
 
-        # stack "unfolding" cases 
         elif expr.is_Mul:
             num_factors = len(expr.args)
-            parts       = profiles_stack[-num_factors:]
+            parts = profiles_stack[-num_factors:]
 
-            total = {0 : 1}
+            total = {0: 1}
             for p in parts:
                 total = _mul_profiles(total, p)
 
             del profiles_stack[-num_factors:]
             del parts
-
             profiles_stack.append(total)
 
         elif expr.is_Add:
             num_terms = len(expr.args)
-            part      = profiles_stack[-num_terms:]
-            final = {}
+            part = profiles_stack[-num_terms:]
 
             for i in range(0, len(part)):
                 if i + 1 == len(part):
                     break
-                part[i+1], cancellation_flag = _add_profiles(part[i], part[i+1])
+
+                part[i + 1], cancellation_flag = (
+                    _add_profiles(part[i], part[i + 1])
+                )
 
                 if cancellation_flag:
                     return None
@@ -5013,12 +4999,11 @@ def __degree_it (f, gen):
 
             del profiles_stack[-num_terms:]
             del part
-
             profiles_stack.append(final)
 
         elif expr.is_Pow:
-            exponent_profile    = profiles_stack.pop()
-            base_profile        = profiles_stack.pop()
+            exponent_profile = profiles_stack.pop()
+            base_profile = profiles_stack.pop()
 
             if len(exponent_profile) != 1 or 0 not in exponent_profile:
                 return None
@@ -5029,6 +5014,7 @@ def __degree_it (f, gen):
                 return None
 
             profiles_stack.append(_pow_profile(base_profile, int(exponent)))
+
         else:
             return None
 
@@ -7837,8 +7823,8 @@ def cancel(f, *gens, _signsimp=True, **args):
     >>> together(_)
     (x + 2)/2
     """
-    from sympy.simplify.simplify import signsimp
     from sympy.polys.rings import sring
+    from sympy.simplify.simplify import signsimp
     options.allowed_flags(args, ['polys'])
 
     f = sympify(f)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4926,15 +4926,17 @@ def _mul_profiles (dict_1, dict_2): # add keys, multiply values
 
 
 def _add_profiles (dict_1, dict_2): # keep keys the same, add values
-    result = dict(dict_1)
+    result            = dict(dict_1)
+    cancellation_flag = False
     
     for deg, coeff in dict_2.items():
         result[deg] = result.get(deg, 0) + coeff
         
         if result[deg] == 0:
+            cancellation_flag = True
             del result[deg]
             
-    return result
+    return result, cancellation_flag
 
 
 def _pow_profile (dict_, exponent):
@@ -4959,12 +4961,12 @@ def __degree_it (f, gen):
     if isinstance(f, Poly):
         f = f.as_expr()
     
-    profiles_stack = []
+    profiles_stack    = []
     
     for expr in postorder_traversal(f):
         
         if expr == 0:
-            return S.NegativeInfinity
+            profiles_stack.append({})
         
         elif not expr.has(gen): 
             profile = {0 : expr}
@@ -4996,7 +4998,10 @@ def __degree_it (f, gen):
             for i in range(0, len(part)):
                 if i + 1 == len(part):
                     break
-                part[i+1] = _add_profiles(part[i], part[i+1])
+                part[i+1], cancellation_flag = _add_profiles(part[i], part[i+1])
+                
+                if cancellation_flag:
+                    return None
                 
             final = part[-1]
             
@@ -5015,7 +5020,7 @@ def __degree_it (f, gen):
             exponent = exponent_profile[0]
 
             if not exponent.is_Integer or not exponent.is_nonnegative:
-                return None
+                return None 
             
             profiles_stack.append(_pow_profile(base_profile, int(exponent)))
         else:
@@ -5112,7 +5117,7 @@ def degree(f, gen=0):
     
     if not isinstance(f, Poly) or gen not in f.gens:
         d = __degree_it(f, gen)
-        if d == S.NegativeInfinity or d == None or d == 0:
+        if d == None:
             f = poly_from_expr(f, gen)[0]
             return _degree(f.degree(gen))
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4916,11 +4916,11 @@ def _update_args(args, key, value):
 def _mul_profiles (dict_1, dict_2): # add keys, multiply values
     result = {}
     for k, v in dict_1.items():
-         for k_, v_ in dict_2.items():
-             result[k + k_] = result.get(k + k_, 0) + v * v_
+        for k_, v_ in dict_2.items():
+            result[k + k_] = result.get(k + k_, 0) + v * v_
              
-             if result[k + k_] == 0:
-                 del result[k + k_]
+            if result[k + k_] == 0:
+                del result[k + k_]
     
     return result
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4939,7 +4939,7 @@ def _add_profiles (dict_1, dict_2): # keep keys the same, add values
     return result, cancellation_flag
 
 
-def _pow_profile (dict_, exponent, cutoff=50):
+def _pow_profile (dict_, exponent, cutoff=550):
     
     if exponent == 0:
         return {0 : 1}

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4913,6 +4913,125 @@ def _update_args(args, key, value):
     return args
 
 
+def _mul_profiles (dict_1, dict_2): # add keys, multiply values
+    result = {}
+    for k, v in dict_1.items():
+         for k_, v_ in dict_2.items():
+             result[k + k_] = result.get(k + k_, 0) + v * v_
+             
+             if result[k + k_] == 0:
+                 del result[k + k_]
+    
+    return result
+
+
+def _add_profiles (dict_1, dict_2): # keep keys the same, add values
+    result = dict(dict_1)
+    
+    for deg, coeff in dict_2.items():
+        result[deg] = result.get(deg, 0) + coeff
+        
+        if result[deg] == 0:
+            del result[deg]
+            
+    return result
+
+
+def _pow_profile (dict_, exponent):
+    
+    if exponent == 0:
+        return {0 : 1}
+    
+    result = {}
+    for deg, coeff in dict_.items():
+        k, v = deg*exponent, coeff**exponent
+        result[k] = result.get(k, 0) + v
+        
+    return result
+
+from sympy import postorder_traversal
+
+def __degree_it (f, gen):
+    
+    f   = sympify(f)
+    gen = sympify(gen)
+    
+    if isinstance(f, Poly):
+        f = f.as_expr()
+    
+    profiles_stack = []
+    
+    for expr in postorder_traversal(f):
+        
+        if expr == 0:
+            return S.NegativeInfinity
+        
+        elif not expr.has(gen): 
+            profile = {0 : expr}
+            profiles_stack.append(profile)
+        
+        elif expr == gen: 
+            profile = {1 : 1}
+            profiles_stack.append(profile)
+            
+        # stack "unfolding" cases
+        elif expr.is_Mul:
+            num_factors = len(expr.args)
+            parts       = profiles_stack[-num_factors:]
+            
+            total = {0 : 1}
+            for p in parts:
+                total = _mul_profiles(total, p)
+            
+            del profiles_stack[-num_factors:]
+            del parts
+            
+            profiles_stack.append(total)
+        
+        elif expr.is_Add:
+            num_terms = len(expr.args) 
+            part      = profiles_stack[-num_terms:]
+            final = {}
+            
+            for i in range(0, len(part)):
+                if i + 1 == len(part):
+                    break
+                part[i+1] = _add_profiles(part[i], part[i+1])
+                
+            final = part[-1]
+            
+            del profiles_stack[-num_terms:]
+            del part
+            
+            profiles_stack.append(final)
+            
+        elif expr.is_Pow: 
+            exponent_profile    = profiles_stack.pop()
+            base_profile        = profiles_stack.pop()
+            
+            if len(exponent_profile) != 1 or 0 not in exponent_profile:
+                return None
+            
+            exponent = exponent_profile[0]
+
+            if not exponent.is_Integer or not exponent.is_nonnegative:
+                return None
+            
+            profiles_stack.append(_pow_profile(base_profile, int(exponent)))
+        else:
+            return None
+        
+    if len(profiles_stack) != 1:
+        return None
+    
+    final_profile = profiles_stack[0]
+    
+    if not final_profile:
+        return S.NegativeInfinity
+    
+    return max(final_profile)
+
+
 @public
 def degree(f, gen=0):
     """
@@ -4988,9 +5107,16 @@ def degree(f, gen=0):
         return p.degree(gen)
 
     gen = sympify(gen, strict=True)
+    if isinstance(f, Poly) and gen in f.gens:
+        return _degree(f.degree(gen))
+    
     if not isinstance(f, Poly) or gen not in f.gens:
-        f = poly_from_expr(f, gen)[0]
-    return _degree(f.degree(gen))
+        d = __degree_it(f, gen)
+        if d == S.NegativeInfinity or d == None or d == 0:
+            f = poly_from_expr(f, gen)[0]
+            return _degree(f.degree(gen))
+        else:
+            return _degree(d)
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5124,7 +5124,7 @@ def degree(f, gen=0):
 
     if not isinstance(f, Poly) or gen not in f.gens:
         d = __degree_it(f, gen)
-        if d == None:
+        if d is None:
             f = poly_from_expr(f, gen)[0]
             return _degree(f.degree(gen))
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4906,7 +4906,7 @@ def __degree_it(f, gen):
         for deg_1, coeff_1 in profile_1.items():
             for deg_2, coeff_2 in profile_2.items():
                 result[deg_1 + deg_2] = (
-                    result.get(deg_1 + deg_2, 0) + coeff_1 * coeff_2
+                    result.get(deg_1 + deg_2, S.Zero) + coeff_1 * coeff_2
                 )
 
                 if result[deg_1 + deg_2] == 0:
@@ -4919,7 +4919,7 @@ def __degree_it(f, gen):
         cancellation_flag = False
 
         for deg, coeff in profile_2.items():
-            result[deg] = result.get(deg, 0) + coeff
+            result[deg] = result.get(deg, S.Zero) + coeff
 
             if result[deg] == 0:
                 cancellation_flag = True
@@ -4929,7 +4929,7 @@ def __degree_it(f, gen):
 
     def _pow_profile(profile, exponent, cutoff=550):
         if exponent == 0:
-            return {0: 1}
+            return {0: S.One}
         elif exponent == 1:
             return profile
 
@@ -4938,11 +4938,11 @@ def __degree_it(f, gen):
 
             for deg, coeff in profile.items():
                 new_deg, new_coeff = deg * exponent, coeff**exponent
-                result[new_deg] = result.get(new_deg, 0) + new_coeff
+                result[new_deg] = result.get(new_deg, S.Zero) + new_coeff
 
             return result
 
-        result = {0: 1}
+        result = {0: S.One}
         for _ in range(int(exponent)):
             result = _mul_profiles(result, profile)
 
@@ -4957,6 +4957,12 @@ def __degree_it(f, gen):
     profiles_stack = []
 
     for expr in postorder_traversal(f):
+        if isinstance(expr, Tuple):
+            return None
+
+        if not isinstance(expr, Expr):
+            return None
+
         if expr == 0:
             profiles_stack.append({})
 
@@ -4965,14 +4971,14 @@ def __degree_it(f, gen):
             profiles_stack.append(profile)
 
         elif expr == gen:
-            profile = {1: 1}
+            profile = {1: S.One}
             profiles_stack.append(profile)
 
         elif expr.is_Mul:
             num_factors = len(expr.args)
             parts = profiles_stack[-num_factors:]
 
-            total = {0: 1}
+            total = {0: S.One}
             for p in parts:
                 total = _mul_profiles(total, p)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4913,54 +4913,53 @@ def _update_args(args, key, value):
     return args
 
 
-def _mul_profiles (dict_1, dict_2): # add keys, multiply values
-    result = {}
-    for k, v in dict_1.items():
-        for k_, v_ in dict_2.items():
-            result[k + k_] = result.get(k + k_, 0) + v * v_
-
-            if result[k + k_] == 0:
-                del result[k + k_]
-
-    return result
-
-
-def _add_profiles (dict_1, dict_2): # keep keys the same, add values
-    result            = dict(dict_1)
-    cancellation_flag = False
-
-    for deg, coeff in dict_2.items():
-        result[deg] = result.get(deg, 0) + coeff
-
-        if result[deg] == 0:
-            cancellation_flag = True
-            del result[deg]
-
-    return result, cancellation_flag
-
-
-def _pow_profile (dict_, exponent, cutoff=550):
-
-    if exponent == 0:
-        return {0 : 1}
-    elif exponent == 1:
-        return dict_
-
-    if exponent > cutoff:
-        result = {}
-        for deg, coeff in dict_.items():
-            k, v = deg*exponent, coeff**exponent
-            result[k] = result.get(k, 0) + v
-        return result
-    else:
-        result = {0 : 1}
-        for _ in range(int(exponent)):
-            result = _mul_profiles(result, dict_)
-        return result
-
 from sympy import postorder_traversal
 
 def __degree_it (f, gen):
+    
+    def _mul_profiles (dict_1, dict_2): 
+        result = {}
+        for k, v in dict_1.items():
+            for k_, v_ in dict_2.items():
+                result[k + k_] = result.get(k + k_, 0) + v * v_
+
+                if result[k + k_] == 0:
+                    del result[k + k_]
+
+        return result
+
+
+    def _add_profiles (dict_1, dict_2):
+        result            = dict(dict_1)
+        cancellation_flag = False
+
+        for deg, coeff in dict_2.items():
+            result[deg] = result.get(deg, 0) + coeff
+
+            if result[deg] == 0:
+                cancellation_flag = True
+                del result[deg]
+
+        return result, cancellation_flag
+
+
+    def _pow_profile (dict_, exponent, cutoff=550):
+        if exponent == 0:
+            return {0 : 1}
+        elif exponent == 1:
+            return dict_
+
+        if exponent > cutoff:
+            result = {}
+            for deg, coeff in dict_.items():
+                k, v = deg*exponent, coeff**exponent
+                result[k] = result.get(k, 0) + v
+            return result
+        else:
+            result = {0 : 1}
+            for _ in range(int(exponent)):
+                result = _mul_profiles(result, dict_)
+            return result
 
     f   = sympify(f)
     gen = sympify(gen)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4939,17 +4939,24 @@ def _add_profiles (dict_1, dict_2): # keep keys the same, add values
     return result, cancellation_flag
 
 
-def _pow_profile (dict_, exponent):
+def _pow_profile (dict_, exponent, cutoff=50):
     
     if exponent == 0:
         return {0 : 1}
+    elif exponent == 1:
+        return dict_
     
-    result = {}
-    for deg, coeff in dict_.items():
-        k, v = deg*exponent, coeff**exponent
-        result[k] = result.get(k, 0) + v
-        
-    return result
+    if exponent > cutoff:
+        result = {}
+        for deg, coeff in dict_.items():
+            k, v = deg*exponent, coeff**exponent
+            result[k] = result.get(k, 0) + v
+        return result
+    else:
+        result = {0 : 1}
+        for _ in range(int(exponent)):
+            result = _mul_profiles(result, dict_)
+        return result
 
 from sympy import postorder_traversal
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4918,34 +4918,34 @@ def _mul_profiles (dict_1, dict_2): # add keys, multiply values
     for k, v in dict_1.items():
         for k_, v_ in dict_2.items():
             result[k + k_] = result.get(k + k_, 0) + v * v_
-             
+
             if result[k + k_] == 0:
                 del result[k + k_]
-    
+
     return result
 
 
 def _add_profiles (dict_1, dict_2): # keep keys the same, add values
     result            = dict(dict_1)
     cancellation_flag = False
-    
+
     for deg, coeff in dict_2.items():
         result[deg] = result.get(deg, 0) + coeff
-        
+
         if result[deg] == 0:
             cancellation_flag = True
             del result[deg]
-            
+
     return result, cancellation_flag
 
 
 def _pow_profile (dict_, exponent, cutoff=550):
-    
+
     if exponent == 0:
         return {0 : 1}
     elif exponent == 1:
         return dict_
-    
+
     if exponent > cutoff:
         result = {}
         for deg, coeff in dict_.items():
@@ -4961,86 +4961,86 @@ def _pow_profile (dict_, exponent, cutoff=550):
 from sympy import postorder_traversal
 
 def __degree_it (f, gen):
-    
+
     f   = sympify(f)
     gen = sympify(gen)
-    
+
     if isinstance(f, Poly):
         f = f.as_expr()
-    
+
     profiles_stack    = []
-    
+
     for expr in postorder_traversal(f):
-        
+
         if expr == 0:
             profiles_stack.append({})
-        
-        elif not expr.has(gen): 
+
+        elif not expr.has(gen):
             profile = {0 : expr}
             profiles_stack.append(profile)
-        
-        elif expr == gen: 
+
+        elif expr == gen:
             profile = {1 : 1}
             profiles_stack.append(profile)
-            
+
         # stack "unfolding" cases
         elif expr.is_Mul:
             num_factors = len(expr.args)
             parts       = profiles_stack[-num_factors:]
-            
+
             total = {0 : 1}
             for p in parts:
                 total = _mul_profiles(total, p)
-            
+
             del profiles_stack[-num_factors:]
             del parts
-            
+
             profiles_stack.append(total)
-        
+
         elif expr.is_Add:
-            num_terms = len(expr.args) 
+            num_terms = len(expr.args)
             part      = profiles_stack[-num_terms:]
             final = {}
-            
+
             for i in range(0, len(part)):
                 if i + 1 == len(part):
                     break
                 part[i+1], cancellation_flag = _add_profiles(part[i], part[i+1])
-                
+
                 if cancellation_flag:
                     return None
-                
+
             final = part[-1]
-            
+
             del profiles_stack[-num_terms:]
             del part
-            
+
             profiles_stack.append(final)
-            
-        elif expr.is_Pow: 
+
+        elif expr.is_Pow:
             exponent_profile    = profiles_stack.pop()
             base_profile        = profiles_stack.pop()
-            
+
             if len(exponent_profile) != 1 or 0 not in exponent_profile:
                 return None
-            
+
             exponent = exponent_profile[0]
 
             if not exponent.is_Integer or not exponent.is_nonnegative:
-                return None 
-            
+                return None
+
             profiles_stack.append(_pow_profile(base_profile, int(exponent)))
         else:
             return None
-        
+
     if len(profiles_stack) != 1:
         return None
-    
+
     final_profile = profiles_stack[0]
-    
+
     if not final_profile:
         return S.NegativeInfinity
-    
+
     return max(final_profile)
 
 
@@ -5121,7 +5121,7 @@ def degree(f, gen=0):
     gen = sympify(gen, strict=True)
     if isinstance(f, Poly) and gen in f.gens:
         return _degree(f.degree(gen))
-    
+
     if not isinstance(f, Poly) or gen not in f.gens:
         d = __degree_it(f, gen)
         if d == None:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4982,7 +4982,7 @@ def __degree_it (f, gen):
             profile = {1 : 1}
             profiles_stack.append(profile)
 
-        # stack "unfolding" cases
+        # stack "unfolding" cases 
         elif expr.is_Mul:
             num_factors = len(expr.args)
             parts       = profiles_stack[-num_factors:]

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2,29 +2,28 @@
 
 from __future__ import annotations
 
-from collections import Counter, defaultdict
-from functools import reduce, wraps
-from operator import mul
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast, overload
+from typing import TYPE_CHECKING, overload, Literal, Any, cast, Callable
 
-# Required to avoid errors
-import sympy.polys
-from sympy import postorder_traversal
-from sympy.core import Add, Expr, S, Tuple
+from functools import wraps, reduce
+from operator import mul
+from collections import Counter, defaultdict
+
+from sympy.core import (
+    S, Expr, Add, Tuple
+)
 from sympy.core.basic import Basic
 from sympy.core.decorators import _sympifyit
-from sympy.core.evalf import (
-    _evalf_with_bounded_error, evalf, fastlog, pure_complex, quad_to_mpmath)
 from sympy.core.exprtools import Factors, factor_nc, factor_terms
+from sympy.core.evalf import (
+    pure_complex, evalf, fastlog, _evalf_with_bounded_error, quad_to_mpmath)
 from sympy.core.function import Derivative
-from sympy.core.intfunc import ilcm
 from sympy.core.mul import Mul, _keep_coeff
-from sympy.core.numbers import I, Integer, NegativeInfinity, equal_valued
-from sympy.core.relational import Equality, Relational
+from sympy.core.intfunc import ilcm
+from sympy.core.numbers import I, Integer, equal_valued, NegativeInfinity
+from sympy.core.relational import Relational, Equality
 from sympy.core.symbol import Dummy, Symbol
-from sympy.core.sympify import _sympify, sympify
-from sympy.core.traversal import bottom_up, preorder_traversal
-from sympy.external.mpmath import NoConvergence, local_workdps
+from sympy.core.sympify import sympify, _sympify
+from sympy.core.traversal import preorder_traversal, bottom_up
 from sympy.logic.boolalg import BooleanAtom
 from sympy.polys import polyoptions as options
 from sympy.polys.constructor import construct_domain
@@ -34,26 +33,41 @@ from sympy.polys.fglmtools import matrix_fglm
 from sympy.polys.groebnertools import groebner as _groebner
 from sympy.polys.monomials import Monomial
 from sympy.polys.orderings import monomial_key
-from sympy.polys.polyclasses import ANP, DMF, DMP
+from sympy.polys.polyclasses import DMP, DMF, ANP
 from sympy.polys.polyerrors import (
-    CoercionFailed, ComputationFailed, DomainError, ExactQuotientFailed,
-    GeneratorsError, GeneratorsNeeded, MultivariatePolynomialError,
-    OperationNotSupported, PolificationFailed, PolynomialError,
-    UnificationFailed)
+    OperationNotSupported, DomainError,
+    CoercionFailed, UnificationFailed,
+    GeneratorsNeeded, PolynomialError,
+    MultivariatePolynomialError,
+    ExactQuotientFailed,
+    PolificationFailed,
+    ComputationFailed,
+    GeneratorsError,
+)
 from sympy.polys.polyutils import (
-    _dict_from_expr, _dict_reorder, _parallel_dict_from_expr, _sort_gens,
-    _unify_gens, basic_from_dict)
+    basic_from_dict,
+    _sort_gens,
+    _unify_gens,
+    _dict_reorder,
+    _dict_from_expr,
+    _parallel_dict_from_expr,
+)
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import dup_isolate_real_roots_list
-from sympy.utilities import filldedent, group, public
+from sympy.utilities import group, public, filldedent
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable, sift
+from sympy import postorder_traversal
+
+# Required to avoid errors
+import sympy.polys
+from sympy.external.mpmath import local_workdps, NoConvergence
+
 
 if TYPE_CHECKING:
+    from sympy.polys.domains.domain import Domain
     from collections.abc import Iterator
     from typing import Self
-
-    from sympy.polys.domains.domain import Domain
 
 
 def _polifyit(func):
@@ -4142,7 +4156,8 @@ class Poly(Basic):
         from sympy.polys.numberfields.galoisgroups import (
             _galois_group_degree_3, _galois_group_degree_4_lookup,
             _galois_group_degree_5_lookup_ext_factor,
-            _galois_group_degree_6_lookup)
+            _galois_group_degree_6_lookup,
+        )
         if (not f.is_univariate
             or not f.is_irreducible
             or f.domain not in [ZZ, QQ]
@@ -4899,7 +4914,7 @@ def _update_args(args, key, value):
     return args
 
 
-def __degree_it(f, gen):
+def _degree_it(f, gen):
     def _mul_profiles(profile_1, profile_2):
         result = {}
 
@@ -5110,16 +5125,15 @@ def degree(f, gen=0):
         return p.degree(gen)
 
     gen = sympify(gen, strict=True)
-    if isinstance(f, Poly) and gen in f.gens:
-        return _degree(f.degree(gen))
-
     if not isinstance(f, Poly) or gen not in f.gens:
-        d = __degree_it(f, gen)
+        d = _degree_it(f, gen)
         if d is None:
             f = poly_from_expr(f, gen)[0]
             return _degree(f.degree(gen))
         else:
             return _degree(d)
+
+    return _degree(f.degree(gen))
 
 
 @public
@@ -7829,8 +7843,8 @@ def cancel(f, *gens, _signsimp=True, **args):
     >>> together(_)
     (x + 2)/2
     """
-    from sympy.polys.rings import sring
     from sympy.simplify.simplify import signsimp
+    from sympy.polys.rings import sring
     options.allowed_flags(args, ['polys'])
 
     f = sympify(f)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

See #6322
Alternative approach to #29051

#### Brief description of what is fixed or changed
This PR implements an iterative approach for `degree()`, using `postorder_traversal` on the input expression. It avoids unnecessary expansion for certain factored polynomial cases, such as `(x + 1)**10000,` and falls back to the existing method when the fast path (`_degree_it()`) cannot safely determine the degree (mainly on cancelling terms).


#### Other comments
- passes `sympy/polys/tests` locally
- benchmarked on `(x + 1)**10000`, `x*(x + 1)**5000`, `(x + 1)**2 - x**2`, `x*(x + 1) - x**2 - x`, `y*(x + 1)**10000`

#### AI Generation Disclosure

ChatGPT was used only for guidance on PEP 8 formatting and for help setting up the Ruff extension in VS Code. All changes were made manually. The idea and implementation are entirely my own. No code regarding the implementation was produced by AI.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
