### PR TITLE
polys: skip zero generators in sdm_groebner initialization

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1769,6 +1769,7 @@ Zhi-Qiang Zhou <zzq_890709@hotmail.com> zhouzq-thu <zzq_890709@hotmail.com>
 Zhongshi <zj495@nyu.edu>
 Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <123136644+zylipku@users.noreply.github.com>
 Zhuoyuan Li <zy.li@stu.pku.edu.cn> zylipku <zy.li@stu.pku.edu.cn>
+Zihao Qi <zihaoqi@iastate.edu> Zihao Qi <35388022+megapteranovaeangliae@users.noreply.github.com>
 Zlatan Vasović <zlatanvasovic@gmail.com>
 Zoufiné Lauer-Baré <raszoufine@gmail.com> Zoufiné Lauer-Baré <82505312+zolabar@users.noreply.github.com>
 Zoufiné Lauer-Baré <raszoufine@gmail.com> zolabar <raszoufine@gmail.com>

--- a/sympy/polys/agca/tests/test_ideals.py
+++ b/sympy/polys/agca/tests/test_ideals.py
@@ -59,14 +59,12 @@ def test_exceptions():
     assert I != J
 
 
-def test_zero_generators_containment():
+def test_zero_generators_do_not_change_ideal():
     R = QQ.old_poly_ring(x)
 
-    assert R.ideal(0, x).contains(x)
-    assert not R.ideal(0, x).contains(1)
-    assert not R.ideal(0).contains(x)
-    assert not R.ideal(0, 0).contains(x)
-    assert R.ideal(0, x, x).contains(x)
+    assert R.ideal(0, x) == R.ideal(x)
+    assert R.ideal(0, 0) == R.ideal()
+    assert R.ideal(0, x, x) == R.ideal(x)
 
 
 def test_nontriv_global():

--- a/sympy/polys/agca/tests/test_ideals.py
+++ b/sympy/polys/agca/tests/test_ideals.py
@@ -59,6 +59,16 @@ def test_exceptions():
     assert I != J
 
 
+def test_zero_generators_containment():
+    R = QQ.old_poly_ring(x)
+
+    assert R.ideal(0, x).contains(x)
+    assert not R.ideal(0, x).contains(1)
+    assert not R.ideal(0).contains(x)
+    assert not R.ideal(0, 0).contains(x)
+    assert R.ideal(0, x, x).contains(x)
+
+
 def test_nontriv_global():
     R = QQ.old_poly_ring(x, y, z)
 

--- a/sympy/polys/distributedmodules.py
+++ b/sympy/polys/distributedmodules.py
@@ -705,8 +705,10 @@ def sdm_groebner(G, NF, O, K, extended=False):
 
     # First add all the elements of G to S
     for i, f in enumerate(G):
+        if not f:
+            continue
         P = update(f, sdm_deg(f), P)
-        if extended and f:
+        if extended:
             coefficients.append(sdm_from_dict({(i,) + (0,)*numgens: K(1)}, O))
 
     # Now carry out the buchberger algorithm.


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #26572 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This fixes a crash in ideal membership testing when the generating set contains both zero and nonzero generators, e.g.

```python
from sympy import Symbol, QQ
x = Symbol('x')
R = QQ.old_poly_ring(x)
R.ideal(0, x).contains(x)
```
Before this change, the last line raised ValueError: max() iterable argument is empty.

The issue was in sdm_groebner: during initial basis setup it called sdm_deg(f) on every generator before zero generators were filtered out. This patch skips zero generators before computing their initial sugar, which keeps the existing sdm_deg contract unchanged and makes the initialization logic consistent with the rest of sdm_groebner.

This PR also adds regression coverage for zero-generator containment cases in test_ideals.py.

#### Other comments
I tested the patch against the AGCA test files and the local sympy/polys/agca/tests suite.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used OpenAI Codex as an assistive tool for traceback analysis, code inspection, and drafting an initial patch. I manually reviewed the final changes, applied them in my local checkout, ran the tests, and take responsibility for the submitted code and description.

AI-assisted content includes the modified hunk in `sympy/polys/distributedmodules.py`, and the added regression test in `sympy/polys/agca/tests/test_ideals.py`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a crash in `ideal.contains()` when the ideal generators included zero.
<!-- END RELEASE NOTES -->
