### PR TITLE
Printing: further improvements to ordinal printing

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2537,6 +2537,8 @@ class LatexPrinter(Printer):
         else:
             return r"\operatorname{%s} {\left(%s\right)}" % (cls,
                                                              ", ".join(args))
+    def _print_OrdinalZero(self, expr):
+        return "0"
 
     def _print_OrdinalOmega(self, expr):
         return r"\omega"

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -423,8 +423,32 @@ class StrPrinter(Printer):
         else:
             return 'O(%s)' % self.stringify(expr.args, ', ', 0)
 
+    def _print_OrdinalZero(self, expr):
+        return "0"
+
+    def _print_OrdinalOmega(self, expr):
+        return "w"
+
+    def _print_OmegaPower(self, expr):
+        exp, mul = expr.args
+        if exp == 0:
+            return f"{mul}"
+
+        output_str = ""
+        if exp == 1:
+            output_str += "w"
+        elif len(exp.terms) > 1 or exp.is_limit_ordinal:
+            output_str += f"w**({self._print(exp)})"
+        else:
+            output_str += f"w**{self._print(exp)}"
+
+        if mul != 1:
+            output_str += f"*{mul}"
+
+        return output_str
+
     def _print_Ordinal(self, expr):
-        return expr.__str__()
+        return " + ".join([self._print(arg) for arg in expr.args])
 
     def _print_Cycle(self, expr):
         return expr.__str__()

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -71,7 +71,7 @@ from sympy.series.sequences import (SeqAdd, SeqFormula, SeqMul, SeqPer)
 from sympy.sets.conditionset import ConditionSet
 from sympy.sets.contains import Contains
 from sympy.sets.fancysets import (ComplexRegion, ImageSet, Range)
-from sympy.sets.ordinals import Ordinal, OrdinalOmega, OmegaPower
+from sympy.sets.ordinals import Ordinal, OrdinalOmega, OmegaPower, OrdinalZero
 from sympy.sets.powerset import PowerSet
 from sympy.sets.sets import (FiniteSet, Interval, Union, Intersection, Complement, SymmetricDifference, ProductSet)
 from sympy.sets.setexpr import SetExpr
@@ -1200,6 +1200,7 @@ def test_latex_powerset():
 
 def test_latex_ordinals():
     w = OrdinalOmega()
+    assert latex(OrdinalZero()) == "0"
     assert latex(w) == r"\omega"
     wp = OmegaPower(2, 3)
     assert latex(wp) == r'\omega^{2} 3'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -34,6 +34,7 @@ from sympy.matrices import SparseMatrix
 from sympy.polys.polytools import factor
 from sympy.series.limits import Limit
 from sympy.series.order import O
+from sympy.sets.ordinals import Ordinal, OrdinalOmega, OmegaPower, OrdinalZero
 from sympy.sets.sets import (Complement, FiniteSet, Interval, SymmetricDifference)
 from sympy.stats import (Covariance, Expectation, Probability, Variance)
 from sympy.stats.rv import RandomSymbol
@@ -938,6 +939,16 @@ def test_RandomDomain():
     A = Exponential('a', 1)
     B = Exponential('b', 1)
     assert str(pspace(Tuple(A, B)).domain) == "Domain: (0 <= a) & (0 <= b) & (a < oo) & (b < oo)"
+
+
+def test_ordinals():
+    w = OrdinalOmega()
+    assert str(OrdinalZero()) == "0"
+    assert str(w) == 'w'
+    assert str(Ordinal(OmegaPower(5, 3), OmegaPower(3, 2))) == 'w**5*3 + w**3*2'
+    assert str(Ordinal(OmegaPower(5, 3), OmegaPower(0, 5))) == 'w**5*3 + 5'
+    assert str(Ordinal(OmegaPower(1, 3), OmegaPower(0, 5))) == 'w*3 + 5'
+    assert str(Ordinal(OmegaPower(w + 1, 1), OmegaPower(3, 2))) == 'w**(w + 1) + w**3*2'
 
 
 def test_FiniteSet():

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -157,29 +157,6 @@ class Ordinal(Basic):
     def __ge__(self, other):
         return not self < other
 
-    def __str__(self):
-        net_str = ""
-        if self == ord0:
-            return 'ord0'
-        for plus_count, i in enumerate(self.terms):
-            if plus_count:
-                net_str += " + "
-
-            if i.exp == ord0:
-                net_str += str(i.mult)
-            elif i.exp == 1:
-                net_str += 'w'
-            elif len(i.exp.terms) > 1 or i.exp.is_limit_ordinal:
-                net_str += 'w**(%s)'%i.exp
-            else:
-                net_str += 'w**%s'%i.exp
-
-            if not i.mult == 1 and not i.exp == ord0:
-                net_str += '*%s'%i.mult
-        return(net_str)
-
-    __repr__ = __str__
-
     def __add__(self, other):
         if not isinstance(other, Ordinal):
             try:

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -254,4 +254,5 @@ class OrdinalOmega(Ordinal):
 
 
 ord0 = OrdinalZero()
-omega = OrdinalOmega()
+w = OrdinalOmega()
+omega = w

--- a/sympy/sets/tests/test_ordinals.py
+++ b/sympy/sets/tests/test_ordinals.py
@@ -2,12 +2,6 @@ from __future__ import annotations
 from sympy.sets.ordinals import Ordinal, OmegaPower, ord0, omega
 from sympy.testing.pytest import raises
 
-def test_string_ordinals():
-    assert str(omega) == 'w'
-    assert str(Ordinal(OmegaPower(5, 3), OmegaPower(3, 2))) == 'w**5*3 + w**3*2'
-    assert str(Ordinal(OmegaPower(5, 3), OmegaPower(0, 5))) == 'w**5*3 + 5'
-    assert str(Ordinal(OmegaPower(1, 3), OmegaPower(0, 5))) == 'w*3 + 5'
-    assert str(Ordinal(OmegaPower(omega + 1, 1), OmegaPower(3, 2))) == 'w**(w + 1) + w**3*2'
 
 def test_addition_with_integers():
     assert 3 + Ordinal(OmegaPower(5, 3)) == Ordinal(OmegaPower(5, 3))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

see #14752

#### Brief description of what is fixed or changed

- Moved string printing for ordinals from `__str__` on ordinals to the `StrPrinter`.
- Added a LaTeX printer for `OrdinalZero()` so that it prints as `"0"` instead of `"ord0"`.
- Allow `OrdinalOmega()` to be imported as `w`.

#### Other comments
In #14752 it was suggested that the string printers for ordinals print `"omega"` instead of `"w"` since that's what the variable is called. I think it's better to print as `"w"` since that's what is typically done in other ordinal calculators, so I added a line so that `OrdinalOmega()` can be imported as `w`. The old `omega` variable is also left for backwards compatibility.

The tests for the new string ordinal print functions were lifted verbatim from `test_ordinals.py`. The new print functions were not copied directly from the ordinals module, but they are very similar.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * `OrdinalZero()` now prints as `"0"` instead of `"ord0"`.

* sets
  * `OrdinalOmega()` can now be imported as `w`.


<!-- END RELEASE NOTES -->
