### PR TITLE
Update acos positive assumption handler.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -937,6 +937,8 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
 Kishore Gopalakrishnan <kishore96@gmail.com>
+Kiwi <dishaholmukhe521@gmail.com> Disha Holmukhe <dishaholmukhe521@gmail.com>
+Kiwi <dishaholmukhe521@gmail.com> Kiwi-520 <dishaholmukhe521@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -391,7 +391,9 @@ def _(expr, assumptions):
 @PositivePredicate.register(acos)
 def _(expr, assumptions):
     x = expr.args[0]
-    if ask(Q.nonpositive(x - 1) & Q.nonnegative(x + 1), assumptions):
+    if ask(Q.zero(x), assumptions):
+        return True
+    if ask(Q.negative(x - 1) & Q.nonnegative(x + 1), assumptions):
         return True
 
 @PositivePredicate.register(acot)

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -218,6 +218,18 @@ def _(expr, assumptions):
     # TODO: This should be deducible from the nonzero handler
     return fuzzy_or(ask(Q.zero(arg), assumptions) for arg in expr.args)
 
+@ZeroPredicate.register(asin)
+def _(expr, assumptions):
+    return ask(Q.zero(expr.args[0]), assumptions)
+
+@ZeroPredicate.register(atan)
+def _(expr, assumptions):
+    return ask(Q.zero(expr.args[0]), assumptions)
+
+@ZeroPredicate.register(acos)
+def _(expr, assumptions):
+    x = expr.args[0]
+    return ask(Q.zero(x - 1), assumptions)
 
 # NonPositivePredicate
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2363,12 +2363,14 @@ def test_issue_7246():
     assert ask(Q.positive(atan(p)), Q.negative(p)) is False
     assert ask(Q.positive(atan(p)), Q.zero(p)) is False
     assert ask(Q.positive(atan(x))) is None
+    assert ask(Q.zero(atan(x)), Q.zero(x)) is True
 
     assert ask(Q.positive(asin(p)), Q.positive(p)) is None
     assert ask(Q.positive(asin(p)), Q.zero(p)) is None
     assert ask(Q.positive(asin(Rational(1, 7)))) is True
     assert ask(Q.positive(asin(x)), Q.positive(x) & Q.nonpositive(x - 1)) is True
     assert ask(Q.positive(asin(x)), Q.negative(x) & Q.nonnegative(x + 1)) is False
+    assert ask(Q.zero(asin(x)), Q.zero(x)) is True
 
     assert ask(Q.positive(acos(p)), Q.positive(p)) is None
     assert ask(Q.positive(acos(Rational(1, 7)))) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2372,21 +2372,14 @@ def test_issue_7246():
 
     assert ask(Q.positive(acos(p)), Q.positive(p)) is None
     assert ask(Q.positive(acos(Rational(1, 7)))) is True
-    assert ask(Q.positive(acos(x)), Q.nonnegative(x + 1) & Q.nonpositive(x - 1)) is True
+    assert ask(Q.positive(acos(x)), Q.nonnegative(x + 1) & Q.negative(x - 1)) is True
+    assert ask(Q.positive(acos(x)), Q.zero(x)) is True
     assert ask(Q.positive(acos(x)), Q.nonnegative(x - 1)) is None
 
     assert ask(Q.positive(acot(x)), Q.positive(x)) is True
     assert ask(Q.positive(acot(x)), Q.real(x)) is True
     assert ask(Q.positive(acot(x)), Q.imaginary(x)) is False
     assert ask(Q.positive(acot(x))) is None
-
-
-@XFAIL
-def test_issue_7246_failing():
-    #Move this test to test_issue_7246 once
-    #the new assumptions module is improved.
-    assert ask(Q.positive(acos(x)), Q.zero(x)) is True
-
 
 def test_check_old_assumption():
     x = symbols('x', real=True)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #19782

#### Brief description of what is fixed or changed

The assumptions engine previously returned None for ask(Q.positive(acos(x)), Q.zero(x)) because it lacked the explicit mathematical boundary evaluation for acos(0).

This PR:

1. Adds a Q.zero(x) check to the acos handler in sympy/assumptions/handlers/order.py to evaluate acos(0) = pi/2 as strictly positive.

2. Corrects the existing domain logic from Q.nonpositive(x - 1) to Q.negative(x - 1) to mathematically exclude x=1 (since acos(1) = 0, which is not strictly positive).

3. Updates the acos tests in sympy/assumptions/tests/test_query.py to reflect the mathematically correct domain.

4. Removes the @XFAIL decorator from test_issue_7246_failing as the ask(Q.positive(acos(x)), Q.zero(x)) assertion now evaluates correctly to True.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used an AI assistant (Google Gemini) as a mentor to help me navigate the SymPy repository structure, locate the correct handler files (order.py). The core mathematical logic fixes and the final code implementation were manually written and verified by me.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `ask(Q.positive(acos(x)))` returning `None` for `Q.zero(x)` by adding missing boundary logic to the `acos` positivity handler.
<!-- END RELEASE NOTES -->
