### PR TITLE
ask: Handle most real linear inequality assumptions 

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -483,7 +483,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     >>> ask(Q.positive(x), x > 0)
     True
-    >>> ask(x > y, (x - 2*y > 0) & Q.real(x) & Q.real(y))
+    >>> ask(x > y, (x - 2*y > 0) & Q.real(x) & Q.positive(y))
     True
     >>> ask(x + 1 > x, Q.real(x))
     True
@@ -492,7 +492,8 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     In some cases, you may need to specify that the variables are real.
 
-    >>> ask(x > y, (x - 2*y > 0)) # Gives `None`
+    >>> print(ask(x > y, (x - 2*y > 0)))
+    None
 
     This happens because the assumption `x - 2*y > 0` does not guarantee
     that `x - 2*y > 0` is finite; `x > y` could be false if x = oo.

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -455,7 +455,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     ========
 
     >>> from sympy import ask, Q, pi
-    >>> from sympy.abc import x, y
+    >>> from sympy.abc import x, y, z
     >>> ask(Q.rational(pi))
     False
     >>> ask(Q.even(x*y), Q.even(x) & Q.integer(y))
@@ -478,12 +478,24 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     Notes
     =====
 
-    Relations in assumptions are not implemented (yet), so the following
-    will not give a meaningful result.
+    Queries involving real linear inequalities are handled in most cases.
+    For example:
 
     >>> ask(Q.positive(x), x > 0)
+    True
+    >>> ask(x > y, (x - 2*y > 0) & Q.real(x) & Q.real(y))
+    True
+    >>> ask(x + 1 > x, Q.real(x))
+    True
+    >>> ask(x > z, (x > y) & (y > z))
+    True
 
-    It is however a work in progress.
+    In some cases, you may need to specify that the variables are real.
+
+    >>> ask(x > y, (x - 2*y > 0)) # Gives `None`
+
+    This happens because the assumption `x - 2*y > 0` does not guarantee
+    that `x - 2*y > 0` is finite; `x > y` could be false if x = oo.
 
     See Also
     ========

--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -415,6 +415,10 @@ class EncodedCNF:
     def variables(self):
         return range(1, len(self._symbols) + 1)
 
+    @property
+    def reverse_encoding(self):
+        return {value: key for key, value in self.encoding.items()}
+
     def copy(self):
         new_data = [set(clause) for clause in self.data]
         return EncodedCNF(new_data, dict(self.encoding))

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 from sympy.assumptions.assume import global_assumptions
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
+from sympy.core.add import Add
 from sympy.core.numbers import I
+from sympy.core.symbol import Symbol
 from sympy.logic.inference import satisfiable
 from sympy.logic.algorithms.lra_theory import UnhandledInput, ALLOWED_PRED
 from sympy.matrices.kind import MatrixKind
@@ -12,16 +14,12 @@ from sympy.core.mul import Mul
 from sympy.core.singleton import S
 
 
-# Some predicates such as Q.prime can't be handled by lra_satask. For example,
-# (x > 0) & (x < 1) & Q.prime(x) is unsat but lra_satask would think it was sat.
-# WHITE_LIST is a list of predicates that can always be handled.
-WHITE_LIST = ALLOWED_PRED | {Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative,
-    Q.negative_infinite, Q.positive_infinite}
+REAL_PREDICATES = {Q.real, Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative}
+EXTENDED_REAL_PREDICATES = {Q.extended_real, Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
+    Q.extended_nonnegative, Q.extended_nonzero, Q.positive_infinite, Q.negative_infinite, Q.gt, Q.lt, Q.ge, Q.le}
 
-REAL_IMPLYING_PREDICATES = WHITE_LIST | {Q.real}
 
-EXTENED_REAL_IMPLYING_PREDICATES = REAL_IMPLYING_PREDICATES | {Q.extended_real, Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
-    Q.extended_negative, Q.extended_nonzero}
+HANDLED_PREDICATES = EXTENED_REAL_IMPLYING_PREDICATES | {Q.ne}
 
 def lra_satask(proposition, assumptions=True, context=global_assumptions):
     """
@@ -47,16 +45,17 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
 
 
     # Use unit clauses from `assumptions_encoded_cnf` to
-    # deduce some expressions are extened real.
+    # try to deduce if expressions are real or extended real.
     reverse_encoding = {value: key for key, value in assumptions_encoded_cnf.encoding.items()}
     real_exprs = set()
+    extended_real_exprs = set()
     for unit_clause in assumptions_encoded_cnf.data:
         # Check if `unit_clause` is a unit clause.
         if len(unit_clause) != 1:
             continue
 
-        # Continue if negative because negative literals
-        # cannot establish that an expression is entended real.
+        # Negated predicates cannot establish that
+        # an expression is real (or extended real).
         (positive_literal,) = unit_clause
         if not (positive_literal > 0):
             continue
@@ -65,8 +64,11 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         if not isinstance(applied_predicate, AppliedPredicate):
             continue
 
-        if applied_predicate.function in REAL_IMPLYING_PREDICATES:
+        if applied_predicate.function in REAL_PREDICATES:
             real_exprs.update(applied_predicate.arguments)
+        if applied_predicate.function in EXTENDED_REAL_PREDICATES:
+            extended_real_exprs.update(applied_predicate.arguments)
+
 
     # SATIFSIABLE STARTED HERE
 
@@ -78,39 +80,66 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
 
 
     # Check old assumptions to:
-    #   1. Deduce some expressions are extened real.
-    #   2. Add relevant inequality assumptions as unit clauses
-    #      to `assumptions_encoded_cnf`.
+    #   1. Check if expressions are assumed to be real or extened real.
+    #   2. Add relevant inequality assumptions to `assumptions_encoded_cnf`.
     all_pred, all_exprs = get_all_pred_and_expr_from_enc_cnf([sat_true])
     for expr in all_exprs:
-        convertable_to_inequality_applied_predicate, is_real  = extract_assumption_from_old_assumption(expr)
+        # If there are any predicates that can be represented as inequalities,
+        # `relevant_applied_predicate` is set to the most specific of those predicates.
+        relevant_applied_predicate, is_real, is_extended_real  = extract_assumption_from_old_assumption(expr)
         if is_real:
             real_exprs.add(expr)
-        if convertable_to_inequality_applied_predicate is None:
+        elif is_extended_real:
+            extended_real_exprs.add(expr)
+
+        if relevant_applied_predicate is None:
             continue
 
 
-        if convertable_to_inequality_applied_predicate not in assumptions_encoded_cnf.encoding:
+        if relevant_applied_predicate not in assumptions_encoded_cnf.encoding:
             applied_predicate_encoding = len(assumptions_encoded_cnf.encoding) + 1
-            assumptions_encoded_cnf.encoding[convertable_to_inequality_applied_predicate] = applied_predicate_encoding
+            assumptions_encoded_cnf.encoding[relevant_applied_predicate] = applied_predicate_encoding
 
         # Add relevant old assumptions to `assumptions`.
-        applied_predicate_encoding = assumptions_encoded_cnf.encoding[convertable_to_inequality_applied_predicate]
+        applied_predicate_encoding = assumptions_encoded_cnf.encoding[relevant_applied_predicate]
         assumptions_encoded_cnf.data.append([applied_predicate_encoding])
 
-    for expr in all_exprs:
-        if expr not in real_exprs:
-            raise UnhandledInput(f"LRASolver: {expr} must be real")
 
+<<<<<<< HEAD
+    all_symbols = set()
+=======
 
     for pred in all_pred:
-        if pred.function not in EXTENED_REAL_IMPLYING_PREDICATES and pred.function != Q.ne:
+        if pred.function not in HANDLED_PREDICATES:
             raise UnhandledInput(f"LRASolver: {pred} is an unhandled predicate")
+>>>>>>> 70850820c1 (Create HANDLED_PREDICATES for readablity)
     for expr in all_exprs:
         if expr.kind != NumberKind:
             raise UnhandledInput(f"LRASolver: Only scalar expresions are supported. {expr} must be of {NumberKind} but is of {expr.kind} instead.")
         if expr == S.NaN:
             raise UnhandledInput("LRASolver: nan")
+        if expr not in real_exprs and expr not in extended_real_exprs:
+            raise UnhandledInput(f"LRASolver: {expr} must be extended real.")
+
+        # If there exist distinct extended real expresions (that may be infinite),
+        # they must be variable disjoint from each other because extended real
+        # arthmatic is not fully handled. For example, the query `ask(x > x + 1)`
+        # is not handled because `x` and `x + 1` are not variable disjoint.
+        # We have to be careful because `x > x + 1` may be False if x=oo.
+        if expr in extended_real_exprs and expr not in real_exprs:
+            if all_symbols.isdisjoint(expr.free_symbols):
+                all_symbols.update(expr.free_symbols)
+                continue
+
+            raise UnhandledInput(f"LRASolver: Extended real expressions are not variable disjoint.")
+
+
+    for pred in all_pred:
+        if (pred.function not in REAL_PREDICATES and
+            pred.function not in EXTENDED_REAL_PREDICATES and
+            pred.function not in (Q.ne, Q.eq)):
+                raise UnhandledInput(f"LRASolver: {pred} is an unhandled predicate")
+
 
     # check satisfiable
 
@@ -122,12 +151,16 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
 
 
     # Preprocess sat_true and sat_false into encoded CNFs containing only
-    # Q.eq, Q.gt, Q.lt, Q.ge, Q.le, Q.real, Q.extended_real predicates.
-    # Converts every unequality into a disjunction of strict inequalities
-    # (e.g. x != 3  =>  x < 3 OR x > 3) and converts negated Q.ne into
-    # equalities.
-    sat_true = _preprocess(sat_true)
-    sat_false = _preprocess(sat_false)
+    # Q.eq, Q.gt, Q.lt, Q.ge, Q.le, Q.eq, and Q.real predicates. It does the following
+    # transformations:
+    # - Q.positive -> Q.gt, Q.negative -> Q.lt, Q.zero -> Q.eq, etc.
+    # - Q.extended_positive -> Q.gt, Q.extended_negative -> Q.lt, etc.
+    # - Q.ne, ~Q.eq, Q.nonzero -> disjunction of inequalities (e.g. x != 3  =>  x < 3 OR x > 3)
+    # - Q.extended_real -> True
+    # - Q.real -> True or Q.real depending on whether the expr is known to be real
+    # and converts negated Q.ne into equalities.
+    sat_true = _preprocess(sat_true, real_exprs, extended_real_exprs)
+    sat_false = _preprocess(sat_false, real_exprs, extended_real_exprs)
 
     can_be_true = satisfiable(sat_true, use_lra_theory=True) is not False
     can_be_false = satisfiable(sat_false, use_lra_theory=True) is not False
@@ -145,7 +178,7 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         raise ValueError("Inconsistent assumptions")
 
 
-def _preprocess(enc_cnf):
+def _preprocess(enc_cnf, real_exprs, possibly_infinite_extended_real_exprs):
     rev_encoding = {value: key for key, value in enc_cnf.encoding.items()}
     new_encoding = {}
     new_data = []
@@ -157,8 +190,10 @@ def _preprocess(enc_cnf):
 
     for clause in enc_cnf.data:
         new_clause = []
+        skip_new_clause = False
         for lit in clause:
             if lit == 0:
+                # TODO: Add tests for this and look into if it's actually needed.
                 new_clause.append(lit)
                 new_encoding[lit] = False # Preserve existing DIMACS zero-terminator behavior
                 continue
@@ -167,11 +202,39 @@ def _preprocess(enc_cnf):
             is_negated = lit < 0
             sign = -1 if is_negated else 1
 
-            prop = _pred_to_binrel(prop)
-
             if not isinstance(prop, AppliedPredicate):
                 new_clause.append(sign * get_enc(prop))
                 continue
+
+            if prop.function == Q.real and prop.arguments[0] not in real_exprs:
+                new_clause.append(sign * get_enc(prop))
+                continue
+            elif prop.function in (Q.real, Q.extended_real):
+                prop = True
+
+            if prop not in (True, False) and prop.function in (Q.positive_infinite, Q.negative_infinite):
+                if prop.arguments[0] in real_exprs:
+                    prop = False
+                else:
+                    raise UnhandledInput(f"LRASolver: Q.positive_infinite and Q.negative_infinite are not fully handled yet.")
+
+            if prop in (True, False):
+                new_clause.append(sign * get_enc(prop))
+                continue
+
+            # if prop is False:
+            #     # This might result in new_clause to be empty
+            #     # which is intended. In that case, the sat
+            #     # solver will give unsat.
+            #     continue
+            # if prop is True:
+            #     # This could result in new_data to be empty which
+            #     # is intended. In that case, the sat solver will
+            #     # give sat.
+            #     skip_new_clause = True
+            #     break
+
+            prop = _pred_to_binrel(prop)
 
             if (prop.function == Q.eq and is_negated) or (prop.function == Q.ne and not is_negated):
                 # (x != y) -> (x > y) | (x < y)
@@ -183,9 +246,13 @@ def _preprocess(enc_cnf):
                 new_clause.append(get_enc(Q.eq(arg1, arg2)))
             else:
                 # Standard predicates
+                if prop.function not in (Q.gt, Q.lt, Q.ge, Q.le, Q.eq):
+                    pass
                 assert prop.function in (Q.gt, Q.lt, Q.ge, Q.le, Q.eq)
                 new_clause.append(sign * get_enc(prop))
 
+        if skip_new_clause:
+            continue
         new_data.append(new_clause)
 
     return EncodedCNF(new_data, new_encoding)
@@ -195,37 +262,20 @@ def _pred_to_binrel(pred):
     if not isinstance(pred, AppliedPredicate):
         return pred
 
-    if pred.function in pred_to_pos_neg_zero:
-        f = pred_to_pos_neg_zero[pred.function]
-        if f is False:
-            return False
-        pred = f(pred.arguments[0])
-
-    if pred.function == Q.positive:
+    if pred.function in (Q.positive, Q.extended_positive):
         pred = Q.gt(pred.arguments[0], 0)
-    elif pred.function == Q.negative:
+    elif pred.function in (Q.negative, Q.extended_negative):
         pred = Q.lt(pred.arguments[0], 0)
     elif pred.function == Q.zero:
         pred = Q.eq(pred.arguments[0], 0)
-    elif pred.function == Q.nonpositive:
+    elif pred.function in (Q.nonpositive, Q.extended_nonpositive):
         pred = Q.le(pred.arguments[0], 0)
-    elif pred.function == Q.nonnegative:
+    elif pred.function in (Q.nonnegative, Q.extended_nonnegative):
         pred = Q.ge(pred.arguments[0], 0)
-    elif pred.function == Q.nonzero:
+    elif pred.function in (Q.nonzero, Q.extended_nonzero):
         pred = Q.ne(pred.arguments[0], 0)
 
     return pred
-
-
-pred_to_pos_neg_zero = {
-    Q.extended_positive: Q.positive,
-    Q.extended_negative: Q.negative,
-    Q.extended_nonpositive: Q.nonpositive,
-    Q.extended_negative: Q.negative,
-    Q.extended_nonzero: Q.nonzero,
-    Q.negative_infinite: False,
-    Q.positive_infinite: False
-}
 
 
 def get_all_pred_and_expr_from_enc_cnf(enc_cnfs):
@@ -263,15 +313,17 @@ def extract_assumption_from_old_assumption(expr):
     >>> y = symbols("y", integer=True)
     >>> extract_assumption_from_old_assumption(y) # raises exception
     """
