### PR TITLE
Decouple recursive handles from `ask`

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from sympy.assumptions.assume import (global_assumptions, Predicate,
-        AppliedPredicate)
+        AppliedPredicate, recursive_ask)
 from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
 from sympy.core import sympify
 from sympy.core.kind import BooleanKind
@@ -537,9 +537,9 @@ def ask(proposition, assumptions=True, context=global_assumptions):
         return res
 
     # direct resolution method, no logic
-    res = key(*args)._eval_ask(assumptions)
+    res = recursive_ask(proposition, assumptions, context=context)
     if res is not None:
-        return bool(res)
+        return res
 
     # using satask (still costly)
     res = satask(proposition, assumptions=assumptions, context=context)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from sympy.core.symbol import Str
-from sympy.core.sympify import _sympify
+from sympy.core.sympify import _sympify, sympify
 from sympy.logic.boolalg import Boolean, false, true
 from sympy.multipledispatch.dispatcher import Dispatcher, str_signature
 from sympy.utilities.iterables import is_sequence
@@ -426,3 +426,41 @@ def assuming(*assumptions):
     finally:
         global_assumptions.clear()
         global_assumptions.update(old_global_assumptions)
+
+
+def recursive_ask(proposition, assumptions, context=True):
+    from sympy.assumptions.ask import _ask_single_fact, Q, _extract_all_facts
+    from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
+    from sympy.assumptions.cnf import CNF
+    from sympy.core.kind import BooleanKind
+    from sympy.logic.boolalg import And
+
+    proposition = sympify(proposition)
+    assumptions = sympify(assumptions)
+
+    if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
+        raise TypeError("proposition must be a valid logical expression")
+
+    if isinstance(assumptions, Predicate) or assumptions.kind is not BooleanKind:
+        raise TypeError("assumptions must be a valid logical expression")
+
+    binrelpreds = {Eq: Q.eq, Ne: Q.ne, Gt: Q.gt, Lt: Q.lt, Ge: Q.ge, Le: Q.le}
+    if isinstance(proposition, AppliedPredicate):
+        key, args = proposition.function, proposition.arguments
+    elif proposition.func in binrelpreds:
+        key, args = binrelpreds[type(proposition)], proposition.args
+    else:
+        key, args = Q.is_true, (proposition,)
+
+    effective_assumptions = And(assumptions, *context) if context is not True else assumptions
+
+    assump_cnf = CNF.from_prop(effective_assumptions)
+    local_facts = _extract_all_facts(assump_cnf, args)
+
+    res = _ask_single_fact(key, local_facts)
+    if res is not None:
+        return res
+
+    res = key(*args)._eval_ask(effective_assumptions)
+    if res is not None:
+        return bool(res)

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -261,6 +261,14 @@ def _(expr, assumptions):
     return False
 
 
+@PositiveInfinitePredicate.register(Expr)
+def _(expr, assumptions):
+    if ask(Q.complex(expr), assumptions) is True:
+        return False
+    if ask(Q.finite(expr), assumptions) is True:
+        return False
+
+
 # NegativeInfinitePredicate
 
 
@@ -272,3 +280,11 @@ def _(expr, assumptions):
 @NegativeInfinitePredicate.register_many(Infinity, ComplexInfinity)
 def _(expr, assumptions):
     return False
+
+
+@NegativeInfinitePredicate.register(Expr)
+def _(expr, assumptions):
+    if ask(Q.complex(expr), assumptions) is True:
+        return False
+    if ask(Q.finite(expr), assumptions) is True:
+        return False

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -4,7 +4,8 @@ infinitesimal, finite, etc.
 """
 from __future__ import annotations
 
-from sympy.assumptions import Q, ask
+from sympy.assumptions import Q
+from sympy.assumptions.assume import recursive_ask
 from sympy.core import Expr, Add, Mul, Pow, Symbol
 from sympy.core.numbers import (NegativeInfinity, GoldenRatio,
     Infinity, Exp1, ComplexInfinity, ImaginaryUnit, NaN, Number, Pi, E,
@@ -95,10 +96,10 @@ def _(expr, assumptions):
     sign = -1  # sign of unknown or infinite
     result = True
     for arg in expr.args:
-        _bounded = ask(Q.finite(arg), assumptions)
+        _bounded = recursive_ask(Q.finite(arg), assumptions)
         if _bounded:
             continue
-        s = ask(Q.extended_positive(arg), assumptions)
+        s = recursive_ask(Q.extended_positive(arg), assumptions)
         # if there has been more than one sign or if the sign of this arg
         # is None and Bounded is None or there was already
         # an unknown sign, return None
@@ -154,16 +155,16 @@ def _(expr, assumptions):
     result = True
     possible_zero = False
     for arg in expr.args:
-        _bounded = ask(Q.finite(arg), assumptions)
+        _bounded = recursive_ask(Q.finite(arg), assumptions)
         if _bounded:
-            if ask(Q.zero(arg), assumptions) is not False:
+            if recursive_ask(Q.zero(arg), assumptions) is not False:
                 if result is False:
                     return None
                 possible_zero = True
         elif _bounded is None:
             if result is None:
                 return None
-            if ask(Q.extended_nonzero(arg), assumptions) is None:
+            if recursive_ask(Q.extended_nonzero(arg), assumptions) is None:
                 return None
             if result is not False:
                 result = None
@@ -187,25 +188,25 @@ def _(expr, assumptions):
     * Otherwise unknown
     """
     if expr.base == E:
-        return ask(Q.finite(expr.exp), assumptions)
+        return recursive_ask(Q.finite(expr.exp), assumptions)
 
-    base_bounded = ask(Q.finite(expr.base), assumptions)
-    exp_bounded = ask(Q.finite(expr.exp), assumptions)
+    base_bounded = recursive_ask(Q.finite(expr.base), assumptions)
+    exp_bounded = recursive_ask(Q.finite(expr.exp), assumptions)
     if base_bounded is None and exp_bounded is None:  # Common Case
         return None
-    if base_bounded is False and ask(Q.extended_nonzero(expr.exp), assumptions):
+    if base_bounded is False and recursive_ask(Q.extended_nonzero(expr.exp), assumptions):
         return False
     if base_bounded and exp_bounded:
-        is_base_zero = ask(Q.zero(expr.base), assumptions)
-        is_exp_negative = ask(Q.negative(expr.exp), assumptions)
+        is_base_zero = recursive_ask(Q.zero(expr.base), assumptions)
+        is_exp_negative = recursive_ask(Q.negative(expr.exp), assumptions)
         if is_base_zero is True and is_exp_negative is True:
             return False
         if is_base_zero is not False and is_exp_negative is not False:
             return None
         return True
-    if (abs(expr.base) <= 1) == True and ask(Q.extended_positive(expr.exp), assumptions):
+    if (abs(expr.base) <= 1) == True and recursive_ask(Q.extended_positive(expr.exp), assumptions):
         return True
-    if (abs(expr.base) >= 1) == True and ask(Q.extended_negative(expr.exp), assumptions):
+    if (abs(expr.base) >= 1) == True and recursive_ask(Q.extended_negative(expr.exp), assumptions):
         return True
     if (abs(expr.base) >= 1) == True and exp_bounded is False:
         return False
@@ -213,15 +214,15 @@ def _(expr, assumptions):
 
 @FinitePredicate.register(exp)
 def _(expr, assumptions):
-    return ask(Q.finite(expr.exp), assumptions)
+    return recursive_ask(Q.finite(expr.exp), assumptions)
 
 @FinitePredicate.register(log)
 def _(expr, assumptions):
     # After complex -> finite fact is registered to new assumption system,
     # querying Q.infinite may be removed.
-    if ask(Q.infinite(expr.args[0]), assumptions):
+    if recursive_ask(Q.infinite(expr.args[0]), assumptions):
         return False
-    return ask(~Q.zero(expr.args[0]), assumptions)
+    return recursive_ask(~Q.zero(expr.args[0]), assumptions)
 
 @FinitePredicate.register_many(cos, sin, Number, Pi, Exp1, GoldenRatio,
     TribonacciConstant, ImaginaryUnit, sign)
@@ -242,7 +243,7 @@ def _(expr, assumptions):
 
 @InfinitePredicate.register(Expr)
 def _(expr, assumptions):
-    is_finite = Q.finite(expr)._eval_ask(assumptions)
+    is_finite = recursive_ask(Q.finite(expr), assumptions)
     if is_finite is None:
         return None
     return not is_finite
@@ -263,9 +264,9 @@ def _(expr, assumptions):
 
 @PositiveInfinitePredicate.register(Expr)
 def _(expr, assumptions):
-    if ask(Q.complex(expr), assumptions) is True:
+    if recursive_ask(Q.complex(expr), assumptions) is True:
         return False
-    if ask(Q.finite(expr), assumptions) is True:
+    if recursive_ask(Q.finite(expr), assumptions) is True:
         return False
 
 
@@ -284,7 +285,7 @@ def _(expr, assumptions):
 
 @NegativeInfinitePredicate.register(Expr)
 def _(expr, assumptions):
-    if ask(Q.complex(expr), assumptions) is True:
+    if recursive_ask(Q.complex(expr), assumptions) is True:
         return False
