### PR TITLE
assumptions: add refine_exp handler for exp

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -629,6 +629,7 @@ Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
 Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
+Evan <guaguajinchina@gmail.com> Wang 6 <wang6@Wangdebijibendiannao.local>
 Evandro Bernardes <evbernardes@gmail.com> Evandro <15084103+evbernardes@users.noreply.github.com>
 Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
 Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -143,50 +143,9 @@ def refine_Pow(expr, assumptions):
     >>> refine_Pow((-1)**(x+3), True)
     (-1)**(x + 1)
 
-    Exponential expressions are also handled here:
-
-    >>> from sympy import E, exp, I, pi, sqrt
-    >>> refine_Pow(exp(2*pi*I*x), Q.integer(x))
-    1
-    >>> refine_Pow(sqrt(E**x), Q.real(x))
-    exp(x/2)
-
     """
     from sympy.functions.elementary.complexes import Abs
-    from sympy.functions.elementary.exponential import exp
     from sympy.functions import sign
-
-    if isinstance(expr, exp):
-        coeff = expr.exp.as_coefficient(S.Pi * S.ImaginaryUnit)
-        if coeff is None:
-            return expr
-        elif ask(Q.even(coeff), assumptions):
-            return S.One
-        elif ask(Q.odd(coeff), assumptions):
-            return S.NegativeOne
-        elif coeff.is_Add:
-            integer_terms = []
-            remaining_terms = []
-            for term in coeff.args:
-                if ask(Q.integer(term), assumptions):
-                    integer_terms.append(term)
-                else:
-                    remaining_terms.append(term)
-
-            if integer_terms:
-                integer_part = Add(*integer_terms)
-                remaining_part = Add(*remaining_terms)
-                if remaining_part.is_Rational:
-                    phase = expr.func(S.Pi * S.ImaginaryUnit * remaining_part)
-                    if ask(Q.even(integer_part), assumptions):
-                        return phase
-                    if ask(Q.odd(integer_part), assumptions):
-                        return -phase
-                    return (-1)**integer_part * phase
-
-    if isinstance(expr.base, exp) and isinstance(expr.exp, Rational):
-        if ask(Q.real(expr.base.exp), assumptions):
-            return expr.base.func(expr.base.exp * expr.exp)
 
     if isinstance(expr.base, Abs):
         if ask(Q.real(expr.base.args[0]), assumptions) and \
@@ -256,6 +215,43 @@ def refine_Pow(expr, assumptions):
 
                 if old != expr:
                     return expr
+
+
+def refine_exp(expr, assumptions):
+    """
+    Handler for exponential functions.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, exp, I, pi
+    >>> from sympy.assumptions.refine import refine_exp
+    >>> from sympy.abc import x
+    >>> refine_exp(exp(2*pi*I*x), Q.integer(x))
+    1
+    >>> refine_exp(exp(pi*I*(x + 1/2)), Q.integer(x))
+    I*(-1)**x
+    """
+    coeff = expr.exp.as_coefficient(S.Pi * S.ImaginaryUnit)
+    if coeff is None:
+        return expr
+
+    integer_terms = []
+    remaining_terms = []
+    terms = coeff.args if coeff.is_Add else (coeff,)
+    for term in terms:
+        if ask(Q.integer(term), assumptions):
+            integer_terms.append(term)
+        else:
+            remaining_terms.append(term)
+
+    if not integer_terms:
+        return expr
+
+    integer_part = Add(*integer_terms)
+    remaining_part = Add(*remaining_terms)
+    phase = expr.func(S.Pi * S.ImaginaryUnit * remaining_part)
+    return (-1)**integer_part * phase
 
 
 def refine_atan2(expr, assumptions):
@@ -618,7 +614,7 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
-    'exp': refine_Pow,
+    'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -143,9 +143,51 @@ def refine_Pow(expr, assumptions):
     >>> refine_Pow((-1)**(x+3), True)
     (-1)**(x + 1)
 
+    Exponential expressions are also handled here:
+
+    >>> from sympy import E, exp, I, pi, sqrt
+    >>> refine_Pow(exp(2*pi*I*x), Q.integer(x))
+    1
+    >>> refine_Pow(sqrt(E**x), Q.real(x))
+    exp(x/2)
+
     """
     from sympy.functions.elementary.complexes import Abs
+    from sympy.functions.elementary.exponential import exp
     from sympy.functions import sign
