### PR TITLE
fix: label and legend support for plot_implicit

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -642,6 +642,7 @@ Fabian Pedregosa <fabian@fseoane.net> <fabian@debian.(none)>
 Fabio Luporini <fabio@devitocodes.com>
 Faisal Anees <faisal.iiit@gmail.com>
 Faisal Riyaz <faisalriyaz011@gmail.com>
+Fatima Hejazi <hejazi.ima@gmail.com> <60328249+F-Hejazi@users.noreply.github.com>
 Fawaz Alazemi <Mba7eth@gmail.com>
 Felix Kaiser <felix.kaiser@fxkr.net> <felix.kaiser@fxkr.net>
 Felix Kaiser <felix.kaiser@fxkr.net> <kaiser.fx@gmail.com>

--- a/sympy/plotting/backends/matplotlibbackend/matplotlib.py
+++ b/sympy/plotting/backends/matplotlibbackend/matplotlib.py
@@ -172,11 +172,12 @@ class MatplotlibBackend(base_backend.Plot):
                 ylims.append(s._ylim)
                 zlims.append(s._zlim)
             elif s.is_implicit:
+                lbl = _str_or_latex(s.label)
                 points = s.get_data()
                 if len(points) == 2:
                     # interval math plotting
                     x, y = _matplotlib_list(points[0])
-                    ax.fill(x, y, facecolor=s.line_color, edgecolor='None')
+                    ax.fill(x, y, facecolor=s.line_color, edgecolor='None', label=lbl)
                 else:
                     # use contourf or contour depending on whether it is
                     # an inequality or equality.
@@ -188,6 +189,7 @@ class MatplotlibBackend(base_backend.Plot):
                         ax.contour(xarray, yarray, zarray, cmap=colormap)
                     else:
                         ax.contourf(xarray, yarray, zarray, cmap=colormap)
+                    ax.plot([], [], color=s.line_color, label=lbl)
             elif s.is_generic:
                 if s.type == "markers":
                     # s.rendering_kw["color"] = s.line_color

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -217,9 +217,10 @@ def plot_implicit(expr, x_var=None, y_var=None, adaptive=True, depth=0,
     var_start_end_y = _range_tuple(xyvar[1])
 
     kwargs = _set_discretization_points(kwargs, ImplicitSeries)
+    label = kwargs.pop("label", None)
     series_argument = ImplicitSeries(
         expr, var_start_end_x, var_start_end_y,
-        adaptive=adaptive, depth=depth,
+        label=label, adaptive=adaptive, depth=depth,
         n=n, line_color=line_color)
 
     #set the x and y limits

--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -91,6 +91,43 @@ def test_line_color():
     p = plot_implicit(x**2 + y**2 - 1, line_color='r', show=False)
     assert p._series[0].line_color == "r"
 
+def test_label_and_legend():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0',
+        catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+
+    x, y = symbols('x, y')
+    p = plot_implicit(x**2 + y**2 - 1, show=False)
+    assert p._series[0].label == 'x**2 + y**2 - 1'
+
+    p = plot_implicit(x**2 + y**2 - 1, label='unit circle', show=False)
+    assert p._series[0].label == 'unit circle'
+
+    p = plot_implicit(x**2 + y**2 - 1, label='circle', legend=True,
+        show=False, adaptive=True)
+    p._backend._create_figure()
+    p._backend._process_series(p._backend._series, p._backend.ax)
+    handles, labels = p._backend.ax.get_legend_handles_labels()
+    assert labels == ['circle']
+    p._backend.close()
+
+    p = plot_implicit(y > x**2, label='region', legend=True,
+        show=False, adaptive=False)
+    p._backend._create_figure()
+    p._backend._process_series(p._backend._series, p._backend.ax)
+    handles, labels = p._backend.ax.get_legend_handles_labels()
+    assert labels == ['region']
+    p._backend.close()
+
+    p = plot_implicit(x**2 + y**2 - 1, label='circle', legend=True,
+        show=False, adaptive=False)
+    p._backend._create_figure()
+    p._backend._process_series(p._backend._series, p._backend.ax)
+    handles, labels = p._backend.ax.get_legend_handles_labels()
+    assert labels == ['circle']
+    p._backend.close()
+
 def test_matplotlib():
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
     if matplotlib:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #24136 

#### Brief description of what is fixed or changed

`plot_implicit()` accepted `label=` and `legend=True` kwargs but neither worked:
- `label=` was silently dropped. It was never forwarded from `plot_implicit()` to `ImplicitSeries`, so the series always stored an empty string.
- The matplotlib backend never passed a label to any artist when rendering implicit plots, so `ax.legend()` found nothing to display.

**Changes:**
- `plot_implicit.py`: pops `label` from kwargs before passing to `plot_factory`, and forwards it to `ImplicitSeries`.
- `matplotlib.py`: passes `label` to `ax.fill()` for the interval-math (adaptive) path; for `contour`/`contourf` paths (which don't support `label=` natively), adds an empty proxy `ax.plot([], [])` entry so the series appears in the legend.
- `tests/test_plot_implicit.py`: adds a regression test covering label propagation and all three rendering paths (adaptive fill, contourf, contour).

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* plotting
  * Fixed `plot_implicit()` to correctly support the `label` and `legend` keyword arguments.

<!-- END RELEASE NOTES -->
