### PR TITLE
Fix #29647: Safely inherit RandomSymbol assumptions from pspace domain

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -207,6 +207,7 @@ Abdullah Javed Nesar <abduljaved1994@gmail.com>
 Abhay_Dhiman <abhaysdhimans@gmail.com>
 Abhi58 <abhijithbharadwaj58@gmail.com>
 Abhigyan Khaund <mail@abhigyan.xyz>
+Abhijith Shaji <abhijithshajikp@gmail.com>
 Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
 Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -929,7 +929,7 @@ def test_settings():
 def test_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal('x1', 0, 1)
-    assert str(where(X > 0)) == "Domain: (0 < x1) & (x1 < oo)"
+    assert str(where(X > 0)) == "Domain: 0 < x1"
 
     D = Die('d1', 6)
     assert str(where(D > 4)) == "Domain: Eq(d1, 5) | Eq(d1, 6)"

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -42,7 +42,7 @@ from sympy.external import import_module
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
-from sympy import S
+
 
 __doctest_requires__ = {('sample',): ['scipy']}
 
@@ -240,21 +240,6 @@ class SinglePSpace(PSpace):
     """
     def __new__(cls, s, distribution):
         s = _symbol_converter(s)
-        assumptions = s.assumptions0.copy()
-        try:
-            domain_set = distribution.set
-            if 'real' not in assumptions and domain_set.is_subset(S.Reals):
-                assumptions['real'] = True
-            if 'integer' not in assumptions and domain_set.is_subset(S.Integers):
-                assumptions['integer'] = True
-            if 'positive' not in assumptions and domain_set.is_subset(S.Naturals):
-                assumptions['positive'] = True
-            if 'nonnegative' not in assumptions and domain_set.is_subset(S.Naturals0):
-                assumptions['nonnegative'] = True
-        except (AttributeError, NotImplementedError):
-            pass
-        # Re-create the symbol with merged assumptions right at the start
-        s = Symbol(s.name, **assumptions)
         return Basic.__new__(cls, s, distribution)
 
     @property
@@ -303,10 +288,15 @@ class RandomSymbol(Expr):
     convenience functions Normal, Exponential, Coin, Die, FiniteRV, etc....
     """
 
+    is_finite = True
+    is_symbol = True
+    is_Atom = True
+
+    _diff_wrt = True
+
     def __new__(cls, symbol, pspace=None):
         from sympy.stats.joint_rv import JointRandomSymbol
         if pspace is None:
-            # Allow single arg, representing pspace == PSpace()
             pspace = PSpace()
         symbol = _symbol_converter(symbol)
         if not isinstance(pspace, PSpace):
@@ -315,24 +305,49 @@ class RandomSymbol(Expr):
             cls = RandomSymbol
         return Basic.__new__(cls, symbol, pspace)
 
-    is_finite = True
-    is_symbol = True
-    is_Atom = True
-
-    _diff_wrt = True
-
     pspace = property(lambda self: self.args[1])
     symbol = property(lambda self: self.args[0])
     name   = property(lambda self: self.symbol.name)
 
-    def _eval_is_positive(self):
-        return self.symbol.is_positive
+    @property
+    def is_commutative(self):
+        return self.symbol.is_commutative
+
+    @property
+    def free_symbols(self):
+        return {self}
 
     def _eval_is_integer(self):
+        try:
+            if self.pspace.domain.set.is_subset(S.Integers):
+                return True
+        except (AttributeError, NotImplementedError):
+            pass
         return self.symbol.is_integer
 
-    def _eval_is_real(self):
-        return self.symbol.is_real or getattr(self.pspace, 'is_real', False)
+    def _eval_is_positive(self):
+        try:
+            if self.pspace.domain.set.is_subset(S.Naturals):
+                return True
+        except (AttributeError, NotImplementedError):
+            pass
+        return self.symbol.is_positive
+
+    def _eval_is_nonnegative(self):
+        try:
+            if self.pspace.domain.set.is_subset(S.Naturals0):
+                return True
+        except (AttributeError, NotImplementedError):
+            pass
+        return self.symbol.is_nonnegative
+
+    def _eval_is_negative(self):
+        try:
+            if self.pspace.domain.set.is_subset(S.Naturals0):
+                return False
+        except (AttributeError, NotImplementedError):
+            pass
+        return self.symbol.is_negative
 
     @property
     def is_commutative(self):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -42,7 +42,7 @@ from sympy.external import import_module
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
-
+from sympy import S
 
 __doctest_requires__ = {('sample',): ['scipy']}
 
