### PR TITLE
improved documentation of powdenest

### DIFF
--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -522,8 +522,8 @@ def powdenest(eq, force=False, polar=False):
     negative behave as though they are positive, resulting in more
     denesting.
 
-    Setting ``polar`` to ``True`` will do simplifications on the Riemann surface of
-    the logarithm, also resulting in more denestings.
+    Setting ``polar`` to ``True`` will do simplifications on the
+    Riemann surface of the logarithm, also resulting in more denestings.
 
     When there are sums of logs in exp() then a product of powers may be
     obtained e.g. ``exp(3*(log(a) + 2*log(b)))`` - > ``a**3*b**6``.
@@ -534,30 +534,70 @@ def powdenest(eq, force=False, polar=False):
     >>> from sympy.abc import a, b, x, y, z
     >>> from sympy import Symbol, exp, log, sqrt, symbols, powdenest
 
-    >>> powdenest((x**(2*a/3))**(3*x))
-    (x**(2*a/3))**(3*x)
-    >>> powdenest(exp(3*x*log(2)))
-    2**(3*x)
+    >>> p, q = symbols('p q', positive=True)
+    >>> i, j = symbols('i, j', integer=True)
+    >>> expr = (p**(2*i)*q**(4*i))**j
+    >>> expr
+    (p**(2*i)*q**(4*i))**j
+    >>> powdenest(expr)
+    (p*q**2)**(2*i*j)
 
-    Assumptions may prevent expansion:
+    In the following example, ``x`` is a generic symbol with no assumptions
+    and powdenest is unable to denest the powers of the provided expression:
 
-    >>> powdenest(sqrt(x**2))
+    >>> expr = sqrt(x**2)
+    >>> powdenest(expr)
     sqrt(x**2)
 
-    >>> p = symbols('p', positive=True)
-    >>> powdenest(sqrt(p**2))
-    p
+    We can still force a denesting, in which case x is considered non-negative,
+    thus the result won't contain an absolute value:
 
-    No other expansion is done.
+    >>> powdenest(sqrt(x**2), force=True)
+    x
 
-    >>> i, j = symbols('i,j', integer=True)
-    >>> powdenest((x**x)**(i + j)) # -X-> (x**x)**i*(x**x)**j
-    x**(x*(i + j))
+    Other similar examples:
 
-    But exp() will be denested by moving all non-log terms outside of
+    >>> expr = (x**(2*a/3))**(3*x)
+    >>> powdenest(expr)
+    (x**(2*a/3))**(3*x)
+    >>> powdenest(expr, force=True)
+    x**(2*a*x)
+
+    >>> expr = ((x**(2*a/3))**(3*y/i))**x
+    >>> powdenest(expr)
+    ((x**(2*a/3))**(3*y/i))**x
+    >>> powdenest(expr, force=True)
+    x**(2*a*x*y/i)
+
+    >>> expr = (x**(2*i)*y**(4*i))**z
+    >>> powdenest(expr)
+    (x**(2*i)*y**(4*i))**z
+    >>> powdenest(expr, force=True)
+    (x*y**2)**(2*i*z)
+
+    >>> expr = (x**i)**y
+    >>> powdenest(expr)
+    (x**i)**y
+    >>> powdenest(expr, force=True)
+    x**(i*y)
+
+    However, assumptions on symbols may prevent denesting. In the following
+    example, the base is set to be negative, hence the simplification can't
+    be applied:
+
+    >>> n = Symbol('n', negative=True)
+    >>> expr = (n**i)**x
+    >>> powdenest(expr)
+    (n**i)**x
+    >>> powdenest(expr, force=True)
+    (n**i)**x
+
+    exp() will be denested by moving all non-log terms outside of
     the function; this may result in the collapsing of the exp to a power
     with a different base:
 
+    >>> powdenest(exp(3*x*log(2)))
+    2**(3*x)
     >>> powdenest(exp(3*y*log(x)))
     x**(3*y)
     >>> powdenest(exp(y*(log(a) + log(b))))
@@ -567,23 +607,21 @@ def powdenest(eq, force=False, polar=False):
 
     If assumptions allow, symbols can also be moved to the outermost exponent:
 