-    if not hasattr(expr, "free_symbols") or len(expr.free_symbols) == 0:
-        if expr.is_real:
-            return None, True
-        return None, None
-
     # Test for I times imaginary variable. Such expressions are considered
     # real but aren't handled.
     if expr.has(I):
         raise UnhandledInput(f"LRASolver: {expr} must not contain I")
+
+    if not hasattr(expr, "free_symbols") or len(expr.free_symbols) == 0:
+        if expr.is_real:
+            return None, True, True
+        if expr.is_extended_real:
+            return None, None, True
+        return None, None, None
 
     if expr.is_integer == True and expr.is_zero != True:
         raise UnhandledInput(f"LRASolver: {expr} is an integer")
@@ -281,81 +333,20 @@ def extract_assumption_from_old_assumption(expr):
         raise UnhandledInput(f"LRASolver: {expr} is irational")
 
     if expr.is_zero:
-        return Q.zero(expr), True
+        return Q.zero(expr), True, True
     if expr.is_positive:
-        return Q.positive(expr), True
+        return Q.positive(expr), True, True
     if expr.is_negative:
-        return Q.negative(expr), True
+        return Q.negative(expr), True, True
     if expr.is_nonzero:
-        return Q.nonzero(expr), True
+        return Q.nonzero(expr), True, True
     if expr.is_nonpositive:
-        return Q.nonpositive(expr), True
+        return Q.nonpositive(expr), True, True
     if expr.is_nonnegative:
-        return Q.nonnegative(expr), True
+        return Q.nonnegative(expr), True, True
     if expr.is_real:
-        return None, True
+        return None, True, True
+    if expr.is_extended_real:
+        return None, None, True
 
-    return None, None
-
-
-def extract_pred_from_old_assum(all_exprs):
-    """
-    Returns a list of relevant new assumption predicate
-    based on any old assumptions.
-
-    Raises an UnhandledInput exception if any of the assumptions are
-    unhandled.
-
-    Ignored predicate:
-    - commutative
-    - complex
-    - algebraic
-    - transcendental
-    - extended_real
-    - real
-    - all matrix predicate
-    - rational
-    - irrational
-
-    Example
-    =======
-    >>> from sympy.assumptions.lra_satask import extract_pred_from_old_assum
-    >>> from sympy import symbols
-    >>> x, y = symbols("x y", positive=True)
-    >>> extract_pred_from_old_assum([x, y, 2])
-    [Q.positive(x), Q.positive(y)]
-    """
-    ret = []
-    for expr in all_exprs:
-        if not hasattr(expr, "free_symbols"):
-            continue
-        if len(expr.free_symbols) == 0:
-            continue
-
-        if expr.is_real is not True:
-            raise UnhandledInput(f"LRASolver: {expr} must be real")
-        # test for I times imaginary variable; such expressions are considered real
-        if isinstance(expr, Mul) and any(arg.is_real is not True for arg in expr.args):
-            raise UnhandledInput(f"LRASolver: {expr} must be real")
-
-        if expr.is_integer == True and expr.is_zero != True:
-            raise UnhandledInput(f"LRASolver: {expr} is an integer")
-        if expr.is_integer == False:
-            raise UnhandledInput(f"LRASolver: {expr} can't be an integer")
-        if expr.is_rational == False:
-            raise UnhandledInput(f"LRASolver: {expr} is irational")
-
-        if expr.is_zero:
-            ret.append(Q.zero(expr))
-        elif expr.is_positive:
-            ret.append(Q.positive(expr))
-        elif expr.is_negative:
-            ret.append(Q.negative(expr))
-        elif expr.is_nonzero:
-            ret.append(Q.nonzero(expr))
-        elif expr.is_nonpositive:
-            ret.append(Q.nonpositive(expr))
-        elif expr.is_nonnegative:
-            ret.append(Q.nonnegative(expr))
-
-    return ret
+    return None, None, None

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -121,6 +121,11 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
     # sat_false.add_from_cnf(_props)
 
 
+    # Preprocess sat_true and sat_false into encoded CNFs containing only
+    # Q.eq, Q.gt, Q.lt, Q.ge, Q.le, Q.real, Q.extended_real predicates.
+    # Converts every unequality into a disjunction of strict inequalities
+    # (e.g. x != 3  =>  x < 3 OR x > 3) and converts negated Q.ne into
+    # equalities.
     sat_true = _preprocess(sat_true)
     sat_false = _preprocess(sat_false)
 
@@ -141,88 +146,49 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
 
 
 def _preprocess(enc_cnf):
-    """
-    Returns an encoded cnf with only Q.eq, Q.gt, Q.lt,
-    Q.ge, Q.le, Q.real, Q.extended_real predicate.
-
-    Converts every unequality into a disjunction of strict
-    inequalities. For example, x != 3 would become
-    x < 3 OR x > 3.
-
-    Also converts all negated Q.ne predicates into
-    equalities.
-    """
-
-    # loops through each literal in each clause
-    # to construct a new, preprocessed encodedCNF
-
-    enc_cnf = enc_cnf.copy()
-    cur_enc = 1
     rev_encoding = {value: key for key, value in enc_cnf.encoding.items()}
-
     new_encoding = {}
     new_data = []
+
+    def get_enc(p):
+        if p not in new_encoding:
+            new_encoding[p] = len(new_encoding) + 1
+        return new_encoding[p]
+
     for clause in enc_cnf.data:
         new_clause = []
         for lit in clause:
             if lit == 0:
                 new_clause.append(lit)
-                new_encoding[lit] = False
+                new_encoding[lit] = False # Preserve existing DIMACS zero-terminator behavior
                 continue
+
             prop = rev_encoding[abs(lit)]
-            negated = lit < 0
-            sign = (lit > 0) - (lit < 0)
+            is_negated = lit < 0
+            sign = -1 if is_negated else 1
 
             prop = _pred_to_binrel(prop)
 
             if not isinstance(prop, AppliedPredicate):
-                if prop not in new_encoding:
-                    new_encoding[prop] = cur_enc
-                    cur_enc += 1
-                lit = new_encoding[prop]
-                new_clause.append(sign*lit)
+                new_clause.append(sign * get_enc(prop))
                 continue
 
-
-            if negated and prop.function == Q.eq:
-                negated = False
-                prop = Q.ne(*prop.arguments)
-
-            if prop.function == Q.ne:
+            if (prop.function == Q.eq and is_negated) or (prop.function == Q.ne and not is_negated):
+                # (x != y) -> (x > y) | (x < y)
                 arg1, arg2 = prop.arguments
