### PR TITLE
Typing: add return and parameters  types to diophantine

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -708,6 +708,7 @@ Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
 Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
 Gilles Schintgen <gschintgen@hambier.lu>
 Gina <Dr-G@users.noreply.github.com>
+Giovanni Zanotti <giozanotti07@mail.com> <136728817+GiZano@users.noreply.github.com>
 Gleb Siroki <g.shiroki@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
 Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -191,14 +191,14 @@ class DiophantineEquationType:
         self.dimension = len(self.free_symbols)
         self._parameters = None
 
-    def matches(self):
+    def matches(self) -> bool:
         """
         Determine whether the given equation can be matched to the particular equation type.
         """
         return False
 
     @property
-    def n_parameters(self):
+    def n_parameters(self) -> int:
         return self.dimension
 
     @property
@@ -284,7 +284,7 @@ class Linear(DiophantineEquationType):
     def matches(self):
         return self.total_degree == 1
 
-    def solve(self, parameters=None, limit=None):
+    def solve(self, parameters=None, limit=None) -> DiophantineSolutionSet:
         self.pre_solve(parameters)
 
         coeff = self.coeff
@@ -425,7 +425,7 @@ class Linear(DiophantineEquationType):
                 else:  # arg is a Mul or Symbol
                     # example: 3*t_1 -> k = 3
                     # example: t_0 -> k = 1
-                    k, p = arg.as_coeff_Mul()
+                    k, p = arg.as_coeff_Mul()   # type: ignore[assignment]
                     pnew = params[params.index(p) + 1]
 
                 sol = sol_x, sol_y = base_solution_linear(k, Ai, Bi, pnew)
@@ -485,7 +485,7 @@ class BinaryQuadratic(DiophantineEquationType):
 
     name = 'binary_quadratic'
 
-    def matches(self):
+    def matches(self) -> bool:
         return self.total_degree == 2 and self.dimension == 2
 
     def solve(self, parameters=None, limit=None) -> DiophantineSolutionSet:
@@ -684,7 +684,7 @@ class InhomogeneousTernaryQuadratic(DiophantineEquationType):
 
     name = 'inhomogeneous_ternary_quadratic'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension == 3):
             return False
         if not self.homogeneous:
@@ -708,7 +708,7 @@ class HomogeneousTernaryQuadraticNormal(DiophantineEquationType):
 
     name = 'homogeneous_ternary_quadratic_normal'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension == 3):
             return False
         if not self.homogeneous:
@@ -797,7 +797,7 @@ class HomogeneousTernaryQuadratic(DiophantineEquationType):
 
     name = 'homogeneous_ternary_quadratic'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension == 3):
             return False
         if not self.homogeneous:
@@ -808,7 +808,7 @@ class HomogeneousTernaryQuadratic(DiophantineEquationType):
         nonzero = [k for k in self.coeff if self.coeff[k]]
         return not (len(nonzero) == 3 and all(i**2 in nonzero for i in self.free_symbols))
 
-    def solve(self, parameters=None, limit=None):
+    def solve(self, parameters=None, limit=None) -> DiophantineSolutionSet:
         self.pre_solve(parameters)
 
         _var = self.free_symbols
@@ -926,7 +926,7 @@ class InhomogeneousGeneralQuadratic(DiophantineEquationType):
 
     name = 'inhomogeneous_general_quadratic'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension >= 3):
             return False
         if not self.homogeneous_order:
@@ -946,7 +946,7 @@ class HomogeneousGeneralQuadratic(DiophantineEquationType):
 
     name = 'homogeneous_general_quadratic'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension >= 3):
             return False
         if not self.homogeneous_order:
@@ -990,7 +990,7 @@ class GeneralSumOfSquares(DiophantineEquationType):
 
     name = 'general_sum_of_squares'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension >= 3):
             return False
         if not self.homogeneous_order:
@@ -999,7 +999,7 @@ class GeneralSumOfSquares(DiophantineEquationType):
             return False
         return all(self.coeff[k] == 1 for k in self.coeff if k != 1)
 
-    def solve(self, parameters=None, limit=1):
+    def solve(self, parameters=None, limit=1) -> DiophantineSolutionSet:
         self.pre_solve(parameters)
 
         var = self.free_symbols
@@ -1042,7 +1042,7 @@ class GeneralPythagorean(DiophantineEquationType):
 
     name = 'general_pythagorean'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not (self.total_degree == 2 and self.dimension >= 3):
             return False
         if not self.homogeneous_order:
@@ -1061,7 +1061,7 @@ class GeneralPythagorean(DiophantineEquationType):
     def n_parameters(self):
         return self.dimension - 1
 