-    if ask(Q.finite(expr), assumptions) is True:
+    if recursive_ask(Q.finite(expr), assumptions) is True:
         return False

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -4,7 +4,8 @@ This module defines base class for handlers and some core handlers:
 """
 from __future__ import annotations
 
-from sympy.assumptions import Q, ask, AppliedPredicate
+from sympy.assumptions import Q, AppliedPredicate
+from sympy.assumptions.assume import recursive_ask
 from sympy.core import Basic, Symbol
 from sympy.core.logic import _fuzzy_group, fuzzy_and, fuzzy_or
 from sympy.core.numbers import NaN, Number
@@ -31,7 +32,7 @@ def _(expr, assumptions):
 @CommutativePredicate.register(Basic)
 def _(expr, assumptions):
     for arg in expr.args:
-        if not ask(Q.commutative(arg), assumptions):
+        if not recursive_ask(Q.commutative(arg), assumptions):
             return False
     return True
 
@@ -60,7 +61,7 @@ def _(expr, assumptions):
 
 @IsTruePredicate.register(AppliedPredicate)
 def _(expr, assumptions):
-    return ask(expr, assumptions)
+    return recursive_ask(expr, assumptions)
 
 @IsTruePredicate.register(Not)
 def _(expr, assumptions):
@@ -68,7 +69,7 @@ def _(expr, assumptions):
     if arg.is_Symbol:
         # symbol used as abstract boolean object
         return None
-    value = ask(arg, assumptions=assumptions)
+    value = recursive_ask(arg, assumptions=assumptions)
     if value in (True, False):
         return not value
     else:
@@ -78,7 +79,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     result = False
     for arg in expr.args:
-        p = ask(arg, assumptions=assumptions)
+        p = recursive_ask(arg, assumptions=assumptions)
         if p is True:
             return True
         if p is None:
@@ -89,7 +90,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     result = True
     for arg in expr.args:
-        p = ask(arg, assumptions=assumptions)
+        p = recursive_ask(arg, assumptions=assumptions)
         if p is False:
             return False
         if p is None:
@@ -99,15 +100,15 @@ def _(expr, assumptions):
 @IsTruePredicate.register(Implies)
 def _(expr, assumptions):
     p, q = expr.args
-    return ask(~p | q, assumptions=assumptions)
+    return recursive_ask(~p | q, assumptions=assumptions)
 
 @IsTruePredicate.register(Equivalent)
 def _(expr, assumptions):
     p, q = expr.args
-    pt = ask(p, assumptions=assumptions)
+    pt = recursive_ask(p, assumptions=assumptions)
     if pt is None:
         return None
-    qt = ask(q, assumptions=assumptions)
+    qt = recursive_ask(q, assumptions=assumptions)
     if qt is None:
         return None
     return pt == qt
@@ -120,12 +121,12 @@ def test_closed_group(expr, assumptions, key):
     to the current operation.
     """
     return _fuzzy_group(
-        (ask(key(a), assumptions) for a in expr.args), quick_exit=True)
+        (recursive_ask(key(a), assumptions) for a in expr.args), quick_exit=True)
 
 def ask_all(*queries, assumptions):
     return fuzzy_and(
-        (ask(query, assumptions) for query in queries))
+        (recursive_ask(query, assumptions) for query in queries))
 
 def ask_any(*queries, assumptions):
     return fuzzy_or(
-        (ask(query, assumptions) for query in queries))
+        (recursive_ask(query, assumptions) for query in queries))

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -5,7 +5,8 @@ Square, Symmetric, Invertible etc.
 from __future__ import annotations
 
 from sympy.logic.boolalg import conjuncts
-from sympy.assumptions import Q, ask
+from sympy.assumptions import Q
+from sympy.assumptions.assume import recursive_ask
 from sympy.assumptions.handlers import test_closed_group
 from sympy.matrices import MatrixBase
 from sympy.matrices.expressions import (BlockMatrix, BlockDiagMatrix, Determinant,
@@ -43,33 +44,33 @@ def _(expr, assumptions):
 @SymmetricPredicate.register(MatMul)
 def _(expr, assumptions):
     factor, mmul = expr.as_coeff_mmul()
-    if all(ask(Q.symmetric(arg), assumptions) for arg in mmul.args):
+    if all(recursive_ask(Q.symmetric(arg), assumptions) for arg in mmul.args):
         return True
     # TODO: implement sathandlers system for the matrices.
     # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
-    if ask(Q.diagonal(expr), assumptions):
+    if recursive_ask(Q.diagonal(expr), assumptions):
         return True
     if len(mmul.args) >= 2 and mmul.args[0] == mmul.args[-1].T:
         if len(mmul.args) == 2:
             return True
-        return ask(Q.symmetric(MatMul(*mmul.args[1:-1])), assumptions)
+        return recursive_ask(Q.symmetric(MatMul(*mmul.args[1:-1])), assumptions)
 
 @SymmetricPredicate.register(MatPow)
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
-    non_negative = ask(~Q.negative(exp), assumptions)
+    non_negative = recursive_ask(~Q.negative(exp), assumptions)
     if (non_negative or non_negative == False
-                        and ask(Q.invertible(base), assumptions)):
-        return ask(Q.symmetric(base), assumptions)
+                        and recursive_ask(Q.invertible(base), assumptions)):
+        return recursive_ask(Q.symmetric(base), assumptions)
     return None
 
 @SymmetricPredicate.register(MatAdd)
 def _(expr, assumptions):
-    return all(ask(Q.symmetric(arg), assumptions) for arg in expr.args)
+    return all(recursive_ask(Q.symmetric(arg), assumptions) for arg in expr.args)
 
 @SymmetricPredicate.register(MatrixSymbol)
 def _(expr, assumptions):
@@ -77,29 +78,29 @@ def _(expr, assumptions):
         return False
     # TODO: implement sathandlers system for the matrices.
     # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
-    if ask(Q.diagonal(expr), assumptions):
+    if recursive_ask(Q.diagonal(expr), assumptions):
         return True
     if Q.symmetric(expr) in conjuncts(assumptions):
         return True
 
 @SymmetricPredicate.register_many(OneMatrix, ZeroMatrix)
 def _(expr, assumptions):
-    return ask(Q.square(expr), assumptions)
+    return recursive_ask(Q.square(expr), assumptions)
 
 @SymmetricPredicate.register_many(Inverse, Transpose)
 def _(expr, assumptions):
-    return ask(Q.symmetric(expr.arg), assumptions)
+    return recursive_ask(Q.symmetric(expr.arg), assumptions)
 
 @SymmetricPredicate.register(MatrixSlice)
 def _(expr, assumptions):
     # TODO: implement sathandlers system for the matrices.
     # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
-    if ask(Q.diagonal(expr), assumptions):
+    if recursive_ask(Q.diagonal(expr), assumptions):
         return True
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.symmetric(expr.parent), assumptions)
+        return recursive_ask(Q.symmetric(expr.parent), assumptions)
 
 @SymmetricPredicate.register(Identity)
 def _(expr, assumptions):
@@ -111,9 +112,9 @@ def _(expr, assumptions):
 @InvertiblePredicate.register(MatMul)
 def _(expr, assumptions):
     factor, mmul = expr.as_coeff_mmul()
-    if all(ask(Q.invertible(arg), assumptions) for arg in mmul.args):
+    if all(recursive_ask(Q.invertible(arg), assumptions) for arg in mmul.args):
         return True
-    if any(ask(Q.invertible(arg), assumptions) is False
+    if any(recursive_ask(Q.invertible(arg), assumptions) is False
             for arg in mmul.args):
         return False
 
@@ -121,11 +122,11 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
     if exp.is_negative == False:
-        return ask(Q.invertible(base), assumptions)
+        return recursive_ask(Q.invertible(base), assumptions)
     return None
 
 @InvertiblePredicate.register(MatAdd)
@@ -153,14 +154,14 @@ def _(expr, assumptions):
 
 @InvertiblePredicate.register(Transpose)
 def _(expr, assumptions):
-    return ask(Q.invertible(expr.arg), assumptions)
+    return recursive_ask(Q.invertible(expr.arg), assumptions)
 
 @InvertiblePredicate.register(MatrixSlice)
 def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.invertible(expr.parent), assumptions)
+        return recursive_ask(Q.invertible(expr.parent), assumptions)
 
 @InvertiblePredicate.register(MatrixBase)
 def _(expr, assumptions):
@@ -179,24 +180,24 @@ def _(expr, assumptions):
     if not expr.is_square:
         return False
     if expr.blockshape == (1, 1):
-        return ask(Q.invertible(expr.blocks[0, 0]), assumptions)
+        return recursive_ask(Q.invertible(expr.blocks[0, 0]), assumptions)
     expr = reblock_2x2(expr)
     if expr.blockshape == (2, 2):
         [[A, B], [C, D]] = expr.blocks.tolist()
-        if ask(Q.invertible(A), assumptions) == True:
-            invertible = ask(Q.invertible(D - C * A.I * B), assumptions)
+        if recursive_ask(Q.invertible(A), assumptions) == True:
+            invertible = recursive_ask(Q.invertible(D - C * A.I * B), assumptions)
             if invertible is not None:
                 return invertible
-        if ask(Q.invertible(B), assumptions) == True:
-            invertible = ask(Q.invertible(C - D * B.I * A), assumptions)
+        if recursive_ask(Q.invertible(B), assumptions) == True:
+            invertible = recursive_ask(Q.invertible(C - D * B.I * A), assumptions)
             if invertible is not None:
                 return invertible
-        if ask(Q.invertible(C), assumptions) == True:
-            invertible = ask(Q.invertible(B - A * C.I * D), assumptions)
+        if recursive_ask(Q.invertible(C), assumptions) == True:
+            invertible = recursive_ask(Q.invertible(B - A * C.I * D), assumptions)
             if invertible is not None:
                 return invertible
-        if ask(Q.invertible(D), assumptions) == True:
-            invertible = ask(Q.invertible(A - B * D.I * C), assumptions)
+        if recursive_ask(Q.invertible(D), assumptions) == True:
+            invertible = recursive_ask(Q.invertible(A - B * D.I * C), assumptions)
             if invertible is not None:
                 return invertible
     return None
@@ -205,7 +206,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if expr.rowblocksizes != expr.colblocksizes:
         return None
-    return fuzzy_and([ask(Q.invertible(a), assumptions) for a in expr.diag])
+    return fuzzy_and([recursive_ask(Q.invertible(a), assumptions) for a in expr.diag])
 
 
 # OrthogonalPredicate
@@ -213,10 +214,10 @@ def _(expr, assumptions):
 @OrthogonalPredicate.register(MatMul)
 def _(expr, assumptions):
     factor, mmul = expr.as_coeff_mmul()
-    if (all(ask(Q.orthogonal(arg), assumptions) for arg in mmul.args) and
+    if (all(recursive_ask(Q.orthogonal(arg), assumptions) for arg in mmul.args) and
             factor == 1):
         return True
-    if any(ask(Q.invertible(arg), assumptions) is False
+    if any(recursive_ask(Q.invertible(arg), assumptions) is False
             for arg in mmul.args):
         return False
 
@@ -224,21 +225,21 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if int_exp:
-        return ask(Q.orthogonal(base), assumptions)
+        return recursive_ask(Q.orthogonal(base), assumptions)
     return None
 
 @OrthogonalPredicate.register(MatAdd)
 def _(expr, assumptions):
     if (len(expr.args) == 1 and
-            ask(Q.orthogonal(expr.args[0]), assumptions)):
+            recursive_ask(Q.orthogonal(expr.args[0]), assumptions)):
         return True
 
 @OrthogonalPredicate.register(MatrixSymbol)
 def _(expr, assumptions):
     if (not expr.is_square or
-                    ask(Q.invertible(expr), assumptions) is False):
+                    recursive_ask(Q.invertible(expr), assumptions) is False):
         return False
     if Q.orthogonal(expr) in conjuncts(assumptions):
         return True
@@ -253,14 +254,14 @@ def _(expr, assumptions):
 
 @OrthogonalPredicate.register_many(Inverse, Transpose)
 def _(expr, assumptions):
-    return ask(Q.orthogonal(expr.arg), assumptions)
+    return recursive_ask(Q.orthogonal(expr.arg), assumptions)
 
 @OrthogonalPredicate.register(MatrixSlice)
 def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.orthogonal(expr.parent), assumptions)
+        return recursive_ask(Q.orthogonal(expr.parent), assumptions)
 
 @OrthogonalPredicate.register(Factorization)
 def _(expr, assumptions):
@@ -272,10 +273,10 @@ def _(expr, assumptions):
 @UnitaryPredicate.register(MatMul)
 def _(expr, assumptions):
     factor, mmul = expr.as_coeff_mmul()
