### PR TITLE
Implement vector and dyadic equals() methods in the physics module

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -148,10 +148,9 @@ class Dyadic(Printable, EvalfMixin):
     def __eq__(self, other):
         """Tests for equality.
 
-        Is currently weak; needs stronger comparison testing
+        Is currently weak; `.equals()` performs stronger symbolic equality testing.
 
         """
-
         if other == 0:
             other = Dyadic(0)
         other = _check_dyadic(other)
@@ -531,6 +530,50 @@ class Dyadic(Printable, EvalfMixin):
             new_inlist[0] = new_inlist[0].xreplace(rule)
             new_args.append(tuple(new_inlist))
         return Dyadic(new_args)
+
+    def equals(self, other):
+        """Tests for symbolic equality.
+
+        It is very import to note that this is only as good as the SymPy
+        equality test; False does not always mean they are not equivalent
+        Dyadics.
+        If other == 0, it is treated as a zero Dyadic (`Dyadic(0)`).
+        Otherwise, non-Dyadic objects compare False.
+
+        Examples
+        ========
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.mechanics import ReferenceFrame
+        >>> c = symbols('c')
+        >>> N = ReferenceFrame('N')
+        >>> (N.xx * (c + 1)**2).equals(N.xx * (c**2 + 2 * c + 1))
+        True
+        >>> (N.yy - N.yy).equals(0)
+        True
+
+        """
+        if other == 0:
+            other = Dyadic(0)
+        if not isinstance(other, Dyadic):
+            return False
+
+        if (self.args == []) and (other.args == []):
+            return True
+
+        if (self.args == []):
+            frame = other.args[0][1].args[0][1]
+        else:
+            frame = self.args[0][1].args[0][1]
+
+        # Note: this will raise errors if any of the frames used in self or other are not oriented
+        diff = self - other
+        for v1 in frame:
+            diff_dot_v1 = diff.dot(v1)
+            for v2 in frame:
+                if not diff_dot_v1.dot(v2).equals(0):
+                    return False
+        return True
 
 
 def _check_dyadic(other):

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -566,13 +566,16 @@ class Dyadic(Printable, EvalfMixin):
         else:
             frame = self.args[0][1].args[0][1]
 
-        # Note: this will raise errors if any of the frames used in self or other are not oriented
-        diff = self - other
-        for v1 in frame:
-            diff_dot_v1 = diff.dot(v1)
-            for v2 in frame:
-                if not diff_dot_v1.dot(v2).equals(0):
-                    return False
+        # Wrap in try-except so that if frames aren't connected, False is returned
+        try:
+            diff = self - other
+            for v1 in frame:
+                diff_dot_v1 = diff.dot(v1)
+                for v2 in frame:
+                    if not diff_dot_v1.dot(v2).equals(0):
+                        return False
+        except ValueError:
+            return False
         return True
 
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -534,7 +534,7 @@ class Dyadic(Printable, EvalfMixin):
     def equals(self, other):
         """Tests for symbolic equality.
 
-        It is very import to note that this is only as good as the SymPy
+        It is very important to note that this is only as good as the SymPy
         equality test; False does not always mean they are not equivalent
         Dyadics.
         Non-Dyadic objects compare False.
@@ -571,7 +571,7 @@ class Dyadic(Printable, EvalfMixin):
                 for v2 in frame:
                     if not diff_dot_v1.dot(v2).equals(0):
                         return False
-        except ValueError:
+        except ValueError: # Frames disonnected
             return False
         return True
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -537,24 +537,21 @@ class Dyadic(Printable, EvalfMixin):
         It is very import to note that this is only as good as the SymPy
         equality test; False does not always mean they are not equivalent
         Dyadics.
-        If other == 0, it is treated as a zero Dyadic (`Dyadic(0)`).
-        Otherwise, non-Dyadic objects compare False.
+        Non-Dyadic objects compare False.
 
         Examples
         ========
 
         >>> from sympy import symbols
-        >>> from sympy.physics.mechanics import ReferenceFrame
+        >>> from sympy.physics.mechanics import ReferenceFrame, Dyadic
         >>> c = symbols('c')
         >>> N = ReferenceFrame('N')
         >>> (N.xx * (c + 1)**2).equals(N.xx * (c**2 + 2 * c + 1))
         True
-        >>> (N.yy - N.yy).equals(0)
+        >>> (N.yy - N.yy).equals(Dyadic(0))
         True
 
         """
