### PR TITLE
printing: Autodetect Kitty graphics

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -544,6 +544,7 @@ Daniel Hyams <dhyams@gmail.com> dhyams <dhyams@gmail.com>
 Daniel Ingram <ingramds@appstate.edu>
 Daniel Mahler <dmahler@gmail.com>
 Daniel Sears <highpost@users.noreply.github.com>
+Daniel Tang <danielzgtg.opensource@gmail.com>
 Daniel Weindl <daniel.weindl@helmholtz-muenchen.de>
 Daniel Wennberg <daniel.wennberg@gmail.com>
 Danny Hermes <daniel.j.hermes@gmail.com>

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -31,9 +31,15 @@ def _init_python_printing(stringify_func, **settings):
     sys.displayhook = _displayhook
 
 
+try:
+    from IPython.core.kitty import supports_kitty_graphics
+except ImportError:
+    supports_kitty_graphics = False
+
+
 def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                            backcolor, fontsize, latex_mode, print_builtin,
-                           latex_printer, scale, **settings):
+                           latex_printer, scale, printable_only, **settings):
     """Setup printing in IPython interactive session. """
     IPython = import_module("IPython", min_module_version="1.0")
     try:
@@ -223,6 +229,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     # packages to override the methods in their own subclasses of Printable,
     # which avoids the effects of gh-16002.
     printable_types = [float, tuple, list, set, frozenset, dict, int]
+    if printable_only:
+        printable_types = []
 
     plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
@@ -309,7 +317,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   backcolor='Transparent', fontsize='10pt',
                   latex_mode='plain', print_builtin=True,
                   str_printer=None, pretty_printer=None,
-                  latex_printer=None, scale=1.0, **settings):
+                  latex_printer=None, scale=1.0, printable_only=False, **settings):
     r"""
     Initializes pretty-printer depending on the environment.
 
@@ -389,6 +397,9 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     settings :
         Any additional settings for the ``latex`` and ``pretty`` commands can
         be used to fine-tune the output.
+    printable_only :
+         If ``True`` then ``use_latex`` will not affect built-in types like
+         ``int`` or ``list``.
 
     Examples
     ========
@@ -494,13 +505,18 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         else:
             # This will be True if we are in the qtconsole or notebook
             if not isinstance(ip, (InteractiveConsole, TerminalInteractiveShell)) \
-                    and 'ipython-console' not in ''.join(sys.argv):
+                    and 'ipython-console' not in ''.join(sys.argv) \
+                    or supports_kitty_graphics:
                 if use_unicode is None:
                     debug("init_printing: Setting use_unicode to True")
                     use_unicode = True
                 if use_latex is None:
                     debug("init_printing: Setting use_latex to True")
                     use_latex = True
+                    if supports_kitty_graphics:
+                        debug("init_printing: Detected Kitty graphics")
+                        forecolor = 'White'
+                        printable_only = True
 
     if not NO_GLOBAL and not no_global:
         Printer.set_global_settings(order=order, use_unicode=use_unicode,
@@ -527,7 +543,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   "of IPython printing")
         _init_ipython_printing(ip, stringify_func, use_latex, euler,
                                forecolor, backcolor, fontsize, latex_mode,
-                               print_builtin, latex_printer, scale,
+                               print_builtin, latex_printer, scale, printable_only,
                                **settings)
     else:
         _init_python_printing(stringify_func, **settings)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Requires: https://github.com/ipython/ipython/pull/15184

#### Brief description of what is fixed or changed

This makes `init_session` enable graphics in Kitty just like in QTConsole. Default to white-on-black as all Kitty-compatible terminals default to that. Also add `printable_only` option to stop `int` from turning into images.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Autodetect Kitty graphics protocol in terminal

<!-- END RELEASE NOTES -->

# Before

<img width="1824" height="802" alt="integral konsole unicode" src="https://github.com/user-attachments/assets/6011faf6-e0a7-4329-9848-62ea9c48f38b" />

# After

<img width="1824" height="628" alt="integral konsole png" src="https://github.com/user-attachments/assets/47ec6b98-909d-4887-9ea4-d1a282134d61" />
