### PR TITLE
Add type annotations to series/kauers.py and series/residues.py

### DIFF
--- a/sympy/series/kauers.py
+++ b/sympy/series/kauers.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
-def finite_diff(expression, variable, increment=1):
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.core.symbol import Symbol
+    from sympy.concrete.summations import Sum
+def finite_diff(expression:Expr, variable:Symbol|Expr, increment:int|Expr=1)->Expr:
     """
     Takes as input a polynomial expression and the variable used to construct
     it and returns the difference between function's value when the input is
@@ -25,7 +32,7 @@ def finite_diff(expression, variable, increment=1):
     expression2 = expression2.expand()
     return expression2 - expression
 
-def finite_diff_kauers(sum):
+def finite_diff_kauers(sum:Sum)->Expr:
     """
     Takes as input a Sum instance and returns the difference between the sum
     with the upper index incremented by 1 and the original sum. For example,

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -4,14 +4,20 @@ with residues.
 """
 from __future__ import annotations
 
+from typing import Any, TYPE_CHECKING
+
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
+from sympy.core.power import Pow
 
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.core.symbol import Symbol
 
 @timethis('residue')
-def residue(expr, x, x0):
+def residue(expr:Any, x:Symbol|Expr, x0:int|Expr)->Expr:
     """
     Finds the residue of ``expr`` at the point x=x0.
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
See #28806 

#### Brief description of what is fixed or changed
Added annotations to sympy/series/kauers.py and sympy/series/residues.py

Although examples mostly use Symbol and int, the code and tests show that most times Expr is also supported. Typing them as Symbol | Expr or int | Expr helps the linting tools prioritize the most common usage.

- Kauers.py
There are two functions:
```
def finite_diff(expression:Expr, variable:Symbol|Expr, increment:int|Expr=1)->Expr:
```
In all the examples variable is a symbol and increment is int so it is inferred that the usual way of using this function uses these types. 
However the flow of the function and the tests need it to allow for Expr also.
```
def finite_diff_kauers(sum:Sum)->Expr:
```

- residues.py
```
def residue(expr:Any, x:Symbol|Expr, x0:int|Expr)->Expr:
```
Here expr is passed into sympify so it is marked as an ambiguous type by the type Any. 
x and x0 are used in the examples as symbol and int respectively, but in it is necessary to add Expr to cover all test cases.

Changed m.is_Pow to isinstance(m, Pow) so Mypy can correctly infer the type for .exp
#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