-    if (all(ask(Q.unitary(arg), assumptions) for arg in mmul.args) and
+    if (all(recursive_ask(Q.unitary(arg), assumptions) for arg in mmul.args) and
             abs(factor) == 1):
         return True
-    if any(ask(Q.invertible(arg), assumptions) is False
+    if any(recursive_ask(Q.invertible(arg), assumptions) is False
             for arg in mmul.args):
         return False
 
@@ -283,29 +284,29 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if int_exp:
-        return ask(Q.unitary(base), assumptions)
+        return recursive_ask(Q.unitary(base), assumptions)
     return None
 
 @UnitaryPredicate.register(MatrixSymbol)
 def _(expr, assumptions):
     if (not expr.is_square or
-                    ask(Q.invertible(expr), assumptions) is False):
+                    recursive_ask(Q.invertible(expr), assumptions) is False):
         return False
     if Q.unitary(expr) in conjuncts(assumptions):
         return True
 
 @UnitaryPredicate.register_many(Inverse, Transpose)
 def _(expr, assumptions):
-    return ask(Q.unitary(expr.arg), assumptions)
+    return recursive_ask(Q.unitary(expr.arg), assumptions)
 
 @UnitaryPredicate.register(MatrixSlice)
 def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.unitary(expr.parent), assumptions)
+        return recursive_ask(Q.unitary(expr.parent), assumptions)
 
 @UnitaryPredicate.register_many(DFT, Identity)
 def _(expr, assumptions):
@@ -324,16 +325,16 @@ def _(expr, assumptions):
 
 @FullRankPredicate.register(MatMul)
 def _(expr, assumptions):
-    if all(ask(Q.fullrank(arg), assumptions) for arg in expr.args):
+    if all(recursive_ask(Q.fullrank(arg), assumptions) for arg in expr.args):
         return True
 
 @FullRankPredicate.register(MatPow)
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
-    if int_exp and ask(~Q.negative(exp), assumptions):
-        return ask(Q.fullrank(base), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
+    if int_exp and recursive_ask(~Q.negative(exp), assumptions):
+        return recursive_ask(Q.fullrank(base), assumptions)
     return None
 
 @FullRankPredicate.register(Identity)
@@ -350,11 +351,11 @@ def _(expr, assumptions):
 
 @FullRankPredicate.register_many(Inverse, Transpose)
 def _(expr, assumptions):
-    return ask(Q.fullrank(expr.arg), assumptions)
+    return recursive_ask(Q.fullrank(expr.arg), assumptions)
 
 @FullRankPredicate.register(MatrixSlice)
 def _(expr, assumptions):
-    if ask(Q.orthogonal(expr.parent), assumptions):
+    if recursive_ask(Q.orthogonal(expr.parent), assumptions):
         return True
 
 
@@ -363,24 +364,24 @@ def _(expr, assumptions):
 @PositiveDefinitePredicate.register(MatMul)
 def _(expr, assumptions):
     factor, mmul = expr.as_coeff_mmul()
-    if (all(ask(Q.positive_definite(arg), assumptions)
+    if (all(recursive_ask(Q.positive_definite(arg), assumptions)
             for arg in mmul.args) and factor > 0):
         return True
     if (len(mmul.args) >= 2
             and mmul.args[0] == mmul.args[-1].T
-            and ask(Q.fullrank(mmul.args[0]), assumptions)):
-        return ask(Q.positive_definite(
+            and recursive_ask(Q.fullrank(mmul.args[0]), assumptions)):
+        return recursive_ask(Q.positive_definite(
             MatMul(*mmul.args[1:-1])), assumptions)
 
 @PositiveDefinitePredicate.register(MatPow)
 def _(expr, assumptions):
     # a power of a positive definite matrix is positive definite
-    if ask(Q.positive_definite(expr.args[0]), assumptions):
+    if recursive_ask(Q.positive_definite(expr.args[0]), assumptions):
         return True
 
 @PositiveDefinitePredicate.register(MatAdd)
 def _(expr, assumptions):
-    if all(ask(Q.positive_definite(arg), assumptions)
+    if all(recursive_ask(Q.positive_definite(arg), assumptions)
             for arg in expr.args):
         return True
 
@@ -405,14 +406,14 @@ def _(expr, assumptions):
 
 @PositiveDefinitePredicate.register_many(Inverse, Transpose)
 def _(expr, assumptions):
-    return ask(Q.positive_definite(expr.arg), assumptions)
+    return recursive_ask(Q.positive_definite(expr.arg), assumptions)
 
 @PositiveDefinitePredicate.register(MatrixSlice)
 def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.positive_definite(expr.parent), assumptions)
+        return recursive_ask(Q.positive_definite(expr.parent), assumptions)
 
 
 # UpperTriangularPredicate
@@ -420,25 +421,25 @@ def _(expr, assumptions):
 @UpperTriangularPredicate.register(MatMul)
 def _(expr, assumptions):
     factor, matrices = expr.as_coeff_matrices()
-    if all(ask(Q.upper_triangular(m), assumptions) for m in matrices):
+    if all(recursive_ask(Q.upper_triangular(m), assumptions) for m in matrices):
         return True
 
 @UpperTriangularPredicate.register(MatAdd)
 def _(expr, assumptions):
-    if all(ask(Q.upper_triangular(arg), assumptions) for arg in expr.args):
+    if all(recursive_ask(Q.upper_triangular(arg), assumptions) for arg in expr.args):
         return True
 
 @UpperTriangularPredicate.register(MatPow)
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
-    non_negative = ask(~Q.negative(exp), assumptions)
+    non_negative = recursive_ask(~Q.negative(exp), assumptions)
     if (non_negative or non_negative == False
-                        and ask(Q.invertible(base), assumptions)):
-        return ask(Q.upper_triangular(base), assumptions)
+                        and recursive_ask(Q.invertible(base), assumptions)):
+        return recursive_ask(Q.upper_triangular(base), assumptions)
     return None
 
 @UpperTriangularPredicate.register(MatrixSymbol)
@@ -456,18 +457,18 @@ def _(expr, assumptions):
 
 @UpperTriangularPredicate.register(Transpose)
 def _(expr, assumptions):
-    return ask(Q.lower_triangular(expr.arg), assumptions)
+    return recursive_ask(Q.lower_triangular(expr.arg), assumptions)
 
 @UpperTriangularPredicate.register(Inverse)
 def _(expr, assumptions):
-    return ask(Q.upper_triangular(expr.arg), assumptions)
+    return recursive_ask(Q.upper_triangular(expr.arg), assumptions)
 
 @UpperTriangularPredicate.register(MatrixSlice)
 def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.upper_triangular(expr.parent), assumptions)
+        return recursive_ask(Q.upper_triangular(expr.parent), assumptions)
 
 @UpperTriangularPredicate.register(Factorization)
 def _(expr, assumptions):
@@ -478,25 +479,25 @@ def _(expr, assumptions):
 @LowerTriangularPredicate.register(MatMul)
 def _(expr, assumptions):
     factor, matrices = expr.as_coeff_matrices()
-    if all(ask(Q.lower_triangular(m), assumptions) for m in matrices):
+    if all(recursive_ask(Q.lower_triangular(m), assumptions) for m in matrices):
         return True
 
 @LowerTriangularPredicate.register(MatAdd)
 def _(expr, assumptions):
-    if all(ask(Q.lower_triangular(arg), assumptions) for arg in expr.args):
+    if all(recursive_ask(Q.lower_triangular(arg), assumptions) for arg in expr.args):
         return True
 
 @LowerTriangularPredicate.register(MatPow)
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
-    non_negative = ask(~Q.negative(exp), assumptions)
+    non_negative = recursive_ask(~Q.negative(exp), assumptions)
     if (non_negative or non_negative == False
-                        and ask(Q.invertible(base), assumptions)):
-        return ask(Q.lower_triangular(base), assumptions)
+                        and recursive_ask(Q.invertible(base), assumptions)):
+        return recursive_ask(Q.lower_triangular(base), assumptions)
     return None
 
 @LowerTriangularPredicate.register(MatrixSymbol)
@@ -514,18 +515,18 @@ def _(expr, assumptions):
 
 @LowerTriangularPredicate.register(Transpose)
 def _(expr, assumptions):
-    return ask(Q.upper_triangular(expr.arg), assumptions)
+    return recursive_ask(Q.upper_triangular(expr.arg), assumptions)
 
 @LowerTriangularPredicate.register(Inverse)
 def _(expr, assumptions):
-    return ask(Q.lower_triangular(expr.arg), assumptions)
+    return recursive_ask(Q.lower_triangular(expr.arg), assumptions)
 
 @LowerTriangularPredicate.register(MatrixSlice)
 def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.lower_triangular(expr.parent), assumptions)
+        return recursive_ask(Q.lower_triangular(expr.parent), assumptions)
 
 @LowerTriangularPredicate.register(Factorization)
 def _(expr, assumptions):
@@ -542,25 +543,25 @@ def _(expr, assumptions):
     if _is_empty_or_1x1(expr):
         return True
     factor, matrices = expr.as_coeff_matrices()
-    if all(ask(Q.diagonal(m), assumptions) for m in matrices):
+    if all(recursive_ask(Q.diagonal(m), assumptions) for m in matrices):
         return True
 
 @DiagonalPredicate.register(MatPow)
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
-    non_negative = ask(~Q.negative(exp), assumptions)
+    non_negative = recursive_ask(~Q.negative(exp), assumptions)
     if (non_negative or non_negative == False
-                        and ask(Q.invertible(base), assumptions)):
-        return ask(Q.diagonal(base), assumptions)
+                        and recursive_ask(Q.invertible(base), assumptions)):
+        return recursive_ask(Q.diagonal(base), assumptions)
     return None
 
 @DiagonalPredicate.register(MatAdd)
 def _(expr, assumptions):
-    if all(ask(Q.diagonal(arg), assumptions) for arg in expr.args):
+    if all(recursive_ask(Q.diagonal(arg), assumptions) for arg in expr.args):
         return True
 
 @DiagonalPredicate.register(MatrixSymbol)
@@ -576,7 +577,7 @@ def _(expr, assumptions):
 
 @DiagonalPredicate.register_many(Inverse, Transpose)
 def _(expr, assumptions):
-    return ask(Q.diagonal(expr.arg), assumptions)
+    return recursive_ask(Q.diagonal(expr.arg), assumptions)
 
 @DiagonalPredicate.register(MatrixSlice)
 def _(expr, assumptions):
@@ -585,7 +586,7 @@ def _(expr, assumptions):
     if not expr.on_diag:
         return None
     else:
-        return ask(Q.diagonal(expr.parent), assumptions)
+        return recursive_ask(Q.diagonal(expr.parent), assumptions)
 
 @DiagonalPredicate.register_many(DiagonalMatrix, DiagMatrix, Identity, ZeroMatrix)
 def _(expr, assumptions):
