### PR TITLE
Rigid body

### DIFF
--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -221,8 +221,12 @@ class RigidBody(BodyBase):
         """
         I = self.central_inertia
         w = self.frame.ang_vel_in(frame)
+        if point == self.masscenter:
+             return I.dot(w)
         m = self.mass
         r = self.masscenter.pos_from(point)
+        if r == 0:
+            return I.dot(w)
         v = self.masscenter.vel(frame)
 
         return I.dot(w) + r.cross(m * v)

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -183,3 +183,20 @@ def test_deprecated_set_potential_energy():
     B = RigidBody('B', P, A, m, (I, P))
     with warns_deprecated_sympy():
         B.set_potential_energy(m*g*h)
+
+
+def test_angular_momentum_masscenter_optimization():
+    from sympy.physics.mechanics import ReferenceFrame, Point, RigidBody
+    from sympy.physics.mechanics import outer
+    from sympy import symbols
+    m, omega = symbols('m omega')
+    N = ReferenceFrame('N')
+    B_frame = ReferenceFrame('B')
+    B_frame.set_ang_vel(N, omega * B_frame.x)
+    P = Point('P')
+    P.set_vel(N, 0)
+    I = outer(B_frame.x, B_frame.x)
+    B = RigidBody('B', P, B_frame, m, (I, P))
+    H1 = B.angular_momentum(P, N)
+    H2 = B.central_inertia.dot(B.frame.ang_vel_in(N))
+    assert H1 == H2


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

NONE


#### Brief description of what is fixed or changed
Fixed the angular momentum calculation in rigid body dynamics. This can be used in a case when the reference point is the centre of mass. 

#### Other comments
NIL

#### AI Generation Disclosure

AI was used to assist in coding


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
  * Optimized angular momentum computation in RigidBody.
<!-- END RELEASE NOTES -->
