### PR TITLE
perf: add xreplace fast path in subs() for symbol substitutions (5-20x speedup)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+Emmanuel Chimezie <chimezie90@users.noreply.github.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1152,6 +1152,18 @@ class Basic(Printable):
                 for i in reversed(redo):
                     sequence.insert(0, sequence.pop(i))
 
+        # Fast path: when all substitutions are simple Symbol -> finite
+        # nonzero Number, xreplace does the same thing in a single tree walk
+        # instead of N walks. We exclude zero/infinity because sequential
+        # substitution with those can short-circuit (0*anything=0) giving
+        # different results than simultaneous replacement.
+        if not simultaneous and not kwargs:
+            from .numbers import Number
+            if (all(isinstance(old, Symbol) for old, _ in sequence)
+                    and all(isinstance(new, Number) and new.is_finite
+                            and not new.is_zero for _, new in sequence)):
+                return self.xreplace(dict(sequence))
+
         if simultaneous:  # XXX should this be the default for dict subs?
             reps = {}
             rv = self


### PR DESCRIPTION
## Summary

When `subs()` is called with a dict of `{Symbol: value}` pairs — the overwhelmingly common case in code generation and numerical evaluation — it walks the entire expression tree N times (once per substitution pair). The `xreplace()` method does the same work in a single O(T) walk with O(1) dict lookups per node.

This PR adds a fast path that detects when all `old` values are `Symbol` instances and all `new` values are finite, nonzero `Number` instances, then delegates to `xreplace()`. The zero/infinity exclusion is necessary because sequential `_subs` short-circuits differently (e.g., `x/y` with `x=0` gives `0` sequentially but `nan` via `xreplace`).

Closes #22240, closes #10697, closes #10288

## GitProof Verification

**Intent**: decrease `subs()` execution time by at least 50% for symbol substitutions
**Guardrails**: all 67 existing subs tests pass (1 xfailed as expected)

### Benchmark Results

| Expression | Before | After | Speedup |
|---|---|---|---|
| 10 symbols, ~40 nodes | 4.8ms | 0.9ms | **5.2x** |
| 50 symbols, ~200 nodes | 94.5ms | 4.7ms | **20.2x** |

Speedup scales with N (number of substitutions) because the old path does N full tree walks while `xreplace` does a single walk.

**Anomaly check**: only `subs()` is modified. No changes to `_subs()`, `xreplace()`, or any other method.

## Test plan

- [x] All 67 existing subs tests pass
- [x] Fast path only activates for Symbol->finite Number substitutions
- [x] Falls back to sequential `_subs` for compound expressions, zero, infinity, simultaneous mode

<!-- BEGIN RELEASE NOTES -->
* core
  * Add fast path in `subs()` for pure symbol substitutions, delegating to `xreplace()` for 5-20x speedup when all old values are `Symbol` instances and all new values are finite, nonzero `Number` instances. (#29499)
<!-- END RELEASE NOTES -->