-    def solve(self, parameters=None, limit=1):
+    def solve(self, parameters=None, limit=1) -> DiophantineSolutionSet:
         self.pre_solve(parameters)
 
         coeff = self.coeff
@@ -1125,7 +1125,7 @@ class CubicThue(DiophantineEquationType):
 
     name = 'cubic_thue'
 
-    def matches(self):
+    def matches(self) -> bool:
         return self.total_degree == 3 and self.dimension == 2
 
 
@@ -1149,7 +1149,7 @@ class GeneralSumOfEvenPowers(DiophantineEquationType):
 
     name = 'general_sum_of_even_powers'
 
-    def matches(self):
+    def matches(self) -> bool:
         if not self.total_degree > 3:
             return False
         if self.total_degree % 2 != 0:
@@ -1158,7 +1158,7 @@ class GeneralSumOfEvenPowers(DiophantineEquationType):
             return False
         return all(self.coeff[k] == 1 for k in self.coeff if k != 1)
 
-    def solve(self, parameters=None, limit=1):
+    def solve(self, parameters=None, limit=1) -> DiophantineSolutionSet:
         self.pre_solve(parameters)
 
         var = self.free_symbols
@@ -1535,10 +1535,11 @@ def merge_solution(var, var_t, solution):
     return tuple(sol)
 
 
-def _diop_solve(eq, params=None):
+def _diop_solve(eq, params=None) -> DiophantineSolutionSet | None:
     for diop_type in all_diop_classes:
         if diop_type(eq).matches():
             return diop_type(eq).solve(parameters=params)
+    return None
 
 
 def diop_solve(eq, param=symbols("t", integer=True)):
@@ -1845,7 +1846,7 @@ def diop_univariate(eq):
             eq, var[0]).intersect(S.Integers)}
 
 
-def divisible(a, b):
+def divisible(a, b) -> bool:
     """
     Returns `True` if ``a`` is divisible by ``b`` and `False` otherwise.
     """
@@ -3943,7 +3944,7 @@ def sum_of_squares(n, k, zeros=False):
     yield from power_representation(n, 2, k, zeros)
 
 
-def _can_do_sum_of_squares(n, k):
+def _can_do_sum_of_squares(n: int, k: int) -> bool | int:
     """Return True if n can be written as the sum of k squares,
     False if it cannot, or 1 if ``k == 2`` and ``n`` is prime (in which
     case it *can* be written as a sum of two squares). A False

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 from sympy.core.add import Add
 from sympy.core.assumptions import check_assumptions
 from sympy.core.containers import Tuple
 from sympy.core.exprtools import factor_terms
-from sympy.core.expr import Expr
 from sympy.core.function import _mexpand
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational, int_valued
@@ -33,6 +33,8 @@ from sympy.utilities.misc import as_int, filldedent
 from sympy.utilities.iterables import (is_sequence, subsets, permute_signs,
                                        signed_permutations, ordered_partitions)
 
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 # these are imported with 'from sympy.solvers.diophantine import *
 __all__ = ['diophantine', 'classify_diop']

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -4,6 +4,7 @@ from sympy.core.add import Add
 from sympy.core.assumptions import check_assumptions
 from sympy.core.containers import Tuple
 from sympy.core.exprtools import factor_terms
+from sympy.core.expr import Expr
 from sympy.core.function import _mexpand
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational, int_valued
@@ -418,6 +419,8 @@ class Linear(DiophantineEquationType):
             tot_x, tot_y = [], []
 
             for arg in Add.make_args(c):
+                k: Expr
+                p: Expr
                 if arg.is_Integer:
                     # example: 5 -> k = 5
                     k, p = arg, S.One
@@ -425,7 +428,7 @@ class Linear(DiophantineEquationType):
                 else:  # arg is a Mul or Symbol
                     # example: 3*t_1 -> k = 3
                     # example: t_0 -> k = 1
-                    k, p = arg.as_coeff_Mul()   # type: ignore[assignment]
+                    k, p = arg.as_coeff_Mul()
                     pnew = params[params.index(p) + 1]
 
                 sol = sol_x, sol_y = base_solution_linear(k, Ai, Bi, pnew)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

partially fixes #28806 

#### Brief description of what is fixed or changed

Added missing return and parameters types to several classes and helper functions in sympy.solvers.diophantine.diophantine.py

Specifically, I added "-> bool" to the matches() methods, "-> DiophantineSolutionSet" to the solve() methods of the DiophantineEquationType subclasses, and return types to internal helpers like _can_do_sum_of_squares.

#### Other comments

This is meant to be a first incremental step to improve type safety and help static type checkers in the diophantine module. I plan to continue typing the arguments and other functions in future PRs to keep the reviews small and manageable.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