@@ -600,11 +601,11 @@ def _(expr, assumptions):
 
 def BM_elements(predicate, expr, assumptions):
     """ Block Matrix elements. """
-    return all(ask(predicate(b), assumptions) for b in expr.blocks)
+    return all(recursive_ask(predicate(b), assumptions) for b in expr.blocks)
 
 def MS_elements(predicate, expr, assumptions):
     """ Matrix Slice elements. """
-    return ask(predicate(expr.parent), assumptions)
+    return recursive_ask(predicate(expr.parent), assumptions)
 
 def MatMul_elements(matrix_predicate, scalar_predicate, expr, assumptions):
     d = sift(expr.args, lambda x: isinstance(x, MatrixExpr))
@@ -623,11 +624,11 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
     if exp.is_negative == False:
-        return ask(Q.integer_elements(base), assumptions)
+        return recursive_ask(Q.integer_elements(base), assumptions)
     return None
 
 @IntegerElementsPredicate.register_many(Identity, OneMatrix, ZeroMatrix)
@@ -658,13 +659,13 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
-    non_negative = ask(~Q.negative(exp), assumptions)
+    non_negative = recursive_ask(~Q.negative(exp), assumptions)
     if (non_negative or non_negative == False
-                        and ask(Q.invertible(base), assumptions)):
-        return ask(Q.real_elements(base), assumptions)
+                        and recursive_ask(Q.invertible(base), assumptions)):
+        return recursive_ask(Q.real_elements(base), assumptions)
     return None
 
 @RealElementsPredicate.register(MatMul)
@@ -691,13 +692,13 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     # only for integer powers
     base, exp = expr.args
-    int_exp = ask(Q.integer(exp), assumptions)
+    int_exp = recursive_ask(Q.integer(exp), assumptions)
     if not int_exp:
         return None
-    non_negative = ask(~Q.negative(exp), assumptions)
+    non_negative = recursive_ask(~Q.negative(exp), assumptions)
     if (non_negative or non_negative == False
-                        and ask(Q.invertible(base), assumptions)):
-        return ask(Q.complex_elements(base), assumptions)
+                        and recursive_ask(Q.invertible(base), assumptions)):
+        return recursive_ask(Q.complex_elements(base), assumptions)
     return None
 
 @ComplexElementsPredicate.register(MatMul)

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -3,7 +3,8 @@ Handlers for keys related to number theory: prime, even, odd, etc.
 """
 from __future__ import annotations
 
-from sympy.assumptions import Q, ask
+from sympy.assumptions import Q
+from sympy.assumptions.assume import recursive_ask
 from sympy.core import Add, Basic, Expr, Float, Mul, Pow, S
 from sympy.core.numbers import (ImaginaryUnit, Infinity, Integer, NaN,
     NegativeInfinity, NumberSymbol, Rational, int_valued)
@@ -49,7 +50,7 @@ def _(expr, assumptions):
     if expr.is_number:
         return _PrimePredicate_number(expr, assumptions)
     for arg in expr.args:
-        if not ask(Q.integer(arg), assumptions):
+        if not recursive_ask(Q.integer(arg), assumptions):
             return None
     for arg in expr.args:
         if arg.is_number and arg.is_composite:
@@ -62,12 +63,12 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         return _PrimePredicate_number(expr, assumptions)
-    if ask(Q.integer(expr.exp), assumptions) and \
-            ask(Q.integer(expr.base), assumptions):
-        prime_base = ask(Q.prime(expr.base), assumptions)
+    if recursive_ask(Q.integer(expr.exp), assumptions) and \
+            recursive_ask(Q.integer(expr.base), assumptions):
+        prime_base = recursive_ask(Q.prime(expr.base), assumptions)
         if prime_base is False:
             return False
-        is_exp_one = ask(Q.eq(expr.exp, 1), assumptions)
+        is_exp_one = recursive_ask(Q.eq(expr.exp, 1), assumptions)
         if is_exp_one is False:
             return False
         if prime_base is True and is_exp_one is True:
@@ -105,16 +106,16 @@ def _(expr, assumptions):
 
 @CompositePredicate.register(Basic)
 def _(expr, assumptions):
-    _positive = ask(Q.positive(expr), assumptions)
+    _positive = recursive_ask(Q.positive(expr), assumptions)
     if _positive:
-        _integer = ask(Q.integer(expr), assumptions)
+        _integer = recursive_ask(Q.integer(expr), assumptions)
         if _integer:
-            _prime = ask(Q.prime(expr), assumptions)
+            _prime = recursive_ask(Q.prime(expr), assumptions)
             if _prime is None:
                 return
             # Positive integer which is not prime is not
             # necessarily composite
-            _is_one = ask(Q.eq(expr, 1), assumptions)
+            _is_one = recursive_ask(Q.eq(expr, 1), assumptions)
             if _is_one:
                 return False
             if _is_one is None:
@@ -170,15 +171,15 @@ def _(expr, assumptions):
     even, odd, irrational, acc = False, 0, False, 1
     for arg in expr.args:
         # check for all integers and at least one even
-        if ask(Q.integer(arg), assumptions):
-            if ask(Q.even(arg), assumptions):
+        if recursive_ask(Q.integer(arg), assumptions):
+            if recursive_ask(Q.even(arg), assumptions):
                 even = True
-            elif ask(Q.odd(arg), assumptions):
+            elif recursive_ask(Q.odd(arg), assumptions):
                 odd += 1
             elif not even and acc != 1:
-                if ask(Q.odd(acc + arg), assumptions):
+                if recursive_ask(Q.odd(acc + arg), assumptions):
                     even = True
-        elif ask(Q.irrational(arg), assumptions):
+        elif recursive_ask(Q.irrational(arg), assumptions):
             # one irrational makes the result False
             # two makes it undefined
             if irrational:
@@ -207,9 +208,9 @@ def _(expr, assumptions):
         return _EvenPredicate_number(expr, assumptions)
     _result = True
     for arg in expr.args:
-        if ask(Q.even(arg), assumptions):
+        if recursive_ask(Q.even(arg), assumptions):
             pass
-        elif ask(Q.odd(arg), assumptions):
+        elif recursive_ask(Q.odd(arg), assumptions):
             _result = not _result
         else:
             break
@@ -220,10 +221,10 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if expr.is_number:
         return _EvenPredicate_number(expr, assumptions)
-    if ask(Q.integer(expr.exp), assumptions):
-        if ask(Q.positive(expr.exp), assumptions):
-            return ask(Q.even(expr.base), assumptions)
-        elif ask(~Q.negative(expr.exp) & Q.odd(expr.base), assumptions):
+    if recursive_ask(Q.integer(expr.exp), assumptions):
+        if recursive_ask(Q.positive(expr.exp), assumptions):
+            return recursive_ask(Q.even(expr.base), assumptions)
+        elif recursive_ask(~Q.negative(expr.exp) & Q.odd(expr.base), assumptions):
             return False
         elif expr.base is S.NegativeOne:
             return False
@@ -242,17 +243,17 @@ def _(expr, assumptions):
 
 @EvenPredicate.register(Abs)
 def _(expr, assumptions):
-    if ask(Q.real(expr.args[0]), assumptions):
-        return ask(Q.even(expr.args[0]), assumptions)
+    if recursive_ask(Q.real(expr.args[0]), assumptions):
+        return recursive_ask(Q.even(expr.args[0]), assumptions)
 
 @EvenPredicate.register(re)
 def _(expr, assumptions):
-    if ask(Q.real(expr.args[0]), assumptions):
-        return ask(Q.even(expr.args[0]), assumptions)
+    if recursive_ask(Q.real(expr.args[0]), assumptions):
+        return recursive_ask(Q.even(expr.args[0]), assumptions)
 
 @EvenPredicate.register(im)
 def _(expr, assumptions):
-    if ask(Q.real(expr.args[0]), assumptions):
+    if recursive_ask(Q.real(expr.args[0]), assumptions):
         return True
 
 @EvenPredicate.register(NaN)
@@ -271,9 +272,9 @@ def _(expr, assumptions):
 
 @OddPredicate.register(Basic)
 def _(expr, assumptions):
-    _integer = ask(Q.integer(expr), assumptions)
+    _integer = recursive_ask(Q.integer(expr), assumptions)
     if _integer:
-        _even = ask(Q.even(expr), assumptions)
+        _even = recursive_ask(Q.even(expr), assumptions)
         if _even is None:
             return None
         return not _even

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -3,7 +3,8 @@ Handlers related to order relations: positive, negative, etc.
 """
 from __future__ import annotations
 
-from sympy.assumptions import Q, ask
+from sympy.assumptions import Q
+from sympy.assumptions.assume import recursive_ask
 from sympy.core import Add, Basic, Expr, Mul, Pow, S
 from sympy.core.logic import fuzzy_not, fuzzy_and, fuzzy_or
 from sympy.core.numbers import E, ImaginaryUnit, NaN, I, pi
@@ -66,14 +67,14 @@ def _(expr, assumptions):
     if expr.is_number:
         return _NegativePredicate_number(expr, assumptions)
 
-    r = ask(Q.real(expr), assumptions)
+    r = recursive_ask(Q.real(expr), assumptions)
     if r is not True:
         return r
 
     nonpos = 0
     for arg in expr.args:
-        if ask(Q.negative(arg), assumptions) is not True:
-            if ask(Q.positive(arg), assumptions) is False:
+        if recursive_ask(Q.negative(arg), assumptions) is not True:
+            if recursive_ask(Q.positive(arg), assumptions) is False:
                 nonpos += 1
             else:
                 break
@@ -89,9 +90,9 @@ def _(expr, assumptions):
     for arg in expr.args:
         if result is None:
             result = False
-        if ask(Q.negative(arg), assumptions):
+        if recursive_ask(Q.negative(arg), assumptions):
             result = not result
-        elif ask(Q.positive(arg), assumptions):
+        elif recursive_ask(Q.positive(arg), assumptions):
             pass
         else:
             return
