### PR TITLE
Fix Boolean logic bug in recast_to_symbols input validation

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -89,7 +89,7 @@ def recast_to_symbols(eqs, symbols):
     >>> assert [d.get(i, i) for i in s] == syms
 
     """
-    if not iterable(eqs) and iterable(symbols):
+    if not iterable(eqs) or not iterable(symbols):
         raise ValueError('Both eqs and symbols must be iterable')
     orig = list(symbols)
     symbols = list(ordered(symbols))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -27,7 +27,7 @@ from sympy.matrices import MatrixSymbol, SparseMatrix
 from sympy.polys.polytools import Poly, groebner
 from sympy.printing.str import sstr
 from sympy.simplify.radsimp import denom
-from sympy.solvers.solvers import (nsolve, solve, solve_linear)
+from sympy.solvers.solvers import (nsolve, solve, solve_linear, recast_to_symbols)
 
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
@@ -2734,3 +2734,15 @@ def test_solve_maxmin():
     assert solve(system, variables) == [(5 - sqrt(42), 67 - 10*sqrt(42)), (5 + sqrt(42), 10*sqrt(42) + 67)]
     system = [Eq(y, Max(3*x, -(S(1)/3)*x)), Eq(y, -(x**2)+10)]
     assert solve(system, variables) == [(-3, 1), (2, 6)]
+
+
+def test_recast_to_symbols():
+    e, s, d = recast_to_symbols([x - 1], [x])
+    assert e == [x - 1]
+    raises(ValueError, lambda: recast_to_symbols(x - 1, [x]))
+    raises(ValueError, lambda: recast_to_symbols([x - 1], x))
+    raises(ValueError, lambda: recast_to_symbols(x - 1, x))
+    raises(ValueError, lambda: recast_to_symbols([x - 1], None))
+    raises(ValueError, lambda: recast_to_symbols([x - 1], 42))
+    raises(ValueError, lambda: recast_to_symbols(42, [x]))
+    raises(ValueError, lambda: recast_to_symbols(42, 99))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
When runnig this
```python
from sympy.solvers.solvers import recast_to_symbols
recast_to_symbols([1], 42) 
```
Output:- 
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 2
      1 from sympy.solvers.solvers import recast_to_symbols
----> 2 recast_to_symbols([1], 42) 

File /lib/python3.13/site-packages/sympy/solvers/solvers.py:96, in recast_to_symbols(eqs, symbols)
     94 if not iterable(eqs) and iterable(symbols):
     95     raise ValueError('Both eqs and symbols must be iterable')
---> 96 orig = list(symbols)
     97 symbols = list(ordered(symbols))
     98 swap_sym = {}

TypeError: 'int' object is not iterable
```
A logical bug in solvers.recast_to_symbols where non-iterable inputs bypassed the ValueError check and caused deep TypeError crashes.
But Should be:- ValueError instead of TypeError

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
No use of AI

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a silent boolean logic bug in `recast_to_symbols` input validation that let non-iterable items bypass intended ValueError checks and crash internally.
<!-- END RELEASE NOTES -->
