### PR TITLE
Early return in hurwitz_conditions

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1296,7 +1296,7 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
         [-12.0, -1.0, -2.0 - 0.707106781186548*I, -2.0 + 0.707106781186548*I]
         >>> tf3 = TransferFunction(1, p3, s)
         >>> tf3.get_asymptotic_stability_conditions()
-        [True, True, True, True]
+        [True]
 
         >>> k = symbols('k')
         >>> tf4 = TransferFunction(-20*s + 20, s**3 + 2*s**2 + 100*s, s)

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1296,7 +1296,7 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
         [-12.0, -1.0, -2.0 - 0.707106781186548*I, -2.0 + 0.707106781186548*I]
         >>> tf3 = TransferFunction(1, p3, s)
         >>> tf3.get_asymptotic_stability_conditions()
-        [True]
+        [True, True, True, True]
 
         >>> k = symbols('k')
         >>> tf4 = TransferFunction(-20*s + 20, s**3 + 2*s**2 + 100*s, s)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -26,7 +26,6 @@ from sympy.physics.control.lti import (
     DiscreteStateSpace, create_state_space, gbt, bilinear, forward_diff,
     backward_diff, phase_margin, gain_margin)
 from sympy.testing.pytest import raises, XFAIL
-from sympy.logic.boolalg import false, true
 
 from math import isclose
 
@@ -359,8 +358,8 @@ def test_TransferFunction_functions():
         b3*b4 > 0, -b1*b4 + b2*b3 > 0,
         -b0*b3**2*b4 -b1**2*b4**2 + b1*b2*b3*b4 > 0,
         b0*b4 > 0]
-    assert TransferFunction(1, (s+1)*(s+2*I)*(s-2*I), s).get_asymptotic_stability_conditions() == [false]
-    assert TransferFunction(1, (s+1)*(s+2)*(s+1/2), s).get_asymptotic_stability_conditions() == [true, true, true]
+    assert TransferFunction(1, (s+1)*(s+2*I)*(s-2*I), s).get_asymptotic_stability_conditions() == [False]
+    assert TransferFunction(1, (s+1)*(s+2)*(s+1/2), s).get_asymptotic_stability_conditions() == [True]
     assert stable_tf.get_asymptotic_stability_conditions() == [True]
 
     # Zeros of a transfer function.

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -359,7 +359,7 @@ def test_TransferFunction_functions():
         -b0*b3**2*b4 -b1**2*b4**2 + b1*b2*b3*b4 > 0,
         b0*b4 > 0]
     assert TransferFunction(1, (s+1)*(s+2*I)*(s-2*I), s).get_asymptotic_stability_conditions() == [False]
-    assert TransferFunction(1, (s+1)*(s+2)*(s+1/2), s).get_asymptotic_stability_conditions() == [True]
+    assert TransferFunction(1, (s+1)*(s+2)*(s+1/2), s).get_asymptotic_stability_conditions() == [True, True, True]
     assert stable_tf.get_asymptotic_stability_conditions() == [True]
 
     # Zeros of a transfer function.

--- a/sympy/polys/rootconditions.py
+++ b/sympy/polys/rootconditions.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Callable, Any
 
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-    from sympy.polys.domains.domain import Er, Domain, MPZ, PolyElement
+    from sympy.polys.domains.domain import Er, Domain, PolyElement
 
 
 def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:
@@ -47,16 +47,16 @@ def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:
     if K.is_RR:
         pq = dup_convert(f, K, QQ)
         _, pz = dup_clear_denoms(pq, QQ, convert=True)
-        conds: list = _dup_routh_hurwitz_ZZ(pz) # type: ignore
+        conds: list = _dup_routh_hurwitz_fraction_free(pz, K, ZZ.is_negative)
         return [K.convert_from(c, ZZ) for c in conds]
 
     if K.is_QQ:
         _, pz = dup_clear_denoms(f, K, convert=True)
-        conds = _dup_routh_hurwitz_ZZ(pz) # type: ignore
+        conds = _dup_routh_hurwitz_fraction_free(pz, K, ZZ.is_negative)
         return [K.convert_from(c, ZZ) for c in conds]
 
     elif K.is_ZZ:
