### PR TITLE
Fix limit of correlated oscillatory trig differences

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1152,6 +1152,7 @@ Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
+Muhammad Taha <mtk2982007@outlook.com> Muhammad Taha <73759710+TahaKhanM@users.noreply.github.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -30,9 +30,9 @@ def _rewrite_trig_as_product(expr):
         # Apply to Add factors inside a Mul
         new_args = []
         changed = False
-        for arg in expr.args:
-            rewritten = _rewrite_trig_as_product(arg)
-            if rewritten != arg:
+        for a in expr.args:
+            rewritten = _rewrite_trig_as_product(a)
+            if rewritten != a:
                 changed = True
             new_args.append(rewritten)
         return Mul(*new_args) if changed else expr

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -13,6 +13,98 @@ from sympy.polys import PolynomialError, factor
 from sympy.series.order import Order
 from .gruntz import gruntz
 
+
+def _rewrite_trig_as_product(expr):
+    """Rewrite differences of sin/cos with related arguments using
+    sum-to-product identities.
+
+    sin(a) - sin(b) = 2*cos((a+b)/2)*sin((a-b)/2)
+    cos(a) - cos(b) = -2*sin((a+b)/2)*sin((a-b)/2)
+
+    This avoids the loss of correlation when sin/cos terms with infinite
+    arguments are bounded independently as AccumBounds(-1, 1).
+    """
+    from sympy.functions.elementary.trigonometric import sin, cos
+
+    if isinstance(expr, Mul):
+        # Apply to Add factors inside a Mul
+        new_args = []
+        changed = False
+        for arg in expr.args:
+            rewritten = _rewrite_trig_as_product(arg)
+            if rewritten != arg:
+                changed = True
+            new_args.append(rewritten)
+        return Mul(*new_args) if changed else expr
+
+    if not isinstance(expr, Add):
+        return expr
+
+    # Collect sin and cos terms with their coefficients
+    sin_terms = {}  # {argument: coefficient}
+    cos_terms = {}
+    other = S.Zero
+
+    for term in Add.make_args(expr):
+        coeff, rest = term.as_coeff_Mul()
+        if isinstance(rest, sin):
+            arg = rest.args[0]
+            sin_terms[arg] = sin_terms.get(arg, S.Zero) + coeff
+        elif isinstance(rest, cos):
+            arg = rest.args[0]
+            cos_terms[arg] = cos_terms.get(arg, S.Zero) + coeff
+        else:
+            other += term
+
+    result = other
+    sin_args = list(sin_terms.keys())
+    cos_args = list(cos_terms.keys())
+    used_sin = set()
+    used_cos = set()
+
+    # Try to pair sin terms: c1*sin(a) + c2*sin(b) where c1 = -c2
+    for i in range(len(sin_args)):
+        if i in used_sin:
+            continue
+        for j in range(i + 1, len(sin_args)):
+            if j in used_sin:
+                continue
+            a, b = sin_args[i], sin_args[j]
+            ci, cj = sin_terms[a], sin_terms[b]
+            if ci + cj == 0 and ci != 0:
+                # ci*sin(a) - ci*sin(b) = ci * 2*cos((a+b)/2)*sin((a-b)/2)
+                result += ci * 2 * cos((a + b) / 2) * sin((a - b) / 2)
+                used_sin.add(i)
+                used_sin.add(j)
+                break
+
+    # Try to pair cos terms: c1*cos(a) + c2*cos(b) where c1 = -c2
+    for i in range(len(cos_args)):
+        if i in used_cos:
+            continue
+        for j in range(i + 1, len(cos_args)):
+            if j in used_cos:
+                continue
+            a, b = cos_args[i], cos_args[j]
+            ci, cj = cos_terms[a], cos_terms[b]
+            if ci + cj == 0 and ci != 0:
+                # ci*cos(a) - ci*cos(b) = ci * (-2)*sin((a+b)/2)*sin((a-b)/2)
+                result += ci * (-2) * sin((a + b) / 2) * sin((a - b) / 2)
+                used_cos.add(i)
+                used_cos.add(j)
+                break
+
+    # Add back unpaired terms
+    for i, arg in enumerate(sin_args):
+        if i not in used_sin:
+            result += sin_terms[arg] * sin(arg)
+    for i, arg in enumerate(cos_args):
+        if i not in used_cos:
+            result += cos_terms[arg] * cos(arg)
+
+    return result
+
+
 def limit(e, z, z0, dir="+"):
     """Computes the limit of ``e(z)`` at the point ``z0``.
 
@@ -349,8 +441,26 @@ class Limit(Expr):
             except (ValueError, NotImplementedError, PoleError):
                 pass
         else:
-            if isinstance(coeff, AccumBounds) and ex == S.Zero:
-                return coeff
+            if isinstance(coeff, AccumBounds):
+                # Try rewriting trig differences using sum-to-product
+                # identities to preserve correlation between oscillatory terms.
+                # E.g. sin(x+1/x) - sin(x) -> 2*cos(...)*sin(1/(2x))
+                newe2 = _rewrite_trig_as_product(newe)
+                if newe2 != newe:
+                    try:
+                        coeff2, ex2 = newe2.leadterm(newz, cdir=cdir)
+                    except (ValueError, NotImplementedError, PoleError):
+                        pass
+                    else:
+                        # Only use the rewritten result if it strictly
+                        # improves the exponent (e.g. 0 -> positive means
+                        # the limit is now 0 instead of AccumBounds) or
+                        # eliminates the AccumBounds entirely.
+                        if (ex2 - ex).is_positive or \
+                                (ex2 == ex and not coeff2.has(AccumBounds)):
+                            coeff, ex = coeff2, ex2
+                if isinstance(coeff, AccumBounds) and ex == S.Zero:
+                    return coeff
             if coeff.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity, S.NaN):
                 return self
             if not coeff.has(newz):

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -354,6 +354,12 @@ def test_series_AccumBounds():
     # not the exact bound
     assert limit(sin(k) - sin(k)*cos(k), k, oo) == AccumBounds(-2, 2)
 
+    # test for issues #29567 and #29576: correlated oscillatory differences
+    assert limit(sin(x + 1/x) - sin(x), x, oo) == 0
+    assert limit(x*(sin(x + 1/x) - sin(x)), x, oo) == AccumBounds(-1, 1)
+    assert limit(cos(x + 1/x) - cos(x), x, oo) == 0
+    assert limit(x*(cos(x + 1/x) - cos(x)), x, oo) == AccumBounds(-1, 1)
+
     # test for issue #9934
     lo = (-3 + cos(1))/2
     hi = (1 + cos(1))/2


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29567
Fixes #29576
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
When computing limits like `limit(sin(x + 1/x) - sin(x), x, oo)`, SymPy was independently bounding each `sin` term as `AccumBounds(-1, 1)`, losing the correlation between them and returning `AccumBounds(-2, 2)` instead of `0`. Similarly, `limit(x*(sin(x + 1/x) - sin(x)), x, oo)` returned `oo*sign(AccumBounds(-2, 2))` instead of `AccumBounds(-1, 1)`.

This adds a sum-to-product trig rewrite in `Limit.doit()` that converts correlated trig differences like `sin(a) - sin(b)` into `2*cos((a+b)/2)*sin((a-b)/2)` before computing the leading term. The rewrite is only used when it strictly improves the result (different exponent or eliminates AccumBounds entirely), so existing correct AccumBounds results are preserved.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed incorrect limit results for differences of correlated oscillatory functions like `sin(x + 1/x) - sin(x)` as `x -> oo`.
<!-- END RELEASE NOTES -->