### PR TITLE
matrices: group mpmath eigenvectors by eigenvalue

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -84,11 +84,19 @@ def _eigenvals_mpmath(M, multiple=False):
 def _eigenvects_mpmath(M):
     from sympy import ImmutableMatrix
     E, ER = _eigenvals_eigenvects_mpmath(M)
+    grouped_eigenvects = {}
     result = []
     for i in range(M.rows):
         eigenval = _sympify(E[i])
         eigenvect = ImmutableMatrix(ER[i])
-        result.append((eigenval, 1, [eigenvect]))
+
+        if eigenval in grouped_eigenvects:
+            grouped_eigenvects[eigenval].append(eigenvect)
+        else:
+            grouped_eigenvects[eigenval] = [eigenvect]
+
+    for eigenval, eigenvects in grouped_eigenvects.items():
+        result.append((eigenval, len(eigenvects), eigenvects))
 
     return result
 

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -242,6 +242,15 @@ def test_eigenvects():
         assert len(vec_list) == 1
         assert M*vec_list[0] == val*vec_list[0]
 
+    M = Matrix([[5.0, 1.0, 0.0],
+                [0.0, 5.0, 0.0],
+                [0.0, 0.0, 3.0]])
+    vecs = M.eigenvects()
+    assert len(vecs) == 2
+    for val, mult, vec_list in vecs:
+        for v in vec_list:
+            assert M*v == val*v
+
 
 @slow
 def test_eigenvects_slow():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Previoulsy ,it incorrectly returned as separate `(eigenvalue, 1, [eigenvect])` It did't group vectors for same eigen value as normal eigen vectors output.Now correct group eigenvectors of same eigen values.

#### Other comments
Before
```
>>> M = Matrix([[1.0, 0], [0, 1.0]])
>>> M.eigenvects()
[(1.00000000000000, 1, [Matrix([
[1.0],
[  0]])]), (1.00000000000000, 1, [Matrix([
[  0],
[1.0]])])]
```
After
```
>>> M = Matrix([[1.0, 0], [0, 1.0]])
>>> M.eigenvects()
[(1.00000000000000, 2, [Matrix([
[1.0],
[  0]]), Matrix([
[  0],
[1.0]])])]
```

#### AI Generation Disclosure
codex found this issue.
All code in PR is handwritten by me.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
