### PR TITLE
functions.elementary.integers: Remove special methods like `__ge__` and improve their inequalities in general.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -894,6 +894,7 @@ Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
+Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <157145635+JosephMehdiyev@users.noreply.github.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -734,31 +734,31 @@ def _eval_is_le(lhs, rhs): # noqa: F811
         if is_gt(lhs.min, rhs):
             return False
 
-@dispatch(ceiling, AccumulationBounds)
+@dispatch(ceiling, AccumulationBounds)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     return is_ge(lhs, rhs.max)
 
-@dispatch(AccumulationBounds, ceiling)
+@dispatch(AccumulationBounds, ceiling)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     return is_ge(lhs.min, rhs)
 
-@dispatch(AccumulationBounds, floor)
+@dispatch(AccumulationBounds, floor)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     return is_ge(lhs.min, rhs)
 
-@dispatch(floor, AccumulationBounds)
+@dispatch(floor, AccumulationBounds)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     return is_ge(lhs, rhs.max)
 
-@dispatch(frac, AccumulationBounds)
+@dispatch(frac, AccumulationBounds)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     return is_ge(lhs, rhs.max)
 
-@dispatch(AccumulationBounds, frac)
+@dispatch(AccumulationBounds, frac)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     return is_ge(lhs.min, rhs)
 
-@dispatch(AccumulationBounds, AccumulationBounds)
+@dispatch(AccumulationBounds, AccumulationBounds)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if is_ge(lhs.min, rhs.max):
         return True

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -765,6 +765,7 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
     if is_lt(lhs.max, rhs.min):
         return False
 