@@ -106,20 +107,20 @@ def _(expr, assumptions):
     """
     if expr.base == E:
         # Exponential is always positive:
-        if ask(Q.real(expr.exp), assumptions):
+        if recursive_ask(Q.real(expr.exp), assumptions):
             return False
         return
 
     if expr.is_number:
         return _NegativePredicate_number(expr, assumptions)
-    if ask(Q.real(expr.base), assumptions):
-        if ask(Q.positive(expr.base), assumptions):
-            if ask(Q.real(expr.exp), assumptions):
+    if recursive_ask(Q.real(expr.base), assumptions):
+        if recursive_ask(Q.positive(expr.base), assumptions):
+            if recursive_ask(Q.real(expr.exp), assumptions):
                 return False
-        if ask(Q.even(expr.exp), assumptions):
+        if recursive_ask(Q.even(expr.exp), assumptions):
             return False
-        if ask(Q.odd(expr.exp), assumptions):
-            return ask(Q.negative(expr.base), assumptions)
+        if recursive_ask(Q.odd(expr.exp), assumptions):
+            return recursive_ask(Q.negative(expr.base), assumptions)
 
 @NegativePredicate.register_many(Abs, ImaginaryUnit)
 def _(expr, assumptions):
@@ -127,7 +128,7 @@ def _(expr, assumptions):
 
 @NegativePredicate.register(exp)
 def _(expr, assumptions):
-    if ask(Q.real(expr.exp), assumptions):
+    if recursive_ask(Q.real(expr.exp), assumptions):
         return False
     raise MDNotImplementedError
 
@@ -139,7 +140,7 @@ def _(expr, assumptions):
     if expr.is_number:
         notnegative = fuzzy_not(_NegativePredicate_number(expr, assumptions))
         if notnegative:
-            return ask(Q.real(expr), assumptions)
+            return recursive_ask(Q.real(expr), assumptions)
         else:
             return notnegative
 
@@ -162,7 +163,7 @@ def _(expr, assumptions):
 
 @NonZeroPredicate.register(Basic)
 def _(expr, assumptions):
-    if ask(Q.real(expr)) is False:
+    if recursive_ask(Q.real(expr), assumptions) is False:
         return False
     if expr.is_number:
         # if there are no symbols just evalf
@@ -174,14 +175,14 @@ def _(expr, assumptions):
 
 @NonZeroPredicate.register(Add)
 def _(expr, assumptions):
-    if all(ask(Q.positive(x), assumptions) for x in expr.args) \
-            or all(ask(Q.negative(x), assumptions) for x in expr.args):
+    if all(recursive_ask(Q.positive(x), assumptions) for x in expr.args) \
+            or all(recursive_ask(Q.negative(x), assumptions) for x in expr.args):
         return True
 
 @NonZeroPredicate.register(Mul)
 def _(expr, assumptions):
     for arg in expr.args:
-        result = ask(Q.nonzero(arg), assumptions)
+        result = recursive_ask(Q.nonzero(arg), assumptions)
         if result:
             continue
         return result
@@ -191,15 +192,15 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     return fuzzy_and([
         fuzzy_or([
-            ask(Q.nonzero(expr.base), assumptions),
-            ask(Q.zero(expr.exp), assumptions)
+            recursive_ask(Q.nonzero(expr.base), assumptions),
+            recursive_ask(Q.zero(expr.exp), assumptions)
         ]),
-        ask(Q.real(expr), assumptions)
+        recursive_ask(Q.real(expr), assumptions)
     ])
 
 @NonZeroPredicate.register(Abs)
 def _(expr, assumptions):
-    return ask(Q.nonzero(expr.args[0]), assumptions)
+    return recursive_ask(Q.nonzero(expr.args[0]), assumptions)
 
 @NonZeroPredicate.register(NaN)
 def _(expr, assumptions):
@@ -217,13 +218,13 @@ def _(expr, assumptions):
 
 @ZeroPredicate.register(Basic)
 def _(expr, assumptions):
-    return fuzzy_and([fuzzy_not(ask(Q.nonzero(expr), assumptions)),
-        ask(Q.real(expr), assumptions)])
+    return fuzzy_and([fuzzy_not(recursive_ask(Q.nonzero(expr), assumptions)),
+        recursive_ask(Q.real(expr), assumptions)])
 
 @ZeroPredicate.register(Mul)
 def _(expr, assumptions):
     # TODO: This should be deducible from the nonzero handler
-    return fuzzy_or(ask(Q.zero(arg), assumptions) for arg in expr.args)
+    return fuzzy_or(recursive_ask(Q.zero(arg), assumptions) for arg in expr.args)
 
 
 # NonPositivePredicate
@@ -240,7 +241,7 @@ def _(expr, assumptions):
     if expr.is_number:
         notpositive = fuzzy_not(_PositivePredicate_number(expr, assumptions))
         if notpositive:
-            return ask(Q.real(expr), assumptions)
+            return recursive_ask(Q.real(expr), assumptions)
         else:
             return notpositive
 
@@ -284,9 +285,9 @@ def _(expr, assumptions):
         return _PositivePredicate_number(expr, assumptions)
     result = True
     for arg in expr.args:
-        if ask(Q.positive(arg), assumptions):
+        if recursive_ask(Q.positive(arg), assumptions):
             continue
-        elif ask(Q.negative(arg), assumptions):
+        elif recursive_ask(Q.negative(arg), assumptions):
             result = result ^ True
         else:
             return
@@ -297,14 +298,14 @@ def _(expr, assumptions):
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
 
-    r = ask(Q.real(expr), assumptions)
+    r = recursive_ask(Q.real(expr), assumptions)
     if r is not True:
         return r
 
     nonneg = 0
     for arg in expr.args:
-        if ask(Q.positive(arg), assumptions) is not True:
-            if ask(Q.negative(arg), assumptions) is False:
+        if recursive_ask(Q.positive(arg), assumptions) is not True:
+            if recursive_ask(Q.negative(arg), assumptions) is False:
                 nonneg += 1
             else:
                 break
@@ -315,48 +316,48 @@ def _(expr, assumptions):
 @PositivePredicate.register(Pow)
 def _(expr, assumptions):
     if expr.base == E:
-        if ask(Q.real(expr.exp), assumptions):
+        if recursive_ask(Q.real(expr.exp), assumptions):
             return True
-        if ask(Q.imaginary(expr.exp), assumptions):
-            return ask(Q.even(expr.exp/(I*pi)), assumptions)
+        if recursive_ask(Q.imaginary(expr.exp), assumptions):
+            return recursive_ask(Q.even(expr.exp/(I*pi)), assumptions)
         return
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
-    if ask(Q.even(expr.exp), assumptions) and ask(Q.real(expr.base), assumptions):
-        zero_base = ask(Q.zero(expr.base), assumptions)
-        if zero_base and ask(Q.positive(expr.exp), assumptions):
+    if recursive_ask(Q.even(expr.exp), assumptions) and recursive_ask(Q.real(expr.base), assumptions):
+        zero_base = recursive_ask(Q.zero(expr.base), assumptions)
+        if zero_base and recursive_ask(Q.positive(expr.exp), assumptions):
             return False
         elif zero_base is False:
             return True
-    if ask(Q.positive(expr.base), assumptions):
-        if ask(Q.real(expr.exp), assumptions):
+    if recursive_ask(Q.positive(expr.base), assumptions):
+        if recursive_ask(Q.real(expr.exp), assumptions):
             return True
-    if ask(Q.negative(expr.base), assumptions):
-        if ask(Q.odd(expr.exp), assumptions):
+    if recursive_ask(Q.negative(expr.base), assumptions):
+        if recursive_ask(Q.odd(expr.exp), assumptions):
             return False
 
 @PositivePredicate.register(exp)
 def _(expr, assumptions):
-    if ask(Q.real(expr.exp), assumptions):
+    if recursive_ask(Q.real(expr.exp), assumptions):
         return True
-    if ask(Q.imaginary(expr.exp), assumptions):
-        return ask(Q.even(expr.exp/(I*pi)), assumptions)
+    if recursive_ask(Q.imaginary(expr.exp), assumptions):
+        return recursive_ask(Q.even(expr.exp/(I*pi)), assumptions)
 
 @PositivePredicate.register(log)
 def _(expr, assumptions):
-    r = ask(Q.real(expr.args[0]), assumptions)
+    r = recursive_ask(Q.real(expr.args[0]), assumptions)
     if r is not True:
         return r
-    if ask(Q.positive(expr.args[0] - 1), assumptions):
+    if recursive_ask(Q.positive(expr.args[0] - 1), assumptions):
         return True
-    if ask(Q.negative(expr.args[0] - 1), assumptions):
+    if recursive_ask(Q.negative(expr.args[0] - 1), assumptions):
         return False
 
 @PositivePredicate.register(factorial)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.integer(x) & Q.positive(x), assumptions):
+    if recursive_ask(Q.integer(x) & Q.positive(x), assumptions):
             return True
 
 @PositivePredicate.register(ImaginaryUnit)
@@ -365,45 +366,45 @@ def _(expr, assumptions):
 
 @PositivePredicate.register(Abs)
 def _(expr, assumptions):
-    return ask(Q.nonzero(expr), assumptions)
+    return recursive_ask(Q.nonzero(expr), assumptions)
 
 @PositivePredicate.register(Trace)
 def _(expr, assumptions):
-    if ask(Q.positive_definite(expr.arg), assumptions):
+    if recursive_ask(Q.positive_definite(expr.arg), assumptions):
         return True
 
 @PositivePredicate.register(Determinant)
 def _(expr, assumptions):
-    if ask(Q.positive_definite(expr.arg), assumptions):
+    if recursive_ask(Q.positive_definite(expr.arg), assumptions):
         return True
 
 @PositivePredicate.register(MatrixElement)
 def _(expr, assumptions):
     if (expr.i == expr.j
-            and ask(Q.positive_definite(expr.parent), assumptions)):
+            and recursive_ask(Q.positive_definite(expr.parent), assumptions)):
         return True
 
 @PositivePredicate.register(atan)
 def _(expr, assumptions):
-    return ask(Q.positive(expr.args[0]), assumptions)
+    return recursive_ask(Q.positive(expr.args[0]), assumptions)
 
 @PositivePredicate.register(asin)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.positive(x) & Q.nonpositive(x - 1), assumptions):
+    if recursive_ask(Q.positive(x) & Q.nonpositive(x - 1), assumptions):
         return True
-    if ask(Q.negative(x) & Q.nonnegative(x + 1), assumptions):
+    if recursive_ask(Q.negative(x) & Q.nonnegative(x + 1), assumptions):
         return False
 
 @PositivePredicate.register(acos)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.nonpositive(x - 1) & Q.nonnegative(x + 1), assumptions):
+    if recursive_ask(Q.nonpositive(x - 1) & Q.nonnegative(x + 1), assumptions):
         return True
 
 @PositivePredicate.register(acot)
 def _(expr, assumptions):
-    return ask(Q.real(expr.args[0]), assumptions)
+    return recursive_ask(Q.real(expr.args[0]), assumptions)
 
 @PositivePredicate.register(NaN)
 def _(expr, assumptions):
@@ -414,21 +415,21 @@ def _(expr, assumptions):
 
 @ExtendedNegativePredicate.register(object)
 def _(expr, assumptions):
-    return ask(Q.negative(expr) | Q.negative_infinite(expr), assumptions)
+    return recursive_ask(Q.negative(expr) | Q.negative_infinite(expr), assumptions)
 
 
 # ExtendedPositivePredicate
 
 @ExtendedPositivePredicate.register(object)
 def _(expr, assumptions):
-    return ask(Q.positive(expr) | Q.positive_infinite(expr), assumptions)
+    return recursive_ask(Q.positive(expr) | Q.positive_infinite(expr), assumptions)
 
 
 # ExtendedNonZeroPredicate
 
 @ExtendedNonZeroPredicate.register(object)
 def _(expr, assumptions):
-    return ask(
+    return recursive_ask(
         Q.negative_infinite(expr) | Q.negative(expr) | Q.positive(expr) | Q.positive_infinite(expr),
         assumptions)
 
@@ -437,7 +438,7 @@ def _(expr, assumptions):
 
 @ExtendedNonPositivePredicate.register(object)
 def _(expr, assumptions):
-    return ask(
+    return recursive_ask(
         Q.negative_infinite(expr) | Q.negative(expr) | Q.zero(expr),
         assumptions)
 
@@ -446,6 +447,6 @@ def _(expr, assumptions):
 
 @ExtendedNonNegativePredicate.register(object)
 def _(expr, assumptions):
-    return ask(
+    return recursive_ask(
         Q.zero(expr) | Q.positive(expr) | Q.positive_infinite(expr),
         assumptions)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -3,7 +3,8 @@ Handlers for predicates related to set membership: integer, rational, etc.
 """
 from __future__ import annotations
 
