### PR TITLE
printing: fix fcode sign() using complex branch for real=True symbols

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1679,6 +1679,7 @@ Valeriia Gladkova <valeriia.gladkova@gmail.com>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <166912063+vasanthkumargr@users.noreply.github.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1680,8 +1680,8 @@ Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com>
-Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <vasanthakumar23.06.2006@gmail.com>
 Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <166912063+vasanthkumargr@users.noreply.github.com>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <vasanthakumar23.06.2006@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1679,6 +1679,8 @@ Valeriia Gladkova <valeriia.gladkova@gmail.com>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <vasanthakumar23.06.2006@gmail.com>
 Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <166912063+vasanthkumargr@users.noreply.github.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -204,10 +204,14 @@ class FCodePrinter(CodePrinter):
         arg, = expr.args
         if arg.is_integer:
             new_expr = merge(0, isign(1, arg), Eq(arg, 0))
-        elif (arg.is_complex or arg.is_infinite):
+        elif arg.is_real:
+            new_expr = merge(literal_dp(0), dsign(literal_dp(1), arg),
+                             Eq(arg, literal_dp(0)))
+        elif arg.is_complex or arg.is_infinite:
             new_expr = merge(cmplx(literal_dp(0), literal_dp(0)), arg/Abs(arg), Eq(Abs(arg), literal_dp(0)))
         else:
-            new_expr = merge(literal_dp(0), dsign(literal_dp(1), arg), Eq(arg, literal_dp(0)))
+            new_expr = merge(literal_dp(0), dsign(literal_dp(1), arg),
+                             Eq(arg, literal_dp(0)))
         return self._print(new_expr)
 
 


### PR DESCRIPTION
## Description

Fixes #12267

## Problem

`FCodePrinter._print_sign` incorrectly generates complex-style Fortran
code for symbols with `real=True`:
```python
x = symbols('x', real=True)
fcode(sign(x), standard=95)
# Before: merge(cmplx(0d0, 0d0), x/abs(x), abs(x) == 0d0)  ← wrong
```

The root cause is that in SymPy's assumption system, `real=True` implies
`is_complex=True`. So `real` symbols were falling into the complex branch
before reaching the real branch.

## Fix

Added an explicit `is_real` check before the `is_complex` check in
`_print_sign`:
```python
elif arg.is_real:
    new_expr = merge(literal_dp(0), dsign(literal_dp(1), arg),
                     Eq(arg, literal_dp(0)))
elif arg.is_complex or arg.is_infinite:
    ...
```

## Results

| Symbol | Before | After |
|--------|--------|-------|
| `x` real | `merge(cmplx(0d0,0d0), x/abs(x), ...)`  | `merge(0d0, dsign(1d0, x), x == 0d0)`  |
| `n` integer | `merge(0, isign(1, n), n == 0)`  | same  |
| `z` plain | `merge(0d0, dsign(1d0, z), z == 0d0)`  | same  |
| `w` complex | `merge(cmplx(0d0, 0d0), w/abs(w), ...)`  | same  |

## Tests

All 43 tests pass in `sympy/printing/tests/test_fortran.py`.

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed `fcode(sign(x))` generating complex-style Fortran code for symbols with `real=True` assumption.
<!-- END RELEASE NOTES -->