### PR TITLE
solvers.solveset: make `solveset` respect the inner function's range

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -895,6 +895,7 @@ Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
+Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <157145635+JosephMehdiyev@users.noreply.github.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1254,6 +1254,7 @@ def _solveset(f, symbol, domain, _check=False):
 
     if isinstance(f, BooleanTrue):
         return domain
+
     orig_f = f
     if f.is_Mul:
         coeff, f = f.as_independent(symbol, as_Add=False)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -303,6 +303,7 @@ def _invert_real(f, g_ys, symbol):
                 pass  # use default return
 
         if not base_has_sym:
+            print('base_has_sym')
             rhs = g_ys.args[0]
             if base.is_positive:
                 return _invert_real(expo,
@@ -322,6 +323,7 @@ def _invert_real(f, g_ys, symbol):
                     return (expo, S.EmptySet)
 
     if isinstance(f, (TrigonometricFunction, HyperbolicFunction)):
+        print("trig")
         return _invert_trig_hyp_real(f, g_ys, symbol)
 
     return (f, g_ys)
@@ -429,6 +431,7 @@ def _invert_trig_hyp_real(f, g_ys, symbol):
             # returns ConditionSet that will be part of the final (x, set) tuple
             invsimg = Union(*[
                 imageset(n, period*n + inv(g), S.Integers) for inv in invs])
+            invsimg = invsimg.intersect(imageset(symbol, f.args[0], S.Reals))
             inv_f, inv_g_ys = _invert_real(f.args[0], invsimg, symbol)
             if inv_f == symbol:     # inversion successful
                 conds = rng.contains(g)
@@ -1251,7 +1254,6 @@ def _solveset(f, symbol, domain, _check=False):
 
     if isinstance(f, BooleanTrue):
         return domain
-
     orig_f = f
     if f.is_Mul:
         coeff, f = f.as_independent(symbol, as_Add=False)
@@ -1311,6 +1313,7 @@ def _solveset(f, symbol, domain, _check=False):
     elif _is_modular(f, symbol):
         result = _solve_modular(f, symbol, domain)
     else:
+        print("trig")
         lhs, rhs_s = inverter(f, 0, symbol)
         if lhs == symbol:
             # do some very minimal simplification since

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -303,7 +303,6 @@ def _invert_real(f, g_ys, symbol):
                 pass  # use default return
 
         if not base_has_sym:
-            print('base_has_sym')
             rhs = g_ys.args[0]
             if base.is_positive:
                 return _invert_real(expo,
@@ -323,7 +322,6 @@ def _invert_real(f, g_ys, symbol):
                     return (expo, S.EmptySet)
 
     if isinstance(f, (TrigonometricFunction, HyperbolicFunction)):
-        print("trig")
         return _invert_trig_hyp_real(f, g_ys, symbol)
 
     return (f, g_ys)
@@ -431,7 +429,9 @@ def _invert_trig_hyp_real(f, g_ys, symbol):
             # returns ConditionSet that will be part of the final (x, set) tuple
             invsimg = Union(*[
                 imageset(n, period*n + inv(g), S.Integers) for inv in invs])
-            invsimg = invsimg.intersect(imageset(symbol, f.args[0], S.Reals))
+            innerimg = function_range(f.args[0], symbol, S.Reals)
+            if innerimg != Interval(-oo,oo):
+                invsimg = Intersection(invsimg, innerimg)
             inv_f, inv_g_ys = _invert_real(f.args[0], invsimg, symbol)
             if inv_f == symbol:     # inversion successful
                 conds = rng.contains(g)
@@ -1313,7 +1313,6 @@ def _solveset(f, symbol, domain, _check=False):
     elif _is_modular(f, symbol):
         result = _solve_modular(f, symbol, domain)
     else:
-        print("trig")
         lhs, rhs_s = inverter(f, 0, symbol)
         if lhs == symbol:
             # do some very minimal simplification since

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -153,7 +153,7 @@ def _invert(f_x, y, x, domain=S.Complexes):
     >>> invert_complex(exp(x), y, x)
     (x, ImageSet(Lambda(_n, I*(2*_n*pi + arg(y)) + log(Abs(y))), Integers))
     >>> invert_real(exp(x), y, x)
-    (x, Intersection({log(y)}, Reals))
+    (x, ImageSet(Lambda(x, log(x)), Intersection({y}, Interval.open(0, oo))))
 
     When does exp(x) == 1?
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -224,10 +224,7 @@ def _invert_real(f, g_ys, symbol):
     n = Dummy('n', real=True)
 
     if isinstance(f, exp) or (f.is_Pow and f.base == S.Exp1):
-        if isinstance(g_ys, FiniteSet):
-            g_ys = FiniteSet(*[e for e in g_ys if e.is_nonpositive is not True])
-        else:
-            g_ys = g_ys.intersect(Interval.open(0, oo))
+        g_ys = g_ys.intersect(Interval.open(0, oo))
         return _invert_real(f.exp, imageset(Lambda(n, log(n)), g_ys), symbol)
 
     if hasattr(f, 'inverse') and f.inverse() is not None and not isinstance(f, (

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -224,9 +224,11 @@ def _invert_real(f, g_ys, symbol):
     n = Dummy('n', real=True)
 
     if isinstance(f, exp) or (f.is_Pow and f.base == S.Exp1):
-        return _invert_real(f.exp,
-                            imageset(Lambda(n, log(n)), g_ys),
-                            symbol)
+        if isinstance(g_ys, FiniteSet):
+            g_ys = FiniteSet(*[e for e in g_ys if e.is_nonpositive is not True])
+        else:
+            g_ys = g_ys.intersect(Interval.open(0, oo))
+        return _invert_real(f.exp, imageset(Lambda(n, log(n)), g_ys), symbol)
 
     if hasattr(f, 'inverse') and f.inverse() is not None and not isinstance(f, (
             TrigonometricFunction,
@@ -429,9 +431,6 @@ def _invert_trig_hyp_real(f, g_ys, symbol):
             # returns ConditionSet that will be part of the final (x, set) tuple
             invsimg = Union(*[
                 imageset(n, period*n + inv(g), S.Integers) for inv in invs])
-            innerimg = function_range(f.args[0], symbol, S.Reals)
-            if innerimg != Interval(-oo,oo):
-                invsimg = Intersection(invsimg, innerimg)
             inv_f, inv_g_ys = _invert_real(f.args[0], invsimg, symbol)
             if inv_f == symbol:     # inversion successful
                 conds = rng.contains(g)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -138,8 +138,9 @@ def test_invert_real():
 
     assert dumeq(invert_real(sin(exp(x)), y, x), (x,
         ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
-            ImageSet(Lambda(n, log(2*n*pi + asin(y))), S.Integers),
-            ImageSet(Lambda(n, log(pi*2*n + pi - asin(y))), S.Integers)))))
+            ImageSet(Lambda(x, log(x)), Intersection(
+                ImageSet(Lambda(n, 2*n*pi + asin(y)), S.Integers), Interval.open(0, oo))),
+            ImageSet(Lambda(x, log(x)), Intersection(ImageSet(Lambda(n, 2*n*pi - asin(y) + pi), S.Integers), Interval.open(0, oo)))))))
 
     assert dumeq(invert_real(csc(x), y, x), (x,
         ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
@@ -147,9 +148,10 @@ def test_invert_real():
                 ImageSet(Lambda(n, 2*n*pi - acsc(y) + pi), S.Integers)))))
 
     assert dumeq(invert_real(csc(exp(x)), y, x), (x,
-        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
-            Union(ImageSet(Lambda(n, log(2*n*pi + acsc(y))), S.Integers),
-                ImageSet(Lambda(n, log(2*n*pi - acsc(y) + pi)), S.Integers)))))
+        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))), Union(
+            ImageSet(Lambda(x, log(x)), Intersection(
+                ImageSet(Lambda(n, 2*n*pi + acsc(y)), S.Integers), Interval.open(0, oo))),
+            ImageSet(Lambda(x, log(x)), Intersection(ImageSet(Lambda(n, 2*n*pi - acsc(y) + pi), S.Integers), Interval.open(0, oo)))))))
 
     assert dumeq(invert_real(cos(x), y, x), (x,
         ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
@@ -158,8 +160,9 @@ def test_invert_real():
 
     assert dumeq(invert_real(cos(exp(x)), y, x), (x,
         ConditionSet(x, (S(-1) <= y) & (y <= S(1)), Union(
-            ImageSet(Lambda(n, log(2*n*pi + acos(y))), S.Integers),
-            ImageSet(Lambda(n, log(2*n*pi - acos(y))), S.Integers)))))
+            ImageSet(Lambda(x, log(x)), Intersection(
+                ImageSet(Lambda(n, 2*n*pi - acos(y)), S.Integers), Interval.open(0, oo))),
+            ImageSet(Lambda(x, log(x)), Intersection(ImageSet(Lambda(n, 2*n*pi + acos(y)), S.Integers), Interval.open(0, oo)))))))
 
     assert dumeq(invert_real(sec(x), y, x), (x,
         ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
@@ -167,9 +170,11 @@ def test_invert_real():
                 ImageSet(Lambda(n, 2*n*pi - asec(y)), S.Integers)))))
 
     assert dumeq(invert_real(sec(exp(x)), y, x), (x,
-        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <= S(-1))),
-            Union(ImageSet(Lambda(n, log(2*n*pi - asec(y))), S.Integers),
-                ImageSet(Lambda(n, log(2*n*pi + asec(y))), S.Integers)))))
+        ConditionSet(x, ((S(1) <= y) & (y < oo)) | ((-oo < y) & (y <=S(-1))), Union(
+            ImageSet(Lambda(x, log(x)), Intersection(
+                ImageSet(Lambda(n, 2*n*pi - asec(y)), S.Integers),
+                Interval.open(0, oo))),
+            ImageSet(Lambda(x, log(x)), Intersection(ImageSet(Lambda(n, 2*n*pi + asec(y)), S.Integers), Interval.open(0, oo)))))))
 
     assert dumeq(invert_real(tan(x), y, x), (x,
         ConditionSet(x, (-oo < y) & (y < oo),
@@ -177,15 +182,16 @@ def test_invert_real():
 
     assert dumeq(invert_real(tan(exp(x)), y, x), (x,
         ConditionSet(x, (-oo < y) & (y < oo),
-            ImageSet(Lambda(n, log(n*pi + atan(y))), S.Integers))))
+                     ImageSet(Lambda(x, log(x)), Intersection(
+                         ImageSet(Lambda(n, n*pi + atan(y)), S.Integers), Interval.open(0, oo))))))
 
     assert dumeq(invert_real(cot(x), y, x), (x,
         ConditionSet(x, (-oo < y) & (y < oo),
             ImageSet(Lambda(n, n*pi + acot(y)), S.Integers))))
 
     assert dumeq(invert_real(cot(exp(x)), y, x), (x,
-        ConditionSet(x, (-oo < y) & (y < oo),
-            ImageSet(Lambda(n, log(n*pi + acot(y))), S.Integers))))
+        ConditionSet(x, (-oo < y) & (y < oo), ImageSet(Lambda(x, log(x)),
+            Intersection(ImageSet(Lambda(n, n*pi + acot(y)), S.Integers), Interval.open(0, oo))))))
 
     assert dumeq(invert_real(tan(tan(x)), y, x),
         (x, ConditionSet(x, Eq(tan(tan(x)), y), S.Reals)))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3600,4 +3600,9 @@ def test_issue_26077():
         Eq(x*(-5*cot(5*x)**2 - 5) + cot(5*x), 0),
         Complement(S.Reals, excluded_points)
     )