-        if other == 0:
-            other = Dyadic(0)
         if not isinstance(other, Dyadic):
             return False
 

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -147,6 +147,10 @@ def test_dyadic_equals():
 
     assert (N.xx * expr1 + N.yz * expr2).equals(N.xx * expr2 + N.yz * expr1)
 
+    # Invalid type
+    assert not N.xx.equals(5)
+    assert not N.xx.equals('hi')
+
 
 def test_dyadic_equals_different_frames():
     N = ReferenceFrame('N')

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -124,3 +124,37 @@ def test_dyadic_xreplace():
     assert v.xreplace({x:1, z:0}) == D
     raises(TypeError, lambda: v.xreplace())
     raises(TypeError, lambda: v.xreplace([x, y]))
+
+def test_dyadic_equals():
+    N = ReferenceFrame('N')
+    a = symbols('a')
+
+    assert N.xx.equals(N.xx)
+    assert N.xy.equals(N.xy)
+    assert N.zz.equals(N.zz)
+    assert not N.xx.equals(N.xy)
+    assert not N.xy.equals(N.yz)
+
+    # 2 expressions which are mathematically but not structurally equal
+    expr1 = (a + 1) ** 2
+    expr2 = a**2 + 2 * a + 1
+    assert expr1 != expr2 # sanity check, so that this test is sensible
+    assert expr1.equals(expr2)
+
+    assert (N.xx * expr1).equals(N.xx * expr2)
+    assert not (N.xx * expr1).equals(N.xx * (expr2 + 1))
+    assert not (N.xy * expr1).equals(N.xx * (expr2))
+
+    assert (N.xx * expr1 + N.yz * expr2).equals(N.xx * expr2 + N.yz * expr1)
+
+
+def test_dyadic_equals_different_frames():
+    N = ReferenceFrame('N')
+    B = ReferenceFrame('B')
+    B.orient_axis(N, N.z, pi / 2)
+
+    assert B.zz.equals(N.zz)
+    assert B.zx.equals(N.zy)
+    assert not B.zx.equals(N.zx)
+    assert B.zy.equals(-N.zx)
+    assert not B.zy.equals(N.zy)

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -151,10 +151,15 @@ def test_dyadic_equals():
 def test_dyadic_equals_different_frames():
     N = ReferenceFrame('N')
     B = ReferenceFrame('B')
+    C = ReferenceFrame('C')
     B.orient_axis(N, N.z, pi / 2)
+    # Intentionally do not orient C
 
     assert B.zz.equals(N.zz)
     assert B.zx.equals(N.zy)
     assert not B.zx.equals(N.zx)
     assert B.zy.equals(-N.zx)
     assert not B.zy.equals(N.zy)
+
+    # Unoriented frames should not error when comparing
+    assert not C.xx.equals(N.xx)

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -5,7 +5,7 @@ from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.matrices.immutable import ImmutableDenseMatrix as Matrix
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols, outer
-from sympy.physics.vector.dyadic import _check_dyadic
+from sympy.physics.vector.dyadic import _check_dyadic, Dyadic
 from sympy.testing.pytest import raises
 
 A = ReferenceFrame('A')
@@ -163,3 +163,31 @@ def test_dyadic_equals_different_frames():
 
     # Unoriented frames should not error when comparing
     assert not C.xx.equals(N.xx)
+
+
+def test_equals_zero_nontrivial_zero_component():
+    a = symbols("a")
+    N = ReferenceFrame("N")
+
+    # 2 expressions which are mathematically but not structurally equal
+    expr1 = (a + 1) ** 2
+    expr2 = a**2 + 2 * a + 1
+    assert expr1 != expr2 # sanity check, so that this test is sensible
+    assert expr1.equals(expr2)
+
+    assert (N.xx * expr1 - N.xx * expr2).equals(Dyadic(0))
+
+def test_equals_zero_nontrivial_zero_component_refframe():
+    N = ReferenceFrame("N")
+    A = ReferenceFrame("A")
+    A.orient_axis(N, N.x, 0)
+
+    assert (N.xx - A.xx).equals(Dyadic(0))
+    assert (N.yz - A.yz).equals(Dyadic(0))
+    assert (N.zy - A.zy).equals(Dyadic(0))
+    assert not (N.xx - A.yz).equals(Dyadic(0))
+    assert not (N.xx - A.zy).equals(Dyadic(0))
+    assert not (N.yy - A.xx).equals(Dyadic(0))
+    assert not (N.yy - A.zy).equals(Dyadic(0))
+    assert not (N.zz - A.xx).equals(Dyadic(0))
+    assert not (N.zz - A.yz).equals(Dyadic(0))

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -273,3 +273,85 @@ def test_overloaded_operators():
     assert v1 & v2 == v2 & v1
     assert v1 ^ v2 == v1.cross(v2)
     assert v2 ^ v1 == v2.cross(v1)
