### PR TITLE
polys: optimize _primitive and _gf_gcd in modulargcd

### DIFF
--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -5,7 +5,7 @@ from sympy.ntheory import nextprime
 from sympy.ntheory.modular import crt
 from sympy.polys.domains import PolynomialRing
 from sympy.polys.galoistools import (
-    gf_gcd, gf_from_dict, gf_gcdex, gf_div, gf_lcm)
+    gf_gcd, gf_from_dict, gf_gcdex, gf_div, gf_lcm, gf_quo)
 from sympy.polys.polyerrors import ModularGCDFailed
 
 import random
@@ -38,22 +38,12 @@ def _gf_gcd(fp, gp, p):
     Compute the GCD of two univariate polynomials in `\mathbb{Z}_p[x]`.
     """
     dom = fp.ring.domain
+    f_list = fp.to_dense()
+    g_list = gp.to_dense()
 
-    while gp:
-        rem = fp
-        deg = gp.degree()
-        lcinv = dom.invert(gp.LC, p)
+    gcd_list = gf_gcd(f_list, g_list, p, dom)
 
-        while True:
-            degrem = rem.degree()
-            if degrem < deg:
-                break
-            rem = (rem - gp.mul_monom((degrem - deg,)).mul_ground(lcinv * rem.LC)).trunc_ground(p)
-
-        fp = gp
-        gp = rem
-
-    return fp.mul_ground(dom.invert(fp.LC, p)).trunc_ground(p)
+    return fp.ring.from_dense(gcd_list).trunc_ground(p)
 
 
 def _degree_bound_univariate(f, g):
@@ -322,8 +312,8 @@ def _primitive(f, p):
     >>> f = x*y*z - y**2*z**2
     >>> _primitive(f, p)
     (z, x*y - y**2*z)
-
     """
+
     ring = f.ring
     dom = ring.domain
     k = ring.ngens
@@ -335,13 +325,23 @@ def _primitive(f, p):
         coeffs[monom[:-1]][monom[-1]] = coeff
 
     cont = []
-    for coeff in iter(coeffs.values()):
-        cont = gf_gcd(cont, gf_from_dict(coeff, p, dom), p, dom)
+    for mon, coeff in coeffs.items():
+        coeff = gf_from_dict(coeff, p, dom)
+        coeffs[mon] = coeff
+        cont = gf_gcd(cont, coeff, p, dom)
 
-    yring = ring.clone(symbols=ring.symbols[k-1])
+    prim = {}
+    for mon, coeff in coeffs.items():
+        coeff = gf_quo(coeff, cont, p, dom)
+        deg = len(coeff)
+        for i, el in enumerate(coeff):
+            if el != 0:
+                prim[mon + (deg-1-i,)] = el
+
+    yring = ring.clone(symbols=[ring.symbols[k-1]])
     contf = yring.from_dense(cont).trunc_ground(p)
 
-    return contf, f.quo(contf.set_ring(ring))
+    return contf, ring.from_dict(prim).trunc_ground(p)
 
 
 def _deg(f):


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
While I was investigating the file modulargcd to learn about its functions, I was profiling modgcd_multivariate and noticed that quite some time was spent in the 2 functions _primitive and _gf_gcd, so I optimised them by performing the operations with the dense univariate representation, instead of with the sparse representation. 

#### Other comments
I had gemini generate me this script:
```
import cProfile
import pstats
import time
from sympy.polys import ring, ZZ
from sympy.polys.modulargcd import modgcd_multivariate

def generate_test_cases():
    cases = []
    
    R6, x1, x2, x3, x4, x5, x6 = ring("x1, x2, x3, x4, x5, x6", ZZ)
    G1 = x1**5 * x2**3 + x3**7 + x4**3 * x5**4 + x6**5 + 1
    A1 = x1**3 * x6**2 + x2**4 * x3**3 + x4**6 + x5**2 + 2
    B1 = x2**2 * x4**2 * x6**2 + x1**4 * x5**3 + x3**2 + 3
    cases.append(("6 Var (Degree 15, Medium Matrices)", G1*A1, G1*B1))
    
    R8, y1, y2, y3, y4, y5, y6, y7, y8 = ring("y1, y2, y3, y4, y5, y6, y7, y8", ZZ)
    G2 = y1**3 * y8**2 + y2**3 * y3**2 + y4**2 * y5**2 + y6 * y7 + 1
    A2 = y1**2 * y2**2 + y3**3 * y4 + y5**3 * y8 + y6**2 + 2
    B2 = y2 * y4 * y6 * y8 + y1**2 * y3**2 + y5 * y7 + 3
    cases.append(("8 Var (Degree 8, Medium Recursion)", G2*A2, G2*B2))

    R5, z1, z2, z3, z4, z5 = ring("z1, z2, z3, z4, z5", ZZ)
    A3 = z1**4 + z2**3 + z3**2 + z4 + z5 + 1
    B3 = z1*z2*z3*z4*z5 + z1**2 + z3**2 + 5
    cases.append(("5 Var (Coprimes, Early Exit)", A3, B3)) 

    R4, w1, w2, w3, w4 = ring("w1, w2, w3, w4", ZZ)
    G4 = (w1**3 * w2**2 + w1**2 * w2 + 1)**2
    A4 = w4**2 + w3
    B4 = w4**3 + w1*w4 + w2
    cases.append(("4 Var (Huge Content on _primitive)", G4*A4, G4*B4))

    R4_denso, d1, d2, d3, d4 = ring("d1, d2, d3, d4", ZZ)
    G5 = (d1 + d2 + d3 + d4 + 1)**3
    A5 = d1**2 - d2**2 + d3 - 1
    B5 = d1*d2 + d4**2 + 2
    cases.append(("4 Var (Dense, Term Explosion)", G5*A5, G5*B5))

    return cases

def run_profiled_suite():
    cases = generate_test_cases()
    
    for name, f, g in cases:
        print(f"\n{'='*70}")
        print(f" STARTING TEST: {name}")
        print(f"{'='*70}")
        
        profiler = cProfile.Profile()
        start_time = time.perf_counter()
        
        profiler.enable()
        try:
            modgcd_multivariate(f, g)
        except Exception as e:
            print(f"ERROR during GCD: {e}")
            profiler.disable()
            import traceback
            traceback.print_exc()
            continue
        finally:
            profiler.disable()
            
        elapsed = time.perf_counter() - start_time
        print(f"TOTAL TIME: {elapsed:.3f} seconds\n")
        print("--- TOP 20 SLOWEST FUNCTIONS ---")
        
        stats = pstats.Stats(profiler)
        stats.strip_dirs()
        stats.sort_stats('cumulative') 
        stats.print_stats(20)

if __name__ == '__main__':
    run_profiled_suite()
```

The test above resulted in an average of 40.22% reduction in runtime for _primitive and 63.32% for _gf_gcd

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

ai helped me to find the bottlenecks of the 2 functions, code is written by myself

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Optimized _primitive and _gf_gcd in modulargcd.py 
<!-- END RELEASE NOTES -->
