### PR TITLE
Add leqslant lark test

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1599,6 +1599,8 @@ Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
+Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <145254642+suraj5030@users.noreply.github.com>
+Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -241,6 +241,7 @@ RELATION_EXPRESSION_PAIRS = [
     (r"x \geq y", Ge(x, y)),
     (r"x \le y", Le(x, y)),
     (r"x \ge y", Ge(x, y)),
+    (r"x \leqslant y", Le(x, y)),
     (r"x < y", StrictLessThan(x, y)),
     (r"x \leq y", LessThan(x, y)),
     (r"x > y", StrictGreaterThan(x, y)),


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #29489

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Added a test case for \leqslant in the Lark LaTeX parser test suite. The token had no test coverage.

#### Other comments
This was suggested by a @wermos on PR #29489.

#### AI Generation Disclosure
No AI use
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