+
 @dispatch(AccumulationBounds, Expr)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa: F811
     """

--- a/sympy/calculus/accumulationbounds.py
+++ b/sympy/calculus/accumulationbounds.py
@@ -10,6 +10,7 @@ from sympy.logic.boolalg import And
 from sympy.multipledispatch import dispatch
 from sympy.series.order import Order
 from sympy.sets.sets import FiniteSet
+from sympy.functions.elementary.integers import floor, ceiling, frac
 
 
 class AccumulationBounds(Expr):
@@ -733,6 +734,29 @@ def _eval_is_le(lhs, rhs): # noqa: F811
         if is_gt(lhs.min, rhs):
             return False
 
+@dispatch(ceiling, AccumulationBounds)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    return is_ge(lhs, rhs.max)
+
+@dispatch(AccumulationBounds, ceiling)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    return is_ge(lhs.min, rhs)
+
+@dispatch(AccumulationBounds, floor)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    return is_ge(lhs.min, rhs)
+
+@dispatch(floor, AccumulationBounds)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    return is_ge(lhs, rhs.max)
+
+@dispatch(frac, AccumulationBounds)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    return is_ge(lhs, rhs.max)
+
+@dispatch(AccumulationBounds, frac)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    return is_ge(lhs.min, rhs)
 
 @dispatch(AccumulationBounds, AccumulationBounds)
 def _eval_is_ge(lhs, rhs): # noqa:F811
@@ -740,7 +764,6 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
         return True
     if is_lt(lhs.max, rhs.min):
         return False
-
 
 @dispatch(AccumulationBounds, Expr)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa: F811

--- a/sympy/calculus/tests/test_accumulationbounds.py
+++ b/sympy/calculus/tests/test_accumulationbounds.py
@@ -5,6 +5,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
+from sympy.functions.elementary.integers import (floor, ceiling, frac)
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core import Add, Mul, Pow
 from sympy.core.expr import unchanged
@@ -340,3 +341,18 @@ def test_union_AccumBounds():
     assert B(0, 3).union(B(-1, 4)) == B(-1, 4)
     raises(TypeError, lambda: B(0, 3).union(1))
     raises(TypeError, lambda: B(0, 3).union(FiniteSet(1)))
+
+
+def test_floor_ineq():
+    x = Symbol("x", real = True)
+    assert (B(0, oo) <= floor(x)) == False
+
+
+def test_ceiling_ineq():
+    x = Symbol("x", real = True)
+    assert (B(0, oo) <= ceiling(x)) == False
+
+
+def test_frac_ineq():
+    x = Symbol("x", real = True)
+    assert B(1,2) >= frac(x)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -857,12 +857,9 @@ def test_canonical():
     assert Eq(y < x, x > y).canonical is S.true
 
 
-@XFAIL
 def test_issue_8444_nonworkingtests():
     x = symbols('x', real=True)
     assert (x <= oo) == (x >= -oo) == True
-
-    x = symbols('x')
     assert x >= floor(x)
     assert (x < floor(x)) == False
     assert x <= ceiling(x)

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -231,12 +231,12 @@ class floor(RoundFunction):
     def _eval_rewrite_as_frac(self, arg, **kwargs):
         return arg - frac(arg)
 
-@dispatch(floor, Expr)
+@dispatch(floor, Expr)  # type:ignore
 def _eval_is_eq(lhs, rhs): # noqa:F811
     return is_eq(lhs.rewrite(ceiling), rhs) or \
         is_eq(lhs.rewrite(frac),rhs)
 
-@dispatch(floor, floor)
+@dispatch(floor, floor)  # type:ignore
 def _eval_is_ge(lhs,rhs):  # noqa:F811
     x = lhs.args[0]
     y = rhs.args[0]
@@ -248,7 +248,7 @@ def _eval_is_ge(lhs,rhs):  # noqa:F811
                 return is_ge(x, y)
     return None
 
-@dispatch(floor, Expr)
+@dispatch(floor, Expr)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real:
         if rhs.is_integer:
@@ -260,7 +260,7 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
             return False
     return None
 
-@dispatch(Expr, floor)
+@dispatch(Expr, floor)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if rhs.args[0].is_extended_real and lhs.is_extended_real:
         if lhs.is_integer:
@@ -410,7 +410,7 @@ class ceiling(RoundFunction):
 def _eval_is_eq(lhs, rhs): # noqa:F811
     return is_eq(lhs.rewrite(floor), rhs) or is_eq(lhs.rewrite(frac),rhs)
 
-@dispatch(ceiling, ceiling)
+@dispatch(ceiling, ceiling)  # type:ignore
 def _eval_is_ge(lhs,rhs): # noqa:F811
     x = lhs.args[0]
     y = rhs.args[0]
@@ -422,13 +422,13 @@ def _eval_is_ge(lhs,rhs): # noqa:F811
                 return is_ge(x, y)
     return None
 
-@dispatch(ceiling, floor)
+@dispatch(ceiling, floor)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         return is_ge(lhs.args[0], rhs.args[0])
     return None
 
-@dispatch(floor, ceiling)
+@dispatch(floor, ceiling)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         if lhs.args[0].is_integer:
@@ -437,7 +437,7 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
             return is_ge(lhs, rhs.args[0])
     return None
 
-@dispatch(ceiling, Expr)
+@dispatch(ceiling, Expr)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.is_extended_real:
         if rhs.is_integer:
@@ -446,7 +446,7 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
             return True
     return None
 
-@dispatch(Expr, ceiling)
+@dispatch(Expr, ceiling)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if rhs.args[0].is_extended_real and lhs.is_extended_real:
         if lhs.is_integer:
@@ -619,7 +619,7 @@ def _eval_is_eq(lhs, rhs): # noqa:F811
     if res is not None:
         return False
 
-@dispatch(frac, frac)
+@dispatch(frac, frac)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         if lhs.args[0].is_integer:
@@ -628,31 +628,31 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
             return is_ge(lhs, 0)
     return None
 
-@dispatch(frac, floor)
+@dispatch(frac, floor)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         return is_lt(rhs.args[0],S(1))
     return None
 
-@dispatch(floor, frac)
+@dispatch(floor, frac)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         return is_ge(lhs.args[0], S(1))
     return None
 
-@dispatch(frac, ceiling)
+@dispatch(frac, ceiling)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         return is_le(rhs.args[0],S(0))
     return None
 
-@dispatch(ceiling, frac)
+@dispatch(ceiling, frac)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         return is_ge(lhs.args[0],S(0))
     return None
 
-@dispatch(frac, Expr)
+@dispatch(frac, Expr)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     # Check if other <= 0
     if rhs.is_extended_nonpositive:
@@ -663,7 +663,7 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
         return not(res)
     return None
 
-@dispatch(Expr, frac)
+@dispatch(Expr, frac)  # type:ignore
 def _eval_is_ge(lhs, rhs): # noqa:F811
     # Check if other < 0
     if lhs.is_extended_negative:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -240,48 +240,33 @@ def _eval_is_eq(lhs, rhs): # noqa:F811
 def _eval_is_ge(lhs,rhs):  # noqa:F811
     x = lhs.args[0]
     y = rhs.args[0]
-    if x.is_real and y.is_real:
+    if x.is_extended_real and y.is_extended_real:
         if x == y:
             return True
         if x.is_integer:
             if y.is_integer:
                 return is_ge(x, y)
-            if y.is_number:
-                return is_ge(x, floor(y))
-        if x.is_number:
-            if y.is_integer:
-                return is_ge(floor(x), y)
-            if y.is_number:
-                return is_ge(floor(x), floor(y))
     return None
 
 @dispatch(floor, Expr)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real:
+    if lhs.args[0].is_extended_real:
         if rhs.is_integer:
             return is_ge(lhs.args[0], rhs)
-        if rhs.is_number and rhs.is_real:
-            return is_ge(lhs.args[0], ceiling(rhs))
-    if lhs.args[0] == rhs and rhs.is_real:
+    if lhs.args[0] == rhs and rhs.is_extended_real:
         if rhs.is_integer:
             return True
         if rhs.is_noninteger:
             return False
-    if rhs is S.NegativeInfinity and lhs.is_finite:
-        return True
     return None
 
 @dispatch(Expr, floor)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if rhs.args[0].is_real and lhs.is_real:
+    if rhs.args[0].is_extended_real and lhs.is_extended_real:
         if lhs.is_integer:
             return is_lt(rhs.args[0], lhs + 1)
-        if lhs.is_number:
-            return is_lt(rhs.args[0], ceiling(lhs))
         if rhs.args[0] == lhs:
             return True
-    if lhs is S.Infinity and rhs.is_finite:
-        return True
     return None
 
 class ceiling(RoundFunction):
@@ -429,64 +414,45 @@ def _eval_is_eq(lhs, rhs): # noqa:F811
 def _eval_is_ge(lhs,rhs): # noqa:F811
     x = lhs.args[0]
     y = rhs.args[0]
-    if x.is_real and y.is_real:
+    if x.is_extended_real and y.is_extended_real:
         if x == y:
             return True
         if x.is_integer:
             if y.is_integer:
                 return is_ge(x, y)
-            if y.is_number:
-                return is_ge(x, ceiling(y))
-        if x.is_number:
-            if y.is_integer:
-                return is_ge(ceiling(x), y)
-            if y.is_number:
-                return is_ge(ceiling(x), ceiling(y))
     return None
 
 @dispatch(ceiling, floor)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         return is_ge(lhs.args[0], rhs.args[0])
     return None
 
 @dispatch(floor, ceiling)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         if lhs.args[0].is_integer:
             return is_ge(lhs.args[0], rhs)
         if rhs.args[0].is_integer:
             return is_ge(lhs, rhs.args[0])
-        if lhs.args[0].is_number:
-            return is_ge(floor(lhs.args[0]), rhs)
-        if rhs.args[0].is_number:
-            return is_ge(lhs, ceiling(rhs.args[0]))
-    return is_ge(floor(lhs.args[0]) - floor(rhs.args[0]), frac(lhs.args[0]) - frac(rhs.args[0]))
+    return None
 
 @dispatch(ceiling, Expr)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.is_real:
+    if lhs.args[0].is_extended_real and rhs.is_extended_real:
         if rhs.is_integer:
             return is_gt(lhs.args[0], rhs - 1)
-        if rhs.is_number:
-            return is_gt(lhs.args[0], floor(rhs))
         if lhs.args[0] == rhs:
             return True
-    if rhs is S.NegativeInfinity and lhs.is_finite:
-        return True
     return None
 
 @dispatch(Expr, ceiling)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if rhs.args[0].is_real and lhs.is_real:
+    if rhs.args[0].is_extended_real and lhs.is_extended_real:
         if lhs.is_integer:
             return is_le(rhs.args[0], lhs)
-        if lhs.is_number:
-            return is_le(rhs.args[0], floor(lhs))
         if rhs.args[0] == lhs  and lhs.is_integer is False:
             return False
-    if lhs is S.NegativeInfinity and rhs.is_finite:
-        return False
     return None
 
 class frac(DefinedFunction):
@@ -655,7 +621,7 @@ def _eval_is_eq(lhs, rhs): # noqa:F811
 
 @dispatch(frac, frac)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
         if lhs.args[0].is_integer:
             return is_ge(0, rhs)
         if rhs.args[0].is_integer:
@@ -664,26 +630,26 @@ def _eval_is_ge(lhs, rhs): # noqa:F811
 
 @dispatch(frac, floor)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
-        return is_lt(rhs.args[0],1)
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
+        return is_lt(rhs.args[0],S(1))
     return None
 
 @dispatch(floor, frac)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
-        return is_ge(lhs.args[0], 1)
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
+        return is_ge(lhs.args[0], S(1))
     return None
 
 @dispatch(frac, ceiling)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
-        return is_le(rhs.args[0],0)
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
+        return is_le(rhs.args[0],S(0))
     return None
 
 @dispatch(ceiling, frac)
 def _eval_is_ge(lhs, rhs): # noqa:F811
-    if lhs.args[0].is_real and rhs.args[0].is_real:
-        return is_ge(lhs.args[0],0)
+    if lhs.args[0].is_extended_real and rhs.args[0].is_extended_real:
+        return is_ge(lhs.args[0],S(0))
     return None
 
 @dispatch(frac, Expr)

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -8,14 +8,14 @@ from sympy.core.evalf import get_integer_part, PrecisionExhausted
 from sympy.core.function import DefinedFunction
 from sympy.core.logic import fuzzy_or, fuzzy_and
 from sympy.core.numbers import Integer, int_valued
-from sympy.core.relational import Gt, Lt, Ge, Le, Relational, is_eq, is_le, is_lt
-from sympy.core.sympify import _sympify
+from sympy.core.relational import Relational, is_eq, is_le, is_lt, is_ge, is_gt
 from sympy.functions.elementary.complexes import im, re
 from sympy.multipledispatch import dispatch
 
 ###############################################################################
 ######################### FLOOR and CEILING FUNCTIONS #########################
 ###############################################################################
+
 
 
 class RoundFunction(DefinedFunction):
@@ -231,68 +231,58 @@ class floor(RoundFunction):
     def _eval_rewrite_as_frac(self, arg, **kwargs):
         return arg - frac(arg)
 
-    def __le__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] < other + 1
-            if other.is_number and other.is_real:
-                return self.args[0] < ceiling(other)
-        if self.args[0] == other and other.is_real:
-            return S.true
-        if other is S.Infinity and self.is_finite:
-            return S.true
-
-        return Le(self, other, evaluate=False)
-
-    def __ge__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] >= other
-            if other.is_number and other.is_real:
-                return self.args[0] >= ceiling(other)
-        if self.args[0] == other and other.is_real and other.is_noninteger:
-            return S.false
-        if other is S.NegativeInfinity and self.is_finite:
-            return S.true
-
-        return Ge(self, other, evaluate=False)
-
-    def __gt__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] >= other + 1
-            if other.is_number and other.is_real:
-                return self.args[0] >= ceiling(other)
-        if self.args[0] == other and other.is_real:
-            return S.false
-        if other is S.NegativeInfinity and self.is_finite:
-            return S.true
-
-        return Gt(self, other, evaluate=False)
-
-    def __lt__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] < other
-            if other.is_number and other.is_real:
-                return self.args[0] < ceiling(other)
-        if self.args[0] == other and other.is_real and other.is_noninteger:
-            return S.true
-        if other is S.Infinity and self.is_finite:
-            return S.true
-
-        return Lt(self, other, evaluate=False)
-
-
 @dispatch(floor, Expr)
 def _eval_is_eq(lhs, rhs): # noqa:F811
     return is_eq(lhs.rewrite(ceiling), rhs) or \
         is_eq(lhs.rewrite(frac),rhs)
 
+@dispatch(floor, floor)
+def _eval_is_ge(lhs,rhs):  # noqa:F811
+    x = lhs.args[0]
+    y = rhs.args[0]
+    if x.is_real and y.is_real:
+        if x == y:
+            return True
+        if x.is_integer:
+            if y.is_integer:
+                return is_ge(x, y)
+            if y.is_number:
+                return is_ge(x, floor(y))
+        if x.is_number:
+            if y.is_integer:
+                return is_ge(floor(x), y)
+            if y.is_number:
+                return is_ge(floor(x), floor(y))
+    return None
+
+@dispatch(floor, Expr)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real:
+        if rhs.is_integer:
+            return is_ge(lhs.args[0], rhs)
+        if rhs.is_number and rhs.is_real:
+            return is_ge(lhs.args[0], ceiling(rhs))
+    if lhs.args[0] == rhs and rhs.is_real:
+        if rhs.is_integer:
+            return True
+        if rhs.is_noninteger:
+            return False
+    if rhs is S.NegativeInfinity and lhs.is_finite:
+        return True
+    return None
+
+@dispatch(Expr, floor)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if rhs.args[0].is_real and lhs.is_real:
+        if lhs.is_integer:
+            return is_lt(rhs.args[0], lhs + 1)
+        if lhs.is_number:
+            return is_lt(rhs.args[0], ceiling(lhs))
+        if rhs.args[0] == lhs:
+            return True
+    if lhs is S.Infinity and rhs.is_finite:
+        return True
+    return None
 
 class ceiling(RoundFunction):
     """
