### PR TITLE
Fix xfail for test_cross

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -597,6 +597,7 @@ Dominik Stańczak <stanczakdominik@gmail.com>
 Donald Wilson <donwilson1029@gmail.com> wilds-23 <wilds-23@rhodes.edu>
 Duane Nykamp <nykamp@umn.edu>
 Duc-Minh Phan <alephvn@gmail.com>
+Ducket191 <dangminhduc1912008@gmail.com>
 Dustin Gadal <Dustin.Gadal@gmail.com> <dustin.gadal@gmail.com>
 Dzhelil Rufat <drufat@caltech.edu>
 Ebrahim Byagowi <ebrahim@gnu.org>

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -35,7 +35,6 @@ def test_cross():
     assert cross(v1, v2) + cross(v2, v1) == Vector.zero
 
 
-@XFAIL
 def test_cross_xfail():
     v1 = C.x * i + C.z * C.z * j
     v2 = C.x * i + C.y * j + C.z * k

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -15,7 +15,6 @@ from sympy.vector.vector import Cross, Dot, cross
 from sympy.testing.pytest import raises
 from sympy.vector.kind import VectorKind
 from sympy.core.kind import NumberKind
-from sympy.testing.pytest import XFAIL
 
 
 C = CoordSys3D('C')

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -577,7 +577,7 @@ class Cross(Expr):
         obj._expr1 = expr1
         obj._expr2 = expr2
         return obj
-    
+
     def __add__(self, other):
         if other == -self:
             return Vector.zero
@@ -588,6 +588,15 @@ class Cross(Expr):
             return Vector.zero
         return Expr.__radd__(self, other)
 
+    def __sub__(self, other):
+        if other == self:
+            return Vector.zero
+        return Expr.__sub__(self, other)
+
+    def __rsub__(self, other):
+        if other == self:
+            return Vector.zero
+        return Expr.__rsub__(self, other)
 
     def doit(self, **hints):
         return cross(self._expr1, self._expr2)

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -577,6 +577,17 @@ class Cross(Expr):
         obj._expr1 = expr1
         obj._expr2 = expr2
         return obj
+    
+    def __add__(self, other):
+        if other == -self:
+            return Vector.zero
+        return Expr.__add__(self, other)
+
+    def __radd__(self, other):
+        if other == -self:
+            return Vector.zero
+        return Expr.__radd__(self, other)
+
 
     def doit(self, **hints):
         return cross(self._expr1, self._expr2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
I added special conditions for Cross's operations (add, sub, and their reverse) to handle self-cancellation (like A + (-A) = vector 0)

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
