### PR TITLE
combinatorics: Added accepts() and validate() to StateMachine 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1595,6 +1595,9 @@ Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
+
+Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <145254642+suraj5030@users.noreply.github.com>
+Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1595,7 +1595,6 @@ Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
-
 Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <145254642+suraj5030@users.noreply.github.com>
 Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -56,7 +56,7 @@ class StateMachine:
         '''
         new_state = State(state_name, self, state_type, rh_rule)
         self.states[state_name] = new_state
-        
+
     def accepts(self, words):
         '''
         Check whether the state machine accepts each word in a list.

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -56,6 +56,134 @@ class StateMachine:
         '''
         new_state = State(state_name, self, state_type, rh_rule)
         self.states[state_name] = new_state
+        
+    def accepts(self, words):
+        '''
+        Check whether the state machine accepts each word in a list.
+
+        Arguments:
+            words -- a list of strings, each string is checked against
+                the machine character by character.
+
+        Returns
+        =======
+        dict
+            A dictionary mapping each word to ``True`` if accepted,
+            ``False`` otherwise.
+        '''
+        results = {}
+        for word in words:
+            state = self.states['start']
+            accepted = True
+            for symbol in word:
+                if symbol not in self.automaton_alphabet:
+                    accepted = False
+                    break
+                if symbol not in state.transitions:
+                    accepted = False
+                    break
+                state = state.transitions[symbol]
+            if accepted:
+                results[word] = state.state_type == 'a'
+            else:
+                results[word] = False
+        return results
+
+    def validate(self):
+        '''
+        Validate that the machine is a well-formed DFA by checking all five
+        components of the formal 5-tuple (Q, Sigma, delta, q0, F).
+
+        - Q     -- at least one state exists; no empty state names.
+        - Sigma -- the alphabet is non-empty; no empty symbols.
+        - delta -- every state has a transition for every symbol in the
+                   alphabet; no transitions outside the alphabet; all
+                   transition targets exist in Q.
+        - q0    -- exactly one start state exists (state_type ``'s'``);
+                   a state named ``'start'`` must be present in Q.
+        - F     -- at least one accept state exists (state_type ``'a'``).
+
+        Returns
+        =======
+        True
+            If all checks pass.
+
+        Raises
+        ======
+        ValueError
+            With a descriptive message for the first violated check.
+        '''
+        # Q: at least one state
+        if not self.states:
+            raise ValueError(
+                "Q is empty: the machine must have at least one state.")
+
+        # Q: no empty state names
+        if any(name == '' for name in self.states):
+            raise ValueError(
+                "Q violation: state name cannot be an empty string.")
+
+        # Sigma: non-empty alphabet
+        if not self.automaton_alphabet:
+            raise ValueError(
+                "Sigma is empty: the alphabet must contain at least one symbol.")
+
+        # Sigma: no empty symbols
+        if any(s == '' for s in self.automaton_alphabet):
+            raise ValueError(
+                "Sigma violation: alphabet symbol cannot be an empty string.")
+
+        # q0: 'start' state must exist in Q
+        if 'start' not in self.states:
+            raise ValueError(
+                "q0 violation: no state named 'start' found in Q.")
+
+        alphabet = set(self.automaton_alphabet)
+        valid_types = {'s', 'a', 'd'}
+
+        # state_type validity
+        for name, state in self.states.items():
+            if state.state_type not in valid_types:
+                raise ValueError(
+                    f"State '{name}' has unrecognized state_type "
+                    f"'{state.state_type}'; must be one of {valid_types}.")
+
+        # q0: exactly one start state
+        start_states = [s for s in self.states.values() if s.state_type == 's']
+        if len(start_states) != 1:
+            raise ValueError(
+                f"q0 violation: expected exactly 1 start state, "
+                f"found {len(start_states)}.")
+
+        # F: at least one accept state
+        accept_states = [s for s in self.states.values() if s.state_type == 'a']
+        if not accept_states:
+            raise ValueError(
+                "F is empty: the machine must have at least one accept state.")
+
+        # delta: missing, extra, and invalid targets
+        for name, state in self.states.items():
+            defined = set(state.transitions.keys())
+
+            missing = alphabet - defined
+            if missing:
+                raise ValueError(
+                    f"delta violation: state '{name}' is missing transitions "
+                    f"for: {missing}.")
+
+            extra = defined - alphabet
+            if extra:
+                raise ValueError(
+                    f"delta violation: state '{name}' has transitions outside "
+                    f"the alphabet: {extra}.")
+
+            for symbol, dest in state.transitions.items():
+                if dest.name not in self.states:
+                    raise ValueError(
+                        f"delta violation: state '{name}' on '{symbol}' "
+                        f"transitions to unknown state '{dest.name}'.")
+
+        return True
 
     def __repr__(self):
         return "%s" % (self.name)

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from sympy.combinatorics.fp_groups import FpGroup
 from sympy.combinatorics.free_groups import free_group
+from sympy.combinatorics.rewritingsystem_fsm import StateMachine
 from sympy.testing.pytest import raises
-
 
 def test_rewriting():
     F, a, b = free_group("a, b")
@@ -48,3 +48,61 @@ def test_rewriting():
     R.add_rule(a**-3, b)
 
     assert R.add_rule(a, a) == set()
+
+def test_state_machine_accepts():
+
+    # Build odd-length DFA over {"0", "1"}
+    M = StateMachine("odd_length", ["0", "1"])
+    M.add_state("q1", state_type="a")
+    start = M.states["start"]
+    q1 = M.states["q1"]
+    start.add_transition("0", q1)
+    start.add_transition("1", q1)
+    q1.add_transition("0", start)
+    q1.add_transition("1", start)
+
+    results = M.accepts(["0", "010", "01", "", "2"])
+    assert results["0"] is True       # length 1
+    assert results["010"] is True     # length 3
+    assert results["01"] is False     # length 2
+    assert results[""] is False       # empty
+    assert results["2"] is False      # not in alphabet
+
+
+def test_state_machine_validate():
+    
+
+    # Valid machine passes
+    M = StateMachine("odd_length", ["0", "1"])
+    M.add_state("q1", state_type="a")
+    start = M.states["start"]
+    q1 = M.states["q1"]
+    start.add_transition("0", q1)
+    start.add_transition("1", q1)
+    q1.add_transition("0", start)
+    q1.add_transition("1", start)
+    assert M.validate() is True
+
+    # No accept states
+    M2 = StateMachine("no_accept", ["0", "1"])
+    raises(ValueError, lambda: M2.validate())
+
+    # Missing transition
+    M3 = StateMachine("missing", ["0", "1"])
+    M3.add_state("q1", state_type="a")
+    M3.states["start"].add_transition("0", M3.states["q1"])
+    raises(ValueError, lambda: M3.validate())
+
+    # Empty alphabet
+    M4 = StateMachine("empty_alpha", [])
+    raises(ValueError, lambda: M4.validate())
+
+    # Extra transition outside alphabet
+    M5 = StateMachine("extra_trans", ["0", "1"])
+    M5.add_state("q1", state_type="a")
+    M5.states["start"].add_transition("0", M5.states["q1"])
+    M5.states["start"].add_transition("1", M5.states["q1"])
+    M5.states["start"].add_transition("2", M5.states["q1"])
+    M5.states["q1"].add_transition("0", M5.states["start"])
+    M5.states["q1"].add_transition("1", M5.states["start"])
+    raises(ValueError, lambda: M5.validate())

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -70,7 +70,6 @@ def test_state_machine_accepts():
 
 
 def test_state_machine_validate():
-    
 
     # Valid machine passes
     M = StateMachine("odd_length", ["0", "1"])


### PR DESCRIPTION

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
No related issues, this is for GSoC 2026 proposal for automata theory module.
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR adds two new methods to StateMachine in rewritingsystem_fsm.py.

Note: these methods are intended for deterministic finite automata (DFA) only, where every state has exactly one transition per alphabet symbol.

- accepts(words) -- takes a list of strings, returns a dict mapping
  each word to True if the machine accepts it, False otherwise
- validate() -- checks all five components of the DFA 5-tuple
  (Q, Sigma, delta, q0, F) and raises ValueError with a descriptive
  message for each violation

Example:
```
from sympy.combinatorics.rewritingsystem_fsm import StateMachine

# DFA that accepts strings of odd length over {0, 1}
M = StateMachine("odd_length", ["0", "1"])
M.add_state("q1", state_type="a")
start = M.states["start"]
q1 = M.states["q1"]
start.add_transition("0", q1)
start.add_transition("1", q1)
q1.add_transition("0", start)
q1.add_transition("1", start)

M.accepts(["0", "01", "010"])
#  Result : {"0": True, "01": False, "010": True}

M.validate()
# Result : True
```

#### Other comments
This PR is related to my GSoC 2026 proposal for adding an automata
theory module to SymPy. Draft proposal will be linked here once posted to the wiki.

#### AI Generation Disclosure
Claude was used as a reference for discussing edge cases
in the validate() method. The code and tests were written by me.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added ``accepts()`` and ``validate()`` methods to ``StateMachine``
    in ``rewritingsystem_fsm.py``.
<!-- END RELEASE NOTES -->
