### PR TITLE
Fix refine_sign() ignoring passed assumptions for plain Symbol

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -667,6 +667,7 @@ Fredrik Johansson <fredrik.johansson@gmail.com> fredrik.johansson <devnull@local
 Friedrich Hagedorn <friedrich_h@gmx.de>
 Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
 G. D. McBain <gdmcbain@protonmail.com>
+G. Karthik Koundinya <karthik26092005@gmail.com> G26Karthik <karthik26092005@gmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -357,6 +357,11 @@ def refine_sign(expr, assumptions):
     -1
     >>> refine_sign(expr, Q.zero(x))
     0
+    >>> x = Symbol('x')
+    >>> refine_sign(sign(x), Q.positive(x))
+    1
+    >>> refine_sign(sign(x), Q.negative(x))
+    -1
     >>> y = Symbol('y', imaginary = True)
     >>> expr = sign(y)
     >>> refine_sign(expr, Q.positive(im(y)))
@@ -367,12 +372,12 @@ def refine_sign(expr, assumptions):
     arg = expr.args[0]
     if ask(Q.zero(arg), assumptions):
         return S.Zero
-    if ask(Q.real(arg)):
+    if ask(Q.real(arg), assumptions):
         if ask(Q.positive(arg), assumptions):
             return S.One
         if ask(Q.negative(arg), assumptions):
             return S.NegativeOne
-    if ask(Q.imaginary(arg)):
+    if ask(Q.imaginary(arg), assumptions):
         arg_re, arg_im = arg.as_real_imag()
         if ask(Q.positive(arg_im), assumptions):
             return S.ImaginaryUnit

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -171,6 +171,17 @@ def test_sign():
     x = Symbol('x', complex=True)
     assert refine(sign(x), Q.zero(x)) == 0
 
+    # plain Symbol - assumptions must be inferred from passed context (gh-29603)
+    x = Symbol('x')
+    assert refine(sign(x), Q.positive(x)) == 1
+    assert refine(sign(x), Q.negative(x)) == -1
+    assert refine(sign(x), Q.zero(x)) == 0
+    assert refine(sign(x), Q.real(x) & Q.positive(x)) == 1
+    assert refine(sign(x), True) == sign(x)
+    y = Symbol('y')
+    assert refine(sign(y), Q.imaginary(y) & Q.positive(im(y))) == S.ImaginaryUnit
+    assert refine(sign(y), Q.imaginary(y) & Q.negative(im(y))) == -S.ImaginaryUnit
+
 def test_arg():
     x = Symbol('x', complex = True)
     assert refine(arg(x), Q.positive(x)) == 0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29603

#### Brief description of what is fixed or changed

`refine_sign()` calls `ask(Q.real(arg))` and `ask(Q.imaginary(arg))`
without passing `assumptions`. For a plain `Symbol('x')`, this means
`refine(sign(x), Q.positive(x))` returns `sign(x)` instead of `1`.

Adding `, assumptions` to both `ask()` calls fixes it.

Existing tests missed this because they all used `Symbol('x', real=True)`,
where the baked-in flag makes `ask(Q.real(arg))` return `True` anyway.

#### Other comments

Added 7 test assertions in `test_sign()` for plain symbols that cover
the broken cases. Updated the docstring with a plain-symbol example
and added a `.mailmap` entry (first contribution).

#### AI Generation Disclosure

GitHub Copilot helped identify the missing argument and draft some
test assertions. The fix and tests are AI-assisted. This description
is my own.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed ``refine_sign()`` calling ``ask(Q.real(arg))`` and
    ``ask(Q.imaginary(arg))`` without the ``assumptions`` argument,
    causing ``refine(sign(x), Q.positive(x))`` to return ``sign(x)``
    instead of ``1`` for plain ``Symbol`` objects.
<!-- END RELEASE NOTES -->
