### PR TITLE
Fix Piecewise._eval_as_leading_term ignoring limit direction

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -454,6 +454,7 @@ Boris Atamanovskiy <shaomoron@gmail.com>
 Boris Bilich <bilichboris1999@gmail.com>
 Boris Ettinger <ettinger.boris@gmail.com>
 Boris Timokhin <qoqenator@gmail.com>
+Borun Li <borun.li@icloud.com>
 Bradley Dowling <34559056+btdow@users.noreply.github.com>
 Bradley Froehle <brad.froehle@gmail.com>
 Bradley Gannon <bradley.m.gannon@gmail.com>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -224,8 +224,47 @@ class Piecewise(DefinedFunction):
         return piecewise_simplify(self, **kwargs)
 
     def _eval_as_leading_term(self, x, logx, cdir):
+        """Return the leading term of the Piecewise expression as ``x -> 0``.
+
+        The condition of each piece is evaluated from the correct side of
+        the limit point by substituting a small positive dummy ``d`` scaled
+        by the approach direction ``cdir``:
+
+        1. cdir > 0 (right, x -> 0+): substitute x = d
+        2. cdir < 0 (left,  x -> 0-): substitute x = -d
+        3. cdir = 0 (no direction): substitute x = 0
+
+        Examples
+        ========
+
+        >>> from sympy import Piecewise, Symbol
+        >>> x = Symbol('x')
+        >>> p = Piecewise((1, x < 0), (-1, x >= 0))
+        >>> p._eval_as_leading_term(x, None, 1)
+        -1
+        >>> p._eval_as_leading_term(x, None, -1)
+        1
+        """
         for e, c in self.args:
-            if c == True or c.subs(x, 0) == True:
+            if c == True:
+                return e.as_leading_term(x)
+            # Evaluate the condition from the correct side of x=0.
+            # A positive Dummy d scaled by cdir represents a small value
+            # approaching 0 from the direction indicated by cdir:
+            #   cdir > 0  =>  x = +d  (right approach)
+            #   cdir < 0  =>  x = -d  (left approach)
+            # If the substitution is inconclusive (the condition involves a
+            # constant that 0 is strictly interior to, e.g. x <= 0.5 gives
+            # d <= 0.5 which cannot be resolved for an unbounded Dummy), fall
+            # back to evaluating at the limit point x=0 itself.
+            if cdir.is_positive or cdir.is_negative:
+                d = Dummy('d', positive=True)
+                cval = c.subs(x, cdir * d)
+                if cval not in (S.true, S.false):
+                    cval = c.subs(x, S.Zero)
+            else:
+                cval = c.subs(x, S.Zero)
+            if cval == True:
                 return e.as_leading_term(x)
 
     def _eval_adjoint(self):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -230,21 +230,30 @@ class Piecewise(DefinedFunction):
         the limit point by substituting a small positive dummy ``d`` scaled
         by the approach direction ``cdir``:
 
-        1. cdir > 0 (right, x -> 0+): substitute x = d
-        2. cdir < 0 (left,  x -> 0-): substitute x = -d
-        3. cdir = 0 (no direction): substitute x = 0
+        * ``cdir > 0`` (right, ``x -> 0+``): substitute ``x = d``
+        * ``cdir < 0`` (left,  ``x -> 0-``): substitute ``x = -d``
+        * ``cdir = 0`` (no direction): substitute ``x = 0``
+
+        This ensures that boundary conditions such as ``x >= 0`` are
+        resolved correctly for each direction instead of being evaluated
+        at the boundary point itself. If the direction-aware substitution
+        is inconclusive (e.g. ``x <= 0.5`` gives ``d <= 0.5`` which cannot
+        be resolved for an unbounded Dummy), the condition falls back to
+        being evaluated at ``x = 0``.
 
         Examples
         ========
 
-        >>> from sympy import Piecewise, Symbol
+        >>> from sympy import Piecewise, Symbol, S
         >>> x = Symbol('x')
         >>> p = Piecewise((1, x < 0), (-1, x >= 0))
-        >>> p._eval_as_leading_term(x, None, 1)
+        >>> p._eval_as_leading_term(x, None, S.One)
         -1
