### PR TITLE
Fix TypeError in continued_fraction_periodic for symbolic negatives using .is_negative

### DIFF
--- a/sympy/.mailmap
+++ b/sympy/.mailmap
@@ -1,0 +1,1895 @@
+# The .mailmap file
+# =================
+#
+# This file records the name and email address of each contributor to SymPy as
+# it should appear in the AUTHORS file. Contributors should not update the
+# AUTHORS file directly as it will be updated at the time of the next release
+# of SymPy. Instead any new contributors need to add their name and email
+# address to this file so that there is a record of how they would like to be
+# recorded in the AUTHORS file. Contributors often do not use git config to
+# correctly record their name and email address so this file is used to be
+# explicit about who has contributed to SymPy and what name and email address
+# they would like to be known by.
+#
+#
+# New contributors quick description
+# ==================================
+#
+# 1. Before committing make sure that git config records your name and email
+# address correctly as you would like it to be recorded in the AUTHORS file.
+#
+# 2. After committing run the bin/mailmap_check.py script. It will check the
+# commits and look for your name and email address in this file. You should see
+# an error message like "This author is not included ...":
+#
+#   $ python bin/mailmap_check.py
+#   This author is not included in the .mailmap file:
+#   Joe Bloggs <joe@bloggs.com>
+#
+#   The .mailmap file needs to be updated because there are commits with
+#   unrecognised author/email metadata.
+#
+#   For instructions on updating the .mailmap file see:
+#   https://docs.sympy.org/dev/contributing/new-contributors-guide/workflow-process.html#add-your-name-and-email-address-to-the-mailmap-file
+#
+#   ...
+#
+# If it fails, you may need to replace `python` by `python3`, here and below, if
+# you're on a system that still uses python2 by default.
+#
+# 3. Add a line to this file with that same name and email address like:
+#
+#   Joe Bloggs <joe@bloggs.com>
+#
+# 4. Run the bin/mailmap_check.py script. This time it will find your name and
+# address and it will also reorder the lines in this file to be in alphabetical
+# order and it will say "the mailmap file was reordered".
+#
+#   $ python bin/mailmap_check.py
+#   The mailmap file was reordered
+#
+#   For instructions on updating the .mailmap file see:
+#   https://docs.sympy.org/dev/contributing/new-contributors-guide/workflow-process.html#add-your-name-and-email-address-to-the-mailmap-file
+#
+#   ...
+#
+# 5. You should be ready now but just to be sure run the bin/mailmap_check.py
+# script one last time and it should say "No changes needed in .mailmap". The
+# output will show that your name and email address is included in the list of
+# names and email addresses that will be added to the AUTHORS file later (make
+# sure that your name only appears once):
+#
+#   $ python bin/mailmap_check.py
+#   No changes needed in .mailmap
+#
+#   The following authors will be added to the AUTHORS file at the time of
+#   the next SymPy release.
+#
+#   Joe Bloggs <joe@bloggs.com>
+#   Other Author <other@author.com>
+#   ...
+#
+# 6. All done. Commit the change to the .mailmap file. When you open a pull
+# request the AUTHORS check will run in CI and it will run the
+# bin/mailmap_check.py script to check that no changes are needed in .mailmap.
+# If the script succeeded locally then it should also succeed in CI.
+#
+# 7. Once you have been added to the .mailmap file it is not necessary to do
+# these steps in any future pull requests unless you change the name and email
+# address you use to make your commits (see Associating different commits
+# below) or want to be recorded under a different name in the AUTHORS file.
+#
+#
+# Configuring git
+# ===============
+#
+# If you are contributing to SymPy for the first time then first make sure that
+# you have configured your name and email address in your local git install.
+# You can check this using the git config command:
+#
+#   $ git config --global user.name
+#   Joe Bloggs
+#   $ git config --global user.email
+#   joe@bloggs.com
+#
+# This name and email address is what will be recorded in any commits that you
+# make with the git commit command. If you want to change the name and or email
+# address that will be used in your commits then you can do also that with the
+# git config command e.g. you can change the name with:
+#
+#   $ git config --global user.name "Jane Doe"
+#   $ git config --global user.name
+#   Jane Doe
+#
+# You can use the git log command to see what name and email address were used
+# in any commits that you have made. Note that changing your name with git
+# config will not change the name that is *already* recorded in any commits
+# that you have made: you have to amend or redo the commits to change that.
+#
+#
+# Associating different names and emails
+# ======================================
+#
+# Entries in this file can also be used to associate commits made under a
+# different name and email address with your own name and email as you would
+# like it to be recorded in the AUTHORS file. This is useful because for
+# example the GitHub web UI will usually record commits under a different name
+# and email address from the one that you use with git locally. To associate
+# that other name and email address with your own add a line like:
+#
+#   Proper Name <Proper@email> commit name <commit@email>
+#   \-----------+------------/ \----------+-------------/
+#               |                         |
+#            replace                     find
+#
+# For example if Joe Bloggs made a commit through the GitHub web UI then it
+# might be recorded with name/email "joeb <12345+joeb@users.noreply.github.com>".
+# In this case Joe should add the following line to .mailmap:
+#
+#   # DO THIS:
+#   Joe Bloggs <joe@bloggs.com> joeb <12345+joeb@users.noreply.github.com>
+#
+# That tells the .mailmap script that any commits with the second name and
+# email are from the same author as the first name and email. This means that
+# only one entry will be added to the AUTHORS file using the first name and
+# email. You can add multiple lines like this all using the same name and email
+# as the first entry but having different second entries e.g.:
+#
+#   # DO THIS:
+#   Joe Bloggs <joe@bloggs.com> joeb <12345+joeb@users.noreply.github.com>
+#   Joe Bloggs <joe@bloggs.com> Joe <joe@gmail.com>
+#
+# It is important to make sure that each author is listed only once in the
+# AUTHORS file so do *NOT* add separate entries that begin with different names
+# or email addresses:
+#
+#   # DO NOT DO THIS (it will be treated as two unrelated authors):
+#   Joe Bloggs <joe@bloggs.com>
+#   joeb <12345+joeb@users.noreply.github.com>
+#
+# If you are unsure what name and email address has been used in your commits
+# then make sure that your local branch is up to date and run git log. It is
+# also possible to see this on GitHub if you click on a commit and then add
+# ".patch" to the end of the page URL.
+#
+# The email (or name and email) in the "find" part of the entry will
+# be used in a case-insensitive way to identify a git author and
+# replace it with whatever is included in the "replace" part:
+#
+#     author                           author
+#     before    .mailmap entry         after
+#     --------- ---------------------- -----------
+#               Foo <Email>
+#     A <Email> ---------------------> Foo <Email>
+#     B <eMAIL> ---------------------> Foo <eMAIL>
+#
+#               <Email> <email>
+#     A <Email> ---------------------> A <Email>
+#     B <eMAIL> ---------------------> B <Email>
+#
+#               Foo <Email> <email>
+#     A <Email> ---------------------> Foo <Email>
+#     B <eMAIL> ---------------------> Foo <Email>
+#
+#               Foo <EMAIL> b <email>
+#     A <Email> ---------------------> same
+#     B <Email> ---------------------> Foo <EMAIL>
+#     b <eMAIL> ---------------------> Foo <EMAIL>
+#
+#               Foo <Email> b <email>
+#               Foo <Email> <liame>
+#     A <Liame> ---------------------> Foo <Email>
+#     B <Email> ---------------------> Foo <Email>
+#     b <eMAIL> ---------------------> Foo <Email>
+#     c <eMAIL> ---------------------> same
+#
+# See also: 'git shortlog --help' and 'git check-mailmap --help'.
+#
+*Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
+*Dan <coolg49964@gmail.com>
+*Marc-Etienne M.Leveille <protonyc@gmail.com>
+*Ulrich Hecht <ulrich.hecht@gmail.com>
+2torus <boris.ettinger@gmail.com>
+Aadit Kamat <aadit.k12@gmail.com>
+Aaditya Nair <aadityanair6494@gmail.com>
+Aaron Gokaslan <aaronGokaslan@gmail.com>
+Aaron Meurer <asmeurer@gmail.com>
+Aaron Miller <acmiller273@gmail.com> <78561124+aaron-skydio@users.noreply.github.com>
+Aaron Stiff <69512633+AaronStiff@users.noreply.github.com>
+Aaryan Dewan <aaryandewan@yahoo.com> Aaryan Dewan <49852384+aaryandewan@users.noreply.github.com>
+Aasim Ali <aasim250205@gmail.com> Aasim Ali <94692076+aasim-maverick@users.noreply.github.com>
+Aasim Ali <aasim250205@gmail.com> aasim-maverick <aasim250205@gmail.com>
+Abbas <iamabbas7@gmail.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
+Abbas Mohammed <42001049+iam-abbas@users.noreply.github.com> Abbas <42001049+iam-abbas@users.noreply.github.com>
+Abby Ng <abigailjng@gmail.com>
+Abderrahim Kitouni <a.kitouni@gmail.com>
+Abdullah Javed Nesar <abduljaved1994@gmail.com>
+Abhay_Dhiman <abhaysdhimans@gmail.com>
+Abhi58 <abhijithbharadwaj58@gmail.com>
+Abhigyan Khaund <mail@abhigyan.xyz>
+Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
+Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
+Abhinav Agarwal <abhinavagarwal1996@gmail.com>
+Abhinav Anand <abhinav.anand2807@gmail.com>
+Abhinav Chanda <abhinavchanda01@gmail.com>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> Abhinav R Cillanki <95158195+JebronLames32@users.noreply.github.com>
+Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcillanki@gmail.com>
+Abhishek <uchiha@pop-os.localdomain>
+Abhishek Chaudhary <ac5003@columbia.edu>
+Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Kumar <abhishek.nitdelhi@gmail.com> ABHISHEK KUMAR <140839576+abhiphile@users.noreply.github.com>
+Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
+Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
+Abhishek Verma <iamvermaabhishek@gmail.com>
+Abhishek kumar <kumar325571@gmail.com>
+Achal Jain <2achaljain@gmail.com>
+Adam Bloomston <adam@glitterfram.es> <mail@adambloomston>
+Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>
+Addison Cugini <ajcugini@gmail.com>
+Addison Cugini <ajcugini@gmail.com> <addisonc@csmpm4z6d1ax.local>
+Addison Cugini <ajcugini@gmail.com> <addisonc@pcp065368pcs.dhcp.calpoly.edu>
+Aditya Jindal <jaditya8889@gmail.com>
+Aditya Kapoor <aditya.kapoor.apm12@itbhu.ac.in>
+Aditya Kumar Sinha <adityakumar113141@gmail.com> aditya113141 <adityakumar113141@gmail.com>
+Aditya Prakash <prakashaditya2709@gmail.com>
+Aditya Ravuri <infprobscix@gmail.com> InfProbSciX <infprobscix@gmail.com>
+Aditya Rohan <riyuzakiiitk@gmail.com>
+Aditya Shah <adityashah30@gmail.com>
+Advait Pote <apote2050@gmail.com> <advaitpote@192.168.1.4>
+Advait Pote <apote2050@gmail.com> Advait <apote2050@gmail.com>
+Advait Pote <apote2050@gmail.com> Advait Pote <92469698+AdvaitPote@users.noreply.github.com>
+Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.21>
+Advait Pote <apote2050@gmail.com> Advait Pote <advaitpote@192.168.1.2>
+Adwait Baokar <adwaitbaokar18@gmail.com> abaokar-07 <adwaitbaokar18@gmail.com>
+Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com>
+Ajinesh Pratap Singh <152050389+ajinesh703@users.noreply.github.com> Ajinesh Pratap Singh <ajineshpratap@gmail.com>
+Akash Agrawall <akash.wanted@gmail.com>
+Akash Kundu <sk.sayakkundu1997@gmail.com>
+Akash Nagaraj (akasnaga) <akasnaga@cisco.com> Akash Nagaraj <grassknoted@gmail.com>
+Akash Nagaraj <grassknoted@gmail.com> grassknoted <grassknoted@gmail.com>
+Akash Trehan <akash.trehan123@gmail.com>
+Akash Vaish <akash.9712@gmail.com>
+Akhil Rajput <akh1lrjput@gmail.com> Akhil Rajput <43316490+akhil-dh1@users.noreply.github.com>
+Akira Kyle <ak@akirakyle.com>
+Akshansh Bhatt <akshansh@tuta.io>
+Akshansh Bhatt <akshansh@tuta.io> <53227127+akshanshbhatt@users.noreply.github.com>
+Akshat Jain <akshat.jain@students.iiit.ac.in>
+Akshat Maheshwari <akshat14714@gmail.com>
+Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
+Akshay <akshaynukala95@gmail.com>
+Akshay <akshaynukala95@gmail.com> <akshayah3@users.noreply.github.com>
+Akshay Nagar <awesomeay13@yahoo.com>
+Akshay Siramdas <akshaysiramdas@gmail.com>
+Akshay Srinivasan <akshaysrinivasan@gmail.com>
+Akshit Agarwal <akshit.jiit@gmail.com>
+AkuBrain <76952313+Franck2111@users.noreply.github.com>
+Alan Bromborsky <abrombo@verizon.net> <abrombo@verizon.net>
+Alan Bromborsky <abrombo@verizon.net> <brombo@GA.(none)>
+Alberto Jiménez Ruiz <Alberto.Jimenez@uclm.es>
+Alec Kalinin <alec.kalinin@gmail.com>
+Alejandro García Prada <114813960+AlexGarciaPrada@users.noreply.github.com> AlexGarciaPrada <114813960+AlexGarciaPrada@users.noreply.github.com>
+Aleksandar Makelov <amakelov@college.harvard.edu>
+Alex Argunov <sajkoooo@gmail.com>
+Alex Lindsay <adlinds3@ncsu.edu> <lindsayad@users.noreply.github.com>
+Alex Lindsay <adlinds3@ncsu.edu> Alex Lindsay <alexlindsay239@gmail.com>
+Alex Lubbock <code@alexlubbock.com>
+Alex Malins <github@alexmalins.com>
+Alex Meiburg <timeroot.alex@gmail.com>
+Alex Sun <alexsun.srand.nums@gmail.com>
+AlexCQY <alex_chua@u.nus.edu>
+Alexander Behrens <alex.git@gmx.net> Alex <Alex031544@users.noreply.github.com>
+Alexander Behrens <alex.git@gmx.net> Alex031544 <alex.git@gmx.net>
+Alexander Bentkamp <bentkamp@gmail.com>
+Alexander Cockburn <alexander_cockburn12@hotmail.com>
+Alexander Dunlap <alexander.dunlap@gmail.com>
+Alexander Eberspächer <alex.eberspaecher@gmail.com>
+Alexander Grund <alexander.grund@tu-dresden.de> Alexander Grund <Flamefire@users.noreply.github.com>
+Alexander Hirzel <alex@hirzel.us>
+Alexander Pozdneev <pozdneev@users.noreply.github.com>
+Alexander Puck Neuwirth <alexander@neuwirth-informatik.de> Alexander Puck Neuwirth <APN-Pucky@users.noreply.github.com>
+Alexander Zhura <nice.zhura@list.ru>
+Alexandr Gudulin <alexandr.gudulin@gmail.com>
+Alexandr Popov <alexandr.s.popov@gmail.com>
+Alexey Pakhocmhik <cool.Bakov@yandex.ru>
+Alexey Subach <alexey.subach@gmail.com>
+Alexey U. Gudchenko <proga@goodok.ru>
+Alexis Schotte <alexis.schotte@gmail.com> AlexisSchotte <32765319+AlexisSchotte@users.noreply.github.com>
+Alfiya Patil <patilalfiya1@gmail.com>
+Alhussein Ashraf <alhusseinashraf55@gmail.com> Alhussein Ashraf <63222279+huss11ein@users.noreply.github.com>
+Alhussein Ashraf <alhusseinashraf55@gmail.com> huss11ein <alhusseinashraf55@gmail.com>
+Ali Raza Syed <arsyed@gmail.com>
+Alistair Lynn <arplynn@gmail.com>
+Alkiviadis G. Akritas <akritas@uth.gr>
+Alpesh Jamgade <alpeshjamgade21@gmail.com>
+Alsheh <alsheh@rpi.edu>
+Aman <amanmourya295@gmail.com>
+Aman Deep <amandeep1024@gmail.com>
+Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com> Aman-Kumar2211 <kumaraman221104@gmail.com>
+Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com> Skillgod-0 <kumaraman221104@gmail.com>
+Aman Kumar Shukla <theprofessionalaman@gmail.com> Aman Kumar Shukla <77196231+theWiseAman@users.noreply.github.com>
+Aman Sharma <amansharma110603@gmail.com> mostlyaman <85072876+mostlyaman@users.noreply.github.com>
+Aman Sharma <amansharma110603@gmail.com> mostlyaman <amansharma110603@gmail.com>
+Aman Thakur <thakuraman22july@gmail.com> Aman Thakur <54764701+jhonsnow456@users.noreply.github.com>
+Aman Thakur <thakuraman22july@gmail.com> jhonsnow456 <thakuraman22july@gmail.com>
+Amanda Dsouza <meezamanda@yahoo.com>
+Ambar Mehrotra <mehrotraambar@gmail.com>
+Amir Ebrahimi <github@aebrahimi.com>
+Amit Jamadagni <bitsjamadagni@gmail.com>
+Amit Kumar <dtu.amit@gmail.com>
+Amit Kumar <dtu.amit@gmail.com> <aktech@users.noreply.github.com>
+Amit Kumar <dtu.amit@gmail.com> <dtu.amit+gh@gmail.com>
+Amit Manchanda <amitdelhi1995@gmail.com>
+Amit Saha <amitsaha.in@gmail.com> <asaha@redhat.com>
+Ananya H <ananyaha93@gmail.com>
+Anas <anas23khan083@gmail.com>
+Anatolii Koval <weralwolf@gmail.com>
+Andre de Fortier Smit <freevryheid@gmail.com>
+Andreas Klöckner <inform@tiker.net> Andreas Kloeckner <inform@tiker.net>
+Andrej Tokarčík <androsis@gmail.com>
+Andrew Docherty <andrewd@maths.usyd.edu.au>
+Andrew Mosson <amosson@yahoo.com>
+Andrew Phimister <andyph1@hotmail.com> <157378252+Phim226@users.noreply.github.com>
+Andrew Straw <strawman@astraw.com>
+Andrew Taber <andrew.e.taber@gmail.com>
+Andrey Grozin <A.G.Grozin@inp.nsk.su>
+Andrey Lekar <andrey_lekar@adoriasoft.com> blackyblack <andrey_lekar@adoriasoft.com>
+Andrii Oriekhov <andriyorehov@gmail.com> andriyor <andriyorehov@gmail.com>
+Andy R. Terrel <aterrel@uchicago.edu> <andy.terrel@gmail.com>
+Andy R. Terrel <aterrel@uchicago.edu> <aterrel@enthought.com>
+Andy R. Terrel <aterrel@uchicago.edu> <aterrel@uchicago.edu>
+Angad Sandhu <55819847+angadsinghsandhu@users.noreply.github.com>
+Angadh Nanjangud <angadh.n@gmail.com>
+Angus Griffith <16sn6uv@gmail.com>
+Anibal M. Medina-Mardones <ammedmar@gmail.com>
+Animesh Sinha <animeshsinha1309@gmail.com>
+Anish Shah <shah.anish07@gmail.com>
+Anjul Kumar Tyagi <anjul.ten@gmail.com>
+Ankit Agrawal <aaaagrawal@iitb.ac.in>
+Ankit Kumar Singh <ankitdiswar10@gmail.com>
+Ankit Raj Pandey <pandeyan@grinnell.edu> Ankit Pandey <pandeyan@grinnell.edu>
+Annamalai N <srirammount@gmail.com> Annamalai <91740832+RaMathuZen@users.noreply.github.com>
+Annamalai N <srirammount@gmail.com> ramathuzen <srirammount@gmail.com>
+Ansh Mishra <anshmishra471@gmail.com>
+Anshul Sharma <anshulsharma4605@gmail.com>
+Anthony Scopatz <scopatz@gmail.com>
+Anthony Sottile <asottile@umich.edu>
+Anton Akhmerov <anton.akhmerov@gmail.com>
+Anton Golovanov <agolovanov256@gmail.com>
+Anubhav Gupta <anubhav.gupta.cse19@itbhu.ac.in>
+Anup Parikh <parikhanupk@gmail.com> Anup Parikh <84572003+parikhanupk@users.noreply.github.com>
+Anurag Bhat <bhat.1@iitj.ac.in> Anurag Bhat <90216905+faze-geek@users.noreply.github.com>
+Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <90216905+faze-geek@users.noreply.github.com>
+Anurag Bhat <bhat.1@iitj.ac.in> faze-geek <bhat.1@iitj.ac.in>
+Anurag Sharma <anurags92@gmail.com> <sharmaan@iitk.ac.in>
+Anutosh Bhat <andersonbhat491@gmail.com> Anutosh Bhat <87052487+anutosh491@users.noreply.github.com>
+Anutosh Bhat <andersonbhat491@gmail.com> anutosh491 <87052487+anutosh491@users.noreply.github.com>
+Anutosh Bhat <andersonbhat491@gmail.com> anutosh491 <andersonbhat491@gmail.com>
+Anway De <anway1756@gmail.com>
+Aqnouch Mohammed <aqnouch.mohammed@gmail.com>
+Arafat Dad Khan <arafat.da.khan@gmail.com>
+Arafat Dad Khan <arafat.da.khan@gmail.com> <arafat@iitkpg.ac.in>
+Aravind Reddy <aravindreddy255@gmail.com>
+Archit Verma <architv07@gmail.com>
+Arie Bovenberg <a.c.bovenberg@gmail.com>
+Arif Ahmed <arif.ahmed.5.10.1995@gmail.com>
+Arighna Chakrabarty <arighna.chakrabarty100@gmail.com>
+Arihant Parsoya <parsoyaarihant@gmail.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arek <131872816+arkadiusz-trawinski@users.noreply.github.com>
+Arkadiusz Trawiński <arkadiusz.trawinski@gmail.com> Arkadiusz Trawiński <131872816+arkadiusz-trawinski@users.noreply.github.com>
+Arnab Nandi <arnabnandi2002@gmail.com>
+Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
+Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
+Arpit Goyal <agmps18@gmail.com>
+Arshdeep Singh <singh.arshdeep1999@gmail.com>
+Arthur Milchior <arthur@milchior.fr>
+Arthur Ryman <arthur.ryman@gmail.com>
+Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
+Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
+Ashish Kumar Gaurav <ashishkg0022@gmail.com>
+Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
+Ashutosh Saboo <ashutosh.saboo96@gmail.com>
+Ashwini Oruganti <ashwini.oruganti@gmail.com>
+Asish Panda <asishrocks95@gmail.com>
+Atharva Khare <khareatharva@gmail.com>
+Atul Bisht <me.atulbisht@gmail.com>
+Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.noreply.github.com>
+Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
+Augusto Borges <borges.augustoar@gmail.com>
+Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>
+Avanish Salunke <avanishsalunke16@gmail.com> AvanishSalunke <avanishsalunke16@gmail.com>
+Avasam <samuel.06@hotmail.com>
+Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>
+Avichal Dayal <avichal.dayal@gmail.com>
+Avijit Dutta <avijitdutta1230000@gmail.com> Avi123410 <abhijitdutta12340000@email.com>
+Ayden Alvarez <Aydenalv6282@gmail.com>
+Ayodeji Ige <ayodeji18@outlook.com>
+Ayush Aryan <ayush.aryan71@gmail.com> Ayush aryan <75092320+ayush3781@users.noreply.github.com>
+Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71@gmail.com>
+Ayush Aryan <ayush.aryan71@gmail.com> ayush3781 <ayush.aryan71gmail.com>
+Ayush Bisht <bisht.ayush2001@gmail.com> Ayush <bisht.ayush2001@gmail.com>
+Ayush Bisht <bisht.ayush2001@gmail.com> ayushbisht2001 <61404154+ayushbisht2001@users.noreply.github.com>
+Ayush Bothra <ayush9bothra@gmail.com> ayush-bothra <160741168+ayush-bothra@users.noreply.github.com>
+Ayush Bothra <ayush9bothra@gmail.com> ayush-bothra <ayush9bothra@gmail.com>
+Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
+Ayush Kumar Jha <jha44481@gmail.com>
+Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
+Ayush Shridhar <ayush.shridhar1999@gmail.com>
+Ayushman Koul <ayushmankoul4570@gmail.com>
+B McG <bmcg0890@gmail.com>
+Baibhav Singh <baibhavsfs@gmail.com> B-CantCode <s.baibhav@op.iitg.ac.in>
+Baiyuan Qiu <1061688677@qq.com> Baiyuan Qiu <51898470+bugmaker2@users.noreply.github.com>
+Bao Chau <chauquocbao0907@gmail.com>
+Barry Wardell <barry.wardell@gmail.com>
+Barun Parruck <barun.parruck@gmail.com>
+BasileiosKal <61801875+BasileiosKal@users.noreply.github.com>
+Bastian Weber <bastian.weber@gmx-topmail.de>
+Bavish Kulur <bavishkulur@gmail.com> bavish2201 <bavishkulur@gmail.com>
+Ben Goodrich <goodrich.ben@gmail.com>
+Ben Lucato <ben.lucato@gmail.com>
+Ben Oostendorp <oostben@umich.edu> oostben <oostben@umich.edu>
+Ben Payne <ben.is.located@gmail.com> Ben <ben.is.located@gmail.com>
+Bendik Samseth <b.samseth@gmail.com>
+Benedikt Placke <benedikt.placke@outlook.com>
+Benjamin Dolata <bendolata2@gmail.com> MajesticSlacks <bendolata2@gmail.com>
+Benjamin Fishbein <fishbeinb@gmail.com>
+Benjamin Gudehus <hastebrot@gmail.com>
+Benjamin McDonald <mcdonald.ben@gmail.com>
+Benjamin Wolba <mail@benjaminwolba.com>
+Bernhard R. Link <brlink@debian.org>
+Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123rox <bharatraghunthan9767@gmail.com>
+Bharath M R <catchmrbharath@gmail.com>
+Bhaskar Gupta <guptabhanu1999@gmail.com>
+Bhaskar Joshi <bhaskar.joshi@research.iiit.ac.in> BhaskarJoshi-01 <bhaskar.joshi@research.iiit.ac.in>
+Bhautik Mavani <mavanibhautik@gmail.com>
+Bhavik Sachdev <b.sachdev1904@gmail.com> Bhavik Sachdev <69461338+bsach64@users.noreply.github.com>
+Bhavya Srivastava <bhavya17037@iiitd.ac.in>
+Bilal Ahmed <b.ahmed0918@gmail.com>
+Bilal Akhtar <bilalakhtar@ubuntu.com> <bilalakhtar96@yahoo.com>
+Bill Flynn <wflynny@gmail.com>
+Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
+Björn Dahlgren <bjodah@gmail.com>
+Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
+Bobby Palmer <bobbyp@umich.edu>
+Borek Saheli <boreksaheli@gmail.com>
+Boris Atamanovskiy <shaomoron@gmail.com>
+Boris Bilich <bilichboris1999@gmail.com>
+Boris Ettinger <ettinger.boris@gmail.com>
+Boris Timokhin <qoqenator@gmail.com>
+Bradley Dowling <34559056+btdow@users.noreply.github.com>
+Bradley Froehle <brad.froehle@gmail.com>
+Bradley Gannon <bradley.m.gannon@gmail.com>
+Brandon David <brandon.david@zoho.com>
+Brandon T. Willard <brandonwillard@users.noreply.github.com>
+Brian E. Granger <ellisonbg@gmail.com>
+Brian Jorgensen <brian.jorgensen@gmail.com> brian.jorgensen <devnull@localhost>
+Brian Stephanik <xoedusk@gmail.com>
+Buck Shlegeris <buck2@bruceh15.anu.edu.au>
+Buck Shlegeris <buck2@bruceh15.anu.edu.au> <buck2@Bucks-MacBook-Pro.local>
+Bulat <daianovich@mail.ru>
+CJ Carey <perimosocordiae@gmail.com>
+Caley Finn <caleyreuben@gmail.com>
+Calvin Jay Ross <calvinjayross@gmail.com>
+Cameron King <v-caking@microsoft.com>
+Carl Sandrock <carl.sandrock@up.ac.za>
+Carlos Cordoba <ccordoba12@gmail.com>
+Carlos García Montoro <TrilceAC@gmail.com> Carlos García Montoro <cgarcia@ific.uv.es>
+Carson McManus <carson.mcmanus1@gmail.com> Carson McManus <dyc3@users.noreply.github.com>
+Carsten Knoll <CarstenKnoll@gmx.de>
+Case Van Horsen <casevh@gmail.com>
+Cavendish McKay <cmckay@tachycline.com>
+Cezary Marczak <zeddq1@gmail.com>
+Chai Wah Wu <cwwuieee@gmail.com> <postvakje@users.noreply.github.com>
+Chaitanya Jain <chaitanya.jain.dev@gmail.com> Chaitanya Jain <218813421+kaxuya@users.noreply.github.com>
+Chaitanya Jain <chaitanya.jain.dev@gmail.com> Kaxuya <218813421+kaxuya@users.noreply.github.com>
+Chaitanya Jain <chaitanya.jain.dev@gmail.com> kaxuya <218813421+kaxuya@users.noreply.github.com>
+Chaitanya Sai Alaparthi <achaitanyasai@gmail.com>
+Chak-Pong Chung <chakpongchung@gmail.com>
+Chanakya-Ekbote <ca10@iitbbs.ac.in>
+Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
+Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@users.noreply.github.com>
+Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
+Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>
+Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@users.noreply.github.com>
+Charlie Lam <888lamcharlie@gmail.com>
+Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
+Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
+Chetna Gupta <cheta.gup@gmail.com>
+Chiu-Hsiang Hsu <wdv4758h@gmail.com>
+Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
+Chris Conley <chrisconley15@gmail.com>
+Chris Kerr <chris.kerr@mykolab.ch>
+Chris Paul <chrispaul68002@gmail.com> cp50 <chrispaul68002@gmail.com>
+Chris Smith <smichr@gmail.com>
+Chris Smith <smichr@gmail.com> <Donna Smith@.(none)>
+Chris Swierczewski <cswiercz@gmail.com>
+Chris Tefer <ctefer@gmail.com>
+Chris Wu <chris.wu@gmail.com> Chris.Wu <devnull@localhost>
+Chris du Plessis <christopherjonduplessis@gmail.com> Chris du Plessis <45897212+Maelstrom6@users.noreply.github.com>
+Chris du Plessis <christopherjonduplessis@gmail.com> Maelstrom6 <christopherjonduplessis@gmail.com>
+Christian Bühler <christian@cbuehler.de>
+Christian Muise <christian.muise@gmail.com>
+Christian Schubert <chr.schubert@gmx.de>
+Christiano Anderson <canderson@riseup.net>
+Christina Zografou <t8130048@dias.aueb.gr>
+Christoph Gohle <ctg@mpq.mpg.de>
+Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
+Christopher Dembia <cld72@cornell.edu>
+Christopher J. Wright <cjwright4242gh@gmail.com>
+Clayton Rabideau <claytonrabideau@gmail.com> Zer0Credibility <cmr57@cam.ac.uk>
+Clemens Novak <clemens@familie-novak.net>
+Clément M.T. Robert <cr52@protonmail.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>  Teskann <47865674+Teskann@users.noreply.github.com>
+Clément Metz <clement.metz.sympy.tj2qb@simplelogin.com>  Teskann <teskann.dev@protonmail.com>
+Coder-RG <rgoel1999@gmail.com> Rishabh Goel <rgoel1999@gmail.com>
+Cody Herbst <cyherbst@gmail.com>
+Colin B. Macdonald <cbm@m.fsf.org>
+Colin B. Macdonald <cbm@m.fsf.org> <macdonald@maths.ox.ac.uk>
+Colin Marquardt <github@marquardt-home.de>
+Colleen Lee <colleenclee@gmail.com> <clee@coursera.org>
+Comer Duncan <comer.duncan@gmail.com>
+Congxu Yang <u7189828@anu.edu.au>
+Constantin Mateescu <costica1234@me.com>
+Corbet Elkins <corbet286@gmail.com>
+Corey Cerovsek <corey@cerovsek.com>
+Costor <pcs2009@web.de>
+Craig A. Stoudt <craig.stoudt@gmail.com>
+Cristian Di Pietrantonio <cristiandipietrantonio@gmail.com>
+Cristóvão Sousa <crisjss@gmail.com>
+Cédric Travelletti <cedrictravelletti@gmail.com> Cedric <cedric@localhost.localdomain>
+Daan Koning (he/him) <daanolivierkoning@gmail.com>
+Daiki Takahashi <haru.td@gmail.com> haru-44 <36563693+haru-44@users.noreply.github.com>
+Dammina Sahabandu <dmsahabandu@gmail.com>
+Dana Jacobsen <dana@acm.org>
+Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
+Daniel Ingram <ingramds@appstate.edu>
+Daniel Mahler <dmahler@gmail.com>
+Daniel Sears <highpost@users.noreply.github.com>
+Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
+Daniel Wennberg <daniel.wennberg@gmail.com>
+Danny Hermes <daniel.j.hermes@gmail.com>
+Darshan Chaudhary <deathbullet@gmail.com>
+Dave Witte Morris <Dave.Morris@uleth.ca>
+Davi Laerte <davilae011@gmail.com>
+David Brooks <dave@bcs.co.nz> David Brooks <d.brooks@auckland.ac.nz>
+David Brooks <dave@bcs.co.nz> David Brooks <dbrnz@users.noreply.github.com>
+David Daly <david.daly12@kzoo.edu>
+David Hagen <david@drhagen.com>
+David Joyner <wdjoyner@gmail.com>
+David Joyner <wdjoyner@gmail.com> <wdj@tinah.(none)>
+David Ju <Sgtmook314@gmail.com> David Ju <david@David-PC.(none)>
+David Lawrence <dmlawrence@gmail.com>
+David Li <l33tnerd.li@gmail.com> <li.davidm96@gmail.com>
+David Li <l33tnerd.li@gmail.com> unknown <David@David-PC.(none)>
+David Marek <h4wk.cz@gmail.com> <davidm@atrey.karlin.mff.cuni.cz>
+David Menéndez Hurtado <david.menendez.hurtado@scilifelab.se>
+David P. Sanders <dpsanders@gmail.com>
+David Roberts <dvdr18@gmail.com> David Roberts (dvdr18 [at] gmail [dot] com) <devnull@localhost>
+David T <derDavidT@users.noreply.github.com>
+Davide Sandonà <sandona.davide@gmail.com>
+Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
+Dean Price <dean1357price1357@gmail.com>
+Demian Wassermann <demian@bwh.harvard.edu>
+Denis Ivanenko <ivanenko@ucu.edu.ua> Jack <ivanenko@ucu.edu.ua>
+Denis Ivanenko <ivanenko@ucu.edu.ua> LilJohny <ivanenko@ucu.edu.ua>
+Denis Rykov <rykovd@gmail.com>
+Dennis Meckel <meckel@datenschuppen.de>
+Dennis Sweeney <sweeney.427@osu.edu> sweeneyde <sweeney.427@osu.edu>
+Denys Rybalka <rybalka.denis@gmail.com>
+Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
+Devansh <be19b002@smail.iitm.ac.in> prototypevito <96943731+prototypevito@users.noreply.github.com>
+Devesh Sawant <devesh47cool@gmail.com> dsaw <devesh47cool@gmail.com>
+Devesh Sawant <devesh47cool@gmail.com> dsaw <devsaw115@gmail.com>
+Devyani Kota <devyanikota@gmail.com> <divs.passion.18@gmail.com>
+Dhia Kennouche <kendhia@gmail.com>
+Dhia Kennouche <kendhia@gmail.com> <algheart@live.fr>
+Dhruv Bhanushali <dhruv_b@live.com>
+Dhruv Kothari <dhruvkothari22@gmail.com>
+Dhruv Mendiratta <dhruvmendiratta6@gmail.com> Dhruv Mendiratta <42745880+dhruvmendiratta6@users.noreply.github.com>
+Dhruv Mendiratta <dhruvmendiratta6@gmail.com> dhruvmendiratta6 <dhruvmendiratta6@gmail.com>
+Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
+Diane Tchuindjo <dtchuindjo@gmail.com>
+Dimas Abreu Archanjo Dutra <dimasad@ufmg.br>
+Dimitra Konomi <t8130064@dias.aueb.gr>
+Disha Holmukhe <dishaholmukh521@gmail.com> Kiwi-520 <161978494+Kiwi-520@users.noreply.github.com>
+Divyanshu Thakur <divyanshu@iiitmanipur.ac.in> Divyanshu <divyanshu@iiitmanipur.ac.in>
+Dmitry Batkovich <batya239@gmail.com>
+Dmitry Savransky <dsavransky@gmail.com>
+Dominik Stańczak <stanczakdominik@gmail.com>
+Donald Wilson <donwilson1029@gmail.com> wilds-23 <wilds-23@rhodes.edu>
+Duane Nykamp <nykamp@umn.edu>
+Duc-Minh Phan <alephvn@gmail.com>
+Dustin Gadal <Dustin.Gadal@gmail.com> <dustin.gadal@gmail.com>
+Dzhelil Rufat <drufat@caltech.edu>
+Ebrahim Byagowi <ebrahim@gnu.org>
+Edoardo Matachione <edoardomatachione@gmail.com> <35014239+Woodman04@users.noreply.github.com>
+Edoardo Matachione <edoardomatachione@gmail.com> Woodman04 <edoardomatachione@gmail.com>
+Edward Schembor <eschemb1@jhu.edu>
+Edward Z. Yang <ezyang@mit.edu> Edward Z. Yang <ezyang@meta.com>
+Eh Tan <tan2tan2@gmail.com>
+Ehren Metcalfe <ehren.m@gmail.com>
+Ekansh Purohit <purohit.e15@gmail.com>
+Elias Basler <e.e.basler@protonmail.com>
+Elisha Hollander <just4now666666@gmail.com> donno2048 <just4now666666@gmail.com>
+Elliot Marshall <Marshall2389@gmail.com> <marshall2389@gmail.com>
+Elrond der Elbenfuerst <elrond+sympy.org@samba-tng.org>
+Emile Fourcini <emile.fourcin1@gmail.com> Emile <emile.fourcin1@gmail.com>
+Emma Hogan <ehogan@gemini.edu>
+Enric Florit <efz1005@gmail.com>
+Eric Demer <demer@mailbox.org>
+Eric Miller <emiller42@gmail.com>
+Eric Nelson <eric.the.red.XLII@gmail.com>
+Eric Wieser <wieser.eric@gmail.com>
+Erik R. Gomez <gomez@kth.se> erik <gomez@kth.se>
+Erik Welch <erik.n.welch@gmail.com>
+Ethan DeGuire <ethandeguire@gmail.com>
+Ethan Ward <etkewa@gmail.com>
+Ethan Ward <etkewa@gmail.com> <ethanward@email.arizona.edu>
+Ethan Ward <etkewa@gmail.com> Ethan Ward <14932247+ethankward@users.noreply.github.com>
+Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
+Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
+Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
+Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
+Evandro Bernardes <evbernardes@gmail.com> Evandro <15084103+evbernardes@users.noreply.github.com>
+Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
+Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
+Evani Balasubramanyam <balasubramanyam.evani@gmail.com> evani balasubramanyam <balasubramanyam.evani@gmail.com>
+Evelyn King <evelyn.cameron.king@gmail.com>
+Evelyn King <evelyn.cameron.king@gmail.com> Cameron King <v-caking@microsoft.com>
+Evgenia Karunus <lakesare@gmail.com>
+Fabian Ball <fabian.ball@kit.edu>
+Fabian Froehlich <fabian@schaluck.com> FFroehlich <fabian@schaluck.com>
+Fabian Pedregosa <fabian@fseoane.net>
+Fabian Pedregosa <fabian@fseoane.net> <fabian@debian.(none)>
+Fabio Luporini <fabio@devitocodes.com>
+Faisal Anees <faisal.iiit@gmail.com>
+Faisal Riyaz <faisalriyaz011@gmail.com>
+Fawaz Alazemi <Mba7eth@gmail.com>
+Felix Kaiser <felix.kaiser@fxkr.net> <felix.kaiser@fxkr.net>
+Felix Kaiser <felix.kaiser@fxkr.net> <kaiser.fx@gmail.com>
+Felix Kaiser <felix.kaiser@fxkr.net> <whatfxkr@gmail.com>
+Felix Yan <felixonmars@archlinux.org>
+Fermi Paradox <FermiParadox@users.noreply.github.com>
+Fernando Perez <Fernando.Perez@berkeley.edu>
+Fiach Antaw <fiach.antaw+github@gmail.com>
+Filip Gokstorp <filip@gokstorp.se>
+Flamy Owl <flamyowl@protonmail.ch>
+Florian Mickler <florian@mickler.org>
+ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com>
+ForeverHaibara <69423537+ForeverHaibara@users.noreply.github.com> <1378855363@qq.com>
+Francesco Bonazzi <franz.bonazzi@gmail.com> <francesco.bonazzi@mpikg.mpg.de>
+Francesco Bonazzi <franz.bonazzi@gmail.com> <none@universe.org>
+Freddie Witherden <freddie@witherden.org>
+Fredrik Andersson <fredrik.andersson@fcc.chalmers.se>
+Fredrik Eriksson <freeriks@student.chalmers.se>
+Fredrik Johansson <fredrik.johansson@gmail.com> <fredrik.johansson@gmail.com>
+Fredrik Johansson <fredrik.johansson@gmail.com> <fredrik.johansson@gmail.com> <fredrik@airy.(none)>
+Fredrik Johansson <fredrik.johansson@gmail.com> <fredrik@airy.(none)>
+Fredrik Johansson <fredrik.johansson@gmail.com> fredrik.johansson <devnull@localhost>
+Friedrich Hagedorn <friedrich_h@gmx.de>
+Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
+G. D. McBain <gdmcbain@protonmail.com>
+Gabriel Bernardino <gabriel.bernardino@upf.edu>
+Gabriel Orisaka <orisaka@gmail.com>
+Gaetano Guerriero <x.guerriero@tin.it>
+Gagan Mishra <simonsimple305@gmail.com> Gagan Mishra <70949548+GaganMishra305@users.noreply.github.com>
+Gagandeep Singh <Gmadaan450@gmail.com> Gagandeep61 <gmadaan450@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <36567889+czgdp1807@users.noreply.github.com>
+Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <czgdp1807@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <gdp.1807@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <gdp1807@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in> MathLover <36567889+czgdp1807@users.noreply.github.com>
+Gagandeep Singh <singh.23@iitj.ac.in> czgdp1807 <36567889+czgdp1807@users.noreply.github.com>
+Gagandeep Singh <singh.23@iitj.ac.in> czgdp1807 <czgdp1807@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in> czgdp1807 <gdp.1807@gmail.com>
+Gagandeep Singh <singh.23@iitj.ac.in> czgdp1807 <singh.23@iitj.ac.in>
+Gao, Xiang <qasdfgtyuiop@gmail.com>
+Gareth Ma <grhkm21@gmail.com>
+Garrett Folbe <gmfolbe@yahoo.com> gfolbe318 <gmfolbe@yahoo.com>
+Gary Kerr <gary.kerr@blueyonder.co.uk>
+Gaurang Tandon <1gaurangtandon@gmail.com>
+Gaurav Dhingra <gauravdhingra.gxyd@gmail.com>
+Gaurav Dhingra <gauravdhingra.gxyd@gmail.com> <axyd0000@gmail.com>
+Gaurav Dhingra <gauravdhingra.gxyd@gmail.com> <igauravdhingra@protonmail.com>
+Gaurav Jain <gjain369@gmail.com> Gaurav Jain <72644006+gjain-7@users.noreply.github.com>
+Gautam Menghani <gum3ng@protonmail.com> gautammenghani <gautammenghani14@gmail.com>
+Gautam Menghani <gum3ng@protonmail.com> gum3ng <78410304+gum3ng@users.noreply.github.com>
+Gautam Menghani <gum3ng@protonmail.com> gum3ng <gum3ng@protonmail.com>
+Geetika Vadali <geetika.vadali4@gmail.com> Geetika V <geetika047btcsai21@igdtuw.ac.in>
+Geetika Vadali <geetika.vadali4@gmail.com> Geetika Vadali <123307246+geetHonve@users.noreply.github.com>
+Geoffry Song <goffrie@gmail.com>
+George Frolov <gosha@fro.lv>
+George Korepanov <gkorepanov.gk@gmail.com>
+George Pittock <gpittock4@gmail.com>
+George Waksman <waksman@gwax.com>
+Georges Khaznadar <georgesk@debian.org>
+Georgios Giapitzakis Tzintanos <giorgosgiapis@mail.com>
+Gerald Teschl <gerald.teschl@univie.ac.at>
+Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
+Gilbert Gede <gilbertgede@gmail.com> <ggede@Gilbert-Gedes-MacBook.local>
+Gilbert Gede <gilbertgede@gmail.com> <ggede@ucdavis.edu>
+Gilles Schintgen <gschintgen@hambier.lu>
+Gina <Dr-G@users.noreply.github.com>
+Giovanni Zanotti <giozanotti07@mail.com> <136728817+GiZano@users.noreply.github.com>
+Gleb Siroki <g.shiroki@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com>
+Glenn Horton-Smith <glenn.hortonsmith@gmail.com> Glenn Horton-Smith <gahs@phys.ksu.edu>
+GolimarOurHero <metalera94@hotmail.com>
+Gonzalo Tornaría <tornaria@cmat.edu.uy>
+Goran Jelic-Cizmek <jcgoran@protonmail.com> JCGoran <JCGoran@users.noreply.github.com>
+Goutham Lakshminarayan <dl.goutham@gmail.com> Goutham <devnull@localhost>
+Govind Sahai <gsiitbhu@gmail.com>
+Grace Su <grace.duansu@gmail.com>
+Gregory Ashton <gash789@gmail.com> <ga7g08@soton.ac.uk>
+Gregory Ksionda <ksiondag846@gmail.com>
+Grzegorz Świrski <sognat@gmail.com>
+Guido Roncarolo <guido.roncarolo@gmail.com> groncarolo <53181812+groncarolo@users.noreply.github.com>
+Guillaume Gay <contact@damcb.com> <guillaume@mitotic-machine.org>
+Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
+Guo Xingjian <Seeker1995@gmail.com>
+Gurpartap Singh <dhaliwal.gurpartap@gmail.com> Gurpartap Singh <36311440+gurpartap0306@users.noreply.github.com>
+Gurpartap Singh <dhaliwal.gurpartap@gmail.com> gurpartap0306 <dhaliwal.gurpartap@gmail.com>
+Guru Devanla <grdvnl@gmail.com>
+Gustavo Alvarado <igoutta@protonmail.com> GA. <igoutta@users.noreply.github.com>
+Haimo Zhang <zh.hammer.dev@gmail.com>
+Hamish Dickson <hamish.dickson@gmail.com>
+Hampus Malmberg <hampus.malmberg88@gmail.com>
+Han Wei Ang <ang.h.w@u.nus.edu>
+Hannah Kari <hannah.kari@marquette.edu> hannah-kari <42753364+hannah-kari@users.noreply.github.com>
+Hanspeter Schmid <hanspeter.schmid@fhnw.ch>
+Hardik Saini <43683678+Guardianofgotham@users.noreply.github.com>
+Harikrishna Srinivasan <harikrishnasri3@gmail.com>
+Harold Erbin <harold.erbin@gmail.com>
+Harrison Oates <48871176+HarrisonOates@users.noreply.github.com>
+Harry Mountain <harrymountain1@icloud.com>
+Harry Zheng <harry@harryzheng.com>
+Harsh Agarwal <hagarwal9200@gmail.com>
+Harsh Gupta <harsh2125gupta@gmail.com> <150253719+harshgupta2125@users.noreply.github.com>
+Harsh Gupta <harsh2125gupta@gmail.com> harshgupta2125 <harsh2125gupta@gmail.com>
+Harsh Gupta <mail@hargup.in> <gupta.harsh96@gmail.com>
+Harsh Jain <harshjniitr@gmail.com>
+Harsh Kasat <hkasat@waymore.io>
+Harsh Menon <harsh.menon@amd.com> harsh-nod <menonharsh@gmail.com>
+Harshil Goel <harshil158@gmail.com>
+Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
+Harshil Meena <harshil.7535@gmail.com>
+Harshit Gupta <harshithigh2001@gmail.com>
+Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>
+Haruki Moriguchi <harukimoriguchi@gmail.com>
+HeeJae Chang <hechang@microsoft.com>
+Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
+Henrik Johansson <henjo2006@gmail.com>
+Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
+Henry Gebhardt <hsggebhardt@gmail.com>
+Henry Metlov <genrih.metlov@gmail.com>
+Himanshu <hs80941@gmail.com>
+Himanshu Ladia <hladia199811@gmail.com>
+Hiren Chalodiya <hirenchalodiya99@gmail.com>
+Hong Xu <hong@topbug.net>
+Hou-Rui <houruinus@gmail.com> Hou-Rui <13244639785@163.com>
+Huangduirong <huangduirong@huawei.com> Huangxiaodui <hdrong.42@163.com>
+Hubert Tsang <intsangity@gmail.com>
+Hugo Kerstens <hugo@kerstens.me> Hugo Kerstens <hugokk@hotmail.nl>
+Hugo van Kemenade <hugovk@users.noreply.github.com> Hugo <hugovk@users.noreply.github.com>
+Huijun Mai <m.maihuijun@gmail.com>
+Hwayeon Kang <hwayeonniii@gmail.com> <97640870+eh111eh@users.noreply.github.com>
+Hwayeon Kang <hwayeonniii@gmail.com> eh111eh <hwayeonniii@gmail.com>
+Håkon Kvernmoen <haakon.kvernmoen@gmail.com> hkve <haakon.kvernmoen@gmail.com>
+Ian Swire <oversizedpenguin@gmail.com>
+Idan Pazi <idan.kp@gmail.com>
+Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>
+Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
+Ishan Joshi <ishanaj98@gmail.com>
+Ishan Khan <ishan372or@gmail.com> ishan372or <ishan372or@gmail.com>
+Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
+Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
+Ishan Pandhare <ishan9096137017@gmail.com>
+Isidora Araya <iarayaday@gmail.com>
+Islam Mansour <is3mansour@gmail.com>
+Islem BOUZENIA <fi_bouzenia@esi.dz> islem-esi <fi_bouzenia@esi.dz>
+Isuru Fernando <isuruf@gmail.com> <ifernando@quansight.com>
+Isuru Fernando <isuruf@gmail.com> <isuru.11@cse.mrt.ac.lk>
+Itay4 <31018228+Itay4@users.noreply.github.com>
+Ivan A. Melnikov <iv@altlinux.org>
+Ivan Petuhov <ivan@ostrovok.ru>
+Ivan Petukhov <satels@gmail.com>
+Ivan Tkachenko <me@ratijas.tk> ivan tkachenko <ratijas@users.noreply.github.com>
+Ivan Tkachenko <me@ratijas.tk> ratijas <ratijas@users.noreply.github.com>
+JDBetteridge <jack@devitocodes.com> <43041811+JDBetteridge@users.noreply.github.com>
+JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
+Jack Kemp <metaknightdrake-git@yahoo.co.uk>
+Jack Kemp <metaknightdrake-git@yahoo.co.uk> <kempj@tplxdt003.nat.physics.ox.ac.uk>
+Jack McCaffery <jpmccaffery@gmail.com>
+Jack Schmidt <1107865+jackschmidt@users.noreply.github.com>
+Jacob Garber <jgarber1@ualberta.ca>
+Jai Luthra <me@jailuthra.in>
+Jaime R <38530589+Jaime02@users.noreply.github.com>
+Jaime Resano <gemailpersonal02@gmail.com>
+Jainul Vaghasia <jainulvaghasia@gmail.com> <jainulvaghasia@D-10-157-53-226.dhcp4.washington.edu>
+Jakub Wilk <jwilk@jwilk.net>
+James A. Preiss <jamesalanpreiss@gmail.com> jpreiss <jamesalanpreiss@gmail.com>
+James Abbatiello <abbeyj@gmail.com>
+James Aspnes <aspnes@cs.yale.edu>
+James Brandon Milam <jmilam343@gmail.com>
+James Cotton <peabody124@gmail.com>
+James Fiedler <jrfiedler@gmail.com>
+James Goppert <james.goppert@gmail.com>
+James Harrop <ebc121@gmail.com>
+James Pearson <xiong.chiamiov@gmail.com>
+James Taylor <user234683@tutanota.com>
+James Titus <titusjames299@gmail.com> <jamestitus299@gmail.com>
+James Titus <titusjames299@gmail.com> <titusjames299@gmail.com>
+James Whitehead <whiteheadj@gmail.com> jcwhitehead <whiteheadj@gmail.com>
+Jan Jancar <johny@neuromancer.sk> J08nY <johny@neuromancer.sk>
+Jan Jancar <johny@neuromancer.sk> Ján Jančár <J08nY@users.noreply.github.com>
+Jan Kruse <janckruse@t-online.de>
+Jan-Philipp Hoffmann <sonntagsgesicht@icloud.com> Jan-Philipp Hoffmann <90828785+jan-philipp-hoffmann@users.noreply.github.com>
+Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>
+Jaroslaw Tworek <dev.jrx@gmail.com>
+Jashanpreet Singh <jashansingh.4398@gmail.com>
+Jason Gedge <inferno1386@gmail.com> inferno1386 <devnull@localhost>
+Jason Gross <jasongross9@gmail.com>
+Jason Gross <jasongross9@gmail.com> Jason Gross <jgross@mit.edu>
+Jason Ly <jason.ly@gmail.com>
+Jason Moore <moorepants@gmail.com>
+Jason Ross <jasonross1024@gmail.com>
+Jason Siefken <siefkenj@gmail.com>
+Jason Tokayer <jason.tokayer@gmail.com>
+Jason Tokayer <jason.tokayer@gmail.com> <jason.tokayer@capitalone.com>
+Jatin Bhardwaj <bhardwajjatin093@gmail.com> <148186488+Jatinbhardwaj-093@users.noreply.github.com>
+Jatin Gaur <jatingaurchess@gmail.com> <134034110+jatingaur18@users.noreply.github.com>
+Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
+Jatin Yadav <jatinyadav25@gmail.com>
+Javed Nissar <javednissar@gmail.com>
+Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
+Jay Vijan <jvijan@umich.edu> Jay Sun Vijan <145924415+jvijan@users.noreply.github.com>
+Jayesh Lahori <jlahori92@gmail.com>
+Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
+Jean-François B <2589111+jfbu@users.noreply.github.com>
+Jean-Luc Herren <jlh@gmx.ch> jlherren <jlh@gmx.ch>
+Jeffrey Ryan <jeffaryan7@gmail.com>
+Jeffrey Zhang <jiefu.zhang1226@gmail.com>
+Jennifer White <jcrw122@googlemail.com>
+Jens H. Nielsen <jenshnielsen@gmail.com>
+Jens Jørgen Mortensen <jj@smoerhul.dk>
+Jeremey Gluck <jeremygluck@yahoo.com>
+Jeremias Yehdegho <j.yehdegho@gmail.com> <aevirex@aleph.(none)>
+Jeremy <twobitlogic@gmail.com>
+Jeremy Monat <jemonat@calalum.org>
+Jerry James <loganjerry@gmail.com>
+Jerry Li <jerry@jerryli.ca>
+Jezreel Ng <jezreel@gmail.com>
+Jiaxing Liang <liangjiaxing57@gmail.com>
+Jiaxing Liang <liangjiaxing57@gmail.com> <jiaxingl@CS-DEAL-03.cs.sfu.ca>
+Jim Crist <crist042@umn.edu>
+Jim Zhang <Hyriodula@gmail.com>
+Jiri Kuncar <jiri.kuncar@gmail.com>
+Jisoo Song <jeesoo9595@snu.ac.kr> JSS95 <52185322+JSS95@users.noreply.github.com>
+Jisoo Song <jeesoo9595@snu.ac.kr> mcpl-sympy <59268464+mcpl-sympy@users.noreply.github.com>
+Jithin D. George <jithindgeorge93@gmail.com>
+Jo Liss <joliss42@gmail.com>
+Joachim Durchholz <jo@durchholz.org> <jo@durchholz.org>
+Joachim Durchholz <jo@durchholz.org> <toolforger@durchholz.org>
+Joan Creus <joan.creus.c@gmail.com>
+Joannah Nanjekye <joannah.nanjekye@ibm.com> Joannah Nanjekye <jnanjekye@python.org>
+Joannah Nanjekye <joannah.nanjekye@ibm.com> nanjekyejoannah <joannah.nanjekye@ibm.com>
+Joaquim Monserrat <qmonserrat@mailoo.org>
+Jochen Voss <voss@seehuhn.de>
+Jogi Miglani <jmig5776@gmail.com> jmig5776 <jmig5776@gmail.com>
+Johan Blåbäck <johan_bluecreek@riseup.net> <johan.blaback@cea.fr>
+Johan Guzman <jguzm022@ucr.edu>
+Johann Cohen-Tanugi <johann.cohentanugi@gmail.com>
+Johannes Hartung <joha2@gmx.net>
+Johannes Kasimir <johannes.kasimir@math.lu.se>
+John Connor <john.theman.connor@gmail.com>
+John Möller <john.moller@outlook.com>
+John V. Siratt <jvsiratt@gmail.com>
+Jonathan A. Gross <jarthurgross@gmail.com>
+Jonathan Allan <jjallan@users.noreply.github.com>
+Jonathan Daniel <36337649+jond01@users.noreply.github.com>
+Jonathan Gutow <gutow@uwosh.edu> gutow <gutow@uwosh.edu>
+Jonathan Miller <jdmiller93@gmail.com>
+Jonathan Warner <warnerjon12@gmail.com>
+Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
+Jorge E. Cardona <jorgeecardona@gmail.com>
+Jorn Baayen <jorn.baayen@gmail.com>
+Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
+Joseph Dougherty <Github@JWDougherty.com>
+Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
+Joseph Redfern <joseph@redfern.me>
+Josh Burkart <jburkart@gmail.com>
+José Senart <jose.senart@gmail.com>
+João Bravo <joaocgbravo@tecnico.ulisboa.pt>
+João Moura <operte@gmail.com>
+João Rodrigues <abcjoao@hotmail.com>
+Juan Barbosa <js.barbosa10@uniandes.edu.co>
+Juan Felipe Osorio <jfosorio@gmail.com>
+Juan Luis Cano Rodríguez <juanlu001@gmail.com>
+Juha Remes <jremes@outlook.com>
+Julien Palard <julien@palard.fr>
+Julien Rioux <julien.rioux@gmail.com>
+Julio Idichekop Filho <idichekop@yahoo.com.br>
+Jun Lin <junlin0604@gmail.com> wate123 <junlin0604@gmail.com>
+Jurjen N.E. Bos <jnebos@gmail.com> <jnebos@gmail.com>
+Jurjen N.E. Bos <jnebos@gmail.com> Jurjen N.E. Bos <devnull@localhost>
+Justin Blythe <jblythe29@gmail.com>
+Jyn Spring 琴春 <me@vx.st>
+K. Kraus <laqueray@googlemail.com>
+KJaybhaye <krushnajaybhaye01@gmail.com> KJaybhaye <80618101+KJaybhaye@users.noreply.github.com>
+KJaybhaye <krushnajaybhaye01@gmail.com> KJaybhaye <krushnajaybhaye01@gmail.com>
+KJaybhaye <krushnajaybhaye01@gmail.com> Krushna Jaybhaye <80618101+KJaybhaye@users.noreply.github.com>
+Ka Yi <chua.kayi@yahoo.com.sg>
+Kaifeng Zhu <cafeeee@gmail.com>
+Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
+Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>
+Karan <grgkaran03@gmail.com>
+Karan <grgkaran03@gmail.com>
+Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>
+Karan Sharma <karan1276@gmail.com>
+Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
+Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
+Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
+Kaushik Varanasi <kaushik.varanasi1@gmail.com>
+Kaustubh <90597818+kaustubh-765@users.noreply.github.com>
+Kaustubh <kaustubh.am765@gmail.com>
+Kaustubh Chaudhari <ckaustubhm06@gmail.com> Kaustubh <ckaustubhm06@gmail.com>
+Kaustubh Chaudhari <ckaustubhm06@gmail.com> kc611 <ckaustubhm06@gmail.com>
+KaustubhDamania <kaustubh.damania@gmail.com>
+Kazuo Thow <kazuo.thow@gmail.com>
+Ken Wakita <wakita@is.titech.ac.jp>
+Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
+Kenneth Lyons <ixjlyons@gmail.com>
+Keno Goertz <keno@goertz-berlin.com>
+Keval Shah <kevalshah_96@yahoo.co.in>
+Kevin Goodsell <kevin-opensource@omegacrash.net>
+Kevin Hunter <hunteke@earlham.edu>
+Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
+Kevin Ventullo <kevin.ventullo@gmail.com>
+Keyron Linerez <keyronlinarez@gmail.com>  KeyronLinarez <keyronlinarez@gmail.com>
+Keyron Linerez <keyronlinarez@gmail.com> Rona <112719213+KeyronLinarez@users.noreply.github.com>
+Khagesh Patel <khageshpatel93@gmail.com>
+Kibeom Kim <kk1674@nyu.edu>
+Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
+Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
+Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
+Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com>
+Kiyohito Yamazaki <kyamaz@openql.org>
+Klaus Rettinghaus <klaus.rettinghaus@enote.com>
+Konrad Meyer <konrad.meyer@gmail.com>
+Konstantin Togoi <konstantin.togoi@gmail.com> <togoi.konstantin@outlook.com>
+Konstantinos Riganas <kostasriganas24@gmail.com> kostas-rigan <t8200145@aueb.gr>
+Kris Katterjohn <katterjohn@gmail.com>
+Krishnav Bajoria <bajoriakrishnav@gmail.com> Krishnav Bajoria <127018567+krishnavbajoria02@users.noreply.github.com>
+Kristian Brünn <hello@kristianbrunn.com> Kristianmitk <hello@kristianbrunn.com>
+Krit Karan <kritkaran.b13@iiits.in> <kritkaran94@users.noreply.github.com>
+Kshitij <kshitijparwani.mat18@itbhu.ac.in> Kshitij Parwani <44468674+P-Kshitij@users.noreply.github.com>
+Kshitij Saraogi <KshitijSaraogi@gmail.com>
+Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep <kuldeepborkar.jr@gmail.com>
+Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep Borkar Jr <74557588+KuldeepBorkar@users.noreply.github.com>
+Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep-GitWorks <100110333+Kuldeep-GitWorks@users.noreply.github.com>
+Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+Kunal Arora <kunalarora.135@gmail.com>
+Kunal Sheth <kunal@kunalsheth.info>
+Kunal Singh <ksingh19136@gmail.com> kunal singh <ksingh19136@gmail.com>
+Kundan Kumar <kundankumar18581@gmail.com>
+Kyle McDaniel <mcdanie5@illinois.edu> <mcdaniel221@gmail.com>
+Lagaras Stelios <stel.lag@hotmail.com> lagamura <stel.lag@hotmail.com>
+Lai Jien Weng <laijienweng@gmail.com> Jien Weng <reallyhat@gmail.com>
+Lai Jien Weng <laijienweng@gmail.com> JienWeng <laijienweng@gmail.com>
+Lakshya Agrawal <zeeshan.lakshya@gmail.com>
+Langston Barrett <langston.barrett@gmail.com>
+Lars Buitinck <larsmans@gmail.com>
+Laura Domine <temigo@gmx.com>
+Laura Pazini Medeiros <laurapazinimedeiros@gmail.com> Laura Pazini Medeiros <162479440+LauraPaziniMedeiros@users.noreply.github.com>
+Lauren Glattly <laurenglattly@gmail.com>
+Lauren Yim <31467609+cherryblossom000@users.noreply.github.com>
+Laurence Warne <laurencewarne@gmail.com>
+Le Cong Minh Hieu <hieu.lecongminh@gmail.com>
+Lee Johnston <lee.johnston.100@gmail.com>
+Lejla Metohajrova <l.metohajrova@gmail.com>
+Lennart Fricke <lennart@die-frickes.eu>
+Leo Battle <leowbattle@gmail.com>
+Leonardo Mangani <leomangani4@gmail.com> Leonardo Mangani <88255254+leomanga@users.noreply.github.com>
+Leonardo Mangani <leomangani4@gmail.com> leomanga <leomangani4@gmail.com>
+Leonid Blouvshtein <leonidbl91@gmail.com>
+Leonid Kovalev <leonidvkovalev@gmail.com> <leonid.traveling@gmail.com>
+Leonid Kovalev <leonidvkovalev@gmail.com> <normalhuman@users.noreply.github.com>
+Lev Chelyadinov <leva181777@gmail.com>
+Liubov Kryzhalka <kryshalkaliub@gmail.com> KryzhalkaLiuba <126720876+KryzhalkaLiuba@users.noreply.github.com>
+Liwei Cai <cai.lw123@gmail.com>
+Ljubiša Moćić <3rdslasher@gmail.com>
+Lokesh Sharma <lokeshhsharma@gmail.com> <your_email@youremail.com>
+Longqi Wang <iqgnol@gmail.com>
+Lorenz Winkler <lorenz.winkler@tuwien.ac.at>
+Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.noreply.github.com>
+Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>
+Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>
+Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
+Luca Bertoni <lucabertoni@gmail.com> luca-berton1 <kaiserverbalkint@gmail.com>
+Luca Weihs <astronomicalcuriosity@gmail.com>
+Lucas Gallindo <lgallindo@gmail.com>
+Lucas Jones <lucas@lucasjones.co.uk>
+Lucas Kletzander <lucas.kletzander@gmail.com>
+Lucas Verlaan <lucas.verlaan@gmail.com>
+Lucas Wiman <lucas.wiman@gmail.com>
+Lucy Mountain <lucymountain1@icloud.com> LucyMountain <lucymountain1@icloud.com>
+Luis Garcia <ppn.online@me.com>
+Luis Talavera <luisfertalavera15@gmail.com> Luis F. Talavera R <47088091+LuisFerTR@users.noreply.github.com>
+Lukas Molleman <Lukas.Molleman@gmail.com>
+Lukas Zorich <lukas.zorich@gmail.com>
+Luke Peterson <hazelnusse@gmail.com>
+Luv Agarwal <agarwal.iiit@gmail.com>
+Lyle Poley <poleylyle@gmail.com>
+M-Israr-Ul-Haq <israrulhaq590@gmail.com>
+Maciej Baranski <getrox.sc@gmail.com>
+Maciej Skórski <maciej.skorski@gmail.com>
+Madeleine Ball <mpball@gmail.com>
+Malkhan Singh <malkhansinghrathaur@gmail.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com> Praneeth Ratna <63547155+praneethratna@users.noreply.github.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeeth <praneethratna@gmail.com>
+Mamidi Ratna Praneeth <praneethratna@gmail.com> praneeth <praneethratna@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com>
+Manav Sharma <maanav.vashist@gmail.com> octomaanav <116334923+octomaanav@users.noreply.github.com>
+Manish Gill <gill.manish90@gmail.com>
+Manish Shukla <manish.shukla393@gmail> <manish.shukla393@gmail.com>
+Manish Shukla <manish.shukla393@gmail> <shukla@ubuntu.ubuntu-domain>
+Manoj Babu K. <manoj.babu2378@gmail.com>
+Manoj Kumar <manojkumarsivaraj334@gmail.com>
+Marcel Stimberg <marcel.stimberg@ens.fr> <marcel.stimberg@inserm.fr>
+Marcin Briański <marcin.brianski@student.uj.edu.pl>
+Marcin Kostrzewa <>
+Marco Antônio Habitzreuter <mahabitzreuter@gmail.com>
+Marco Mancini <marco.mancini@obspm.fr>
+Marco Mazzone <marco.mazzone06@gmail.com> Mazzone Marco <marco.mazzone06@gmail.com>
+Marco Mazzone <marco.mazzone06@gmail.com> SirMarcoss <marco.mazzone06@gmail.com>
+Marcus Näslund <naslundx@gmail.com>
+Marduk Bolaños <mardukbp@mac.com> mardukbp <mardukbp@mac.com>
+Marek Madejski <marekmadejski@yandex.com>
+Marek Šuppa <mr@shu.io>
+Maria Marginean <33810762+mmargin@users.noreply.github.com>
+Marijan Smetko <marijansmetko123@gmail.com> InCogNiTo124 <marijansmetko123@gmail.com>
+Mario Maio <mario.maio@aruba.it> nopria <mario.maio@aruba.it>
+Mario Pernici <mario.pernici@gmail.com>
+Mark Bell <mark00bell@googlemail.com>
+Mark Dewing <markdewing@gmail.com>
+Mark Dickinson <dickinsm@gmail.com>
+Mark Jeromin <mark.jeromin@sysfrog.net>
+Mark Shoulson <mark@kli.org>
+Mark van Gelder <m.j.vangelder@student.tudelft.nl>
+Mark van Gelder <mvgmvgmvg@live.com> mvg2002 <168417631+mvg2002@users.noreply.github.com>
+Markus Mohrhard <markus.mohrhard@googlemail.com>
+Markus Müller <markus.mueller.1.g@googlemail.com>
+Martha Giannoudovardi <maapxa@gmail.com>
+Martin Manns <mmanns@gmx.net>
+Martin Povišer <martin.povik@gmail.com>
+Martin Roelfs <u0114255@kuleuven.be>
+Martin Thoma <info@martin-thoma.de>
+Martin Ueding <dev@martin-ueding.de>
+Mary Clark <mary.spriteling@gmail.com> <meclark246@gmail.com>
+Mary Clark <mary.spriteling@gmail.com> <meclark256@gmail.com>
+Mateusz Paprocki <mattpap@gmail.com> mattpap <devnull@localhost>
+Mathew Chong <mathewchong.dev@gmail.com>
+Mathias Louboutin <mathias.louboutin@gmail.com>
+Mathis Cros <mathis.cros@telecom-paris.fr>
+Matt Bogosian <matt@bogosian.net>
+Matt Curry <mattjcurry@gmail.com>
+Matt Habel <habelinc@gmail.com>
+Matt Ord <matthew.ord1@gmail.com>
+Matt Ord <matthew.ord1@gmail.com> Matt Ord <55235095+Matt-Ord@users.noreply.github.com>
+Matt Rajca <matt.rajca@me.com>
+Matt Wang <mattwang44@gmail.com>
+Matthew Brett <matthew.brett@gmail.com>
+Matthew Craven <clyring@users.noreply.github.com>
+Matthew Davis <davisml.md@gmail.com> <mlda065@cse.unsw.edu.au>
+Matthew Hoff <mhoff14@gmail.com> <mhoff@calpoly.edu>
+Matthew Parnell <matt@parnmatt.co.uk>
+Matthew Rocklin <mrocklin@cs.uchicago.edu> <mrocklin@gmail.com>
+Matthew Tadd <matt.tadd@gmail.com>
+Matthew Thomas <mnmt@users.noreply.github.com>
+Matthew Treinish <mtreinish@kortar.org>
+Matthew Wardrop <matthew.wardrop@airbnb.com>
+Matthias Bussonnier <bussonniermatthias@gmail.com>
+Matthias Geier <Matthias.Geier@gmail.com>
+Matthias Köppe <mkoeppe@math.ucdavis.edu> Matthias Koeppe <mkoeppe@math.ucdavis.edu>
+Matthias Liesenfeld <116307294+maliesen@users.noreply.github.com>
+Matthias Rettl <matthias.rettl@stud.unileoben.ac.at>
+Matthias Toews <mat.toews@googlemail.com>
+Mauro Garavello <mauro.garavello@unimib.it>
+Max Hutchinson <maxhutch@gmail.com>
+Maxence Mayrand <35958639+maxencemayrand@users.noreply.github.com>
+Mayank Balyan <78949282+MayankBalyan@users.noreply.github.com>
+Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank <54908605+mayankray2020@users.noreply.github.com>
+Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
+Mayank Singh <mayank.singh081997@gmail.com>
+Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
+Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
+Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
+Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
+Meghana Madhyastha <meghana.madhyastha@gmail.com>
+Merin Theres Jose <merintheresjose@gmail.com>
+Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>
+Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <moble@users.noreply.github.com>
+Michael Chu <michael02chu@gmail.com>
+Michael Gallaspy <gallaspy.michael@gmail.com>
+Michael Greminger <michael.greminger@gmail.com> mgreminger <michael.greminger@gmail.com>
+Michael Hohenstein <michael@hohenste.in>
+Michael Mayorov <marchael@kb.csu.ru>
+Michael Mueller <michaeldmueller7@gmail.com>
+Michael S. Hansen <michael.hansen@nih.gov>
+Michael Sparapany <msparapa@purdue.edu>
+Michael Zingale <michael.zingale@stonybrook.edu>
+Michal Grňo <m93a.cz@gmail.com> Michal Grno <m93a.cz@gmail.com>
+Michał Radwański <enedil.isildur@gmail.com>
+Michele Ceccacci <michelececcacci1@gmail.com> Michele Ceccacci <75946413+michelececcacci@users.noreply.github.com>
+Michele Zaffalon <michele.zaffalon@gmail.com>
+Micky <mickydroch@gmail.com>
+Miguel Marco <mmarco@unizar.es>
+Miguel Torres Costa <miguelptcosta1995@gmail.com>
+Miha Marolt <tloramus@gmail.com>
+Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
+Mihail Tarigradschi <m.tarigradschi@gmail.com>
+Mihir Wadwekar <m.mihirw@gmail.com>
+Mikel Rouco <mikel.mrm@gmail.com>
+Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.noreply.github.com>
+Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
+Min Ragan-Kelley <benjaminrk@gmail.com>
+Miro Hrončok <miro@hroncok.cz>
+Mohak Malviya <mohakmalviya2000@gmail.com> Senku <mohakmalviya2000@gmail.com>
+Mohamed Rezk <mohrizq895@gmail.com>
+Mohammad Sadeq Dousti <msdousti@gmail.com>
+Mohammed Bilal <r.mohammedbilal@gmail.com>
+Mohammed Umar <mdumr4@gmail.com>
+Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohit Balwani <44258119+Mohitbalwani26@users.noreply.github.com>
+Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohitbalwani26 <44258119+Mohitbalwani26@users.noreply.github.com>
+Mohit Balwani <mohitbalwani.ict17@gmail.com> Mohitbalwani26 <mohitbalwani.ict17@gmail.com>
+Mohit Chandra <mohit.chandra@research.iiit.ac.in>
+Mohit Gupta <mohitgupta@gmail.com>
+Mohit Shah <mohitshah3111999@gmail.com>
+Morten Olsen Lysgaard <morten@lysgaard.no>
+Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
+MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
+Mridul Seth <seth.mridul@gmail.com>
+Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
+Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
+Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
+Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>
+Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
+Nabanita Dash <dashnabanita@gmail.com> Naba7 <dashnabanita@gmail.com>
+Nabanita Dash <dashnabanita@gmail.com> Nabanita Dash <31562743+Naba7@users.noreply.github.com>
+Naman Gera <namangera15@gmail.com> Naman Gera <43007653+namannimmo10@users.noreply.github.com>
+Naman Gera <namangera15@gmail.com> Namannimmo <namangera15@gmail.com>
+Natalia Nawara <fankalemura@gmail.com>
+Nathan Alison <nathan.f.alison@gmail.com> <nathan@ubuntu.(none)>
+Nathan Goldbaum <ngoldbau@illinois.edu>
+Nathan Musoke <nathan.musoke@gmail.com>
+Nathan Taylor <pecan.pine@gmail.com>
+Nathan Woods <charlesnwoods@gmail.com>
+Naveen Sai <naveensaisreenivas@gmail.com> Naveen Sai <56525288+naveensaigit@users.noreply.github.com>
+Naveen Sai <naveensaisreenivas@gmail.com> naveensaigit <naveensaisreenivas@gmail.com>
+Neel Gorasiya <mgorasiya1974@gmail.com>
+Neil <mistersheik@gmail.com>
+Nguyen Truong Duy <truongduy134@yahoo.com>
+Nichita Utiu <nikita.utiu+github@gmail.com> <nichitautiu@nichitautiu-desktop.(none)>
+Nicholas Bollweg <nick.bollweg@gmail.com> <nbollweg@continuum.io>
+Nicholas J.S. Kinar <n.kinar@usask.ca>
+Nicholas Laustrup <124007393+nicklaustrup@users.noreply.github.com>
+Nick Curtis <nicholas.curtis@uconn.edu> <arghdos@gmail.com>
+Nick Harder <nharder@umich.edu>
+Nicko van Someren <nicko@nicko.org>
+Nico Santamaria <97820814+NicoSantamaria@users.noreply.github.com>
+Nico Santamaria <nicoasantamaria@gmail.com>
+Nico Schlömer <nico.schloemer@gmail.com>
+Nicolas Pourcelot <nicolas.pourcelot@gmail.com>
+Nicolás Guarín-Zapata <nicoguarin@gmail.com>
+Nihir Agarwal <f20180701@pilani.bits-pilani.ac.in>
+Nijso Beishuizen <nijso@koolmees.numerically-related.com>
+Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <47920034+NikhilSDate@users.noreply.github.com>
+Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <nikhil.s.date@gmail.com>
+Nikhil Gopalam <gopalamn@umich.edu> gopalamn <gopalamn@umich.edu>
+Nikhil Maan <nikhilmaan22@gmail.com> Nikhil Maan <nikhilman22@gmail.com>
+Nikhil Pappu <nkhlpappu@gmail.com>
+Nikhil Sarda <diff.operator@gmail.com>
+Nikita <nikita.student.cse19@itbhu.ac.in>
+Niklas Thörne <notrupertthorne@gmail.com>
+Nikolay Lazarov <qwerqwerqwer@abv.bg>
+Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk> Nikoleta Glynatsi <glynatsine@cardiff.ac.uk>
+Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
+Nilabja Bhattacharya <nilabja10201992@gmail.com>
+Nils Schulte <47043622+Schnilz@users.noreply.github.com>
+Nimish Telang <ntelang@gmail.com>
+Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
+Nirmal Sarswat <nirmalsarswat400@gmail.com>
+Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
+Nishant Nikhil <nishantiam@gmail.com>
+Nishith Shah <nishithshah.2211@gmail.com>
+Nitin Chaudhary <nitinmax1000@gmail.com>
+Nityananda Gohain <nityanandagohain@gmail.com>
+NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
+Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com> Oldrich Klimanek <oldrich.klimanek@gmail.com>
+Oldrich Klimanek <oldrich.klimanek@gmail.com> klimanek <oldrich.klimanek@gmail.com>
+Oleksandr Gituliar <gituliar@gmail.com>
+Oliver Lee <oliverzlee@gmail.com>
+Omar Wagih <o.wagih.ow@gmail.com> OmarWagih1 <o.wagih.ow@gmail.com>
+Omkaar <79257339+Pysics@users.noreply.github.com>
+Ondřej Čertík <ondrej@certik.cz>
+Ondřej Čertík <ondrej@certik.cz> <ondrej.certik@gmail.com>
+Ondřej Čertík <ondrej@certik.cz> <ondrej@certik.us>
+Ondřej Čertík <ondrej@certik.cz> ondrej.certik <devnull@localhost>
+Or Dvory <gidesa@gmail.com>
+Orestis Vaggelis <orestisvaggelis@mail.com>  OrestisVaggelis <orestis22000@gmail.com>
+Oriel Malihi <orielmalihi1@gmail.com> oriel <orielmalihi1@gmail.com>
+Oriel Malihi <orielmalihi1@gmail.com> orielmalihi <57680696+orielmalihi@users.noreply.github.com>
+Oscar Benjamin <oscar.j.benjamin@gmail.com> <enojb@it051545.wks.bris.ac.uk>
+Oscar Benjamin <oscar.j.benjamin@gmail.com> <oscar@kar-wench.(none)>
+Oscar Gerardo Lazo Arjona <oscar.lazoarjona@physics.ox.ac.uk> oscarlazoarjona <oscar.lazoarjona@physics.ox.ac.uk>
+Oscar Gustafsson <oscar.gustafsson@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> OvskMendov1 <bbb23exposed@gmail.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <138492675+bbb23exposed@users.noreply.github.com>
+Ovsk Mendov <bbb23exposed@gmail.com> bbb23exposed <bbb23exposed@gmail.com>
+P. Sai Prasanth <psai.prasanth.min16@itbhu.ac.in>
+Pablo Galindo Salgado <pablogsal@gmail.com> Pablo <48098178+PabloRuizCuevas@users.noreply.github.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo <pablogsal@gmail.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> Pablo Galindo Salgado <Pablogsal@gmail.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <Pablogsal@gmail.com>
+Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <pablogsal@gmail.com>
+Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
+Pablo Zubieta <pabloferz@yahoo.com.mx>
+Padam Rathi <rathipadamr5@gmail.com>
+Pan Peng <pengpanster@gmail.com>
+Param Singh <paramsingh258@gmail.com>
+Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>
+Parcly Taxel <reddeloostw@gmail.com>
+Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
+Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>
+Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
+Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@gmail.com>
+Pastafarianist <mr.pastafarianist@gmail.com>
+Patrick Lacasse <patrick.m.lacasse@gmail.com>
+Patrick Poitras <acebulf@gmail.com>
+Paul Mandel <paulmandel@google.com>
+Paul Scofield <Cerebral.Paul@gmail.com>
+Paul Scott <paul.scott@nicta.com.au>
+Paul Spiering <paul@spiering.org> ThePauliPrinciple <35560762+ThePauliPrinciple@users.noreply.github.com>
+Paul Strickland <p.e.strickland@gmail.com>
+Pauli Virtanen <pav@iki.fi>
+Pavel Fedotov <fedotovp@gmail.com>
+Pavel Tkachenko <paveltkachenko@email.com>
+Pearu Peterson <pearu.peterson@gmail.com> pearu.peterson <devnull@localhost>
+Pedro H. S. Prestes <pedrohsprestes@gmail.com> Pedro H. Prestes <146496459+phprestes@users.noreply.github.com>
+Pedro Rosa <pedro_sxbr@usp.br>
+Peeyush Kushwaha <peeyush.p97@gmail.com>
+Peleg Michaeli <freepeleg@gmail.com> <peleg@palgo-at.com>
+Pengning Chao <8857165+PengningChao@users.noreply.github.com>
+Peter Brady <petertbrady@gmail.com> Peter Brady <ptb@.lanl.gov>
+Peter Brady <petertbrady@gmail.com> Peter Brady <ptb@lanl.gov>
+Peter Brady <petertbrady@gmail.com> peter <petertbrady@gmail.com>
+Peter Cock <p.j.a.cock@googlemail.com>
+Peter Enenkel <peter.enenkel+git@gmail.com> <peter.enenkel+github@gmail.com>
+Peter Schmidt <peter@peterjs.com>
+Peter Stahlecker <peter.stahlecker@gmail.com>   Peter Stahlecker <83544146+Peter230655@users.noreply.github.com>
+Peter Stangl <peter.stangl@ph.tum.de>
+Petr Kungurtsev <corwinat@gmail.com> Corwinpro <corwinat@gmail.com>
+Phil LeMaitre <phil_lemaitre@live.ca> <112662371+AntiPhoton47@users.noreply.github.com>
+Phil Ruffwind <rf@rufflewind.com>
+Philippe Bouafia <philippe.bouafia@ensea.fr>
+Phillip Berndt <phillip.berndt@googlemail.com>
+Pierre Haessig <pierre.haessig@crans.org>
+Pieter Eendebak <pieter.eendebak@gmail.com>
+Pieter Gijsbers <p.gijsbers@tue.nl>
+Piotr Korgul <p.korgul@gmail.com>
+Pontus von Brömssen <pontus.vonbromssen+github@gmail.com> <118356995+Pontus-vB@users.noreply.github.com>
+Poom Chiarawongse <eight1911@gmail.com> <15707729+Eight1911@users.noreply.github.com>
+Poom Chiarawongse <eight1911@gmail.com> <Eight1911@users.noreply.github.com>
+Prabhjot Singh <prabhjot.nith@gmail.com>
+Pradyot Ranjan <99216956+prady0t@users.noreply.github.com>
+Pradyot Ranjan <99216956+pradyotRanjan@users.noreply.github.com>
+Pradyumna <pradyu1993@gmail.com>
+Prafullkumar P. Tale <hector1618@gmail.com> <Hector1618@gmail.com>
+Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
+Prajwal Pathade <prajwalpathade7@gmail.com> Prajwal <prajwalpathade7@gmail.com>
+Pramod Ch <pramodch14@gmail.com>
+Pranjal Tale <pranjaltale16@gmail.com>
+Prashant Tandon <102211549+PT-10@users.noreply.github.com>\
+Prashant Tandon <tandonprashant101@gmail.com>
+Prashant Tyagi <prashanttyagi221295@gmail.com>
+Prasoon Shukla <prasoon92.iitr@gmail.com>
+Prateek Papriwal <papriwalprateek@gmail.com>
+Pratyksh Gupta <pratykshgupta9999@gmail.com> Pg999999 <pratykshgupta9999@gmail.com>
+Praveen Perumal <ppraveen98841@gmail.com> Praveen Perumal <58477724+solvedbiscuit71@users.noreply.github.com>
+Praveen Sahu <povinsahu@gmail.com> povinsahu1909 <povinsahu@gmail.com>
+Prayag V <v.prayag2005@gmail.com> vprayag2005 <v.prayag2005@gamil.com>
+Prayush Dawda <35144226+iamprayush@users.noreply.github.com>
+Prempal Singh <prempal.42@gmail.com>
+Prey Patel <patel.prey@iitgn.ac.in>
+Priit Laes <plaes@plaes.org>
+Prince Gupta <codemastercpp@gmail.com> LAPTOP-AS1M2R8B\codem <codemastercpp@gmail.com>
+Prionti Nasir <pdn3628@rit.edu>
+Priyank Patel <pspbot7@gmail.com>
+Priyansh Rathi <techiepriyansh@gmail.com> techiepriyansh <techiepriyansh@gmail.com>
+Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Prakhar Saxena <prakharsaxena.civ18@iitbhu.ac.in>
+Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <50932406+Psycho-Pirate@users.noreply.github.com>
+Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <prakharsaxena.cer18@itbhu.ac.in>
+Puneeth Chaganti <punchagan@gmail.com>
+Qijia Liu <liumeo@pku.edu.cn> Liumeo <liumeo@pku.edu.cn>
+Qijia Liu <liumeo@pku.edu.cn> eagleoflqj <liumeo@pku.edu.cn>
+Qingsha Shi <googol.sqs@gmail.com> sqs <googol.sqs@gmail.com>
+QuaBoo <kisonchristian@gmail.com>
+Quek Zi Yao <ziyaoqzy2001@gmail.com> ZiYao <151983618+ZiYao54@users.noreply.github.com>
+Quek Zi Yao <ziyaoqzy2001@gmail.com> ZiYao54 <ziyaoqzy2001@gmail.com>
+Raffaele De Feo <alberthilbert@gmail.com>
+Raghav Jajodia <jajodia.raghav@gmail.com>
+Rahil Hastu <rahilhastu@gmail.com> rahil hastu <rahilhastu@gmail.com>
+Rahil Parikh <r.parikh@somaiya.edu> rprkh <r.parikh@somaiya.edu>
+Raj <raj454raj@gmail.com>
+Raj Sapale <raj4sapale4@gmail.com>
+Rajat Aggarwal <rajataggarwal1975@gmail.com>
+Rajat Thakur <rajatthakur1997@gmail.com>
+Rajat Thakur <rajatthakur1997@gmail.com> <Rajat Thakur>
+Rajat Thakur <rajatthakur1997@gmail.com> <rajatatthakur23@gmail.com>
+Rajath Shashidhara <rajaths.rajaths@gmail.com>
+Rajeev Singh <rajs2010@gmail.com>
+Rajiv Ranjan Singh <rajivperfect007@gmail.com> Rajiv Ranjan Singh <42106787+iamrajiv@users.noreply.github.com>
+Ralf Stephan <ralf@ark.in-berlin.de>
+Ralph Bean <rbean@redhat.com>
+Ramana Venkata <idlike2dream@gmail.com>
+Ramana Venkata <idlike2dream@gmail.com> <vramana@users.noreply.github.com>
+Randy Heydon <randy.heydon@clockworklab.net>
+Ranjith Kumar <ranjith.dakshana2015@gmail.com>
+Raoul Bourquin <raoulb@bluewin.ch>
+Raoul Bourquin <raoulb@bluewin.ch> <raoulb@bluewin.chh>
+Raphael Lehner <raphael.lehner@gmail.com> Raphael Lehner <50210395+gnrraphi@users.noreply.github.com>
+Raphael Lehner <raphael.lehner@gmail.com> gnrraphi <raphael.lehner@gmail.com>
+Raphael Michel <webmaster@raphaelmichel.de>
+Rashmi Shehana <rashmi.watagedara@syscolabs.com>
+Rastislav Rabatin <rastislav.rabatin@gmail.com>
+Ravi charan <ravicharan.vsp@gmail.com>
+Ravindu-Hirimuthugoda <ravindu.18@cse.mrt.ac.lk>
+Ray Cathcart <github@cathcart.us> <pix2@_nospam_.cathcart.us>
+Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuy.(none)>
+Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuyJr.(none)>
+Raymond Wong <rayman_407@yahoo.com> <rayman@CoolGuyJr>
+Rehas Sachdeva <aquannie@gmail.com>
+Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redeboer@gmx.com>
+Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redeboer@outlook.com>
+Renato Coutinho <renato.coutinho@gmail.com>
+Renato Orsino <renato.orsino@gmail.com>
+Rhea Parekh <rheaparekh12@gmail.com>
+Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
+Riccardo Gori <goriccardo@gmail.com>
+Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
+Rich LaSota <rjlasota@gmail.com>
+Richard Osborn <richardosborn@mac.com>
+Richard Otis <richard.otis@outlook.com> <ovolve@users.noreply.github.com>
+Richard Otis <richard.otis@outlook.com> <richard.otis@jpl.nasa.gov>
+Richard Rodenbusch <rrodenbusch@gmail.com> rrodenbusch <rrodenbusch@gmail.com>
+Richard Samuel <98638849+samuelard7@users.noreply.github.com>
+Richard Samuel <samuelrichard214@gmail.com>
+Rick Muller <rpmuller@gmail.com>
+Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
+Riley Britten <nrb1324@hotmail.com>
+Rimi <rimibis@umich.edu>
+Rishabh Chordiya <rishabh.arceus@gmail.com> <96073601+rishabhc33@users.noreply.github.com>
+Rishabh Daal <rishabhdaal@gmail.com>
+Rishabh Dixit <rishabhdixit11@gmail.com>
+Rishabh Kamboj <111004091+VectorNd@users.noreply.github.com> VectorNd <rishabh.kamboj.eee21@itbhu.ac.in>
+Rishabh Madan <rishabhmadan96@gmail.com>
+Rishat Iskhakov <iskhakov@frtk.ru>
+Rishav Chakraborty <annonymousxyz@outlook.com>
+Risiraj Dey <risirajdey@gmail.com> RDxR10 <risirajdey@gmail.com>
+Ritesh Kumar <ritesh99rakesh@gmail.com> riteshkumar <riteshk@uber.com>
+Ritu Raj Singh <RituRajSingh878@gmail.com> <rituraj.singh.mat17@itbhu.ac.in>
+Ritu Raj Singh <RituRajSingh878@gmail.com> Ritu Raj Singh <37741324+RituRajSingh878@users.noreply.github.com>
+Ritu Raj Singh <RituRajSingh878@gmail.com> Ritu Raj Singh <riturajsingh878@gmail.com>
+Ritu Raj Singh <RituRajSingh878@gmail.com> RituRajSingh878 <RituRajSingh878@gmail.com>
+Riyan Dhiman <Riyandhiman14@gmail.com> Riyan <43529842+Ryand1234@users.noreply.github.com>
+Rizgar Mella <rizgar.mella@gmail.com> <RizgarMella rizgar.mella@gmail.com>
+Rob Drynkin <rob.drynkin@gmail.com>
+Rob Zinkov <rob@zinkov.com>
+Robert <average.programmer@gmail.com>
+Robert Brijder <rbrijder@gmail.com> rbrijder <35840674+rbrijder@users.noreply.github.com>
+Robert Cimrman <cimrman3@ntc.zcu.cz> <robert.cimrman@gmail.com>
+Robert Dougherty-Bliss <robert.w.bliss@gmail.com>
+Robert Johansson <jrjohansson@gmail.com>
+Robert Kern <robert.kern@gmail.com>
+Robert Pollak <robert.pollak@posteo.net> Robert Pollak <robert.pollak@jku.at>
+Robert Schwarz <lethargo@googlemail.com> lethargo <devnull@localhost>
+Roberto Colistete, Jr. <roberto.colistete@gmail.com>
+Roberto Díaz Pérez <r.r.1994a@gmail.com>
+Roberto Nobrega <rwnobrega@gmail.com>
+Robin Neatherway <robin.neatherway@gmail.com>
+Robin Richard <raisin@ecomail.fr> Nornort <francois.lalleve@laposte.net>
+Robin Richard <raisin@ecomail.fr> robinechuca <61911191+robinechuca@users.noreply.github.com>
+Robin Richard <raisin@ecomail.fr> robinechuca <raisin@ecomail.fr>
+Rodrigo Luger <rodluger@gmail.com>
+Roelof Rietbroek <r.rietbroek@utwente.nl> Roelof Rietbroek <strawpants@users.noreply.github.com>
+Rohit Jain <rohitjain3241@gmail.com>
+Rohit Rango <rohit.rango@gmail.com>
+Rohit Sharma <31184621+rohitx007@users.noreply.github.com>
+Roland Dixon <rols121@gmail.com>
+Roland Puntaier <roland.puntaier@chello.at>
+Rom le Clair <jacen.guardian@gmail.com>
+Roman Inflianskas <infroma@gmail.com>
+Ronan Lamy <ronan.lamy@gmail.com> <Ronan.Lamy@normalesup.org>
+Rudr Tiwari <rudrtiwari@gmail.com>
+Rupesh Harode <rupeshharode@gmail.com>
+Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
+Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>
+Russell Fordyce <rfordyce@expressive-py.org> <6064285+rfordyce@users.noreply.github.com>
+Russell Fordyce <rfordyce@expressive-py.org> <rfordyce@users.noreply.github.com>
+Ryan Krauss <ryanlists@gmail.com>
+Rémy Léone <rleone@online.net>
+S. Hanko <suzy.hanko@gmail.com>
+S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
+S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
+S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
+Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
+Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>
+Sachin Agarwal <sachinagarwal0499@gmail.com> sachin-4099 <sachinagarwal0499@gmail.com>
+Sachin Irukula <sachin.irukula@gmail.com>
+Sachin Joglekar <srjoglekar246@gmail.com>
+Sachin Joglekar <srjoglekar246@gmail.com> <root@sachin-Inspiron-5520.(none)>
+Sachin Singh <sachinishu02@gmail.com> sachinSingh16-09 <sachinishu02@gmail.com>
+Safiya03 <safiyanesar@gmail.com>
+Sagar Bharadwaj <sagarbharadwaj50@gmail.com>
+Sagar231 <sagarfeb298@gmail.com>
+Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Sai Kiran P <parnandi.saikiran@gmail.com> saikiranp-24 <parnandi.saikiran@gmail.com>
+Sai Nikhil <tsnlegend@gmail.com>
+Sai Udayagiri <saibabu.udayagiri@gmail.com> <144413200+saiudayagiri@users.noreply.github.com>
+Sai Udayagiri <saibabu.udayagiri@gmail.com> Sai Udayagiri <saibabu.udayagiri@email.com>
+Saicharan <62512681+saicharan2804@users.noreply.github.com>
+Saicharan <saicharanhahaha@gmail.com>
+Saikat Das <saikatdchhe@gmail.com>
+Saket Kumar Singh <saketkumar1202@gmail.com>
+Saketh <alurusaisaketh@gmail.com>
+Sakirul Alam <binarysakir@gmail.com>
+Saksham Alok <sakshamalok13@gmail.com> Saksham-13 <sakshamalok13@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg> SalahDin Rezk <salah2112004@gmail.com>
+SalahDin Rezk <s-salahdin.rezk@zewailcity.edu.eg> salastro <salah2112004@gmail.com>
+Salil Vishnu Kapur <salilvishnukapur@gmail.com>
+Salmista-94 <alejandrogroso@hotmail.com> alejandrogroso@hotmail.com <Salmista-94>
+Saloni Jain <tosalonijain@gmail.com>
+Sam Brockie <sambrockie@icloud.com>
+Sam Lubelsky <sammy56lt@gmail.com> SamLubelsky <78610785+SamLubelsky@users.noreply.github.com>
+Sam Lubelsky <sammy56lt@gmail.com> SamLubelsky <sammy56lt@gmail.com>
+Sam Magura <samtheman132@gmail.com>
+Sam Ritchie <sam@mentat.org> sritchie09 <sritchie09@gmail.com>
+Sam Sleight <samuel.sleight@gmail.com>
+Sam Tygier <sam.tygier@hep.manchester.ac.uk>
+Sambuddha Basu <sammygamer@live.com>
+Samesh <samesh.lakhotia@gmail.com> Samesh Lakhotia <43701530+sameshl@users.noreply.github.com>
+Samesh Lakhotia <samesh.lakhotia@gmail.com> Samesh Lakhotia <samesh.lakhotia@gmail.com>
+Samith Karunathilake <55777141+samithkavishke@users.noreply.github.com> samithkavishke <55777141+samithkavishke@users.noreply.github.com>
+Samnan Rahee <namanush.rsr.16@gmail.com>
+Sampad Kumar Saha <sampadsaha5@gmail.com>
+Samyak Jain <samyak.jain2016a@vitstudent.ac.in> Samyak Jain <samtan106@gmail.com>
+Sandeep Murthy <smurthy@protonmail.ch>
+Sandeep Veethu <sandeep.veethu@gmail.com>
+Sanket Agarwal <sanket@sanketagarwal.com>
+Sanya Khurana <sanya@monica.in>
+Saptarshi Mandal <sapta.iitkgp@gmail.com>
+Saroj Adhikari <adh.saroj@gmail.com>
+Sartaj Singh <singhsartaj94@gmail.com>
+Sarwar Chahal <chahal.sarwar98@gmail.com>
+Satya Prakash Dwibedi <akash581050@gmail.com>
+Saurabh Agarwal <shourabh.agarwal@gmail.com>
+Saurabh Jha <saurabh.jhaa@gmail.com>
+Sayan Goswami <Sayan98@users.noreply.github.com>
+Sayan Mitra <ee18b156@smail.iitm.ac.in>
+Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>
+Sean Ge <seange727@gmail.com>
+Sean P. Cornelius <spcornelius@gmail.com>
+Sean Vig <sean.v.775@gmail.com>
+Seb Tiburzio <sebtiburzio@gmail.com>
+Sebastian East <sebastianeast@ymail.com> sebastian-east <sebastianeast@ymail.com>
+Sebastian Koslowski <koslowski@kit.edu>
+Sebastian Krause <sebastian.krause@gmx.de>
+Sebastian Kreft <skreft@gmail.com>
+Sebastian Krämer <basti.kr@gmail.com> basti.kr <devnull@localhost>
+Segev Finer <segev208@gmail.com>
+Ser Kim <serk.kmh@gmail.com> SK <78915702+sskserk@users.noreply.github.com>
+Sergey B Kirpichev <skirpichev@gmail.com>
+Sergey Pestov <pestov-sa@yandex.ru>
+Sergiu Ivanov <unlimitedscolobb@gmail.com>
+Seshagiri Prabhu <seshagiriprabhu@gmail.com>
+Seth Ebner <murgrehk@gmail.com>
+Seth Poulsen <poulsenseth@yahoo.com>
+Seth Troisi <sethtroisi@google.com>
+Shahid Rahaman <shahidrahman333@gmail.com> <44476706+shahid-rahaman@users.noreply.github.com>
+Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
+Shaoliang Jin <18322825326@163.com> 0382 <18322825326@163.com>
+Shaoliang Jin <18322825326@163.com> jinshaoliang <18322825326@163.com>
+Shashank Agarwal <shashank.agarwal94@gmail.com>
+Shashank KS <shashankks0987@gmail.com> Shashank KS <shashankks@sahaj.ai>
+Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
+Shekhar Prasad Rajak <shekharrajak@live.com> <shekharstudy@ymail.com>
+Shekhar Prasad Rajak <shekharrajak@live.com> shekharrajak <shekharrajak@live.com>
+Sherjil Ozair <sherjilozair@gmail.com>
+Shikhar Jaiswal <jaiswalshikhar87@gmail.com>
+Shikhar Makhija <shikharmakhija2@gmail.com>
+Shipra Banga <bangashipra@gmail.com>
+Shishir Kushwaha <138311586+shishir-11@users.noreply.github.com> shishir-11 <kushwahashishir1112@gmail.com>
+Shishir Kushwaha <kushwahashishir1112@gmail.com>
+Shishir Kushwaha <kushwahashishir1112@gmail.com> shishir-11 <138311586+shishir-11@users.noreply.github.com>
+Shital Mule <shitalmule04@gmail.com>
+Shivam Agarwal <knowthyself2503@gmail.com>
+Shivam Sagar <technoshivam12@gmail.com> Shivam Sagar <77241314+hey-sagar@users.noreply.github.com>
+Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
+Shivam Vats <shivamvats.iitkgp@gmail.com> <aries@aries-Inspiron-3521.(none)>
+Shivam Vats <shivamvats.iitkgp@gmail.com> <shivamhzb@gmail.com>
+Shivang Dubey <shivangdubey8@gmail.com>
+Shivani Kohli <shivanikohli.09@gmail.com>
+Shiyao Guo <mivikq@gmail.com> Mivik <54128043+Mivik@users.noreply.github.com>
+Shiyao Guo <mivikq@gmail.com> Mivik <mivikq@gmail.com>
+Shravas K Rao <shravas@gmail.com>
+Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
+Shruti Mangipudi <shruti2395@gmail.com>
+Shuai Zhou <shuaivzhou@berkeley.edu>
+Shubham Abhang <shubhamabhang77@gmail.com>
+Shubham Agrawal <shubham.ag6845@gmail.com>
+Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
+Shubham Maheshwari <rmaheshwari05@gmail.com>
+Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
+Shubham Tibra <shubh.tibra@gmail.com>
+Siddhanathan Shanmugam <siddhanathan@gmail.com>
+Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
+Siddhant Jain <getsiddhant@gmail.com>
+Siddhant Jain <siddhantashoknagar@gmail.com> Siddhant Jain <77455093+me-t1me@users.noreply.github.com>
+Siddhant Jain <siddhantashoknagar@gmail.com> me-t1me <siddhantashoknagar@gmail.com>
+Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpal@users.noreply.github.com>
+Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
+Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
+Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
+Simon Sørensen <simonblsoerensen@gmail.com>
+Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <61250140+zarstensen@users.noreply.github.com>
+SirJohnFranklin <sirjfu@googlemail.com>
+Smit Gajjar <smitgajjar.gs@gmail.com>
+Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit Lunagariya <55887635+Smit-create@users.noreply.github.com>
+Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit-create <55887635+Smit-create@users.noreply.github.com>
+Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit-create <smitlunagariya.mat18@itbhu.ac.in>
+Sneha Goddu <s.goddu@wustl.edu>
+Soniya Nayak <soniyanayak51@gmail.com> Soniyanayak51 <39791511+Soniyanayak51@users.noreply.github.com>
+Sophia Pustova <tripplezzed@gmail.com>
+Soumendra Ganguly <soumendraganguly@gmail.com>
+Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>
+Soumya Dipta Biswas <sdb1323@gmail.com>
+Soumya Sakshi <s1december2005@gmail.com>
+Sourav Ghosh <souravghosh2197@gmail.com>
+Sourav Goyal <souravgl0@gmail.com>
+Sourav Singh <souravsingh@users.noreply.github.com>
+Srajan Garg <srajan.garg@gmail.com>
+Srinivas Vasudevan <srvasude@gmail.com>
+Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Arun Yeragudipati <ysarun1999@gmail.com>
+Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Srinivasa Arun Yeragudipati <38272686+arun-y99@users.noreply.github.com>
+Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> arun <ysarun1999@gmail.com>
+Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> arun-y99 <ysarun1999@gmail.com>
+Stan Schymanski <stan.schymanski@env.ethz.ch>
+Stas Kelvich <stanconn@gmail.com>
+Stefan Behnle <84378403+behnle@users.noreply.github.com>
+Stefan Krastanov <krastanov.stefan@gmail.com>
+Stefan Petrea <stefan@garage-coding.com>
+Stefan van der Walt <stefan@sun.ac.za>
+Stefano Maggiolo <s.maggiolo@gmail.com>
+Stefen Yin <zqyin@ucdavis.edu>
+Stepan Roucka <stepan@roucka.eu>
+Stepan Simsa <simsa.st@gmail.com>
+Steph Papanik <spapanik21@gmail.com>
+Stephan Seitz <stephan.seitz@fau.de>
+Stephen Loo <shikil@yahoo.com>
+Steve Anton <anxuiz.nx@gmail.com>
+Steve Kieffer <sk@skieffer.info>
+Steve Wolfman <steven.wolfman@gmail.com> <wolf@mail.ubc.ca>
+Steven Burns <royalstream@hotmail.com>
+Steven Esquea <steven.esquea@irreverente.net>
+Steven Lee <stevenlee123@protonmail.com> <41497963+stevenleeS0ht@users.noreply.github.com>
+Stewart Wadsworth <stewart.wadsworth@gmail.com>
+Subhash Saurabh <subhashsaurabh419@gmail.com>
+Sudarshan Kamath <sudarshan.kamath97@gmail.com>
+Sudeep Sidhu <sudeepmanilsidhu@gmail.com> sidhu1012 <sudeepmanilsidhu@gmail.com>
+Sudhanshu Mishra <mrsud94@gmail.com>
+Sujal Kumar <sujaljayantkumar06@gmail.com> Sujal Kumar <91939382+SujalKumar06@users.noreply.github.com>
+Suman mondal <smondal.qwerty@gmail.com>
+Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
+Sumith Kulal <sumith1896@gmail.com>
+Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
+Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
+Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
+Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
+Sushant Hiray <hiraysushant@gmail.com>
+Susumu Ishizuka <susumu.ishizuka@kii.com>
+Swapnil Agarwal <swapnilag29@gmail.com>
+Szymon Mieszczak <szymon.mieszczak@gmail.com>
+Takafumi Arakaki <aka.tkf@gmail.com>
+Takumasa Nakamura <n.takumasa@gmail.com>
+Tanay Agrawal <tanay_agrawal@hotmail.com>
+Tanmay Rath <rathjyotshna@gmail.com> DeadlyPancakes45 <rathjyotshna@gmail.com>
+Tanmay Rath <rathjyotshna@gmail.com> Tanmay Rath <144689448+Tanthetaa45@users.noreply.github.com>
+Tanu Hari Dixit <tokencolour@gmail.com>
+Tarang Patel <tarangrockr@gmail.com> <tarang@ubuntu.ubuntu-domain>
+Tarun Gaba <tarun.gaba7@gmail.com>
+Tasha Kim <jae_young_kim@brown.edu>
+Taylan Sahin <info@taylansahin.net>
+Ted Dokos <tdokos@gmail.com> <t.dokos@gmail.com>
+Ted Horst <ted.horst@earthlink.net>
+Tejaswini Sanapathi <sastejaswini2002@gmail.com>
+Temiloluwa Yusuf ytemiloluwa@gmail.com Temi <ytemiloluwa@gmail.com>
+Temiloluwa Yusuf ytemiloluwa@gmail.com ytemiloluwa <ytemiloluwa@gmail.com>
+Thangaraju Sibiraj <85477603+t-sibiraj@users.noreply.github.com> Sibi <85477603+t-sibiraj@users.noreply.github.com>
+Tharupahan Jayawardana <tharupahanjayawardana@gmail.com> tharu-jwd <tharupahanjayawardana@gmail.com>
+Theodore Dias <theodore.dias@hotmail.co.uk>
+Theodore Han <theodorehan@hotmail.com> <theodorehan373@gmail.com>
+Theodore Han <theodorehan@hotmail.com> <tqhan317@gmail.com>
+Thilina Rathnayake <thilinarmtb@gmail.com>
+Thomas A Caswell <tcaswell@gmail.com>
+Thomas Aarholt <thomasaarholt@gmail.com>
+Thomas Baruchel <baruchel@gmx.com>
+Thomas Dixon <thom@thomdixon.org>
+Thomas Hickman <Thomas.Hickman42@gmail.com>
+Thomas Hisch <t.hisch@gmail.com> <thomas.hisch@ims.co.at>
+Thomas Hisch <t.hisch@gmail.com> <thomas.hisch@tuwien.ac.at>
+Thomas Hunt <thomashunt13@gmail.com> <twhunt@users.noreply.github.com>
+Thomas Sidoti <TSidoti@gmail.com>
+Thomas Wiecki <thomas.wiecki@gmail.com> <thomas.wieki@gmail.com>
+Thomas Wiecki <thomas.wiecki@gmail.com> <whyking@Lateralus.(none)>
+Tien Nguyen <viettien23102006@gmail.com> <95487001+tiennguyen2310@users.noreply.github.com>
+Tiffany Zhu <bubble.wubble.303@gmail.com>
+Tilo Reneau-Cardoso <tiloreneau@gmail.com> Tilo Reneau-Cardoso <67246777+TiloRC@users.noreply.github.com>
+Tim Gates <tim.gates@iress.com>
+Tim Lahey <tim.lahey@gmail.com>
+Tim Swast <tswast@gmail.com>
+Timo Stienstra <timostienstra00@gmail.com> TJStienstra <T.J.Stienstra@student.tudelft.nl>
+Timo Stienstra <timostienstra00@gmail.com> TJStienstra <timostienstra00@gmail.com>
+Timo Stienstra <timostienstra00@gmail.com> Timo Stienstra <97806294+TJStienstra@users.noreply.github.com>
+Timothy Cyrus <tcyrus@users.noreply.github.com>
+Timothy Reluga <treluga@math.psu.edu> <tcr-public2@psu.edu>
+Timothy Reluga <treluga@math.psu.edu> me <none@none>
+Tirthankar Mazumder <63574588+wermos@users.noreply.github.com>
+TitanSnow <sweeto@live.cn>
+Tobias Lenz <t_lenz94@web.de>
+Tom Bachmann <e_mc_h2@web.de> <ness987@googlemail.com>
+Tom Fryers <61272761+TomFryers@users.noreply.github.com>
+Tom Gijselinck <tomgijselinck@gmail.com>
+Tom van Woudenberg <t.r.vanwoudenberg@tudelft.nl>
+Tomasz Buchert <thinred@gmail.com>
+Tomasz Pytel <tompytel@gmail.com>
+Tommaso Vaccari <05-gesto-follemente@icloud.com> T-vaccari <05-gesto-follemente@icloud.com>
+Tommy Olofsson <tommy.olofsson.90@gmail.com>
+Tomo Lazovich <lazovich@gmail.com>
+Tomáš Bambas <tomas.bambas@gmail.com>
+Toon Verstraelen <Toon.Verstraelen@UGent.be> <toon.verstraelen@gmail.com>
+Toon Verstraelen <Toon.Verstraelen@UGent.be> <toon.verstraelen@ugent.be>
+Travis Ens <ens.travis@gmail.com>
+Tristan Hume <tris.hume@gmail.com>
+TrungPQ <trungpqhe171493@gmail.com> XLR8 <86862725+AcceleratorHTH@users.noreply.github.com>
+Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
+Tuan Manh Lai <laituan245@gmail.com>
+Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
+Tyler Pirtle <teeler@gmail.com>
+Unknown <kunda@scribus.net>
+Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
+Uwe L. Korn <uwelk@xhochy.com>
+V1krant <46847915+V1krant@users.noreply.github.com>
+Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
+Vaishnav Damani <vaishnavdamani3496@gmail.com>
+Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
+Varun Garg <varun.garg03@gmail.com>
+Varun Joshi <joshi.142@osu.edu>
+Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
+Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
+Vasiliy Dommes <vasdommes@gmail.com>
+Vasily Povalyaev <vapovalyaev@gmail.com>
+Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
+Vedant Kadam <vedantkadam3498@gmail.com>
+Vedant Rathore <vedantr1998@gmail.com>
+Vedarth Sharma <vedarth.sharma@gmail.com>
+Velibor Zeli <velibor@mech.kth.se>
+Venkatesh Halli <venkatesh.fatality@gmail.com>
+Vera Lozhkina <veralozhkina@gmail.com>
+Versus Void <versusvoid@gmail.com>
+ViacheslavP <public.viacheslav@gmail.com>
+Victor Brebenar <v.brebenar@gmail.com>
+Victor Immanuel <chrollolucilfer1402@gmail.com> victor immanuel <89346667+victorchrollo14@users.noreply.github.com>
+Victoria Koval <bictoriakoval16@gmail.com> vicoolchik <bictoriakoval16@gmail.com>
+Victoria Koval <bictoriakoval16@gmail.com> viktoria_koval <78905683+vicoolchik@users.noreply.github.com>
+Victory Omole <vtomole2@gmail.com>
+Vighnesh Shenoy <vighneshq@gmail.com>
+Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijair <vijair@umich.edu>
+Vijairam Ganesh Moorthy <vijairamg@gmail.com> vijairam20 <vijairamg@gmail.com>
+Vikrant Malik <vikrantmalik051@gmail.com> Vikrant <vikrant@Vikrant.local>
+Vikrant Malik <vikrantmalik051@gmail.com> Vikrant <vikrantmalik051@gmail.com>
+Vinay Kumar <gnulinooks@gmail.com>
+Vinay Singh <csvinay.d@gmail.com> <vinay.035.kumar@gmail.com>
+Vincent Delecroix <vincent.delecroix@labri.fr>
+Vinit Ravishankar <vinit.ravishankar@gmail.com>
+Vinzent Steinberg <vinzent.steinberg@gmail.com> <Vinzent.Steinberg@gmail.com>
+Vinzent Steinberg <vinzent.steinberg@gmail.com> <vinzent.steinberg@googlemail.com>
+Viraj Palnitkar <virajpalnitkar@gmail.com> <167699246+VirajPalnitkar@users.noreply.github.com>
+Viraj Vekaria <virajv5593@gmail.com>
+Vishal <vishalg2235@gmail.com>
+Vishesh Mangla <manglavishesh64@gmail.com>
+Vivek Gaddam <vivek.gaddam2005@gmail.com>
+Vivek Gaddam <vivek.gaddam2005@gmail.com> <154349504+VivekGaddam@users.noreply.github.com>
+Vivek Gaddam <vivek.gaddam2005@gmail.com> vivekgaddam <vivek.gaddam2005@gmail.com>
+Vivek Soni <sonisheela1977@gmail.com>
+Vlad Seghete <vlad.seghete@gmail.com>
+Vladimir Lagunov <werehuman@gmail.com>
+Vladimir Perić <vlada.peric@gmail.com>
+Vladimir Poluhsin <vovapolu@gmail.com>
+Vladimir Sereda <voffch@gmail.com>
+Voaides Negustor Robert <134785947+voaidesr@users.noreply.github.com> <voaides.r@yahoo.com>
+Waldir Pimenta <waldyrious@gmail.com>
+Wang Ran (汪然) <wangr@smail.nju.edu.cn>
+Warren Jacinto <warrenjacinto@gmail.com>
+Wes Galbraith <galbwe92@gmail.com>
+Wes Turner <50891+westurner@users.noreply.github.com>
+Willem Melching <willem.melching@gmail.com>
+Wolfgang Stöcher <wolfgang@stoecher.com> coproc <wolfgang@stoecher.com>
+Wonsik Jung <algrthm@umich.edu> wonsik99 <algrthm@umich.edu>
+Wyatt Peak <wyattpeak@gmail.com>
+Xiang Wu <hsiangwu@fb.com>
+Xiao <muzumayao@126.com> Xiao <88570037+T90REAL@users.noreply.github.com>
+Xiao <muzumayao@126.com> Xiao <muzumayao@126.com>
+Yang Yang <wdscxsj@gmail.com>
+Yaser AlOsh <yaseralosh@outlook.com> Yaser <yaseralosh@outlook.com>
+Yash Reddy <write2yashreddy@gmail.com>
+Yathartha Joshi <yathartha32@gmail.com>
+Yatna Verma <yatnavermaa@gmail.com> yatna <yatnavermaa@gmail.com>
+Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
+Yeshwanth N <yeshsurya@gmail.com> <yeshwanth.nagaraj@aptean.com>
+YiDing Jiang <yidinggjiangg@gmail.com>
+Yicong Guo <guoyicong100@gmail.com>
+Yogesh Mishra <ymishra013@gmail.com> yogesh1997 <ymishra013@gmail.com>
+Your Name <your.email@example.com>
+Yu Kobayashi <yukoba@accelart.jp>
+Yukai Chou <muzimuzhi@gmail.com> muzimuzhi <muzimuzhi@gmail.com>
+Yuki Matsuda <yuki.matsuda.w@gmail.com>
+Yuri Karadzhov <yuri.karadzhov@gmail.com>
+Yuriy Demidov <iurii.demidov@gmail.com>
+Yury G. Kudryashov <urkud.urkud@gmail.com>
+Yves Tumushimire <yvestumushimire@gmail.com>
+Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zach <20629897+craymichael@users.noreply.github.com>
+Zach Carmichael <20629897+craymichael@users.noreply.github.com> Zachariah Carmichael <20629897+craymichael@users.noreply.github.com>
+Zach Raines <raineszm@gmail.com>
+Zachariah Etienne <zachetie@gmail.com>
+Zamrath Nizam <zamiguy_ni@yahoo.com> <zamiguy.ni@gmail.com>
+Zaz Brown <zazbrown@zazbrown.com>
+Zedmat <104870914+harshkasat@users.noreply.github.com>
+Zeel Shah <kshah215@gmail.com>
+Zer0Credibility <cmr57@cam.ac.uk>
+Zexuan Zhou (Bruce) <zzx498636727@gmail.com>
+Zhenxu Zhu <xzdlj@outlook.com> xzdlj <xzdlj@outlook.com>
+Zhi-Qiang Zhou <zzq_890709@hotmail.com> zhouzq-thu <zzq_890709@hotmail.com>
+Zhongshi <zj495@nyu.edu>
+Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <123136644+zylipku@users.noreply.github.com>
+Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <zy.li@stu.pku.edu.cn>
+Zlatan Vasović <zlatanvasovic@gmail.com>
+Zoufiné Lauer-Baré <raszoufine@gmail.com> Zoufiné Lauer-Baré <82505312+zolabar@users.noreply.github.com>
+Zoufiné Lauer-Baré <raszoufine@gmail.com> zolabar <raszoufine@gmail.com>
+Zouhair <zouhair.mahboubi@gmail.com>
+Zulfikar <zulfikar97@gmail.com>
+abhinav28071999 <41710346+abhinav28071999@users.noreply.github.com>
+adhoc-king <46354827+adhoc-king@users.noreply.github.com>
+aditisingh2362 <aditisingh2362@gmail.com>
+akshaytheflash <akshayrajhans053@gmail.com> <akshaytheflash@gmail.com>
+alejandro <amartinhernan@gmail.com>
+alijosephine <alijosephine@gmail.com>
+amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
+anca-mc <anca-mc@users.noreply.github.com>
+andreo <andrey.torba@gmail.com>
+arooshiverma <av22@iitbbs.ac.in>
+atharvParlikar <atharvparlikar@gmail.com>
+bharatAmeria <21001019007@jcboseust.ac.in> bharatAmeria <147488804+bharatAmeria@users.noreply.github.com>
+bluebrook <perl4logic@gmail.com>
+carstimon <carstimon@gmail.com>
+ck Lux <lux.r.ck@gmail.com>
+cocolato <haiizhu@outlook.com> Hai Zhu <35182391+cocolato@users.noreply.github.com>
+codecruisader <nnisarg55@gmail.com>
+cym1 <16437732+cym1@users.noreply.github.com>
+damianos <damianos@semmle.com>
+dandiez <47832466+dandiez@users.noreply.github.com>
+der-blaue-elefant <github@kklein.de>
+dimasvq <dimas.vq.2020@bristol.ac.uk>
+dispasha <dispasha@users.noreply.github.com>
+dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.com>
+dps7ud <dps7ud@virginia.edu>
+dranknight09 <cbhaavan@gmail.com>
+dustyrockpyle <dustyrockpyle@gmail.com>
+elvis-sik <e.sikora@grad.ufsc.br>
+erdOne <36414270+erdOne@users.noreply.github.com>
+extraymond <extraymond@gmail.com>
+faizan2700 <syedfaizan824@gmail.com>
+fazledyn-or <ataf@openrefactory.com>
+foice <foice.news@gmail.com>
+goddus <39923708+goddus@users.noreply.github.com>
+gregmedlock <gmedlo@gmail.com>
+helo9 <helo9@users.noreply.github.com>
+hm <hacman0@gmail.com>
+immerrr <immerrr@gmail.com>
+jerryma1121 <jerryma1121@gmail.com>
+jgulian <josephdgulian@gmail.com>
+jhanwar <f2015463@pilani.bits-pilani.ac.in>
+kamimura <kamimura@live.jp>
+kangzhiq <709563092@qq.com> <32410422+kangzhiq@users.noreply.github.com>
+kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
+kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
+kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
+klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+lastcodestanding <rohang71604@gmail.com>
+latot <felipematas@yahoo.com>
+leastloris <ivedants05@gmail.com>
+luzpaz <luzpaz@users.noreply.github.com> luz paz <luzpaz@pm.me>
+luzpaz <luzpaz@users.noreply.github.com> luz.paz <luzpaz@users.noreply.github.com>
+mao8 <thisisma08@gmail.com>
+mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
+mohammedouahman <simofun85@gmail.com>
+mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>
+naelsondouglas <naelson17@gmail.com>
+noam simcha finkelstein <noam.finkelstein@protonmail.com>
+numbermaniac <5206120+numbermaniac@users.noreply.github.com>
+oittaa <8972248+oittaa@users.noreply.github.com>
+omahs <73983677+omahs@users.noreply.github.com>
+oxygen dioxide <54425948+oxygen-dioxide@users.noreply.github.com>
+pekochun <hamburg_hamburger2000@yahoo.co.jp>
+philwillnyc <56197213+philwillnyc@users.noreply.github.com>
+phipf <phipf@online.de>
+platypus <platypus.computerchip@gmail.com>
+prshnt19 <prashant.rawat216@gmail.com>
+rahil-amin <rahilamin201@gmail.com>
+rahuldan <rahul02013@gmail.com>
+ramvenkat98 <ramvenkat98@gmail.com>
+rathmann <rathmann.os@gmail.com> <peter@ubuntu.ubuntu-domain>
+rationa-kunal <kunalgk1999@gmail.com> kunal <kunalgk1999@gmail.com>
+rationa-kunal <kunalgk1999@gmail.com> kunal <kunalgk1999@protonmail.com>
+rbl <rlee@grove.co>
+richierichrawr <richierichrawr@users.noreply.github.com>
+rimibis <33387803+rimibis@users.noreply.github.com>
+risubaba <risubhjain1010@gmail.com>
+ritikBhandari <ritikbhandari68@gmail.com>
+rushyam <rushyamsonu@gmail.com>
+sbt4104 <sthorat661@gmail.com>
+scimax <max.kellermeier@hotmail.de>
+seadavis <45022599+seadavis@users.noreply.github.com>
+sevaader <sevaader@gmail.com>
+sfoo <sfoohei@gmail.com>
+sharma-kunal <kunalsharma6914@gmail.com>
+shiksha11 <shiksharawat01@gmail.com> shiksha11 <33157995+shiksha11@users.noreply.github.com>
+shruti <shrutishrm512@gmail.com>
+shubhayu09 <guptashubhayu601@gmail.com> shubhayu09 <87441886+shubhayu09@users.noreply.github.com>
+sirnicolaf <43586954+sirnicolaf@users.noreply.github.com>
+slacker404 <pchantza@gmail.com>
+soumi7 <soumibardhan10@gmail.com>
+symbolique <symbolique@users.noreply.github.com>
+tborisova <ts.borisova3@gmail.com> <ts_borisova@abv.bg>
+tnzl <you@example.com>
+tools4origins <tools4origins@gmail.com>
+tttc3 <T.Coxon2@lboro.ac.uk>
+user202729 <25191436+user202729@users.noreply.github.com>
+vedantc98 <vedantc98@gmail.com>
+vezeli <37907135+vezeli@users.noreply.github.com>
+viocha <66580331+viocha@users.noreply.github.com>
+vishal <vishal.panjwani15@gmail.com>
+w495 <w495@yandex-team.ru>
+wookie184 <wookie1840@gmail.com>
+wuyudi <wuyudi119@163.com>
+xndcn <xndchn@gmail.com>
+ylemkimon <ylemkimon@naver.com> <mail@ylem.kim>
+znxftw <vishnu2101@gmail.com>
+zsc347 <zsc347@gmail.com>
+zzc <1378113190@qq.com> zzc <58017008+zzc0430@users.noreply.github.com>
+zzj <29055749+zjzh@users.noreply.github.com>
+Élie Goudout <eliegoudout@hotmail.com> eliegoudout <114467748+eliegoudout@users.noreply.github.com>
+Óscar Nájera <najera.oscar@gmail.com>
+Øyvind Jensen <jensen.oyvind@gmail.com>
+Łukasz Pankowski <lukpank@o2.pl>
+彭于斌 <1931127624@qq.com>
+袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Ajinesh Pratap Singh <ajineshpratap@gmail.com>
+Ajinesh Pratap Singh <152050389+ajinesh703@users.noreply.github.com> Ajinesh Pratap Singh <ajineshpratap@gmail.com>

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import itertools
+from typing import TYPE_CHECKING
+
 from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import Integer, Rational
 from sympy.core.singleton import S
