### PR TITLE
assumptions: Update `refine_sin_cos` to handle more simplifications

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -440,10 +440,7 @@ def refine_sin_cos(expr, assumptions):
         return AccumBounds(-1, 1)
 
     if ask(Q.zero(arg), assumptions):
-        if expr_is_sin:
-            return 0
-        else:
-            return 1
+        return 0 if expr_is_sin else 1
 
     integer_coeffs_of_pi_half = []
     remaining_terms = []

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -435,12 +435,9 @@ def refine_sin_cos(expr, assumptions):
     arg = expr.args[0]
     expr_is_sin = isinstance(expr, sin)
 
-    if ask(Q.infinite(arg), assumptions):
-        expr_is_extended_real = ask(Q.extended_real(arg), assumptions)
-        if expr_is_extended_real:
-            return AccumBounds(-1, 1)
-        elif expr_is_extended_real is False:
-            return S.NaN
+    if (ask(Q.infinite(arg), assumptions) and
+         ask(Q.extended_real(arg), assumptions)):
+        return AccumBounds(-1, 1)
 
     if ask(Q.zero(arg), assumptions):
         if expr_is_sin:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -428,10 +428,11 @@ def refine_sin_cos(expr, assumptions):
     """
     from sympy.functions.elementary.trigonometric import sin, cos
     from sympy.calculus.accumulationbounds import AccumBounds
-    arg = expr.args[0]
 
     if not isinstance(expr, (sin, cos)):
         raise TypeError("refine_sin_cos expects a sin or cos function.")
+
+    arg = expr.args[0]
     expr_is_sin = isinstance(expr, sin)
 
     if ask(Q.infinite(arg), assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -427,7 +427,22 @@ def refine_sin_cos(expr, assumptions):
     cos(x + y)
     """
     from sympy.functions.elementary.trigonometric import sin, cos
+    from sympy.calculus.accumulationbounds import AccumBounds
     arg = expr.args[0]
+    expr_is_sin = isinstance(expr, sin)
+
+    if ask(Q.infinite(arg), assumptions):
+        expr_is_extended_real = ask(Q.extended_real(arg), assumptions)
+        if expr_is_extended_real:
+            return AccumBounds(-1, 1)
+        elif expr_is_extended_real is False:
+            return S.NaN
+
+    if ask(Q.zero(arg), assumptions):
+        if expr_is_sin:
+            return 0
+        else:
+            return 1
 
     integer_coeffs_of_pi_half = []
     remaining_terms = []
@@ -461,7 +476,7 @@ def refine_sin_cos(expr, assumptions):
         return expr
 
     # Treat sin as a phase-shifted cosine so a single logic path can handle both.
-    if isinstance(expr, sin):
+    if expr_is_sin:
         k = sum_of_parity_known_coeffs - 1
         k_is_even = not sum_of_parity_known_coeffs_is_even
     else:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -429,6 +429,9 @@ def refine_sin_cos(expr, assumptions):
     from sympy.functions.elementary.trigonometric import sin, cos
     from sympy.calculus.accumulationbounds import AccumBounds
     arg = expr.args[0]
+
+    if not isinstance(expr, (sin, cos)):
+        raise TypeError("refine_sin_cos expects a sin or cos function.")
     expr_is_sin = isinstance(expr, sin)
 
     if ask(Q.infinite(arg), assumptions):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
 from sympy.assumptions.refine import refine
+from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
 from sympy.core.singleton import S
@@ -286,6 +287,18 @@ def test_sin_cos():
     assert refine(cos(x + n*pi/2 + k*pi/2 + m*pi/2), \
                   Q.odd(n) & Q.odd(k) & Q.integer(m)) == \
         (-1)**((n + k)/2) * cos(x + m*pi/2)
+
+    assert refine(cos(x), Q.zero(x)) == 1
+    assert refine(sin(x), Q.zero(x)) == 0
+
+    assert (refine(sin(x), Q.infinite(x) & Q.extended_real(x)) ==
+        AccumBounds(-1, 1))
+    assert (refine(cos(x), Q.infinite(x) & Q.extended_real(x)) ==
+        AccumBounds(-1, 1))
+    assert refine(sin(x), Q.infinite(x) & ~Q.extended_real(x)) is nan
+    assert refine(cos(x), Q.infinite(x) & ~Q.extended_real(x)) is nan
+    assert refine(sin(x), Q.infinite(x)) == sin(x)
+    assert refine(cos(x), Q.infinite(x)) == cos(x)
 
 
 def test_floor_ceiling():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -297,14 +297,13 @@ def test_sin_cos():
         AccumBounds(-1, 1))
     assert (refine(cos(x), Q.infinite(x) & Q.extended_real(x)) ==
         AccumBounds(-1, 1))
-    assert refine(sin(x), Q.infinite(x) & ~Q.extended_real(x)) is nan
-    assert refine(cos(x), Q.infinite(x) & ~Q.extended_real(x)) is nan
     assert refine(sin(x), Q.infinite(x)) == sin(x)
     assert refine(cos(x), Q.infinite(x)) == cos(x)
 
     raises(TypeError, lambda: refine_sin_cos(tan(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(exp(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(x, Q.real(x)))
+
 
 def test_floor_ceiling():
     assert refine(floor(x), Q.integer(x)) == x

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.refine import refine
+from sympy.assumptions.refine import refine, refine_sin_cos
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
@@ -9,13 +9,15 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
+
+from sympy.testing.pytest import raises
 
 
 def test_Abs():
@@ -300,6 +302,9 @@ def test_sin_cos():
     assert refine(sin(x), Q.infinite(x)) == sin(x)
     assert refine(cos(x), Q.infinite(x)) == cos(x)
 
+    raises(TypeError, lambda: refine_sin_cos(tan(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sin_cos(exp(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sin_cos(x, Q.real(x)))
 
 def test_floor_ceiling():
     assert refine(floor(x), Q.integer(x)) == x


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Original Comment by @TiloRC : https://github.com/sympy/sympy/pull/28873#issuecomment-3923732976
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

As suggested by @TiloRC in https://github.com/sympy/sympy/pull/28873#issuecomment-3923732976, taking consideration of how old assumptions, more simplifications for sin and cos are added. One being the use of `AccumBounds` and another being the handling of `args` being `zero`.

Added a type check in `refine_sin_cos` so things like this don't happen.
```python
>>> refine_sin_cos(tan(x), Q.zero(x))
1 # incorrectly identifies tan as cos
```

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
