### PR TITLE
Fix sympy__sympy-18211

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -389,10 +389,14 @@ class Relational(Boolean, EvalfMixin):
     def _eval_as_set(self):
         # self is univariate and periodicity(self, x) in (0, None)
         from sympy.solvers.inequalities import solve_univariate_inequality
+        from sympy.sets.conditionset import ConditionSet
         syms = self.free_symbols
         assert len(syms) == 1
         x = syms.pop()
-        return solve_univariate_inequality(self, x, relational=False)
+        try:
+            return solve_univariate_inequality(self, x, relational=False)
+        except NotImplementedError:
+            return ConditionSet(x, self, S.Reals)
 
     @property
     def binary_symbols(self):


### PR DESCRIPTION
Fix solveset raising NotImplementedError instead of returning ConditionSet

When solve_univariate_inequality raises NotImplementedError for equations it cannot solve (e.g. n*cos(n) - 3*sin(n) = 0), catch the exception in Relational._eval_as_set and return a ConditionSet instead.

Before:
```python
>>> Eq(n*cos(n) - 3*sin(n), 0).as_set()
NotImplementedError
```

After:
```python
>>> Eq(n*cos(n) - 3*sin(n), 0).as_set()
ConditionSet(n, Eq(n*cos(n) - 3*sin(n), 0), Reals)
```

Fixes #18211