### PR TITLE
Fix \left being parsed as LTE in LaTeX lark parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1599,6 +1599,7 @@ Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
+Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1599,8 +1599,6 @@ Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
-Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <145254642+suraj5030@users.noreply.github.com>
-Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1599,7 +1599,7 @@ Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
-Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
+Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <145254642+suraj5030@users.noreply.github.com>
 Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1600,6 +1600,7 @@ Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
 Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
+Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -98,7 +98,10 @@ UNDERSCORE: "_"
 EQUAL: "="
 NOT_EQUAL: /\\neq(?![a-zA-Z])/ | /\\ne(?![a-zA-Z])/
 LT: "<"
-LTE: "\\leq" | /\\le(?![a-zA-Z])/ | "\\leqslant"
+
+// \le requires a negative lookahead to avoid matching as a prefix of \left as \left is defined in %ignore.
+
+LTE: "\\leq" | /\\le(?![a-zA-Z])/ | "\\leqslant"   
 GT: ">"
 GTE: "\\geq" | "\\ge" | "\\geqslant"
 

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -6,7 +6,7 @@
 %ignore "\\vrule" | "\\vcenter" | "\\vbox" | "\\vskip" | "\\vspace" | "\\hfill"
 %ignore "\\*" | "\\-" | "\\." | "\\/" | "\\(" | "\\="
 
-%ignore /\\left(?![a-zA-Z])/ | "\\right"
+%ignore "\\left" | "\\right"
 %ignore "\\limits" | "\\nolimits"
 %ignore "\\displaystyle"
 
@@ -98,7 +98,7 @@ UNDERSCORE: "_"
 EQUAL: "="
 NOT_EQUAL: /\\neq(?![a-zA-Z])/ | /\\ne(?![a-zA-Z])/
 LT: "<"
-LTE: "\\leq" | "\\le" | "\\leqslant"
+LTE: /\\leq(?![a-zA-Z])/ | /\\le(?![a-zA-Z])/ | "\\leqslant"
 GT: ">"
 GTE: "\\geq" | "\\ge" | "\\geqslant"
 

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -98,7 +98,7 @@ UNDERSCORE: "_"
 EQUAL: "="
 NOT_EQUAL: /\\neq(?![a-zA-Z])/ | /\\ne(?![a-zA-Z])/
 LT: "<"
-LTE: /\\leq(?![a-zA-Z])/ | /\\le(?![a-zA-Z])/ | "\\leqslant"
+LTE: "\\leq" | /\\le(?![a-zA-Z])/ | "\\leqslant"
 GT: ">"
 GTE: "\\geq" | "\\ge" | "\\geqslant"
 

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -6,7 +6,7 @@
 %ignore "\\vrule" | "\\vcenter" | "\\vbox" | "\\vskip" | "\\vspace" | "\\hfill"
 %ignore "\\*" | "\\-" | "\\." | "\\/" | "\\(" | "\\="
 
-%ignore "\\left" | "\\right"
+%ignore /\\left(?![a-zA-Z])/ | "\\right"
 %ignore "\\limits" | "\\nolimits"
 %ignore "\\displaystyle"
 

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -98,9 +98,8 @@ UNDERSCORE: "_"
 EQUAL: "="
 NOT_EQUAL: /\\neq(?![a-zA-Z])/ | /\\ne(?![a-zA-Z])/
 LT: "<"
-
-// \le requires a negative lookahead to avoid matching as a prefix of \left as \left is defined in %ignore.
-
+// "\le" requires a negative lookahead to avoid matching as a prefix of "\left". Without the negative lookahead,
+// LTE was matching the "\le" part of "\left", leaving behind "ft" as garbage tokens.
 LTE: "\\leq" | /\\le(?![a-zA-Z])/ | "\\leqslant"   
 GT: ">"
 GTE: "\\geq" | "\\ge" | "\\geqslant"


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" 

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29488 (see https://github.com/sympy/sympy/issues/29488)
#### Brief description of what is fixed or changed
 In latex.lark, the LTE token was defined to match \le which is a prefix 
of \left. This caused the parser to consume \le as LTE  and leave ft behind as symbol tokens.

Fixed by using a negative lookahead regex so \le and \leq only match 
when not followed by a letter.
Changed:
LTE: "\\leq" | "\\le" | "\\leqslant"

To:
LTE: "\\leq" | /\\le(?![a-zA-Z])/ | "\\leqslant"
#### Other comments


#### AI Generation Disclosure
AI was used to help format the issue description and PR description.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed a bug in the LaTeX lark parser where ``\left`` was incorrectly
    tokenized as LTE due to ``\le`` being a prefix of ``\left``.
<!-- END RELEASE NOTES -->