-from sympy.assumptions import Q, ask
+from sympy.assumptions import Q
+from sympy.assumptions.assume import recursive_ask
 from sympy.core import Add, Basic, Expr, Mul, Pow, S
 from sympy.core.numbers import (AlgebraicNumber, ComplexInfinity, Exp1, Float,
     GoldenRatio, ImaginaryUnit, Infinity, Integer, NaN, NegativeInfinity,
@@ -72,7 +73,7 @@ def _(expr, assumptions):
     if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
-        neg_exp = ask(Q.negative(expr.exp), assumptions)
+        neg_exp = recursive_ask(Q.negative(expr.exp), assumptions)
         if neg_exp is False:
             return True
         base_pm_1 = ask_any(Q.zero(expr.base - 1), Q.zero(expr.base + 1), assumptions=assumptions)
@@ -93,13 +94,13 @@ def _(expr, assumptions):
         return _IntegerPredicate_number(expr, assumptions)
     _output = True
     for arg in expr.args:
-        if not ask(Q.integer(arg), assumptions):
+        if not recursive_ask(Q.integer(arg), assumptions):
             if arg.is_Rational:
                 if arg.q == 2:
-                    return ask(Q.even(2*expr), assumptions)
+                    return recursive_ask(Q.even(2*expr), assumptions)
                 if ~(arg.q & 1):
                     return None
-            elif ask(Q.irrational(arg), assumptions):
+            elif recursive_ask(Q.irrational(arg), assumptions):
                 if _output:
                     _output = False
                 else:
@@ -111,12 +112,12 @@ def _(expr, assumptions):
 
 @IntegerPredicate.register(Abs)
 def _(expr, assumptions):
-    if ask(Q.integer(expr.args[0]), assumptions):
+    if recursive_ask(Q.integer(expr.args[0]), assumptions):
         return True
 
 @IntegerPredicate.register_many(Determinant, MatrixElement, Trace)
 def _(expr, assumptions):
-    return ask(Q.integer_elements(expr.args[0]), assumptions)
+    return recursive_ask(Q.integer_elements(expr.args[0]), assumptions)
 
 
 # RationalPredicate
@@ -162,55 +163,55 @@ def _(expr, assumptions):
     """
     if expr.base == E:
         x = expr.exp
-        if ask(Q.rational(x), assumptions):
-            return ask(Q.zero(x), assumptions)
+        if recursive_ask(Q.rational(x), assumptions):
+            return recursive_ask(Q.zero(x), assumptions)
         return
 
-    is_exp_integer = ask(Q.integer(expr.exp), assumptions)
+    is_exp_integer = recursive_ask(Q.integer(expr.exp), assumptions)
     if is_exp_integer:
-        is_base_rational = ask(Q.rational(expr.base), assumptions)
+        is_base_rational = recursive_ask(Q.rational(expr.base), assumptions)
         if is_base_rational:
-            is_base_zero = ask(Q.zero(expr.base), assumptions)
+            is_base_zero = recursive_ask(Q.zero(expr.base), assumptions)
             if is_base_zero is False:
                 return True
-            if is_base_zero and ask(Q.positive(expr.exp)):
+            if is_base_zero and recursive_ask(Q.positive(expr.exp), assumptions):
                 return True
-        if ask(Q.algebraic(expr.base), assumptions) is False:
-            return ask(Q.zero(expr.exp), assumptions)
-        if ask(Q.irrational(expr.base), assumptions) and ask(Q.eq(expr.exp, -1)):
+        if recursive_ask(Q.algebraic(expr.base), assumptions) is False:
+            return recursive_ask(Q.zero(expr.exp), assumptions)
+        if recursive_ask(Q.irrational(expr.base), assumptions) and recursive_ask(Q.eq(expr.exp, -1), assumptions):
             return False
         return
-    elif ask(Q.rational(expr.exp), assumptions):
-        if ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:
+    elif recursive_ask(Q.rational(expr.exp), assumptions):
+        if recursive_ask(Q.prime(expr.base), assumptions) and is_exp_integer is False:
             return False
-        if ask(Q.zero(expr.base)) and ask(Q.positive(expr.exp)):
+        if recursive_ask(Q.zero(expr.base), assumptions) and recursive_ask(Q.positive(expr.exp), assumptions):
             return True
-        if ask(Q.eq(expr.base, 1)):
+        if recursive_ask(Q.eq(expr.base, 1), assumptions):
             return True
 
 @RationalPredicate.register_many(asin, atan, cos, sin, tan)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.rational(x), assumptions):
-        return ask(~Q.nonzero(x), assumptions)
+    if recursive_ask(Q.rational(x), assumptions):
+        return recursive_ask(~Q.nonzero(x), assumptions)
 
 @RationalPredicate.register(exp)
 def _(expr, assumptions):
     x = expr.exp
-    if ask(Q.rational(x), assumptions):
-        return ask(~Q.nonzero(x), assumptions)
+    if recursive_ask(Q.rational(x), assumptions):
+        return recursive_ask(~Q.nonzero(x), assumptions)
 
 @RationalPredicate.register_many(acot, cot)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.rational(x), assumptions):
+    if recursive_ask(Q.rational(x), assumptions):
         return False
 
 @RationalPredicate.register_many(acos, log)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.rational(x), assumptions):
-        return ask(~Q.nonzero(x - 1), assumptions)
+    if recursive_ask(Q.rational(x), assumptions):
+        return recursive_ask(~Q.nonzero(x - 1), assumptions)
 
 
 # IrrationalPredicate
@@ -224,9 +225,9 @@ def _(expr, assumptions):
 
 @IrrationalPredicate.register(Basic)
 def _(expr, assumptions):
-    _real = ask(Q.real(expr), assumptions)
+    _real = recursive_ask(Q.real(expr), assumptions)
     if _real:
-        _rational = ask(Q.rational(expr), assumptions)
+        _rational = recursive_ask(Q.rational(expr), assumptions)
         if _rational is None:
             return None
         return not _rational
@@ -282,9 +283,9 @@ def _(expr, assumptions):
         return _RealPredicate_number(expr, assumptions)
     result = True
     for arg in expr.args:
-        if ask(Q.real(arg), assumptions):
+        if recursive_ask(Q.real(arg), assumptions):
             pass
-        elif ask(Q.imaginary(arg), assumptions):
+        elif recursive_ask(Q.imaginary(arg), assumptions):
             result = result ^ True
         else:
             break
@@ -313,77 +314,77 @@ def _(expr, assumptions):
         return _RealPredicate_number(expr, assumptions)
 
     if expr.base == E:
-        return ask(
+        return recursive_ask(
             Q.integer(expr.exp/I/pi) | Q.real(expr.exp), assumptions
         )
 
     if expr.base.func == exp or (expr.base.is_Pow and expr.base.base == E):
-        if ask(Q.imaginary(expr.base.exp), assumptions):
-            if ask(Q.imaginary(expr.exp), assumptions):
+        if recursive_ask(Q.imaginary(expr.base.exp), assumptions):
+            if recursive_ask(Q.imaginary(expr.exp), assumptions):
                 return True
         # If the i = (exp's arg)/(I*pi) is an integer or half-integer
         # multiple of I*pi then 2*i will be an integer. In addition,
         # exp(i*I*pi) = (-1)**i so the overall realness of the expr
         # can be determined by replacing exp(i*I*pi) with (-1)**i.
         i = expr.base.exp/I/pi
-        if ask(Q.integer(2*i), assumptions):
-            return ask(Q.real((S.NegativeOne**i)**expr.exp), assumptions)
+        if recursive_ask(Q.integer(2*i), assumptions):
+            return recursive_ask(Q.real((S.NegativeOne**i)**expr.exp), assumptions)
         return
 
-    if ask(Q.imaginary(expr.base), assumptions):
-        if ask(Q.integer(expr.exp), assumptions):
-            odd = ask(Q.odd(expr.exp), assumptions)
+    if recursive_ask(Q.imaginary(expr.base), assumptions):
+        if recursive_ask(Q.integer(expr.exp), assumptions):
+            odd = recursive_ask(Q.odd(expr.exp), assumptions)
             if odd is not None:
                 return not odd
             return
 
-    if ask(Q.imaginary(expr.exp), assumptions):
-        imlog = ask(Q.imaginary(log(expr.base)), assumptions)
+    if recursive_ask(Q.imaginary(expr.exp), assumptions):
+        imlog = recursive_ask(Q.imaginary(log(expr.base)), assumptions)
         if imlog is not None:
             # I**i -> real, log(I) is imag;
             # (2*I)**i -> complex, log(2*I) is not imag
             return imlog
 
-    if ask(Q.real(expr.base), assumptions):
-        if ask(Q.real(expr.exp), assumptions):
+    if recursive_ask(Q.real(expr.base), assumptions):
+        if recursive_ask(Q.real(expr.exp), assumptions):
             if (expr.exp.is_Rational and
-                    ask(Q.even(expr.exp.q), assumptions)):
-                return ask(Q.nonnegative(expr.base), assumptions)
-            base_is_zero = ask(Q.zero(expr.base), assumptions)
-            if base_is_zero or ask(Q.integer(expr.exp), assumptions):
+                    recursive_ask(Q.even(expr.exp.q), assumptions)):
+                return recursive_ask(Q.nonnegative(expr.base), assumptions)
+            base_is_zero = recursive_ask(Q.zero(expr.base), assumptions)
+            if base_is_zero or recursive_ask(Q.integer(expr.exp), assumptions):
                 # Division by zero : If the base is 0 and the exponent
                 # is negative, ``expr`` evaluates to complex infinity.
                 expr_is_complex_infinity = fuzzy_and([base_is_zero,
-                                ask(Q.negative(expr.exp), assumptions)])
+                                recursive_ask(Q.negative(expr.exp), assumptions)])
                 return fuzzy_not(expr_is_complex_infinity)
-            elif ask(Q.positive(expr.base), assumptions):
+            elif recursive_ask(Q.positive(expr.base), assumptions):
                 return True
 
 @RealPredicate.register_many(cos, sin)
 def _(expr, assumptions):
-    if ask(Q.real(expr.args[0]), assumptions):
+    if recursive_ask(Q.real(expr.args[0]), assumptions):
             return True
 
 @RealPredicate.register(exp)
 def _(expr, assumptions):
-    return ask(
+    return recursive_ask(
         Q.integer(expr.exp/I/pi) | Q.real(expr.exp), assumptions
     )
 
 @RealPredicate.register(log)
 def _(expr, assumptions):
-    return ask(Q.positive(expr.args[0]), assumptions)
+    return recursive_ask(Q.positive(expr.args[0]), assumptions)
 
 @RealPredicate.register_many(Determinant, MatrixElement, Trace)
 def _(expr, assumptions):
-    return ask(Q.real_elements(expr.args[0]), assumptions)
+    return recursive_ask(Q.real_elements(expr.args[0]), assumptions)
 
 
 # ExtendedRealPredicate
 
 @ExtendedRealPredicate.register(object)
 def _(expr, assumptions):
-    return ask(Q.negative_infinite(expr)
+    return recursive_ask(Q.negative_infinite(expr)
                | Q.negative(expr)
                | Q.zero(expr)
                | Q.positive(expr)
@@ -405,7 +406,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if isinstance(expr, MatrixBase):
         return None
-    return ask(Q.real(expr), assumptions)
+    return recursive_ask(Q.real(expr), assumptions)
 
 @HermitianPredicate.register(Add) # type:ignore
 def _(expr, assumptions):
@@ -431,11 +432,11 @@ def _(expr, assumptions):
     nccount = 0
     result = True
     for arg in expr.args:
-        if ask(Q.antihermitian(arg), assumptions):
+        if recursive_ask(Q.antihermitian(arg), assumptions):
             result = result ^ True
-        elif not ask(Q.hermitian(arg), assumptions):
+        elif not recursive_ask(Q.hermitian(arg), assumptions):
             break
-        if ask(~Q.commutative(arg), assumptions):
+        if recursive_ask(~Q.commutative(arg), assumptions):
             nccount += 1
             if nccount > 1:
                 break
@@ -450,23 +451,23 @@ def _(expr, assumptions):
     if expr.is_number:
         raise MDNotImplementedError
     if expr.base == E:
-        if ask(Q.hermitian(expr.exp), assumptions):
+        if recursive_ask(Q.hermitian(expr.exp), assumptions):
             return True
         raise MDNotImplementedError
-    if ask(Q.hermitian(expr.base), assumptions):
-        if ask(Q.integer(expr.exp), assumptions):
+    if recursive_ask(Q.hermitian(expr.base), assumptions):
+        if recursive_ask(Q.integer(expr.exp), assumptions):
             return True
     raise MDNotImplementedError
 
 @HermitianPredicate.register_many(cos, sin) # type:ignore
 def _(expr, assumptions):
-    if ask(Q.hermitian(expr.args[0]), assumptions):
+    if recursive_ask(Q.hermitian(expr.args[0]), assumptions):
         return True
     raise MDNotImplementedError
 
 @HermitianPredicate.register(exp) # type:ignore
 def _(expr, assumptions):
-    if ask(Q.hermitian(expr.exp), assumptions):
+    if recursive_ask(Q.hermitian(expr.exp), assumptions):
         return True
     raise MDNotImplementedError
 
@@ -516,7 +517,7 @@ def _(expr, assumptions):
 
 @ComplexPredicate.register_many(Determinant, MatrixElement, Trace) # type:ignore
 def _(expr, assumptions):
-    return ask(Q.complex_elements(expr.args[0]), assumptions)
+    return recursive_ask(Q.complex_elements(expr.args[0]), assumptions)
 
 @ComplexPredicate.register(NaN) # type:ignore
 def _(expr, assumptions):
@@ -557,9 +558,9 @@ def _(expr, assumptions):
 
     reals = 0
     for arg in expr.args:
-        if ask(Q.imaginary(arg), assumptions):
+        if recursive_ask(Q.imaginary(arg), assumptions):
             pass
-        elif ask(Q.real(arg), assumptions):
+        elif recursive_ask(Q.real(arg), assumptions):
             reals += 1
         else:
             break
@@ -581,9 +582,9 @@ def _(expr, assumptions):
     result = False
     reals = 0
     for arg in expr.args:
-        if ask(Q.imaginary(arg), assumptions):
+        if recursive_ask(Q.imaginary(arg), assumptions):
             result = result ^ True
-        elif not ask(Q.real(arg), assumptions):
+        elif not recursive_ask(Q.real(arg), assumptions):
             break
     else:
         if reals == len(expr.args):
@@ -608,65 +609,65 @@ def _(expr, assumptions):
 
     if expr.base == E:
         a = expr.exp/I/pi
-        return ask(Q.integer(2*a) & ~Q.integer(a), assumptions)
+        return recursive_ask(Q.integer(2*a) & ~Q.integer(a), assumptions)
 
     if expr.base.func == exp or (expr.base.is_Pow and expr.base.base == E):
-        if ask(Q.imaginary(expr.base.exp), assumptions):
-            if ask(Q.imaginary(expr.exp), assumptions):
+        if recursive_ask(Q.imaginary(expr.base.exp), assumptions):
+            if recursive_ask(Q.imaginary(expr.exp), assumptions):
                 return False
             i = expr.base.exp/I/pi
-            if ask(Q.integer(2*i), assumptions):
-                return ask(Q.imaginary((S.NegativeOne**i)**expr.exp), assumptions)
+            if recursive_ask(Q.integer(2*i), assumptions):
+                return recursive_ask(Q.imaginary((S.NegativeOne**i)**expr.exp), assumptions)
 
-    if ask(Q.imaginary(expr.base), assumptions):
-        if ask(Q.integer(expr.exp), assumptions):
-            odd = ask(Q.odd(expr.exp), assumptions)
+    if recursive_ask(Q.imaginary(expr.base), assumptions):
+        if recursive_ask(Q.integer(expr.exp), assumptions):
+            odd = recursive_ask(Q.odd(expr.exp), assumptions)
             if odd is not None:
                 return odd
             return
 
-    if ask(Q.imaginary(expr.exp), assumptions):
-        imlog = ask(Q.imaginary(log(expr.base)), assumptions)
+    if recursive_ask(Q.imaginary(expr.exp), assumptions):
+        imlog = recursive_ask(Q.imaginary(log(expr.base)), assumptions)
         if imlog is not None:
             # I**i -> real; (2*I)**i -> complex ==> not imaginary
             return False
 
-    if ask(Q.real(expr.base) & Q.real(expr.exp), assumptions):
-        if ask(Q.positive(expr.base), assumptions):
+    if recursive_ask(Q.real(expr.base) & Q.real(expr.exp), assumptions):
+        if recursive_ask(Q.positive(expr.base), assumptions):
             return False
         else:
-            rat = ask(Q.rational(expr.exp), assumptions)
+            rat = recursive_ask(Q.rational(expr.exp), assumptions)
             if not rat:
                 return rat
-            if ask(Q.integer(expr.exp), assumptions):
+            if recursive_ask(Q.integer(expr.exp), assumptions):
                 return False
             else:
-                half = ask(Q.integer(2*expr.exp), assumptions)
+                half = recursive_ask(Q.integer(2*expr.exp), assumptions)
                 if half:
-                    return ask(Q.negative(expr.base), assumptions)
+                    return recursive_ask(Q.negative(expr.base), assumptions)
                 return half
 
 @ImaginaryPredicate.register(log) # type:ignore
 def _(expr, assumptions):
-    if ask(Q.real(expr.args[0]), assumptions):
-        if ask(Q.positive(expr.args[0]), assumptions):
+    if recursive_ask(Q.real(expr.args[0]), assumptions):
+        if recursive_ask(Q.positive(expr.args[0]), assumptions):
             return False
         return
     # XXX it should be enough to do
-    # return ask(Q.nonpositive(expr.args[0]), assumptions)
-    # but ask(Q.nonpositive(exp(x)), Q.imaginary(x)) -> None;
+    # return recursive_ask(Q.nonpositive(expr.args[0]), assumptions)
+    # but recursive_ask(Q.nonpositive(exp(x)), Q.imaginary(x)) -> None;
     # it should return True since exp(x) will be either 0 or complex
     if expr.args[0].func == exp or (expr.args[0].is_Pow and expr.args[0].base == E):
         if expr.args[0].exp in [I, -I]:
             return True
-    im = ask(Q.imaginary(expr.args[0]), assumptions)
+    im = recursive_ask(Q.imaginary(expr.args[0]), assumptions)
     if im is False:
         return False
 
 @ImaginaryPredicate.register(exp) # type:ignore
 def _(expr, assumptions):
     a = expr.exp/I/pi
-    return ask(Q.integer(2*a) & ~Q.integer(a), assumptions)
+    return recursive_ask(Q.integer(2*a) & ~Q.integer(a), assumptions)
 
 @ImaginaryPredicate.register_many(Number, NumberSymbol) # type:ignore
 def _(expr, assumptions):
@@ -683,9 +684,9 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if isinstance(expr, MatrixBase):
         return None
-    if ask(Q.zero(expr), assumptions):
+    if recursive_ask(Q.zero(expr), assumptions):
         return True
-    return ask(Q.imaginary(expr), assumptions)
+    return recursive_ask(Q.imaginary(expr), assumptions)
 
 @AntihermitianPredicate.register(Add) # type:ignore
 def _(expr, assumptions):
@@ -711,11 +712,11 @@ def _(expr, assumptions):
     nccount = 0
     result = False
     for arg in expr.args:
-        if ask(Q.antihermitian(arg), assumptions):
+        if recursive_ask(Q.antihermitian(arg), assumptions):
             result = result ^ True
-        elif not ask(Q.hermitian(arg), assumptions):
+        elif not recursive_ask(Q.hermitian(arg), assumptions):
             break
-        if ask(~Q.commutative(arg), assumptions):
+        if recursive_ask(~Q.commutative(arg), assumptions):
             nccount += 1
             if nccount > 1:
                 break
@@ -731,13 +732,13 @@ def _(expr, assumptions):
     """
     if expr.is_number:
         raise MDNotImplementedError
-    if ask(Q.hermitian(expr.base), assumptions):
-        if ask(Q.integer(expr.exp), assumptions):
+    if recursive_ask(Q.hermitian(expr.base), assumptions):
+        if recursive_ask(Q.integer(expr.exp), assumptions):
             return False
-    elif ask(Q.antihermitian(expr.base), assumptions):
-        if ask(Q.even(expr.exp), assumptions):
+    elif recursive_ask(Q.antihermitian(expr.base), assumptions):
+        if recursive_ask(Q.even(expr.exp), assumptions):
             return False
-        elif ask(Q.odd(expr.exp), assumptions):
+        elif recursive_ask(Q.odd(expr.exp), assumptions):
             return True
     raise MDNotImplementedError
 
@@ -780,26 +781,26 @@ def _(expr, assumptions):
 @AlgebraicPredicate.register(Pow) # type:ignore
 def _(expr, assumptions):
     if expr.base == E:
-        if ask(Q.algebraic(expr.exp), assumptions):
-            return ask(~Q.nonzero(expr.exp), assumptions)
+        if recursive_ask(Q.algebraic(expr.exp), assumptions):
+            return recursive_ask(~Q.nonzero(expr.exp), assumptions)
         return
     if expr.base == pi:
-        if ask(Q.integer(expr.exp), assumptions) and ask(Q.positive(expr.exp), assumptions):
+        if recursive_ask(Q.integer(expr.exp), assumptions) and recursive_ask(Q.positive(expr.exp), assumptions):
             return False
         return
-    exp_rational = ask(Q.rational(expr.exp), assumptions)
-    base_algebraic = ask(Q.algebraic(expr.base), assumptions)
-    exp_algebraic = ask(Q.algebraic(expr.exp), assumptions)
+    exp_rational = recursive_ask(Q.rational(expr.exp), assumptions)
+    base_algebraic = recursive_ask(Q.algebraic(expr.base), assumptions)
+    exp_algebraic = recursive_ask(Q.algebraic(expr.exp), assumptions)
     if base_algebraic and exp_algebraic:
         if exp_rational:
             return True
         # Check based on the Gelfond-Schneider theorem:
         # If the base is algebraic and not equal to 0 or 1, and the exponent
         # is irrational,then the result is transcendental.
-        if ask(Q.ne(expr.base, 0) & Q.ne(expr.base, 1)) and exp_rational is False:
+        if recursive_ask(Q.ne(expr.base, 0) & Q.ne(expr.base, 1), assumptions) and exp_rational is False:
             return False
 
-    exp_integer = ask(Q.integer(expr.exp), assumptions)
+    exp_integer = recursive_ask(Q.integer(expr.exp), assumptions)
     if base_algebraic is False and exp_integer:
         if expr.exp > 0:
             return False
@@ -811,26 +812,26 @@ def _(expr, assumptions):
 @AlgebraicPredicate.register_many(asin, atan, cos, sin, tan) # type:ignore
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.algebraic(x), assumptions):
-        return ask(~Q.nonzero(x), assumptions)
+    if recursive_ask(Q.algebraic(x), assumptions):
+        return recursive_ask(~Q.nonzero(x), assumptions)
 
 @AlgebraicPredicate.register(exp) # type:ignore
 def _(expr, assumptions):
     x = expr.exp
