### PR TITLE
Combinatorics: Add type hints to subsets.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1505,7 +1505,7 @@ Shaoliang Jin <18322825326@163.com> jinshaoliang <18322825326@163.com>
 Shashank Agarwal <shashank.agarwal94@gmail.com>
 Shashank KS <shashankks0987@gmail.com> Shashank KS <shashankks@sahaj.ai>
 Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
-Shaza Allam <shazaallam90@gmail.com> <61089681+ShazaAllam2001@users.noreply.github.com>
+ShazaAllam2001 <shazaallam90@gmail.com> <61089681+ShazaAllam2001@users.noreply.github.com>
 Shekhar Prasad Rajak <shekharrajak@live.com> <shekharstudy@ymail.com>
 Shekhar Prasad Rajak <shekharrajak@live.com> shekharrajak <shekharrajak@live.com>
 Sherjil Ozair <sherjilozair@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1888,3 +1888,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+ShazaAllam2001 <shazaallam90@gmail.com> ShazaAllam2001 <61089681+ShazaAllam2001@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1505,6 +1505,7 @@ Shaoliang Jin <18322825326@163.com> jinshaoliang <18322825326@163.com>
 Shashank Agarwal <shashank.agarwal94@gmail.com>
 Shashank KS <shashankks0987@gmail.com> Shashank KS <shashankks@sahaj.ai>
 Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
+Shaza Allam <shazaallam90@gmail.com> <61089681+ShazaAllam2001@users.noreply.github.com>
 Shekhar Prasad Rajak <shekharrajak@live.com> <shekharstudy@ymail.com>
 Shekhar Prasad Rajak <shekharrajak@live.com> shekharrajak <shekharrajak@live.com>
 Sherjil Ozair <sherjilozair@gmail.com>
@@ -1889,4 +1890,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-ShazaAllam2001 <shazaallam90@gmail.com> ShazaAllam2001 <61089681+ShazaAllam2001@users.noreply.github.com>

--- a/doc/src/modules/combinatorics/subsets.rst
+++ b/doc/src/modules/combinatorics/subsets.rst
@@ -5,6 +5,8 @@ Subsets
 
 .. module:: sympy.combinatorics.subsets
 
+.. py:class:: T
+
 .. autoclass:: Subset
    :members:
 

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -31,9 +31,9 @@ class Subset(Generic[T]):
     ['c']
     """
 
-    _rank_binary: int
-    _rank_lex: int
-    _rank_graycode: int
+    _rank_binary: int | None = None
+    _rank_lex: int | None = None
+    _rank_graycode: int | None = None
     _subset: list[T]
     _superset: list[T]
 
@@ -568,7 +568,7 @@ class Subset(Generic[T]):
         return Subset.subset_from_bitlist(superset, graycode_bitlist)
 
     @classmethod
-    def subset_indices(self, subset: list[T], superset: list[T]) -> list[T]:
+    def subset_indices(self, subset: list[T], superset: list[T]) -> list[int]:
         """Return indices of subset in superset in a list; the list is empty
         if all elements of ``subset`` are not in ``superset``.
 

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 from itertools import combinations
+from typing import TypeVar
+
+T = TypeVar('T')
 
 from sympy.combinatorics.graycode import GrayCode
 
@@ -28,13 +31,13 @@ class Subset():
     ['c']
     """
 
-    _rank_binary = None
-    _rank_lex = None
-    _rank_graycode = None
-    _subset = None
-    _superset = None
+    _rank_binary: int | None = None
+    _rank_lex: int | None  = None
+    _rank_graycode: int | None  = None
+    _subset: list | None = None
+    _superset: list | None = None
 
-    def __new__(cls, subset, superset):
+    def __new__(cls, subset: list[T], superset: list[T]) -> Subset:
         """
         Default constructor.
 
@@ -64,7 +67,7 @@ class Subset():
         obj._superset = superset
         return obj
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Return a boolean indicating whether a == b on the basis of
         whether both objects are of the class Subset and if the values
         of the subset and superset attributes are the same.
@@ -73,7 +76,7 @@ class Subset():
             return NotImplemented
         return self.subset == other.subset and self.superset == other.superset
 