@@ -7,8 +9,10 @@ from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
 from sympy.utilities.misc import as_int
 
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
-def continued_fraction(a) -> list:
+def continued_fraction(a: object) -> list:
     """Return the continued fraction representation of a Rational or
     quadratic irrational.
 
@@ -57,7 +61,8 @@ def continued_fraction(a) -> list:
                     a = S.Zero
                     bc = p
                 if a.is_Integer:
-                    b = S.NaN
+                    b: Expr = S.NaN
+                    c: Expr = S.NaN
                     if bc.is_Mul and len(bc.args) == 2:
                         b, c = bc.args
                     elif bc.is_Pow:
@@ -72,7 +77,7 @@ def continued_fraction(a) -> list:
     raise ValueError(f"expecting a rational or quadratic irrational, not {e}")
 
 
-def continued_fraction_periodic(p, q, d=0, s=1) -> list:
+def continued_fraction_periodic(p: int | Expr, q: int | Expr, d: int | Expr = 0, s: int | Expr = 1) -> list:
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
@@ -152,7 +157,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
         p, q, s = -p, -q, -s
 
     n = (p + s*sd)/q
-    if n < 0:
+    if n.is_negative:
         w = floor(-n)
         f = -n - w
         one_f = continued_fraction(1 - f)  # 1-f < 1 so cf is [0 ... [...]]
@@ -168,7 +173,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
         p *= q
         q *= q
 
-    terms: list[int] = []
+    terms: list[Expr] = []
     pq = {}
 
     while (p, q) not in pq:
@@ -181,7 +186,7 @@ def continued_fraction_periodic(p, q, d=0, s=1) -> list:
     return terms[:i] + [terms[i:]]  # type: ignore
 
 
-def continued_fraction_reduce(cf):
+def continued_fraction_reduce(cf: object) -> Expr:
     """
     Reduce a continued fraction to a rational or quadratic irrational.
 
