### PR TITLE
Fix `GroupHomomorphism.invert` identity for permutation-group domains

### DIFF
--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -95,9 +95,11 @@ class GroupHomomorphism:
                 gens = image.generator_product(g)[::-1]
                 dtype = type(w)
                 return dtype.prod(
-                    self._inverses[s] if s in self._inverses
-                    else self._inverses[s**-1]**-1
-                    for s in gens if not s.is_identity
+                    itertools.chain([w], (
+                        self._inverses[s] if s in self._inverses
+                        else self._inverses[s**-1]**-1
+                        for s in gens if not s.is_identity
+                    ))
                 )
 
             else:

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -51,6 +51,8 @@ def test_homomorphism():
     assert T.is_injective()
     assert not T.is_isomorphism()
     assert T.invert(p**3) == p**3
+    assert T.invert(T.image().identity) == T.domain.identity
+    assert T(T.invert(T.image().identity)) == T.image().identity
 
     T2 = homomorphism(F, P, [F.generators[0]], P.generators)
     T = T.compose(T2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
This regression was introduced in #29106.
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Fixed that `invert` returned degree-0 permutation when inverting identity.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Used codex to find the bug and fix the bug. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
