### PR TITLE
assumptions: fix handlers for Mul of 0 with irrational/imaginary numbers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -242,6 +242,8 @@ Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.21>
 Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.2>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
 Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com> Ajinesh Pratap Singh <152050389+ajinesh703@users.noreply.github.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com> ajinesh703 <ajineshpratap@gmail.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>
 Akash Nagaraj (akasnaga) <akasnaga@cisco.com> Akash Nagaraj <grassknoted@gmail.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -82,9 +82,13 @@ def _(expr, assumptions):
     * Integer*Irrational   -> !Integer
     * Odd/Even             -> !Integer
     * Integer*Rational     -> ?
+    * 0*anything           -> Integer (0 is an integer)
     """
     if expr.is_number:
         return _IntegerPredicate_number(expr, assumptions)
+    # If the product is zero, it is an integer
+    if ask(Q.zero(expr), assumptions):
+        return True
     _output = True
     for arg in expr.args:
         if not ask(Q.integer(arg), assumptions):
@@ -271,9 +275,13 @@ def _(expr, assumptions):
     * Real*Real               -> Real
     * Real*Imaginary          -> !Real
     * Imaginary*Imaginary     -> Real
+    * 0*anything              -> Real (0 is real)
     """
     if expr.is_number:
         return _RealPredicate_number(expr, assumptions)
+    # If the product is zero, it is real
+    if ask(Q.zero(expr), assumptions):
+        return True
     result = True
     for arg in expr.args:
         if ask(Q.real(arg), assumptions):
@@ -569,9 +577,13 @@ def _(expr, assumptions):
     """
     * Real*Imaginary      -> Imaginary
     * Imaginary*Imaginary -> Real
+    * 0*anything          -> not Imaginary (0 is real)
     """
     if expr.is_number:
         return _Imaginary_number(expr, assumptions)
+    # If the product is zero, it is not imaginary (0 is real)
+    if ask(Q.zero(expr), assumptions):
+        return False
     result = False
     reals = 0
     for arg in expr.args:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29480

#### Brief description of what is fixed or changed
Fixed `Q.zero` check in `Mul` handlers for `IntegerPredicate`,
`RealPredicate`, and `ImaginaryPredicate` in
`sympy/assumptions/handlers/sets.py`.

When a product evaluates to zero (e.g. `n*I` where `n=0`),
the handlers were not checking for this case and returning
incorrect results. The fix adds a `Q.zero(expr)` check at
the start of each handler:
- `RealPredicate`: returns `True` (0 is real)
- `ImaginaryPredicate`: returns `False` (0 is not imaginary)
- `IntegerPredicate`: returns `True` (0 is an integer)

#### Other comments
Before fix:
```python
ask(Q.real(n * I), Q.zero(n))      # False (wrong)
ask(Q.imaginary(n * I), Q.zero(n)) # True  (wrong)
ask(Q.integer(n * pi), Q.zero(n))  # False (wrong)
```
After fix:
```python
ask(Q.real(n * I), Q.zero(n))      # True  (correct)
ask(Q.imaginary(n * I), Q.zero(n)) # False (correct)
ask(Q.integer(n * pi), Q.zero(n))  # True  (correct)
```

#### AI Generation Disclosure
I used Claude (Anthropic) as an AI assistant to help identify
which handlers needed to be fixed and understand the codebase.
The fix (adding Q.zero checks in three Mul handlers) was
applied and tested by me locally.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `ask` returning incorrect results for `Mul` of 0
    with irrational/imaginary numbers. For example,
    `ask(Q.real(n * I), Q.zero(n))` now correctly returns
    `True`.
<!-- END RELEASE NOTES -->