### PR TITLE
assumptions: Fix handlers for Mul of 0 with irrational/imaginary numbers

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -85,6 +85,8 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
+    if ask(Q.zero(expr), assumptions):
+        return True
     _output = True
     for arg in expr.args:
         if not ask(Q.integer(arg), assumptions):
@@ -274,6 +276,8 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _RealPredicate_number(expr, assumptions)
+    if ask(Q.zero(expr), assumptions):
+        return True
     result = True
     for arg in expr.args:
         if ask(Q.real(arg), assumptions):
@@ -572,6 +576,8 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _Imaginary_number(expr, assumptions)
+    if ask(Q.zero(expr), assumptions):
+        return True
     result = False
     reals = 0
     for arg in expr.args:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -85,7 +85,8 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
-    if ask(Q.zero(expr), assumptions):
+    is_zero = ask(Q.zero(expr), assumptions)
+    if is_zero:
         return True
     _output = True
     for arg in expr.args:
@@ -103,6 +104,8 @@ def _(expr, assumptions):
             else:
                 return
 
+    if _output is False:
+        return False if is_zero is False else None
     return _output
 
 @IntegerPredicate.register(Abs)
@@ -276,7 +279,8 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _RealPredicate_number(expr, assumptions)
-    if ask(Q.zero(expr), assumptions):
+    is_zero = ask(Q.zero(expr), assumptions)
+    if is_zero:
         return True
     result = True
     for arg in expr.args:
@@ -287,6 +291,8 @@ def _(expr, assumptions):
         else:
             break
     else:
+        if result is False:
+            return False if is_zero is False else None
         return result
 
 @RealPredicate.register(Pow)
@@ -576,8 +582,9 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _Imaginary_number(expr, assumptions)
-    if ask(Q.zero(expr), assumptions):
-        return True
+    is_zero = ask(Q.zero(expr), assumptions)
+    if is_zero:
+        return False
     result = False
     reals = 0
     for arg in expr.args:
@@ -588,6 +595,8 @@ def _(expr, assumptions):
     else:
         if reals == len(expr.args):
             return False
+        if result is True:
+            return True if is_zero is False else None
         return result
 
 @ImaginaryPredicate.register(Pow) # type:ignore

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -582,9 +582,6 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _Imaginary_number(expr, assumptions)
-    is_zero = ask(Q.zero(expr), assumptions)
-    if is_zero:
-        return False
     result = False
     reals = 0
     for arg in expr.args:
@@ -595,8 +592,6 @@ def _(expr, assumptions):
     else:
         if reals == len(expr.args):
             return False
-        if result is True:
-            return True if is_zero is False else None
         return result
 
 @ImaginaryPredicate.register(Pow) # type:ignore

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1652,6 +1652,8 @@ def test_imaginary():
     # issue 7886
     assert ask(Q.imaginary(Pow(x, Rational(1, 4))), Q.real(x) & Q.negative(x)) is False
 
+    # https://github.com/sympy/sympy/issues/29480
+    assert ask(Q.imaginary(n * I), Q.zero(n)) is False
 
 def test_integer():
     assert ask(Q.integer(x)) is None
@@ -1666,7 +1668,7 @@ def test_integer():
     assert ask(Q.integer(2*x), Q.prime(x)) is True
     assert ask(Q.integer(2*x), Q.rational(x)) is None
     assert ask(Q.integer(2*x), Q.real(x)) is None
-    assert ask(Q.integer(sqrt(2)*x), Q.integer(x)) is False
+    assert ask(Q.integer(sqrt(2)*x), Q.integer(x)) is None
     assert ask(Q.integer(sqrt(2)*x), Q.irrational(x)) is None
 
     assert ask(Q.integer(x/2), Q.odd(x)) is False
@@ -1694,6 +1696,8 @@ def test_integer():
     assert ask(Q.integer(pi**x), Q.zero(x)) is True
     assert ask(Q.integer(x**y), Q.imaginary(x) & Q.zero(y)) is True
 
+    # https://github.com/sympy/sympy/issues/29480
+    assert ask(Q.integer(n * pi), Q.zero(n)) is True
 
 def test_negative():
     assert ask(Q.negative(x), Q.negative(x)) is True
@@ -2020,7 +2024,7 @@ def test_real_basic():
     assert ask(Q.real(x), Q.prime(x)) is True
 
     assert ask(Q.real(x/sqrt(2)), Q.real(x)) is True
-    assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is False
+    assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is None
 
     assert ask(Q.real(x + 1), Q.real(x)) is True
     assert ask(Q.real(x + I), Q.real(x)) is False
@@ -2031,6 +2035,9 @@ def test_real_basic():
     assert ask(Q.real(I*x), Q.imaginary(x)) is True
     assert ask(Q.real(I*x), Q.complex(x)) is None
 
+    # https://github.com/sympy/sympy/issues/29480
+    assert ask(Q.real(n * pi), Q.zero(n)) is True
+    assert ask(Q.real(n * I), Q.zero(n)) is True
 
 def test_real_pow():
     assert ask(Q.real(x**2), Q.real(x)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1652,8 +1652,6 @@ def test_imaginary():
     # issue 7886
     assert ask(Q.imaginary(Pow(x, Rational(1, 4))), Q.real(x) & Q.negative(x)) is False
 
-    # https://github.com/sympy/sympy/issues/29480
-    assert ask(Q.imaginary(n * I), Q.zero(n)) is False
 
 def test_integer():
     assert ask(Q.integer(x)) is None
@@ -1669,6 +1667,7 @@ def test_integer():
     assert ask(Q.integer(2*x), Q.rational(x)) is None
     assert ask(Q.integer(2*x), Q.real(x)) is None
     assert ask(Q.integer(sqrt(2)*x), Q.integer(x)) is None
+    assert ask(Q.integer(sqrt(2)*x), Q.integer(x) & ~Q.zero(x)) is False
     assert ask(Q.integer(sqrt(2)*x), Q.irrational(x)) is None
 
     assert ask(Q.integer(x/2), Q.odd(x)) is False
@@ -2025,6 +2024,7 @@ def test_real_basic():
 
     assert ask(Q.real(x/sqrt(2)), Q.real(x)) is True
     assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is None
+    assert ask(Q.real(x/sqrt(-2)), Q.real(x) & ~Q.zero(x)) is False
 
     assert ask(Q.real(x + 1), Q.real(x)) is True
     assert ask(Q.real(x + I), Q.real(x)) is False
@@ -2037,7 +2037,7 @@ def test_real_basic():
 
     # https://github.com/sympy/sympy/issues/29480
     assert ask(Q.real(n * pi), Q.zero(n)) is True
-    assert ask(Q.real(n * I), Q.zero(n)) is True
+
 
 def test_real_pow():
     assert ask(Q.real(x**2), Q.real(x)) is True


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes: #29480

#### Brief description of what is fixed or changed
`ask` was not properly handling multiplication with 0 for irrational/imaginary numbers.

The issue was with handlers of `Integer`, `Real` and `Imaginary` predicates, completely skipping over the edge case being the `expr` could be 0.

New tests have been added in `test_query.py` while some tests are updated following the new correct behaviour.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed a bug where `ask` used to give wrong results when 0 was multiplied by irrational/imaginary numbers. For example - `ask(Q.real(n * I), Q.zero(n))` returns `True` now instead of wrongly returning `False`.
<!-- END RELEASE NOTES -->