+
+def test_equals():
+    a = symbols("a")
+    N = ReferenceFrame("N")
+
+    # 2 expressions which are mathematically but not structurally equal
+    expr1 = (a + 1) ** 2
+    expr2 = a**2 + 2 * a + 1
+    assert expr1 != expr2 # sanity check, so that this test is sensible
+    assert expr1.equals(expr2)
+
+    assert (N.x * expr1).equals(N.x * expr2)
+    assert not (N.x * expr1).equals(N.x * (expr2 - 1))
+    assert not (N.x * expr1).equals(N.y * expr1)
+
+    assert (N.x * expr1 + N.y * expr2).equals(N.x * expr2 + N.y * expr1)
+
+    # A is not linked to N; this comparison shows up in
+    A = ReferenceFrame("A")
+    assert N.x + A.y != 0
+    assert not (N.x + A.y).equals(0)
+
+
+def test_equals_zero_simple():
+    N = ReferenceFrame("N")
+
+    assert Vector(0).equals(N.x - N.x)
+    assert N.x - N.x.equals(Vector(0))
+    assert Vector(0).equals(0)
+    assert (N.x - N.x).equals(0)
+
+    assert Vector(0).equals(Vector(0))
+    assert (N.x - N.x).equals(N.x - N.x)
+
+    assert 0 == N.x - N.x
+    assert 0 == Vector(0)
+
+def test_equals_zero_equal_reference_frames():
+    N = ReferenceFrame("N")
+    A = ReferenceFrame("A")
+    A.orient_axis(N, N.x, 0)
+
+    assert N.x.equals(A.x)
+    assert N.y.equals(A.y)
+    assert N.z.equals(A.z)
+    assert not N.x.equals(A.y)
+    assert not N.x.equals(A.z)
+    assert not N.y.equals(A.x)
+    assert not N.y.equals(A.z)
+    assert not N.z.equals(A.x)
+    assert not N.z.equals(A.y)
+
+# For the following 2 XFAIL tests: See https://github.com/sympy/sympy/issues/29546#issuecomment-4142372261
+from sympy.testing.pytest import XFAIL
+@XFAIL
+def test_equals_zero_nontrivial_zero_component():
+    a = symbols("a")
+    N = ReferenceFrame("N")
+
+    # 2 expressions which are mathematically but not structurally equal
+    expr1 = (a + 1) ** 2
+    expr2 = a**2 + 2 * a + 1
+    assert expr1 != expr2 # sanity check, so that this test is sensible
+    assert expr1.equals(expr2)
+
+    assert (N.x * expr1 - N.x * expr2).equals(0)
+
+@XFAIL
+def test_equals_zero_nontrivial_zero_component_refframe():
+    N = ReferenceFrame("N")
+    A = ReferenceFrame("A")
+    A.orient_axis(N, N.x, 0)
+
+    assert (N.x - A.x).equals(0)
+    assert (N.y - A.y).equals(0)
+    assert (N.z - A.z).equals(0)
+    assert not (N.x - A.y).equals(0)
+    assert not (N.x - A.z).equals(0)
+    assert not (N.y - A.x).equals(0)
+    assert not (N.y - A.z).equals(0)
+    assert not (N.z - A.x).equals(0)
+    assert not (N.z - A.y).equals(0)

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -295,17 +295,18 @@ def test_equals():
     assert N.x + A.y != 0
     assert not (N.x + A.y).equals(0)
 
+    # Invalid type
+    assert not N.x.equals(5)
+    assert not N.x.equals('hi')
+
 
 def test_equals_zero_simple():
     N = ReferenceFrame("N")
 
     assert Vector(0).equals(N.x - N.x)
-    assert N.x - N.x.equals(Vector(0))
-    assert Vector(0).equals(Vector(0))
-    assert (N.x - N.x).equals(Vector(0))
-
     assert Vector(0).equals(Vector(0))
     assert (N.x - N.x).equals(N.x - N.x)
