### PR TITLE
typ(ntheory): add type annotations to bbp_pi.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -384,6 +384,7 @@ Arthur Milchior <arthur@milchior.fr>
 Arthur Ryman <arthur.ryman@gmail.com>
 Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
 Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
+Aryan Vishwakarma <aryanvishwakarma275@gmail.com> Aryan-202 <aryanvishwakarma275@gmail.com>
 Ashish Kumar Gaurav <ashishkg0022@gmail.com>
 Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
 Ashutosh Saboo <ashutosh.saboo96@gmail.com>

--- a/sympy/ntheory/bbp_pi.py
+++ b/sympy/ntheory/bbp_pi.py
@@ -75,9 +75,9 @@ from typing import TYPE_CHECKING
 
 from sympy.utilities.misc import as_int
 
-
 if TYPE_CHECKING:
     from typing import SupportsIndex
+
 
 def _series(j: int, n: int, prec: int = 14) -> int:
 

--- a/sympy/ntheory/bbp_pi.py
+++ b/sympy/ntheory/bbp_pi.py
@@ -71,9 +71,13 @@ array (perhaps just a matter of preference).
 
 '''
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 from sympy.utilities.misc import as_int
 
+
+if TYPE_CHECKING:
+    from typing import SupportsIndex
 
 def _series(j: int, n: int, prec: int = 14) -> int:
 
@@ -107,7 +111,7 @@ def _series(j: int, n: int, prec: int = 14) -> int:
     return total
 
 
-def pi_hex_digits(n: int, prec: int = 14) -> str:
+def pi_hex_digits(n: SupportsIndex, prec: int = 14) -> str:
     """Returns a string containing ``prec`` (default 14) digits
     starting at the nth digit of pi in hex. Counting of digits
     starts at 0 and the decimal is not counted, so for n = 0 the


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

See #28806

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR adds type annotations to `sympy/ntheory/bbp_pi.py`.

- Added `from __future__ import annotations`.
- Annotated `pi_hex_digits`, `_series`, and `_dn`.
- Used `SupportsIndex` for arguments processed with `as_int()`.
- Verified types locally with mypy, including checking that `pi_hex_digits` returns `str`.

#### Other comments

All tests in `sympy/ntheory/tests/` passed locally.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.



DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->




<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