-                if negated:
-                    new_prop = Q.eq(arg1, arg2)
-                    if new_prop not in new_encoding:
-                        new_encoding[new_prop] = cur_enc
-                        cur_enc += 1
+                new_clause.extend([get_enc(Q.gt(arg1, arg2)), get_enc(Q.lt(arg1, arg2))])
+            elif prop.function == Q.ne and is_negated:
+                # ~(x != y) -> x == y
+                arg1, arg2 = prop.arguments
+                new_clause.append(get_enc(Q.eq(arg1, arg2)))
+            else:
+                # Standard predicates
+                assert prop.function in (Q.gt, Q.lt, Q.ge, Q.le, Q.eq)
+                new_clause.append(sign * get_enc(prop))
 
-                    new_enc = new_encoding[new_prop]
-                    new_clause.append(new_enc)
-                    continue
-                else:
-                    new_props = (Q.gt(arg1, arg2), Q.lt(arg1, arg2))
-                    for new_prop in new_props:
-                        if new_prop not in new_encoding:
-                            new_encoding[new_prop] = cur_enc
-                            cur_enc += 1
-
-                        new_enc = new_encoding[new_prop]
-                        new_clause.append(new_enc)
-                    continue
-
-            if prop.function == Q.eq and negated:
-                assert False
-
-            if prop not in new_encoding:
-                new_encoding[prop] = cur_enc
-                cur_enc += 1
-            new_clause.append(new_encoding[prop]*sign)
         new_data.append(new_clause)
 
-    assert len(new_encoding) >= cur_enc - 1
-
-    enc_cnf = EncodedCNF(new_data, new_encoding)
-    return enc_cnf
+    return EncodedCNF(new_data, new_encoding)
 
 
 def _pred_to_binrel(pred):

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -2,24 +2,17 @@ from __future__ import annotations
 from sympy.assumptions.assume import global_assumptions
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
-from sympy.core.add import Add
 from sympy.core.numbers import I
-from sympy.core.symbol import Symbol
 from sympy.logic.inference import satisfiable
-from sympy.logic.algorithms.lra_theory import UnhandledInput, ALLOWED_PRED
-from sympy.matrices.kind import MatrixKind
+from sympy.logic.algorithms.lra_theory import UnhandledInput
 from sympy.core.kind import NumberKind
 from sympy.assumptions.assume import AppliedPredicate
-from sympy.core.mul import Mul
 from sympy.core.singleton import S
 
 
 REAL_PREDICATES = {Q.real, Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative}
 EXTENDED_REAL_PREDICATES = {Q.extended_real, Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
     Q.extended_nonnegative, Q.extended_nonzero, Q.positive_infinite, Q.negative_infinite, Q.gt, Q.lt, Q.ge, Q.le}
-
-
-HANDLED_PREDICATES = EXTENED_REAL_IMPLYING_PREDICATES | {Q.ne}
 
 def lra_satask(proposition, assumptions=True, context=global_assumptions):
     """
@@ -50,9 +43,8 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
     real_exprs = set()
     extended_real_exprs = set()
     for unit_clause in assumptions_encoded_cnf.data:
-        # Check if `unit_clause` is a unit clause.
         if len(unit_clause) != 1:
-            continue
+            continue # Not a unit clause.
 
         # Negated predicates cannot establish that
         # an expression is real (or extended real).
@@ -69,8 +61,6 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         if applied_predicate.function in EXTENDED_REAL_PREDICATES:
             extended_real_exprs.update(applied_predicate.arguments)
 
-
-    # SATIFSIABLE STARTED HERE
 
     factbase = assumptions_encoded_cnf
     sat_true = factbase.copy()
@@ -105,14 +95,7 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         assumptions_encoded_cnf.data.append([applied_predicate_encoding])
 
 
-<<<<<<< HEAD
     all_symbols = set()
-=======
-
-    for pred in all_pred:
-        if pred.function not in HANDLED_PREDICATES:
-            raise UnhandledInput(f"LRASolver: {pred} is an unhandled predicate")
->>>>>>> 70850820c1 (Create HANDLED_PREDICATES for readablity)
     for expr in all_exprs:
         if expr.kind != NumberKind:
             raise UnhandledInput(f"LRASolver: Only scalar expresions are supported. {expr} must be of {NumberKind} but is of {expr.kind} instead.")
@@ -127,11 +110,11 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         # is not handled because `x` and `x + 1` are not variable disjoint.
         # We have to be careful because `x > x + 1` may be False if x=oo.
         if expr in extended_real_exprs and expr not in real_exprs:
-            if all_symbols.isdisjoint(expr.free_symbols):
-                all_symbols.update(expr.free_symbols)
-                continue
+            if not all_symbols.isdisjoint(expr.free_symbols):
+                raise UnhandledInput("LRASolver: Extended real expressions are not variable disjoint.")
 
-            raise UnhandledInput(f"LRASolver: Extended real expressions are not variable disjoint.")
+            all_symbols.update(expr.free_symbols)
+
 
 
     for pred in all_pred:
@@ -141,15 +124,6 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
                 raise UnhandledInput(f"LRASolver: {pred} is an unhandled predicate")
 
 
-    # check satisfiable
-
-    # factbase = assumptions_encoded_cnf
-    # sat_true = factbase.copy()
-    # sat_false = factbase.copy()
-    # sat_true.add_from_cnf(props)
-    # sat_false.add_from_cnf(_props)
-
-
     # Preprocess sat_true and sat_false into encoded CNFs containing only
     # Q.eq, Q.gt, Q.lt, Q.ge, Q.le, Q.eq, and Q.real predicates. It does the following
     # transformations:
@@ -157,8 +131,8 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
     # - Q.extended_positive -> Q.gt, Q.extended_negative -> Q.lt, etc.
     # - Q.ne, ~Q.eq, Q.nonzero -> disjunction of inequalities (e.g. x != 3  =>  x < 3 OR x > 3)
     # - Q.extended_real -> True
-    # - Q.real -> True or Q.real depending on whether the expr is known to be real
-    # and converts negated Q.ne into equalities.
+    # - Q.real -> True or Q.real depending on whether the expr is known to be real.
+    # - ~Q.ne -> Q.eq
     sat_true = _preprocess(sat_true, real_exprs)
     sat_false = _preprocess(sat_false, real_exprs)
 
@@ -187,33 +161,33 @@ def _preprocess(enc_cnf, real_exprs):
     >>> from sympy.assumptions.lra_satask import _preprocess
     >>> x, y = symbols('x y')
 
-    >>> r = _preprocess(EncodedCNF([[1]], {Q.positive(x): 1}), {x}, set())
+    >>> r = _preprocess(EncodedCNF([[1]], {Q.positive(x): 1}), {x})
     >>> Q.gt(x, 0) in r.encoding and Q.positive(x) not in r.encoding
     True
 
-    >>> r = _preprocess(EncodedCNF([[1]], {Q.nonzero(x): 1}), {x}, set())
+    >>> r = _preprocess(EncodedCNF([[1]], {Q.nonzero(x): 1}), {x})
     >>> Q.gt(x, 0) in r.encoding and Q.lt(x, 0) in r.encoding and len(r.data[0]) == 2
     True
 
-    >>> r = _preprocess(EncodedCNF([[-1]], {Q.eq(x, y): 1}), {x, y}, set())
+    >>> r = _preprocess(EncodedCNF([[-1]], {Q.eq(x, y): 1}), {x, y})
     >>> Q.gt(x, y) in r.encoding and Q.lt(x, y) in r.encoding and len(r.data[0]) == 2
     True
 
-    >>> r = _preprocess(EncodedCNF([[-1]], {Q.ne(x, y): 1}), {x, y}, set())
+    >>> r = _preprocess(EncodedCNF([[-1]], {Q.ne(x, y): 1}), {x, y})
     >>> Q.eq(x, y) in r.encoding and len(r.data[0]) == 1
     True
 
-    >>> Q.gt(x, 0) in _preprocess(EncodedCNF([[1]], {Q.extended_positive(x): 1}), set(), {x}).encoding
+    >>> Q.gt(x, 0) in _preprocess(EncodedCNF([[1]], {Q.extended_positive(x): 1}), set()).encoding
     True
 
-    >>> r = _preprocess(EncodedCNF([[1]], {Q.real(x): 1}), {x}, set())
+    >>> r = _preprocess(EncodedCNF([[1]], {Q.real(x): 1}), {x})
     >>> True in r.encoding and Q.real(x) not in r.encoding
     True
 
-    >>> Q.real(x) in _preprocess(EncodedCNF([[1]], {Q.real(x): 1}), set(), {x}).encoding
+    >>> Q.real(x) in _preprocess(EncodedCNF([[1]], {Q.real(x): 1}), set()).encoding
     True
 
-    >>> r = _preprocess(EncodedCNF([[1], [2]], {Q.positive(x): 1, Q.negative(y): 2}), {x, y}, set())
+    >>> r = _preprocess(EncodedCNF([[1], [2]], {Q.positive(x): 1, Q.negative(y): 2}), {x, y})
     >>> Q.gt(x, 0) in r.encoding and Q.lt(y, 0) in r.encoding and len(r.data) == 2
     True
     """
@@ -228,7 +202,6 @@ def _preprocess(enc_cnf, real_exprs):
 
     for clause in enc_cnf.data:
         new_clause = []
-        skip_new_clause = False
         for lit in clause:
             if lit == 0:
                 # TODO: Add tests for this and look into if it's actually needed.
@@ -254,23 +227,11 @@ def _preprocess(enc_cnf, real_exprs):
                 if prop.arguments[0] in real_exprs:
                     prop = False
                 else:
-                    raise UnhandledInput(f"LRASolver: Q.positive_infinite and Q.negative_infinite are not fully handled yet.")
+                    raise UnhandledInput("LRASolver: Q.positive_infinite and Q.negative_infinite are not fully handled yet.")
 
             if prop in (True, False):
                 new_clause.append(sign * get_enc(prop))
                 continue
-
-            # if prop is False:
-            #     # This might result in new_clause to be empty
-            #     # which is intended. In that case, the sat
-            #     # solver will give unsat.
-            #     continue
-            # if prop is True:
-            #     # This could result in new_data to be empty which
-            #     # is intended. In that case, the sat solver will
-            #     # give sat.
-            #     skip_new_clause = True
-            #     break
 
             prop = _pred_to_binrel(prop)
 
@@ -283,14 +244,10 @@ def _preprocess(enc_cnf, real_exprs):
                 arg1, arg2 = prop.arguments
                 new_clause.append(get_enc(Q.eq(arg1, arg2)))
             else:
-                # Standard predicates
                 if prop.function not in (Q.gt, Q.lt, Q.ge, Q.le, Q.eq):
-                    pass
-                assert prop.function in (Q.gt, Q.lt, Q.ge, Q.le, Q.eq)
+                    raise ValueError(f"Unexpected proposition function: {prop.function}")
                 new_clause.append(sign * get_enc(prop))
 
-        if skip_new_clause:
-            continue
         new_data.append(new_clause)
 
     return EncodedCNF(new_data, new_encoding)