@@ -256,7 +261,7 @@ def continued_fraction_reduce(cf):
     return rv
 
 
-def continued_fraction_iterator(x):
+def continued_fraction_iterator(x: Expr):
     """
     Return continued fraction expansion of x as iterator.
 
@@ -300,7 +305,7 @@ def continued_fraction_iterator(x):
         x = 1/x
 
 
-def continued_fraction_convergents(cf):
+def continued_fraction_convergents(cf: object):
     """
     Return an iterator over the convergents of a continued fraction (cf).
 


### PR DESCRIPTION
### Summary

This PR fixes an issue in `continued_fraction_periodic` where symbolic inputs could cause a runtime error during comparison.

### What was happening

The code used a direct comparison:
```python
if n < 0:
```

When `n` was a symbolic SymPy expression (e.g., `Symbol('n')`), this raised a `TypeError` because symbolic comparisons are not directly supported.

### Fix applied

Replaced the comparison with `.is_negative` property:
```python
if n.is_negative:
```

This is the SymPy-idiomatic way to check negativity for both numeric and symbolic inputs.

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed `TypeError` in `continued_fraction_periodic` when called with symbolic arguments by using `.is_negative` instead of `< 0` comparison. Fixes #ISSUE_NUMBER.
<!-- END RELEASE NOTES -->