### PR TITLE
TensMul.doit: fix issue where doit needed to be called twice to obtain a stable form

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3463,10 +3463,7 @@ class TensMul(TensExpr, AssocOp):
                 newarg = arg
             newargs.append(newarg)
 
-        args = newargs
-
-        # Flatten:
-        args = [i for arg in args for i in (arg.args if isinstance(arg, (TensMul, Mul)) else [arg])]
+        args = cls._flatten_args(newargs)
 
         args, indices, free, dum = TensMul._tensMul_contract_indices(args, replace_indices=False)
 
@@ -3663,6 +3660,16 @@ class TensMul(TensExpr, AssocOp):
         obj._coeff = coeff
         obj._is_canon_bp = is_canon_bp
         return obj
+
+    @staticmethod
+    def _flatten_args(args):
+        flat = []
+        for arg in args:
+            if isinstance(arg, (TensMul, Mul)):
+                flat.extend(arg.args)
+            else:
+                flat.append(arg)
+        return flat
 
     # TODO: this method should be private
     # TODO: should this method be renamed _from_components_free_dum ?

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3630,7 +3630,7 @@ class TensMul(TensExpr, AssocOp):
         else:
             args = self.args
 
-        args = [arg for arg in args if arg != self.identity]
+        args = self._flatten_args([arg for arg in args if arg != self.identity])
 
         # Extract non-tensor coefficients:
         coeff = reduce(lambda a, b: a*b, [arg for arg in args if not isinstance(arg, TensExpr)], S.One)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1802,6 +1802,15 @@ def test_TensMul_data():
         # Test the deleter
         del g.data
 
+def test_TensMul_doit():
+    R3 = TensorIndexType("R3", dim=3)
+    i,j = symbols("i j", cls=TensorIndex, tensor_index_type=R3)
+    K = TensorHead("K", index_types=[R3])
+
+    expr = TensMul(K(j), TensAdd(2, -2, 2*K(i)*K(-i)))
+
+    assert expr.doit() == 2*K(j)*K(i)*K(-i)
+
 def test_issue_11020_TensAdd_data():
     with warns_deprecated_sympy():
         Lorentz = TensorIndexType('Lorentz', metric_symmetry=1, dummy_name='i', dim=2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Some non-`TensMul` objects can become `TensMul` after `doit` is called on them. However, `TensMul.doit` did not check whether any of its args is a `TensMul` (in which case, one needs to flatten by using the associative property). I have changed `TensMul.doit` to explicitly attempt to flatten the arguments after calling `doit` on them.

#### Other comments
On master (isympy session):
```
In [1]: from sympy.tensor.tensor import TensorIndexType, TensorIndex, Tensor
      ⋮ Head, TensMul, TensAdd
   ...: 

In [2]: R3 = TensorIndexType("R3", dim=3)

In [3]: i,j = symbols("i j", cls=TensorIndex, tensor_index_type=R3)

In [4]: K = TensorHead("K", index_types=[R3])

In [5]: expr = TensMul(K(j), TensAdd(2, -2, 2*K(i)*K(-i)))

In [6]: expr.doit()
Out[6]: 
 j    R₀    
K ⋅2⋅K  ⋅K  
          R₀

In [7]: expr.doit().doit()
Out[7]: 
   j  R₀    
2⋅K ⋅K  ⋅K  
          R₀

```
With these changes:
```
In [6]: expr.doit()
Out[6]: 
   j  R₀    
2⋅K ⋅K  ⋅K  
          R₀

In [7]: assert expr.doit() == expr.doit().doit()

```


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fixed issue where `TensMul.doit` would sometimes need to be called twice to obtain a stable form.
<!-- END RELEASE NOTES -->
