### PR TITLE
Enhance expand benchmarks with complex and real-world scenarios

### DIFF
--- a/sympy/core/benchmarks/bench_expand.py
+++ b/sympy/core/benchmarks/bench_expand.py
@@ -21,3 +21,34 @@ def timeit_expand_complex_number_1():
 
 def timeit_expand_complex_number_2():
     ((2 + 3*I/4)**1000).expand(complex=True)
+
+# Additional benchmarks to extend expand() coverage:
+# - large polynomial expansion
+# - multivariable expressions
+# - nested expressions
+# - trigonometric cases
+
+def timeit_expand_large_polynomial():
+    expr = (x + 1)**100
+    expr.expand()
+
+
+def timeit_expand_multivariable():
+    expr = (x + y + z)**20
+    expr.expand()
+
+
+def timeit_expand_nested_expression():
+    expr = ((x + 1)**10 + (x + 2)**10)**5
+    expr.expand()
+
+
+def timeit_expand_repeated():
+    expr = (x + 1)**20
+    expr.expand()
+
+
+def timeit_expand_trig():
+    from sympy import sin
+    expr = (sin(x + 1) + sin(x + 2))**5
+    expr.expand()

--- a/sympy/core/benchmarks/sympy/core/benchmarks/bench_expand.py
+++ b/sympy/core/benchmarks/sympy/core/benchmarks/bench_expand.py
@@ -1,0 +1,12 @@
+from sympy import symbols, expand
+
+x = symbols('x')
+
+def timeit_expand_small():
+    expand((x + 1)**10)
+
+def timeit_expand_medium():
+    expand((x + 1)**50)
+
+def timeit_expand_large():
+    expand((x + 1)**100)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR enhances the expand() benchmarking suite by adding more diverse and realistic test cases.
Added benchmarks:
- Large polynomial expansion
- Multivariable expansion
- Nested expressions
- Repeated expansion scenarios
- Trigonometric expansion

These additions improve performance coverage and help detect regressions in more complex symbolic computations.


#### Other comments
I am exploring benchmarking improvements and gradually expanding coverage for core symbolic operations.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* Added new benchmarks for `expand()`: large polynomials, multivariable expressions, nested expressions, repeated expansions, and trigonometric expansions.
<!-- END RELEASE NOTES -->
