### PR TITLE
Fix FIXME comment: added NaN checks to bessel functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1807,6 +1807,7 @@ foice <foice.news@gmail.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
 helo9 <helo9@users.noreply.github.com>
+hinautica <152785405+hinautica@users.noreply.github.com>
 hm <hacman0@gmail.com>
 immerrr <immerrr@gmail.com>
 jerryma1121 <jerryma1121@gmail.com>

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -180,6 +180,8 @@ class besselj(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
+        if z is S.NaN or nu is S.NaN:
+                return S.NaN
         if z.is_zero:
             if nu.is_zero:
                 return S.One
@@ -188,8 +190,6 @@ class besselj(BesselBase):
             elif re(nu).is_negative and not (nu.is_integer is True):
                 return S.ComplexInfinity
             elif nu.is_imaginary:
-                return S.NaN
-        elif z is S.NaN or nu is S.NaN:
                 return S.NaN
         if z in (S.Infinity, S.NegativeInfinity):
             return S.Zero
@@ -330,6 +330,8 @@ class bessely(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
+        if z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z.is_zero:
             if nu.is_zero:
                 return S.NegativeInfinity
@@ -337,8 +339,6 @@ class bessely(BesselBase):
                 return S.ComplexInfinity
             elif re(nu).is_zero:
                 return S.NaN
-        elif z is S.NaN or nu is S.NaN:
-            return S.NaN
         if z in (S.Infinity, S.NegativeInfinity):
             return S.Zero
         if z == I*S.Infinity:
@@ -487,6 +487,8 @@ class besseli(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
+        if z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z.is_zero:
             if nu.is_zero:
                 return S.One
@@ -496,8 +498,6 @@ class besseli(BesselBase):
                 return S.ComplexInfinity
             elif nu.is_imaginary:
                 return S.NaN
-        elif z is S.NaN or nu is S.NaN:
-            return S.NaN
         if im(z) in (S.Infinity, S.NegativeInfinity):
             return S.Zero
         if z is S.Infinity:
@@ -656,6 +656,8 @@ class besselk(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
+        if z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z.is_zero:
             if nu.is_zero:
                 return S.Infinity
@@ -663,8 +665,6 @@ class besselk(BesselBase):
                 return S.ComplexInfinity
             elif re(nu).is_zero:
                 return S.NaN
-        elif z is S.NaN or nu is S.NaN:
-            return S.NaN
         if z in (S.Infinity, I*S.Infinity, I*S.NegativeInfinity):
             return S.Zero
 
@@ -1008,6 +1008,8 @@ class jn(SphericalBesselBase):
     """
     @classmethod
     def eval(cls, nu, z):
+        if z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z.is_zero:
             if nu.is_zero:
                 return S.One
@@ -1016,8 +1018,6 @@ class jn(SphericalBesselBase):
                     return S.Zero
                 else:
                     return S.ComplexInfinity
-        elif z is S.NaN or nu is S.NaN:
-            return S.NaN
         if z in (S.NegativeInfinity, S.Infinity):
             return S.Zero
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -62,6 +62,8 @@ class BesselBase(DefinedFunction):
 
     @classmethod
     def eval(cls, nu, z):
+        if nu is S.NaN or z is S.NaN:
+            return S.NaN
         return
 
     def fdiff(self, argindex=2):
@@ -186,6 +188,8 @@ class besselj(BesselBase):
             elif re(nu).is_negative and not (nu.is_integer is True):
                 return S.ComplexInfinity
             elif nu.is_imaginary:
+                return S.NaN
+        elif z is S.NaN or nu is S.NaN:
                 return S.NaN
         if z in (S.Infinity, S.NegativeInfinity):
             return S.Zero
@@ -333,6 +337,8 @@ class bessely(BesselBase):
                 return S.ComplexInfinity
             elif re(nu).is_zero:
                 return S.NaN
+        elif z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z in (S.Infinity, S.NegativeInfinity):
             return S.Zero
         if z == I*S.Infinity:
@@ -490,6 +496,8 @@ class besseli(BesselBase):
                 return S.ComplexInfinity
             elif nu.is_imaginary:
                 return S.NaN
+        elif z is S.NaN or nu is S.NaN:
+            return S.NaN
         if im(z) in (S.Infinity, S.NegativeInfinity):
             return S.Zero
         if z is S.Infinity:
@@ -655,6 +663,8 @@ class besselk(BesselBase):
                 return S.ComplexInfinity
             elif re(nu).is_zero:
                 return S.NaN
+        elif z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z in (S.Infinity, I*S.Infinity, I*S.NegativeInfinity):
             return S.Zero
 
@@ -1006,6 +1016,8 @@ class jn(SphericalBesselBase):
                     return S.Zero
                 else:
                     return S.ComplexInfinity
+        elif z is S.NaN or nu is S.NaN:
+            return S.NaN
         if z in (S.NegativeInfinity, S.Infinity):
             return S.Zero
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -512,9 +512,10 @@ def test_bessel_eval():
 
 
 def test_bessel_nan():
-    # FIXME: could have these return NaN; for now just fix infinite recursion
     for f in [besselj, bessely, besseli, besselk, hankel1, hankel2, yn, jn]:
-        assert f(1, S.NaN) == f(1, S.NaN, evaluate=False)
+        assert f(1, S.NaN) == S.NaN
+        assert f(S.NaN, 1) == S.NaN
+        assert f(S.NaN, S.NaN) == S.NaN
 
 
 def test_meromorphic():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.
Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.
As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.
The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.
If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).
If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

No references to Issues.
This PR fixes FIXME comment in test_bessel.py L515:

```python
def test_bessel_nan():
    # FIXME: could have these return NaN; for now just fix infinite recursion
    for f in [besselj, bessely, besseli, besselk, hankel1, hankel2, yn, jn]:
        assert f(1, S.NaN) == f(1, S.NaN, evaluate=False)
```

#### Brief description of what is fixed or changed

Bessel functions (besselj, bessely, besseli, besselk, hankel1, hankel2, yn, jn) now return NaN when either argument is NaN, instead of returning an unevaluated expression. Added NaN checks to the `eval` classmethod of each Bessel function class.
In addition, `test_bessel.py` is updated to check if bessel functions return `nan` in such a condition.

Before:
```python
>>> besselj(1,S.NaN)
besselj(1, nan)
>>> besselj(S.NaN,1)
besselj(nan, 1)
```

After:
```python
>>> besselj(1,S.NaN)
nan
>>> besselj(S.NaN,1)   
nan
```

#### Other comments

This is my first contribution to SymPy. Though I found some other functions (e.g. `sin()`, `gamma()`) to return NaN instantly when argument is NaN, if the behaviors of bessel functions are not intended, please let me know.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.
DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:
* solvers
  * Added a new solver for logarithmic equations.
* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.
* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.
or if no release note(s) should be included use:
NO ENTRY
See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* functions
  * Bessel functions (`besselj()`, `bessely()`, `besseli()`, `besselk()`, `hankel1()`, `hankel2()`, `yn()`, `jn()`) now return NaN instantly when either argument is NaN.

<!-- END RELEASE NOTES -->