### PR TITLE
Add type annotations to _eval_difference_delta in add.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1890,3 +1890,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Soha Chand <sohachand@yahoo.com>

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -19,7 +19,7 @@ from sympy.utilities.iterables import is_sequence, sift
 if TYPE_CHECKING:
     from sympy.core.numbers import Number
     from sympy.series.order import Order
-
+    from sympy.core.symbol import Symbol
 
 def _could_extract_minus_sign(expr):
     # assume expr is Add-like
@@ -1243,7 +1243,7 @@ class Add(Expr, AssocOp):
         from .sorting import default_sort_key
         return tuple(sorted(self.args, key=default_sort_key))
 
-    def _eval_difference_delta(self, n, step):
+    def _eval_difference_delta(self, n: Symbol, step: Expr) -> Expr:
         from sympy.series.limitseq import difference_delta as dd
         return self.func(*[dd(a, n, step) for a in self.args])
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1243,7 +1243,7 @@ class Add(Expr, AssocOp):
         from .sorting import default_sort_key
         return tuple(sorted(self.args, key=default_sort_key))
 
-    def _eval_difference_delta(self, n: Symbol, step: Expr) -> Expr:
+    def _eval_difference_delta(self, n: 'Symbol', step: Expr) -> Expr:
         from sympy.series.limitseq import difference_delta as dd
         return self.func(*[dd(a, n, step) for a in self.args])
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #28806

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Added type annotations to _eval_difference_delta in sympy/core/add.py.
Added Symbol to the TYPE_CHECKING import block.

#### Other comments
This is my first contribution to SymPy. Happy to make any changes based on feedback.

#### AI Generation Disclosure
NO AI USE

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
