### PR TITLE
Parsing: fix Global context prefix and handle missing 'p' attribute in precedence

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1356,6 +1356,8 @@ Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redebo
 Remco de Boer <29308176+redeboer@users.noreply.github.com> Remco de Boer <redeboer@outlook.com>
 Renato Coutinho <renato.coutinho@gmail.com>
 Renato Orsino <renato.orsino@gmail.com>
+Renato Pestana <renato.mendes.pestana@tecnico.ulisboa.pt> <renato.mendes.pestana@tecnico.ulisboa.pt>
+Renato Pestana <renato.mendes.pestana@tecnico.ulisboa.pt> renasrmp78 <renato.mendes.pestana@gmail.com>
 Rhea Parekh <rheaparekh12@gmail.com>
 Riccardo Di Girolamo <riccardodigirolamo01@gmail.com>
 Riccardo Gori <goriccardo@gmail.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -78,7 +78,19 @@ def parse_mathematica(s):
     Apply(Plus, (x, y, z))
     >>> parse_mathematica("f[x_, 3] := x^3 /; x > 0")
     SetDelayed(f(Pattern(x, Blank()), 3), Condition(x**3, x > 0))
+
+    Notes
+    =====
+    Mathematica's default namespace prefix "Global`" is automatically
+    removed from identifiers during parsing to ensure correct variable
+    naming in SymPy.
     """
+
+    # Remove Mathematica's 'Global`' prefix from identifiers to prevent
+    # it from being interpreted as a multiplication (Global * identifier).
+    if isinstance(s, str):
+        s = re.sub(r'\bGlobal`([a-zA-Z0-9])', r'\1', s)
+
     parser = MathematicaParser()
     return parser.parse(s)
 

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -92,6 +92,9 @@ def test_mathematica():
         'a + b\\[Gamma]\\[CapitalGamma]d': 'a + bγΓd',
         'a + b \\[Gamma] \\[CapitalGamma] d': 'a + b*γ*Γ*d',
         'a\\[LongEqual]b': 'Eq(a,b)',
+        'Global`x': 'x', # test cases for issue 26748
+        'Sin[Global`x]': 'sin(x)',
+        'Plus[Times[Rational[1,3], Power[Global`x,3]], Times[-1, Cos[Global`x]]]': 'x**3/3 - cos(x)',
         }
 
     for e in d:
@@ -378,3 +381,13 @@ def test_mathematica_not_operator():
     # Factorial with implicit multiplication
     assert parse_mathematica("x!y") == y*factorial(x)
     assert parse_mathematica("x!y!") == factorial(x)*factorial(y)
+
+def test_mathematica_global_prefix():
+    # Test that the Global` prefix is removed correctly
+    assert parse_mathematica("Global`x") == x
+    assert parse_mathematica("Plus[Global`x, Global`y]") == x + y
+    assert parse_mathematica("Sin[Global`x]") == sin(x)
+    # Test robustness: should NOT remove 'Global' if it's part of a variable name
+    # (This requires the re.sub(r'\bGlobal`', '', s) fix)
+    MyGlobalVar = symbols('MyGlobalVar')
+    assert parse_mathematica("MyGlobalVar") == MyGlobalVar

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -75,7 +75,10 @@ def precedence_Mul(item):
 
 
 def precedence_Rational(item):
-    if item.p < 0:
+    # Some objects might not have the '.p' attribute (numerator).
+    # We check for it to avoid AttributeError while maintaining
+    # correct precedence for negative rational numbers.
+    if hasattr(item, 'p') and item.p < 0:
         return PRECEDENCE["Add"]
     return PRECEDENCE["Mul"]
 

--- a/sympy/printing/tests/test_precedence.py
+++ b/sympy/printing/tests/test_precedence.py
@@ -9,7 +9,7 @@ from sympy.functions import sin
 from sympy.integrals.integrals import Integral
 from sympy.series.order import Order
 
-from sympy.printing.precedence import precedence, PRECEDENCE
+from sympy.printing.precedence import precedence, PRECEDENCE, precedence_Rational
 
 x, y = symbols("x,y")
 
@@ -127,3 +127,16 @@ def test_custom_function_precedence_comparison():
 
     test_low_precedence()
     test_high_precedence()
+
+def test_precedence_Rational_robustness():
+    """
+    Test that precedence_Rational handles objects without the 'p' attribute,
+    preventing AttributeError as reported in issue #26748.
+    """
+
+    class MockRational:
+        pass
+
+    mock_r = MockRational()
+    # Deve retornar Mul (50) em vez de crashar
+    assert precedence_Rational(mock_r) == PRECEDENCE["Mul"]


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #26748

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This pull request addresses the incorrect parsing of Mathematica expressions that include the default `Global`` context prefix.

Main changes:

sympy/parsing/mathematica.py: Added a regex-based sanitization step in parse_mathematica to strip the `Global`` prefix before the string is processed by the parser.

sympy/printing/precedence.py: Added a defensive hasattr(item, 'p') check in precedence_Rational to prevent AttributeError when the parser encounters objects that do not follow the standard Rational structure.

Tests: Added regression tests in both test_mathematica.py and test_precedence.py covering the reported failing cases.

#### Other comments

The implementation was verified with the complex example provided in the original issue and passes all existing parsing tests.

#### AI Generation Disclosure

I used Gemini 3 Flash as an assistant to help debug the Git history (squashing multiple merge commits) and to refine the regex pattern for the Mathematica string sanitization. The final logic and test cases were implemented and verified by me to ensure they meet the project's standards.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- parsing
  - Fixed parse_mathematica to correctly handle the `Global`` prefix in Mathematica expressions.

- printing
  - Improved robustness of precedence_Rational by adding a defensive hasattr check for Rational-like objects.

<!-- END RELEASE NOTES -->
