### PR TITLE
Fix nonlinsolve duplicate

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -242,7 +242,7 @@ Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.21>
 Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.2>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
 Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
-Ajinesh Pratap Singh <ajineshpratap@gmail.com> ajinesh703 <ajineshpratap@gmail.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com> Ajinesh Pratap Singh <152050389+ajinesh703@users.noreply.github.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>
 Akash Nagaraj (akaSsnaga) <akasnaga@cisco.com> Akash Nagaraj <grassknoted@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -243,6 +243,7 @@ Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.2>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
 Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Ajinesh Pratap Singh <ajineshpratap@gmail.com> Ajinesh Pratap Singh <152050389+ajinesh703@users.noreply.github.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com> ajinesh703 <ajineshpratap@gmail.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>
 Akash Nagaraj (akaSsnaga) <akasnaga@cisco.com> Akash Nagaraj <grassknoted@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -242,9 +242,10 @@ Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.21>
 Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.2>
 Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
 Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com> ajinesh703 <ajineshpratap@gmail.com>
 Akash Agrawall <akash.wanted@gmail.com>
 Akash Kundu <sk.sayakkundu1997@gmail.com>
-Akash Nagaraj (akasnaga) <akasnaga@cisco.com> Akash Nagaraj <grassknoted@gmail.com>
+Akash Nagaraj (akaSsnaga) <akasnaga@cisco.com> Akash Nagaraj <grassknoted@gmail.com>
 Akash Nagaraj <grassknoted@gmail.com> grassknoted <grassknoted@gmail.com>
 Akash Trehan <akash.trehan123@gmail.com>
 Akash Vaish <akash.9712@gmail.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3747,7 +3747,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                            if isinstance(a, Expr) and isinstance(b, Expr)):
                         is_dup = True
                         break
-                except Exception:
+                except (TypeError, AttributeError):
                     pass
         if not is_dup:
             seen.append(tup)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3731,10 +3731,25 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
             result_all_variables, intersections, complements)
 
     # convert to ordered tuple
+    # convert to ordered tuple, removing mathematically duplicate solutions
     result = S.EmptySet
+    seen = []
     for r in result_all_variables:
         temp = [r[symb] for symb in all_symbols]
-        result += FiniteSet(tuple(temp))
+        tup = tuple(temp)
+        is_dup = False
+        for seen_tup in seen:
+            try:
+                if all(simplify(a - b) == 0
+                       for a, b in zip(tup, seen_tup)
+                       if isinstance(a, Expr) and isinstance(b, Expr)):
+                    is_dup = True
+                    break
+            except Exception:
+                pass
+        if not is_dup:
+            seen.append(tup)
+            result += FiniteSet(tup)
     return result
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3738,15 +3738,17 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         temp = [r[symb] for symb in all_symbols]
         tup = tuple(temp)
         is_dup = False
-        for seen_tup in seen:
-            try:
-                if all(simplify(a - b) == 0
-                       for a, b in zip(tup, seen_tup)
-                       if isinstance(a, Expr) and isinstance(b, Expr)):
-                    is_dup = True
-                    break
-            except Exception:
-                pass
+        has_set = any(isinstance(x, Set) for x in tup)
+        if not has_set:
+            for seen_tup in seen:
+                try:
+                    if all(simplify(a - b) == 0
+                           for a, b in zip(tup, seen_tup)
+                           if isinstance(a, Expr) and isinstance(b, Expr)):
+                        is_dup = True
+                        break
+                except Exception:
+                    pass
         if not is_dup:
             seen.append(tup)
             result += FiniteSet(tup)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2454,7 +2454,7 @@ def test_substitution_redundant():
     # the system below has three solutions. Two of the solutions
     # returned by substitution are redundant.
     res = substitution([x - y, y**3 - 3*y**2 + 1], [x, y])
-    assert len(res) == 5
+    assert len(res) == 3
 
 
 def test_issue_5132_substitution():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #13961

#### Brief description of what is fixed or changed
Fixed `substitution` function in `sympy/solvers/solveset.py` to remove
mathematically duplicate solutions from the output of `nonlinsolve`.

The fix adds a deduplication check at the end of the `substitution`
function that uses `simplify` to detect when two solutions are
mathematically equivalent. Solutions containing `ImageSet` or other
`Set` objects are excluded from deduplication to avoid incorrectly
removing distinct infinite solution families.

The test `test_substitution_redundant` was updated to reflect the
new correct behaviour.

#### AI Generation Disclosure
I used an AI assistant to help identify the fix. The changes were
applied and tested by me locally.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed `nonlinsolve` returning duplicate solutions when the solutions are mathematically equivalent but expressed in different forms.
<!-- END RELEASE NOTES -->