### PR TITLE
[docs]: Added examples to constant_rule in manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1353,7 +1353,19 @@ def alternatives(*rules):
                 return AlternativeRule(*integral, alts)
     return _alternatives
 
-def constant_rule(integral):
+def constant_rule(integral): 
+    """
+    Returns the integral of a constant.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol
+    >>> from sympy.integrals.manualintegrate import manualintegrate
+    >>> x = Symbol('x')
+    >>> manualintegrate(5, x)
+    5*x
+    """
     return ConstantRule(*integral)
 
 def power_rule(integral):


### PR DESCRIPTION
#### References to other Issues or PRs
Not applicable

#### Brief description of what is fixed or changed
I have added a missing Examples section (doctest) , to the constant_rule function in sympy/integrals/manualintegrate.py file. While exploring the codebase for my GSoC application, I noticed that some of the basic rules lacked clear and some executable examples in their docstrings. I added a simple case for integrating a constant to help future users and contributors understand the expected input/output of this rule.

#### Other comments
I have verified this change by running python bin/doctest sympy/integrals/manualintegrate.py and it passed with 0 failures as you can check below. 
<img width="1919" height="1071" alt="ss_testing" src="https://github.com/user-attachments/assets/46f57a0b-1936-4e5f-9492-8c841f50feef" />


#### AI Generation Disclosure

I used Gemini to help me understand the SymPy contribution workflow, mainl to set up my local environment, and identify where documentation was missing. The specific example added to the code was manually verified by me using the SymPy library on my local machine.



#### Release Notes

* integrals
  * Added docstring example to _constant_rule in manualintegrate.