+
+    if isinstance(expr, exp):
+        coeff = expr.exp.as_coefficient(S.Pi * S.ImaginaryUnit)
+
+        if coeff is not None:
+            if ask(Q.even(coeff), assumptions):
+                return S.One
+            if ask(Q.odd(coeff), assumptions):
+                return S.NegativeOne
+
+            if coeff.is_Add:
+                integer_terms = []
+                remaining_terms = []
+                for term in coeff.args:
+                    if ask(Q.integer(term), assumptions):
+                        integer_terms.append(term)
+                    else:
+                        remaining_terms.append(term)
+
+                if integer_terms:
+                    integer_part = Add(*integer_terms)
+                    remaining_part = Add(*remaining_terms)
+                    if remaining_part.is_Rational:
+                        phase = expr.func(S.Pi * S.ImaginaryUnit * remaining_part)
+                        if ask(Q.even(integer_part), assumptions):
+                            return phase
+                        if ask(Q.odd(integer_part), assumptions):
+                            return -phase
+
+    if isinstance(expr.base, exp) and isinstance(expr.exp, Rational):
+        if ask(Q.real(expr.base.exp), assumptions):
+            return expr.base.func(expr.base.exp * expr.exp)
+
     if isinstance(expr.base, Abs):
         if ask(Q.real(expr.base.args[0]), assumptions) and \
                 ask(Q.even(expr.exp), assumptions):
@@ -495,64 +537,6 @@ def refine_sin_cos(expr, assumptions):
         pow_expr = (-1)**((k + 1) / 2)
         refined_pow = refine_Pow(pow_expr, assumptions)
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
-
-
-def refine_exp(expr, assumptions):
-    """
-    Handler for the exponential function.
-
-    Examples
-    ========
-
-    >>> from sympy.assumptions.refine import refine_exp
-    >>> from sympy import Q, Rational, exp, I, pi
-    >>> from sympy.abc import x
-    >>> refine_exp(exp(2*pi*I*x), Q.integer(x))
-    1
-    >>> refine_exp(exp(pi*I*x), Q.even(x))
-    1
-    >>> refine_exp(exp(pi*I*x), Q.odd(x))
-    -1
-    >>> refine_exp(exp(2*pi*I*(x + Rational(1, 4))), Q.integer(x))
-    I
-    >>> refine_exp(exp(2*pi*I*(x + Rational(3, 4))), Q.integer(x))
-    -I
-
-    """
-    arg = expr.args[0]
-    pi_i = S.Pi * S.ImaginaryUnit
-
-    coeff = arg.coeff(pi_i)
-    if coeff == 0 or (arg - coeff*pi_i).expand() != 0:
-        return expr
-    coeff = coeff.expand()
-
-    if ask(Q.even(coeff), assumptions):
-        return S.One
-    if ask(Q.odd(coeff), assumptions):
-        return S.NegativeOne
-
-    if coeff.is_Add:
-        integer_terms = []
-        remaining_terms = []
-        for term in coeff.args:
-            if ask(Q.integer(term), assumptions):
-                integer_terms.append(term)
-            else:
-                remaining_terms.append(term)
-
-        if integer_terms:
-            integer_part = Add(*integer_terms)
-            remaining_part = Add(*remaining_terms)
-            if remaining_part.is_Rational:
-                phase = expr.func(pi_i*remaining_part)
-                if ask(Q.even(integer_part), assumptions):
-                    return phase
-                if ask(Q.odd(integer_part), assumptions):
-                    return -phase
-    return expr
-
-
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.
@@ -632,7 +616,7 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
-    'exp': refine_exp,
+    'exp': refine_Pow,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -497,6 +497,62 @@ def refine_sin_cos(expr, assumptions):
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
 
+def refine_exp(expr, assumptions):
+    """
+    Handler for the exponential function.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_exp
+    >>> from sympy import Q, Rational, exp, I, pi
+    >>> from sympy.abc import x
+    >>> refine_exp(exp(2*pi*I*x), Q.integer(x))
+    1
+    >>> refine_exp(exp(pi*I*x), Q.even(x))
+    1
+    >>> refine_exp(exp(pi*I*x), Q.odd(x))
+    -1
+    >>> refine_exp(exp(2*pi*I*(x + Rational(1, 4))), Q.integer(x))
+    I
+    >>> refine_exp(exp(2*pi*I*(x + Rational(3, 4))), Q.integer(x))
+    -I
+
+    """
+    arg = expr.args[0]
+    pi_i = S.Pi * S.ImaginaryUnit
+
+    coeff = arg.coeff(pi_i)
+    if coeff == 0 or (arg - coeff*pi_i).expand() != 0:
+        return expr
+    coeff = coeff.expand()
+
+    if ask(Q.even(coeff), assumptions):
+        return S.One
+    if ask(Q.odd(coeff), assumptions):
+        return S.NegativeOne
+
+    if coeff.is_Add:
+        integer_terms = []
+        remaining_terms = []
+        for term in coeff.args:
+            if ask(Q.integer(term), assumptions):
+                integer_terms.append(term)
+            else:
+                remaining_terms.append(term)
+
+        if integer_terms:
+            integer_part = Add(*integer_terms)
+            remaining_part = Add(*remaining_terms)
+            if remaining_part.is_Rational:
+                phase = expr.func(pi_i*remaining_part)
+                if ask(Q.even(integer_part), assumptions):
+                    return phase
+                if ask(Q.odd(integer_part), assumptions):
+                    return -phase
+    return expr
+
+
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.
@@ -576,6 +632,7 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -224,13 +224,12 @@ def refine_exp(expr, assumptions):
     Examples
     ========
 
