### PR TITLE
tensor: replace_with_arrays: try harder to match transposed tensors as well

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -953,7 +953,8 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
-Kishore Gopalakrishnan <kishore96@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com> Kishore G <kishore96@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com> Kishore G. <kishore96.work@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2230,13 +2230,13 @@ class TensExpr(Expr, ABC):
         # Check if variance of indices needs to be fixed:
         pos2up = []
         pos2down = []
+        free1remaining = []
         free2remaining = free_ind2[:]
         for pos1, index1 in enumerate(free_ind1):
             if index1 in free2remaining:
                 pos2 = free2remaining.index(index1)
                 free2remaining[pos2] = None
-                continue
-            if -index1 in free2remaining:
+            elif -index1 in free2remaining:
                 pos2 = free2remaining.index(-index1)
                 free2remaining[pos2] = None
                 free_ind2[pos2] = index1
@@ -2245,16 +2245,26 @@ class TensExpr(Expr, ABC):
                 else:
                     pos2down.append(pos2)
             else:
-                index2 = free2remaining[pos1]
-                if index2 is None:
+                free1remaining.append(pos1)
+
+        for pos1, index1 in enumerate(free_ind1):
+            if pos1 in free1remaining:
+                #Handle indices which have no exact match
+                pos2 = None
+                for i in range(len(free2remaining)):
+                    if free2remaining[i] is not None:
+                        pos2 = i
+                        break
+                if pos2 is None:
                     raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")
-                free2remaining[pos1] = None
-                free_ind2[pos1] = index1
+                index2 = free2remaining[pos2]
+                free2remaining[pos2] = None
+                free_ind2[pos2] = index1
                 if index1.is_up ^ index2.is_up:
                     if index1.is_up:
-                        pos2up.append(pos1)
+                        pos2up.append(pos2)
                     else:
-                        pos2down.append(pos1)
+                        pos2down.append(pos2)
 
         if len(set(free_ind1) & set(free_ind2)) < len(free_ind1):
             raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1982,6 +1982,7 @@ def test_tensor_replacement():
     i, j, k, l = tensor_indices("i j k l", L)
     A, B, C, D = tensor_heads("A B C D", [L])
     H = TensorHead("H", [L, L])
+    J = TensorHead("J", [L, L])
     K = TensorHead("K", [L]*4)
 
     expr = H(i, j)
@@ -2015,10 +2016,19 @@ def test_tensor_replacement():
     assert expr.replace_with_arrays(repl, [-j, i]) == Array([[1, 3], [-2, -4]])
     assert expr.replace_with_arrays(repl, [-j, -i]) == Array([[1, -3], [-2, 4]])
 
+    # Transpose
+    expr = H(j,i)
+    repl = {H(i,j): [[1,2],[3,4]]}
+    assert expr.replace_with_arrays(repl, [i,j]) == Array([[1,3],[2,4]])
+
     # Not the same indices:
     expr = H(i,k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr._extract_data(repl) == ([i, k], Array([[1, 2], [3, 4]]))
+
+    expr = H(j, k)
+    repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k]) == Array([[1,2],[3,4]])
 
     expr = A(i)*A(-i)
     repl = {A(i): [1,2], L: diag(1, -1)}
@@ -2080,6 +2090,18 @@ def test_tensor_replacement():
         L: Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
     }
     assert expr._extract_data(repl) == ([], 4)
+
+    # Transposed replacement array
+    repl = {
+        H(i, j): [[1, 2], [3, 4]],
+        J(i, j): [[1, 3], [2, 4]], #transpose of above
+        L: diag(1,1),
+        }
+    expr_1 = H(i,k)*H(-k,j)
+    expr_2 = H(i,k)*J(j,-k)
+    arr_1 = expr_1.replace_with_arrays(repl)
+    assert arr_1 == Array([[7,10],[15,22]])
+    assert expr_2.replace_with_arrays(repl) == arr_1
 
     # Replace with array, raise exception if indices are not compatible:
     expr = A(i)*A(j)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2033,10 +2033,6 @@ def test_tensor_replacement():
     repl = {K(i,j,k,l): Array([ (i+1) for i in range(2**4)]).reshape(2,2,2,2), L: diag(1, -1)}
     assert expr.replace_with_arrays(repl) == Array([(i+1)*(-1)**i for i in range(2**4)]).reshape(2,2,2,2)
 
-    expr = H(j, k)
-    repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
-    raises(ValueError, lambda: expr._extract_data(repl))
-
     expr = A(i)
     repl = {B(i): [1, 2]}
     raises(ValueError, lambda: expr._extract_data(repl))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes issue #28949

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This allows `replace_with_arrays` to handle some cases where it is possible to replace a tensor by the transpose of the given array.
E.g. if the array form of H(j,k) is specified and the user tries to use `replace_with_arrays` on an expression containing H(i,j), we now replace H(i,j) by the transpose of the given array (whereas earlier, a ValueError would be raised).

#### Other comments
Before this PR:
```python
IPython console for SymPy 1.14.0 (Python 3.14.4-64-bit) (ground types: gmpy)

These commands were executed:
>>> from sympy import *
>>> x, y, z, t = symbols('x y z t')
>>> k, m, n = symbols('k m n', integer=True)
>>> f, g, h = symbols('f g h', cls=Function)
>>> init_printing()

Documentation can be found at https://docs.sympy.org/1.14.0/

In [1]: import sympy.tensor.tensor as tens

In [2]: R2 = tens.TensorIndexType("R2", dim=2, dummy_name="r")

In [3]: i,j,a = symbols("i j a", cls=tens.TensorIndex, tensor_index_type=R2)

In [5]: H = symbols("H", cls=tens.TensorHead, index_types=[R2,R2])

In [6]: repl = {
   ...:        H(i, j): [[1, 2], [3, 4]],
   ...:        R2: diag(1,1),
   ...:        }

In [7]: ( H(j,i) ).replace_with_arrays(repl)
Out[7]: 
⎡1  3⎤
⎢    ⎥
⎣2  4⎦

In [8]: ( H(j,a) ).replace_with_arrays(repl)

ValueError: incompatible indices: [j, a] and [i, j]

```
After this PR:
```python
In [6]: ( H(j,a) ).replace_with_arrays(repl)
Out[6]: 
⎡1  3⎤
⎢    ⎥
⎣2  4⎦

```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * `replace_with_arrays` now tries harder to match transposed tensors.
<!-- END RELEASE NOTES -->
