### PR TITLE
Fix directional limits of Piecewise at discontinuities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1100,11 +1100,11 @@ Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Merin Theres Jose <merintheresjose@gmail.com>
-Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1104,6 +1104,7 @@ Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>
 Merin Theres Jose <merintheresjose@gmail.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>
 Micah Fitch <micahscopes@gmail.com> <fitchmicah@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com>
 Michael Boyle <michael.oliver.boyle@gmail.com> Mike Boyle <boyle@astro.cornell.edu>
@@ -1887,4 +1888,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1887,3 +1887,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Meer Patel <meerpatel1314@gmail.com> TheMS1314 <164546264+TheMS1314@users.noreply.github.com>

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -117,7 +117,8 @@ copybutton_prompt_is_regexp = True
 nitpicky = True
 
 nitpick_ignore = [
-    ('py:class', 'sympy.logic.boolalg.Boolean')
+    ('py:class', 'sympy.logic.boolalg.Boolean'),
+    ('py:class', 'sympy.core.function.AppliedUndef'),
 ]
 
 # To stop docstrings inheritance.

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -224,9 +224,24 @@ class Piecewise(DefinedFunction):
         return piecewise_simplify(self, **kwargs)
 
     def _eval_as_leading_term(self, x, logx, cdir):
+        from sympy.core.numbers import Rational
+        if cdir == S.Zero or cdir == 0:
+            test_point = S.Zero
+        elif cdir > 0:
+            test_point = Rational(1, 10000)
+        else:
+            test_point = Rational(-1, 10000)
+
         for e, c in self.args:
-            if c == True or c.subs(x, 0) == True:
-                return e.as_leading_term(x)
+            if c == True:
+                return e.as_leading_term(x, logx=logx, cdir=cdir)
+            try:
+                if c.subs(x, test_point) == True:
+                    return e.as_leading_term(x, logx=logx, cdir=cdir)
+            except TypeError:
+                continue
+
+        return self.args[-1].expr.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_adjoint(self):
         return self.func(*[(e.adjoint(), c) for e, c in self.args])

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1639,25 +1639,6 @@ def test_piecewise__eval_is_meromorphic():
     assert f.is_meromorphic(x, Symbol('a')) is None
     assert f.is_meromorphic(x, Symbol('a', real=True)) is None
 
-def test_piecewise_limit_directional():
-    """Test directional limits of Piecewise functions.
-    See https://github.com/sympy/sympy/issues/27236
-    """
-    from sympy import limit
-    from sympy.testing.pytest import raises
-
-    x = symbols('x')
-
-    # issue #27236: two-sided limit should not exist when left != right
-    f = Piecewise((1, x < 0), (-1, True))
-    assert limit(f, x, 0, '-') == 1
-    assert limit(f, x, 0, '+') == -1
-    raises(ValueError, lambda: limit(f, x, 0, '+-'))
-
-    # directional limits at interior discontinuity
-    p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
-    assert limit(p, x, 3, '+') == -9
-    assert limit(p, x, 3, '-') == 27
 
 def test_piecewise_limit_directional():
     from sympy import limit
@@ -1672,8 +1653,6 @@ def test_piecewise_limit_directional():
 
     # issue #23836: directional limits at interior discontinuity
     p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
-    assert limit(p, x, 3, '+') == -9
-    assert limit(p, x, 3, '-') == 27
     raises(ValueError, lambda: limit(p, x, 3, '+-'))
 
     # issue #26313: right limit respects strict inequality boundary

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1638,3 +1638,23 @@ def test_piecewise__eval_is_meromorphic():
     assert f.is_meromorphic(x, 2) == True
     assert f.is_meromorphic(x, Symbol('a')) is None
     assert f.is_meromorphic(x, Symbol('a', real=True)) is None
+
+def test_piecewise_limit_directional():
+    """Test directional limits of Piecewise functions.
+    See https://github.com/sympy/sympy/issues/27236
+    """
+    from sympy import limit
+    from sympy.testing.pytest import raises
+
+    x = symbols('x')
+
+    # issue #27236: two-sided limit should not exist when left != right
+    f = Piecewise((1, x < 0), (-1, True))
+    assert limit(f, x, 0, '-') == 1
+    assert limit(f, x, 0, '+') == -1
+    raises(ValueError, lambda: limit(f, x, 0, '+-'))
+
+    # directional limits at interior discontinuity
+    p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
+    assert limit(p, x, 3, '+') == -9
+    assert limit(p, x, 3, '-') == 27

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1658,3 +1658,25 @@ def test_piecewise_limit_directional():
     p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
     assert limit(p, x, 3, '+') == -9
     assert limit(p, x, 3, '-') == 27
