### PR TITLE
Add type annotations to continued_fraction module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1300,6 +1300,7 @@ Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Prakhar Saxena <prakharsaxena.c
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <50932406+Psycho-Pirate@users.noreply.github.com>
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <prakharsaxena.cer18@itbhu.ac.in>
 Puneeth Chaganti <punchagan@gmail.com>
+Pushpender111 <145033156+Pushpender111@users.noreply.github.com> <Pushpender.ug23@nsut.ac.in>
 Qijia Liu <liumeo@pku.edu.cn> Liumeo <liumeo@pku.edu.cn>
 Qijia Liu <liumeo@pku.edu.cn> eagleoflqj <liumeo@pku.edu.cn>
 Qingsha Shi <googol.sqs@gmail.com> sqs <googol.sqs@gmail.com>

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -9,7 +9,7 @@ from sympy.utilities.misc import as_int
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-from typing import Iterator,Iterable,Any
+from typing import Iterator,Any
 
 def continued_fraction(a:Any) -> list[int|list[int]]:
     """Return the continued fraction representation of a Rational or
@@ -362,8 +362,8 @@ def continued_fraction_convergents(cf: list[int]) :
     """
     if isinstance(cf, list) and isinstance(cf[-1], list):
         cf = itertools.chain(cf[:-1], itertools.cycle(cf[-1]))
-    p_2, q_2 = S.Zero, S.One  # type: Expr, Expr
-    p_1, q_1 = S.One, S.Zero  # type: Expr, Expr
+    p_2, q_2 = S.Zero, S.One 
+    p_1, q_1 = S.One, S.Zero  
     for a in cf:
         p, q = a*p_1 + p_2, a*q_1 + q_2
         p_2, q_2 = p_1, q_1

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -362,8 +362,8 @@ def continued_fraction_convergents(cf: list[int]) :
     """
     if isinstance(cf, list) and isinstance(cf[-1], list):
         cf = itertools.chain(cf[:-1], itertools.cycle(cf[-1]))
-    p_2, q_2 = S.Zero, S.One 
-    p_1, q_1 = S.One, S.Zero  
+    p_2, q_2 = S.Zero, S.One
+    p_1, q_1 = S.One, S.Zero
     for a in cf:
         p, q = a*p_1 + p_2, a*q_1 + q_2
         p_2, q_2 = p_1, q_1

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -154,10 +154,10 @@ def continued_fraction_periodic(p: int, q: int, d: int = 0, s: int = 1) -> list[
     if q < 0:
         p, q, s = -p, -q, -s
 
-    n: Expr = (p + s*sd)/q
+    n = (p + s*sd)/q
     if n < 0:
         w = floor(-n)
-        f:Expr = -n - w
+        f = -n - w
         one_f = continued_fraction(1 - f)  # 1-f < 1 so cf is [0 ... [...]]
         one_f[0] -= w + 1
         return one_f

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -9,9 +9,9 @@ from sympy.utilities.misc import as_int
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-from typing import Iterator,Any
+from typing import Iterator,Any,Iterable
 
-def continued_fraction(a: Any) -> list[int | list[int]]:
+def continued_fraction(a) -> list[int | list[int]]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -240,13 +240,13 @@ def continued_fraction_reduce(cf: list[int])->  list[int | list[int]]:
                 break
             yield nxt
 
-    a = S.Zero
+    a:Expr = S.Zero
     for a in continued_fraction_convergents(untillist(cf)):
         pass
 
     if period:
         y = Dummy('y')
-        solns: list = solve(continued_fraction_reduce(period + [y]) - y, y)
+        solns = solve(continued_fraction_reduce(period + [y]) - y, y)
         solns.sort()
         pure = solns[-1]
         rv = a.subs(x, pure).radsimp()
@@ -303,7 +303,7 @@ def continued_fraction_iterator(x: Expr) -> Iterator[int]:
         x = 1/x
 
 
-def continued_fraction_convergents(cf: list[int]) :
+def continued_fraction_convergents(cf: Iterable[Expr | list[int] | int]) -> Iterator[Expr]:
     """
     Return an iterator over the convergents of a continued fraction (cf).
 

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -6,7 +6,9 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
 from sympy.utilities.misc import as_int
