### PR TITLE
Dividing Dyadic by an integer should not cast that integer to float.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -856,6 +856,7 @@ Jeremy <twobitlogic@gmail.com>
 Jeremy Monat <jemonat@calalum.org>
 Jerry James <loganjerry@gmail.com>
 Jerry Li <jerry@jerryli.ca>
+Jesse Li <jesse.li2002@gmail.com>
 Jezreel Ng <jezreel@gmail.com>
 Jiaxing Liang <liangjiaxing57@gmail.com>
 Jiaxing Liang <liangjiaxing57@gmail.com> <jiaxingl@CS-DEAL-03.cs.sfu.ca>

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sympy import sympify, Add, ImmutableMatrix as Matrix
+from sympy import sympify, Add, ImmutableMatrix as Matrix, S
 from sympy.core.evalf import EvalfMixin
 from sympy.external.mpmath import prec_to_dps
 from sympy.printing.defaults import Printable
@@ -143,7 +143,7 @@ class Dyadic(Printable, EvalfMixin):
 
     def __truediv__(self, other):
         """Divides the Dyadic by a sympifyable expression. """
-        return self.__mul__(1 / other)
+        return self.__mul__(S.One / other)
 
     def __eq__(self, other):
         """Tests for equality.

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from sympy import S
 from sympy.core.numbers import (Float, pi)
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin)
@@ -18,6 +19,7 @@ def test_dyadic():
     assert d1 != 0
     assert d1 * 2 == 2 * A.x | A.x
     assert d1 / 2. == 0.5 * d1
+    assert d1 / 3 == (S.One / 3) * d1
     assert d1 & (0 * d1) == 0
     assert d1 & d2 == 0
     assert d1 & A.x == A.x


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
`sympy.physics.vector.dyadic.Dyadic.__truediv__` will cast integer division to float, which is surprising and presumably not intentional. I've changed it to `self.__mul__(S.One / other)` to bring in line with `sympy.physics.vector.vector.Vector.__truediv__`.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Dividing Dyadic by an integer no longer casts that integer to float.
<!-- END RELEASE NOTES -->
