### PR TITLE
utilities: make lambdify dummify smarter - only dummify unsafe identifiers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1679,6 +1679,9 @@ Valeriia Gladkova <valeriia.gladkova@gmail.com>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <166912063+vasanthkumargr@users.noreply.github.com>
+Vasanthkumar GR <vasanthkumar23.06.2006@gmail.com> <vasanthakumar23.06.2006@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1275,7 +1275,7 @@ class _EvaluatorPrinter:
         # Args of type Dummy can cause name collisions with args
         # of type Symbol.  Force dummify of everything in this
         # situation.
-        dummify = self._dummify or any(
+        has_dummy_args = any(
             isinstance(arg, Dummy) for arg in flatten(args))
 
         argstrs = [None]*len(args)
@@ -1295,7 +1295,7 @@ class _EvaluatorPrinter:
                 s = str(arg)
             elif isinstance(arg, Basic) and arg.is_symbol:
                 s = str(arg)
-                if dummify or not self._is_safe_ident(s):
+                if self._dummify or not self._is_safe_ident(s) or (has_dummy_args and isinstance(arg, Dummy)):
                     dummy = Dummy()
                     if isinstance(expr, Expr):
                         dummy = uniquely_named_symbol(
@@ -1303,7 +1303,7 @@ class _EvaluatorPrinter:
                     s = self._argrepr(dummy)
                     update_dummies(arg, dummy)
                     expr = self._subexpr(expr, _dummies_dict)
-            elif dummify or isinstance(arg, (Function, Derivative)):
+            elif self._dummify or isinstance(arg, (Function, Derivative)):
                 dummy = Dummy()
                 s = self._argrepr(dummy)
                 update_dummies(arg, dummy)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2341,13 +2341,13 @@ def test_dummify_smart():
     x = symbols('x')
     d = Dummy()
 
-    # Case 1: safe identifier — should NOT be dummified
+    # Case 1: safe identifier - should NOT be dummified
     f = lambdify(x, sin(x), dummify=False)
     src = inspect.getsource(f)
     assert 'Dummy' not in src
     assert '(x)' in src          # readable name preserved
 
-    # Case 2: explicit dummify=True — should dummify everything
+    # Case 2: explicit dummify=True - should dummify everything
     f2 = lambdify(x, sin(x), dummify=True)
     src2 = inspect.getsource(f2)
     assert 'Dummy' in src2

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2331,3 +2331,29 @@ def test_issue_28803_jointrandonsymbol_recursion():
 
     # Should not raise RecursionError
     lambdify(a, z * a)
+
+
+def test_dummify_smart():
+    from sympy import symbols, sin, Dummy
+    from sympy.utilities.lambdify import lambdify
+    import inspect
+
+    x = symbols('x')
+    d = Dummy()
+
+    # Case 1: safe identifier — should NOT be dummified
+    f = lambdify(x, sin(x), dummify=False)
+    src = inspect.getsource(f)
+    assert 'Dummy' not in src
+    assert '(x)' in src          # readable name preserved
+
+    # Case 2: explicit dummify=True — should dummify everything
+    f2 = lambdify(x, sin(x), dummify=True)
+    src2 = inspect.getsource(f2)
+    assert 'Dummy' in src2
+
+    # Case 3: mix of Dummy + safe symbol
+    # safe symbol 'x' should stay as 'x', not get dummified
+    f3 = lambdify([x, d], x + d, dummify=False)
+    src3 = inspect.getsource(f3)
+    assert '(x,' in src3         # x stays readable


### PR DESCRIPTION
Fixes #12463

## Problem

When any `Dummy` symbol is present in the arguments, `lambdify` set a
global `dummify` flag to `True`, causing ALL arguments (even safe,
readable ones like `x`) to be replaced with unreadable `_Dummy_123`
names in the generated function signature.

This made introspection (e.g. `help(f)`, `inspect.getsource(f)`) 
confusing for end users.

Root cause — line 1278 in `sympy/utilities/lambdify.py`:
```python
# BEFORE: one Dummy arg = dummify EVERYTHING
dummify = self._dummify or any(
    isinstance(arg, Dummy) for arg in flatten(args))
```

## Fix

Replaced the global `dummify` flag with per-argument logic. A safe
identifier (passes `_is_safe_ident`) keeps its readable name. Only
actual `Dummy` args or unsafe identifiers get dummified.
```python
# AFTER: per-argument check
has_dummy_args = any(isinstance(arg, Dummy) for arg in flatten(args))
...
if self._dummify or not self._is_safe_ident(s) or (has_dummy_args and isinstance(arg, Dummy)):
```

## Before vs After
```python
from sympy import symbols, Dummy
from sympy.utilities.lambdify import lambdify
import inspect

x = symbols('x')
d = Dummy()
f = lambdify([x, d], x + d)
print(inspect.getsource(f))

# BEFORE:
# def _lambdifygenerated(_Dummy_1, _Dummy_2):    x lost its name

# AFTER:
# def _lambdifygenerated(x, _Dummy_2):           x preserved
```

## Tests

Added `test_dummify_smart()` to `sympy/utilities/tests/test_lambdify.py` covering:
- Safe identifier with no Dummy args → name preserved
- Explicit `dummify=True` → everything dummified (existing behavior)
- Mix of safe symbol + Dummy → only Dummy gets dummified

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fixed `lambdify` unnecessarily dummifying safe identifier arguments when `Dummy` symbols are present in the argument list.
<!-- END RELEASE NOTES -->