-    >>> from sympy import Q, exp, I, pi
-    >>> from sympy.assumptions.refine import refine_exp
+    >>> from sympy import Q, S, exp, I, pi, refine
     >>> from sympy.abc import x
-    >>> refine_exp(exp(2*pi*I*x), Q.integer(x))
+    >>> refine(exp(2*pi*I*x), Q.integer(x))
     1
-    >>> refine_exp(exp(pi*I*(x + 1/2)), Q.integer(x))
-    I*(-1)**x
+    >>> refine(exp(pi*I*(x + S.Half)), Q.integer(x))
+    (-1)**x*I
     """
     coeff = expr.exp.as_coefficient(S.Pi * S.ImaginaryUnit)
     if coeff is None:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -537,8 +537,8 @@ def refine_sin_cos(expr, assumptions):
         pow_expr = (-1)**((k + 1) / 2)
         refined_pow = refine_Pow(pow_expr, assumptions)
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
-    
-    
+
+
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -158,31 +158,31 @@ def refine_Pow(expr, assumptions):
 
     if isinstance(expr, exp):
         coeff = expr.exp.as_coefficient(S.Pi * S.ImaginaryUnit)
+        if coeff is None:
+            return expr
+        elif ask(Q.even(coeff), assumptions):
+            return S.One
+        elif ask(Q.odd(coeff), assumptions):
+            return S.NegativeOne
+        elif coeff.is_Add:
+            integer_terms = []
+            remaining_terms = []
+            for term in coeff.args:
+                if ask(Q.integer(term), assumptions):
+                    integer_terms.append(term)
+                else:
+                    remaining_terms.append(term)
 
-        if coeff is not None:
-            if ask(Q.even(coeff), assumptions):
-                return S.One
-            if ask(Q.odd(coeff), assumptions):
-                return S.NegativeOne
-
-            if coeff.is_Add:
-                integer_terms = []
-                remaining_terms = []
-                for term in coeff.args:
-                    if ask(Q.integer(term), assumptions):
-                        integer_terms.append(term)
-                    else:
-                        remaining_terms.append(term)
-
-                if integer_terms:
-                    integer_part = Add(*integer_terms)
-                    remaining_part = Add(*remaining_terms)
-                    if remaining_part.is_Rational:
-                        phase = expr.func(S.Pi * S.ImaginaryUnit * remaining_part)
-                        if ask(Q.even(integer_part), assumptions):
-                            return phase
-                        if ask(Q.odd(integer_part), assumptions):
-                            return -phase
+            if integer_terms:
+                integer_part = Add(*integer_terms)
+                remaining_part = Add(*remaining_terms)
+                if remaining_part.is_Rational:
+                    phase = expr.func(S.Pi * S.ImaginaryUnit * remaining_part)
+                    if ask(Q.even(integer_part), assumptions):
+                        return phase
+                    if ask(Q.odd(integer_part), assumptions):
+                        return -phase
+                    return (-1)**integer_part * phase
 
     if isinstance(expr.base, exp) and isinstance(expr.exp, Rational):
         if ask(Q.real(expr.base.exp), assumptions):
@@ -537,6 +537,8 @@ def refine_sin_cos(expr, assumptions):
         pow_expr = (-1)**((k + 1) / 2)
         refined_pow = refine_Pow(pow_expr, assumptions)
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
+    
+    
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -3,7 +3,7 @@ from sympy.assumptions.ask import Q
 from sympy.assumptions.refine import refine, refine_sin_cos
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
-from sympy.core.numbers import (I, Rational, nan, pi)
+from sympy.core.numbers import (E, I, Rational, nan, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
@@ -93,6 +93,10 @@ def test_exp():
     assert refine(exp(2*pi*I*(x + y + Rational(1, 4))),
         Q.integer(x) & Q.integer(y)) == I
     assert refine(exp(pi*I*x), Q.integer(x)) == exp(pi*I*x)
+
+    assert refine(sqrt(E**x), Q.real(x)) == exp(x/2)
+    assert refine((E**x)**Rational(3, 2), Q.real(x)) == exp(3*x/2)
+    assert refine(sqrt(E**x)) == sqrt(exp(x))
 
 
 def test_Piecewise():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -3,7 +3,7 @@ from sympy.assumptions.ask import Q
 from sympy.assumptions.refine import refine, refine_sin_cos
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
-from sympy.core.numbers import (E, I, Rational, nan, pi)
+from sympy.core.numbers import (I, Rational, nan, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
@@ -93,12 +93,7 @@ def test_exp():
 
     assert refine(exp(2*pi*I*(x + y + Rational(1, 4))),
         Q.integer(x) & Q.integer(y)) == I
-    assert refine(exp(pi*I*x), Q.integer(x)) == exp(pi*I*x)
-
-    assert refine(sqrt(E**x), Q.real(x)) == exp(x/2)
-    assert refine((E**x)**Rational(3, 2), Q.real(x)) == exp(3*x/2)
-    assert refine(sqrt(E**x)) == sqrt(exp(x))
-
+    assert refine(exp(pi*I*x), Q.integer(x)) == (-1)**x
 
 def test_Piecewise():
     assert refine(Piecewise((1, x < 0), (3, True)), (x < 0)) == 1

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -78,6 +78,22 @@ def test_exp():
     assert refine(exp(pi*I*2*(x + Rational(1, 4)))) == I
     assert refine(exp(pi*I*2*(x + Rational(3, 4)))) == -I
 
+    x = Symbol('x')
+    assert refine(exp(pi*I*2*x), Q.integer(x)) == 1
+    assert refine(exp(pi*I*x), Q.even(x)) == 1
+    assert refine(exp(pi*I*2*(x + S.Half)), Q.integer(x)) == -1
+    assert refine(exp(pi*I*x), Q.odd(x)) == -1
+    assert refine(exp(pi*I*2*(x + Rational(1, 4))), Q.integer(x)) == I
+    assert refine(exp(pi*I*2*(x + Rational(3, 4))), Q.integer(x)) == -I
+
+    assert refine(exp(pi*I*(x + Rational(1, 2))), Q.even(x)) == I
+    assert refine(exp(pi*I*(x + Rational(1, 2))), Q.odd(x)) == -I
+    assert refine(exp(pi*I*(x + Rational(3, 2))), Q.odd(x)) == I
+
+    assert refine(exp(2*pi*I*(x + y + Rational(1, 4))),
+        Q.integer(x) & Q.integer(y)) == I
+    assert refine(exp(pi*I*x), Q.integer(x)) == exp(pi*I*x)
+
 
 def test_Piecewise():
     assert refine(Piecewise((1, x < 0), (3, True)), (x < 0)) == 1

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -89,6 +89,7 @@ def test_exp():
     assert refine(exp(pi*I*(x + Rational(1, 2))), Q.even(x)) == I
     assert refine(exp(pi*I*(x + Rational(1, 2))), Q.odd(x)) == -I
     assert refine(exp(pi*I*(x + Rational(3, 2))), Q.odd(x)) == I
+    assert refine(exp(pi*I*(x + Rational(1, 2))), Q.integer(x)) == I*(-1)**x
 
     assert refine(exp(2*pi*I*(x + y + Rational(1, 4))),
         Q.integer(x) & Q.integer(y)) == I


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes [#29196](https://github.com/sympy/sympy/issues/29196) and part of [#27888](https://github.com/sympy/sympy/issues/27888)
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Issue #29196 shows that refine(exp(...), assumptions) does not simplify key exp(I*pi*k) forms when assumptions are passed explicitly. This code adds a `refine_exp` handler to `sympy/assumptions/refine.py` so that
refine can simplify the exp function under the new assumptions system.

Before:
```
>>> refine(exp(x*2*I*pi), Q.integer(x))        
exp(2*I*pi*x)                           #expected 1
>>> refine(exp(pi*I*2*(x + Rational(1, 4))), Q.integer(x)) 
exp(2*I*pi*(x + 1/4))                   #expected I
```
After:
```
>>> refine(exp(x*2*I*pi), Q.integer(x))        
1
>>> refine(exp(pi*I*2*(x + Rational(1, 4))), Q.integer(x)) 
I
```
#### Other comments
I have also added the corresponding tests in sympy/assumptions/tests/test_refine.py.

#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
    * Enable `refine` to perform simplifications of `exp` expressions.

<!-- END RELEASE NOTES -->