-    assert solution.as_dummy() == critical_points.as_dummy()
+    assert solution.as_dummy() == critical_points.as_dummy()\
+
+def test_issue_29674():
+    dumeq(solveset(sin(exp(x)), x, domain=S.Reals),
+          Union(ImageSet(Lambda(n, log(2*n*pi + pi)), Range(0, oo, 1)),
+                ImageSet(Lambda(n, log(2*n*pi + 2*pi)) , Range(0, oo, 1))))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3600,7 +3600,7 @@ def test_issue_26077():
         Eq(x*(-5*cot(5*x)**2 - 5) + cot(5*x), 0),
         Complement(S.Reals, excluded_points)
     )
-    assert solution.as_dummy() == critical_points.as_dummy()\
+    assert solution.as_dummy() == critical_points.as_dummy()
 
 def test_issue_29674():
     dumeq(solveset(sin(exp(x)), x, domain=S.Reals),

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -86,10 +86,7 @@ def assert_close_nl(sol1, sol2):
 def test_invert_real():
     x = Symbol('x', real=True)
 
-    def ireal(x, s=S.Reals):
-        return Intersection(s, x)
-
-    assert invert_real(exp(x), z, x) == (x, ireal(FiniteSet(log(z))))
+    assert invert_real(exp(x), z, x) == (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(z), Interval.open(0, oo))))
 
     y = Symbol('y', positive=True)
     n = Symbol('n', real=True)