-
+from sympy.core.expr import Expr
+from sympy import Integer
+from typing import Iterator,Iterable
 
 def continued_fraction(a) -> list:
     """Return the continued fraction representation of a Rational or
@@ -72,7 +74,7 @@ def continued_fraction(a) -> list:
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
-def continued_fraction_periodic(p, q, d=0, s=1) -> list:
+def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -143,7 +145,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
         d = 0
 
     # check for rational case
-    sd = sqrt(d)
+    sd: Expr = sqrt(d)
     if sd.is_Integer:
         return list(continued_fraction_iterator(Rational(p + s*sd, q)))
 
@@ -151,7 +153,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
     if q < 0:
         p, q, s = -p, -q, -s
 
-    n = (p + s*sd)/q
+    n: Expr = (p + s*sd)/q
     if n < 0:
         w = floor(-n)
         f = -n - w
@@ -181,7 +183,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
     return terms[:i] + [terms[i:]]  # type: ignore
 
 
-def continued_fraction_reduce(cf):
+def continued_fraction_reduce(cf: list[int])-> Expr:
     """
     Reduce a continued fraction to a rational or quadratic irrational.
 
@@ -243,7 +245,7 @@ def continued_fraction_reduce(cf):
 
     if period:
         y = Dummy('y')
-        solns = solve(continued_fraction_reduce(period + [y]) - y, y)
+        solns: list = solve(continued_fraction_reduce(period + [y]) - y, y)
         solns.sort()
         pure = solns[-1]
         rv = a.subs(x, pure).radsimp()
@@ -256,7 +258,7 @@ def continued_fraction_reduce(cf):
     return rv
 
 
-def continued_fraction_iterator(x):
+def continued_fraction_iterator(x: Expr) -> Iterator[Integer]:
     """
     Return continued fraction expansion of x as iterator.
 
@@ -300,7 +302,7 @@ def continued_fraction_iterator(x):
         x = 1/x
 
 
-def continued_fraction_convergents(cf):
+def continued_fraction_convergents(cf: Iterable):
     """
     Return an iterator over the convergents of a continued fraction (cf).
 
@@ -359,8 +361,10 @@ def continued_fraction_convergents(cf):
     """
     if isinstance(cf, list) and isinstance(cf[-1], list):
         cf = itertools.chain(cf[:-1], itertools.cycle(cf[-1]))
-    p_2, q_2 = S.Zero, S.One
-    p_1, q_1 = S.One, S.Zero
+    p_2: Expr = S.Zero
+    q_2: Expr = S.One
+    p_1: Expr = S.One
+    q_1: Expr = S.Zero
     for a in cf:
         p, q = a*p_1 + p_2, a*q_1 + q_2
         p_2, q_2 = p_1, q_1

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -9,7 +9,7 @@ from sympy.utilities.misc import as_int
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-from typing import Iterator,Iterable,Any,List,Union
+from typing import Iterator,Iterable,Any
 
 def continued_fraction(a) -> list[Any]:
     """Return the continued fraction representation of a Rational or
@@ -75,7 +75,7 @@ def continued_fraction(a) -> list[Any]:
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
-def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> List[Union[Integer, List[Integer]]]:
+def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list[Integer| list[Integer]]:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -184,7 +184,7 @@ def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> List[Un
     return terms[:i] + [terms[i:]]  # type: ignore
 
 
-def continued_fraction_reduce(cf: list[int])->  List[Union[int, List[int]]]:
+def continued_fraction_reduce(cf: list[int])->  list[int| list[int]]:
     """
     Reduce a continued fraction to a rational or quadratic irrational.
 

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -240,7 +240,7 @@ def continued_fraction_reduce(cf: list[int])->  list[int | list[int]]:
                 break
             yield nxt
 
-    a:Expr = S.Zero
+    a: Expr = S.Zero
     for a in continued_fraction_convergents(untillist(cf)):
         pass
 

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -362,8 +362,8 @@ def continued_fraction_convergents(cf: list[int]) :
     """
     if isinstance(cf, list) and isinstance(cf[-1], list):
         cf = itertools.chain(cf[:-1], itertools.cycle(cf[-1]))
-    p_2, q_2 = S.Zero, S.One
-    p_1, q_1 = S.One, S.Zero
+    p_2, q_2 = S.Zero, S.One #type: Expr,Expr
+    p_1, q_1 = S.One, S.Zero #type: Expr,Expr
     for a in cf:
         p, q = a*p_1 + p_2, a*q_1 + q_2
         p_2, q_2 = p_1, q_1

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
 from typing import Iterator,Iterable
 
-def continued_fraction(a: Rational | Expr) -> list[int | list[int]]:
+def continued_fraction(a: complex | Expr) -> list[int | list[int]]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -40,10 +40,8 @@ def continued_fraction(a: Rational | Expr) -> list[int | list[int]]:
                 e.args[1].is_Pow and
                 e.args[1].base.is_Integer and
                 e.args[1].exp is S.Half):