+    assert (N.x - N.x).equals(Vector(0))
 
     assert 0 == N.x - N.x
     assert 0 == Vector(0)

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -290,7 +290,7 @@ def test_equals():
 
     assert (N.x * expr1 + N.y * expr2).equals(N.x * expr2 + N.y * expr1)
 
-    # A is not linked to N; this comparison shows up in
+    # A is not linked to N; this comparison shows up in e.g. partial_velocity() usage
     A = ReferenceFrame("A")
     assert N.x + A.y != 0
     assert not (N.x + A.y).equals(0)

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -301,8 +301,8 @@ def test_equals_zero_simple():
 
     assert Vector(0).equals(N.x - N.x)
     assert N.x - N.x.equals(Vector(0))
-    assert Vector(0).equals(0)
-    assert (N.x - N.x).equals(0)
+    assert Vector(0).equals(Vector(0))
+    assert (N.x - N.x).equals(Vector(0))
 
     assert Vector(0).equals(Vector(0))
     assert (N.x - N.x).equals(N.x - N.x)
@@ -325,9 +325,6 @@ def test_equals_zero_equal_reference_frames():
     assert not N.z.equals(A.x)
     assert not N.z.equals(A.y)
 
-# For the following 2 XFAIL tests: See https://github.com/sympy/sympy/issues/29546#issuecomment-4142372261
-from sympy.testing.pytest import XFAIL
-@XFAIL
 def test_equals_zero_nontrivial_zero_component():
     a = symbols("a")
     N = ReferenceFrame("N")
@@ -338,20 +335,19 @@ def test_equals_zero_nontrivial_zero_component():
     assert expr1 != expr2 # sanity check, so that this test is sensible
     assert expr1.equals(expr2)
 
-    assert (N.x * expr1 - N.x * expr2).equals(0)
+    assert (N.x * expr1 - N.x * expr2).equals(Vector(0))
 
-@XFAIL
 def test_equals_zero_nontrivial_zero_component_refframe():
     N = ReferenceFrame("N")
     A = ReferenceFrame("A")
     A.orient_axis(N, N.x, 0)
 
-    assert (N.x - A.x).equals(0)
-    assert (N.y - A.y).equals(0)
-    assert (N.z - A.z).equals(0)
-    assert not (N.x - A.y).equals(0)
-    assert not (N.x - A.z).equals(0)
-    assert not (N.y - A.x).equals(0)
-    assert not (N.y - A.z).equals(0)
-    assert not (N.z - A.x).equals(0)
-    assert not (N.z - A.y).equals(0)
+    assert (N.x - A.x).equals(Vector(0))
+    assert (N.y - A.y).equals(Vector(0))
+    assert (N.z - A.z).equals(Vector(0))
+    assert not (N.x - A.y).equals(Vector(0))
+    assert not (N.x - A.z).equals(Vector(0))
+    assert not (N.y - A.x).equals(Vector(0))
+    assert not (N.y - A.z).equals(Vector(0))
+    assert not (N.z - A.x).equals(Vector(0))
+    assert not (N.z - A.y).equals(Vector(0))

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -132,23 +132,7 @@ class Vector(Printable, EvalfMixin):
         If none of the above, only accepts other as a Vector.
 
         """
-
-        if other == 0:
-            other = Vector(0)
-        try:
-            other = _check_vector(other)
-        except TypeError:
-            return False
-        if (self.args == []) and (other.args == []):
-            return True
-        elif (self.args == []) or (other.args == []):
-            return False
-
-        frame = self.args[0][1]
-        for v in frame:
-            if expand((self - other).dot(v)) != 0:
-                return False
-        return True
+        return self.equals(other)
 
     def __mul__(self, other):
         """Multiplies the Vector by a sympifyable expression.
@@ -790,6 +774,46 @@ class Vector(Printable, EvalfMixin):
             mat = mat.xreplace(rule)
             new_args.append([mat, frame])
         return Vector(new_args)
