### PR TITLE
Type hints for sets.ordinals

### DIFF
--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -1,8 +1,8 @@
-# mypy: disallow-untyped-defs
-
 from __future__ import annotations
+
+from operator import lt
 from typing import Callable, Self
-import operator
+
 from sympy.core import Basic, Integer
 
 
@@ -55,7 +55,7 @@ class OmegaPower(Basic):
                 other = OmegaPower(0, other)
             except TypeError:
                 return NotImplemented
-        return self._compare_term(other, operator.lt)
+        return self._compare_term(other, lt)
 
 
 class Ordinal(Basic):

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -1,6 +1,9 @@
+# mypy: disallow-untyped-defs
+
 from __future__ import annotations
-from sympy.core import Basic, Integer
+from typing import Callable, Self
 import operator
+from sympy.core import Basic, Integer
 
 
 class OmegaPower(Basic):
@@ -9,7 +12,9 @@ class OmegaPower(Basic):
     building blocks of the :class:`Ordinal` class.
     In ``OmegaPower(a, b)``, ``a`` represents exponent and ``b`` represents multiplicity.
     """
-    def __new__(cls, a, b):
+    args: tuple[Ordinal, Integer]
+
+    def __new__(cls, a: Ordinal | Integer | int, b: Integer | int) -> Self:
         if isinstance(b, int):
             b = Integer(b)
         if not isinstance(b, Integer) or b <= 0:
@@ -21,31 +26,30 @@ class OmegaPower(Basic):
         return Basic.__new__(cls, a, b)
 
     @property
-    def exp(self):
+    def exp(self) -> Ordinal:
         return self.args[0]
 
     @property
-    def mult(self):
+    def mult(self) -> Integer:
         return self.args[1]
 
-    def _compare_term(self, other, op):
+    def _compare_term(self, other: OmegaPower, op: Callable) -> bool:
         if self.exp == other.exp:
             return op(self.mult, other.mult)
         else:
             return op(self.exp, other.exp)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, OmegaPower):
-            try:
-                other = OmegaPower(0, other)
-            except TypeError:
+            if not isinstance(other, (Integer, int)):
                 return NotImplemented
+            other = OmegaPower(0, other)
         return self.args == other.args
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return Basic.__hash__(self)
 
-    def __lt__(self, other):
+    def __lt__(self, other: OmegaPower | Integer | int) -> bool:
         if not isinstance(other, OmegaPower):
             try:
                 other = OmegaPower(0, other)
@@ -79,7 +83,9 @@ class Ordinal(Basic):
 
     .. [1] https://en.wikipedia.org/wiki/Ordinal_arithmetic
     """
-    def __new__(cls, *terms):
+    args: tuple[OmegaPower, ...]
+
+    def __new__(cls, *terms: OmegaPower) -> Self:
         obj = super().__new__(cls, *terms)
         powers = [i.exp for i in obj.args]
         if not all(powers[i] >= powers[i+1] for i in range(len(powers) - 1)):
@@ -87,57 +93,57 @@ class Ordinal(Basic):
         return obj
 
     @property
-    def terms(self):
+    def terms(self) -> tuple[OmegaPower, ...]:
         return self.args
 
     @property
-    def leading_term(self):
+    def leading_term(self) -> OmegaPower:
         if self == ord0:
             raise ValueError("ordinal zero has no leading term")
         return self.terms[0]
 
     @property
-    def trailing_term(self):
+    def trailing_term(self) -> OmegaPower:
         if self == ord0:
             raise ValueError("ordinal zero has no trailing term")
         return self.terms[-1]
 
     @property
-    def is_successor_ordinal(self):
+    def is_successor_ordinal(self) -> bool:
         try:
             return self.trailing_term.exp == ord0
         except ValueError:
             return False
 
     @property
-    def is_limit_ordinal(self):
+    def is_limit_ordinal(self) -> bool:
         try:
             return not self.trailing_term.exp == ord0
         except ValueError:
             return False
 
     @property
-    def degree(self):
+    def degree(self) -> Ordinal:
         return self.leading_term.exp
 
     @classmethod
-    def convert(cls, integer_value):
+    def convert(cls, integer_value: Integer | int) -> Ordinal:
         if integer_value == 0:
             return ord0
         return Ordinal(OmegaPower(0, integer_value))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Ordinal):
-            try:
-                other = Ordinal.convert(other)
-            except TypeError:
+            if not isinstance(other, (Integer, int)):
                 return NotImplemented
+            other = Ordinal.convert(other)
+
         return self.terms == other.terms
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.args)
 
