### PR TITLE
solvers: fix RecursionError in decompogen for multi-argument functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -484,6 +484,7 @@ Chaitanya Sai Alaparthi <achaitanyasai@gmail.com>
 Chak-Pong Chung <chakpongchung@gmail.com>
 Chanakya-Ekbote <ca10@iitbbs.ac.in>
 Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
+Chandra Prakash <235066282+mn-ram@users.noreply.github.com> prakash-kalwaniya <mn-ram@users.noreply.github.com>
 Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -49,6 +49,8 @@ def decompogen(f, symbol):
             arg = f.args[0]
         if arg == symbol:
             return [f]
+        if any(a.has(symbol) for a in f.args[1:]):
+            return [f]
         return [f.subs(arg, symbol)] + decompogen(arg, symbol)
 
     # ===== Min/Max Functions ===== #


### PR DESCRIPTION
### Fix incorrect decomposition of multi-argument functions in `decompogen`

Fixes #26632

---

### Problem

`decompogen()` incorrectly handled `Function` nodes with multiple arguments by only substituting `args[0]` during decomposition, leaving other arguments unchanged.

This leads to invalid decompositions when additional arguments still contain the target symbol.

For example:

```python
PythonMod(2*s0 + 3, s0 - 3)
```

was decomposed into:

```python
PythonMod(s0, s0 - 3)
```

Here, the second argument still contains `s0`, making the decomposition invalid.

---

### Root Cause

In `sympy/solvers/decompogen.py`, the implementation assumes a single-argument function:

```python
arg = f.args[0]
return [f.subs(arg, symbol)] + decompogen(arg, symbol)
```

This logic ignores all arguments beyond `args[0]`, which breaks correctness for multi-argument functions.

---

### Fix

Before performing decomposition, ensure that no arguments beyond `args[0]` contain the target symbol. If they do, the function cannot be reduced to a valid single-input composition, so return it unchanged:

```python
if any(a.has(symbol) for a in f.args[1:]):
    return [f]
```

---

### Minimal Reproducer

```python
import sympy

class PythonMod(sympy.Function):
    nargs = (2,)
    is_integer = True

    @classmethod
    def eval(cls, p, q):
        pass

s0 = sympy.Symbol('s0', integer=True)

exprs = [
    s0 >= 2,
    sympy.Eq(PythonMod(2*s0 + 3, s0 - 3), 0),
    s0 <= 100
]

sympy.solvers.inequalities.reduce_inequalities(exprs, s0)
```

- **Before fix:** `RecursionError` (deep recursion in `periodicity()`)
- **After fix:** `NotImplementedError` (correct behavior for unsupported case)

---

### Tests

All existing tests in `test_decompogen.py` pass unchanged. Single-argument function decomposition (e.g., `sin(cos(x))`) remains unaffected.

---

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a `RecursionError` in `decompogen` when decomposing multi-argument functions where arguments beyond the first also contain the decomposition symbol (e.g., `PythonMod(2*s0 + 3, s0 - 3)`).
<!-- END RELEASE NOTES -->