### PR TITLE
ntheory: fix EllipticCurvePoint.__add__ for general Weierstrass form

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1665,6 +1665,7 @@ Tomo Lazovich <lazovich@gmail.com>
 Tomáš Bambas <tomas.bambas@gmail.com>
 Toon Verstraelen <Toon.Verstraelen@UGent.be> <toon.verstraelen@gmail.com>
 Toon Verstraelen <Toon.Verstraelen@UGent.be> <toon.verstraelen@ugent.be>
+Tejas Attarde <tejasattardexx@gmail.com> Tejas <tejasae-afk@users.noreply.github.com>
 Travis Ens <ens.travis@gmail.com>
 Tristan Hume <tris.hume@gmail.com>
 TrungPQ <trungpqhe171493@gmail.com> XLR8 <86862725+AcceleratorHTH@users.noreply.github.com>

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -323,7 +323,7 @@ class EllipticCurvePoint:
             slope = (y1 - y2) / (x1 - x2)
             yint = (y1 * x2 - y2 * x1) / (x2 - x1)
         else:
-            if (y1 + y2) == 0:
+            if (y1 + y2 + a1*x1 + a3) == 0:
                 return self.point_at_infinity(self._curve)
             slope = (3 * x1**2 + 2*a2*x1 + a4 - a1*y1) / (a1 * x1 + a3 + 2 * y1)
             yint = (-x1**3 + a4*x1 + 2*a6 - a3*y1) / (a1*x1 + a3 + 2*y1)

--- a/sympy/ntheory/tests/test_elliptic_curve.py
+++ b/sympy/ntheory/tests/test_elliptic_curve.py
@@ -22,3 +22,9 @@ def test_elliptic_curve():
     # Issue 28546: -O should return canonical infinity point
     O = EllipticCurvePoint.point_at_infinity(e3)
     assert (-O).x == O.x and (-O).y == O.y and (-O).z == O.z
+    # Issue 28529: P + (-P) must return point at infinity on general Weierstrass curves.
+    # The curve y^2 + y = x^3 + x^2 has a3=1, so the additive inverse of (x, y)
+    # is (x, -y - a3) = (x, -y - 1), not (x, -y). The check y1+y2==0 was wrong.
+    e4 = EllipticCurve(0, 0, 0, 1, 1)
+    P = e4(0, 0)
+    assert (P + (-P)).z == 0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #28529

#### Brief description of what is fixed or changed

In the general Weierstrass equation `y^2 + a1*xy + a3*y = x^3 + a2*x^2 + a4*x + a6`, the additive inverse of a point `(x, y)` is `(x, -y - a1*x - a3)`. This is what `__neg__` correctly computes. The `__add__` method, however, was checking `y1 + y2 == 0` to detect `P + (-P)`, which is only correct for the short Weierstrass form where `a1 = a3 = 0`.

For a curve with `a3 != 0`, that condition fails even when `P2 == -P1`, so the code falls through to the tangent-line formula and returns a spurious finite point instead of the point at infinity.

The fix is a single character change: replace the incorrect `y1 + y2 == 0` with `y1 + y2 + a1*x1 + a3 == 0`, matching the negation formula already in `__neg__`. For short Weierstrass curves (`a1 = a3 = 0`) the behaviour is identical to before.

A regression test is added using the curve `y^2 + y = x^3 + x^2` (a3=1) and the point `P = (0, 0)`, where `P + (-P)` was returning `(-1, -1)` instead of the point at infinity.

#### AI Generation Disclosure

Used an AI assistant for code review and feedback on the fix. The code change and test were written by me.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed `EllipticCurvePoint.__add__` incorrectly returning a finite point instead of the point at infinity when `P + (-P)` is computed on a general Weierstrass curve with nonzero `a1` or `a3`. ([#28529](https://github.com/sympy/sympy/issues/28529))
<!-- END RELEASE NOTES -->