### PR TITLE
Add eval_frequency method to StateSpaceBase

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5589,6 +5589,22 @@ class StateSpaceBase(LinearTimeInvariant, ABC):
     C = output_matrix
     D = feedforward_matrix
 
+    def eval_frequency(self, other):
+        """
+        Evaluate the system response at a given complex frequency.
+
+        For a state space model, this computes:
+
+            H(s) = C*(s*I - A)**(-1)*B + D
+
+        where `s = other`.
+        """
+        from sympy.matrices import eye
+
+        n = self.A.shape[0]
+        sI_minus_A = other * eye(n) - self.A
+        return self.C * sI_minus_A.inv() * self.B + self.D
+
     @property
     def num_states(self):
         """

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -3315,6 +3315,22 @@ def test_StateSpace_construction():
     raises(TypeError, lambda: StateSpace(Matrix([2, 0.5]), Matrix([-1]),
                                          Matrix([1]), 0))
 
+
+def test_statespace_eval_frequency():
+    from sympy import Matrix, S
+    from sympy.physics.control import StateSpace
+
+    A = Matrix([[-1]])
+    B = Matrix([[1]])
+    C = Matrix([[1]])
+    D = Matrix([[0]])
+
+    ss = StateSpace(A, B, C, D)
+
+    result = ss.eval_frequency(2)
+
+    assert result == Matrix([[S(1)/3]])
+
 def test_StateSpace_add_mul():
     A1 = Matrix([[4, 1],[2, -3]])
     B1 = Matrix([[5, 2],[-3, -3]])


### PR DESCRIPTION
#### References to other Issues or PRs

N/A

#### Brief description of what is fixed or changed

Add `eval_frequency` method to `StateSpaceBase`.

`TransferFunction` provides an `eval_frequency` method, but an equivalent
method is not available for state-space models. This adds support for
evaluating the frequency response directly from a state-space representation
using:

    H(s) = C (sI - A)^(-1) B + D

#### Other comments

None

#### AI Generation Disclosure

Assisted by AI for identifying the approach and drafting the implementation. All changes were reviewed and validated manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.control
  * Added eval_frequency method to StateSpaceBase.

<!-- END RELEASE NOTES -->