### PR TITLE
Piecewise: Propagate Undefined in piecewise_fold for inequality branches

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -5,7 +5,7 @@ from sympy.core.function import DefinedFunction
 from sympy.core.numbers import Rational, NumberSymbol, _illegal
 from sympy.core.parameters import global_parameters
 from sympy.core.relational import (Lt, Gt, Eq, Ne, Relational,
-    _canonical, _canonical_coeff)
+    _Inequality, _canonical, _canonical_coeff)
 from sympy.core.sorting import ordered
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or, Not,
@@ -29,6 +29,11 @@ class ExprCondPair(Tuple):
         elif isinstance(cond, Basic) and cond.has(Piecewise):
             cond = piecewise_fold(cond)
             if isinstance(cond, Piecewise):
+                # Replace Undefined branches with False: an undefined
+                # condition means the branch is not taken.
+                cond = cond.func(*[
+                    (false, c) if e is Undefined else (e, c)
+                    for e, c in cond.args])
                 cond = cond.rewrite(ITE)
 
         if not isinstance(cond, Boolean):
@@ -1088,7 +1093,10 @@ def piecewise_fold(expr, evaluate=True):
                 (i.args if isinstance(i, Piecewise) else
                  [(i, true)]) for i in folded]):
             e, c = zip(*ec)
-            new_args.append((expr.func(*e), And(*c)))
+            if isinstance(expr, _Inequality) and S.NaN in e:
+                new_args.append((Undefined, And(*c)))
+            else:
+                new_args.append((expr.func(*e), And(*c)))
 
     if evaluate is None:
         # don't return duplicate conditions, otherwise don't evaluate

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -699,6 +699,43 @@ def test_piecewise_fold_piecewise_in_cond_2():
     assert(piecewise_fold(p2) == p3)
 
 
+def test_piecewise_fold_nan_inequality():
+    # Issue #28331: piecewise_fold should not crash when folding
+    # ordering relationals into Piecewise branches containing NaN.
+
+    p = Piecewise((x, x > 0), (Undefined, True))
+
+    # Ordering relationals: NaN branches become Undefined
+    assert piecewise_fold(p > 0) == Piecewise(
+        (x > 0, x > 0), (Undefined, True))
+    assert piecewise_fold(p < 5) == Piecewise(
+        (x < 5, x > 0), (Undefined, True))
+    assert piecewise_fold(p >= 0) == Piecewise(
+        (x >= 0, x > 0), (Undefined, True))
+    assert piecewise_fold(p <= 3) == Piecewise(
+        (x <= 3, x > 0), (Undefined, True))
+
+    # Eq/Ne handle NaN natively - should not be affected
+    assert piecewise_fold(Eq(p, 1)) == Piecewise(
+        (Eq(x, 1), x > 0), (False, True))
+    assert piecewise_fold(Ne(p, 0)) == Piecewise(
+        (Ne(x, 0), x > 0), (True, True))
+
+    # Substitution: defined branch evaluates, undefined stays NaN
+    folded = piecewise_fold(p > 0)
+    assert folded.subs(x, 2) == True
+    assert folded.subs(x, -1) == Undefined
+
+    # Used as condition in ExprCondPair: Undefined -> False
+    p2 = Piecewise((1, p > 0), (0, True))
+    assert p2.subs(x, 2) == 1
+    assert p2.subs(x, -1) == 0
+
+    # Arithmetic fold with NaN still propagates NaN (unchanged behavior)
+    assert piecewise_fold(p + 1) == Piecewise(
+        (x + 1, x > 0), (Undefined, True))
+
+
 def test_piecewise_fold_expand():
     p1 = Piecewise((1, Interval(0, 1, False, True).contains(x)), (0, True))
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #28331

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

The ordering relationals throw a TypeError when compared to a NaN. When folding one over Piecewise with a NaN region, it makes sense to emit `Undefined` for the region. As the regions can now be `True`, `False`, or `Undefined`, we need to update `ExprCondPair` to handle `Undefined` regions by treating them as `False`.

#### Other comments

`Eq` and `Ne` have defined NaN semantics, so they were left alone. As far as I can tell, this change should not affect any other part of the library, and should make solvers over Piecewise objects more reliable.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
The test cases were written by Claude Opus 4.6 and reviewed by me. They should follow sympy's testing guidelines and cover any relevant edge cases.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `piecewise_fold` raising `TypeError` when folding ordering relationals over Piecewise branches containing NaN.
<!-- END RELEASE NOTES -->
