### PR TITLE
Sets: small refactor of ordinals to remove unnecessary imports

### DIFF
--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from operator import lt
-from typing import Callable
-
 from sympy.core import Basic, Integer
 
 
@@ -33,12 +30,6 @@ class OmegaPower(Basic):
     def mult(self) -> Integer:
         return self.args[1]
 
-    def _compare_term(self, other: OmegaPower, op: Callable) -> bool:
-        if self.exp == other.exp:
-            return op(self.mult, other.mult)
-        else:
-            return op(self.exp, other.exp)
-
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, OmegaPower):
             if not isinstance(other, (Integer, int)):
@@ -55,7 +46,10 @@ class OmegaPower(Basic):
                 other = OmegaPower(0, other)
             except TypeError:
                 return NotImplemented
-        return self._compare_term(other, lt)
+        if self.exp == other.exp:
+            return self.mult < other.mult
+        else:
+            return self.exp < other.exp
 
 
 class Ordinal(Basic):


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See https://github.com/sympy/sympy/pull/29519#discussion_r2985457560

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Previously, `sets.ordinals` imported `lt` from the `operators` module. This was only used once, as an argument in the private method `_compare` to call less than recursively. I moved the code from `_compare` inside the `__lt__` dunder, making the import unnecessary.

#### Other comments
This saved 20 ms of import time for `sets.ordinals` on my machine.

#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
