### PR TITLE
sets: Extended image set equality to work with any variables

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1135,6 +1135,7 @@ Mihir Wadwekar <m.mihirw@gmail.com>
 Mikel Rouco <mikel.mrm@gmail.com>
 Mikhail Remnev <maremnev@gmail.com> Mikhail Remnev <141655736+maremnev@users.noreply.github.com>
 Milan Jolly <milan.cs16@iitp.ac.in> mijo2 <milan.cs16@iitp.ac.in>
+Milan Jolly <milan.jolly18@gmail.com>
 Min Ragan-Kelley <benjaminrk@gmail.com>
 Miro Hrončok <miro@hroncok.cz>
 Mohak Malviya <mohakmalviya2000@gmail.com> Senku <mohakmalviya2000@gmail.com>

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -420,6 +420,46 @@ class ImageSet(Set):
                 already_seen.add(val)
                 yield val
 
+    def __eq__(self, other):
+        if not isinstance(other, ImageSet):
+            return False
+
+        if self is other:
+            return True
+
+        return (self.lamda.dummy_eq(other.lamda) and
+            self.base_set == other.base_set)
+
+    def __ne__(self, other):
+        return not(self == other)
+
+    def __hash__(self):
+        return super().__hash__()
+
+    # Overriding the Basic._hashable_content function for the ImageSet class. This will be used in Basic.__hash__ to
+    # compute the hash of an ImageSet object
+    def _hashable_content(self):
+
+        def _get_lambda_string_representation_for_hash(lambda_input):
+            """We reduce the lambda expression by replacing the variables with standard ones(n_0, n_1, ...) and then
+            returning a string value to be used for hash. This ensures that two lambda expressions using different dummy
+            variables but represents the same lambda are marked as equal for image set equality.
+
+            For example: if lambda_input is either `Lambda((x, y), 2*x + y)` or `Lambda((a, b), 2*a + b)`,
+            then output would be the same for both the inputs: `Lambda((n_0, n_1), 2*n_0 + n_1)`.
+            """
+            variables, expr = lambda_input.args
+            dummy_variables_dict = { variable: Dummy(f'n_{i}') for i, variable in enumerate(variables) }
+            new_lambda_expr = lambda_input.copy()
+            for variable in variables:
+                new_lambda_expr = new_lambda_expr.subs(variable, dummy_variables_dict[variable])
+
+            return str(new_lambda_expr)
+
+        lambda_expr, *sets = self.args
+
+        return _get_lambda_string_representation_for_hash(lambda_expr), tuple(sets)
+
     def _is_multivariate(self):
         return len(self.lamda.variables) > 1
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1312,3 +1312,30 @@ def test_issue_17859():
     r = Range(oo,-oo,-1)
     raises(ValueError,lambda: r[::2])
     raises(ValueError, lambda: r[::-2])
+
+def test_image_set_equality_29054():
+    _n1, _n2, _n3, _n4 = Dummy('n1'), Dummy('n2'), Dummy('n3'), Dummy('n4')
+
+    assert (ImageSet(Lambda(_n1, 2*_n1*pi + pi/2), S.Integers) ==
+            ImageSet(Lambda(_n2, 2*_n2*pi + pi/2), S.Integers))
+
+    assert (ImageSet(Lambda(_n1, 2 * _n1 * pi + pi / 2), S.Integers) !=
+            ImageSet(Lambda(_n2, 2 * _n2 * pi + pi / 2), S.Reals))
+
+    assert (ImageSet(Lambda(_n1, 2 * _n1 * pi + pi / 2), S.Integers) !=
+            ImageSet(Lambda(_n2, 2 * _n2 * pi - pi / 2), S.Integers))
+
+    assert (ImageSet(Lambda((_n1, _n2), 2*_n1 + _n2), S.Reals, S.Reals) ==
+            ImageSet(Lambda((_n3, _n4), 2*_n3 + _n4), S.Reals, S.Reals))
+
+    assert not (ImageSet(Lambda((_n1, _n2), 2 * _n1 + _n2), S.Reals, S.Reals) !=
+            ImageSet(Lambda((_n3, _n4), 2 * _n3 + _n4), S.Reals, S.Reals))
+
+    assert (ImageSet(Lambda((_n1, _n2), 2 * _n1 + _n2), S.Reals, S.Reals) !=
+            ImageSet(Lambda((_n3, _n4), 2 * _n3 + _n4), S.Reals, S.Integers))
+
+    assert (ImageSet(Lambda((_n1, _n2), 2 * _n1 + _n2), S.Reals, S.Reals) !=
+            ImageSet(Lambda((_n3, _n4), 2 * _n3 + _n4), S.Integers, S.Reals))
+
+    assert (ImageSet(Lambda((_n1, _n2), 2 * _n1 + _n2), S.Reals, S.Reals) !=
+            ImageSet(Lambda((_n3, _n4), 2 * _n3 - _n4), S.Reals, S.Reals))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3595,3 +3595,8 @@ def test_issue_26077():
         Complement(S.Reals, excluded_points)
     )
     assert solution.as_dummy() == critical_points.as_dummy()
+
+def test_issue_29054():
+    x = symbols("x")
+
+    assert solveset(Eq(sin(x), 1)) == solveset(Eq(sin(x), 1))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29054

#### Brief description of what is fixed or changed
Image set equality had a rudimentary implementation, wherein two
equivalent image sets defined with different dummy variables would
be unequal if their underlying dummy variables were different.
For example: Before this change, the following would happen:

```
>>> from sympy import Lambda, S
>>> x, y = symbols("x y")

>>> ImageSet(Lambda(x, 2*x), S.Reals) == ImageSet(Lambda(y, 2*y), S.Reals)
False
```

With this change, the above has been fixed -
```
>>> ImageSet(Lambda(x, 2*x), S.Reals) == ImageSet(Lambda(y, 2*y), S.Reals)
True
```

Along with that, __hash__ function's sub-component function _hashable_content
has been overridden too so that other types which depend on hash would be
able to work with this new __eq__ method's changes.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Extended image set's equality to work with any internal dummy variable
<!-- END RELEASE NOTES -->