-    if ask(Q.algebraic(x), assumptions):
-        return ask(~Q.nonzero(x), assumptions)
+    if recursive_ask(Q.algebraic(x), assumptions):
+        return recursive_ask(~Q.nonzero(x), assumptions)
 
 @AlgebraicPredicate.register_many(acot, cot) # type:ignore
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.algebraic(x), assumptions):
+    if recursive_ask(Q.algebraic(x), assumptions):
         return False
 
 @AlgebraicPredicate.register_many(acos, log) # type:ignore
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.algebraic(x), assumptions):
-        return ask(~Q.nonzero(x - 1), assumptions)
+    if recursive_ask(Q.algebraic(x), assumptions):
+        return recursive_ask(~Q.nonzero(x - 1), assumptions)
 
 
 # TranscendentalPredicate
@@ -841,8 +842,8 @@ def _(expr, assumptions):
     if ret is not None:
         return ret
 
-    is_complex = ask(Q.complex(expr), assumptions)
+    is_complex = recursive_ask(Q.complex(expr), assumptions)
     if is_complex:
-        is_algebraic = ask(Q.algebraic(expr), assumptions)
+        is_algebraic = recursive_ask(Q.algebraic(expr), assumptions)
         return fuzzy_not(is_algebraic)
     return is_complex

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -72,8 +72,14 @@ def _(expr, assumptions):
     if ask_all(~Q.zero(expr.base), Q.finite(expr.base), Q.zero(expr.exp), assumptions=assumptions):
         return True
     if ask_all(Q.integer(expr.base), Q.integer(expr.exp), assumptions=assumptions):