@@ -431,67 +421,73 @@ class ceiling(RoundFunction):
     def _eval_is_nonpositive(self):
         return self.args[0].is_nonpositive
 
-    def __lt__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] <= other - 1
-            if other.is_number and other.is_real:
-                return self.args[0] <= floor(other)
-        if self.args[0] == other and other.is_real:
-            return S.false
-        if other is S.Infinity and self.is_finite:
-            return S.true
-
-        return Lt(self, other, evaluate=False)
-
-    def __gt__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] > other
-            if other.is_number and other.is_real:
-                return self.args[0] > floor(other)
-        if self.args[0] == other and other.is_real and other.is_noninteger:
-            return S.true
-        if other is S.NegativeInfinity and self.is_finite:
-            return S.true
-
-        return Gt(self, other, evaluate=False)
-
-    def __ge__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] > other - 1
-            if other.is_number and other.is_real:
-                return self.args[0] > floor(other)
-        if self.args[0] == other and other.is_real:
-            return S.true
-        if other is S.NegativeInfinity and self.is_finite:
-            return S.true
-
-        return Ge(self, other, evaluate=False)
-
-    def __le__(self, other):
-        other = S(other)
-        if self.args[0].is_real:
-            if other.is_integer:
-                return self.args[0] <= other
-            if other.is_number and other.is_real:
-                return self.args[0] <= floor(other)
-        if self.args[0] == other and other.is_real and other.is_noninteger:
-            return S.false
-        if other is S.Infinity and self.is_finite:
-            return S.true
-
-        return Le(self, other, evaluate=False)
-
-
 @dispatch(ceiling, Basic)  # type:ignore
 def _eval_is_eq(lhs, rhs): # noqa:F811
     return is_eq(lhs.rewrite(floor), rhs) or is_eq(lhs.rewrite(frac),rhs)
 
