### PR TITLE
Fix truss logic by replacing `cmath` with `sympy` imports and unifying infinity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -492,6 +492,7 @@ Charlie Lam <888lamcharlie@gmail.com>
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chidroopakanaparthy <chidroopak007@gmail.com> Chidroopa Kanaparthy <chidroopak007@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/sympy/physics/continuum_mechanics/truss.py
+++ b/sympy/physics/continuum_mechanics/truss.py
@@ -5,13 +5,7 @@ to 2D Trusses.
 from __future__ import annotations
 
 
-from cmath import atan, inf
-from sympy.core.add import Add
-from sympy.core.evalf import INF
-from sympy.core.mul import Mul
-from sympy.core.symbol import Symbol
-from sympy.core.sympify import sympify
-from sympy import Matrix, pi
+from sympy import Matrix, pi, atan, oo, Symbol, sympify, Add, Mul
 from sympy.external.importtools import import_module
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import zeros
@@ -744,7 +738,7 @@ class Truss:
         forces_matrix = (Matrix(coefficients_matrix)**-1)*load_matrix
         self._reaction_loads = {}
         i = 0
-        min_load = inf
+        min_load = oo
         for node in self._nodes:
             if node[0] in self._loads:
                 for load in self._loads[node[0]]:
@@ -839,10 +833,10 @@ class Truss:
         load_annotations = self._draw_loads()
         annotations += load_annotations
 
-        xmax = -INF
-        xmin = INF
-        ymax = -INF
-        ymin = INF
+        xmax = -oo
+        xmin = oo
+        ymax = -oo
+        ymin = oo
 
         for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
@@ -910,10 +904,10 @@ class Truss:
 
         member_rectangles = []
 
-        xmax = -INF
-        xmin = INF
-        ymax = -INF
-        ymin = INF
+        xmax = -oo
+        xmin = oo
+        ymax = -oo
+        ymin = oo
 
         for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
@@ -1000,10 +994,10 @@ class Truss:
     def _draw_supports(self):
         support_markers = []
 
-        xmax = -INF
-        xmin = INF
-        ymax = -INF
-        ymin = INF
+        xmax = -oo
+        xmin = oo
+        ymax = -oo
+        ymin = oo
 
         for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])
@@ -1070,10 +1064,10 @@ class Truss:
     def _draw_loads(self):
         load_annotations = []
 
-        xmax = -INF
-        xmin = INF
-        ymax = -INF
-        ymin = INF
+        xmax = -oo
+        xmin = oo
+        ymax = -oo
+        ymin = oo
 
         for node in self._node_coordinates:
             xmax = max(xmax, self._node_coordinates[node][0])


### PR DESCRIPTION
#### References to other Issues or PRs

none

#### Brief description of what is fixed or changed

Replaced `cmath.atan` with `sympy.atan`. `cmath` functions return complex types and fail when passed SymPy Symbols, which broke trusses with symbolic coordinates. Replaced `cmath.inf` with `sympy.oo` which caused numerical reaction forces to be divided by a complex infinity wiping valid forces to 0 and across the file to ensure consistent behavior in calculations for plots.

#### Other comments

The changes ensure that the `Truss` module remains fully compatible with SymPy's symbolic engine

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.continuum_mechanics

   * Replaced `cmath` with `sympy` functions in `Truss` to support symbolic coordinates and fixed a bug where reaction forces were incorrectly zeroed.
  
<!-- END RELEASE NOTES -->
