### PR TITLE
assumptions: add refine handler for Relational and support non-negative Pow

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -384,6 +384,7 @@ Arthur Milchior <arthur@milchior.fr>
 Arthur Ryman <arthur.ryman@gmail.com>
 Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
 Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
+Aryan Vishwakarma <aryanvishwakarma275@gmail.com> Aryan-202 <aryanvishwakarma275@gmail.com>
 Ashish Kumar Gaurav <ashishkg0022@gmail.com>
 Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -150,6 +150,27 @@ def _(expr, assumptions):
         raise MDNotImplementedError
     return ret
 
+@NonNegativePredicate.register(Pow)
+def _(expr, assumptions):
+    if expr.is_number:
+        notnegative = fuzzy_not(_NegativePredicate_number(expr, assumptions))
+        if notnegative:
+            return ask(Q.real(expr), assumptions)
+        else:
+            return notnegative
+
+    r = ask(Q.real(expr), assumptions)
+    if r:
+        if ask(Q.even(expr.exp), assumptions):
+            return True
+        if expr.exp == S.Half:
+            return True
+
+    ret = expr.is_nonnegative
+    if ret is None:
+        raise MDNotImplementedError
+    return ret
+
 
 # NonZeroPredicate
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -551,6 +551,50 @@ def refine_floor_ceiling(expr, assumptions):
         return Add(*gaussian_integer_terms) + expr.func(Add(*nongausian_intergers_terms))
     return expr
 
+def refine_Relational(expr, assumptions):
+    """
+    Handler for Relational.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine
+    >>> from sympy.assumptions.ask import Q
+    >>> from sympy import Symbol, sqrt
+    >>> x = Symbol('x', real=True)
+    >>> refine(sqrt(x) >= 0, Q.real(sqrt(x)))
+    True
+    """
+    from sympy.assumptions.ask import ask, Q
+    from sympy.core.relational import LessThan, StrictLessThan, GreaterThan, StrictGreaterThan, Eq, Ne
+    diff = expr.lhs - expr.rhs
+    if isinstance(expr, GreaterThan):
+        res = ask(Q.nonnegative(diff), assumptions)
+        if res: return S.true
+        if res is False: return S.false
+    elif isinstance(expr, StrictGreaterThan):
+        res = ask(Q.positive(diff), assumptions)
+        if res: return S.true
+        if res is False: return S.false
+    elif isinstance(expr, LessThan):
+        res = ask(Q.nonpositive(diff), assumptions)
+        if res: return S.true
+        if res is False: return S.false
+    elif isinstance(expr, StrictLessThan):
+        res = ask(Q.negative(diff), assumptions)
+        if res: return S.true
+        if res is False: return S.false
+    elif isinstance(expr, Eq):
+        res = ask(Q.zero(diff), assumptions)
+        if res: return S.true
+        if res is False: return S.false
+    elif isinstance(expr, Ne):
+        res = ask(Q.zero(diff), assumptions)
+        if res: return S.false
+        if res is False: return S.true
+
+    return expr
+
 
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
@@ -566,4 +610,10 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'GreaterThan': refine_Relational,
+    'StrictGreaterThan': refine_Relational,
+    'LessThan': refine_Relational,
+    'StrictLessThan': refine_Relational,
+    'Eq': refine_Relational,
+    'Ne': refine_Relational,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -320,3 +320,18 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+def test_Relational():
+    assert refine(x >= 0, Q.nonnegative(x)) == S.true
+    assert refine(x >= 0, Q.negative(x)) == S.false
+    assert refine(x > 0, Q.positive(x)) == S.true
+    assert refine(x > 0, Q.nonpositive(x)) == S.false
+    assert refine(x <= 0, Q.nonpositive(x)) == S.true
+    assert refine(x <= 0, Q.positive(x)) == S.false
+    assert refine(x < 0, Q.negative(x)) == S.true
+    assert refine(x < 0, Q.nonnegative(x)) == S.false
+    assert refine(Eq(x, 0), Q.zero(x)) == S.true
+    assert refine(Eq(x, 0), Q.nonzero(x)) == S.false
+    assert refine(Ne(x, 0), Q.zero(x)) == S.false
+    assert refine(Ne(x, 0), Q.nonzero(x)) == S.true
+    assert refine(sqrt(x) >= 0, Q.real(sqrt(x))) == S.true


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #27750

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Added refine_Relational to handle inequalities using ask() on their differences.

Registered NonNegativePredicate for Pow to correctly evaluate expressions like sqrt(x) under real assumptions.

This resolves the issue where:
(sqrt(x) >= 0).refine(Q.real(sqrt(x))) did not simplify to True.



#### Other comments

Added test cases to verify relational refinement behavior.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used an AI coding assistant to help me navigate the SymPy codebase and understand the relationship between ask() and refine(). However, I manually reviewed, integrated, and thoroughly tested the changes locally to ensure they fit the project's structure and standards. I take full responsibility for this code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Improved refine handling for relational expressions and non-negative Pow.
<!-- END RELEASE NOTES -->
