### PR TITLE
Add early_return option to RouthHurwitz to stop computation early

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -943,6 +943,7 @@ Keval Shah <kevalshah_96@yahoo.co.in>
 Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
+Kevin Raj <kevinrajken@gmail.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Keyron Linerez <keyronlinarez@gmail.com>  KeyronLinarez <keyronlinarez@gmail.com>
 Keyron Linerez <keyronlinarez@gmail.com> Rona <112719213+KeyronLinarez@users.noreply.github.com>

--- a/sympy/physics/control/routh_table.py
+++ b/sympy/physics/control/routh_table.py
@@ -147,14 +147,14 @@ class RouthHurwitz(MutableDenseMatrix):
     .. [3] https://www.circuitbread.com/tutorials/routh-hurwitz-criterion-part-2-3-3
 
     """
-    def __new__(cls, polynomial, var):
+    def __new__(cls, polynomial, var, early_return=False):
         if not isinstance(var, Symbol):
             raise ValueError("var must be a Symbol")
         n = Poly(polynomial, var).degree()
 
         return super().__new__(cls, n + 1, n//2 + 1, [0]*(n + 1)*(n//2 + 1))
 
-    def __init__(self, polynomial, var):
+    def __init__(self, polynomial, var, early_return=False):
         self._var = var
         self._polynomial = Poly(polynomial, var)
         self._poly_degree = self._polynomial.degree()
@@ -168,12 +168,11 @@ class RouthHurwitz(MutableDenseMatrix):
             self[0, 0] = self._coeffs[0]
             return
 
-        self._build_table()
+        self._build_table(early_return=early_return)
 
-    def _build_table(self):
-        """Build the Routh-Hurwitz table."""
+    def _build_table(self, early_return=False):
         self._initialize()
-        self._calculate()
+        self._calculate(early_return=early_return)
 
     def _initialize(self):
         """"Initialize the table with the coefficients of the polynomial."""
@@ -189,20 +188,38 @@ class RouthHurwitz(MutableDenseMatrix):
 
         self._handle_special_cases(1)
 
-    def _calculate(self):
+    def _calculate(self, early_return=False):
         """Calculate the table using the first 2 rows."""
         for i in range(2, self.rows):
-            self._calculate_row(i)
+            stop = self._calculate_row(i, early_return=early_return)
+
+            if stop:
+                return
+
             self._handle_special_cases(i)
 
-    def _calculate_row(self, i):
+    def _calculate_row(self, i, early_return=False):
         active_row_length = self.cols - i//2
-        for j in range(active_row_length):
+
+        if active_row_length > 0:
+            num = (self[i-1, 0] * self[i-2, 1]
+                   - self[i-2, 0] * self[i-1, 1])
+            den = self[i-1, 0]
+
+            val = num / den
+            self[i, 0] = val
+
+            if early_return and val.is_nonpositive:
+                return True
+
+        for j in range(1, active_row_length):
             num = (self[i-1, 0] * self[i-2, j+1]
                    - self[i-2, 0] * self[i-1, j+1])
             den = self[i-1, 0]
 
             self[i, j] = num / den
+
+        return False
 
     def _handle_special_cases(self, i):
         active_row_length = self.cols - i//2

--- a/sympy/physics/control/tests/test_routh_table.py
+++ b/sympy/physics/control/tests/test_routh_table.py
@@ -51,3 +51,30 @@ def test_table():
     assert t3.equals(expected3)
     assert t3.zero_row_case is True
     assert t3.auxiliary_polynomials == [Poly(2*s**4 + 12*s**2 + 16, s)]
+
+
+def test_routh_early_return_stops():
+    p = s**3 - s**2 - s - 1  # unstable
+
+    full = RouthHurwitz(p, s)
+    early = RouthHurwitz(p, s, early_return=True)
+
+    # First column
+    full_col = full[:, 0]
+    early_col = early[:, 0]
+
+    # There must be a non-positive entry (instability detected)
+    assert any(val.is_nonpositive is True for val in full_col)
+    assert any(val.is_nonpositive is True for val in early_col)
+
+    # KEY CHECK: early stops computation
+    # Later rows should remain default (0) or uncomputed
+    assert not early.equals(full)
+
+def test_routh_no_early_return_equivalence():
+    p = s**4 + s**3 + 2*s**2 + s + 1
+
+    t1 = RouthHurwitz(p, s)
+    t2 = RouthHurwitz(p, s, early_return=False)
+
+    assert t1.equals(t2)


### PR DESCRIPTION
References to other Issues or PRs

Fixes #28388

Brief description of what is fixed or changed

Adds an optional early_return parameter to the RouthHurwitz table construction. When enabled, the table construction stops as soon as a non-positive element is detected in the first column, which determines stability. This avoids unnecessary computation for unstable polynomials while preserving the default behavior when the parameter is not used.

Other comments

The early termination is implemented by checking the first element of each computed row during table construction. If a non-positive value is detected and early_return is enabled, further computation is stopped. Additional tests have been added to verify the early termination behavior and to ensure that the default behavior remains unchanged.

AI Generation Disclosure

Used ChatGPT for guidance in understanding the codebase and structuring the implementation. All code and tests were written and adapted manually.

<!-- BEGIN RELEASE NOTES -->

* physics.control
  * Added early termination option to RouthHurwitz to stop table construction when instability is detected.

<!-- END RELEASE NOTES -->