+@dispatch(ceiling, ceiling)
+def _eval_is_ge(lhs,rhs): # noqa:F811
+    x = lhs.args[0]
+    y = rhs.args[0]
+    if x.is_real and y.is_real:
+        if x == y:
+            return True
+        if x.is_integer:
+            if y.is_integer:
+                return is_ge(x, y)
+            if y.is_number:
+                return is_ge(x, ceiling(y))
+        if x.is_number:
+            if y.is_integer:
+                return is_ge(ceiling(x), y)
+            if y.is_number:
+                return is_ge(ceiling(x), ceiling(y))
+    return None
+
+@dispatch(ceiling, floor)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        return is_ge(lhs.args[0], rhs.args[0])
+    return None
+
+@dispatch(floor, ceiling)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        if lhs.args[0].is_integer:
+            return is_ge(lhs.args[0], rhs)
+        if rhs.args[0].is_integer:
+            return is_ge(lhs, rhs.args[0])
+        if lhs.args[0].is_number:
+            return is_ge(floor(lhs.args[0]), rhs)
+        if rhs.args[0].is_number:
+            return is_ge(lhs, ceiling(rhs.args[0]))
+    return is_ge(floor(lhs.args[0]) - floor(rhs.args[0]), frac(lhs.args[0]) - frac(rhs.args[0]))
+
+@dispatch(ceiling, Expr)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.is_real:
+        if rhs.is_integer:
+            return is_gt(lhs.args[0], rhs - 1)
+        if rhs.is_number:
+            return is_gt(lhs.args[0], floor(rhs))
+        if lhs.args[0] == rhs:
+            return True
+    if rhs is S.NegativeInfinity and lhs.is_finite:
+        return True
+    return None
+
+@dispatch(Expr, ceiling)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if rhs.args[0].is_real and lhs.is_real:
+        if lhs.is_integer:
+            return is_le(rhs.args[0], lhs)
+        if lhs.is_number:
+            return is_le(rhs.args[0], floor(lhs))
+        if rhs.args[0] == lhs  and lhs.is_integer is False:
+            return False
+    if lhs is S.NegativeInfinity and rhs.is_finite:
+        return False
+    return None
 
 class frac(DefinedFunction):
     r"""Represents the fractional part of x
@@ -598,54 +594,6 @@ class frac(DefinedFunction):
     def _eval_is_negative(self):
         return False
 
-    def __ge__(self, other):
-        if self.is_extended_real:
-            other = _sympify(other)
-            # Check if other <= 0
-            if other.is_extended_nonpositive:
-                return S.true
-            # Check if other >= 1
-            res = self._value_one_or_more(other)
-            if res is not None:
-                return not(res)
-        return Ge(self, other, evaluate=False)
-
-    def __gt__(self, other):
-        if self.is_extended_real:
-            other = _sympify(other)
-            # Check if other < 0
-            res = self._value_one_or_more(other)
-            if res is not None:
-                return not(res)
-            # Check if other >= 1
-            if other.is_extended_negative:
-                return S.true
-        return Gt(self, other, evaluate=False)
-
-    def __le__(self, other):
-        if self.is_extended_real:
-            other = _sympify(other)
-            # Check if other < 0
-            if other.is_extended_negative:
-                return S.false
-            # Check if other >= 1
-            res = self._value_one_or_more(other)
-            if res is not None:
-                return res
-        return Le(self, other, evaluate=False)
-
-    def __lt__(self, other):
-        if self.is_extended_real:
-            other = _sympify(other)
-            # Check if other <= 0
-            if other.is_extended_nonpositive:
-                return S.false
-            # Check if other >= 1
-            res = self._value_one_or_more(other)
-            if res is not None:
-                return res
-        return Lt(self, other, evaluate=False)
-
     def _value_one_or_more(self, other):
         if other.is_extended_real:
             if other.is_number:
@@ -692,7 +640,6 @@ class frac(DefinedFunction):
                 res += r
             return res
 
-
 @dispatch(frac, Basic)  # type:ignore
 def _eval_is_eq(lhs, rhs): # noqa:F811
     if (lhs.rewrite(floor) == rhs) or \
@@ -705,3 +652,58 @@ def _eval_is_eq(lhs, rhs): # noqa:F811
     res = lhs._value_one_or_more(rhs)
     if res is not None:
         return False
+
+@dispatch(frac, frac)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        if lhs.args[0].is_integer:
+            return is_ge(0, rhs)
+        if rhs.args[0].is_integer:
+            return is_ge(lhs, 0)
+    return None
+
+@dispatch(frac, floor)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        return is_lt(rhs.args[0],1)
+    return None
+
+@dispatch(floor, frac)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        return is_ge(lhs.args[0], 1)
+    return None
+
+@dispatch(frac, ceiling)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        return is_le(rhs.args[0],0)
+    return None
+
+@dispatch(ceiling, frac)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    if lhs.args[0].is_real and rhs.args[0].is_real:
+        return is_ge(lhs.args[0],0)
+    return None
+
+@dispatch(frac, Expr)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    # Check if other <= 0
+    if rhs.is_extended_nonpositive:
+        return True
+    # Check if other >= 1
+    res = lhs._value_one_or_more(rhs)
+    if res is not None:
+        return not(res)
+    return None
+
+@dispatch(Expr, frac)
+def _eval_is_ge(lhs, rhs): # noqa:F811
+    # Check if other < 0
+    if lhs.is_extended_negative:
+        return False
+    # Check if other >= 1
+    res = rhs._value_one_or_more(lhs)
+    if res is not None:
+        return res
+    return None

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -659,3 +659,75 @@ def test_issue_25230():
     assert ceiling(x/b).as_leading_term(x, cdir = -1) == 0
     assert ceiling(x/c).as_leading_term(x, cdir = 1) == 0
     assert ceiling(x/c).as_leading_term(x, cdir = -1) == 1
+
+
+def test_floor_vs_ceiling():
+    x    = Symbol("x", real=True)
+    n    = Symbol("n", integer=True)
+    posn = Symbol("pos0", nonnegative=True, integer=True)
+    negn = Symbol("neg0", nonpositive=True, integer=True)
+
+    assert (floor(x) <= ceiling(x)) == (ceiling(x) >= floor(x)) == True
+    assert (floor(x) > ceiling(x))  == (ceiling(x) < floor(x))  == False
+    assert (floor(x) >= ceiling(x)) == Ge(floor(x), ceiling(x), evaluate=False)
+    assert (ceiling(x) <= floor(x)) == Le(ceiling(x), floor(x), evaluate=False)
+    assert (floor(x) < ceiling(x))  == Lt(floor(x), ceiling(x), evaluate=False)
+    assert (ceiling(x) > floor(x))  == Gt(ceiling(x), floor(x), evaluate=False)
+
+    for x in [n, posn, negn]:
+        assert (floor(x) >= ceiling(x)) == (ceiling(x) <= floor(x)) == True
+        assert (floor(x) <= ceiling(x)) == (ceiling(x) >= floor(x)) == True
+
+
+def test_floor_vs_frac():
+    x    = Symbol("x", real=True)
+    neg  = Symbol("neg", extended_negative=True)
+    posn = Symbol("pos0", nonnegative=True, integer=True)
+    negn = Symbol("neg0", nonpositive=True, integer=True)
+
+    assert (floor(x) > frac(x))  == Gt(floor(x), frac(x), evaluate=False)
+    assert (frac(x) < floor(x))  == Lt(frac(x), floor(x), evaluate=False)
+    assert (floor(x) >= frac(x)) == Ge(floor(x), frac(x), evaluate=False)
+    assert (frac(x) <= floor(x)) == Le(frac(x), floor(x), evaluate=False)
+    assert (floor(x) < frac(x))  == Lt(floor(x), frac(x), evaluate=False)
+    assert (frac(x) > floor(x))  == Gt(frac(x), floor(x), evaluate=False)
+    assert (floor(x) <= frac(x)) == Le(floor(x), frac(x), evaluate=False)
+    assert (frac(x) >= floor(x)) == Ge(frac(x), floor(x), evaluate=False)
+
+    assert (floor(neg) > frac(neg))  == (frac(neg) < floor(neg))  == False
+    assert (floor(neg) >= frac(neg)) == (frac(neg) <= floor(neg)) == False
+
+    assert (floor(posn) >= frac(posn)) == (frac(posn) <= floor(posn)) == True
+    assert (floor(posn) > frac(posn))  == Gt(floor(posn), frac(posn), evaluate=False)
+
+    assert (floor(negn) <= frac(negn)) == (frac(negn) >= floor(negn)) == True
+    assert (floor(negn) >= frac(negn)) == Ge(floor(negn), frac(negn), evaluate=False)
+
+
+def test_ceiling_vs_frac():
+    x    = Symbol("x", real=True)
+    pos  = Symbol("pos", extended_positive=True)
+    neg  = Symbol("neg", extended_negative=True)
+    posn = Symbol("pos0", nonnegative=True, integer=True)
+    negn = Symbol("neg0", nonpositive=True, integer=True)
+
+    assert (ceiling(x) > frac(x))  == Gt(ceiling(x), frac(x), evaluate=False)
+    assert (frac(x) < ceiling(x))  == Lt(frac(x), ceiling(x), evaluate=False)
+    assert (ceiling(x) >= frac(x)) == Ge(ceiling(x), frac(x), evaluate=False)
+    assert (frac(x) <= ceiling(x)) == Le(frac(x), ceiling(x), evaluate=False)
+    assert (ceiling(x) < frac(x))  == Lt(ceiling(x), frac(x), evaluate=False)
+    assert (frac(x) > ceiling(x))  == Gt(frac(x), ceiling(x), evaluate=False)
+    assert (ceiling(x) <= frac(x)) == Le(ceiling(x), frac(x), evaluate=False)
+    assert (frac(x) >= ceiling(x)) == Ge(frac(x), ceiling(x), evaluate=False)
+
+    assert (ceiling(pos) > frac(pos))  == (frac(pos) < ceiling(pos)) == True
+    assert (ceiling(pos) >= frac(pos)) == (frac(pos) <= ceiling(pos)) == True
+
+    assert (ceiling(neg) < frac(neg))  == (frac(neg) > ceiling(neg)) == True
+    assert (ceiling(neg) <= frac(neg)) == (frac(neg) >= ceiling(neg)) == True
+
+    assert (ceiling(posn) >= frac(posn)) == (frac(posn) <= ceiling(posn)) == True
+    assert (ceiling(posn) > frac(posn))  == Gt(ceiling(posn), frac(posn), evaluate=False)
+
+    assert (ceiling(negn) <= frac(negn)) == (frac(negn) >= ceiling(negn)) == True
+    assert (ceiling(negn) >= frac(negn)) == Ge(ceiling(negn), frac(negn), evaluate=False)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -169,17 +169,12 @@ def test_floor():
     assert (floor(neg) > 0) == False
     assert (floor(neg) >= 0) == False
     assert (floor(neg) <= -1) == True
-    assert (floor(neg) >= -3) == (neg >= -3)
-    assert (floor(neg) < 5) == (neg < 5)
 
     assert (floor(nn) < 0) == False
     assert (floor(nn) >= 0) == True
 
     assert (floor(pos) < 0) == False
-    assert (floor(pos) <= 0) == (pos < 1)
-    assert (floor(pos) > 0) == (pos >= 1)
     assert (floor(pos) >= 0) == True
-    assert (floor(pos) >= 3) == (pos >= 3)
 
     assert (floor(np) <= 0) == True
     assert (floor(np) > 0) == False
@@ -213,15 +208,7 @@ def test_floor():
     assert (floor(x) < 2.9) == Lt(floor(x), 2.9, evaluate=False)
     assert (floor(x) > -1.7) == Gt(floor(x), -1.7, evaluate=False)
 
-    assert (floor(y) <= 5.5) == (y < 6)
-    assert (floor(y) >= -3.2) == (y >= -3)
-    assert (floor(y) < 2.9) == (y < 3)
-    assert (floor(y) > -1.7) == (y >= -1)
 
-    assert (floor(y) <= n) == (y < n + 1)
-    assert (floor(y) >= n) == (y >= n)
-    assert (floor(y) < n) == (y < n)
-    assert (floor(y) > n) == (y >= n + 1)
 
     assert floor(RootOf(x**3 - 27*x, 2)) == 5
 
@@ -366,11 +353,7 @@ def test_ceiling():
     np = Symbol('np', nonpositive=True)
 
     assert (ceiling(neg) <= 0) == True
-    assert (ceiling(neg) < 0) == (neg <= -1)
     assert (ceiling(neg) > 0) == False
-    assert (ceiling(neg) >= 0) == (neg > -1)
-    assert (ceiling(neg) > -3) == (neg > -3)
-    assert (ceiling(neg) <= 10) == (neg <= 10)
 
     assert (ceiling(nn) < 0) == False
     assert (ceiling(nn) >= 0) == True
@@ -380,7 +363,6 @@ def test_ceiling():
     assert (ceiling(pos) > 0) == True
     assert (ceiling(pos) >= 0) == True
     assert (ceiling(pos) >= 1) == True
-    assert (ceiling(pos) > 5) == (pos > 5)
 
     assert (ceiling(np) <= 0) == True
     assert (ceiling(np) > 0) == False
@@ -413,16 +395,6 @@ def test_ceiling():
     assert (ceiling(x) >= -3.2) == Ge(ceiling(x), -3.2, evaluate=False)
     assert (ceiling(x) < 2.9) == Lt(ceiling(x), 2.9, evaluate=False)
     assert (ceiling(x) > -1.7) == Gt(ceiling(x), -1.7, evaluate=False)
-
-    assert (ceiling(y) <= 5.5) == (y <= 5)
-    assert (ceiling(y) >= -3.2) == (y > -4)
-    assert (ceiling(y) < 2.9) == (y <= 2)
-    assert (ceiling(y) > -1.7) == (y > -2)
-
-    assert (ceiling(y) <= n) == (y <= n)
-    assert (ceiling(y) >= n) == (y > n - 1)
-    assert (ceiling(y) < n) == (y <= n - 1)
-    assert (ceiling(y) > n) == (y > n)
 
     assert ceiling(RootOf(x**3 - 27*x, 2)) == 6
     s = ImageSet(Lambda(n, n + (CRootOf(x**5 - x**2 + 1, 0))), Integers)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #8444 #29618
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Removed all the special methods like `__ge__` from floor, frac, ceiling. The inequalities are now improved. See below for examples:
```Python
x    = Symbol("x", real=True)
neg  = Symbol("neg", extended_negative=True)
pos  = Symbol("pos", extended_positive=True)
(floor(neg) > frac(neg)) # False
floor(x) <= ceiling(x) # True
ceiling(pos) > frac(pos) # True
```
Also, it is possible to properly compare between accumBounds and these functions now.
The new tests should include all the new cases I have found.

#### Other comments
The deleted tests are mainly because of this  #29618
The deleted line in XFAIL test is mainly because the integer functions cannot be evaluated (evaluated as in, they cannot return bool value) if we cannot assure `x` is real.
The `AccumBounds` was touched because otherwise dispatch would throw warnings. Importing `AccumBounds` to the integers file throws circle import error.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude was used for `test_integers.py`. All other code is written by hand.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Improved inequalities for `floor`, `ceiling` and `frac` functions.
* calculus
  * Added inequality support between AccumBounds  and `floor`, `ceiling`, `frac` functions

<!-- END RELEASE NOTES -->
