### PR TITLE
Added bidirectional sign equivalence for odd powers in sathandlers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -937,6 +937,8 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
 Kishore Gopalakrishnan <kishore96@gmail.com>
+Kiwi <dishaholmukhe521@gmail.com> Disha Holmukhe <dishaholmukhe521@gmail.com>
+Kiwi <dishaholmukhe521@gmail.com> Kiwi-520 <dishaholmukhe521@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -292,7 +292,9 @@ def _(expr):
         (Q.real(base) & Q.even(exp) & Q.nonnegative(exp)) >> Q.nonnegative(expr),
         (Q.nonnegative(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonnegative(expr),
         (Q.nonpositive(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonpositive(expr),
-        Equivalent(Q.zero(expr), Q.zero(base) & Q.positive(exp))
+        Equivalent(Q.zero(expr), Q.zero(base) & Q.positive(exp)),
+        Q.odd(exp) >> Equivalent(Q.positive(base), Q.positive(expr)),
+        Q.odd(exp) >> Equivalent(Q.negative(base), Q.negative(expr))
     ]
 
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -289,14 +289,13 @@ def _(expr):
 def _(expr):
     base, exp = expr.base, expr.exp
     return [
-        (Q.real(base) & Q.even(exp) & Q.nonnegative(exp)) >> Q.nonnegative(expr),
-        (Q.nonnegative(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonnegative(expr),
-        (Q.nonpositive(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonpositive(expr),
-        Equivalent(Q.zero(expr), Q.zero(base) & Q.positive(exp)),
-        (Q.odd(exp) & Q.positive(expr)) >> (Q.positive(base) & Q.real(base)),
-        (Q.odd(exp) & Q.negative(expr)) >> (Q.negative(base) & Q.real(base))
-    ]
-
+            Equivalent(Q.zero(expr), Q.zero(base) & Q.positive(exp)),
+            # Odd powers
+            Q.odd(exp) >> Equivalent(Q.positive(expr), Q.positive(base) & Q.real(base)),
+            Q.odd(exp) >> Equivalent(Q.negative(expr), Q.negative(base) & Q.real(base)),
+            # Even powers
+            (Q.even(exp) & Q.nonzero(exp) & Q.real(base)) >> Equivalent(Q.positive(expr), Q.nonzero(base))
+        ]
 
 ### Numbers ###
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -293,8 +293,8 @@ def _(expr):
         (Q.nonnegative(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonnegative(expr),
         (Q.nonpositive(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonpositive(expr),
         Equivalent(Q.zero(expr), Q.zero(base) & Q.positive(exp)),
-        (Q.real(base) & Q.odd(exp)) >> Equivalent(Q.positive(base), Q.positive(expr)),
-        (Q.real(base) & Q.odd(exp)) >> Equivalent(Q.negative(base), Q.negative(expr))
+        (Q.odd(exp) & Q.positive(expr)) >> (Q.positive(base) & Q.real(base)),
+        (Q.odd(exp) & Q.negative(expr)) >> (Q.negative(base) & Q.real(base))
     ]
 
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -293,8 +293,8 @@ def _(expr):
         (Q.nonnegative(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonnegative(expr),
         (Q.nonpositive(base) & Q.odd(exp) & Q.nonnegative(exp)) >> Q.nonpositive(expr),
         Equivalent(Q.zero(expr), Q.zero(base) & Q.positive(exp)),
-        Q.odd(exp) >> Equivalent(Q.positive(base), Q.positive(expr)),
-        Q.odd(exp) >> Equivalent(Q.negative(base), Q.negative(expr))
+        (Q.real(base) & Q.odd(exp)) >> Equivalent(Q.positive(base), Q.positive(expr)),
+        (Q.real(base) & Q.odd(exp)) >> Equivalent(Q.negative(base), Q.negative(expr))
     ]
 
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1942,6 +1942,8 @@ def test_positive():
     assert ask(Q.positive(x**2), Q.positive(x)) is True
     assert ask(Q.positive(x**2), Q.negative(x)) is True
     assert ask(Q.positive(x**3), Q.negative(x)) is False
+    assert ask(Q.positive(x), Q.real(x) & Q.positive(x**3)) is True
+    assert ask(Q.negative(x), Q.real(x) & Q.negative(x**3)) is True
     assert ask(Q.positive(1/(1 + x**2)), Q.real(x)) is True
     assert ask(Q.positive(2**I)) is False
     assert ask(Q.positive(2 + I)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1942,8 +1942,8 @@ def test_positive():
     assert ask(Q.positive(x**2), Q.positive(x)) is True
     assert ask(Q.positive(x**2), Q.negative(x)) is True
     assert ask(Q.positive(x**3), Q.negative(x)) is False
-    assert ask(Q.positive(x), Q.real(x) & Q.positive(x**3)) is True
-    assert ask(Q.negative(x), Q.real(x) & Q.negative(x**3)) is True
+    assert ask(Q.positive(x), Q.positive(x**3)) is True
+    assert ask(Q.negative(x), Q.negative(x**3)) is True
     assert ask(Q.positive(1/(1 + x**2)), Q.real(x)) is True
     assert ask(Q.positive(2**I)) is False
     assert ask(Q.positive(2 + I)) is False


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #27878

#### Brief description of what is fixed or changed
The assumptions engine previously returned `None` for `ask(Q.positive(x), Q.positive(x**3))` because `sathandlers.py` lacked the bidirectional rules to infer the sign of a base from an evaluated odd power.

This PR:
1. Updates the `Pow` handler in `sympy/assumptions/sathandlers.py` to add equivalence rules for odd exponents:
 `Q.odd(exp) >> Equivalent(Q.positive(base), Q.positive(expr))` and `Q.odd(exp) >> Equivalent(Q.negative(base), Q.negative(expr))`.

#### Other comments
I implemented the bidirectional logic for odd exponents exactly as suggested by @TiloRC in the original issue discussion.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used an AI assistant (Google Gemini) to help me navigate the SymPy repository structure. The core logic fixes, testing, and final code implementation were manually written and verified by me.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Made `ask(Q.positive(x), Q.positive(x**3))` give `True` instead of `None`.
<!-- END RELEASE NOTES -->