-            a, b = e.args
-            if not isinstance(a, Rational):
-                raise TypeError("Expected Rational")
-            return continued_fraction_periodic(0, a.q, b.base, a.p)
+            r, b = e.args
+            return continued_fraction_periodic(0, r.q, b.base, r.p)
         else:
             # this should not have to work very hard- no
             # simplification, cancel, etc... which should be
@@ -57,11 +55,11 @@ def continued_fraction(a: Rational | Expr) -> list[int | list[int]]:
                 # look for a + b*c
                 # with c = sqrt(s)
                 if p.is_Add and len(p.args) == 2:
-                    a, bc = p.args
+                    t, bc = p.args
                 else:
-                    a = S.Zero
+                    t = S.Zero
                     bc = p
-                if a.is_Integer:
+                if t.is_Integer:
                     b = S.NaN
                     if bc.is_Mul and len(bc.args) == 2:
                         b, c = bc.args
@@ -73,7 +71,7 @@ def continued_fraction(a: Rational | Expr) -> list[int | list[int]]:
                             c.base.is_Integer):
                         # (a + b*sqrt(c))/d
                         c = c.base
-                        return continued_fraction_periodic(int(a), int(d), int(c), int(b))
+                        return continued_fraction_periodic(t, d, c, b)
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -6,8 +6,9 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
 from sympy.utilities.misc import as_int
-from sympy.core.expr import Expr
-from sympy import Integer
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 from typing import Iterator,Iterable
 
 def continued_fraction(a) -> list:

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -9,9 +9,9 @@ from sympy.utilities.misc import as_int
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-from typing import Iterator,Any,Iterable
+from typing import Iterator,Iterable
 
-def continued_fraction(a: Any) -> list[int | list[int]]:
+def continued_fraction(a: Rational | Expr) -> list[int | list[int]]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -41,6 +41,8 @@ def continued_fraction(a: Any) -> list[int | list[int]]:
                 e.args[1].base.is_Integer and
                 e.args[1].exp is S.Half):
             a, b = e.args
+            if not isinstance(a, Rational):
+                raise TypeError("Expected Rational")
             return continued_fraction_periodic(0, a.q, b.base, a.p)
         else:
             # this should not have to work very hard- no
@@ -71,7 +73,7 @@ def continued_fraction(a: Any) -> list[int | list[int]]:
                             c.base.is_Integer):
                         # (a + b*sqrt(c))/d
                         c = c.base
-                        return continued_fraction_periodic(a, d, c, b)
+                        return continued_fraction_periodic(int(a), int(d), int(c), int(b))
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
 from typing import Iterator,Any
 