@@ -334,8 +291,6 @@ def extract_assumption_from_old_assumption(expr):
     if there are any. Otherwise, it either returns None or raises an exception
     if a dissallowed assumption is present.
 
-    Gives a
-
     Example
     =======
     >>> from sympy.assumptions.lra_satask import extract_assumption_from_old_assumption
@@ -363,11 +318,11 @@ def extract_assumption_from_old_assumption(expr):
             return None, None, True
         return None, None, None
 
-    if expr.is_integer == True and expr.is_zero != True:
+    if expr.is_integer is True and expr.is_zero is not True:
         raise UnhandledInput(f"LRASolver: {expr} is an integer")
-    if expr.is_integer == False:
+    if expr.is_integer is False:
         raise UnhandledInput(f"LRASolver: {expr} can't be an integer")
-    if expr.is_rational == False:
+    if expr.is_rational is False:
         raise UnhandledInput(f"LRASolver: {expr} is irational")
 
     if expr.is_zero:

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from sympy.assumptions.assume import global_assumptions
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
+from sympy.core.numbers import I
 from sympy.logic.inference import satisfiable
 from sympy.logic.algorithms.lra_theory import UnhandledInput, ALLOWED_PRED
 from sympy.matrices.kind import MatrixKind
@@ -10,6 +11,17 @@ from sympy.assumptions.assume import AppliedPredicate
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 
+
+# Some predicates such as Q.prime can't be handled by lra_satask. For example,
+# (x > 0) & (x < 1) & Q.prime(x) is unsat but lra_satask would think it was sat.
+# WHITE_LIST is a list of predicates that can always be handled.
+WHITE_LIST = ALLOWED_PRED | {Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative,
+    Q.negative_infinite, Q.positive_infinite}
+
+REAL_IMPLYING_PREDICATES = WHITE_LIST | {Q.real}
+
+EXTENED_REAL_IMPLYING_PREDICATES = REAL_IMPLYING_PREDICATES | {Q.extended_real, Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
+    Q.extended_negative, Q.extended_nonzero}
 
 def lra_satask(proposition, assumptions=True, context=global_assumptions):
     """
@@ -24,36 +36,75 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
     _props = CNF.from_prop(~proposition)
 
     cnf = CNF.from_prop(assumptions)
-    assumptions = EncodedCNF()
-    assumptions.from_cnf(cnf)
+    assumptions_encoded_cnf = EncodedCNF()
+    assumptions_encoded_cnf.from_cnf(cnf)
 
     context_cnf = CNF()
     if context:
         context_cnf = context_cnf.extend(context)
 
-    assumptions.add_from_cnf(context_cnf)
-
-    return check_satisfiability(props, _props, assumptions)
-
-# Some predicates such as Q.prime can't be handled by lra_satask.
-# For example, (x > 0) & (x < 1) & Q.prime(x) is unsat but lra_satask would think it was sat.
-# WHITE_LIST is a list of predicates that can always be handled.
-WHITE_LIST = ALLOWED_PRED | {Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative,
-                                            Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
-                                            Q.extended_negative, Q.extended_nonzero, Q.negative_infinite,
-                                            Q.positive_infinite}
+    assumptions_encoded_cnf.add_from_cnf(context_cnf)
 
 
-def check_satisfiability(prop, _prop, factbase):
+    # Use unit clauses from `assumptions_encoded_cnf` to
+    # deduce some expressions are extened real.
+    reverse_encoding = {value: key for key, value in assumptions_encoded_cnf.encoding.items()}
+    real_exprs = set()
+    for unit_clause in assumptions_encoded_cnf.data:
+        # Check if `unit_clause` is a unit clause.
+        if len(unit_clause) != 1:
+            continue
+
+        # Continue if negative because negative literals
+        # cannot establish that an expression is entended real.
+        (positive_literal,) = unit_clause
+        if not (positive_literal > 0):
+            continue
+
+        applied_predicate = reverse_encoding[positive_literal]
+        if not isinstance(applied_predicate, AppliedPredicate):
+            continue
+
+        if applied_predicate.function in REAL_IMPLYING_PREDICATES:
+            real_exprs.update(applied_predicate.arguments)
+
+    # SATIFSIABLE STARTED HERE
+
+    factbase = assumptions_encoded_cnf
     sat_true = factbase.copy()
     sat_false = factbase.copy()
-    sat_true.add_from_cnf(prop)
-    sat_false.add_from_cnf(_prop)
+    sat_true.add_from_cnf(props)
+    sat_false.add_from_cnf(_props)
 
-    all_pred, all_exprs = get_all_pred_and_expr_from_enc_cnf(sat_true)
+
+    # Check old assumptions to:
+    #   1. Deduce some expressions are extened real.
+    #   2. Add relevant inequality assumptions as unit clauses
+    #      to `assumptions_encoded_cnf`.
+    all_pred, all_exprs = get_all_pred_and_expr_from_enc_cnf([sat_true])
+    for expr in all_exprs:
+        convertable_to_inequality_applied_predicate, is_real  = extract_assumption_from_old_assumption(expr)
+        if is_real:
+            real_exprs.add(expr)
+        if convertable_to_inequality_applied_predicate is None:
+            continue
+
+
+        if convertable_to_inequality_applied_predicate not in assumptions_encoded_cnf.encoding:
+            applied_predicate_encoding = len(assumptions_encoded_cnf.encoding) + 1
+            assumptions_encoded_cnf.encoding[convertable_to_inequality_applied_predicate] = applied_predicate_encoding
+
+        # Add relevant old assumptions to `assumptions`.
+        applied_predicate_encoding = assumptions_encoded_cnf.encoding[convertable_to_inequality_applied_predicate]
+        assumptions_encoded_cnf.data.append([applied_predicate_encoding])
+
+    for expr in all_exprs:
+        if expr not in real_exprs:
+            raise UnhandledInput(f"LRASolver: {expr} must be real")
+
 
     for pred in all_pred:
-        if pred.function not in WHITE_LIST and pred.function != Q.ne:
+        if pred.function not in EXTENED_REAL_IMPLYING_PREDICATES and pred.function != Q.ne:
             raise UnhandledInput(f"LRASolver: {pred} is an unhandled predicate")
     for expr in all_exprs:
         if expr.kind == MatrixKind(NumberKind):
@@ -61,18 +112,13 @@ def check_satisfiability(prop, _prop, factbase):
         if expr == S.NaN:
             raise UnhandledInput("LRASolver: nan")
 
-    # convert old assumptions into predicates and add them to sat_true and sat_false
-    # also check for unhandled predicates
-    for assm in extract_pred_from_old_assum(all_exprs):
-        n = len(sat_true.encoding)
-        if assm not in sat_true.encoding:
-            sat_true.encoding[assm] = n+1
-        sat_true.data.append([sat_true.encoding[assm]])
+    # check satisfiable
 
-        n = len(sat_false.encoding)
-        if assm not in sat_false.encoding:
-            sat_false.encoding[assm] = n+1
-        sat_false.data.append([sat_false.encoding[assm]])
+    # factbase = assumptions_encoded_cnf
+    # sat_true = factbase.copy()
+    # sat_false = factbase.copy()
+    # sat_true.add_from_cnf(props)
+    # sat_false.add_from_cnf(_props)
 
 
     sat_true = _preprocess(sat_true)
@@ -97,7 +143,7 @@ def check_satisfiability(prop, _prop, factbase):
 def _preprocess(enc_cnf):
     """
     Returns an encoded cnf with only Q.eq, Q.gt, Q.lt,
-    Q.ge, and Q.le predicate.
+    Q.ge, Q.le, Q.real, Q.extended_real predicate.
 
     Converts every unequality into a disjunction of strict
     inequalities. For example, x != 3 would become
@@ -204,6 +250,7 @@ def _pred_to_binrel(pred):
 
     return pred
 
