### PR TITLE
`TensAdd.doit`: convert `TensAdd` to `Add` if it does not contain any `TensExpr`

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2545,6 +2545,8 @@ class TensAdd(TensExpr, AssocOp):
         # it there is only a component tensor return it
         if len(args) == 1:
             return args[0]
+        if not any(isinstance(a, TensExpr) for a in args):
+            return Add(*args)
 
         obj = self.func(*args)
         return obj

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -624,6 +624,13 @@ def test_add1():
     #Test whether TensAdd.doit chokes on subterms that are zero.
     assert TensAdd(p(a), TensMul(0, p(a)) ).doit() == p(a)
 
+    #If none of the arguments of a TensAdd are TensExpr, it should be converted to an add by doit
+    f = Function("f")
+    x = Symbol("x")
+
+    expr = TensAdd(3, f(x))
+    assert isinstance(expr.doit(), Add)
+
 def test_special_eq_ne():
     # test special equality cases:
     Lorentz = TensorIndexType('Lorentz', dummy_name='L')


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
If none of the arguments of a `TensAdd` instance is a `TensExpr` instance, it is now converted to `Add` by `TensAdd.doit()`. This is consistent with what is already done by `TensMul.doit`.

#### Other comments

On master:
```
In [1]: f = Function("f")

In [2]: x = Symbol("x")

In [3]: from sympy.tensor.tensor import TensAdd

In [4]: expr = TensAdd(3, f(x))

In [5]: type(expr)
Out[5]: sympy.tensor.tensor.TensAdd

In [6]: type(expr.doit())
Out[6]: sympy.tensor.tensor.TensAdd
```
With the changes in this MR:
```
In [3]: type(expr)
Out[3]: sympy.tensor.tensor.TensAdd

In [4]: type(expr.doit())
Out[4]: sympy.core.add.Add
```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * `TensAdd.doit` now returns `Add` if none of the arguments are `TensExpr`.
<!-- END RELEASE NOTES -->
