### PR TITLE
Improved robustness of Bode magnitude's numerical data generation

### DIFF
--- a/sympy/physics/control/control_plots.py
+++ b/sympy/physics/control/control_plots.py
@@ -760,7 +760,6 @@ def bode_magnitude_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit
     # However, numerical computation might introduce imaginary parts.
     # Let's request the data series to discard any imaginary part.
     kwargs["return"] = "real"
-    mag = 20*log(Abs(w_expr), 10)
 
     x, y = LineOver1DRangeSeries(mag,
         (_w, 10**initial_exp, 10**final_exp), xscale='log', **kwargs).get_points()

--- a/sympy/physics/control/control_plots.py
+++ b/sympy/physics/control/control_plots.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 from sympy.core.numbers import I, pi
-from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.complexes import re, im
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.polys.partfrac import apart
 from sympy.core.symbol import Dummy

--- a/sympy/physics/control/control_plots.py
+++ b/sympy/physics/control/control_plots.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from sympy.core.numbers import I, pi
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.complexes import re, im
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.polys.partfrac import apart
 from sympy.core.symbol import Dummy
@@ -748,6 +750,16 @@ def bode_magnitude_numerical_data(system, initial_exp=-5, final_exp=5, freq_unit
         repl = I*_w
     w_expr = expr.subs({system.var: repl})
 
+    # NOTE: instead of Abs(w_expr), another way would be
+    # sqrt(re(w_expr)**2 + im(w_expr)**2)
+    # but re(), im() are going to evaluate the symbolic expression, potentially
+    # adding a significant overhead for longer transfer functions.
+    mag = 20*log(Abs(w_expr), 10)
+
+    # We are computing the magnitude, which must return real data.
+    # However, numerical computation might introduce imaginary parts.
+    # Let's request the data series to discard any imaginary part.
+    kwargs["return"] = "real"
     mag = 20*log(Abs(w_expr), 10)
 
     x, y = LineOver1DRangeSeries(mag,

--- a/sympy/physics/control/tests/test_control_plots.py
+++ b/sympy/physics/control/tests/test_control_plots.py
@@ -334,6 +334,9 @@ def test_nichols_expr():
 
 
 def test_issue_29530():
+    if not numpy:
+        skip("NumPy is required for this test")
+
     num = numpy.array([
         3.48799648e-03+0.00000000e+00j,  3.94714557e+00-3.27602726e+02j,
        -1.26370216e+07-8.62936992e+05j, -2.85822924e+10+2.68995812e+11j,

--- a/sympy/physics/control/tests/test_control_plots.py
+++ b/sympy/physics/control/tests/test_control_plots.py
@@ -331,3 +331,20 @@ def test_nichols_expr():
     assert p3 == 180*arg(-w3*I/(w3**3*I + 1))/pi
     assert m4 == 20*log(10/(w4**2*Abs(w4)))/log(10)
     assert p4 == 180*arg(I/w4**3)/pi
+
+
+def test_issue_29530():
+    num = numpy.array([
+        3.48799648e-03+0.00000000e+00j,  3.94714557e+00-3.27602726e+02j,
+       -1.26370216e+07-8.62936992e+05j, -2.85822924e+10+2.68995812e+11j,
+        3.49538064e+15+3.72323599e+14j,  2.17691576e+18-2.86131354e+19j,
+       -1.47410187e+23-3.86894682e+21j,  1.76676107e+25+4.66860012e+26j,
+        8.63781663e+29-1.02652261e+29j, -1.90093975e+32-8.42072953e+32j,
+       -3.29925768e+35+1.22585000e+35j])
+    den = numpy.array([-9.19119158e+36-5.78774471e+36j])
+    num_poly = numpy.sum([num[i] * s**(int(len(num) - 1 - i)) for i in range(len(num))])
+    den_poly = numpy.sum([den[i] * s**(int(len(den) - 1 - i)) for i in range(len(den))])
+    sym_tf = TransferFunction(num_poly, den_poly, s)
+    freq, mag = bode_magnitude_numerical_data(
+        sym_tf, freq_unit ='Hz', initial_exp=0, final_exp=5)
+    assert not numpy.isnan(mag).any()


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29530

#### Brief description of what is fixed or changed

The magnitude of a LTI system is always real. However, due to numerical errors, small imaginary parts could appear. 
This PR request that only the real part of the magnitude's numerical data be returned, thus fixing the issue mentioned above.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Improved robustness of Bode magnitude's numerical data generation
<!-- END RELEASE NOTES -->
