### PR TITLE
fix Eq.simplify() wrong result for complex zeros (fixes #25142)

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -439,10 +439,11 @@ class Relational(Boolean, EvalfMixin):
             # allow a definitive comparison with 0
             v = None
             if dif.is_comparable:
-                v = dif.n(2)
-                if any(i._prec == 1 for i in v.as_real_imag()):
-                    rv, iv = [i.n(2) for i in dif.as_real_imag()]
+                rv, iv = [i.n(2) for i in dif.as_real_imag()]
+                if not any(i._prec == 1 for i in (rv, iv)):
                     v = rv + S.ImaginaryUnit*iv
+                else:
+                    v = dif.n(2)
             elif dif.equals(0):  # XXX this is expensive
                 v = S.Zero
             if v is not None:

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -749,6 +749,11 @@ def test_simplify_relational():
     z = cos(1)**2 + sin(1)**2 - 1  # z.is_zero is None
     assert Eq(z*x, 0).simplify() == S.true
 
+    # sum of cube roots of unity is zero (complex cancellation, issue #25142)
+    from sympy import I, exp, pi as PI
+    cru = 1 + exp(2*I*PI/3) + exp(-2*I*PI/3)
+    assert Eq(cru, 0).simplify() == S.true
+
     assert Ne(y, x).simplify() == Ne(x, y)
     assert Ne(x - 1, 0).simplify() == Ne(x, 1)
     assert Ne(x - 1, x).simplify() == S.true


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #25142

#### Brief description of what is fixed or changed

In `_eval_simplify` for relational expressions, `dif.n(2)` was applied directly to expressions that are mathematically zero but not symbolically simplified. This could result in tiny non-zero floating-point values (e.g., for sums of cube roots of unity), causing incorrect simplification results such as:

```python
Eq(expr, 0).simplify()  # returning False instead of True
```

This change ensures that symbolic cancellation occurs before numerical evaluation by splitting the expression into real and imaginary parts using `as_real_imag()`, and then applying low-precision numeric evaluation. This avoids false negatives caused by floating-point artifacts.

#### Other comments

N/A

#### AI Generation Disclosure

No

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core

  * Fixed `Eq(expr, 0).simplify()` incorrectly returning `False` for complex expressions that evaluate to zero, such as the sum of cube roots of unity.

<!-- END RELEASE NOTES -->
