### PR TITLE
Added type annotations to sympy/logic/inference.py, related to #28806

### DIFF
--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -6,12 +6,10 @@ from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
 from sympy.logic.boolalg import Boolean, BooleanFunction
-from typing import TYPE_CHECKING
 from typing import cast
 from sympy.core.basic import Basic
+from sympy.core.symbol import Symbol
 
-if TYPE_CHECKING:
-    from sympy.core import Symbol
 
 def literal_symbol(literal: Boolean | bool) -> Symbol | bool:
     """

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -8,10 +8,9 @@ from sympy.external.importtools import import_module
 from sympy.logic.boolalg import Boolean, BooleanFunction
 from typing import cast
 from sympy.core.basic import Basic
-from sympy.core.symbol import Symbol
 
 
-def literal_symbol(literal: Boolean | bool) -> Symbol | bool:
+def literal_symbol(literal):
     """
     The symbol in this literal (without the negation).
 
@@ -27,12 +26,10 @@ def literal_symbol(literal: Boolean | bool) -> Symbol | bool:
 
     """
 
-    if literal is True or literal is False:
-        return literal
-    elif isinstance(literal, Symbol):
+    if literal is True or literal is False or literal.is_Symbol:
         return literal
     elif literal.is_Not:
-        return literal_symbol(cast(Boolean, literal.args[0]))
+        return literal_symbol(literal.args[0])
     else:
         raise ValueError("Argument must be a boolean literal.")
 

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -12,7 +12,7 @@ from sympy.core.basic import Basic
 
 if TYPE_CHECKING:
     from sympy.core import Symbol
-    
+
 def literal_symbol(literal: Boolean | bool) -> Symbol | bool:
     """
     The symbol in this literal (without the negation).

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -5,9 +5,12 @@ from sympy.logic.boolalg import And, Not, conjuncts, to_cnf, BooleanFunction
 from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
+from sympy.logic.boolalg import Boolean, BooleanFunction
+from sympy.core import Symbol
+from typing import cast
+from sympy.core.basic import Basic
 
-
-def literal_symbol(literal):
+def literal_symbol(literal: Boolean | bool) -> Symbol | bool:
     """
     The symbol in this literal (without the negation).
 
@@ -23,10 +26,12 @@ def literal_symbol(literal):
 
     """
 
-    if literal is True or literal is False or literal.is_Symbol:
+    if literal is True or literal is False:
+        return literal
+    elif isinstance(literal, Symbol):
         return literal
     elif literal.is_Not:
-        return literal_symbol(literal.args[0])
+        return literal_symbol(cast(Boolean, literal.args[0]))
     else:
         raise ValueError("Argument must be a boolean literal.")
 
@@ -118,7 +123,7 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_t
     raise NotImplementedError
 
 
-def valid(expr):
+def valid(expr) -> bool:
     """
     Check validity of a propositional sentence.
     A valid propositional sentence is True under every assignment.
@@ -142,7 +147,7 @@ def valid(expr):
     return not satisfiable(Not(expr))
 
 
-def pl_true(expr, model=None, deep=False):
+def pl_true(expr, model=None, deep=False) -> bool | None:
     """
     Returns whether the given assignment is a model or not.
 
@@ -215,7 +220,7 @@ def pl_true(expr, model=None, deep=False):
     return None
 
 
-def entails(expr, formula_set=None):
+def entails(expr, formula_set=None) -> bool:
     """
     Check whether the given expr_set entail an expr.
     If formula_set is empty then it returns the validity of expr.
@@ -250,29 +255,29 @@ def entails(expr, formula_set=None):
 
 class KB:
     """Base class for all knowledge bases"""
-    def __init__(self, sentence=None):
-        self.clauses_ = set()
+    def __init__(self, sentence: Boolean|None = None) -> None:
+        self.clauses_: set[Basic] = set()
         if sentence:
             self.tell(sentence)
 
-    def tell(self, sentence):
+    def tell(self, sentence: Boolean) -> None:
         raise NotImplementedError
 
-    def ask(self, query):
+    def ask(self, query: Boolean) -> bool:
         raise NotImplementedError
 
-    def retract(self, sentence):
+    def retract(self, sentence: Boolean) -> None:
         raise NotImplementedError
 
     @property
-    def clauses(self):
+    def clauses(self) -> list:
         return list(ordered(self.clauses_))
 
 
 class PropKB(KB):
     """A KB for Propositional Logic.  Inefficient, with no indexing."""
 
-    def tell(self, sentence):
+    def tell(self, sentence:Boolean) -> None:
         """Add the sentence's clauses to the KB
 
         Examples
@@ -296,7 +301,7 @@ class PropKB(KB):
         for c in conjuncts(to_cnf(sentence)):
             self.clauses_.add(c)
 
-    def ask(self, query):
+    def ask(self, query:Boolean) -> bool:
         """Checks if the query is true given the set of clauses.
 
         Examples
@@ -314,7 +319,7 @@ class PropKB(KB):
         """
         return entails(query, self.clauses_)
 
-    def retract(self, sentence):
+    def retract(self, sentence:Boolean) -> None:
         """Remove the sentence's clauses from the KB
 
         Examples

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -1,12 +1,10 @@
 """Inference in propositional logic"""
 from __future__ import annotations
 
-from sympy.logic.boolalg import And, Not, conjuncts, to_cnf, BooleanFunction
+from sympy.logic.boolalg import And, Not, conjuncts, to_cnf, BooleanFunction, Boolean
 from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
-from sympy.logic.boolalg import Boolean, BooleanFunction
-from typing import cast
 from sympy.core.basic import Basic
 
 

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -6,10 +6,13 @@ from sympy.core.sorting import ordered
 from sympy.core.sympify import sympify
 from sympy.external.importtools import import_module
 from sympy.logic.boolalg import Boolean, BooleanFunction
-from sympy.core import Symbol
+from typing import TYPE_CHECKING
 from typing import cast
 from sympy.core.basic import Basic
 
+if TYPE_CHECKING:
+    from sympy.core import Symbol
+    
 def literal_symbol(literal: Boolean | bool) -> Symbol | bool:
     """
     The symbol in this literal (without the negation).


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Related to https://github.com/sympy/sympy/issues/28806

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Add type annotations to `sympy/logic/inference.py`.

### Changes
- `valid(expr: Boolean) -> bool`
- `pl_true(expr: Boolean, model: dict | None = None, deep: bool = False) -> bool | None`
- `entails(expr: Boolean, formula_set=None) -> bool`
- `KB.__init__`, `KB.tell`, `KB.ask`, `KB.retract` with proper return types
- `PropKB.tell`, `PropKB.ask`, `PropKB.retract` with proper return types
- `KB.clauses_` annotated as `set[Basic]`
- Moved `Symbol` import under `TYPE_CHECKING` to fix circular import

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added type annotations for logic/inference.py
<!-- END RELEASE NOTES -->