+
+    def equals(self, other):
+        """Tests for symbolic equality.
+
+        It is very import to note that this is only as good as the SymPy
+        equality test; False does not always mean they are not equivalent
+        Vectors.
+        If other is 0, and self is empty, returns True.
+        If other is 0 and self is not empty, returns False.
+        If none of the above, only accepts other as a Vector.
+
+        Examples
+        ========
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.mechanics import ReferenceFrame
+        >>> c = symbols('c')
+        >>> N = ReferenceFrame('N')
+        >>> (N.x * (c + 1)**2).equals(N.x * (c**2 + 2 * c + 1))
+        True
+        >>> (N.x - N.x).equals(0)
+        True
+
+        """
+        if other == 0:
+            other = Vector(0)
+        try:
+            other = _check_vector(other)
+        except TypeError:
+            return False
+        if (self.args == []) and (other.args == []):
+            return True
+        elif (self.args == []) or (other.args == []):
+            return False
+
+        frame = self.args[0][1]
+        for v in frame:
+            if expand((self - other).dot(v)) != 0:
+                return False
+        return True
 
 
 class VectorTypeError(TypeError):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -132,9 +132,23 @@ class Vector(Printable, EvalfMixin):
         If none of the above, only accepts other as a Vector.
 
         """
+
         if other == 0:
-            return self.args == []
-        return self.equals(other)
+            other = Vector(0)
+        try:
+            other = _check_vector(other)
+        except TypeError:
+            return False
+        if (self.args == []) and (other.args == []):
+            return True
+        elif (self.args == []) or (other.args == []):
+            return False
+
+        frame = self.args[0][1]
+        for v in frame:
+            if expand((self - other).dot(v)) != 0:
+                return False
+        return True
 
     def __mul__(self, other):
         """Multiplies the Vector by a sympifyable expression.

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -124,7 +124,7 @@ class Vector(Printable, EvalfMixin):
     def __eq__(self, other):
         """Tests for equality.
 
-        It is very import to note that this is only as good as the SymPy
+        It is very important to note that this is only as good as the SymPy
         equality test; False does not always mean they are not equivalent
         Vectors.
         If other is 0, and self is empty, returns True.
@@ -132,6 +132,8 @@ class Vector(Printable, EvalfMixin):
         If none of the above, only accepts other as a Vector.
 
         """
+        if other == 0:
+            return self.args == []
         return self.equals(other)
 
     def __mul__(self, other):
@@ -778,41 +780,43 @@ class Vector(Printable, EvalfMixin):
     def equals(self, other):
         """Tests for symbolic equality.
 
-        It is very import to note that this is only as good as the SymPy
+        It is very important to note that this is only as good as the SymPy
         equality test; False does not always mean they are not equivalent
         Vectors.
-        If other is 0, and self is empty, returns True.
-        If other is 0 and self is not empty, returns False.
-        If none of the above, only accepts other as a Vector.
+        Non-Vector objects compare false.
 
         Examples
         ========
 
         >>> from sympy import symbols
-        >>> from sympy.physics.mechanics import ReferenceFrame
+        >>> from sympy.physics.mechanics import ReferenceFrame, Vector
         >>> c = symbols('c')
         >>> N = ReferenceFrame('N')
         >>> (N.x * (c + 1)**2).equals(N.x * (c**2 + 2 * c + 1))
         True
-        >>> (N.x - N.x).equals(0)
+        >>> (N.x - N.x).equals(Vector(0))
         True
 
         """
-        if other == 0:
-            other = Vector(0)
-        try:
-            other = _check_vector(other)
-        except TypeError:
-            return False
-        if (self.args == []) and (other.args == []):
-            return True
-        elif (self.args == []) or (other.args == []):
+        if not isinstance(other, Vector):
             return False
 
-        frame = self.args[0][1]
-        for v in frame:
-            if expand((self - other).dot(v)) != 0:
-                return False
+        if (self.args == []) and (other.args == []):
+            return True
+
+        if (self.args == []):
+            frame = other.args[0][1]
+        else:
+            frame = self.args[0][1]
+
+        diff = self - other
+        # Wrap in try-except so that if frames aren't connected, False is returned
+        try:
+            for v in frame:
+                if not diff.dot(v).equals(0):
+                    return False
+        except ValueError: # Frames disconnected
+            return False
         return True
 
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29546 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Implement `.equals()` for `Vector` and `Dyadic` of the physics module, which do symbolic equality checking.

#### Other comments
I decided to leave `Vector.__eq__()` as is, to maximize backward compatibility and discourage future use of `==` over `.equals()` or `(a - b).simplify()`  for symbolic equality comparison.


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Implemented `.equals()` method for `Dyadic` and `Vector`. 

<!-- END RELEASE NOTES -->
