### PR TITLE
Remove `_eval_binrel`

### DIFF
--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -38,10 +38,10 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
 # Some predicates such as Q.prime can't be handled by lra_satask.
 # For example, (x > 0) & (x < 1) & Q.prime(x) is unsat but lra_satask would think it was sat.
 # WHITE_LIST is a list of predicates that can always be handled.
-WHITE_LIST = ALLOWED_PRED | {Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative,
-                                            Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
-                                            Q.extended_negative, Q.extended_nonzero, Q.negative_infinite,
-                                            Q.positive_infinite}
+WHITE_LIST = ALLOWED_PRED.keys() | {Q.positive, Q.negative, Q.zero, Q.nonzero, Q.nonpositive, Q.nonnegative,
+                                    Q.extended_positive, Q.extended_negative, Q.extended_nonpositive,
+                                    Q.extended_negative, Q.extended_nonzero, Q.negative_infinite,
+                                    Q.positive_infinite}
 
 
 def check_satisfiability(prop, _prop, factbase):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -122,7 +122,7 @@ from sympy.assumptions.ask import Q
 from sympy.core import Dummy
 from sympy.core.mul import Mul
 from sympy.core.add import Add
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ge, Gt, Le, Lt
 from sympy.core.sympify import sympify
 from sympy.core.singleton import S
 from sympy.core.numbers import Rational, oo
@@ -137,7 +137,7 @@ class UnhandledInput(Exception):
     """
 
 # predicates that LRASolver understands and makes use of
-ALLOWED_PRED = {Q.eq, Q.gt, Q.lt, Q.le, Q.ge}
+ALLOWED_PRED = {Q.eq: Eq, Q.gt: Gt, Q.lt: Lt, Q.le: Le, Q.ge: Ge}
 
 # if true ~Q.gt(x, y) implies Q.le(x, y)
 HANDLE_NEGATION = True
@@ -281,16 +281,15 @@ class LRASolver():
                 raise UnhandledInput(f"{prop} contains infinity")
 
             expr = prop.lhs - prop.rhs
-            match prop.function.eval([expr, S.Zero]):
-                case True:
-                    conflicts.append([enc])
-                    continue
-                case False:
-                    conflicts.append([-enc])
-                    continue
-                case _:
-                    if len(expr.free_symbols) == 0:
-                        raise UnhandledInput(f"{prop} could not be simplified")
+            pred = ALLOWED_PRED[prop.function](expr, S.Zero)
+            if pred == True:
+                conflicts.append([enc])
+                continue
+            if pred == False:
+                conflicts.append([-enc])
+                continue
+            if not expr.free_symbols:
+                raise UnhandledInput(f"{prop} could not be simplified")
 
             if prop.function in [Q.ge, Q.gt]:
                 expr = -expr

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -279,16 +279,15 @@ class LRASolver():
                 raise UnhandledInput(f"{prop} contains an imaginary component")
             if prop.lhs == oo or prop.rhs == oo:
                 raise UnhandledInput(f"{prop} contains infinity")
-
-            prop = _eval_binrel(prop)  # simplify variable-less quantities to True / False if possible
-            if prop == True:
-                conflicts.append([enc])
+            if len(prop.lhs.free_symbols) == len(prop.rhs.free_symbols) == 0:
+                match prop.function.eval([prop.lhs, prop.rhs]):
+                    case True:
+                        conflicts.append([enc])
+                    case False:
+                        conflicts.append([-enc])
+                    case _:
+                        raise UnhandledInput(f"{prop} could not be simplified")
                 continue
-            elif prop == False:
-                conflicts.append([-enc])
-                continue
-            elif prop is None:
-                raise UnhandledInput(f"{prop} could not be simplified")
 
             expr = prop.lhs - prop.rhs
             if prop.function in [Q.ge, Q.gt]:
@@ -734,31 +733,6 @@ def _sep_const_terms(expr):
                       lambda t: len(t.free_symbols) == 0,
                       binary=True)
     return Add(*var), Add(*const)
-
-
-def _eval_binrel(binrel):
-    """
-    Simplify binary relation to True / False if possible.
-    """
-    if not (len(binrel.lhs.free_symbols) == 0 and len(binrel.rhs.free_symbols) == 0):
-        return binrel
-    if binrel.function == Q.lt:
-        res = binrel.lhs < binrel.rhs
-    elif binrel.function == Q.gt:
-        res = binrel.lhs > binrel.rhs
-    elif binrel.function == Q.le:
-        res = binrel.lhs <= binrel.rhs
-    elif binrel.function == Q.ge:
-        res = binrel.lhs >= binrel.rhs
-    elif binrel.function == Q.eq:
-        res = Eq(binrel.lhs, binrel.rhs)
-    elif binrel.function == Q.ne:
-        res = Ne(binrel.lhs, binrel.rhs)
-
-    if res == True or res == False:
-        return res
-    else:
-        return None
 
 
 class Boundary:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -122,7 +122,7 @@ from sympy.assumptions.ask import Q
 from sympy.core import Dummy
 from sympy.core.mul import Mul
 from sympy.core.add import Add
-from sympy.core.relational import Eq, Ne
+from sympy.core.relational import Eq
 from sympy.core.sympify import sympify
 from sympy.core.singleton import S
 from sympy.core.numbers import Rational, oo

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -279,37 +279,21 @@ class LRASolver():
                 raise UnhandledInput(f"{prop} contains an imaginary component")
             if prop.lhs == oo or prop.rhs == oo:
                 raise UnhandledInput(f"{prop} contains infinity")
-            if len(prop.lhs.free_symbols) == len(prop.rhs.free_symbols) == 0:
-                match prop.function.eval([prop.lhs, prop.rhs]):
-                    case True:
-                        conflicts.append([enc])
-                    case False:
-                        conflicts.append([-enc])
-                    case _:
-                        raise UnhandledInput(f"{prop} could not be simplified")
-                continue
 
             expr = prop.lhs - prop.rhs
+            match prop.function.eval([expr, S.Zero]):
+                case True:
+                    conflicts.append([enc])
+                    continue
+                case False:
+                    conflicts.append([-enc])
+                    continue
+                case _:
+                    if len(expr.free_symbols) == 0:
+                        raise UnhandledInput(f"{prop} could not be simplified")
+
             if prop.function in [Q.ge, Q.gt]:
                 expr = -expr
-
-            # expr should be less than (or equal to) 0
-            # otherwise prop is False
-            if prop.function in [Q.le, Q.ge]:
-                bool = (expr <= 0)
-            elif prop.function in [Q.lt, Q.gt]:
-                bool = (expr < 0)
-            else:
-                assert prop.function == Q.eq
-                bool = Eq(expr, 0)
-
-            if bool == True:
-                conflicts.append([enc])
-                continue
-            elif bool == False:
-                conflicts.append([-enc])
-                continue
-
 
             vars, const = _sep_const_terms(expr)  # example: (2x + 3y + 2) --> (2x + 3y), (2)
             vars, var_coeff = _sep_const_coeff(vars)  # examples: (2x) --> (x, 2); (2x + 3y) --> (2x + 3y), (1)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
#29542
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
`_eval_binrel` evaluates inequalities using the `function` passed as an argument. However, these classes already provide an `eval` method, which makes it unnecessary to write separate case distinctions. In that situation, there is little benefit to keeping `_eval_binrel` as a standalone function. In particular, its return value is not very intuitive, and writing the logic directly at the call site makes the control flow clearer. Therefore, `_eval_binrel` has been removed and its logic has been inlined into the caller.

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