-        if ask_any(Q.positive(expr.exp), Q.nonnegative(expr.exp) & ~Q.zero(expr.base), Q.zero(expr.base-1), Q.zero(expr.base+1), assumptions=assumptions):
+        neg_exp = ask(Q.negative(expr.exp), assumptions)
+        if neg_exp is False:
             return True
+        base_pm_1 = ask_any(Q.zero(expr.base - 1), Q.zero(expr.base + 1), assumptions=assumptions)
+        if base_pm_1:
+            return True
+        if neg_exp and base_pm_1 is False:
+            return False
 
 @IntegerPredicate.register(Mul)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1711,6 +1711,8 @@ def test_integer():
     assert ask(Q.integer(x**y), Q.zero(x) & Q.integer(y) & Q.positive(y)) is True
     assert ask(Q.integer(pi**x), Q.zero(x)) is True
     assert ask(Q.integer(x**y), Q.imaginary(x) & Q.zero(y)) is True
+    assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y) & ~Q.negative(y)) is True
+    assert ask(Q.integer(x**y), Q.integer(x) & Q.integer(y) & Q.negative(y) & ~Q.zero(x - 1) & ~Q.zero(x + 1)) is False
 
 
 def test_negative():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1474,8 +1474,7 @@ def test_rational():
     assert ask(Q.rational(x**y),Q.irrational(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.prime(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y),Q.integer(x) & Q.integer(y)) is None
-    assert ask(Q.rational(x**y),Q.integer(x) & Q.eq(x,0) & Q.integer(y)) is None
-    assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is None
+    assert ask(Q.rational(x**y),Q.eq(x,1) & Q.rational(y)) is True
     assert ask(Q.rational(x**y),Q.eq(x,-1) & Q.rational(y)) is None
     assert ask(Q.rational(x**y), Q.prime(x) & Q.rational(y)) is None
     assert ask(Q.rational(x**y), ~Q.rational(x) & Q.integer(y) ) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -256,6 +256,24 @@ def test_complex_infinity():
     assert ask(Q.transcendental(zoo)) is False
 
 
+def test_positive_infinite_symbolic():
+    assert ask(Q.positive_infinite(x), Q.positive(x)) is False
+    assert ask(Q.positive_infinite(x), Q.finite(x)) is False
+    assert ask(Q.positive_infinite(x), Q.complex(x)) is False
+    assert ask(Q.positive_infinite(x + I), Q.real(x)) is False
+    assert ask(Q.positive_infinite(x*I), Q.real(x)) is False
+    assert ask(Q.positive_infinite(x + y), Q.real(x) & Q.imaginary(y)) is False
+
+
+def test_negative_infinite_symbolic():
+    assert ask(Q.negative_infinite(x), Q.positive(x)) is False
+    assert ask(Q.negative_infinite(x), Q.finite(x)) is False
+    assert ask(Q.negative_infinite(x), Q.complex(x)) is False
+    assert ask(Q.negative_infinite(x + I), Q.real(x)) is False
+    assert ask(Q.negative_infinite(x*I), Q.real(x)) is False
+    assert ask(Q.negative_infinite(x + y), Q.real(x) & Q.imaginary(y)) is False
+
+
 def test_nan():
     nan = S.NaN
     assert ask(Q.commutative(nan)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from sympy.abc import t, w, x, y, z, n, k, m, p, i
 from sympy.assumptions import (ask, AssumptionsContext, Q)
-from sympy.assumptions.assume import assuming, global_assumptions, Predicate
+from sympy.assumptions.assume import (assuming, global_assumptions, Predicate,
+    recursive_ask)
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.facts import (single_fact_lookup,
     get_known_facts, generate_known_facts_dict, get_known_facts_keys)
@@ -1156,6 +1157,13 @@ def test_bounded():
     assert ask(Q.finite(cos(x)**2)) is True
     assert ask(Q.finite(cos(x) + sin(x))) is True
 
+@XFAIL
+def test_unbounded_xfail():
+    # TODO: Rewrite the logic for the zero and nonzero recursive
+    # handlers in handlers/order.py so that these tests pass.
+    assert recursive_ask(Q.zero(1/y), Q.finite(y) & ~Q.zero(y)) is False
+    # This is no longer handled as a side effect of the fix for issue #28129.
+    assert ask(Q.infinite(x / y), Q.infinite(x) & Q.finite(y) & ~Q.zero(y)) is True
 
 def test_unbounded():
     assert ask(Q.infinite(I * oo)) is True
@@ -1164,7 +1172,6 @@ def test_unbounded():
     assert ask(Q.infinite(-I * oo)) is True
     assert ask(Q.infinite(1 + zoo)) is True
     assert ask(Q.infinite(I * zoo)) is True
-    assert ask(Q.infinite(x / y), Q.infinite(x) & Q.finite(y) & ~Q.zero(y)) is True
     assert ask(Q.infinite(I * oo - I * oo)) is None
     assert ask(Q.infinite(x * I * oo)) is None
     assert ask(Q.infinite(1 / x), Q.finite(x) & ~Q.zero(x)) is False


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes https://github.com/sympy/sympy/issues/28129. More current version of https://github.com/sympy/sympy/pull/29078. 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Replaced all calls to `ask` in the recursive handlers to a new function, `recursive_ask`. This way `ask` queries are guaranteed to only ever make one call to `satask`. Beyond performance improvements, this will make testing the different assumptions subsystems much easier. 

I ran the assumptions tests 10 times on master and 10 times on this branch and these were the results:
| Branch | Min | Max | Avg | Pass |
| :--- | :---: | :---: | :---: | :---: |
| `master` | 13.135s | 15.461s | 13.650s | 10/10 |
| `ask-rec-march-2` | 7.808s | 8.977s | 8.246s | 10/10 |


#### Other comments

Some queries needed a combination of the recursive handlers and satask so they will not be handled anymore. For example, the following query now gives `None` when it previously gave `True`: 
```python
ask(Q.infinite(x / y), Q.infinite(x) & Q.finite(y) & ~Q.zero(y))
```

These PRs were/are needed to make this one possible:
- https://github.com/sympy/sympy/pull/27492
- https://github.com/sympy/sympy/pull/28417
- https://github.com/sympy/sympy/pull/29918
- https://github.com/sympy/sympy/pull/29917


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

All code is human written other than the first commit which replaces `ask` with `recursive_ask`. The `recursive_ask` function which is defined in that commit is human written. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions 
  * Fixed design flaw with `ask` that made all queries roughly twice as slow. As an unfortunate consequence of this fix, some queries now give `None` instead of correctly giving `True` or `False` such as the following:
    * `ask(Q.infinite(x / y), Q.infinite(x) & Q.finite(y) & ~Q.zero(y)) # previously gave True` 

<!-- END RELEASE NOTES -->
