### PR TITLE
Removing test eigen vects Xfail

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1433,8 +1433,7 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
-Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com>
-Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com> Your GitHub Name <cycertron@gmail.com>
+Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com> cycertron <cycertron@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1433,6 +1433,8 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
+Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com>
+Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com> Your GitHub Name <cycertron@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1433,7 +1433,7 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
-cycertron <cycertron@gmail.com>
+Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1433,7 +1433,7 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
-Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com> cycertron <cycertron@gmail.com>
+cycertron <cycertron@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1433,7 +1433,7 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
-Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com> Your GitHub Name <cycertron@gmail.com>
+cycertron <134198286+cycertron@users.noreply.github.com> <cycertron@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1433,7 +1433,7 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
-Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com>
+Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com> Your GitHub Name <cycertron@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1433,7 +1433,6 @@ Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
 Safiya03 <safiyanesar@gmail.com>
 Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
 Sagar231 <sagarfeb298@gmail.com>
-cycertron <134198286+cycertron@users.noreply.github.com> <cycertron@gmail.com>
 Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
@@ -1789,6 +1788,9 @@ carstimon <carstimon@gmail.com>
 ck Lux <lux.r.ck@gmail.com>
 cocolato <haiizhu@outlook.com> Hai Zhu <35182391+cocolato@users.noreply.github.com>
 codecruisader <nnisarg55@gmail.com>
+cycertron <cycertron@gmail.com> Saharsha Raj Pandey <134198286+cycertron@users.noreply.github.com>
+cycertron <cycertron@gmail.com> Your GitHub Name <cycertron@gmail.com>
+cycertron <cycertron@gmail.com> cycertron <134198286+cycertron@users.noreply.github.com>
 cym1 <16437732+cym1@users.noreply.github.com>
 damianos <damianos@semmle.com>
 dandiez <47832466+dandiez@users.noreply.github.com>

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -7,7 +7,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices import eye, Matrix
 from sympy.core.singleton import S
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises
 from sympy.matrices.exceptions import NonSquareMatrixError, MatrixError
 from sympy.matrices.expressions.fourier import DFT
 from sympy.simplify.simplify import simplify
@@ -158,16 +158,6 @@ def test_float_eigenvals():
     for x, y in zip(n_evals, s_evals):
         assert abs(x-y) < 10**-9
 
-
-@XFAIL
-def test_eigen_vects():
-    m = Matrix(2, 2, [1, 0, 0, I])
-    raises(NotImplementedError, lambda: m.is_diagonalizable(True))
-    # !!! bug because of eigenvects() or roots(x**2 + (-1 - I)*x + I, x)
-    # see issue 5292
-    assert not m.is_diagonalizable(True)
-    raises(MatrixError, lambda: m.diagonalize(True))
-    (P, D) = m.diagonalize(True)
 
 def test_issue_8240():
     # Eigenvalues of large triangular matrices
@@ -415,6 +405,9 @@ def test_diagonalize():
     assert D == Matrix([
                  [-I, 0],
                  [ 0, I]])
+    
+    m = Matrix(2, 2, [1, 0, 0, I])
+    raises(MatrixError, lambda: m.diagonalize(reals_only=True))
 
     # make sure we use floats out if floats are passed in
     m = Matrix(2, 2, [0, .5, .5, 0])
@@ -442,6 +435,8 @@ def test_is_diagonalizable():
     assert m.is_diagonalizable()
     assert not m.is_diagonalizable(reals_only=True)
 
+    m = Matrix(2, 2, [1, 0, 0, I])
+    assert not m.is_diagonalizable(reals_only=True)
 
 def test_jordan_form():
     from sympy import nsimplify

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -405,7 +405,7 @@ def test_diagonalize():
     assert D == Matrix([
                  [-I, 0],
                  [ 0, I]])
-    
+
     m = Matrix(2, 2, [1, 0, 0, I])
     raises(MatrixError, lambda: m.diagonalize(reals_only=True))
 


### PR DESCRIPTION
#### References to other Issues or PRs
"Fixes #29425"



#### Brief description of what is fixed or changed
The test eigen vects was completely removed and also the remaining checks were moved into test_diagonalize and test_is_diagonalizable. The XFAIL from the imports was also removed.

#### Other comments


#### AI Generation Disclosure
No, AI was used.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
