### PR TITLE
Add decode_literal method to EncodedCNF

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1543,7 +1543,8 @@ Siddhant Jain <siddhantashoknagar@gmail.com> me-t1me <siddhantashoknagar@gmail.c
 Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpal@users.noreply.github.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
-Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
+Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>]
+Sidra Bibi <sidrasaqlain11@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <61250140+zarstensen@users.noreply.github.com>
 SirJohnFranklin <sirjfu@googlemail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+Sidra Bibi <sidrasaqlain11@gmail.com>

--- a/sympy/assumptions/cnf.py
+++ b/sympy/assumptions/cnf.py
@@ -439,5 +439,31 @@ class EncodedCNF:
         else:
             return value
 
+
+    def decode_literal(self, literal):
+        """
+        Given an encoded literal, return the corresponding symbol.
+        A negative literal returns the negated symbol.
+
+        Examples
+        ========
+
+        >>> from sympy import Q
+        >>> from sympy.assumptions.cnf import CNF, EncodedCNF
+        >>> from sympy.abc import x
+        >>> cnf = CNF.from_prop(Q.real(x))
+        >>> enc = EncodedCNF()
+        >>> enc.from_cnf(cnf)
+        >>> enc.decode_literal(1)
+        Q.real(x)
+        >>> enc.decode_literal(-1)
+        ~Q.real(x)
+        """
+        from sympy.logic.boolalg import Not
+        symbol = self._symbols[abs(literal) - 1]
+        if literal < 0:
+            return Not(symbol)
+        return symbol
+
     def encode(self, clause):
         return {self.encode_arg(arg) if not arg.lit == S.false else 0 for arg in clause}


### PR DESCRIPTION
references to other Issues or PRs
revives #25390, see #29542

added a decode_literal method to EncodedCNF it takes an encoded integer and returns the symbol back. If the integer 
is negative it returns the negated symbol

TiloRC mentioned in #29542 that having a convenient decode method in EncodedCNF would be useful this is my attempt 
at that

i used claude (AI assistant) to help structure the method i understand the code fully and can explain every line
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->