@@ -240,6 +240,21 @@ class SinglePSpace(PSpace):
     """
     def __new__(cls, s, distribution):
         s = _symbol_converter(s)
+        assumptions = s.assumptions0.copy()
+        try:
+            domain_set = distribution.set
+            if 'real' not in assumptions and domain_set.is_subset(S.Reals):
+                assumptions['real'] = True
+            if 'integer' not in assumptions and domain_set.is_subset(S.Integers):
+                assumptions['integer'] = True
+            if 'positive' not in assumptions and domain_set.is_subset(S.Naturals):
+                assumptions['positive'] = True
+            if 'nonnegative' not in assumptions and domain_set.is_subset(S.Naturals0):
+                assumptions['nonnegative'] = True
+        except (AttributeError, NotImplementedError):
+            pass
+        # Re-create the symbol with merged assumptions right at the start
+        s = Symbol(s.name, **assumptions)
         return Basic.__new__(cls, s, distribution)
 
     @property
@@ -317,7 +332,7 @@ class RandomSymbol(Expr):
         return self.symbol.is_integer
 
     def _eval_is_real(self):
-        return self.symbol.is_real or self.pspace.is_real
+        return self.symbol.is_real or getattr(self.pspace, 'is_real', False)
 
     @property
     def is_commutative(self):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -321,7 +321,7 @@ class RandomSymbol(Expr):
         try:
             if self.pspace.domain.set.is_subset(S.Integers):
                 return True
-        except (AttributeError, NotImplementedError):
+        except (AttributeError, NotImplementedError, IndexError):
             pass
         return self.symbol.is_integer
 
@@ -337,7 +337,7 @@ class RandomSymbol(Expr):
         try:
             if self.pspace.domain.set.is_subset(S.Naturals0):
                 return True
-        except (AttributeError, NotImplementedError):
+        except (AttributeError, NotImplementedError, IndexError):
             pass
         return self.symbol.is_nonnegative
 
@@ -345,17 +345,12 @@ class RandomSymbol(Expr):
         try:
             if self.pspace.domain.set.is_subset(S.Naturals0):
                 return False
-        except (AttributeError, NotImplementedError):
+        except (AttributeError, NotImplementedError, IndexError):
             pass
         return self.symbol.is_negative
 
-    @property
-    def is_commutative(self):
-        return self.symbol.is_commutative
-
-    @property
-    def free_symbols(self):
-        return {self}
+    def _eval_is_real(self):
+        return self.symbol.is_real or getattr(self.pspace, 'is_real', False)
 
 class RandomIndexedSymbol(RandomSymbol):
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -290,6 +290,7 @@ class RandomSymbol(Expr):
 
     is_finite = True
     is_symbol = True
+    is_Symbol = True
     is_Atom = True
 
     _diff_wrt = True
@@ -350,7 +351,12 @@ class RandomSymbol(Expr):
         return self.symbol.is_negative
 
     def _eval_is_real(self):
-        return self.symbol.is_real or getattr(self.pspace, 'is_real', False)
+        try:
+            if self.pspace.domain.set.is_subset(S.Reals):
+                return True
+        except (AttributeError, NotImplementedError, IndexError):
+            pass
+        return self.symbol.is_real
 
 class RandomIndexedSymbol(RandomSymbol):
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -29,6 +29,7 @@ from sympy.core.numbers import comp
 from sympy.stats.frv_types import BernoulliDistribution
 from sympy.core.symbol import Dummy
 from sympy.functions.elementary.piecewise import Piecewise
+from sympy import Rational
 
 def test_where():
     X, Y = Die('X'), Die('Y')
@@ -438,3 +439,10 @@ def test_issue_20286():
     k = Dummy('k', integer = True)
     eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
     assert eq.dummy_eq(H(B))
+
+def test_issue_29647_rv_assumptions():
+    X1 = Geometric('X1', Rational(1, 2))
+    assert X1.is_integer is True
+    assert X1.is_negative is False
+    assert X1.is_nonnegative is True
+    assert X1.is_real is True

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -29,7 +29,6 @@ from sympy.core.numbers import comp
 from sympy.stats.frv_types import BernoulliDistribution
 from sympy.core.symbol import Dummy
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy import Rational
 
 def test_where():
     X, Y = Die('X'), Die('Y')


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

* stats
    * RandomSymbols now correctly inherit mathematical assumptions from their probability space domain. Fix #29647 