### PR TITLE
Fix eigenvals(rational=True) returning floats for numeric matrices

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -207,15 +207,15 @@ def _eigenvals(M,
     if not M.is_square:
         raise NonSquareMatrixError("{} must be a square matrix.".format(M))
 
-    if M._rep.domain not in (ZZ, QQ):
-        # Skip this check for ZZ/QQ because it can be slow
-        if all(x.is_number for x in M) and M.has(Float):
-            return _eigenvals_mpmath(M, multiple=multiple)
-
     if rational:
         from sympy.simplify import nsimplify
         M = M.applyfunc(
             lambda x: nsimplify(x, rational=True) if x.has(Float) else x)
+
+    if M._rep.domain not in (ZZ, QQ):
+        # Skip this check for ZZ/QQ because it can be slow
+        if all(x.is_number for x in M) and M.has(Float):
+            return _eigenvals_mpmath(M, multiple=multiple)
 
     if multiple:
         return _eigenvals_list(

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -158,6 +158,9 @@ def test_float_eigenvals():
     for x, y in zip(n_evals, s_evals):
         assert abs(x-y) < 10**-9
 
+    m = Matrix([[1.0, 0.0], [0.0, 2.0]])
+    assert m.eigenvals(rational=True) == {1: 1, 2: 1}
+
 
 @XFAIL
 def test_eigen_vects():


### PR DESCRIPTION

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The Problem is before making a matrix rational when rational flag is true, the code will find eigen values by mpmath.
I have moved rational check earlier so it correctly convert matrix to rational which prevent it from falling to  find eigen values by mpmath. I have also added a test for it.

#### Other comments
Before
```
>>> from sympy import Matrix
>>> Matrix([[1.0, 0.0], [0.0, 2.0]]).eigenvals(rational=True)
{1.00000000000000: 1, 2.00000000000000: 1}
```

After
```
>>> from sympy import Matrix
>>> Matrix([[1.0, 0.0], [0.0, 2.0]]).eigenvals(rational=True)
{1: 1, 2: 1}
```
#### AI Generation Disclosure
Codex found this issue and produce a reproducible example.
The code in this PR is fully handwritten by me.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