-def continued_fraction(a:Any) -> list[int|list[int]]:
+def continued_fraction(a: Any) -> list[int | list[int]]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -75,7 +75,7 @@ def continued_fraction(a:Any) -> list[int|list[int]]:
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
-def continued_fraction_periodic(p: int, q: int, d: int = 0, s: int = 1) -> list[int|list[int]]:
+def continued_fraction_periodic(p: int, q: int, d: int = 0, s: int = 1) -> list[int | list[int]]:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -184,7 +184,7 @@ def continued_fraction_periodic(p: int, q: int, d: int = 0, s: int = 1) -> list[
     return terms[:i] + [terms[i:]]  # type: ignore
 
 
-def continued_fraction_reduce(cf: list[int])->  list[int| list[int]]:
+def continued_fraction_reduce(cf: list[int])->  list[int | list[int]]:
     """
     Reduce a continued fraction to a rational or quadratic irrational.
 
@@ -362,8 +362,10 @@ def continued_fraction_convergents(cf: list[int]) :
     """
     if isinstance(cf, list) and isinstance(cf[-1], list):
         cf = itertools.chain(cf[:-1], itertools.cycle(cf[-1]))
-    p_2, q_2 = S.Zero, S.One #type: Expr,Expr
-    p_1, q_1 = S.One, S.Zero #type: Expr,Expr
+    p_2: Expr = S.Zero
+    q_2: Expr = S.One
+    p_1: Expr = S.One
+    q_1: Expr = S.Zero
     for a in cf:
         p, q = a*p_1 + p_2, a*q_1 + q_2
         p_2, q_2 = p_1, q_1

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
 from typing import Iterator,Iterable,Any
 
-def continued_fraction(a) -> list[Any]:
+def continued_fraction(a:Any) -> list[int|list[int]]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -75,7 +75,7 @@ def continued_fraction(a) -> list[Any]:
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
-def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list[Integer| list[Integer]]:
+def continued_fraction_periodic(p: int, q: int, d: int = 0, s: int = 1) -> list[int|list[int]]:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -146,7 +146,7 @@ def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list[In
         d = 0
 
     # check for rational case
-    sd: Expr = sqrt(d)
+    sd = sqrt(d)
     if sd.is_Integer:
         return list(continued_fraction_iterator(Rational(p + s*sd, q)))
 
@@ -259,7 +259,7 @@ def continued_fraction_reduce(cf: list[int])->  list[int| list[int]]:
     return rv
 
 
-def continued_fraction_iterator(x: Expr) -> Iterator[Integer]:
+def continued_fraction_iterator(x: Expr) -> Iterator[int]:
     """
     Return continued fraction expansion of x as iterator.
 
@@ -303,7 +303,7 @@ def continued_fraction_iterator(x: Expr) -> Iterator[Integer]:
         x = 1/x
 
 
-def continued_fraction_convergents(cf: Iterable):
+def continued_fraction_convergents(cf: list[int]) :
     """
     Return an iterator over the convergents of a continued fraction (cf).
 

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -9,9 +9,9 @@ from sympy.utilities.misc import as_int
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-from typing import Iterator,Iterable
+from typing import Iterator,Iterable,Any,List,Union
 
-def continued_fraction(a) -> list:
+def continued_fraction(a) -> list[Any]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -75,7 +75,7 @@ def continued_fraction(a) -> list:
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
-def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list:
+def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> List[Union[Integer, List[Integer]]]:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -157,7 +157,7 @@ def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list:
     n: Expr = (p + s*sd)/q
     if n < 0:
         w = floor(-n)
-        f = -n - w
+        f:Expr = -n - w
         one_f = continued_fraction(1 - f)  # 1-f < 1 so cf is [0 ... [...]]
         one_f[0] -= w + 1
         return one_f
@@ -184,7 +184,7 @@ def continued_fraction_periodic(p: int, q: int, d: int =0, s: int =1) -> list:
     return terms[:i] + [terms[i:]]  # type: ignore
 
 
-def continued_fraction_reduce(cf: list[int])-> Expr:
+def continued_fraction_reduce(cf: list[int])->  List[Union[int, List[int]]]:
     """
     Reduce a continued fraction to a rational or quadratic irrational.
 
@@ -362,10 +362,8 @@ def continued_fraction_convergents(cf: Iterable):
     """
     if isinstance(cf, list) and isinstance(cf[-1], list):
         cf = itertools.chain(cf[:-1], itertools.cycle(cf[-1]))
-    p_2: Expr = S.Zero
-    q_2: Expr = S.One
-    p_1: Expr = S.One
-    q_1: Expr = S.Zero
+    p_2, q_2 = S.Zero, S.One  # type: Expr, Expr
+    p_1, q_1 = S.One, S.Zero  # type: Expr, Expr
     for a in cf:
         p, q = a*p_1 + p_2, a*q_1 + q_2
         p_2, q_2 = p_1, q_1

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
 from typing import Iterator,Any,Iterable
 
-def continued_fraction(a) -> list[int | list[int]]:
+def continued_fraction(a: Any) -> list[int | list[int]]:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
 see  #28806 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Added type annotation in continued-fraction.py file 

#### Other comments
None

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
