### PR TITLE
Refactoring inner functions in `lra_theory`

### DIFF
--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -127,6 +127,8 @@ from sympy.core.sympify import sympify
 from sympy.core.singleton import S
 from sympy.core.numbers import Rational, oo
 from sympy.matrices.dense import Matrix
+from sympy.utilities.iterables import sift
+
 
 class UnhandledInput(Exception):
     """
@@ -314,7 +316,7 @@ class LRASolver():
             vars, var_coeff = _sep_const_coeff(vars)  # examples: (2x) --> (x, 2); (2x + 3y) --> (2x + 3y), (1)
             const = const / var_coeff
 
-            terms = _list_terms(vars)  # example: (2x + 3y) --> [2x, 3y]
+            terms = Add.make_args(vars)  # example: (2x + 3y) --> [2x, 3y]
             for term in terms:
                 term, _ = _sep_const_coeff(term)
                 assert len(term.free_symbols) > 0
@@ -712,27 +714,10 @@ def _sep_const_coeff(expr):
     """
     if isinstance(expr, Add):
         return expr, sympify(1)
-
-    if isinstance(expr, Mul):
-        coeffs = expr.args
-    else:
-        coeffs = [expr]
-
-    var, const = [], []
-    for c in coeffs:
-        c = sympify(c)
-        if len(c.free_symbols)==0:
-            const.append(c)
-        else:
-            var.append(c)
+    const, var = sift(Mul.make_args(expr),
+                      lambda c: len(sympify(c).free_symbols) == 0,
+                      binary=True)
     return Mul(*var), Mul(*const)
-
-
-def _list_terms(expr):
-    if not isinstance(expr, Add):
-        return [expr]
-
-    return expr.args
 
 
 def _sep_const_terms(expr):
@@ -745,18 +730,10 @@ def _sep_const_terms(expr):
     >>> _sep_const_terms(2*x + 3*y + 2)
     (2*x + 3*y, 2)
     """
-    if isinstance(expr, Add):
-        terms = expr.args
-    else:
-        terms = [expr]
-
-    var, const = [], []
-    for t in terms:
-        if len(t.free_symbols) == 0:
-            const.append(t)
-        else:
-            var.append(t)
-    return sum(var), sum(const)
+    const, var = sift(Add.make_args(expr),
+                      lambda t: len(t.free_symbols) == 0,
+                      binary=True)
+    return Add(*var), Add(*const)
 
 
 def _eval_binrel(binrel):


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
#29542
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
`_list_terms` can be written using `Add.make_args`, so it was changed to use `Add.make_args` instead of a custom helper function. Both `_sep_const_coeff` and `_sep_const_terms` contain logic to split expressions into parts with `free_symbols` and parts without them. This had been implemented manually, but since `sympy.utilities.iterables.sift` provides an equivalent implementation, it was changed to use `sift` instead.

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
