### PR TITLE
fix \neg tokens being misread as \ne in Lark

### DIFF
--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -96,7 +96,7 @@ UNDERSCORE: "_"
 
 // relational symbols
 EQUAL: "="
-NOT_EQUAL: "\\neq" | "\\ne"
+NOT_EQUAL: /\\neq(?![a-zA-Z])/ | /\\ne(?![a-zA-Z])/
 LT: "<"
 LTE: "\\leq" | "\\le" | "\\leqslant"
 GT: ">"

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -234,6 +234,7 @@ EVALUATED_FRACTION_EXPRESSION_PAIRS = [
 RELATION_EXPRESSION_PAIRS = [
     (r"x = y", Eq(x, y)),
     (r"x \neq y", Ne(x, y)),
+    (r"x \ne y", Ne(x, y)),
     (r"x < y", Lt(x, y)),
     (r"x > y", Gt(x, y)),
     (r"x \leq y", Le(x, y)),
@@ -245,6 +246,7 @@ RELATION_EXPRESSION_PAIRS = [
     (r"x > y", StrictGreaterThan(x, y)),
     (r"x \geq y", GreaterThan(x, y)),
     (r"x \neq y", Unequality(x, y)), # same as 2nd one in the list
+    (r"x \ne y", Unequality(x, y)),
     (r"a^2 + b^2 = c^2", Eq(a**2 + b**2, c**2))
 ]
 
@@ -873,12 +875,30 @@ def test_common_function_expressions():
         assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
-# unhandled bug causing these to fail
-@XFAIL
 def test_spacing():
     for latex_str, sympy_expr in SPACING_RELATED_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+
+def test_negthinspace_not_equal_conflict():
+    assert parse_latex_lark(r"a \negthinspace b") == a * b
+    assert parse_latex_lark(r"x \negthinspace y") == x * y
+    assert parse_latex_lark(r"x \negthinspace + y") == x + y
+
+    assert parse_latex_lark(r"a \negmedspace b") == a * b
+    assert parse_latex_lark(r"x \negmedspace y") == x * y
+    assert parse_latex_lark(r"x \negmedspace + y") == x + y
+
+    assert parse_latex_lark(r"a \negthickspace b") == a * b
+    assert parse_latex_lark(r"x \negthickspace y") == x * y
+    assert parse_latex_lark(r"x \negthickspace + y") == x + y
+
+    assert parse_latex_lark(r"x \ne y") == Ne(x, y)
+    assert parse_latex_lark(r"x \neq y") == Ne(x, y)
+
+    assert parse_latex_lark(r"\negthinspace x \ne y") == Ne(x, y)
+    assert parse_latex_lark(r"x \neq \negmedspace y") == Ne(x, y)
 
 
 def test_binomial_expressions():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29467 

#### Brief description of what is fixed or changed
Tokens `\negthinspace`, `\negmedspace`, and `\negthickspace` were being misread as NOT_EQUAL (`\ne`/`\neq`) by the Lark LaTeX parser. The tokenizer greedily matched `\ne` as `NOT_EQUAL` before reading the full token.

Fix:
```python
NOT_EQUAL: /\\neq(?![a-zA-Z])/ | /\\ne(?![a-zA-Z])/
```
#### Other comments
* Removed the @XFAIL decorator 
* Added test case

#### AI Generation Disclosure
Used AI to properly structure the PR description and fix grammer.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed a bug in the Lark LaTeX parser where `\negthinspace`, `\negmedspace`, and `\negthickspace` spacing tokens were incorrectly parsed as the NOT_EQUAL relation (`\ne`/`\neq`) due to greedy prefix matching.
<!-- END RELEASE NOTES -->