@@ -100,7 +97,7 @@ def test_invert_real():
     assert invert_real(exp(3*x), y, x) == (x, FiniteSet(log(y) / 3))
     assert invert_real(exp(x + 3), y, x) == (x, FiniteSet(log(y) - 3))
 
-    assert invert_real(exp(x) + 3, y, x) == (x, ireal(FiniteSet(log(y - 3))))
+    assert invert_real(exp(x) + 3, y, x) == (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(y - 3), Interval.open(0, oo))))
     assert invert_real(exp(x)*3, y, x) == (x, FiniteSet(log(y / 3)))
 
     assert invert_real(log(x), y, x) == (x, FiniteSet(exp(y)))
@@ -110,7 +107,7 @@ def test_invert_real():
     assert invert_real(Abs(x), y, x) == (x, FiniteSet(y, -y))
 
     assert invert_real(2**x, y, x) == (x, FiniteSet(log(y)/log(2)))
-    assert invert_real(2**exp(x), y, x) == (x, ireal(FiniteSet(log(log(y)/log(2)))))
+    assert invert_real(2**exp(x), y, x) == (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(log(y)/log(2)), Interval.open(0, oo))))
 
     assert invert_real(x**2, y, x) == (x, FiniteSet(sqrt(y), -sqrt(y)))
     assert invert_real(x**S.Half, y, x) == (x, FiniteSet(y**2))
