### PR TITLE
add more comprehensive tests to permutation group functionality

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1830,6 +1830,7 @@ mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohammedouahman <simofun85@gmail.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>
+n-nazz <ncnazare@uwaterloo.ca>
 naelsondouglas <naelson17@gmail.com>
 noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1205,6 +1205,7 @@ Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
+Noah Nazareth <ncnazare@uwaterloo.ca>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
 Oldrich Klimanek <oldrich.klimanek@gmail.com> Oldrich Klimanek <oldrich.klimanek@gmail.com>

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -831,8 +831,11 @@ def test_is_nilpotent():
         assert Ab.is_nilpotent
     Ab = AbelianGroup(5, 7, 10)
     assert Ab.is_nilpotent
-    # A_5 is not solvable and thus not nilpotent
-    assert AlternatingGroup(5).is_nilpotent is False
+    # A_i is not solvable for i>=5, and thus not nilpotent
+    # it follows that S_i are also not nilpotent for i>=5
+    for i in (5, 6, 7):
+        assert AlternatingGroup(i).is_nilpotent is False
+        assert SymmetricGroup(i).is_nilpotent is False
 
 
 def test_is_trivial():
@@ -888,6 +891,9 @@ def test_coset_transvesal():
          Permutation(1, 2, 4), Permutation(4)(1, 2, 3), Permutation(1, 3)(2, 4),
          Permutation(0, 1, 2, 3, 4), Permutation(0, 1, 2, 4, 3),
          Permutation(0, 1, 3, 2, 4), Permutation(0, 2, 4, 1, 3)]
+    # transversals of a group G in itself are all singletons from G
+    assert len(G.coset_transversal(G)) == 1
+    assert len(H.coset_transversal(H)) == 1
 
 
 def test_coset_table():
@@ -901,12 +907,27 @@ def test_coset_table():
          [6, 6, 6, 6, 2, 1, 11, 11, 2, 2], [9, 10, 8, 10, 11, 3, 1, 1, 7, 7],
          [10, 9, 10, 7, 3, 11, 2, 2, 11, 11], [8, 7, 9, 9, 9, 9, 4, 4, 9, 9],
          [7, 8, 7, 8, 10, 10, 5, 5, 10, 10], [11, 11, 11, 11, 8, 7, 6, 6, 8, 8]]
+    S = SymmetricGroup(4)
+    K = PermutationGroup(Permutation(2, 3))
+    assert S.coset_table(K) == \
+            [[1, 2, 3, 3], [4, 0, 5, 5], [0, 4, 6, 6], [7, 8, 0, 0], [2, 1, 4, 4],
+             [9, 6, 1, 1], [5, 10, 2, 2], [11, 3, 10, 10], [3, 11, 9, 9],
+             [10, 5, 8, 8], [6, 9, 7, 7], [8, 7, 11, 11]]
+    # coset table of G in G is always one element
+    assert len(G.coset_table(G)) == 1
+    assert len(S.coset_table(S)) == 1
 
 
 def test_subgroup():
     G = PermutationGroup(Permutation(0,1,2), Permutation(0,2,3))
     H = G.subgroup([Permutation(0,1,3)])
+    K = G.subgroup([Permutation(0,2,3)])
     assert H.is_subgroup(G)
+    assert K.is_subgroup(G)
+    assert G.is_subgroup(H) is False
+    assert G.is_subgroup(K) is False
+    assert K.is_subgroup(H) is False
+    assert H.is_subgroup(K) is False
 
 
 def test_generator_product():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The tests for is_nilpotent only checked cases where the result was True; I added some which were false. Similarly coset_transversal, coset_table, and is_subgroup each only had one test, so I added a few more.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
   * Added tests for the functions is_nilpotent, coset_transversal, coset_table, and is_subgroup. 
<!-- END RELEASE NOTES -->
