### PR TITLE
vector: fix normalizing rigid transformation tuple inputs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -465,6 +465,7 @@ Brian Stephanik <xoedusk@gmail.com>
 Buck Shlegeris <buck2@bruceh15.anu.edu.au>
 Buck Shlegeris <buck2@bruceh15.anu.edu.au> <buck2@Bucks-MacBook-Pro.local>
 Bulat <daianovich@mail.ru>
+CAIMEOX <phillipdickted@gmail.com> CAIMEO <38813005+CAIMEOX@users.noreply.github.com>
 CJ Carey <perimosocordiae@gmail.com>
 Caley Finn <caleyreuben@gmail.com>
 Calvin Jay Ross <calvinjayross@gmail.com>

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -81,6 +81,7 @@ class CoordSys3D(Basic):
                 if isinstance(transformation[0], MatrixBase):
                     rotation_matrix = transformation[0]
                     location = transformation[1]
+                    transformation = None
                 else:
                     transformation = Lambda(transformation[0],
                                             transformation[1])
@@ -393,7 +394,7 @@ class CoordSys3D(Basic):
                 return lambda r, theta, h: (S.One, r, S.One)
             raise ValueError('Wrong set of parameters.'
                              ' Type of coordinate system is not defined')
-        return CoordSys3D._calculate_lame_coefficients(curv_coord_name)
+        return CoordSys3D._calculate_lame_coeff(curv_coord_name)
 
     @staticmethod
     def _calculate_lame_coeff(equations):

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -310,6 +310,32 @@ def test_create_new():
            (sqrt(a.x**2 + a.y**2 + a.z**2), acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2)), atan2(a.y, a.x))
 
 
+def test_matrix_location_transformation():
+    a = CoordSys3D('a')
+    displacement = a.i + 2*a.j
+
+    def check_system(system):
+        assert system._parent == a
+        assert system.transformation_to_parent() == (
+            system.x + 1, system.y + 2, system.z
+        )
+        assert system.lame_coefficients() == (1, 1, 1)
+        assert system.origin.position_wrt(a.origin) == displacement
+        assert system.rotation_matrix(a) == eye(3)
+
+    for name, transformation in (
+        ('b', (eye(3), displacement)),
+        ('c', [eye(3), displacement]),
+    ):
+        check_system(CoordSys3D(name, parent=a, transformation=transformation))
+
+    for name, transformation in (
+        ('d', (eye(3), displacement)),
+        ('e', [eye(3), displacement]),
+    ):
+        check_system(a.create_new(name, transformation=transformation))
+
+
 def test_evalf():
     A = CoordSys3D('A')
     v = 3*A.i + 4*A.j + a*A.k


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

`CoordSys3D` already supports rigid transforms through `rotation_matrix` and `location`, but the equivalent `(matrix, location)` form was not normalized correctly when passed through
  `transformation`. The constructor unpacked the pair but left the original Python tuple/list in place, so it skipped the rigid-transform branch and fell into the generic transformation path. That wrong path also exposed a typo in `_get_lame_coeff()`, which raised a misleading `AttributeError`.

This patch normalizes tuple/list rigid transforms into the existing Cartesian path and adds regression tests for both `CoordSys3D(...)` and `create_new(...)`.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* vector
  * Fixed `CoordSys3D` so rigid transformations passed as `(rotation_matrix, location)` or `[rotation_matrix, location]` are normalized correctly instead of falling through to the generic transformation path.

<!-- END RELEASE NOTES -->