@@ -432,8 +429,7 @@ def test_solve_invert():
     assert solveset_real(3**(x + 2), x) == FiniteSet()
     assert solveset_real(3**(2 - x), x) == FiniteSet()
 
-    assert solveset_real(y - b*exp(a/x), x) == Intersection(
-        S.Reals, FiniteSet(a/log(y/b)))
+    assert solveset_real(y - b*exp(a/x), x) == ImageSet(Lambda(x, a/log(x)), Intersection(FiniteSet(y/b), Interval.open(0, oo)))
 
     # issue 4504
     assert solveset_real(2**x - 10, x) == FiniteSet(1 + log(5)/log(2))
@@ -798,8 +794,9 @@ def test_units():
 def test_solve_only_exp_1():
     y = Symbol('y', positive=True)
     assert solveset_real(exp(x) - y, x) == FiniteSet(log(y))
-    assert solveset_real(exp(x) + exp(-x) - 4, x) == \
-        FiniteSet(log(-sqrt(3) + 2), log(sqrt(3) + 2))
+    assert solveset_real(exp(x) + exp(-x) - 4, x) == Union(
+        ImageSet(Lambda(x, log(x)), FiniteSet(2 - sqrt(3))),
+        ImageSet(Lambda(x, log(x)), FiniteSet(sqrt(3) + 2)))
     assert solveset_real(exp(x) + exp(-x) - y, x) != S.EmptySet
 
 
@@ -2302,7 +2299,8 @@ def test_issue_5132_2():
     x, y = symbols('x, y', real=True)
     eqs = [exp(x)**2 - sin(y) + z**2]
     n = Dummy('n')