+
+def test_piecewise_limit_directional():
+    from sympy import limit
+    from sympy.testing.pytest import raises
+    x = symbols('x')
+
+    # issue #27236: two-sided limit should raise when left != right
+    f = Piecewise((1, x < 0), (-1, True))
+    assert limit(f, x, 0, '-') == 1
+    assert limit(f, x, 0, '+') == -1
+    raises(ValueError, lambda: limit(f, x, 0, '+-'))
+
+    # issue #23836: directional limits at interior discontinuity
+    p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
+    assert limit(p, x, 3, '+') == -9
+    assert limit(p, x, 3, '-') == 27
+    raises(ValueError, lambda: limit(p, x, 3, '+-'))
+
+    # issue #26313: right limit respects strict inequality boundary
+    p2 = Piecewise((x**2, x <= 2), (5*x - 7, x > 2))
+    assert limit(p2, x, 2, '+') == 3
+    assert limit(p2, x, 2, '-') == 4

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -15,7 +15,7 @@ from sympy.core.function import Derivative, AppliedUndef
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr: Basic, func: Any | None = None, hint: str | None = '_Integral') -> tuple[Basic, Any]:
+def _preprocess(expr: Basic, func: AppliedUndef | None = None, hint: str | None = '_Integral') -> tuple[Basic, AppliedUndef]:
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -93,7 +93,7 @@ def _preprocess(expr: Basic, func: Any | None = None, hint: str | None = '_Integ
     return eq, func
 
 
-def ode_order(expr: Basic, func: Any) -> int:
+def ode_order(expr: Basic, func: AppliedUndef) -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -133,7 +133,7 @@ def ode_order(expr: Basic, func: Any) -> int:
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
+def _desolve(eq: Basic | Equality, func: AppliedUndef | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 
@@ -192,11 +192,11 @@ def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default
     x0 = kwargs.get('x0', 0)
     terms = kwargs.get('n')
 
+    classifier: Any = None
+    allhints: tuple[str, ...] = ()
     if type == 'ode':
         from sympy.solvers.ode import classify_ode, allhints
         classifier = classify_ode
-        string = 'ODE '
-        dummy = ''
 
     elif type == 'pde':
         from sympy.solvers.pde import classify_pde, allhints
@@ -246,7 +246,7 @@ def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default
                       prep=prep, x0=x0, classify=False, order=hints['order'],
                       match=hints[hints['default']], xi=xi, eta=eta, n=terms, type=type)
     elif hint in ('all', 'all_Integral', 'best'):
-        retdict = {}
+        retdict: dict[str, Any] = {}
         gethints = set(hints) - {'order', 'default', 'ordered_hints'}
         if hint == 'all_Integral':
             for i in hints:

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -9,12 +9,14 @@ _desolve
 
 """
 from __future__ import annotations
-from sympy.core import Pow
+from typing import Any
+from sympy.core import Pow, Basic
 from sympy.core.function import Derivative, AppliedUndef
+from typing import TYPE_CHECKING
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr, func=None, hint='_Integral'):
+def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | None = '_Integral') -> "tuple[Basic, AppliedUndef]":
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -92,7 +94,7 @@ def _preprocess(expr, func=None, hint='_Integral'):
     return eq, func
 
 
-def ode_order(expr, func):
+def ode_order(expr: Basic, func: "AppliedUndef") -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -132,7 +134,7 @@ def ode_order(expr, func):
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq, func=None, hint="default", ics=None, simplify=True, *, prep=True, **kwargs):
+def _desolve(eq: Basic | Equality, func: "AppliedUndef | None" = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 
@@ -174,7 +176,7 @@ def _desolve(eq, func=None, hint="default", ics=None, simplify=True, *, prep=Tru
     classify_pde(pde.py)
     """
     if isinstance(eq, Equality):
-        eq = eq.lhs - eq.rhs
+        eq = eq.lhs - eq.rhs  # type: ignore[operator]
 
     # preprocess the equation and find func if not given
     if prep or func is None:

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from typing import Any
 from sympy.core import Pow, Basic
 from sympy.core.function import Derivative, AppliedUndef
-from typing import TYPE_CHECKING
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -194,9 +194,13 @@ def _desolve(eq: Basic | Equality, func: AppliedUndef | None = None, hint: str =
 
     classifier: Any = None
     allhints: tuple[str, ...] = ()
+    string: str = ''
+    dummy: str = ''
     if type == 'ode':
         from sympy.solvers.ode import classify_ode, allhints
         classifier = classify_ode
+        string = 'ODE '
+        dummy = ''
 
     elif type == 'pde':
         from sympy.solvers.pde import classify_pde, allhints

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -15,7 +15,7 @@ from sympy.core.function import Derivative, AppliedUndef
 from sympy.core.relational import Equality
 from sympy.core.symbol import Wild
 
-def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | None = '_Integral') -> "tuple[Basic, AppliedUndef]":
+def _preprocess(expr: Basic, func: Any | None = None, hint: str | None = '_Integral') -> tuple[Basic, Any]:
     """Prepare expr for solving by making sure that differentiation
     is done so that only func remains in unevaluated derivatives and
     (if hint does not end with _Integral) that doit is applied to all
@@ -93,7 +93,7 @@ def _preprocess(expr: Basic, func: "AppliedUndef | None" = None, hint: str | Non
     return eq, func
 
 
-def ode_order(expr: Basic, func: "AppliedUndef") -> int:
+def ode_order(expr: Basic, func: Any) -> int:
     """
     Returns the order of a given differential
     equation with respect to func.
@@ -133,7 +133,7 @@ def ode_order(expr: Basic, func: "AppliedUndef") -> int:
         return max(ode_order(_, func) for _ in expr.args) if expr.args else 0
 
 
-def _desolve(eq: Basic | Equality, func: "AppliedUndef | None" = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
+def _desolve(eq: Basic | Equality, func: Any | None = None, hint: str = "default", ics: dict[str, Any] | None = None, simplify: bool = True, *, prep: bool = True, **kwargs: Any) -> dict[str, Any]:
     """This is a helper function to dsolve and pdsolve in the ode
     and pde modules.
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #27236
Fixes #23836
Fixes #26313

#### Brief description of what is fixed or changed

`_eval_as_leading_term` in `Piecewise` previously ignored the `cdir`
parameter entirely, always substituting `x=0` to determine the active
piece. This caused both one-sided limits to return the same value (from
the `True` branch), so two-sided limit checks incorrectly passed and
returned a wrong value instead of raising `ValueError`. Directional
limits at interior discontinuities were also wrong for the same reason.

**Root cause chain:**
1. `limit(f, x, z0, '+-')` calls `limit(f, x, z0, '+')` and `limit(f, x, z0, '-')`
2. Both called `_eval_as_leading_term` with `cdir=1` and `cdir=-1` respectively
3. But the old code substituted `x=0` regardless of `cdir`, always
   picking the `True` branch → both returned the same wrong value
4. `r == l` → `True`, so returned wrong value instead of raising `ValueError`

**Fix:** substitute a small positive (`1/10000`) or negative (`-1/10000`)
test point based on `cdir` to correctly identify which piece is active
as `x → 0` from each direction.

#### Examples fixed
```python
from sympy import symbols, Piecewise, limit
x = symbols('x')

# issue #27236 — two-sided limit should not exist
f = Piecewise((1, x < 0), (-1, True))
limit(f, x, 0, '+')   # -1  ✓
limit(f, x, 0, '-')   #  1  ✓
limit(f, x, 0, '+-')  # raises ValueError  ✓  (was returning -1)

# issue #23836 — directional limits at interior discontinuity
p = Piecewise((x**3, x < 3), (-x**2, x > 3), (2, True))
limit(p, x, 3, '+')   # -9  ✓  (was returning 2)
limit(p, x, 3, '-')   # 27  ✓  (was returning 2)

# issue #26313 — right limit respects strict inequality boundary
p2 = Piecewise((x**2, x <= 2), (5*x - 7, x > 2))
limit(p2, x, 2, '+')  #  3  ✓  (was returning 4)
limit(p2, x, 2, '-')  #  4  ✓
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `Piecewise._eval_as_leading_term` to respect the direction
    of approach (`cdir`) when computing limits, fixing incorrect results
    for directional and two-sided limits at discontinuities
    (issues #27236, #23836, #26313).
<!-- END RELEASE NOTES -->