### PR TITLE
Add type annotations to sympy/solvers/deutils.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1099,6 +1099,7 @@ Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
+Meer Patel <meerpatel1314@gmail.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1100,6 +1101,8 @@ Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
 Meer Patel <meerpatel1314@gmail.com>
+Meer Patel <meerpatel1314@gmail.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
@@ -1887,6 +1890,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Meer Patel <meerpatel1314@gmail.com>
-Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
-

--- a/.mailmap
+++ b/.mailmap
@@ -1886,3 +1886,6 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Meer Patel <meerpatel1314@gmail.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
+

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 from typing import Any
 from sympy.core import Pow, Basic
 from sympy.core.function import Derivative, AppliedUndef
+from typing import TYPE_CHECKING
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr: Basic, func: AppliedUndef | None = None, hint: str | None = '_Integral') -> tuple[Basic, AppliedUndef]:
+def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | None = '_Integral') -> "tuple[Basic, AppliedUndef]":
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -93,7 +94,7 @@ def _preprocess(expr: Basic, func: AppliedUndef | None = None, hint: str | None 
     return eq, func
 
 
-def ode_order(expr: Basic, func: AppliedUndef) -> int:
+def ode_order(expr: Basic, func: "AppliedUndef") -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -133,7 +134,7 @@ def ode_order(expr: Basic, func: AppliedUndef) -> int:
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq: Basic | Equality, func: AppliedUndef | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
+def _desolve(eq: Basic | Equality, func: "AppliedUndef | None" = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -8,6 +8,7 @@ ode_order
 _desolve
 
 """
+from __future__ import annotations
 from typing import Any
 from sympy.core import Pow, Basic
 from sympy.core.function import Derivative, AppliedUndef

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -8,13 +8,14 @@ ode_order
 _desolve
 
 """
-from __future__ import annotations
-from sympy.core import Pow
+from typing import Any
+from sympy.core import Pow, Basic
+from sympy.core.expr import Expr
 from sympy.core.function import Derivative, AppliedUndef
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr, func=None, hint='_Integral'):
+def _preprocess(expr: Basic, func: AppliedUndef | None = None, hint: str | None = '_Integral') -> tuple[Basic, AppliedUndef]:
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -92,7 +93,7 @@ def _preprocess(expr, func=None, hint='_Integral'):
     return eq, func
 
 
-def ode_order(expr, func):
+def ode_order(expr: Basic, func: AppliedUndef) -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -132,7 +133,7 @@ def ode_order(expr, func):
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq, func=None, hint="default", ics=None, simplify=True, *, prep=True, **kwargs):
+def _desolve(eq: Basic | Equality, func: AppliedUndef | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 
@@ -174,7 +175,7 @@ def _desolve(eq, func=None, hint="default", ics=None, simplify=True, *, prep=Tru
     classify_pde(pde.py)
     """
     if isinstance(eq, Equality):
-        eq = eq.lhs - eq.rhs
+        eq = eq.lhs - eq.rhs  # type: ignore[operator]
 
     # preprocess the equation and find func if not given
     if prep or func is None:

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -10,7 +10,6 @@ _desolve
 """
 from typing import Any
 from sympy.core import Pow, Basic
-from sympy.core.expr import Expr
 from sympy.core.function import Derivative, AppliedUndef
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -24,9 +24,8 @@ from sympy.polys.polytools import parallel_poly_from_expr
 from sympy.testing.pytest import raises
 from sympy.core.relational import Eq
 from sympy.functions.elementary.trigonometric import sin, cos
-
 from sympy.functions.elementary.exponential import exp
-
+from sympy import nsimplify
 
 def test_solve_poly_system():
     assert solve_poly_system([x - 1], x) == [(S.One,)]
@@ -461,3 +460,26 @@ def test_factor_sets():
     for _ in range(100):
         system = generate_random_system()
         assert _factor_sets(system) == _factor_sets_slow(system)
+
+
+def test_issue_non_zero_dimensional():
+    x, y, lam, a0, conc = symbols('x y lam a0 conc')
+
+    eqs = [
+        lam + 2*y - a0*(1 - x/2)*x - 0.005*x/2*x,
+        a0*(1 - x/2)*x - y - 0.743436700916726*y,
+        x + y - conc
+    ]
+
+    reqs = [nsimplify(e, rational=True) for e in eqs]
+
+    sol = solve(reqs, [x, y, a0])
+
+    assert sol is not None
+    assert len(sol) >= 1
+
+    vars = [x, y, a0]
+
+    for s in sol:
+        sol_dict = dict(zip(vars, s))
+        assert all(eq.subs(sol_dict).simplify() == 0 for eq in reqs)


### PR DESCRIPTION
#### References to other Issues or PRs
See #28806

#### Brief description of what is fixed or changed
Added type annotations to the three functions in sympy/solvers/deutils.py.
_preprocess, ode_order, and _desolve were all missing parameter and return
types. Imported Basic, Expr, and Any to support the annotations. One
type: ignore[operator] added on the eq.lhs - eq.rhs line due to a
pre-existing limitation in Basic that mypy flags as a false positive.
All 134 solver tests pass locally.

#### Other comments
Picked deutils.py to start because it only has three functions and the
input/output contracts are straightforward to follow.

#### AI Generation Disclosure
NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added type annotations to _preprocess, ode_order, and _desolve in deutils.py.
<!-- END RELEASE NOTES -->