### PR TITLE
ntheory: fix typing overloads in cycle_length

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -728,6 +728,7 @@ Gurpartap Singh <dhaliwal.gurpartap@gmail.com> Gurpartap Singh <36311440+gurpart
 Gurpartap Singh <dhaliwal.gurpartap@gmail.com> gurpartap0306 <dhaliwal.gurpartap@gmail.com>
 Guru Devanla <grdvnl@gmail.com>
 Gustavo Alvarado <igoutta@protonmail.com> GA. <igoutta@users.noreply.github.com>
+Giovanni Zanotti <giozanotti07@mail.com> <136728817+GiZano@users.noreply.github.com>
 Haimo Zhang <zh.hammer.dev@gmail.com>
 Hamish Dickson <hamish.dickson@gmail.com>
 Hampus Malmberg <hampus.malmberg88@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -708,6 +708,7 @@ Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>
 Gina <Dr-G@users.noreply.github.com>
+Giovanni Zanotti <giozanotti07@mail.com> <136728817+GiZano@users.noreply.github.com>
 Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
@@ -728,7 +729,6 @@ Gurpartap Singh <dhaliwal.gurpartap@gmail.com> Gurpartap Singh <36311440+gurpart
 Gurpartap Singh <dhaliwal.gurpartap@gmail.com> gurpartap0306 <dhaliwal.gurpartap@gmail.com>
 Guru Devanla <grdvnl@gmail.com>
 Gustavo Alvarado <igoutta@protonmail.com> GA. <igoutta@users.noreply.github.com>
-Giovanni Zanotti <giozanotti07@mail.com> <136728817+GiZano@users.noreply.github.com>
 Haimo Zhang <zh.hammer.dev@gmail.com>
 Hamish Dickson <hamish.dickson@gmail.com>
 Hampus Malmberg <hampus.malmberg88@gmail.com>

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -1092,17 +1092,9 @@ def cycle_length(
     f: Callable[[int], int],
     x0: int,
     nmax: SupportsIndex | None = None,
+    *,
     values: Literal[False] = False,
 ) -> Iterator[tuple[int, int | None]]:
-    ...
-
-@overload
-def cycle_length(
-    f: Callable[[int], int],
-    x0: int,
-    nmax: SupportsIndex | None,
-    values: Literal[True],
-) -> Iterator[int]:
     ...
 
 @overload
@@ -1115,10 +1107,12 @@ def cycle_length(
 ) -> Iterator[int]:
     ...
 
+
 def cycle_length(
     f: Callable[[int], int],
     x0: int,
     nmax: SupportsIndex | None = None,
+    *,
     values: bool = False,
 ) -> Iterator[int] | Iterator[tuple[int, int | None]]:
     """For a given iterated sequence, return a generator that gives

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -1091,7 +1091,7 @@ def primorial(n: int, nth: bool = True) -> int:
 def cycle_length(
     f: Callable[[int], int],
     x0: int,
-    nmax: int | None = None,
+    nmax: SupportsIndex | None = None,
     values: Literal[False] = False,
 ) -> Iterator[tuple[int, int | None]]:
     ...
@@ -1100,10 +1100,9 @@ def cycle_length(
 def cycle_length(
     f: Callable[[int], int],
     x0: int,
-    nmax: SupportsIndex | None = None,
-    *,
-    values: Literal[False] = False,
-) -> Iterator[tuple[int, int | None]]:
+    nmax: SupportsIndex | None,
+    values: Literal[True],
+) -> Iterator[int]:
     ...
 
 @overload


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

partially fixes #28806 

#### Brief description of what is fixed or changed

- Fixed @overload signature of cycle length because the asterisk (*) would block the use of values=True as positional argument (e.g. cycle_length(f, x0, 10, True)).

- I made the nmax type unified to SupportsIndex | None for consistency across all overloads.

#### Other comments

All tests pass locally.
Type hints verified using pyright.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used an AI assistant (Google Gemini) to help me understand the typing errors and suggest the correct overload syntax. I manually reviewed the logic, applied the fix and verified everything through pytest and pyright.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed typing overloads for `cycle_length` to correctly support positional arguments.
<!-- END RELEASE NOTES -->