-        >>> p._eval_as_leading_term(x, None, -1)
+        >>> p._eval_as_leading_term(x, None, S.NegativeOne)
         1
         """
+        from sympy.core.sympify import sympify
+        cdir = sympify(cdir)
         for e, c in self.args:
             if c == True:
                 return e.as_leading_term(x)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from itertools import product
 
-from sympy import Lt, Le, Gt, Ge, Ne, Eq
+from sympy import Ne, Eq
 from sympy.concrete.summations import Sum
 from sympy.core.function import (Function, diff)
 from sympy.core import EulerGamma, GoldenRatio

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -164,6 +164,7 @@ def test_piecewise2():
     assert limit(func2, x, 0) == 0
     assert limit(func3, x, -1) == 2
 
+
 def test_piecewise_limit_issue_27236():
     # https://github.com/sympy/sympy/issues/27236
     x = symbols('x')
@@ -175,19 +176,20 @@ def test_piecewise_limit_issue_27236():
     assert limit(f, x, 0, '+') == -1
     raises(ValueError, lambda: limit(f, x, 0, '+-'))
 
-    # Case 2: Ne condition — the function equals 1 everywhere except x=0,
+    # Case 2: Ne condition: the function equals 1 everywhere except x=0,
     # so all one-sided and two-sided limits are 1.
     p = Piecewise((1, Ne(x, 0)), (0, True))
     assert limit(p, x, 0, '-') == 1
     assert limit(p, x, 0, '+') == 1
     assert limit(p, x, 0) == 1
 
-    # Case 3: Eq condition — the function equals 1 everywhere except x=0,
+    # Case 3: Eq condition: the function equals 1 everywhere except x=0,
     # so all one-sided and two-sided limits are 1.
     q = Piecewise((0, Eq(x, 0)), (1, True))
     assert limit(q, x, 0, '-') == 1
     assert limit(q, x, 0, '+') == 1
     assert limit(q, x, 0) == 1
+
 
 def test_basic5():
     class my(Function):

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from itertools import product
 
+from sympy import Lt, Le, Gt, Ge, Ne, Eq
 from sympy.concrete.summations import Sum
 from sympy.core.function import (Function, diff)
 from sympy.core import EulerGamma, GoldenRatio
@@ -163,6 +164,30 @@ def test_piecewise2():
     assert limit(func2, x, 0) == 0
     assert limit(func3, x, -1) == 2
 
+def test_piecewise_limit_issue_27236():
+    # https://github.com/sympy/sympy/issues/27236
+    x = symbols('x')
+
+    # Case 1: directional limits at a jump discontinuity.
+    # The two-sided limit does not exist and must raise ValueError.
+    f = Piecewise((1, x < 0), (-1, x >= 0))
+    assert limit(f, x, 0, '-') == 1
+    assert limit(f, x, 0, '+') == -1
+    raises(ValueError, lambda: limit(f, x, 0, '+-'))
+
+    # Case 2: Ne condition — the function equals 1 everywhere except x=0,
+    # so all one-sided and two-sided limits are 1.
+    p = Piecewise((1, Ne(x, 0)), (0, True))
+    assert limit(p, x, 0, '-') == 1
+    assert limit(p, x, 0, '+') == 1
+    assert limit(p, x, 0) == 1
+
+    # Case 3: Eq condition — the function equals 1 everywhere except x=0,
+    # so all one-sided and two-sided limits are 1.
+    q = Piecewise((0, Eq(x, 0)), (1, True))
+    assert limit(q, x, 0, '-') == 1
+    assert limit(q, x, 0, '+') == 1
+    assert limit(q, x, 0) == 1
 
 def test_basic5():
     class my(Function):


### PR DESCRIPTION
## References to other Issues or PRs
Fixes #27236

## Brief description of what is fixed or changed
`Piecewise._eval_as_leading_term` ignored the `cdir` parameter and
always evaluated conditions at `x=0`. This caused one-sided limits at
jump discontinuities to return the same wrong value, and the two-sided
limit to silently return it instead of raising `ValueError`.

Fix: substitute a positive `Dummy` scaled by `cdir` to evaluate
conditions from the correct side of the limit point, with a fallback
to `x=0` when the substitution is inconclusive.

## AI Generation Disclosure:
I used Claude Code as an assistive tool for understanding the project structure, revising test cases, and improve my wordings in the documentation to avoid unclear expressions.

## Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed `Piecewise._eval_as_leading_term` to respect the limit
    direction (`cdir`), correcting one-sided and two-sided limits
    at jump discontinuities.
<!-- END RELEASE NOTES -->