-    def iterate_binary(self, k):
+    def iterate_binary(self, k: int) -> Subset:
         """
         This is a helper function. It iterates over the
         binary subsets by ``k`` steps. This variable can be
@@ -100,7 +103,7 @@ class Subset():
         bits = f'{n:b}'.rjust(self.superset_size, '0')
         return Subset.subset_from_bitlist(self.superset, bits)
 
-    def next_binary(self):
+    def next_binary(self) -> Subset:
         """
         Generates the next binary ordered subset.
 
@@ -122,7 +125,7 @@ class Subset():
         """
         return self.iterate_binary(1)
 
-    def prev_binary(self):
+    def prev_binary(self) -> Subset:
         """
         Generates the previous binary ordered subset.
 
@@ -144,7 +147,7 @@ class Subset():
         """
         return self.iterate_binary(-1)
 
-    def next_lexicographic(self):
+    def next_lexicographic(self) -> Subset:
         """
         Generates the next lexicographically ordered subset.
 
@@ -189,7 +192,7 @@ class Subset():
             ret_set.append(super_set[i])
         return Subset(ret_set, super_set)
 
-    def prev_lexicographic(self):
+    def prev_lexicographic(self) -> Subset:
         """
         Generates the previous lexicographically ordered subset.
 
@@ -229,7 +232,7 @@ class Subset():
             ret_set.append(super_set[i])
         return Subset(ret_set, super_set)
 
-    def iterate_graycode(self, k):
+    def iterate_graycode(self, k: int) -> Subset:
         """
         Helper function used for prev_gray and next_gray.
         It performs ``k`` step overs to get the respective Gray codes.
@@ -254,7 +257,7 @@ class Subset():
         return Subset.subset_from_bitlist(self.superset,
                                           unranked_code)
 
-    def next_gray(self):
+    def next_gray(self) -> Subset:
         """
         Generates the next Gray code ordered subset.
 
@@ -273,7 +276,7 @@ class Subset():
         """
         return self.iterate_graycode(1)
 
-    def prev_gray(self):
+    def prev_gray(self) -> Subset:
         """
         Generates the previous Gray code ordered subset.
 
@@ -474,7 +477,7 @@ class Subset():
         return 2**(self.superset_size)
 
     @classmethod
-    def subset_from_bitlist(self, super_set, bitlist):
+    def subset_from_bitlist(self, super_set: list[T], bitlist: str):
         """
         Gets the subset defined by the bitlist.
 
@@ -499,7 +502,7 @@ class Subset():
         return Subset(ret_set, super_set)
 
     @classmethod
-    def bitlist_from_subset(self, subset, superset):
+    def bitlist_from_subset(self, subset: list[T], superset: list[T]):
         """
         Gets the bitlist corresponding to a subset.
 
@@ -523,7 +526,7 @@ class Subset():
         return ''.join(bitlist)
 
     @classmethod
-    def unrank_binary(self, rank, superset):
+    def unrank_binary(self, rank: int, superset: list[T]):
         """
         Gets the binary ordered subset of the specified rank.
 
@@ -543,7 +546,7 @@ class Subset():
         return Subset.subset_from_bitlist(superset, bits)
 
     @classmethod
-    def unrank_gray(self, rank, superset):
+    def unrank_gray(self, rank: int, superset: list[T]):
         """
         Gets the Gray code ordered subset of the specified rank.
 
@@ -565,7 +568,7 @@ class Subset():
         return Subset.subset_from_bitlist(superset, graycode_bitlist)
 
     @classmethod
-    def subset_indices(self, subset, superset):
+    def subset_indices(self, subset: list[T], superset: list[T]):
         """Return indices of subset in superset in a list; the list is empty
         if all elements of ``subset`` are not in ``superset``.
 
@@ -596,7 +599,7 @@ class Subset():
         return [d[bi] for bi in b]
 
 
-def ksubsets(superset, k):
+def ksubsets(superset: list[T], k: int):
     """
     Finds the subsets of size ``k`` in lexicographic order.
 

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 from itertools import combinations
 from typing import TypeVar
 
-T = TypeVar('T')
-
 from sympy.combinatorics.graycode import GrayCode
+
+T = TypeVar('T')
 
 
 class Subset():

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -34,10 +34,10 @@ class Subset(Generic[T]):
     _rank_binary: int | None = None
     _rank_lex: int | None  = None
     _rank_graycode: int | None  = None
-    _subset: list[T] | None = None
-    _superset: list[T] | None = None
+    _subset: list[T]
+    _superset: list[T]
 
-    def __new__(cls, subset: list[T], superset: list[T]) -> Subset:
+    def __new__(cls, subset: list[T], superset: list[T]) -> Subset[T]:
         """
         Default constructor.
 