-    soln_real = (log(-z**2 + sin(y))/2, z)
+    soln_real = (ImageSet(Lambda(x, log(x)/2),
+        Intersection(FiniteSet(-z**2 + sin(y)), Interval.open(0, oo))), z)
     lam = Lambda( n, I*(2*n*pi + arg(-z**2 + sin(y)))/2 + log(Abs(z**2 - sin(y)))/2)
     img = ImageSet(lam, S.Integers)
     # not sure about the complex soln. But it looks correct.
@@ -2704,7 +2702,7 @@ def test_issue_8715():
 
 def test_issue_11174():
     eq = z**2 + exp(2*x) - sin(y)
-    soln = Intersection(S.Reals, FiniteSet(log(-z**2 + sin(y))/2))
+    soln = ImageSet(Lambda(x, log(x)/2), Intersection(FiniteSet(-z**2 + sin(y)), Interval.open(0, oo)))
     assert solveset(eq, x, S.Reals) == soln
 
     eq = sqrt(r)*Abs(tan(t))/sqrt(tan(t)**2 + 1) + x*tan(t)
@@ -2829,10 +2827,8 @@ def test_issue_10158():
 
 def test_issue_14300():
     f = 1 - exp(-18000000*x) - y
-    a1 = FiniteSet(-log(-y + 1)/18000000)
 
-    assert solveset(f, x, S.Reals) == \
-        Intersection(S.Reals, a1)
+    assert solveset(f, x, S.Reals) == ImageSet(Lambda(x, -log(x)/18000000), Intersection(FiniteSet(-y + 1), Interval.open(0, oo)))
     assert dumeq(solveset(f, x),
         ImageSet(Lambda(n, -I*(2*n*pi + arg(-y + 1))/18000000 -
             log(Abs(y - 1))/18000000), S.Integers))
@@ -2889,8 +2885,7 @@ def test_exponential_real():
     assert solveset(e2, x, S.Reals) == FiniteSet(Rational(4, 15))
     assert solveset(e3, x, S.Reals) == S.EmptySet
     assert solveset(e4, x, S.Reals) == FiniteSet(0)
-    assert solveset(e5, x, S.Reals) == Intersection(
-        S.Reals, FiniteSet(y*log(2*exp(z/y))))
+    assert solveset(e5, x, S.Reals) == ImageSet(Lambda(x, y*log(x)), Intersection(FiniteSet(2*exp(z/y)), Interval.open(0, oo)))
     assert solveset(e6, x, S.Reals) == FiniteSet(0)
     assert solveset(e7, x, S.Reals) == FiniteSet(2)
     assert solveset(e8, x, S.Reals) == FiniteSet(-2*log(2)/5 + 2*log(3)/5 + Rational(4, 5))
@@ -2906,8 +2901,7 @@ def test_exponential_real():
     # coverage test
     C1, C2 = symbols('C1 C2')
     f = Function('f')
-    assert solveset_real(C1 + C2/x**2 - exp(-f(x)), f(x)) == Intersection(
-        S.Reals, FiniteSet(-log(C1 + C2/x**2)))
+    assert solveset_real(C1 + C2/x**2 - exp(-f(x)), f(x)) == ImageSet(Lambda(x, -log(x)), Intersection(FiniteSet(C1 + C2/x**2), Interval.open(0, oo)))
     y = symbols('y', positive=True)
     assert solveset_real(x**2 - y**2/exp(x), y) == Intersection(
         S.Reals, FiniteSet(-sqrt(x**2*exp(x)), sqrt(x**2*exp(x))))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -86,7 +86,7 @@ def assert_close_nl(sol1, sol2):
 def test_invert_real():
     x = Symbol('x', real=True)
 
-    assert invert_real(exp(x), z, x) == (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(z), Interval.open(0, oo))))
+    assert dumeq(invert_real(exp(x), z, x), (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(z), Interval.open(0, oo)))))
 
     y = Symbol('y', positive=True)
     n = Symbol('n', real=True)