-    def __lt__(self, other):
+    def __lt__(self, other: Ordinal | Integer | int) -> bool:
         if not isinstance(other, Ordinal):
             try:
                 other = Ordinal.convert(other)
@@ -148,16 +154,16 @@ class Ordinal(Basic):
                 return term_self < term_other
         return len(self.terms) < len(other.terms)
 
-    def __le__(self, other):
+    def __le__(self, other: Ordinal | Integer | int) -> bool:
         return (self == other or self < other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: Ordinal | Integer | int) -> bool:
         return not self <= other
 
-    def __ge__(self, other):
+    def __ge__(self, other: Ordinal | Integer | int) -> bool:
         return not self < other
 
-    def __str__(self):
+    def __str__(self) -> str:
         net_str = ""
         if self == ord0:
             return 'ord0'
@@ -180,7 +186,7 @@ class Ordinal(Basic):
 
     __repr__ = __str__
 
-    def __add__(self, other):
+    def __add__(self, other: Ordinal | Integer | int) -> Ordinal:
         if not isinstance(other, Ordinal):
             try:
                 other = Ordinal.convert(other)
@@ -203,7 +209,7 @@ class Ordinal(Basic):
             terms = a_terms[:r+1] + b_terms
         return Ordinal(*terms)
 
-    def __radd__(self, other):
+    def __radd__(self, other: Ordinal | Integer | int) -> Ordinal:
         if not isinstance(other, Ordinal):
             try:
                 other = Ordinal.convert(other)
@@ -211,7 +217,7 @@ class Ordinal(Basic):
                 return NotImplemented
         return other + self
 
-    def __mul__(self, other):
+    def __mul__(self, other: Ordinal | Integer | int) -> Ordinal:
         if not isinstance(other, Ordinal):
             try:
                 other = Ordinal.convert(other)
@@ -234,7 +240,7 @@ class Ordinal(Basic):
             summation += list(self.terms[1:])
         return Ordinal(*summation)
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: Ordinal | Integer | int) -> Ordinal:
         if not isinstance(other, Ordinal):
             try:
                 other = Ordinal.convert(other)
@@ -242,7 +248,7 @@ class Ordinal(Basic):
                 return NotImplemented
         return other * self
 
-    def __pow__(self, other):
+    def __pow__(self, other: Ordinal | Integer | int) -> Ordinal:
         if not self == omega:
             return NotImplemented
         return Ordinal(OmegaPower(other, 1))
@@ -268,11 +274,11 @@ class OrdinalOmega(Ordinal):
     >>> omega + omega
     w*2
     """
-    def __new__(cls):
+    def __new__(cls) -> Self:
         return Ordinal.__new__(cls)
 
     @property
-    def terms(self):
+    def terms(self) -> tuple[OmegaPower]:
         return (OmegaPower(1, 1),)
 
 

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from operator import lt
-from typing import Callable, Self
+from typing import Callable
 
 from sympy.core import Basic, Integer
 
@@ -14,7 +14,7 @@ class OmegaPower(Basic):
     """
     args: tuple[Ordinal, Integer]
 
-    def __new__(cls, a: Ordinal | Integer | int, b: Integer | int) -> Self:
+    def __new__(cls, a: Ordinal | Integer | int, b: Integer | int):
         if isinstance(b, int):
             b = Integer(b)
         if not isinstance(b, Integer) or b <= 0:
@@ -85,7 +85,7 @@ class Ordinal(Basic):
     """
     args: tuple[OmegaPower, ...]
 
-    def __new__(cls, *terms: OmegaPower) -> Self:
+    def __new__(cls, *terms: OmegaPower):
         obj = super().__new__(cls, *terms)
         powers = [i.exp for i in obj.args]
         if not all(powers[i] >= powers[i+1] for i in range(len(powers) - 1)):
@@ -274,7 +274,7 @@ class OrdinalOmega(Ordinal):
     >>> omega + omega
     w*2
     """
-    def __new__(cls) -> Self:
+    def __new__(cls):
         return Ordinal.__new__(cls)
 
     @property


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

see #28806 

#### Brief description of what is fixed or changed

Added type hints for all functions in sets.ordinals. I also refactored the header since I was adding new imports anyways.

#### Other comments

The `__eq__` methods on `Ordinal` and `OmegaPower` were refactored with type narrowing to satisfy Mypy.

#### AI Generation Disclosure

I asked ChatGPT for suggestions on refactoring `__eq__`, and I chose the option that seemed best. All type annotations were done by hand.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
