### PR TITLE
Fix multiple bugs in Cable class: typo, TypeError, and logic errors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -492,6 +492,7 @@ Charlie Lam <888lamcharlie@gmail.com>
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chidroopa Kanaparthy <chidroopak007@gmail.com> Chidroopakanaparthy <chidroopak007@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/physics/continuum_mechanics/cable.py
+++ b/sympy/physics/continuum_mechanics/cable.py
@@ -251,7 +251,7 @@ class Cable:
         y = sympify(new_support[2])
 
         for l in self._loads_position:
-            if l[0] >= max(x, x1) or l[0] <= min(x, x1):
+            if self._loads_position[l][0] >= max(x, x1) or self._loads_position[l][0] <= min(x, x1):
                 raise ValueError("The change in support will throw an existing load out of range")
 
         self._supports.pop(label)
@@ -405,14 +405,14 @@ class Cable:
         for i in args:
             if len(self._loads_position) == 0:
                 if i not in self._loads['distributed']:
-                    raise ValueError("Error removing load " + i + ": no such load exists")
+                    raise ValueError(f"Error removing load {i}: no such load exists")
 
                 else:
-                    self._loads['disrtibuted'].pop(i)
+                    self._loads['distributed'].pop(i)
 
             else:
                 if i not in self._loads['point_load']:
-                    raise ValueError("Error removing load " + i + ": no such load exists")
+                    raise ValueError(f"Error removing load {i}: no such load exists")
 
                 else:
                     self._loads['point_load'].pop(i)

--- a/sympy/physics/continuum_mechanics/tests/test_cable.py
+++ b/sympy/physics/continuum_mechanics/tests/test_cable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from sympy.physics.continuum_mechanics.cable import Cable
 from sympy.core.symbol import Symbol
+from sympy.testing.pytest import raises
 
 
 def test_cable():
@@ -82,3 +83,40 @@ def test_cable():
     assert abs(c.reaction_loads[Symbol("R_A_y")] + 49793.0000000000) < 10e-11
     assert abs(c.reaction_loads[Symbol("R_B_x")] - 44399.9537590861) < 10e-11
     assert abs(c.reaction_loads[Symbol("R_B_y")] - 42868.2071025955 ) < 10e-11
+
+
+def test_cable_remove_loads_bug():
+    # Test for KeyErrror: 'disrtibuted' fix
+    c = Cable(('A', 0, 10), ('B', 10, 10))
+    c.apply_load(0, ('X', 9))
+    assert 'X' in c.loads['distributed']
+    c.remove_loads('X')
+    assert 'X' not in c.loads['distributed']
+
+    # Test for TypeError with Symbol labels
+    P = Symbol('P')
+    c.apply_load(-1, (P, 5, 5, 12, 30))
+    assert P in c.loads['point_load']
+    # Removing a non-existent load with a Symbol should raise ValueError not TypeError
+    Q = Symbol('Q')
+    with raises(ValueError, match="Error removing load Q: no such load exists"):
+        c.remove_loads(Q)
+
+    # Removing existing Symbol load should work
+    c.remove_loads(P)
+    assert P not in c.loads['point_load']
+
+
+def test_cable_change_support_bug():
+    # Test for TypeError: '>=' not supported between instances of 'str' and 'Integer'
+    c = Cable(('A', 0, 10), ('B', 10, 10))
+    c.apply_load(-1, ('P', 5, 5, 12, 30))
+
+    # This should work now. It checks if P (at x=5) is between A(0) and C(15)
+    c.change_support('B', ('C', 15, 10))
+    assert 'C' in c.supports
+    assert c.supports['C'] == [15, 10]
+
+    # This should raise ValueError because P(5) is outside A(10)-C(15)
+    with raises(ValueError, match="The change in support will throw an existing load out of range"):
+        c.change_support('A', ('D', 10, 10))

--- a/sympy/physics/continuum_mechanics/tests/test_cable.py
+++ b/sympy/physics/continuum_mechanics/tests/test_cable.py
@@ -86,7 +86,7 @@ def test_cable():
 
 
 def test_cable_remove_loads_bug():
-    # Test for KeyErrror: 'disrtibuted' fix
+    # Test for KeyErrror: disrtibuted fix
     c = Cable(('A', 0, 10), ('B', 10, 10))
     c.apply_load(0, ('X', 9))
     assert 'X' in c.loads['distributed']
@@ -97,12 +97,9 @@ def test_cable_remove_loads_bug():
     P = Symbol('P')
     c.apply_load(-1, (P, 5, 5, 12, 30))
     assert P in c.loads['point_load']
-    # Removing a non-existent load with a Symbol should raise ValueError not TypeError
     Q = Symbol('Q')
     with raises(ValueError, match="Error removing load Q: no such load exists"):
         c.remove_loads(Q)
-
-    # Removing existing Symbol load should work
     c.remove_loads(P)
     assert P not in c.loads['point_load']
 
@@ -111,12 +108,9 @@ def test_cable_change_support_bug():
     # Test for TypeError: '>=' not supported between instances of 'str' and 'Integer'
     c = Cable(('A', 0, 10), ('B', 10, 10))
     c.apply_load(-1, ('P', 5, 5, 12, 30))
-
-    # This should work now. It checks if P (at x=5) is between A(0) and C(15)
     c.change_support('B', ('C', 15, 10))
     assert 'C' in c.supports
     assert c.supports['C'] == [15, 10]
-
-    # This should raise ValueError because P(5) is outside A(10)-C(15)
+    # Should raise ValueError because P(5) is outside A(10)-C(15)
     with raises(ValueError, match="The change in support will throw an existing load out of range"):
         c.change_support('A', ('D', 10, 10))


### PR DESCRIPTION
#### References to other Issues or PRs

None, found while exploring.

#### Brief description of what is fixed or changed

i addressed three bugs in the `cable` class:
- I corrected the misspelling of the internal dictionary key `disrtibuted` -> `distributed` which prevented users from removing distributed loads.
- I replaced manual string concatenation with f-strings in error messages.  Preventing a crash when a SymPy `Symbol` is used as a load label and cannot be directly concatenated with strings.
- I corrected a type mismatch where the method compared a string label to a numerical coordinate. Logic now correctly accesses load positions via `self._loads_position[l][0]` and ensures point loads remain within the updated support span.

Additionally, I have updated `test_cable.py` with new test cases covering these regressions .

#### Other comments

All existing tests in test_cable.py pass. and I added myself to .mailmap

#### AI Generation Disclosure

All logic changes in `cable.py` were implemented by me. I used Antigravity to assist in identifying edge cases for the `Cable` class and to verify that the new test suite in `test_cable.py` covers the `TypeError` and `KeyError` regressions effectively.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.continuum_mechanics
    * Fixed a typo in `Cable.remove_loads` that caused a `KeyError`.
    * Fixed a `TypeError` in `Cable` error messages when using `Symbol` as a load label.
    * Fixed logic in `Cable.change_support` to correctly handle load position access and boundary validation.

<!-- END RELEASE NOTES -->