@@ -97,7 +97,7 @@ def test_invert_real():
     assert invert_real(exp(3*x), y, x) == (x, FiniteSet(log(y) / 3))
     assert invert_real(exp(x + 3), y, x) == (x, FiniteSet(log(y) - 3))
 
-    assert invert_real(exp(x) + 3, y, x) == (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(y - 3), Interval.open(0, oo))))
+    assert dumeq(invert_real(exp(x) + 3, y, x), (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(y - 3), Interval.open(0, oo)))))
     assert invert_real(exp(x)*3, y, x) == (x, FiniteSet(log(y / 3)))
 
     assert invert_real(log(x), y, x) == (x, FiniteSet(exp(y)))
@@ -107,7 +107,7 @@ def test_invert_real():
     assert invert_real(Abs(x), y, x) == (x, FiniteSet(y, -y))
 
     assert invert_real(2**x, y, x) == (x, FiniteSet(log(y)/log(2)))
-    assert invert_real(2**exp(x), y, x) == (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(log(y)/log(2)), Interval.open(0, oo))))
+    assert dumeq(invert_real(2**exp(x), y, x), (x, ImageSet(Lambda(x, log(x)), Intersection(FiniteSet(log(y)/log(2)), Interval.open(0, oo)))))
 
     assert invert_real(x**2, y, x) == (x, FiniteSet(sqrt(y), -sqrt(y)))
     assert invert_real(x**S.Half, y, x) == (x, FiniteSet(y**2))
@@ -3597,7 +3597,7 @@ def test_issue_26077():
     assert solution.as_dummy() == critical_points.as_dummy()
 
 def test_invert_exp():
-    # issue 20674
+    # issue 29674
     assert dumeq(solveset(sin(exp(x)), x, domain=S.Reals),
           Union(ImageSet(Lambda(n, log(2*n*pi + pi)), Range(0, oo, 1)),
                 ImageSet(Lambda(n, log(2*n*pi + 2*pi)), Range(0, oo, 1))))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1663,6 +1663,7 @@ def test_issue_10085():
     assert invert_real(exp(x),0,x) == (x, S.EmptySet)
 
 
+
 def test_linsolve():
     x1, x2, x3, x4 = symbols('x1, x2, x3, x4')
 
@@ -3602,7 +3603,10 @@ def test_issue_26077():
     )
     assert solution.as_dummy() == critical_points.as_dummy()
 
-def test_issue_29674():
-    dumeq(solveset(sin(exp(x)), x, domain=S.Reals),
+def test_invert_exp():
+    # issue 20674
+    assert dumeq(solveset(sin(exp(x)), x, domain=S.Reals),
           Union(ImageSet(Lambda(n, log(2*n*pi + pi)), Range(0, oo, 1)),
-                ImageSet(Lambda(n, log(2*n*pi + 2*pi)) , Range(0, oo, 1))))
+                ImageSet(Lambda(n, log(2*n*pi + 2*pi)), Range(0, oo, 1))))
+    assert invert_real(exp(x), -1, x) == (x, S.EmptySet)
+    assert invert_real(exp(x), 1, x) == (x, FiniteSet(0))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1663,7 +1663,6 @@ def test_issue_10085():
     assert invert_real(exp(x),0,x) == (x, S.EmptySet)
 
 
-
 def test_linsolve():
     x1, x2, x3, x4 = symbols('x1, x2, x3, x4')
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes https://github.com/sympy/sympy/issues/29674

#### Brief description of what is fixed or changed
Change `_invert_trig_hyp_real`  so it respects the range of the inside function

#### Other comments
As far as I can see  `function_range` is computationally expensive on some cases, but I could not find other reliable fix for this.
Also, the outputs of methods like these are not fully simplified (like the union in the issue), but it is unrelated to this issue. The output should be mathematically correct now.

#### AI Generation Disclosure
~All the code and tests were written/modified manually by me. No AI was used.~

Edit: Claude was to modify some of the tests.
Claude also was used to review the code
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a bug in `solveset` function. Before, it would ignore the range of the inner functions such as `sin(exp(x))`
<!-- END RELEASE NOTES -->
