### PR TITLE
Remove unused math and conditionalize numpy imports in autolev parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1799,6 +1799,7 @@ dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.co
 dps7ud <dps7ud@virginia.edu>
 dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>
+egoistpizza <yusufozcetin@proton.me>
 elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>

--- a/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
+++ b/doc/src/explanation/modules/physics/mechanics/autolev_parser.rst
@@ -87,7 +87,6 @@ The parser can be used as follows::
     >>> print(sympy_code)
     import sympy.physics.mechanics as me
     import sympy as sm
-    import math as m
     import numpy as np
 
     q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')

--- a/sympy/parsing/autolev/__init__.py
+++ b/sympy/parsing/autolev/__init__.py
@@ -50,7 +50,6 @@ def parse_autolev(autolev_code, include_numeric=False):
     >>> print(parse_autolev(my_al_text, include_numeric=True))
     import sympy.physics.mechanics as _me
     import sympy as _sm
-    import math as m
     import numpy as _np
     <BLANKLINE>
     q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -441,8 +441,8 @@ if AutolevListener:
             # Write code to import common dependencies.
             self.output_code.append("import sympy.physics.mechanics as _me\n")
             self.output_code.append("import sympy as _sm\n")
-            self.output_code.append("import math as m\n")
-            self.output_code.append("import numpy as _np\n")
+            if include_numeric:
+                self.output_code.append("import numpy as _np\n")
             self.output_code.append("\n")
 
             # Just a store for the max degree variable in a line.

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 g, lb, w, h = _sm.symbols('g lb w h', real=True)

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 q1, q2, u1, u2 = _me.dynamicsymbols('q1 q2 u1 u2')

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 m, k, b, g = _sm.symbols('m k b g', real=True)

--- a/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py
+++ b/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 q1, q2 = _me.dynamicsymbols('q1 q2')

--- a/sympy/parsing/autolev/test-examples/ruletest1.py
+++ b/sympy/parsing/autolev/test-examples/ruletest1.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 f = _sm.S(3)

--- a/sympy/parsing/autolev/test-examples/ruletest10.py
+++ b/sympy/parsing/autolev/test-examples/ruletest10.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')

--- a/sympy/parsing/autolev/test-examples/ruletest11.py
+++ b/sympy/parsing/autolev/test-examples/ruletest11.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')

--- a/sympy/parsing/autolev/test-examples/ruletest12.py
+++ b/sympy/parsing/autolev/test-examples/ruletest12.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')

--- a/sympy/parsing/autolev/test-examples/ruletest2.py
+++ b/sympy/parsing/autolev/test-examples/ruletest2.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 x1, x2 = _me.dynamicsymbols('x1 x2')

--- a/sympy/parsing/autolev/test-examples/ruletest3.py
+++ b/sympy/parsing/autolev/test-examples/ruletest3.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 frame_a = _me.ReferenceFrame('a')

--- a/sympy/parsing/autolev/test-examples/ruletest4.py
+++ b/sympy/parsing/autolev/test-examples/ruletest4.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 frame_a = _me.ReferenceFrame('a')

--- a/sympy/parsing/autolev/test-examples/ruletest5.py
+++ b/sympy/parsing/autolev/test-examples/ruletest5.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')

--- a/sympy/parsing/autolev/test-examples/ruletest6.py
+++ b/sympy/parsing/autolev/test-examples/ruletest6.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 q1, q2 = _me.dynamicsymbols('q1 q2')

--- a/sympy/parsing/autolev/test-examples/ruletest7.py
+++ b/sympy/parsing/autolev/test-examples/ruletest7.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 x, y = _me.dynamicsymbols('x y')

--- a/sympy/parsing/autolev/test-examples/ruletest8.py
+++ b/sympy/parsing/autolev/test-examples/ruletest8.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 frame_a = _me.ReferenceFrame('a')

--- a/sympy/parsing/autolev/test-examples/ruletest9.py
+++ b/sympy/parsing/autolev/test-examples/ruletest9.py
@@ -1,6 +1,5 @@
 import sympy.physics.mechanics as _me
 import sympy as _sm
-import math as m
 import numpy as _np
 
 frame_n = _me.ReferenceFrame('n')


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #15186

#### Brief description of what is fixed or changed

The `autolev` parser was generating unnecessary `import math as m` lines and was unconditionally importing `numpy`, even when numeric output wasn't requested.

In this PR, I have:

* Removed the hardcoded `import math as m` from the generated header in `_listener_autolev_antlr.py`.

* Refactored the `numpy` import to be conditional: it is now only included if the `include_numeric` flag is set to `True`.

* Updated the doctest in `sympy/parsing/autolev/__init__.py` and the documentation in `autolev_parser.rst` to reflect these changes.

* Synchronized all "expected output" files in `sympy/parsing/autolev/test-examples/` and the `pydy-example-repo` to ensure the test suite stays green.

#### Other comments

All tests were verified locally via python bin/test sympy/parsing/tests/test_autolev.py and passed successfully (5 passed). I ensured that no trailing whitespaces were left in the modified files to maintain code quality.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* parsing
  * Removed unused math and conditionalized numpy imports in the autolev parser output.

<!-- END RELEASE NOTES -->