-    >>> i = Symbol('i', integer=True)
-    >>> powdenest(((x**(2*i))**(3*y))**x)
+    >>> expr = ((x**(2*i))**(3*y))**x
+    >>> powdenest(expr)
     ((x**(2*i))**(3*y))**x
-    >>> powdenest(((x**(2*i))**(3*y))**x, force=True)
+    >>> powdenest(expr, force=True)
     x**(6*i*x*y)
 
-    >>> powdenest(((x**(2*a/3))**(3*y/i))**x)
-    ((x**(2*a/3))**(3*y/i))**x
-    >>> powdenest((x**(2*i)*y**(4*i))**z, force=True)
-    (x*y**2)**(2*i*z)
+    Sometime, more denesting can be achieved by setting ``polar=True``:
 
-    >>> n = Symbol('n', negative=True)
-
-    >>> powdenest((x**i)**y, force=True)
-    x**(i*y)
-    >>> powdenest((n**i)**x, force=True)
-    (n**i)**x
+    >>> expr = (x*y*z)**a
+    >>> powdenest(expr)
+    (x*y*z)**a
+    >>> powdenest(expr, force=True)
+    (x*y*z)**a
+    >>> powdenest(expr, polar=True)
+    x**a*y**a*z**a
 
     """
     from sympy.simplify.simplify import posify

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -555,31 +555,13 @@ def powdenest(eq, force=False, polar=False):
     >>> powdenest(sqrt(x**2), force=True)
     x
 
-    Other similar examples:
-
-    >>> expr = (x**(2*a/3))**(3*x)
-    >>> powdenest(expr)
-    (x**(2*a/3))**(3*x)
-    >>> powdenest(expr, force=True)
-    x**(2*a*x)
-
-    >>> expr = ((x**(2*a/3))**(3*y/i))**x
-    >>> powdenest(expr)
-    ((x**(2*a/3))**(3*y/i))**x
-    >>> powdenest(expr, force=True)
-    x**(2*a*x*y/i)
+    Another similar example:
 
     >>> expr = (x**(2*i)*y**(4*i))**z
     >>> powdenest(expr)
     (x**(2*i)*y**(4*i))**z
     >>> powdenest(expr, force=True)
     (x*y**2)**(2*i*z)
-
-    >>> expr = (x**i)**y
-    >>> powdenest(expr)
-    (x**i)**y
-    >>> powdenest(expr, force=True)
-    x**(i*y)
 
     However, assumptions on symbols may prevent denesting. In the following
     example, the base is set to be negative, hence the simplification can't
@@ -592,9 +574,10 @@ def powdenest(eq, force=False, polar=False):
     >>> powdenest(expr, force=True)
     (n**i)**x
 
-    exp() will be denested by moving all non-log terms outside of
-    the function; this may result in the collapsing of the exp to a power
-    with a different base:
+    exp() will be denested by applying logarithmic identities. In particular,
+    expressions of the form exp(k*log(x)) are rewritten as x**k, and
+    logarithmic sums/products inside exponents are combined where possible
+    to produce a single power:
 
     >>> powdenest(exp(3*x*log(2)))
     2**(3*x)
@@ -604,14 +587,6 @@ def powdenest(eq, force=False, polar=False):
     (a*b)**y
     >>> powdenest(exp(3*(log(a) + log(b))))
     a**3*b**3
-
-    If assumptions allow, symbols can also be moved to the outermost exponent:
-
-    >>> expr = ((x**(2*i))**(3*y))**x
-    >>> powdenest(expr)
-    ((x**(2*i))**(3*y))**x
-    >>> powdenest(expr, force=True)
-    x**(6*i*x*y)
 
     Sometime, more denesting can be achieved by setting ``polar=True``:
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29326

#### Brief description of what is fixed or changed

In the "Examples" section of  `powdenest`'s docstring,  a couple of symbolic expressions were evaluated/simplified before being processed by `powdenest`. A user reading it could be confused into thinking that the simplification was performed by `powdenest`, when in reality it was not.

This fixes it, and better reorganizes the examples.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