@@ -76,7 +76,7 @@ class Subset(Generic[T]):
             return NotImplemented
         return self.subset == other.subset and self.superset == other.superset
 
-    def iterate_binary(self, k: int) -> Subset:
+    def iterate_binary(self, k: int) -> Subset[T]:
         """
         This is a helper function. It iterates over the
         binary subsets by ``k`` steps. This variable can be
@@ -103,7 +103,7 @@ class Subset(Generic[T]):
         bits = f'{n:b}'.rjust(self.superset_size, '0')
         return Subset.subset_from_bitlist(self.superset, bits)
 
-    def next_binary(self) -> Subset:
+    def next_binary(self) -> Subset[T]:
         """
         Generates the next binary ordered subset.
 
@@ -125,7 +125,7 @@ class Subset(Generic[T]):
         """
         return self.iterate_binary(1)
 
-    def prev_binary(self) -> Subset:
+    def prev_binary(self) -> Subset[T]:
         """
         Generates the previous binary ordered subset.
 
@@ -147,7 +147,7 @@ class Subset(Generic[T]):
         """
         return self.iterate_binary(-1)
 
-    def next_lexicographic(self) -> Subset:
+    def next_lexicographic(self) -> Subset[T]:
         """
         Generates the next lexicographically ordered subset.
 
@@ -192,7 +192,7 @@ class Subset(Generic[T]):
             ret_set.append(super_set[i])
         return Subset(ret_set, super_set)
 
-    def prev_lexicographic(self) -> Subset:
+    def prev_lexicographic(self) -> Subset[T]:
         """
         Generates the previous lexicographically ordered subset.
 
@@ -232,7 +232,7 @@ class Subset(Generic[T]):
             ret_set.append(super_set[i])
         return Subset(ret_set, super_set)
 
-    def iterate_graycode(self, k: int) -> Subset:
+    def iterate_graycode(self, k: int) -> Subset[T]:
         """
         Helper function used for prev_gray and next_gray.
         It performs ``k`` step overs to get the respective Gray codes.
@@ -257,7 +257,7 @@ class Subset(Generic[T]):
         return Subset.subset_from_bitlist(self.superset,
                                           unranked_code)
 
-    def next_gray(self) -> Subset:
+    def next_gray(self) -> Subset[T]:
         """
         Generates the next Gray code ordered subset.
 
@@ -276,7 +276,7 @@ class Subset(Generic[T]):
         """
         return self.iterate_graycode(1)
 
-    def prev_gray(self) -> Subset:
+    def prev_gray(self) -> Subset[T]:
         """
         Generates the previous Gray code ordered subset.
 

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -67,7 +67,7 @@ class Subset(Generic[T]):
         obj._superset = superset
         return obj
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return a boolean indicating whether a == b on the basis of
         whether both objects are of the class Subset and if the values
         of the subset and superset attributes are the same.
@@ -98,10 +98,10 @@ class Subset(Generic[T]):
 
         next_binary, prev_binary
         """
-        bin_list = Subset.bitlist_from_subset(self.subset, self.superset)
+        bin_list = self.bitlist_from_subset(self.subset, self.superset)
         n = (int(''.join(bin_list), 2) + k) % 2**self.superset_size
         bits = f'{n:b}'.rjust(self.superset_size, '0')
-        return Subset.subset_from_bitlist(self.superset, bits)
+        return self.subset_from_bitlist(self.superset, bits)
 
     def next_binary(self) -> Subset[T]:
         """
@@ -168,7 +168,7 @@ class Subset(Generic[T]):
         prev_lexicographic
         """
         i = self.superset_size - 1
-        indices = Subset.subset_indices(self.subset, self.superset)
+        indices = self.subset_indices(self.subset, self.superset)
 
         if i in indices:
             if i - 1 in indices:
@@ -186,7 +186,7 @@ class Subset(Generic[T]):
                 i = i - 1
             indices.append(i + 1)
 
