### PR TITLE
Change `return NotImplementedError` to `raise NotImplementedError`

### DIFF
--- a/sympy/plotting/intervalmath/lib_interval.py
+++ b/sympy/plotting/intervalmath/lib_interval.py
@@ -282,6 +282,8 @@ def asin(x):
             start = np.arcsin(x.start)
             end = np.arcsin(x.end)
             return interval(start, end, is_valid=x.is_valid)
+    else:
+        raise NotImplementedError(f"asin for {type(x)}")
 
 
 def acos(x):
@@ -304,6 +306,8 @@ def acos(x):
             start = np.arccos(x.start)
             end = np.arccos(x.end)
             return interval(start, end, is_valid=x.is_valid)
+    else:
+        raise NotImplementedError(f"acos for {type(x)}")
 
 
 def ceil(x):

--- a/sympy/plotting/intervalmath/lib_interval.py
+++ b/sympy/plotting/intervalmath/lib_interval.py
@@ -180,7 +180,7 @@ def imin(*args):
     """Evaluates the minimum of a list of intervals"""
     np = import_module('numpy')
     if not all(isinstance(arg, (int, float, interval)) for arg in args):
-        return NotImplementedError
+        raise NotImplementedError(f"imin for argument types {[type(arg) for arg in args]}")
     else:
         new_args = [a for a in args if isinstance(a, (int, float))
                     or a.is_valid]
@@ -201,7 +201,7 @@ def imax(*args):
     """Evaluates the maximum of a list of intervals"""
     np = import_module('numpy')
     if not all(isinstance(arg, (int, float, interval)) for arg in args):
-        return NotImplementedError
+        raise NotImplementedError(f"imax for argument types {[type(arg) for arg in args]}")
     else:
         new_args = [a for a in args if isinstance(a, (int, float))
                     or a.is_valid]
@@ -324,7 +324,7 @@ def ceil(x):
                 #Not continuous over the interval
                 return interval(start, end, is_valid=None)
     else:
-        return NotImplementedError
+        raise NotImplementedError(f"ceil for {type(x)}")
 
 
 def floor(x):
@@ -345,7 +345,7 @@ def floor(x):
                 #not continuous over the interval
                 return interval(start, end, is_valid=None)
     else:
-        return NotImplementedError
+        raise NotImplementedError(f"floor for {type(x)}")
 
 
 def acosh(x):
@@ -369,7 +369,7 @@ def acosh(x):
             end = np.arccosh(x.end)
             return interval(start, end, is_valid=x.is_valid)
     else:
-        return NotImplementedError
+        raise NotImplementedError(f"acosh for {type(x)}")
 
 
 #Monotonic
@@ -383,7 +383,7 @@ def asinh(x):
         end = np.arcsinh(x.end)
         return interval(start, end, is_valid=x.is_valid)
     else:
-        return NotImplementedError
+        raise NotImplementedError(f"asinh for {type(x)}")
 
 
 def atanh(x):
@@ -407,7 +407,7 @@ def atanh(x):
             end = np.arctanh(x.end)
             return interval(start, end, is_valid=x.is_valid)
     else:
-        return NotImplementedError
+        raise NotImplementedError(f"atanh for {type(x)}")
 
 
 #Three valued logic for interval plotting.

--- a/sympy/plotting/intervalmath/lib_interval.py
+++ b/sympy/plotting/intervalmath/lib_interval.py
@@ -15,7 +15,7 @@ def Abs(x):
         else:
             return interval(abs(x.start), abs(x.end))
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"Abs for {type(x)}")
 
 #Monotonic
 
@@ -28,7 +28,7 @@ def exp(x):
     elif isinstance(x, interval):
         return interval(np.exp(x.start), np.exp(x.end), is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"exp for {type(x)}")
 
 
 #Monotonic
@@ -50,7 +50,7 @@ def log(x):
 
         return interval(np.log(x.start), np.log(x.end))
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"log for {type(x)}")
 
 
 #Monotonic
@@ -71,7 +71,7 @@ def log10(x):
             return interval(-np.inf, np.inf, is_valid=None)
         return interval(np.log10(x.start), np.log10(x.end))
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"log10 for {type(x)}")
 
 
 #Monotonic
@@ -85,7 +85,7 @@ def atan(x):
         end = np.arctan(x.end)
         return interval(start, end, is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"atan for {type(x)}")
 
 
 #periodic
@@ -114,7 +114,7 @@ def sin(x):
                 start = -1
             return interval(start, end)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"sin for {type(x)}")
 
 
 #periodic
@@ -145,7 +145,7 @@ def cos(x):
                 start = -1
             return interval(start, end, is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"cos for {type(x)}")
 
 
 def tan(x):
@@ -173,7 +173,7 @@ def sqrt(x):
             return interval(np.sqrt(x.start), np.sqrt(x.end),
                     is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"sqrt for {type(x)}")
 
 
 def imin(*args):
@@ -228,7 +228,7 @@ def sinh(x):
     elif isinstance(x, interval):
         return interval(np.sinh(x.start), np.sinh(x.end), is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"sinh for {type(x)}")
 
 
 def cosh(x):
@@ -247,7 +247,7 @@ def cosh(x):
             end = np.cosh(x.end)
             return interval(start, end, is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"cosh for {type(x)}")
 
 
 #Monotonic
@@ -259,7 +259,7 @@ def tanh(x):
     elif isinstance(x, interval):
         return interval(np.tanh(x.start), np.tanh(x.end), is_valid=x.is_valid)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(f"tanh for {type(x)}")
 
 
 def asin(x):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3026,7 +3026,8 @@ class Tensor(TensExpr):
             return 0
         elif isinstance(other, Tensor):
             return self.component.commutes_with(other.component)
-        return NotImplementedError
+        else:
+            raise NotImplementedError(f"commutes_with between {type(self)} and {type(other)}")
 
     def perm2tensor(self, g, is_canon_bp=False):
         """


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

`sympy.plotting.intervalmath.lib_interval` and `sympy.tensor.tensor` had some functions where `NotImplementedError` was returned instead of being raised. I took a look at these functions, and returning the error class didn't seem to make sense.

I've also added messages for many `NotImplementedError`s in `lib_interval.py`, and fixed bugs in `asin` and `acos` wherein they would silently return nothing for unhandled types (they now raise `NotImplementedError`).

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