+
 pred_to_pos_neg_zero = {
     Q.extended_positive: Q.positive,
     Q.extended_negative: Q.negative,
@@ -214,15 +261,76 @@ pred_to_pos_neg_zero = {
     Q.positive_infinite: False
 }
 
-def get_all_pred_and_expr_from_enc_cnf(enc_cnf):
+
+def get_all_pred_and_expr_from_enc_cnf(enc_cnfs):
     all_exprs = set()
     all_pred = set()
-    for pred in enc_cnf.encoding.keys():
-        if isinstance(pred, AppliedPredicate):
-            all_pred.add(pred)
-            all_exprs.update(pred.arguments)
+    for enc_cnf in enc_cnfs:
+        for pred in enc_cnf.encoding.keys():
+            if isinstance(pred, AppliedPredicate):
+                all_pred.add(pred)
+                all_exprs.update(pred.arguments)
 
     return all_pred, all_exprs
+
+
+def extract_assumption_from_old_assumption(expr):
+    """
+    Extracts a single relevant assumption from the old assumption system
+    if there are any. Otherwise, it either returns None or raises an exception
+    if a dissallowed assumption is present.
+
+    Gives a
+
+    Example
+    =======
+    >>> from sympy.assumptions.lra_satask import extract_assumption_from_old_assumption
+    >>> from sympy import symbols
+    >>> x = symbols("x")
+    >>> extract_assumption_from_old_assumption(x) is None
+    True
+    >>> y = symbols("y", positive=True)
+    >>> extract_assumption_from_old_assumption(y)
+    Q.positive(y)
+    >>> extract_assumption_from_old_assumption(-y)
+    Q.negative(-y)
+    >>> y = symbols("y", integer=True)
+    >>> extract_assumption_from_old_assumption(y) # raises exception
+    """
+    if not hasattr(expr, "free_symbols") or len(expr.free_symbols) == 0:
+        if expr.is_real:
+            return None, True
+        return None, None
+
+    # Test for I times imaginary variable. Such expressions are considered
+    # real but aren't handled.
+    if expr.has(I):
+        raise UnhandledInput(f"LRASolver: {expr} must not contain I")
+
+    if expr.is_integer == True and expr.is_zero != True:
+        raise UnhandledInput(f"LRASolver: {expr} is an integer")
+    if expr.is_integer == False:
+        raise UnhandledInput(f"LRASolver: {expr} can't be an integer")
+    if expr.is_rational == False:
+        raise UnhandledInput(f"LRASolver: {expr} is irational")
+
+    if expr.is_zero:
+        return Q.zero(expr), True
+    if expr.is_positive:
+        return Q.positive(expr), True
+    if expr.is_negative:
+        return Q.negative(expr), True
+    if expr.is_nonzero:
+        return Q.nonzero(expr), True
+    if expr.is_nonpositive:
+        return Q.nonpositive(expr), True
+    if expr.is_nonnegative:
+        return Q.nonnegative(expr), True
+    if expr.is_real:
+        return None, True
+
+    return None, None
+
 
 def extract_pred_from_old_assum(all_exprs):
     """

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -159,8 +159,8 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
     # - Q.extended_real -> True
     # - Q.real -> True or Q.real depending on whether the expr is known to be real
     # and converts negated Q.ne into equalities.
-    sat_true = _preprocess(sat_true, real_exprs, extended_real_exprs)
-    sat_false = _preprocess(sat_false, real_exprs, extended_real_exprs)
+    sat_true = _preprocess(sat_true, real_exprs)
+    sat_false = _preprocess(sat_false, real_exprs)
 
     can_be_true = satisfiable(sat_true, use_lra_theory=True) is not False
     can_be_false = satisfiable(sat_false, use_lra_theory=True) is not False
@@ -178,7 +178,45 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         raise ValueError("Inconsistent assumptions")
 
 
-def _preprocess(enc_cnf, real_exprs, possibly_infinite_extended_real_exprs):
+def _preprocess(enc_cnf, real_exprs):
+    """
+    Examples
+    ========
+    >>> from sympy import symbols, Q
+    >>> from sympy.assumptions.cnf import EncodedCNF
+    >>> from sympy.assumptions.lra_satask import _preprocess
+    >>> x, y = symbols('x y')
+
+    >>> r = _preprocess(EncodedCNF([[1]], {Q.positive(x): 1}), {x}, set())
+    >>> Q.gt(x, 0) in r.encoding and Q.positive(x) not in r.encoding
+    True
+
+    >>> r = _preprocess(EncodedCNF([[1]], {Q.nonzero(x): 1}), {x}, set())
+    >>> Q.gt(x, 0) in r.encoding and Q.lt(x, 0) in r.encoding and len(r.data[0]) == 2
+    True
+
+    >>> r = _preprocess(EncodedCNF([[-1]], {Q.eq(x, y): 1}), {x, y}, set())
+    >>> Q.gt(x, y) in r.encoding and Q.lt(x, y) in r.encoding and len(r.data[0]) == 2
+    True
+
+    >>> r = _preprocess(EncodedCNF([[-1]], {Q.ne(x, y): 1}), {x, y}, set())
+    >>> Q.eq(x, y) in r.encoding and len(r.data[0]) == 1
+    True
+
+    >>> Q.gt(x, 0) in _preprocess(EncodedCNF([[1]], {Q.extended_positive(x): 1}), set(), {x}).encoding
+    True
+
+    >>> r = _preprocess(EncodedCNF([[1]], {Q.real(x): 1}), {x}, set())
+    >>> True in r.encoding and Q.real(x) not in r.encoding
+    True
+
+    >>> Q.real(x) in _preprocess(EncodedCNF([[1]], {Q.real(x): 1}), set(), {x}).encoding
+    True
+
+    >>> r = _preprocess(EncodedCNF([[1], [2]], {Q.positive(x): 1, Q.negative(y): 2}), {x, y}, set())
+    >>> Q.gt(x, 0) in r.encoding and Q.lt(y, 0) in r.encoding and len(r.data) == 2
+    True
+    """
     rev_encoding = {value: key for key, value in enc_cnf.encoding.items()}
     new_encoding = {}
     new_data = []

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -296,15 +296,18 @@ def extract_assumption_from_old_assumption(expr):
     >>> from sympy.assumptions.lra_satask import extract_assumption_from_old_assumption
     >>> from sympy import symbols
     >>> x = symbols("x")
-    >>> extract_assumption_from_old_assumption(x) is None
-    True
+    >>> extract_assumption_from_old_assumption(x)
+    (None, None, None)
     >>> y = symbols("y", positive=True)
     >>> extract_assumption_from_old_assumption(y)
-    Q.positive(y)
+    (Q.positive(y), True, True)
     >>> extract_assumption_from_old_assumption(-y)
-    Q.negative(-y)
-    >>> y = symbols("y", integer=True)
-    >>> extract_assumption_from_old_assumption(y) # raises exception
+    (Q.negative(-y), True, True)
+    >>> z = symbols("z", integer=True)
+    >>> extract_assumption_from_old_assumption(z)  # doctest: +SKIP
+    Traceback (most recent call last):
+    ...
+    UnhandledInput: LRASolver: z is an integer
     """
     # Test for I times imaginary variable. Such expressions are considered
     # real but aren't handled.

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -46,7 +46,7 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
 
     # Use unit clauses from `assumptions_encoded_cnf` to
     # try to deduce if expressions are real or extended real.
-    reverse_encoding = {value: key for key, value in assumptions_encoded_cnf.encoding.items()}
+    reverse_encoding = assumptions_encoded_cnf.reverse_encoding
     real_exprs = set()
     extended_real_exprs = set()
     for unit_clause in assumptions_encoded_cnf.data:
@@ -217,7 +217,7 @@ def _preprocess(enc_cnf, real_exprs):
     >>> Q.gt(x, 0) in r.encoding and Q.lt(y, 0) in r.encoding and len(r.data) == 2
     True
     """
-    rev_encoding = {value: key for key, value in enc_cnf.encoding.items()}
+    rev_encoding = enc_cnf.reverse_encoding
     new_encoding = {}
     new_data = []
 

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -107,8 +107,8 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
         if pred.function not in EXTENED_REAL_IMPLYING_PREDICATES and pred.function != Q.ne:
             raise UnhandledInput(f"LRASolver: {pred} is an unhandled predicate")
     for expr in all_exprs:
-        if expr.kind == MatrixKind(NumberKind):
-            raise UnhandledInput(f"LRASolver: {expr} is of MatrixKind")
+        if expr.kind != NumberKind:
+            raise UnhandledInput(f"LRASolver: Only scalar expresions are supported. {expr} must be of {NumberKind} but is of {expr.kind} instead.")
         if expr == S.NaN:
             raise UnhandledInput("LRASolver: nan")
 

--- a/sympy/assumptions/tests/test_hypothesis.py
+++ b/sympy/assumptions/tests/test_hypothesis.py
@@ -1,0 +1,613 @@
+"""
+Hypothesis-based structural tests for lra_satask SMT solver.
+
+This test suite focuses on structural/grammar-based fuzzing to stress-test
+the SMT solver's handling of complex formula structures, rather than testing
+specific numerical values. The approach is inspired by academic SMT testing
+methodologies (Brummayer & Biere 2009, Winterer et al. 2020).
+
+Key Testing Principles:
+1. Structural Fuzzing: Generate complex AST topologies, not just vary constants
+2. Boolean Complexity: Deep disjunctions, nested negations, implications
+3. Formula Composition: Build formulas from smaller equisatisfiable pieces
+4. Soundness Properties: Test invariants that must hold for ANY formula
+
+Lessons Learned During Development:
+1. Test formula STRUCTURE (deep nesting, complex boolean combinations), not specific constant values.
+2. Only test lra_satask itself, not internal helper functions like _preprocess or extract_assumption_from_old_assumption.
+3. Q.real(x) syntax doesn't propagate to derived expressions like -x or 2*x, unlike symbols('x', real=True).
+4. Use assume() to filter contradictory inputs before testing, rather than catching ValueError in try-except.
+5. Check assumption consistency with lra_satask(assumption, True) before running the actual test.
+
+Related Git Commits (check-real branch):
+- 14a47b1382: assumptions: Clean up lra_satask
+- c3d9e39520: lra_satask: Partially handle extended real exprs
+- 34760714a3: lra_satask: Use unit clauses and refactor
+"""
+
+from hypothesis import given, assume, settings, strategies as st
+from hypothesis.strategies import composite
+from sympy import symbols, Q, Or, And, Not, Implies
+from sympy.assumptions.lra_satask import lra_satask
+from sympy.logic.algorithms.lra_theory import UnhandledInput
+from sympy.testing.pytest import XFAIL
+
+
+# Configuration: Disable new Q.real syntax due to limitations with derived expressions
+# When True, uses Q.real(x) as assumptions. When False, uses symbols('x', real=True)
+# Currently disabled because Q.real(x) doesn't propagate to expressions like -x, 2*x, x+y
+USE_NEW_QREAL_SYNTAX = False
+
+
+# Strategy: Generate variable pools for building formulas
+@composite
+def variable_pool(draw, min_vars=1, max_vars=4):
+    """
+    Generate a list of distinct real-valued symbols.
+    Randomizes between old assumption syntax (real=True) and new syntax (Q.real).
+    Returns: (vars, real_assumptions) where real_assumptions is None or a formula
+    """
+    num_vars = draw(st.integers(min_value=min_vars, max_value=max_vars))
+    var_names = [f'x{i}' for i in range(num_vars)]
+    
+    # Choose between old and new assumption syntax based on configuration
+    use_old_syntax = not USE_NEW_QREAL_SYNTAX
+    
+    if use_old_syntax:
+        # Old syntax: symbols('x y', real=True)
+        vars = symbols(' '.join(var_names), real=True)
+        if not isinstance(vars, tuple):
+            vars = (vars,)
+        return vars, None
+    else:
+        # New syntax: symbols('x y') with Q.real(x) & Q.real(y)
+        vars = symbols(' '.join(var_names))
+        if not isinstance(vars, tuple):
+            vars = (vars,)
+        # Build Q.real assumptions
+        real_assumptions = Q.real(vars[0])
+        for var in vars[1:]:
+            real_assumptions = And(real_assumptions, Q.real(var))
+        return vars, real_assumptions
+
+
+# Strategy: Generate atomic inequality predicates
+@composite
+def atomic_inequality(draw, vars):
+    """Generate a single atomic inequality like x > 0 or x < y."""
+    if not vars:
+        vars = [symbols('x', real=True)]
+    if not isinstance(vars, (list, tuple)):
+        vars = [vars]
+    
+    var = draw(st.sampled_from(vars))
+    
+    # Choose relation type
+    relation = draw(st.sampled_from([Q.gt, Q.lt, Q.ge, Q.le, Q.eq]))
+    
+    # Choose right-hand side: another variable or a constant
+    use_var = draw(st.booleans()) and len(vars) > 1
+    if use_var:
+        # Compare with another variable
+        other_vars = [v for v in vars if v != var]
+        rhs = draw(st.sampled_from(other_vars))
+    else:
+        # Compare with constant
+        rhs = draw(st.integers(min_value=-10, max_value=10))
+    
+    return relation(var, rhs)
+
+
+# Strategy: Generate complex boolean combinations
+@composite
+def boolean_formula(draw, vars, max_depth=3):
+    """
+    Generate structurally complex boolean formulas with deep nesting.
+    This stresses the SAT engine component of the SMT solver.
+    """
+    if max_depth == 0:
+        return draw(atomic_inequality(vars))
+    
+    depth = draw(st.integers(min_value=0, max_value=max_depth))
+    if depth == 0:
+        return draw(atomic_inequality(vars))
+    
+    # Choose boolean operator
+    op_choice = draw(st.sampled_from(['and', 'or', 'not', 'implies']))
+    
+    if op_choice == 'not':
+        subformula = draw(boolean_formula(vars, max_depth=depth-1))
+        return Not(subformula)
+    elif op_choice == 'implies':
+        left = draw(boolean_formula(vars, max_depth=depth-1))
+        right = draw(boolean_formula(vars, max_depth=depth-1))
+        return Implies(left, right)
+    elif op_choice == 'and':
+        num_conjuncts = draw(st.integers(min_value=2, max_value=4))
+        conjuncts = [draw(boolean_formula(vars, max_depth=depth-1)) 
+                     for _ in range(num_conjuncts)]
+        return And(*conjuncts)
+    else:  # 'or'
+        num_disjuncts = draw(st.integers(min_value=2, max_value=4))
+        disjuncts = [draw(boolean_formula(vars, max_depth=depth-1)) 
+                     for _ in range(num_disjuncts)]
+        return Or(*disjuncts)
+
+
+# Strategy: Generate inequality chains (transitivity structure)
+@composite
+def inequality_chain(draw, vars, min_length=2, max_length=5):
+    """
+    Generate chained inequalities like x > y > z > w.
+    Tests structural transitivity reasoning.
+    """
+    if not vars or len(vars) < 2:
+        vars = symbols('x y z w', real=True)
+    
+    length = draw(st.integers(min_value=min_length, max_value=min(max_length, len(vars))))
+    chain_vars = draw(st.permutations(vars[:length]))
+    
+    # Choose direction: all > or all <
+    use_gt = draw(st.booleans())
+    relation = Q.gt if use_gt else Q.lt
+    
+    # Build chain: v0 > v1 > v2 > ...
+    chain = relation(chain_vars[0], chain_vars[1])
+    for i in range(2, len(chain_vars)):
+        chain = chain & relation(chain_vars[i-1], chain_vars[i])
+    
+    return chain, chain_vars
+
+
+# Strategy: Generate linear combinations
+@composite
+def linear_expression(draw, vars):
+    """Generate linear expressions like 2*x + 3*y - z."""
+    if not vars:
+        vars = [symbols('x', real=True)]
+    if not isinstance(vars, (list, tuple)):
+        vars = [vars]
+    
+    num_terms = draw(st.integers(min_value=1, max_value=len(vars)))
+    selected_vars = draw(st.lists(st.sampled_from(vars), min_size=num_terms, max_size=num_terms, unique=True))
+    
+    expr = 0
+    for var in selected_vars:
+        coeff = draw(st.integers(min_value=-5, max_value=5).filter(lambda x: x != 0))
+        expr += coeff * var
+    
+    # Optionally add constant
+    if draw(st.booleans()):
+        const = draw(st.integers(min_value=-10, max_value=10))
+        expr += const
+    
+    return expr
+
+
+# SOUNDNESS TESTS: Properties that must hold for ANY formula
+
+@given(data=st.data())
+def test_formula_self_consistency(data):
+    """
+    Soundness: A formula with itself as assumption should always be True.
+    For any formula P: P |- P should always hold.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=1, max_vars=3))
+    formula = data.draw(boolean_formula(vars, max_depth=2))
+    
+    # Build assumption: formula AND real assumptions (if using new syntax)
+    assumption = And(formula, real_assump) if real_assump is not None else formula
+    
+    # Check if assumptions are contradictory first to avoid ValueError
+    if assumption is not True:
+        consistency_check = lra_satask(assumption, True)
+        assume(consistency_check is not False)  # Skip test if assumptions are contradictory
+    
+    result = lra_satask(formula, assumption)
+    # If formula is satisfiable, it should entail itself
+    # Note: Implications may return None when they're vacuously true or undecidable
+    assert result in [True, None], f"Formula {formula} with assumptions {assumption} should entail itself, got {result}"
+
+
+@given(data=st.data())
+def test_contradiction_detection(data):
+    """
+    Soundness: P and ~P should be unsatisfiable.
+    Tests that the solver detects basic contradictions.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=1, max_vars=2))
+    formula = data.draw(boolean_formula(vars, max_depth=2))
+    
+    # Build contradictory assumption
+    contradiction = And(formula, Not(formula))
+    if real_assump is not None:
+        contradiction = And(contradiction, real_assump)
+    
+    # Asking if formula is true, given formula and its negation
+    # This may raise ValueError for contradictory assumptions, which is expected
+    try:
+        result = lra_satask(formula, contradiction)
+        # Should return False/None, not True
+        assert result is not True, f"Contradiction should not be satisfiable"
+    except ValueError:
+        # ValueError is expected for contradictory assumptions
+        pass
+
+
+@given(data=st.data())
+def test_weakening_property(data):
+    """
+    Soundness: If P |- Q, then (P & R) |- Q for any R.
+    Adding assumptions can't make provable things unprovable.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    conclusion = data.draw(atomic_inequality(vars))
+    assumption1 = data.draw(boolean_formula(vars, max_depth=2))
+    assumption2 = data.draw(atomic_inequality(vars))
+    
+    # Add real assumptions to both assumption sets
+    assump1 = And(assumption1, real_assump) if real_assump is not None else assumption1
+    assump2 = And(assumption1, assumption2, real_assump) if real_assump is not None else And(assumption1, assumption2)
+    
+    # Check if assumptions are contradictory first
+    if assump1 is not True:
+        consistency_check = lra_satask(assump1, True)
+        assume(consistency_check is not False)
+    
+    if assump2 is not True:
+        consistency_check2 = lra_satask(assump2, True)
+        assume(consistency_check2 is not False)
+    
+    result1 = lra_satask(conclusion, assump1)
+    result2 = lra_satask(conclusion, assump2)
+    
+    # If assumption1 proves conclusion, verify the result is valid
+    if result1 is True:
+        # result2 should still be True, False, or None
+        assert result2 in [True, False, None]
+
+
+@given(data=st.data())
+def test_deep_disjunction_handling(data):
+    """
+    Structural test: Generate formulas with deep disjunctive structure.
+    Tests the SAT engine's clause learning and backtracking.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    # Build a deep disjunctive formula: (a|b|c) & (d|e|f) & (g|h|i)
+    num_clauses = data.draw(st.integers(min_value=2, max_value=4))
+    clauses = []
+    for _ in range(num_clauses):
+        num_literals = data.draw(st.integers(min_value=2, max_value=3))
+        literals = [data.draw(atomic_inequality(vars)) for _ in range(num_literals)]
+        clauses.append(Or(*literals))
+    
+    cnf_formula = And(*clauses)
+    assumption = real_assump if real_assump is not None else True
+    
+    # Test that it doesn't crash and returns a valid answer
+    # May hit known bugs (ValueError for contradictions, IndexError for dpll2 bug)
+    try:
+        result = lra_satask(cnf_formula, assumption)
+        assert result in [True, False, None]
+    except (ValueError, IndexError):
+        # ValueError: contradictory assumptions (expected)
+        # IndexError: known bug tracked in test_dpll2_indexerror_bug
+        pass
+
+
+@given(data=st.data())
+def test_implication_chains(data):
+    """
+    Structural test: Generate implication chains like (A -> B) & (B -> C).
+    Tests handling of complex boolean structure.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    # Build chain: A -> B -> C
+    chain_length = data.draw(st.integers(min_value=2, max_value=4))
+    atoms = [data.draw(atomic_inequality(vars)) for _ in range(chain_length)]
+    
+    # Build chain of implications
+    implications = Implies(atoms[0], atoms[1])
+    for i in range(2, len(atoms)):
+        implications = And(implications, Implies(atoms[i-1], atoms[i]))
+    
+    # Build assumptions: first atom AND implications AND real assumptions
+    assumptions = And(atoms[0], implications)
+    if real_assump is not None:
+        assumptions = And(assumptions, real_assump)
+    
+    # Check if assumptions are contradictory first
+    if assumptions is not True:
+        consistency_check = lra_satask(assumptions, True)
+        assume(consistency_check is not False)
+    
+    # Test: Given A and the chain, should be able to derive C
+    result = lra_satask(atoms[-1], assumptions)
+    # Result can be True (derivable), False (disprovable), or None (undecidable)
+    assert result in [True, False, None]
+
+
+@given(data=st.data())
+def test_transitivity_with_structure(data):
+    """
+    Structural test: Generate random inequality chains and test transitivity.
+    Focus is on chain structure, not specific values.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=3, max_vars=5))
+    chain, chain_vars = data.draw(inequality_chain(vars, min_length=2, max_length=4))
+    
+    # Build assumption from chain and real assumptions
+    assumption = And(chain, real_assump) if real_assump is not None else chain
+    
+    # Check if assumptions are contradictory first
+    if assumption is not True:
+        consistency_check = lra_satask(assumption, True)
+        assume(consistency_check is not False)
+    
+    # Test: Given the chain, first > last (or first < last)
+    if 'Q.gt' in str(chain):
+        conclusion = Q.gt(chain_vars[0], chain_vars[-1])
+    else:
+        conclusion = Q.lt(chain_vars[0], chain_vars[-1])
+    
+    result = lra_satask(conclusion, assumption)
+    assert result is True, f"Transitivity failed for chain: {chain}"
+
+
+@given(data=st.data())
+def test_linear_combination_structure(data):
+    """
+    Structural test: Generate inequalities with linear combinations.
+    Tests handling of arithmetic expressions, not just variables.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    lhs = data.draw(linear_expression(vars))
+    rhs = data.draw(linear_expression(vars))
+    
+    relation = data.draw(st.sampled_from([Q.gt, Q.lt, Q.ge, Q.le, Q.eq]))
+    formula = relation(lhs, rhs)
+    
+    assumption = real_assump if real_assump is not None else True
+    
+    # Test that complex expressions don't crash the solver
+    result = lra_satask(formula, assumption)
+    assert result in [True, False, None]
+
+
+@given(data=st.data())
+def test_negation_depth(data):
+    """
+    Structural test: Generate formulas with nested negations.
+    Tests: ~(~P) handling, De Morgan's laws, etc.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=1, max_vars=2))
+    
+    # Start with simple atom
+    atom = data.draw(atomic_inequality(vars))
+    
+    # Add multiple layers of negation and conjunctions
+    num_layers = data.draw(st.integers(min_value=1, max_value=3))
+    formula = atom
+    for _ in range(num_layers):
+        op = data.draw(st.sampled_from(['not', 'and', 'or']))
+        if op == 'not':
+            formula = Not(formula)
+        elif op == 'and':
+            other = data.draw(atomic_inequality(vars))
+            formula = And(formula, other)
+        else:
+            other = data.draw(atomic_inequality(vars))
+            formula = Or(formula, other)
+    
+    assumption = real_assump if real_assump is not None else True
+    
+    # Test with nested negations - may hit known bugs
+    try:
+        result = lra_satask(formula, assumption)
+        assert result in [True, False, None]
+    except (ValueError, IndexError):
+        # ValueError: contradictory assumptions (expected)
+        # IndexError: known bug tracked in test_dpll2_indexerror_bug
+        pass
+
+
+@given(data=st.data())
+def test_mixed_equality_inequality(data):
+    """
+    Structural test: Mix equality and inequality predicates.
+    Tests theory combination between equality reasoning and LRA.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    # Generate mix of equalities and inequalities
+    num_atoms = data.draw(st.integers(min_value=2, max_value=4))
+    atoms = []
+    for _ in range(num_atoms):
+        relation = data.draw(st.sampled_from([Q.eq, Q.gt, Q.lt, Q.ge, Q.le]))
+        v1 = data.draw(st.sampled_from(vars))
+        v2 = data.draw(st.sampled_from([v for v in vars if v != v1]))
+        atoms.append(relation(v1, v2))
+    
+    formula = And(*atoms)
+    assumption = real_assump if real_assump is not None else True
+    
+    # Check if formula with assumptions is contradictory first
+    # This avoids ValueError for inherently contradictory formulas
+    try:
+        result = lra_satask(formula, assumption)
+        assert result in [True, False, None]
+    except ValueError:
+        # Formula is self-contradictory - skip this test case
+        assume(False)
+
+
+@given(data=st.data())
+def test_disjunctive_assumptions(data):
+    """
+    Structural test: Use disjunctive assumptions, not just conjunctive.
+    Tests case-splitting in the solver.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    # Create disjunctive assumption: (x > 0) | (x < 0)
+    atom1 = data.draw(atomic_inequality(vars))
+    atom2 = data.draw(atomic_inequality(vars))
+    disj_assumption = Or(atom1, atom2)
+    
+    conclusion = data.draw(atomic_inequality(vars))
+    
+    # Combine with real assumptions
+    assumption = And(disj_assumption, real_assump) if real_assump is not None else disj_assumption
+    
+    result = lra_satask(conclusion, assumption)
+    assert result in [True, False, None]
+
+
+@given(data=st.data())
+@settings(max_examples=50)
+def test_random_formula_doesnt_crash(data):
+    """
+    Robustness test: Random complex formulas shouldn't crash the solver.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=4))
+    
+    # Generate proposition and assumptions
+    proposition = data.draw(boolean_formula(vars, max_depth=3))
+    assumption = data.draw(boolean_formula(vars, max_depth=2))
+    
+    # Combine with real assumptions if using new syntax
+    if real_assump is not None:
+        assumption = And(assumption, real_assump)
+    
+    try:
+        result = lra_satask(proposition, assumption)
+        # Should return True, False, None, or raise UnhandledInput/ValueError
+        assert result in [True, False, None]
+    except (UnhandledInput, ValueError, IndexError):
+        # These are acceptable outcomes for unsupported/contradictory formulas
+        # IndexError: known bug tracked in test_dpll2_indexerror_bug
+        pass
+
+
+# Semantic fusion inspired test
+@given(data=st.data())
+def test_semantic_fusion_equisatisfiability(data):
+    """
+    If P is satisfiable and Q is satisfiable independently,
+    then (P | Q) should also be satisfiable.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    p = data.draw(atomic_inequality(vars))
+    q = data.draw(atomic_inequality(vars))
+    
+    # Use real assumptions as the assumption, not combined with propositions
+    assumption = real_assump if real_assump is not None else True
+    
+    # Check if assumptions are contradictory first
+    if assumption is not True:
+        consistency_check = lra_satask(assumption, True)
+        assume(consistency_check is not False)
+    
+    # Check if P and Q are individually consistent
+    p_sat = lra_satask(p, assumption)
+    q_sat = lra_satask(q, assumption)
+    
+    if p_sat in [True, None] and q_sat in [True, None]:
+        # Then P | Q should also be satisfiable
+        or_sat = lra_satask(Or(p, q), assumption)
+        assert or_sat in [True, None], f"Disjunction of satisfiable formulas should be satisfiable"
+
+@given(data=st.data())
+def test_conjunction_satisfiability_monotonic(data):
+    """
+    If P & Q is satisfiable, then both P and Q must be satisfiable.
+    """
+    vars, real_assump = data.draw(variable_pool(min_vars=2, max_vars=3))
+    
+    p = data.draw(atomic_inequality(vars))
+    q = data.draw(atomic_inequality(vars))
+    
+    # Use real assumptions as the assumption, not combined with propositions
+    assumption = real_assump if real_assump is not None else True
+    
+    # Check if assumptions are contradictory first
+    if assumption is not True:
+        consistency_check = lra_satask(assumption, True)
+        assume(consistency_check is not False)
+    
+    and_sat = lra_satask(And(p, q), assumption)
+    
+    if and_sat is True:
+        # Then both P and Q should be individually satisfiable
+        p_sat = lra_satask(p, assumption)
+        q_sat = lra_satask(q, assumption)
+        assert p_sat in [True, None], f"Conjunct P should be satisfiable if conjunction is"
+        assert q_sat in [True, None], f"Conjunct Q should be satisfiable if conjunction is"
+
+
+# XFAIL TESTS: Known bugs and limitations discovered by hypothesis testing
+
+@XFAIL
+def test_new_qreal_syntax_limitation():
+    """
+    XFAIL: Q.real syntax doesn't propagate to derived expressions.
+    
+    Limitation: When using Q.real(x) as an assumption (new syntax), derived
+    expressions like -x, 2*x, x+y are NOT automatically recognized as real.
+    This is in contrast to the old syntax symbols('x', real=True) where
+    .is_real propagates to all arithmetic combinations.
+    
+    Example that fails:
+    - x = symbols('x')  # No realness in symbol definition
+    - lra_satask(Q.gt(-x, 0), Q.real(x))  # Fails: -x not recognized as real
+    
+    Example that works:
+    - x = symbols('x', real=True)  # Realness in symbol definition
+    - lra_satask(Q.gt(-x, 0), True)  # Works: -x.is_real is True
+    
+    This limitation affects any test that generates linear combinations like
+    2*x + 3*y - z when using the new Q.real syntax.
+    """
+    x = symbols('x')  # New syntax: no real assumption in symbol
+    
+    # This should work but currently raises:
+    # UnhandledInput: LRASolver: -x must be extended real.
+    result = lra_satask(Q.gt(-x, 0), Q.real(x))
+    assert result in [True, False, None]
+
+
+@XFAIL
+def test_dpll2_indexerror_bug():
+    """
+    XFAIL: IndexError bug in dpll2.py:310 discovered by hypothesis testing.
+    
+    Bug: When checking satisfiability of certain formula combinations,
+    the DPLL solver tries to access self.levels[-1] when self.levels is empty,
+    causing IndexError: list index out of range.
+    
+    This specific test case was found by hypothesis fuzzing in
+    test_random_formula_doesnt_crash.
+    
+    Traceback:
+      File "sympy/logic/algorithms/dpll2.py", line 310, in _current_level
+        return self.levels[-1]
+    IndexError: list index out of range
+    
+    Formulas that trigger the bug:
+    - formula1 = Q.ge(x0, x1) & Q.le(x1, x0)  # Equivalent to x0 == x1
+    - formula2 = Q.lt(x1, x0) | (Q.gt(x0, 0) & Q.gt(x0, x1))
+    """
+    x0, x1 = symbols('x0 x1', real=True)
+    
+    # Formula that triggers the bug
+    formula1 = Q.ge(x0, x1) & Q.le(x1, x0)  # Equivalent to x0 == x1
+    formula2 = Q.lt(x1, x0) | (Q.gt(x0, 0) & Q.gt(x0, x1))
+    
+    # This currently raises IndexError but should return a valid result
+    result = lra_satask(formula1, formula2)
+    assert result in [True, False, None]

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -111,19 +111,19 @@ def test_extended_real_number_line():
     a, b, c = symbols("a b c")
 
     # `a + 1 > a` may be false if a=oo.
-    assert ask(a + 1 > a, Q.extended_real(a)) is None
-    assert ask(a + 1 > a, Q.extended_real(a) & Q.extended_real(a + 1)) is None
-    assert ask(a + b > a, Q.extended_real(a) & Q.positive(b)) is None
-    assert ask(a + b > a, Q.extended_real(a) & Q.positive(b) & Q.extended_real(a + b)) is None
-    assert ask(a - 1 >= a, Q.extended_real(a)) is None
+    raises(UnhandledInput, lambda: lra_satask(a + 1 > a, Q.extended_real(a)))
+    raises(UnhandledInput, lambda: lra_satask(a + 1 > a, Q.extended_real(a) & Q.extended_real(a + 1)))
+    raises(UnhandledInput, lambda: lra_satask(a + b > a, Q.extended_real(a) & Q.positive(b)))
+    raises(UnhandledInput, lambda: lra_satask(a + b > a, Q.extended_real(a) & Q.positive(b) & Q.extended_real(a + b)))
+    raises(UnhandledInput, lambda: lra_satask(a - 1 >= a, Q.extended_real(a)))
 
-    assert ask(a > oo, Q.extended_real(a)) is False
-    assert ask(a > b, Q.extended_real(a) & Q.extended_real(b) & (a >= oo)) is None # False would be better
+    raises(UnhandledInput, lambda: lra_satask(a > oo, Q.extended_real(a)))
+    raises(UnhandledInput, lambda: lra_satask(a > b, Q.extended_real(a) & Q.extended_real(b) & (a >= oo)))
 
     # If a = oo and b = -oo, then `a + b` is undefined. Inequalities
     # involving undefined quantities are also undefined so `ask` should
     # give None for expressions that may involve undefined quantities.
-    assert ask(a + b + 1 >= a + b, Q.extended_real(a) & Q.extended_real(b)) is None
+    raises(UnhandledInput, lambda: lra_satask(a + b + 1 >= a + b, Q.extended_real(a) & Q.extended_real(b)))
 
 
 @XFAIL

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -5,12 +5,13 @@ from sympy.assumptions.ask import Q, ask
 
 from sympy.core import symbols, Symbol
 from sympy.matrices.expressions.matexpr import MatrixSymbol
-from sympy.core.numbers import I
+from sympy.core.numbers import I, oo
 
 from sympy.testing.pytest import raises, XFAIL
-x, y, z = symbols("x y z", real=True)
+
 
 def test_lra_satask():
+    x = symbols("x", real=True)
     im = Symbol('im', imaginary=True)
 
     # test preprocessing of unequalities is working correctly
@@ -79,6 +80,7 @@ def test_old_assumptions():
 
 
 def test_rel_queries():
+    x, y, z = symbols("x y z", real=True)
     assert ask(Q.lt(x, 2) & Q.gt(x, 3)) is False
     assert ask(Q.positive(x - z), (x > y) & (y > z)) is True
     assert ask(x + y > 2, (x < 0) & (y <0)) is False
@@ -91,6 +93,7 @@ def test_unhandled_queries():
 
 
 def test_all_pred():
+    x= symbols("x", real=True)
     # test usable pred
     assert lra_satask(Q.extended_positive(x), (x > 2)) is True
     assert lra_satask(Q.positive_infinite(x)) is False
@@ -102,6 +105,43 @@ def test_all_pred():
     raises(UnhandledInput, lambda: lra_satask((x > 0), (x > 2) & Q.odd(x)))
     raises(UnhandledInput, lambda: lra_satask((x > 0), (x > 2) & Q.even(x)))
     raises(UnhandledInput, lambda: lra_satask((x > 0), (x > 2) & Q.integer(x)))
+
+
+def test_extended_real_number_line():
+    a, b, c = symbols("a b c")
+
+    # `a + 1 > a` may be false if a=oo.
+    assert ask(a + 1 > a, Q.extended_real(a)) is None
+    assert ask(a + 1 > a, Q.extended_real(a) & Q.extended_real(a + 1)) is None
+    assert ask(a + b > a, Q.extended_real(a) & Q.positive(b)) is None
+    assert ask(a + b > a, Q.extended_real(a) & Q.positive(b) & Q.extended_real(a + b)) is None
+    assert ask(a - 1 >= a, Q.extended_real(a)) is None
+
+    assert ask(a > oo, Q.extended_real(a)) is False
+    assert ask(a > b, Q.extended_real(a) & Q.extended_real(b) & (a >= oo)) is None # False would be better
+
+    # If a = oo and b = -oo, then `a + b` is undefined. Inequalities
+    # involving undefined quantities are also undefined so `ask` should
+    # give None for expressions that may involve undefined quantities.
+    assert ask(a + b + 1 >= a + b, Q.extended_real(a) & Q.extended_real(b)) is None
+
+
+@XFAIL
+def test_extended_real_number_line_xfail():
+    a, b, c = symbols("a b c")
+
+    # Transitivity
+    # If a <= b and b <= c, then a <= c.
+    assert ask(a <= c, (a <= b) & (b <= c)) is True
+    # If a <= b and b < c, then a < c.
+    assert ask(a < c, (a <= b) & (b < c)) is True
+    # If a < b and b <= c, then a < c.
+    assert ask(a < c, (a < b) & (b <= c)) is True
+
+    # Addition and subtraction
+    # If a <= b, then a + c <= b + c and a - c <= b - c.
+    assert ask(a + c <= b + c, (a <= b) & Q.extended_real(a + c) & Q.extended_real(b + c)) is True
+    assert ask(a - c <= b - c, (a <= b) & Q.extended_real(a - c) & Q.extended_real(b - c)) is True
 
 
 def test_number_line_properties():
@@ -151,6 +191,8 @@ def test_failing_number_line_properties():
 
 
 def test_equality():
+    x, y, z = symbols("x y z", real=True)
+
     # test symmetry and reflexivity
     assert ask(Q.eq(x, x)) is True
     assert ask(Q.eq(y, x), Q.eq(x, y)) is True
@@ -162,6 +204,7 @@ def test_equality():
 
 @XFAIL
 def test_equality_failing():
+    x, y, z = symbols("x y z", real=True)
     # Note that implementing the substitution property of equality
     # most likely requires a redesign of the new assumptions.
     # See issue #25485 for why this is the case and general ideas

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -127,6 +127,7 @@ def test_extended_real_number_line():
     assert lra_satask(a > c, (a > b) & (b > c)) is True
     assert lra_satask(2*a > 0, 2*a > 1) is True
     assert lra_satask(a**2 > 0, a**2 > 1) is True
+    assert lra_satask(a > b, (a - 2*b > 0) & Q.real(a) & Q.positive(b)) is True
 
     # TODO: Make this give `False` instead of `None`. (Probably very hard).
     assert ask(a > b, Q.extended_real(a) & Q.extended_real(b) & Q.eq(b, c) & Q.positive_infinite(c)) is None
@@ -191,7 +192,7 @@ def test_failing_number_line_properties():
     # From:
     # https://en.wikipedia.org/wiki/Inequality_(mathematics)#Properties_on_the_number_line
 
-    a, b, c = symbols("a b c", real=True)
+    a, b, c, x = symbols("a b c x", real=True)
 
     # Multiplication and division
     # If a <= b and c > 0, then ac <= bc and a/c <= b/c. (True for non-zero c)

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -33,6 +33,10 @@ def test_lra_satask():
 
 
 def test_lra_satask_unhandled():
+
+    x, y, z = symbols("x y z", real=True)
+    assert lra_satask(Q.eq(x, z), Q.ne(x, y) & Q.eq(y, z) ) is False
+
     im = Symbol('im', imaginary=True)
 
     # (im * I).is_real returns True but is not handled
@@ -43,6 +47,9 @@ def test_lra_satask_unhandled():
     raises(UnhandledInput, lambda: lra_satask(Q.gt(S.NaN, 0)))
     raises(UnhandledInput, lambda: lra_satask(Q.gt(Interval(0, 1), 0)))
     raises(UnhandledInput, lambda: lra_satask(Q.eq(S.Reals, 0)))
+
+    x, y, z = symbols("x y z", real=True)
+    assert lra_satask(Q.eq(x, z), Q.ne(x, y) & Q.eq(y, z) ) is False
 
 
 def test_old_assumptions():
@@ -116,20 +123,29 @@ def test_all_pred():
 def test_extended_real_number_line():
     a, b, c = symbols("a b c")
 
+
+    assert lra_satask(a > c, (a > b) & (b > c)) is True
+    assert lra_satask(2*a > 0, 2*a > 1) is True
+    assert lra_satask(a**2 > 0, a**2 > 1) is True
+
+    # TODO: Make this give `False` instead of `None`. (Probably very hard).
+    assert ask(a > b, Q.extended_real(a) & Q.extended_real(b) & Q.eq(b, c) & Q.positive_infinite(c)) is None
+
     # `a + 1 > a` may be false if a=oo.
     raises(UnhandledInput, lambda: lra_satask(a + 1 > a, Q.extended_real(a)))
     raises(UnhandledInput, lambda: lra_satask(a + 1 > a, Q.extended_real(a) & Q.extended_real(a + 1)))
     raises(UnhandledInput, lambda: lra_satask(a + b > a, Q.extended_real(a) & Q.positive(b)))
     raises(UnhandledInput, lambda: lra_satask(a + b > a, Q.extended_real(a) & Q.positive(b) & Q.extended_real(a + b)))
     raises(UnhandledInput, lambda: lra_satask(a - 1 >= a, Q.extended_real(a)))
+    raises(UnhandledInput, lambda: lra_satask(a + b + 1 >= a + b, Q.extended_real(a) & Q.extended_real(b)))
+
+    # `2*a > a` assuming `a > 0` may be false if a=oo.
+    raises(UnhandledInput, lambda: lra_satask(2*a > a, a > 0))
+    assert ask((2*a > a), (a > 0)) is None
 
     raises(UnhandledInput, lambda: lra_satask(a > oo, Q.extended_real(a)))
     raises(UnhandledInput, lambda: lra_satask(a > b, Q.extended_real(a) & Q.extended_real(b) & (a >= oo)))
 
-    # If a = oo and b = -oo, then `a + b` is undefined. Inequalities
-    # involving undefined quantities are also undefined so `ask` should
-    # give None for expressions that may involve undefined quantities.
-    raises(UnhandledInput, lambda: lra_satask(a + b + 1 >= a + b, Q.extended_real(a) & Q.extended_real(b)))
 
 
 @XFAIL

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -6,13 +6,14 @@ from sympy.assumptions.ask import Q, ask
 from sympy.core import symbols, Symbol
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.core.numbers import I, oo
+from sympy.core.singleton import S
+from sympy.sets.sets import Interval
 
 from sympy.testing.pytest import raises, XFAIL
 
 
 def test_lra_satask():
     x = symbols("x", real=True)
-    im = Symbol('im', imaginary=True)
 
     # test preprocessing of unequalities is working correctly
     assert lra_satask(Q.eq(x, 1), ~Q.ne(x, 0)) is False
@@ -30,13 +31,18 @@ def test_lra_satask():
     assert lra_satask(Q.gt(x, 0), True) is None
     assert raises(ValueError, lambda: lra_satask(Q.gt(x, 0), False))
 
-    # check imaginary numbers are correctly handled
-    # (im * I).is_real returns True so this is an edge case
+
+def test_lra_satask_unhandled():
+    im = Symbol('im', imaginary=True)
+
+    # (im * I).is_real returns True but is not handled
     raises(UnhandledInput, lambda: lra_satask(Q.gt(im * I, 0), Q.gt(im * I, 0)))
 
-    # check matrix inputs
     X = MatrixSymbol("X", 2, 2)
     raises(UnhandledInput, lambda: lra_satask(Q.lt(X, 2) & Q.gt(X, 3)))
+    raises(UnhandledInput, lambda: lra_satask(Q.gt(S.NaN, 0)))
+    raises(UnhandledInput, lambda: lra_satask(Q.gt(Interval(0, 1), 0)))
+    raises(UnhandledInput, lambda: lra_satask(Q.eq(S.Reals, 0)))
 
 
 def test_old_assumptions():

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -270,6 +270,8 @@ class LRASolver():
 
                 raise ValueError(f"Unhandled Predicate: {prop}")
 
+            if prop.function in (Q.real, Q.extended_real):
+                continue
             assert prop.function in ALLOWED_PRED
             if prop.lhs == S.NaN or prop.rhs == S.NaN:
                 raise ValueError(f"{prop} contains nan")

--- a/sympy/logic/algorithms/z3_wrapper.py
+++ b/sympy/logic/algorithms/z3_wrapper.py
@@ -49,7 +49,7 @@ def z3_satisfiable(expr, all_models=False):
 
 
 def z3_model_to_sympy_model(z3_model, enc_cnf):
-    rev_enc = {value: key for key, value in enc_cnf.encoding.items()}
+    rev_enc = enc_cnf.reverse_encoding
     result = {}
     for var in z3_model:
         var_name = var.name()


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes https://github.com/sympy/sympy/issues/27834

Related PRs:
- https://github.com/sympy/sympy/pull/25544
- old pr attempting to do the same thing: https://github.com/sympy/sympy/pull/25762

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

`ask` now handles most queries involving linear inequalities (e.g. `ask(x > z, (x > y) & (y > z))` now gives True instead of None). This was accomplished by using a simple heuristic approach to check unit clauses in the assumptions for real and extended real implying predicates. The most significant limitation is the following type of case:
```python
print(ask(2*x+1 > 0, Q.positive(x))) # continues to give True
print(ask(2*x+1 > 0, (x > 0) & Q.real(x))) # gives None; currently still unable to give True
print(ask(2*x+1 > 0, (x > 0) & Q.real(x) & Q.real(2*x + 1))) # now gives True instead of None
```

#### Other comments

Because extended real arthritic does not behave the same as real arithmetic, we have to be much more careful when variables are assumed to be extended real but not real.  Only a narrow set of such cases should give anything other than None. For example, it would be wrong to give True for the following cases:
```python
print(ask((2*a > a), (a > 0))) # None
print(ask((a + 1 > a))) # None
```
This PR uses a heuristic to determine when it's ok to use `lra_ask` if some of the variables are known to be extended real but not real. Namely, if distinct expressions share any variables that are extended real, then an UnhandledInput exception is raised. Otherwise, it is deemed safe to use the LRA theory solver. 

#### TODO
Before this can get merged, there are some other things we should do first:
- https://github.com/sympy/sympy/issues/29505
- https://github.com/sympy/sympy/issues/29413


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

All code was human written **other than the following**:
- lra_satask: Generate hypothesis tests 
   * Entirely written by llm (zed IDE with whatever llm model is the default for free trial). May have also use Gemini CLI. 
- Some of the refactoring changes to `_preprocess` to make it more readable were AI assisted with portions of copy pasted AI code from Gemini chat interface. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions 
  * Enabled `ask` to handle most queries involving linear inequalities (e.g. `ask(x > z, (x > y) & (y > z))`.  

<!-- END RELEASE NOTES -->