-        ret_set = []
+        ret_set: list[T] = []
         super_set = self.superset
         for i in indices:
             ret_set.append(super_set[i])
@@ -213,7 +213,7 @@ class Subset(Generic[T]):
         next_lexicographic
         """
         i = self.superset_size - 1
-        indices = Subset.subset_indices(self.subset, self.superset)
+        indices = self.subset_indices(self.subset, self.superset)
 
         while i >= 0 and i not in indices:
             i = i - 1
@@ -226,7 +226,7 @@ class Subset(Generic[T]):
                 indices.append(i - 1)
             indices.append(self.superset_size - 1)
 
-        ret_set = []
+        ret_set: list[T] = []
         super_set = self.superset
         for i in indices:
             ret_set.append(super_set[i])
@@ -254,8 +254,7 @@ class Subset(Generic[T]):
         """
         unranked_code = GrayCode.unrank(self.superset_size,
                                        (self.rank_gray + k) % self.cardinality)
-        return Subset.subset_from_bitlist(self.superset,
-                                          unranked_code)
+        return self.subset_from_bitlist(self.superset, unranked_code)
 
     def next_gray(self) -> Subset[T]:
         """
@@ -318,8 +317,7 @@ class Subset(Generic[T]):
         """
         if self._rank_binary is None:
             self._rank_binary = int("".join(
-                Subset.bitlist_from_subset(self.subset,
-                                           self.superset)), 2)
+                self.bitlist_from_subset(self.subset, self.superset)), 2)
         return self._rank_binary
 
     @property
@@ -339,15 +337,20 @@ class Subset(Generic[T]):
         43
         """
         if self._rank_lex is None:
-            def _ranklex(self, subset_index, i, n):
+
+            def _ranklex(
+                self: Subset[T], subset_index: list[int], i: int, n: int
+            ) -> int:
                 if subset_index == [] or i > n:
                     return 0
                 if i in subset_index:
                     subset_index.remove(i)
                     return 1 + _ranklex(self, subset_index, i + 1, n)
                 return 2**(n - i - 1) + _ranklex(self, subset_index, i + 1, n)
-            indices = Subset.subset_indices(self.subset, self.superset)
+
+            indices = self.subset_indices(self.subset, self.superset)
             self._rank_lex = _ranklex(self, indices, 0, self.superset_size)
+
         return self._rank_lex
 
     @property
@@ -372,7 +375,7 @@ class Subset(Generic[T]):
         iterate_graycode, unrank_gray
         """
         if self._rank_graycode is None:
-            bits = Subset.bitlist_from_subset(self.subset, self.superset)
+            bits = self.bitlist_from_subset(self.subset, self.superset)
             self._rank_graycode = GrayCode(len(bits), start=bits).rank
         return self._rank_graycode
 
@@ -477,7 +480,7 @@ class Subset(Generic[T]):
         return 2**(self.superset_size)
 
     @classmethod
-    def subset_from_bitlist(self, super_set: list[T], bitlist: str) -> Subset[T]:
+    def subset_from_bitlist(cls, super_set: list[T], bitlist: str) -> Subset[T]:
         """
         Gets the subset defined by the bitlist.
 
@@ -495,14 +498,14 @@ class Subset(Generic[T]):
         """
         if len(super_set) != len(bitlist):
             raise ValueError("The sizes of the lists are not equal")
-        ret_set = []
+        ret_set: list[T] = []
         for i in range(len(bitlist)):
             if bitlist[i] == '1':
                 ret_set.append(super_set[i])
         return Subset(ret_set, super_set)
 
     @classmethod
-    def bitlist_from_subset(self, subset: list[T], superset: list[T]) -> str:
+    def bitlist_from_subset(cls, subset: list[T] | Subset[T], superset: list[T]) -> str:
         """
         Gets the bitlist corresponding to a subset.
 
@@ -521,12 +524,12 @@ class Subset(Generic[T]):
         bitlist = ['0'] * len(superset)
         if isinstance(subset, Subset):
             subset = subset.subset
-        for i in Subset.subset_indices(subset, superset):
+        for i in cls.subset_indices(subset, superset):
             bitlist[i] = '1'
         return ''.join(bitlist)
 
     @classmethod
-    def unrank_binary(self, rank: int, superset: list[T]) -> Subset[T]:
+    def unrank_binary(cls, rank: int, superset: list[T]) -> Subset[T]:
         """
         Gets the binary ordered subset of the specified rank.
 
