### PR TITLE
Relational: Make  `is_ge` handle extended real numbers properly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -893,6 +893,7 @@ Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
+Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <yusifmehdiyev55@gmail.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -893,7 +894,7 @@ Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
-Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <yusifmehdiyev55@gmail.com>
+Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <157145635+JosephMehdiyev@users.noreply.github.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>

--- a/doc/src/explanation/solve_output.rst
+++ b/doc/src/explanation/solve_output.rst
@@ -130,7 +130,7 @@ Boolean or Relational
     flags are ignored).
 
     >>> solve([x**2 > 4, x > 0])
-    (2 < x) & (x < oo)
+    2 < x
 
     >>> from sympy import Unequality as Ne
     >>> solve([x**2 - 4, Ne(x, -2)])

--- a/doc/src/guides/solving/reduce-inequalities-algebraically.md
+++ b/doc/src/guides/solving/reduce-inequalities-algebraically.md
@@ -149,7 +149,7 @@ the constraints on $y$.
 >>> from sympy import reduce_inequalities, symbols
 >>> x, y = symbols("x y")
 >>> reduce_inequalities([x + y > 1, y > 0], x)
-(0 < y) & (y < oo) & (x > 1 - y)
+(0 < y) & (x > 1 - y)
 ```
 
 (`oo` is {class}`~.Infinity`.)
@@ -161,7 +161,7 @@ the set of inequalities for multiple symbols:
 >>> from sympy import reduce_inequalities, symbols
 >>> x, y = symbols("x y")
 >>> x_y_reduced = reduce_inequalities([x > 1, y > 0], [x, y]); x_y_reduced
-(0 < y) & (1 < x) & (x < oo) & (y < oo)
+(0 < y) & (1 < x)
 ```
 
 Note that this provides no mathematical insight beyond reducing the inequalities
@@ -170,9 +170,9 @@ separately:
 ```py
 >>> from sympy import And
 >>> x_reduced = reduce_inequalities(x > 1, x); x_reduced
-(1 < x) & (x < oo)
+1 < x
 >>> y_reduced = reduce_inequalities(y > 0, y); y_reduced
-(0 < y) & (y < oo)
+0 < y
 >>> And(x_reduced, y_reduced) == x_y_reduced
 True
 ```
@@ -191,7 +191,7 @@ both:
 >>> reduce_inequalities([x ** 2 < 4, x > 0], x)
 (0 < x) & (x < 2)
 >>> reduce_inequalities([x < y, x > 0], x)
-(0 < x) & (x < oo) & (x < y)
+(0 < x) & (x < y)
 >>> reduce_inequalities([x ** 2 - y < 4, x > 0], x)
 Traceback (most recent call last):
 ...
@@ -212,7 +212,7 @@ the equation, here $2\pi$.
 >>> from sympy.abc import x, y
 >>> from sympy.calculus.util import periodicity
 >>> reduce_inequalities([2*cos(x) < 1, x > 0], x)
