### PR TITLE
Fix #29267: solve_decomposition UnboundLocalError

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1889,3 +1889,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt>

--- a/.mailmap
+++ b/.mailmap
@@ -1889,4 +1889,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt>
+Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt> <67421012+tiagobfpinto@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1634,6 +1634,7 @@ Thomas Hunt <thomashunt13@gmail.com> <twhunt@users.noreply.github.com>
 Thomas Sidoti <TSidoti@gmail.com>
 Thomas Wiecki <thomas.wiecki@gmail.com> <thomas.wieki@gmail.com>
 Thomas Wiecki <thomas.wiecki@gmail.com> <whyking@Lateralus.(none)>
+Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt> <67421012+tiagobfpinto@users.noreply.github.com>
 Tien Nguyen <viettien23102006@gmail.com> <95487001+tiennguyen2310@users.noreply.github.com>
 Tiffany Zhu <bubble.wubble.303@gmail.com>
 Tilo Reneau-Cardoso <tiloreneau@gmail.com> Tilo Reneau-Cardoso <67246777+TiloRC@users.noreply.github.com>
@@ -1889,4 +1890,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt> <67421012+tiagobfpinto@users.noreply.github.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1219,6 +1219,9 @@ def solve_decomposition(f, symbol, domain):
                 # y_s is not in the range of g in g_s, so no solution exists
                 #in the given domain
                 return S.EmptySet
+            else:
+                # y_s is an unhandled set type (e.g. unevaluated Intersection)
+                return ConditionSet(symbol, Eq(f, 0), domain)
 
             for iset in iter_iset:
                 new_solutions = solveset(Eq(iset.lamda.expr, g), symbol, domain)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1807,6 +1807,7 @@ def test_solve_decomposition():
     f5 = exp(x + 2) - 1
     f6 = 1/log(x)
     f7 = 1/x
+    f8 = exp(sin(x) + a) - 1
 
     s1 = ImageSet(Lambda(n, 2*n*pi), S.Integers)
     s2 = ImageSet(Lambda(n, 2*n*pi + pi), S.Integers)
@@ -1822,6 +1823,7 @@ def test_solve_decomposition():
     assert solve_decomposition(f6, x, S.Reals) == S.EmptySet
     assert solve_decomposition(f7, x, S.Reals) == S.EmptySet
     assert solve_decomposition(x, x, Interval(1, 2)) == S.EmptySet
+    assert solve_decomposition(f8, x, S.Reals) == ConditionSet(x, Eq(f8, 0), S.Reals)
 
 
 # nonlinsolve testcases


### PR DESCRIPTION
When y_s evaluates to an unevaluated Intersection (e.g. with symbolic parameters), the else branch did not assign iter_iset, causing an UnboundLocalError. Fix adds a fallback else clause that returns a ConditionSet when y_s is an unhandled set type.

Add regression test: solve_decomposition(exp(sin(x)+a)-1, x, S.Reals) should return ConditionSet without raising.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
The reference issue is https://github.com/sympy/sympy/issues/29267 
Fixes #29267 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
When y_s was evaluating an unevaluated intersection, the "else" branch did not assign iter_iset, and that would cause an error. This fix adds a fallback "else" clause that returns a ConditionSet when y_s is an unhandled set type.

#### Other comments
The implementation was inspired by the original issue description suggested fix.

#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed ``solve_decomposition`` raising ``UnboundLocalError``
    when ``y_s`` evaluates to an unevaluated ``Intersection``.
<!-- END RELEASE NOTES -->