@@ -543,10 +546,10 @@ class Subset(Generic[T]):
         iterate_binary, rank_binary
         """
         bits = f'{rank:b}'.rjust(len(superset), '0')
-        return Subset.subset_from_bitlist(superset, bits)
+        return cls.subset_from_bitlist(superset, bits)
 
     @classmethod
-    def unrank_gray(self, rank: int, superset: list[T]) -> Subset[T]:
+    def unrank_gray(cls, rank: int, superset: list[T]) -> Subset[T]:
         """
         Gets the Gray code ordered subset of the specified rank.
 
@@ -565,10 +568,10 @@ class Subset(Generic[T]):
         iterate_graycode, rank_gray
         """
         graycode_bitlist = GrayCode.unrank(len(superset), rank)
-        return Subset.subset_from_bitlist(superset, graycode_bitlist)
+        return cls.subset_from_bitlist(superset, graycode_bitlist)
 
     @classmethod
-    def subset_indices(self, subset: list[T], superset: list[T]) -> list[int]:
+    def subset_indices(cls, subset: list[T], superset: list[T]) -> list[int]:
         """Return indices of subset in superset in a list; the list is empty
         if all elements of ``subset`` are not in ``superset``.
 

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from itertools import combinations
-from typing import TypeVar, Generic
+from typing import Iterator, TypeVar, Generic
 
 from sympy.combinatorics.graycode import GrayCode
 
@@ -31,9 +31,9 @@ class Subset(Generic[T]):
     ['c']
     """
 
-    _rank_binary: int | None = None
-    _rank_lex: int | None  = None
-    _rank_graycode: int | None  = None
+    _rank_binary: int
+    _rank_lex: int
+    _rank_graycode: int
     _subset: list[T]
     _superset: list[T]
 
@@ -296,7 +296,7 @@ class Subset(Generic[T]):
         return self.iterate_graycode(-1)
 
     @property
-    def rank_binary(self):
+    def rank_binary(self) -> int:
         """
         Computes the binary ordered rank.
 
@@ -323,7 +323,7 @@ class Subset(Generic[T]):
         return self._rank_binary
 
     @property
-    def rank_lexicographic(self):
+    def rank_lexicographic(self) -> int:
         """
         Computes the lexicographic ranking of the subset.
 
@@ -351,7 +351,7 @@ class Subset(Generic[T]):
         return self._rank_lex
 
     @property
-    def rank_gray(self):
+    def rank_gray(self) -> int:
         """
         Computes the Gray code ranking of the subset.
 
@@ -377,7 +377,7 @@ class Subset(Generic[T]):
         return self._rank_graycode
 
     @property
-    def subset(self):
+    def subset(self) -> list[T]:
         """
         Gets the subset represented by the current instance.
 
@@ -397,7 +397,7 @@ class Subset(Generic[T]):
         return self._subset[:]
 
     @property
-    def size(self):
+    def size(self) -> int:
         """
         Gets the size of the subset.
 
@@ -417,7 +417,7 @@ class Subset(Generic[T]):
         return len(self.subset)
 
     @property
-    def superset(self):
+    def superset(self) -> list[T]:
         """
         Gets the superset of the subset.
 
@@ -437,7 +437,7 @@ class Subset(Generic[T]):
         return self._superset[:]
 
     @property
-    def superset_size(self):
+    def superset_size(self) -> int:
         """
         Returns the size of the superset.
 
@@ -457,7 +457,7 @@ class Subset(Generic[T]):
         return len(self.superset)
 
     @property
-    def cardinality(self):
+    def cardinality(self) -> int:
         """
         Returns the number of all possible subsets.
 
@@ -477,7 +477,7 @@ class Subset(Generic[T]):
         return 2**(self.superset_size)
 
     @classmethod
-    def subset_from_bitlist(self, super_set: list[T], bitlist: str):
+    def subset_from_bitlist(self, super_set: list[T], bitlist: str) -> Subset[T]:
         """
         Gets the subset defined by the bitlist.
 