-(0 < x) & (x < oo) & (pi/3 < x) & (x < 5*pi/3)
+(0 < x) & (pi/3 < x) & (x < 5*pi/3)
 >>> periodicity(2*cos(x), x)
 2*pi
 ```

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1408,7 +1408,6 @@ def is_ge(lhs, rhs, assumptions=None):
 
     if not (isinstance(lhs, Expr) and isinstance(rhs, Expr)):
         raise TypeError("Can only compare inequalities with Expr")
-
     retval = _eval_is_ge(lhs, rhs)
 
     if retval is not None:
@@ -1425,13 +1424,33 @@ def is_ge(lhs, rhs, assumptions=None):
         _lhs = AssumptionsWrapper(lhs, assumptions)
         _rhs = AssumptionsWrapper(rhs, assumptions)
         if _lhs.is_extended_real and _rhs.is_extended_real:
-            if (_lhs.is_infinite and _lhs.is_extended_positive) or (_rhs.is_infinite and _rhs.is_extended_negative):
+            if _lhs.is_infinite:
+                if _rhs.is_infinite:
+                    return _lhs.is_extended_positive or (not _rhs.is_extended_positive)
+                if _lhs.is_extended_positive:
+                    return True
+                return False
+
+            if _rhs.is_infinite:
+                if _rhs.is_extended_positive:
+                    return False
                 return True
-            diff = lhs - rhs
-            if diff is not S.NaN:
-                rv = is_extended_nonnegative(diff, assumptions)
-                if rv is not None:
-                    return rv
+
+            if _lhs.is_infinite == None:
+                if _rhs.is_infinite and _rhs.is_extended_negative:
+                    return True
+            if _rhs.is_infinite == None:
+                if _lhs.is_infinite and _lhs.is_extended_positive:
+                    return True
+
+            if _lhs.is_infinite == False and _rhs.is_infinite == False:
+                # This difference is mathamatically valid ONLY if none of LHS nor RHS is infinite.
+                diff = lhs - rhs
+                if diff is not S.NaN:
+                    rv = is_extended_nonnegative(diff, assumptions)
+                    if rv is not None:
+                        return rv
+    return None
 
 
 def is_neq(lhs, rhs, assumptions=None):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1436,14 +1436,14 @@ def is_ge(lhs, rhs, assumptions=None):
                     return False
                 return True
 
-            if _lhs.is_infinite == None:
+            if _lhs.is_infinite is None:
                 if _rhs.is_infinite and _rhs.is_extended_negative:
                     return True
-            if _rhs.is_infinite == None:
+            if _rhs.is_infinite is None:
                 if _lhs.is_infinite and _lhs.is_extended_positive:
                     return True
 
-            if _lhs.is_infinite == False and _rhs.is_infinite == False:
+            if _lhs.is_infinite is False and _rhs.is_infinite is False:
                 # This difference is mathamatically valid ONLY if none of LHS nor RHS is infinite.
                 diff = lhs - rhs
                 if diff is not S.NaN:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1426,22 +1426,27 @@ def is_ge(lhs, rhs, assumptions=None):
         if _lhs.is_extended_real and _rhs.is_extended_real:
             if _lhs.is_infinite:
                 if _rhs.is_infinite:
-                    return _lhs.is_extended_positive or (not _rhs.is_extended_positive)
-                if _lhs.is_extended_positive:
-                    return True
-                return False
+                # This checks all 9 possibilities of fuzz bool values
+                    if _lhs.is_extended_positive or _rhs.is_extended_negative:
+                        return True
+                    if _lhs.is_extended_positive is None:
+                        return None
+                    if _rhs.is_extended_negative is None:
+                        return None
+                return _lhs.is_extended_positive
 
             if _rhs.is_infinite:
-                if _rhs.is_extended_positive:
-                    return False
-                return True
+                return _rhs.is_extended_negative
 
             if _lhs.is_infinite is None:
                 if _rhs.is_infinite and _rhs.is_extended_negative:
                     return True
+                return None
+
             if _rhs.is_infinite is None:
                 if _lhs.is_infinite and _lhs.is_extended_positive:
                     return True
+                return None
 
             if _lhs.is_infinite is False and _rhs.is_infinite is False:
                 # This difference is mathamatically valid ONLY if none of LHS nor RHS is infinite.

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1267,10 +1267,10 @@ def test_issue_23731():
 
 def test_issue_29413():
     x = Symbol("x",extended_real = True)
-    assert is_lt(x + 1, x) == None
-    assert is_lt(x - 1, x) == None
-    assert is_gt(x + 1, x) == None
-    assert is_gt(x - 1, x) == None
+    assert is_lt(x + 1, x) is None
+    assert is_lt(x - 1, x) is None
+    assert is_gt(x + 1, x) is None
+    assert is_gt(x - 1, x) is None
 
 def test_rewrite_Add():
     from sympy.testing.pytest import warns_deprecated_sympy

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1265,6 +1265,12 @@ def test_issue_23731():
     nr = symbols('nr', rational=False)
     assert Eq(nr, .1) == False
 
+def test_issue_29413():
+    x = Symbol("x",extended_real = True)
+    assert is_lt(x + 1, x) == None
+    assert is_lt(x - 1, x) == None
+    assert is_gt(x + 1, x) == None
+    assert is_gt(x - 1, x) == None
 
 def test_rewrite_Add():
     from sympy.testing.pytest import warns_deprecated_sympy

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1146,8 +1146,7 @@ def test_issue_6900():
 
 def test_issue_10122():
     assert solve(abs(x) + abs(x - 1) - 1 > 0, x
-        ) == Or(And(-oo < x, x < S.Zero), And(S.One < x, x < oo))
-
+        ) == Or(x < S.Zero, S.One < x)
 
 def test_issue_4313():
     u = Piecewise((0, x <= 0), (1, x >= a), (x/a, True))
@@ -1161,7 +1160,7 @@ def test_issue_4313():
             (-y**2/(-a**2*y + a**2*M) + 1/(-y + M) -
                 1/(x - y) - 2*y*log(-y)/a**2 + 2*y*log(-y +
                 M)/a**2 - y/a**2 + M/a**2, True)),
-        ((a <= y) & (y <= 0)) | ((y <= 0) & (y > -oo))),
+        ((a <= y) & (y <= 0)) | ((y <= 0) )),
         (Piecewise(
             (-1/(x - y), x <= 0),
             (-a**2/(a**2*x - a**2*y) + 2*a*y/(a**2*x - a**2*y) -
@@ -1298,7 +1297,7 @@ def test_unevaluated_integrals():
     # solve_univariate_inequality fails
     assert p.integrate(y) == Piecewise(
         (y, Eq(f(x), 1) | ((x < 10) & Eq(f(x), 1))),
-        (2*y, (x > -oo) & (x < 10)), (0, True))
+        (2*y, (x < 10)), (0, True))
 
 
 def test_conditions_as_alternate_booleans():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -675,7 +675,7 @@ def test_integrate_returns_piecewise():
     assert integrate(x*sin(n*x), x) == Piecewise(
         (-x*cos(n*x)/n + sin(n*x)/n**2, Ne(n, 0)), (0, True))
     assert integrate(exp(x*y), (x, 0, z)) == Piecewise(
-        (exp(y*z)/y - 1/y, (y > -oo) & (y < oo) & Ne(y, 0)), (z, True))
+        (exp(y*z)/y - 1/y, Ne(y, 0)), (z, True))
     # https://github.com/sympy/sympy/issues/23707
     assert integrate(exp(t)*exp(-t*sqrt(x - y)), t) == Piecewise(
         (-exp(t)/(sqrt(x - y)*exp(t*sqrt(x - y)) - exp(t*sqrt(x - y))),
@@ -1642,7 +1642,7 @@ def test_issue_15509():
     N = CoordSys3D('N')
     x = N.x
     assert integrate(cos(a*x + b), (x, x_1, x_2), heurisch=True) == Piecewise(
-        (-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, (a > -oo) & (a < oo) & Ne(a, 0)), \
+        (-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, Ne(a, 0)), \
             (-x_1*cos(b) + x_2*cos(b), True))
 
 
@@ -1752,7 +1752,7 @@ def test_issue_7827():
         Sum(Piecewise((-cos(n*x)/n, Ne(n, 0)), (0, True)), (n, 1, N))
     assert integrate(integrate(summation(sin(n*x), (n,1,N)), x), x) == \
         Piecewise((Sum(Piecewise((-sin(n*x)/n**2, Ne(n, 0)), (-x/n, True)),
-        (n, 1, N)), (n > -oo) & (n < oo) & Ne(n, 0)), (0, True))
+        (n, 1, N)), Ne(n, 0)), (0, True))
     assert integrate(Sum(x, (n, 1, M)), x) == M*x**2/2
     raises(ValueError, lambda: integrate(Sum(x, (x, y, n)), y))
     raises(ValueError, lambda: integrate(Sum(x, (x, 1, n)), n))
@@ -1797,7 +1797,7 @@ def test_issue_5547():
 
     assert integrate(r0**2*cos(R0*z)**2, (z, -L/2, L/2)) == Piecewise(
         (-r0**2*(-L*R0/4 - sin(L*R0/2)*cos(L*R0/2)/2)/R0 +
-         r0**2*(L*R0/4 + sin(L*R0/2)*cos(L*R0/2)/2)/R0, (R0 > -oo) & (R0 < oo) & Ne(R0, 0)),
+         r0**2*(L*R0/4 + sin(L*R0/2)*cos(L*R0/2)/2)/R0,  Ne(R0, 0)),
         (L*r0**2, True))
 
     w = 2*pi*z/L

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -930,9 +930,9 @@ def test_max_shear_force():
     b.apply_load(2, 2, 0, end=3)
     b.solve_for_reaction_loads(R, M)
     assert b.max_shear_force() == (Interval(0, 2), 8)
-
-    l = symbols('l', positive=True)
-    P = Symbol('P')
+    # Length and P cannot be infinite, it has to be defined otherwise this wont work.
+    l = symbols('l', positive=True, infinite=False)
+    P = Symbol('P', infinite=False)
     b = Beam(l, E, I)
     R1, R2 = symbols('R1, R2')
     b.apply_load(R1, 0, -1)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1307,7 +1307,7 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
         >>> ineq
         [2*k**2 > 0, 200*k**2 - 60*k > 0, 20*k > 0]
         >>> reduce_inequalities(ineq)
-        (3/10 < k) & (k < oo)
+        3/10 < k
 
         """
         pass

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -648,6 +648,8 @@ def test_signsimp():
 
 
 def test_besselsimp():
+    # Not quite knowledgeable with Bessel functions, but it seems like a cannot be infinite.
+    a = symbols("a",infinite=False)
     from sympy.functions.special.bessel import (besseli, besselj, bessely)
     from sympy.integrals.transforms import cosine_transform
     assert besselsimp(exp(-I*pi*y/2)*besseli(y, z*exp_polar(I*pi/2))) == \

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -221,7 +221,7 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
 
     >>> y = Symbol('y', extended_real=True)
     >>> reduce_rational_inequalities([[y + 2 > 0]], y)
-    (-2 < y) & (y < oo)
+    -2 < y
     """
     exact = True
     solution = S.EmptySet  # add pieces for each group
@@ -363,7 +363,7 @@ def reduce_abs_inequalities(exprs, gen):
 
     >>> reduce_abs_inequalities([(Abs(3*x - 5) - 7, '<'),
     ... (Abs(x + 25) - 13, '>')], x)
-    (-2/3 < x) & (x < 4) & (((-oo < x) & (x < -38)) | ((-12 < x) & (x < oo)))
+    (-2/3 < x) & (x < 4) & ((-12 < x) | (x < -38))
 
     >>> reduce_abs_inequalities([(Abs(x - 4) + Abs(3*x - 5) - 7, '<')], x)
     (1/2 < x) & (x < 4)
@@ -933,10 +933,10 @@ def reduce_inequalities(inequalities, symbols=[]):
     >>> from sympy import reduce_inequalities
 
     >>> reduce_inequalities(0 <= x + 3, [])
-    (-3 <= x) & (x < oo)
+    -3 <= x
 
     >>> reduce_inequalities(0 <= x + y*2 - 1, [x])
-    (x < oo) & (x >= 1 - 2*y)
+    x >= 1 - 2*y
     """
     if not iterable(inequalities):
         inequalities = [inequalities]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -585,18 +585,18 @@ def solve(f, *symbols, **flags):
     are ignored):
 
         >>> solve(x < 3)
-        (-oo < x) & (x < 3)
+        x < 3
         >>> solve([x < 3, x**2 > 4], x)
-        ((-oo < x) & (x < -2)) | ((2 < x) & (x < 3))
+        (x < -2) | ((2 < x) & (x < 3))
         >>> solve([x + y - 3, x > 3], x)
-        (3 < x) & (x < oo) & Eq(x, 3 - y)
+        (3 < x) & Eq(x, 3 - y)
 
     Although checking of assumptions on symbols in relationals
     is not done, setting assumptions will affect how certain
     relationals might automatically simplify:
 
         >>> solve(x**2 > 4)
-        ((-oo < x) & (x < -2)) | ((2 < x) & (x < oo))
+        (2 < x) | (x < -2)
 
         >>> r = Symbol('r', real=True)
         >>> solve(r**2 > 4)
@@ -624,7 +624,7 @@ def solve(f, *symbols, **flags):
     the expressions can be processed for multiple symbols:
 
         >>> reduce_inequalities([0 <= x  - 1, y < 3], [x, y])
-        (-oo < y) & (1 <= x) & (x < oo) & (y < 3)
+        (1 <= x) & (y < 3)
 
     But an error is raised if any relationship has more than one
     symbol of interest:

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -198,8 +198,8 @@ def test_reduce_abs_inequalities():
     assert reduce_inequalities(e, x) == ans
     assert reduce_inequalities(abs(x - 5)) == Eq(x, 5)
     assert reduce_inequalities(
-        abs(2*x + 3) >= 8) == Or(And(Le(Rational(5, 2), x), Lt(x, oo)),
-        And(Le(x, Rational(-11, 2)), Lt(-oo, x)))
+        abs(2*x + 3) >= 8) == Or(Le(Rational(5, 2), x),
+        Le(x, Rational(-11, 2)))
     assert reduce_inequalities(abs(x - 4) + abs(
         3*x - 5) < 7) == And(Lt(S.Half, x), Lt(x, 4))
     assert reduce_inequalities(abs(x - 4) + abs(3*abs(x) - 5) < 7) == \
@@ -207,12 +207,12 @@ def test_reduce_abs_inequalities():
 
     nr = Symbol('nr', extended_real=False)
     raises(TypeError, lambda: reduce_inequalities(abs(nr - 5) < 3))
-    assert reduce_inequalities(x < 3, symbols=[x, nr]) == And(-oo < x, x < 3)
+    assert reduce_inequalities(x < 3, symbols=[x, nr]) == (x < 3)
 
 
 def test_reduce_inequalities_general():
-    assert reduce_inequalities(Ge(sqrt(2)*x, 1)) == And(sqrt(2)/2 <= x, x < oo)
-    assert reduce_inequalities(x + 1 > 0) == And(S.NegativeOne < x, x < oo)
+    assert reduce_inequalities(Ge(sqrt(2)*x, 1)) == (sqrt(2)/2 <= x)
+    assert reduce_inequalities(x + 1 > 0) == (S.NegativeOne < x)
 
 
 def test_reduce_inequalities_boolean():
@@ -224,8 +224,8 @@ def test_reduce_inequalities_boolean():
 
 def test_reduce_inequalities_multivariate():
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == And(
-        Or(And(Le(S.One, x), Lt(x, oo)), And(Le(x, -1), Lt(-oo, x))),
-        Or(And(Le(S.One, y), Lt(y, oo)), And(Le(y, -1), Lt(-oo, y))))
+        Or(Le(S.One, x), Le(x, -1)),
+        Or(Le(S.One, y), Le(y, -1)))
 
 
 def test_reduce_inequalities_errors():
@@ -235,7 +235,7 @@ def test_reduce_inequalities_errors():
 
 def test__solve_inequalities():
     assert reduce_inequalities(x + y < 1, symbols=[x]) == (x < 1 - y)
-    assert reduce_inequalities(x + y >= 1, symbols=[x]) == (x < oo) & (x >= -y + 1)
+    assert reduce_inequalities(x + y >= 1, symbols=[x]) == (x >= -y + 1)
     assert reduce_inequalities(Eq(0, x - y), symbols=[x]) == Eq(x, y)
     assert reduce_inequalities(Ne(0, x - y), symbols=[x]) == Ne(x, y)
 
@@ -252,13 +252,13 @@ def test_issue_8235():
     assert reduce_inequalities(x**2 - 1 <= 0) == \
         And(S.NegativeOne <= x, x <= 1)
     assert reduce_inequalities(x**2 - 1 > 0) == \
-        Or(And(-oo < x, x < -1), And(x < oo, S.One < x))
+        Or(x < -1,  S.One < x)
     assert reduce_inequalities(x**2 - 1 >= 0) == \
-        Or(And(-oo < x, x <= -1), And(S.One <= x, x < oo))
+        Or(x <= -1, S.One <= x)
 
     eq = x**8 + x - 9  # we want CRootOf solns here
     sol = solve(eq >= 0)
-    tru = Or(And(rootof(eq, 1) <= x, x < oo), And(-oo < x, x <= rootof(eq, 0)))
+    tru = Or(rootof(eq, 1) <= x,  x <= rootof(eq, 0))
     assert sol == tru
 
     # recast vanilla as real
@@ -379,7 +379,7 @@ def test_issue_8545():
     ans = And(Lt(1, x), Lt(x, oo))
     assert reduce_abs_inequality(eq, '<', x) == ans
     eq = 1 - x - sqrt((1 - x)**2)
-    assert reduce_inequalities(eq < 0) == ans
+    assert reduce_inequalities(eq < 0) == Lt(1, x)
 
 
 def test_issue_8974():
@@ -389,7 +389,7 @@ def test_issue_8974():
 
 def test_issue_10198():
     assert reduce_inequalities(
-        -1 + 1/abs(1/x - 1) < 0) == (x > -oo) & (x < S(1)/2) & Ne(x, 0)
+        -1 + 1/abs(1/x - 1) < 0) == (x < S(1)/2) & Ne(x, 0)
 
     assert reduce_inequalities(abs(1/sqrt(x)) - 1, x) == Eq(x, 1)
     assert reduce_abs_inequality(-3 + 1/abs(1 - 1/x), '<', x) == \
@@ -498,4 +498,4 @@ def test_issue_25738():
 
 
 def test_issue_25983():
-    assert(reduce_inequalities(pi/Abs(x) <= 1) == ((pi <= x) & (x < oo)) | ((-oo < x) & (x <= -pi)))
+    assert(reduce_inequalities(pi/Abs(x) <= 1) == ((pi <= x) ) | ( (x <= -pi)))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -810,7 +810,7 @@ def test_solve_undetermined_coeffs():
 
 def test_solve_inequalities():
     x = Symbol('x')
-    sol = And(S.Zero < x, x < oo)
+    sol = S.Zero < x
     assert solve(x + 1 > 1) == sol
     assert solve([x + 1 > 1]) == sol
     assert solve([x + 1 > 1], x) == sol
@@ -1914,9 +1914,10 @@ def test_issues_6819_6820_6821_6248_8692_25777_25779():
 
 def test_issue_17638():
 
-    assert solve(((2-exp(2*x))*exp(x))/(exp(2*x)+2)**2 > 0, x) == (-oo < x) & (x < log(2)/2)
-    assert solve(((2-exp(2*x)+2)*exp(x+2))/(exp(x)+2)**2 > 0, x) == (-oo < x) & (x < log(4)/2)
-    assert solve((exp(x)+2+x**2)*exp(2*x+2)/(exp(x)+2)**2 > 0, x) == (-oo < x) & (x < oo)
+    assert solve(((2-exp(2*x))*exp(x))/(exp(2*x)+2)**2 > 0, x) == (x < log(2)/2)
+    assert solve(((2-exp(2*x)+2)*exp(x+2))/(exp(x)+2)**2 > 0, x) ==  (x < log(4)/2)
+    # This is true for all extended reals then?
+    assert solve((exp(x)+2+x**2)*exp(2*x+2)/(exp(x)+2)**2 > 0, x)
 
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2820,6 +2820,8 @@ def test_issue_10158():
     raises(ValueError, lambda: solveset(Abs(x - 1) - Abs(y), x, dom))
     raises(ValueError, lambda: solveset(Abs(x + 4*Abs(x + 1)), x, dom))
 
+    assert solve(x*Max(x, 15) - 10, x) == [Rational(2,3)]
+
 
 def test_issue_14300():
     f = 1 - exp(-18000000*x) - y

--- a/sympy/stats/compound_rv.py
+++ b/sympy/stats/compound_rv.py
@@ -71,7 +71,10 @@ class CompoundPSpace(PSpace):
         return self._get_newpspace().domain
 
     def _get_newpspace(self, evaluate=False):
-        x = Dummy('x')
+        if isinstance(self.distribution.args[0], DiscreteDistribution):
+            x = Dummy('x', integer=True, nonnegative=True)
+        else:
+            x = Dummy('x')
         parent_dist = self.distribution.args[0]
         func = Lambda(x, self.distribution.pdf(x, evaluate))
         new_pspace = self._transform_pspace(self.symbol, parent_dist, func)
@@ -188,6 +191,9 @@ class CompoundDistribution(Distribution, NamedArgsMixin):
         if isinstance(dist, SingleFiniteDistribution):
             y = Dummy('y', integer=True, negative=False)
             expr = dist.pmf(y)
+        elif isinstance(dist, DiscreteDistribution):
+            y = Dummy('y', integer=True)
+            expr = dist.pdf(y)
         else:
             y = Dummy('y')
             expr = dist.pdf(y)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes [#29413](https://github.com/sympy/sympy/issues/29413) and properly fixes https://github.com/sympy/sympy/issues/10158
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Changed `is_ge` function from `relational.py` to handle the infinite and finite cases properly.

#### Other comments
The tests that are failing seems like were technically wrong anyways. We do NOT know if `x` is extended real or not, so saying `x < oo` implies x cannot be extended real, which is not true in these test cases.
(Assume `from sympy.abc import x, y, a etc.` unless stated otherwise)
Note that initializing variables as reals (or extended reals), makes them equivalent anyways. Seems like `x < oo` etc are not intended.
Here are some before the PR and after PR pictures that makes the tests fail:
```python
solve(abs(x) + abs(x - 1) - 1 > 0, x)
```
<img width="427" height="54" alt="image" src="https://github.com/user-attachments/assets/9704188a-261d-4aeb-bb87-f80f34db2b0a" />
<img width="427" height="54" alt="image" src="https://github.com/user-attachments/assets/6fd24020-512a-4cda-aaf0-e8e0abf24135" />

```python
u = Piecewise((0, x <= 0), (1, x >= a), (x/a, True))
e = (u - u.subs(x, y))**2/(x - y)**2
integrate(e,  x).expand()

```

<img width="510" height="77" alt="image" src="https://github.com/user-attachments/assets/09c446dd-a76f-4223-acaf-6090defc6fa4" />
<img width="510" height="77" alt="image" src="https://github.com/user-attachments/assets/29769136-0afd-4861-b707-45a6b1bded5b" />


```python
f = Function('f')
p = Piecewise((1, Eq(f(x) - 1, 0)), (2, x - 10 < 0), (0, True))
p.integrate(y)
```
<img width="532" height="127" alt="image" src="https://github.com/user-attachments/assets/9adea410-6c75-4992-8adf-4136c756554c" />
<img width="532" height="127" alt="image" src="https://github.com/user-attachments/assets/edddf8c6-fd20-4d16-9982-c299dc1e63c5" />

If the maintainers are OK with changing the tests, I can manually check all 22 cases that are failing and change them accordingly IF the issue is related to ` x < oo` of course.
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug of relational `is_ge `to handle the infinite cases when the variables are unknown to be extended reals.
<!-- END RELEASE NOTES -->
