### PR TITLE
Fix errors in Probability/Expectation rewrites

### DIFF
--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -113,7 +113,17 @@ class Probability(Expr):
             return sampling_P(condition, given_condition, numsamples=numsamples)
         if given_condition is not None:  # If there is a condition
             # Recompute on new conditional expr
-            return Probability(given(condition, given_condition)).doit()
+            return self.func(given(condition, given_condition)).doit(**hints) 
+            # another issue I think is, 
+            # 1. Condition gets lost 
+            # Initially we had: Probability(condition, given_condition)
+            # But after this line: Probability(given(condition, given_condition)), The given_condition will be no longer tracked
+
+            # 2. Ignores hints
+            # .doit() is called without **hints
+            # But after this line: Probability(given(condition, given_condition)), The given_condition will be no longer tracked
+            # My fix - self.func(...) - [Keeps the same class (Probability)] and [Keeps behavior unifrm]
+            # .doit(**hints) - Preserves user settings
 
         # Otherwise pass work off to the ProbabilitySpace
         if pspace(condition) == PSpace():
@@ -312,11 +322,14 @@ class Expectation(Expr):
 
         if rv.pspace.is_Continuous:
             return Integral(arg.replace(rv, symbol)*Probability(Eq(rv, symbol), condition), (symbol, rv.pspace.domain.set.inf, rv.pspace.domain.set.sup))
+            # ok so the issue here is "rv.pspace.set.sup" does not exist right
+            # that means the correct path is: pspace - domain - set - sup
+
         else:
             if rv.pspace.is_Finite:
                 raise NotImplementedError
             else:
-                return Sum(arg.replace(rv, symbol)*Probability(Eq(rv, symbol), condition), (symbol, rv.pspace.domain.set.inf, rv.pspace.set.sup))
+                return Sum(arg.replace(rv, symbol)*Probability(Eq(rv, symbol), condition), (symbol, rv.pspace.domain.set.inf, rv.pspace.domain.set.sup))
 
     def _eval_rewrite_as_Integral(self, arg, condition=None, evaluate=False, **kwargs):
         return self.func(arg, condition=condition).doit(deep=False, evaluate=evaluate)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* stats
  * Fixed an AttributeError in Expectation rewrite to Probability due to incorrect access of probability space bounds.
  * Fixed incorrect handling of conditional evaluation in Probability.doit where conditions and hints could be lost. <!-- END RELEASE NOTES -->

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed. -->

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title.

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