@@ -502,7 +502,7 @@ class Subset(Generic[T]):
         return Subset(ret_set, super_set)
 
     @classmethod
-    def bitlist_from_subset(self, subset: list[T], superset: list[T]):
+    def bitlist_from_subset(self, subset: list[T], superset: list[T]) -> str:
         """
         Gets the bitlist corresponding to a subset.
 
@@ -526,7 +526,7 @@ class Subset(Generic[T]):
         return ''.join(bitlist)
 
     @classmethod
-    def unrank_binary(self, rank: int, superset: list[T]):
+    def unrank_binary(self, rank: int, superset: list[T]) -> Subset[T]:
         """
         Gets the binary ordered subset of the specified rank.
 
@@ -546,7 +546,7 @@ class Subset(Generic[T]):
         return Subset.subset_from_bitlist(superset, bits)
 
     @classmethod
-    def unrank_gray(self, rank: int, superset: list[T]):
+    def unrank_gray(self, rank: int, superset: list[T]) -> Subset[T]:
         """
         Gets the Gray code ordered subset of the specified rank.
 
@@ -568,7 +568,7 @@ class Subset(Generic[T]):
         return Subset.subset_from_bitlist(superset, graycode_bitlist)
 
     @classmethod
-    def subset_indices(self, subset: list[T], superset: list[T]):
+    def subset_indices(self, subset: list[T], superset: list[T]) -> list[T]:
         """Return indices of subset in superset in a list; the list is empty
         if all elements of ``subset`` are not in ``superset``.
 
@@ -599,7 +599,7 @@ class Subset(Generic[T]):
         return [d[bi] for bi in b]
 
 
-def ksubsets(superset: list[T], k: int):
+def ksubsets(superset: list[T], k: int) -> Iterator[tuple[T, ...]]:
     """
     Finds the subsets of size ``k`` in lexicographic order.
 

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 from itertools import combinations
-from typing import TypeVar
+from typing import TypeVar, Generic
 
 from sympy.combinatorics.graycode import GrayCode
 
 T = TypeVar('T')
 
 
-class Subset():
+class Subset(Generic[T]):
     """
     Represents a basic subset object.
 
@@ -34,8 +34,8 @@ class Subset():
     _rank_binary: int | None = None
     _rank_lex: int | None  = None
     _rank_graycode: int | None  = None
-    _subset: list | None = None
-    _superset: list | None = None
+    _subset: list[T] | None = None
+    _superset: list[T] | None = None
 
     def __new__(cls, subset: list[T], superset: list[T]) -> Subset:
         """


### PR DESCRIPTION
#### References to other Issues or PRs

Related to issue [#28806](https://github.com/sympy/sympy/issues/28806) concerned about adding type hints to the codebase to make it more readable and useable. 


#### Brief description of what is fixed or changed
Added type hints to all of the functions and properties inside sympy /combinatorics/subsets.py like:

- Properties that I added type hints to:
    - `` _rank_binary``
    -  ``_rank_lex``
    -  ``_rank_graycode``
    -  ``_subset``
    -  ``_superset``
- Functions that I added type hints to:
    - ``def __new__(cls, subset: list[T], superset: list[T]) -> Subset:``
    - ``def __eq__(self, other) -> bool:``
    - ``def iterate_binary(self, k: int) -> Subset:``
    - ``def next_binary(self) -> Subset:``
    - ``def prev_binary(self) -> Subset:``
    - ``def next_lexicographic(self) -> Subset:``
    - ``def prev_lexicographic(self) -> Subset:``
    - ``def iterate_graycode(self, k: int) -> Subset:``
    - ``def next_gray(self) -> Subset:``
    - ``def prev_gray(self) -> Subset:``
    - ``def subset_from_bitlist(self, super_set: list[T], bitlist: str):``
    - ``def bitlist_from_subset(self, subset: list[T], superset: list[T]):``
    - ``def unrank_binary(self, rank: int, superset: list[T]):``
    - ``def unrank_gray(self, rank: int, superset: list[T]):``
    - ``def subset_indices(self, subset: list[T], superset: list[T]):``
    - ``def ksubsets(superset: list[T], k: int):``

Ran all quality checks and tests inside test_subsets.py with zero problems.


#### AI Generation Disclosure
Minor usage for guidance on how to run quality check and unit tests.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->