### PR TITLE
Fix: correct formatting in DiscreteStateSpace __repr__

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -6717,11 +6717,8 @@ class DiscreteStateSpace(StateSpaceBase):
         C_str = self.C.__repr__()
         D_str = self.D.__repr__()
 
-        return f"""DiscreteStateSpace(\n{A_str},
-        \n{B_str},
-        \n{C_str},
-        \n{D_str},
-        \nst: {self.sampling_time})"""
+        return (f"DiscreteStateSpace(\n{A_str},\n{B_str},\n"
+                f"{C_str},\n{D_str}, {self.sampling_time})")
 
     def _eval_rewrite_as_DiscreteTransferFunction(self, *args):
         """

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -3315,6 +3315,22 @@ def test_StateSpace_construction():
     raises(TypeError, lambda: StateSpace(Matrix([2, 0.5]), Matrix([-1]),
                                          Matrix([1]), 0))
 
+
+def test_discrete_state_space_repr():
+    from sympy import Matrix
+    from sympy.physics.control import DiscreteStateSpace
+
+    A = Matrix([[1]])
+    B = Matrix([[1]])
+    C = Matrix([[1]])
+    D = Matrix([[0]])
+
+    ss = DiscreteStateSpace(A, B, C, D, 1)
+
+    rep = repr(ss)
+
+    assert "DiscreteStateSpace" in rep
+
 def test_StateSpace_add_mul():
     A1 = Matrix([[4, 1],[2, -3]])
     B1 = Matrix([[5, 2],[-3, -3]])


### PR DESCRIPTION
#### References to other Issues or PRs

N/A

#### Brief description of what is fixed or changed

Fix formatting inconsistency in `DiscreteStateSpace.__repr__`.

The previous implementation had extra indentation and inconsistent
line breaks, making the output harder to read and inconsistent with
`StateSpace.__repr__`.

This update aligns the formatting with the existing `StateSpace` style.

#### Other comments

None

#### AI Generation Disclosure

Assisted by AI for identifying the issue and drafting the fix. All changes were reviewed and validated manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.control
  * Fixed formatting inconsistency in DiscreteStateSpace __repr__ output.

<!-- END RELEASE NOTES -->