### PR TITLE
Fix unicode pretty printing of vector subscripts

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -596,6 +596,7 @@ Dominik Stańczak <stanczakdominik@gmail.com>
 Donald Wilson <donwilson1029@gmail.com> wilds-23 <wilds-23@rhodes.edu>
 Duane Nykamp <nykamp@umn.edu>
 Duc-Minh Phan <alephvn@gmail.com>
+Ducket191 <dangminhduc1912008@gmail.com>
 Dustin Gadal <Dustin.Gadal@gmail.com> <dustin.gadal@gmail.com>
 Dzhelil Rufat <drufat@caltech.edu>
 Ebrahim Byagowi <ebrahim@gnu.org>

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -19,6 +19,7 @@ N = ReferenceFrame('N')
 
 v = a ** 2 * N.x + b * N.y + c * sin(alpha) * N.z
 w = alpha * N.x + sin(omega) * N.y + alpha * beta * N.z
+frac_w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
 ww = alpha * N.x + asin(omega) * N.y - alpha.diff() * beta * N.z
 o = a/b * N.x + (c+b)/a * N.y + c**2/b * N.z
 
@@ -51,6 +52,19 @@ def test_vector_pretty_print():
 
     # TODO : The pretty print division does not print correctly here:
     # w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
+
+    expected = '''\
+                             alpha    
+alpha n_x + sin(omega) n_y + ----- n_z
+                             beta     \
+'''
+    uexpected = '''\
+                    α    
+α nₓ + sin(ω) n_y + ─ n_z
+                    β    \
+'''
+    assert ascii_vpretty(frac_w) == expected
+    assert unicode_vpretty(frac_w) == uexpected
 
     assert ascii_vpretty(alpha * N.x) == 'alpha n_x'
     assert unicode_vpretty(alpha * N.x) == 'α nₓ'

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -52,20 +52,23 @@ def test_vector_pretty_print():
     # TODO : The pretty print division does not print correctly here:
     # w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
 
+    assert ascii_vpretty(alpha * N.x) == 'alpha n_x'
+    assert unicode_vpretty(alpha * N.x) == 'α nₓ'
+
     expected = """\
  2                               \n\
 a  n_x + b n_y + c*sin(alpha) n_z\
 """
     uexpected = """\
- 2                           \n\
-a  n_x + b n_y + c⋅sin(α) n_z\
+ 2                          \n\
+a  nₓ + b n_y + c⋅sin(α) n_z\
 """
 
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected
 
     expected = 'alpha n_x + sin(omega) n_y + alpha*beta n_z'
-    uexpected = 'α n_x + sin(ω) n_y + α⋅β n_z'
+    uexpected = 'α nₓ + sin(ω) n_y + α⋅β n_z'
 
     assert ascii_vpretty(w) == expected
     assert unicode_vpretty(w) == uexpected
@@ -77,10 +80,10 @@ a       b + c       c     \n\
 b         a         b     \
 """
     uexpected = """\
-                     2    \n\
-a       b + c       c     \n\
-─ n_x + ───── n_y + ── n_z\n\
-b         a         b     \
+                    2    \n\
+a      b + c       c     \n\
+─ nₓ + ───── n_y + ── n_z\n\
+b        a         b     \
 """
 
     assert ascii_vpretty(o) == expected
@@ -283,28 +286,28 @@ def test_issue_13354():
 def test_vector_derivative_printing():
     # First order
     v = omega.diff() * N.x
-    assert unicode_vpretty(v) == 'ω̇ n_x'
+    assert unicode_vpretty(v) == 'ω̇ nₓ'
     assert ascii_vpretty(v) == "omega'(t) n_x"
 
     # Second order
     v = omega.diff().diff() * N.x
 
     assert vlatex(v) == r'\ddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω̈ n_x'
+    assert unicode_vpretty(v) == 'ω̈ nₓ'
     assert ascii_vpretty(v) == "omega''(t) n_x"
 
     # Third order
     v = omega.diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\dddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω⃛ n_x'
+    assert unicode_vpretty(v) == 'ω⃛ nₓ'
     assert ascii_vpretty(v) == "omega'''(t) n_x"
 
     # Fourth order
     v = omega.diff().diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\ddddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω⃜ n_x'
+    assert unicode_vpretty(v) == 'ω⃜ nₓ'
     assert ascii_vpretty(v) == "omega''''(t) n_x"
 
     # Fifth order
@@ -319,11 +322,11 @@ d             \n\
 dt            \
 '''
     uexpected = '''\
- 5        \n\
-d         \n\
-───(ω) n_x\n\
-  5       \n\
-dt        \
+ 5       \n\
+d        \n\
+───(ω) nₓ\n\
+  5      \n\
+dt       \
 '''
     assert unicode_vpretty(v) == uexpected
     assert ascii_vpretty(v) == expected

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from sympy import (S, sympify, expand, sqrt, Add, zeros, acos,
-                   ImmutableMatrix as Matrix, simplify)
+                   ImmutableMatrix as Matrix, simplify, Symbol)
 from sympy.simplify.trigsimp import trigsimp
 from sympy.printing.defaults import Printable
 from sympy.utilities.misc import filldedent
@@ -277,7 +277,7 @@ class Vector(Printable, EvalfMixin):
                 elif M[i] == -1:
                     terms.append(prettyForm("-1") * prettyForm(N.pretty_vecs[i]))
                 else:
-                    terms.append(juxtapose(M[i], N.pretty_vecs[i]))
+                    terms.append(juxtapose(M[i], Symbol(N.pretty_vecs[i])))
 
         if terms:
             pretty_result = prettyForm.__add__(*terms)


### PR DESCRIPTION
#### References to other Issues or PRs

In preparing my Patch for GSoC 2026, I found the TODO in sympy/physics/vector/tests/test_printing.py

TODO: The unit vectors should print with subscripts, but they just
print as `n_x` instead of making `x` a subscript with unicode.

TODO: The pretty print division does not print correctly here:
w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z

#### Brief description of what is fixed or changed

I added a regression test for the 2nd TODOs. The test passed, so I think the 2nd TODO has been previously solved
As for the 1st TODO, I try to make all x,y,z to subscript, but only x can be a subscript with unicode
I also added regression tests for the 1st TODOs, with only `n_x` having `x` as a subscript.


#### Other comments

#### AI Generation Disclosure

I used ChatGPT to understand the codebase and the problems

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
