### PR TITLE
Add type annotations to sympy/solvers/deutils.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1100,11 +1100,11 @@ Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Merin Theres Jose <merintheresjose@gmail.com>
-Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1104,6 +1104,7 @@ Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Merin Theres Jose <merintheresjose@gmail.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>
@@ -1887,4 +1888,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1887,3 +1887,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -117,7 +117,8 @@ copybutton_prompt_is_regexp = True
 nitpicky = True
 
 nitpick_ignore = [
-    ('py:class', 'sympy.logic.boolalg.Boolean')
+    ('py:class', 'sympy.logic.boolalg.Boolean'),
+    ('py:class', 'sympy.core.function.AppliedUndef'),
 ]
 
 # To stop docstrings inheritance.

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -15,7 +15,7 @@ from sympy.core.function import Derivative, AppliedUndef
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr: Basic, func: Any | None = None, hint: str | None = '_Integral') -> tuple[Basic, Any]:
+def _preprocess(expr: Basic, func: AppliedUndef | None = None, hint: str | None = '_Integral') -> tuple[Basic, AppliedUndef]:
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -93,7 +93,7 @@ def _preprocess(expr: Basic, func: Any | None = None, hint: str | None = '_Integ
     return eq, func
 
 
-def ode_order(expr: Basic, func: Any) -> int:
+def ode_order(expr: Basic, func: AppliedUndef) -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -133,7 +133,7 @@ def ode_order(expr: Basic, func: Any) -> int:
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
+def _desolve(eq: Basic | Equality, func: AppliedUndef | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 
@@ -192,11 +192,11 @@ def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default
     x0 = kwargs.get('x0', 0)
     terms = kwargs.get('n')
 
+    classifier: Any = None
+    allhints: tuple[str, ...] = ()
     if type == 'ode':
         from sympy.solvers.ode import classify_ode, allhints
         classifier = classify_ode
-        string = 'ODE '
-        dummy = ''
 
     elif type == 'pde':
         from sympy.solvers.pde import classify_pde, allhints
@@ -246,7 +246,7 @@ def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default
                       prep=prep, x0=x0, classify=False, order=hints['order'],
                       match=hints[hints['default']], xi=xi, eta=eta, n=terms, type=type)
     elif hint in ('all', 'all_Integral', 'best'):
-        retdict = {}
+        retdict: dict[str, Any] = {}
         gethints = set(hints) - {'order', 'default', 'ordered_hints'}
         if hint == 'all_Integral':
             for i in hints:

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -9,12 +9,14 @@ _desolve
 
 """
 from __future__ import annotations
-from sympy.core import Pow
+from typing import Any
+from sympy.core import Pow, Basic
 from sympy.core.function import Derivative, AppliedUndef
+from typing import TYPE_CHECKING
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr, func=None, hint='_Integral'):
+def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | None = '_Integral') -> "tuple[Basic, AppliedUndef]":
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -92,7 +94,7 @@ def _preprocess(expr, func=None, hint='_Integral'):
     return eq, func
 
 
-def ode_order(expr, func):
+def ode_order(expr: Basic, func: "AppliedUndef") -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -132,7 +134,7 @@ def ode_order(expr, func):
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq, func=None, hint="default", ics=None, simplify=True, *, prep=True, **kwargs):
+def _desolve(eq: Basic | Equality, func: "AppliedUndef | None" = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 
@@ -174,7 +176,7 @@ def _desolve(eq, func=None, hint="default", ics=None, simplify=True, *, prep=Tru
     classify_pde(pde.py)
     """
     if isinstance(eq, Equality):
-        eq = eq.lhs - eq.rhs
+        eq = eq.lhs - eq.rhs  # type: ignore[operator]
 
     # preprocess the equation and find func if not given
     if prep or func is None:

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from typing import Any
 from sympy.core import Pow, Basic
 from sympy.core.function import Derivative, AppliedUndef
-from typing import TYPE_CHECKING
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -194,9 +194,13 @@ def _desolve(eq: Basic | Equality, func: AppliedUndef | None = None, hint: str =
 
     classifier: Any = None
     allhints: tuple[str, ...] = ()
+    string: str = ''
+    dummy: str = ''
     if type == 'ode':
         from sympy.solvers.ode import classify_ode, allhints
         classifier = classify_ode
+        string = 'ODE '
+        dummy = ''
 
     elif type == 'pde':
         from sympy.solvers.pde import classify_pde, allhints

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -15,7 +15,7 @@ from sympy.core.function import Derivative, AppliedUndef
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | None = '_Integral') -> "tuple[Basic, AppliedUndef]":
+def _preprocess(expr: Basic, func: Any | None = None, hint: str | None = '_Integral') -> tuple[Basic, Any]:
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -93,7 +93,7 @@ def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | Non
     return eq, func
 
 
-def ode_order(expr: Basic, func: "AppliedUndef") -> int:
+def ode_order(expr: Basic, func: Any) -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -133,7 +133,7 @@ def ode_order(expr: Basic, func: "AppliedUndef") -> int:
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq: Basic | Equality, func: "AppliedUndef | None" = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
+def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 


### PR DESCRIPTION
#### References to other Issues or PRs
See #28806

#### Brief description of what is fixed or changed
Added type annotations to the three functions in sympy/solvers/deutils.py.
_preprocess, ode_order, and _desolve were all missing parameter and return
types. Imported Basic, Any, and used string literals for AppliedUndef to
avoid Sphinx resolution issues. One type: ignore[operator] added on the
eq.lhs - eq.rhs line due to a pre-existing limitation in Basic.
All 134 solver tests pass locally.

#### Other comments
Picked deutils.py because it only has three functions with clear
Input/Output contracts, good starting point for the annotations effort.

#### AI Generation Disclosure
NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added type annotations to _preprocess, ode_order, and _desolve in deutils.py.
<!-- END RELEASE NOTES -->