-        return _dup_routh_hurwitz_ZZ(f) # type: ignore
+        return _dup_routh_hurwitz_fraction_free(f, K, ZZ.is_negative)
 
     elif K.is_PolynomialRing:
         return _dup_routh_hurwitz_fraction_free(
@@ -75,58 +75,6 @@ def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:
         pe = dup_convert(f, K, EXRAW)
         conds = _dup_routh_hurwitz_exraw(pe)
         return [K.convert_from(c, EXRAW) for c in conds]
-
-
-def _dup_routh_hurwitz_ZZ(p: list[MPZ]) -> list[MPZ]:
-    if len(p) == 1:
-        return []
-    elif len(p) == 2:
-        return [p[0] * p[1]]
-    elif len(p) == 3:
-        return [p[0] * p[1], p[0] * p[2]]
-
-    LC = p[0]
-    TC = p[-1]
-
-    is_LC_negative = ZZ.is_negative(LC)
-
-    if ZZ.is_zero(TC) or (is_LC_negative ^ ZZ.is_negative(TC)):
-        return [-ZZ.one]
-
-    if ZZ.is_zero(p[1]) or (is_LC_negative ^ ZZ.is_negative(p[1])):
-        return [-ZZ.one]
-
-    p1s = [p[1]]
-    p1s_count = 1
-
-    while len(p) > 3:
-        qs = [p[1] * qi for qi in p[1:]]
-        for i in range(1, len(qs) - 1, 2):
-            qs[i] = qs[i] - p[i + 2] * p[0]
-        p = qs
-
-        p1 = p[1]
-        if ZZ.is_zero(p1):
-            return [-ZZ.one]
-
-        if (p1s_count % 2 == 0 and is_LC_negative) ^ ZZ.is_negative(p1):
-            return [-ZZ.one]
-
-        if p1s_count >= 2:
-            p1 = ZZ.exquo(p1, p1s[-2])
-        if p1s_count >= 3:
-            p1 = ZZ.exquo(p1, p1s[-3])
-            p1 = ZZ.exquo(p1, p1s[-3])
-            p = dup_exquo_ground(p, p1s[-3], ZZ)
-            p = dup_exquo_ground(p, p1s[-3], ZZ)
-
-        p1s.append(p1)
-        p1s_count += 1
-
-        if len(p1s) > 3:
-            p1s.pop(0)
-
-    return [ZZ.one]
 
 
 def _is_negative_PolynomialRing(pi: PolyElement) -> bool | None:

--- a/sympy/polys/rootconditions.py
+++ b/sympy/polys/rootconditions.py
@@ -10,11 +10,11 @@ from sympy.polys.densetools import dup_clear_denoms, dup_transform, dup_eval
 from sympy.core.exprtools import factor_terms
 from sympy.simplify.simplify import signsimp
 from sympy.core.mul import Mul
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Any
 
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-    from sympy.polys.domains.domain import Er, Domain
+    from sympy.polys.domains.domain import Er, Domain, MPZ, PolyElement
 
 
 def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:
@@ -47,24 +47,28 @@ def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:
     if K.is_RR:
         pq = dup_convert(f, K, QQ)
         _, pz = dup_clear_denoms(pq, QQ, convert=True)
-        conds: list = _dup_routh_hurwitz_fraction_free(pz, ZZ)
+        conds: list = _dup_routh_hurwitz_ZZ(pz) # type: ignore
         return [K.convert_from(c, ZZ) for c in conds]
 
     if K.is_QQ:
         _, pz = dup_clear_denoms(f, K, convert=True)
-        conds = _dup_routh_hurwitz_fraction_free(pz, ZZ)
+        conds = _dup_routh_hurwitz_ZZ(pz) # type: ignore
         return [K.convert_from(c, ZZ) for c in conds]
 
     elif K.is_ZZ:
-        return _dup_routh_hurwitz_fraction_free(f, K)
+        return _dup_routh_hurwitz_ZZ(f) # type: ignore
 
     elif K.is_PolynomialRing:
-        return _dup_routh_hurwitz_fraction_free(f, K)
+        return _dup_routh_hurwitz_fraction_free(
+            f, K, _is_negative_PolynomialRing
+        )
 
     elif K.is_FractionField:
         _, pp = dup_clear_denoms(f, K, convert=True)
-        conds = _dup_routh_hurwitz_fraction_free(pp, K)
         R = K.get_ring()
+        conds = _dup_routh_hurwitz_fraction_free(
+            pp, R, _is_negative_PolynomialRing
+        )
         return [K.convert_from(c, R) for c in conds]
 
     else:
@@ -73,7 +77,68 @@ def dup_routh_hurwitz(f: dup[Er], K: Domain[Er]) -> list[Er]:
         return [K.convert_from(c, EXRAW) for c in conds]
 
 
-def _dup_routh_hurwitz_fraction_free(p: dup[Er], K: Domain[Er]) -> list[Er]:
+def _dup_routh_hurwitz_ZZ(p: list[MPZ]) -> list[MPZ]:
+    if len(p) == 1:
+        return []
+    elif len(p) == 2:
+        return [p[0] * p[1]]
+    elif len(p) == 3:
+        return [p[0] * p[1], p[0] * p[2]]
+
+    LC = p[0]
+    TC = p[-1]
+
+    is_LC_negative = ZZ.is_negative(LC)
+
+    if ZZ.is_zero(TC) or (is_LC_negative ^ ZZ.is_negative(TC)):
+        return [-ZZ.one]
+
+    if ZZ.is_zero(p[1]) or (is_LC_negative ^ ZZ.is_negative(p[1])):
+        return [-ZZ.one]
+
+    p1s = [p[1]]
+    p1s_count = 1
+
+    while len(p) > 3:
+        qs = [p[1] * qi for qi in p[1:]]
+        for i in range(1, len(qs) - 1, 2):
+            qs[i] = qs[i] - p[i + 2] * p[0]
+        p = qs
+
+        p1 = p[1]
+        if ZZ.is_zero(p1):
+            return [-ZZ.one]
+
+        if (p1s_count % 2 == 0 and is_LC_negative) ^ ZZ.is_negative(p1):
+            return [-ZZ.one]
+
+        if p1s_count >= 2:
+            p1 = ZZ.exquo(p1, p1s[-2])
+        if p1s_count >= 3:
+            p1 = ZZ.exquo(p1, p1s[-3])
+            p1 = ZZ.exquo(p1, p1s[-3])
+            p = dup_exquo_ground(p, p1s[-3], ZZ)
+            p = dup_exquo_ground(p, p1s[-3], ZZ)
+
+        p1s.append(p1)
+        p1s_count += 1
+
+        if len(p1s) > 3:
+            p1s.pop(0)
+
+    return [ZZ.one]
+
+
+def _is_negative_PolynomialRing(pi: PolyElement) -> bool | None:
+    """Checks if `pi` is negative. If `pi` is not a number returns None."""
+    if not pi.is_ground:
+        return None
+    return pi.is_negative
+
+
+def _dup_routh_hurwitz_fraction_free(
+    p: dup[Er], K: Domain[Er], is_negative: Callable[[Any], bool | None]
+) -> list[Er]:
     if len(p) == 1:
         return []
     elif len(p) == 2:
@@ -84,6 +149,14 @@ def _dup_routh_hurwitz_fraction_free(p: dup[Er], K: Domain[Er]) -> list[Er]:
     LC = p[0]
     TC = p[-1]
     monic = K.is_one(LC)
+
+    is_LC_negative = is_negative(LC)
+
+    if is_LC_negative is not None:
+        for coeff in (TC, p[1]):
+            neg = is_negative(coeff)
+            if neg is not None and (K.is_zero(coeff) or (is_LC_negative ^ neg)):
+                return [-K.one]
 
     p1s = [p[1]]
 
@@ -104,6 +177,14 @@ def _dup_routh_hurwitz_fraction_free(p: dup[Er], K: Domain[Er]) -> list[Er]:
             p1 = K.exquo(p1, p1s[-3])
             p = dup_exquo_ground(p, p1s[-3], K)
             p = dup_exquo_ground(p, p1s[-3], K)
+
+        negp1 = is_negative(p1)
+        if negp1 is not None:
+            if len(p1s) % 2 == 0:
+                if is_LC_negative is not None and (is_LC_negative ^ negp1):
+                    return [-K.one]
+            elif negp1:
+                return [-K.one]
 
         p1s.append(p1)
 
@@ -167,6 +248,10 @@ def _rec_dup_routh_hurwitz_exraw_no_div(
     cond, previous_cond, nonzeros = _clear_cond_exraw(
         p[0] * p[1], previous_cond, nonzeros
     )
+
+    if cond.is_nonpositive is True:
+        return [-EXRAW.one]
+
     return [cond] + _rec_dup_routh_hurwitz_exraw_no_div(
         qs, previous_cond, nonzeros
     )

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -4154,7 +4154,7 @@ def test_hurwitz_conditions():
     p5_ = Poly(b0 + b1*s**2 + b1*s + b3*s**4 + b3*s**3, s, domain = EXRAW)
 
     assert p5.hurwitz_conditions() == [-1]
-    assert p5_.hurwitz_conditions() == [1, 0, 1, 1, b3**2]
+    assert p5_.hurwitz_conditions() == [1, -1]
 
     p6 = Poly(b0 * s**2 + b1**2 * s + b2, s)
     p6_ = Poly(b0 * s**2 + b1**2 * s + b2, s, domain = EXRAW)
@@ -4235,7 +4235,7 @@ def test_hurwitz_conditions():
 
     p14 = Poly(x**2 + 1/y, x)
     assert 0 in p14.hurwitz_conditions()
-    assert 0 in p14.set_domain(EXRAW).hurwitz_conditions()
+    assert p14.set_domain(EXRAW).hurwitz_conditions() == [-1]
 
 
 def test_schur_conditions():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #28388

#### Brief description of what is fixed or changed
Now `hurwitz_conditions` returns as soon as a negative condition is calculated.

Now it uses a slightly different function for pure numerical domains using less memory, cleaning up no longer useful conditions.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Used Gemini for checking the logic.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
