### PR TITLE
printing.latex: Make powers of expressions print outside i.e `f(x)^2`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -895,6 +895,7 @@ Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
+Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <157145635+JosephMehdiyev@users.noreply.github.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>

--- a/doc/src/tutorials/intro-tutorial/intro.rst
+++ b/doc/src/tutorials/intro-tutorial/intro.rst
@@ -178,7 +178,7 @@ spherical Bessel function `j_\nu(z)`.
 Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\mathrm{\LaTeX}`.
 
   >>> latex(Integral(cos(x)**2, (x, 0, pi)))
-  \int\limits_{0}^{\pi} \cos^{2}{\left(x \right)}\, dx
+  \int\limits_{0}^{\pi} \cos{\left(x \right)}^{2}\, dx
 
 Why SymPy?
 ==========

--- a/doc/src/tutorials/intro-tutorial/intro.rst
+++ b/doc/src/tutorials/intro-tutorial/intro.rst
@@ -178,7 +178,7 @@ spherical Bessel function `j_\nu(z)`.
 Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\mathrm{\LaTeX}`.
 
   >>> latex(Integral(cos(x)**2, (x, 0, pi)))
-  \int\limits_{0}^{\pi} \cos{\left(x \right)}^{2}\, dx
+  \int\limits_{0}^{\pi} \cos^{2}{\left(x \right)}\, dx
 
 Why SymPy?
 ==========

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -148,6 +148,7 @@ class LatexPrinter(Printer):
         "fold_func_brackets": False,
         "fold_short_frac": None,
         "inv_trig_style": "abbreviated",
+        "trig_pow_outside": True,
         "itex": False,
         "ln_notation": False,
         "long_frac_ratio": None,
@@ -1003,6 +1004,14 @@ class LatexPrinter(Printer):
                     if exp is not None:
                         can_fold_brackets = False
 
+            trig_table = [
+                "sin", "cos", "tan",
+                "csc", "sec", "cot",
+                "sinh", "cosh", "tanh",
+                "csch", "sech", "coth",
+            ]
+            trig_pow_outside = self._settings['trig_pow_outside']
+
             if inv_trig_power_case:
                 if func in accepted_latex_functions:
                     name = r"\%s^{-1}" % func
@@ -1011,7 +1020,10 @@ class LatexPrinter(Printer):
             elif exp is not None:
                 func_tex = self._hprint_Function(func)
                 func_tex = self.parenthesize_super(func_tex)
-                name = r'%s^{%s}' % (func_tex, exp)
+                if not trig_pow_outside and func in trig_table:
+                    name = r'%s^{%s}' % (func_tex, exp)
+                else:
+                    name = func_tex
             else:
                 name = self._hprint_Function(func)
 
@@ -1026,6 +1038,8 @@ class LatexPrinter(Printer):
                 name += r"{\left(%s \right)}"
 
             if inv_trig_power_case and exp is not None:
+                name += r"^{%s}" % exp
+            elif exp is not None and func and trig_pow_outside:
                 name += r"^{%s}" % exp
 
             return name % ",".join(args)
@@ -1218,7 +1232,7 @@ class LatexPrinter(Printer):
     def _print_elliptic_k(self, expr, exp=None):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
         if exp is not None:
-            return r"K^{%s}%s" % (exp, tex)
+            return r"K%s^{%s}" % (tex, exp)
         else:
             return r"K%s" % tex
 
@@ -1226,7 +1240,7 @@ class LatexPrinter(Printer):
         tex = r"\left(%s\middle| %s\right)" % \
             (self._print(expr.args[0]), self._print(expr.args[1]))
         if exp is not None:
-            return r"F^{%s}%s" % (exp, tex)
+            return r"F%s^{%s}" % (tex, exp)
         else:
             return r"F%s" % tex
 
@@ -1237,7 +1251,7 @@ class LatexPrinter(Printer):
         else:
             tex = r"\left(%s\right)" % self._print(expr.args[0])
         if exp is not None:
-            return r"E^{%s}%s" % (exp, tex)
+            return r"E%s^{%s}" % (tex, exp)
         else:
             return r"E%s" % tex
 
@@ -1250,7 +1264,7 @@ class LatexPrinter(Printer):
             tex = r"\left(%s\middle| %s\right)" % \
                 (self._print(expr.args[0]), self._print(expr.args[1]))
         if exp is not None:
-            return r"\Pi^{%s}%s" % (exp, tex)
+            return r"\Pi%s^{%s}" % (tex, exp)
         else:
             return r"\Pi%s" % tex
 
@@ -1261,7 +1275,7 @@ class LatexPrinter(Printer):
         tex = rf"\left({x}, {y}\right)"
 
         if exp is not None:
-            return r"\operatorname{B}^{%s}%s" % (exp, tex)
+            return r"\operatorname{B}%s^{%s}" % (tex, exp)
         else:
             return r"\operatorname{B}%s" % tex
 
@@ -1270,7 +1284,7 @@ class LatexPrinter(Printer):
         tex = r"\left(%s, %s\right)" % (largs[0], largs[1])
 
         if exp is not None:
-            return r"\operatorname{%s}_{(%s, %s)}^{%s}%s" % (operator, largs[2], largs[3], exp, tex)
+            return r"\operatorname{%s}_{(%s, %s)}%s^{%s}" % (operator, largs[2], largs[3], tex, exp)
         else:
             return r"\operatorname{%s}_{(%s, %s)}%s" % (operator, largs[2], largs[3], tex)
 
@@ -1282,7 +1296,7 @@ class LatexPrinter(Printer):
                                         self._print(expr.args[1]))
 
         if exp is not None:
-            return r"\Gamma^{%s}%s" % (exp, tex)
+            return r"\Gamma%s^{%s}" % (tex, exp)
         else:
             return r"\Gamma%s" % tex
 
@@ -1291,7 +1305,7 @@ class LatexPrinter(Printer):
                                         self._print(expr.args[1]))
 
         if exp is not None:
-            return r"\gamma^{%s}%s" % (exp, tex)
+            return r"\gamma%s^{%s}" % (tex, exp)
         else:
             return r"\gamma%s" % tex
 
@@ -1309,7 +1323,7 @@ class LatexPrinter(Printer):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
-            return r"\operatorname{Chi}^{%s}%s" % (exp, tex)
+            return r"\operatorname{Chi}%s^{%s}" % (tex, exp)
         else:
             return r"\operatorname{Chi}%s" % tex
 
@@ -1318,7 +1332,7 @@ class LatexPrinter(Printer):
         nu = self._print(expr.args[0])
 
         if exp is not None:
-            return r"\operatorname{E}_{%s}^{%s}%s" % (nu, exp, tex)
+            return r"\operatorname{E}_{%s}%s^{%s}" % (nu, tex, exp)
         else:
             return r"\operatorname{E}_{%s}%s" % (nu, tex)
 
@@ -1326,7 +1340,7 @@ class LatexPrinter(Printer):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
-            return r"S^{%s}%s" % (exp, tex)
+            return r"S%s^{%s}" % (tex, exp)
         else:
             return r"S%s" % tex
 
@@ -1334,7 +1348,7 @@ class LatexPrinter(Printer):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
-            return r"C^{%s}%s" % (exp, tex)
+            return r"C%s^{%s}" % (tex, exp)
         else:
             return r"C%s" % tex
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1009,7 +1009,7 @@ class LatexPrinter(Printer):
                 "csc", "sec", "cot",
                 "sinh", "cosh", "tanh",
                 "csch", "sech", "coth",
-            ]
+            ] + inv_trig_table
             trig_pow_outside = self._settings['trig_pow_outside']
 
             if inv_trig_power_case:
@@ -1040,7 +1040,7 @@ class LatexPrinter(Printer):
             if inv_trig_power_case and exp is not None:
                 name += r"^{%s}" % exp
             elif exp is not None:
-                if trig_pow_outside or func not in trig_table:
+                if trig_pow_outside or func not in trig_table :
                     name += r"^{%s}" % exp
 
             return name % ",".join(args)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1039,8 +1039,9 @@ class LatexPrinter(Printer):
 
             if inv_trig_power_case and exp is not None:
                 name += r"^{%s}" % exp
-            elif exp is not None and func and trig_pow_outside:
-                name += r"^{%s}" % exp
+            elif exp is not None:
+                if trig_pow_outside or func not in trig_table:
+                    name += r"^{%s}" % exp
 
             return name % ",".join(args)
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -148,7 +148,7 @@ class LatexPrinter(Printer):
         "fold_func_brackets": False,
         "fold_short_frac": None,
         "inv_trig_style": "abbreviated",
-        "trig_pow_outside": True,
+        "trig_pow_outside": False,
         "itex": False,
         "ln_notation": False,
         "long_frac_ratio": None,
@@ -990,6 +990,13 @@ class LatexPrinter(Printer):
                 "acsch", "asech", "acoth",
             ]
 
+            inv_trig_table_full = [
+                "arcsin", "arccos", "arctan",
+                "arccsc", "arcsec", "arccot",
+                "arsinh", "arcosh", "artanh",
+                "arcsch", "arsech", "arcoth",
+            ]
+
             # If the function is an inverse trig function, handle the style
             if func in inv_trig_table:
                 if inv_trig_style == "abbreviated":
@@ -1009,7 +1016,7 @@ class LatexPrinter(Printer):
                 "csc", "sec", "cot",
                 "sinh", "cosh", "tanh",
                 "csch", "sech", "coth",
-            ] + inv_trig_table
+            ] + inv_trig_table + inv_trig_table_full
             trig_pow_outside = self._settings['trig_pow_outside']
 
             if inv_trig_power_case:
@@ -1037,10 +1044,10 @@ class LatexPrinter(Printer):
             else:
                 name += r"{\left(%s \right)}"
 
-            if inv_trig_power_case and exp is not None:
-                name += r"^{%s}" % exp
-            elif exp is not None:
-                if trig_pow_outside or func not in trig_table :
+            if exp is not None:
+                if inv_trig_power_case:
+                    name += r"^{%s}" % exp
+                elif trig_pow_outside or func not in trig_table:
                     name += r"^{%s}" % exp
 
             return name % ",".join(args)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1046,6 +1046,7 @@ class LatexPrinter(Printer):
 
             if exp is not None:
                 if inv_trig_power_case:
+                    name = self._add_parens(name)
                     name += r"^{%s}" % exp
                 elif trig_pow_outside or func not in trig_table:
                     name += r"^{%s}" % exp

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -234,9 +234,9 @@ def test_latex_basic():
     assert latex(1/sin(x)) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**Rational(3, 2)) == \
-        r"\sin^{\frac{3}{2}}{\left(x \right)}"
+        r"\sin{\left(x \right)}^{\frac{3}{2}}"
     assert latex(sin(x)**Rational(3, 2), fold_frac_powers=True) == \
-        r"\sin^{3/2}{\left(x \right)}"
+        r"\sin{\left(x \right)}^{3/2}"
 
     assert latex(~x) == r"\neg x"
     assert latex(x & y) == r"x \wedge y"
@@ -471,7 +471,7 @@ def test_latex_functions():
     assert latex(mybeta(x, y, z)) == r"\beta{\left(x,y,z \right)}"
     assert latex(beta(x, y)) == r'\operatorname{B}\left(x, y\right)'
     assert latex(beta(x, evaluate=False)) == r'\operatorname{B}\left(x, x\right)'
-    assert latex(beta(x, y)**2) == r'\operatorname{B}^{2}\left(x, y\right)'
+    assert latex(beta(x, y)**2) == r'\operatorname{B}\left(x, y\right)^{2}'
     assert latex(mybeta(x)) == r"\beta{\left(x \right)}"
     assert latex(mybeta) == r"\beta"
 
@@ -508,17 +508,17 @@ def test_latex_functions():
     #   does not work on functions without brackets
 
     # > with argument and power combined
-    assert latex(Function('ab')()**2) == r"\operatorname{ab}^{2}{\left( \right)}"
-    assert latex(Function('ab1')()**2) == r"\operatorname{ab}_{1}^{2}{\left( \right)}"
-    assert latex(Function('ab12')()**2) == r"\operatorname{ab}_{12}^{2}{\left( \right)}"
-    assert latex(Function('ab_1')()**2) == r"\operatorname{ab}_{1}^{2}{\left( \right)}"
-    assert latex(Function('ab_12')()**2) == r"\operatorname{ab}_{12}^{2}{\left( \right)}"
-    assert latex(Function('ab')(Symbol('x'))**2) == r"\operatorname{ab}^{2}{\left(x \right)}"
-    assert latex(Function('ab1')(Symbol('x'))**2) == r"\operatorname{ab}_{1}^{2}{\left(x \right)}"
-    assert latex(Function('ab12')(Symbol('x'))**2) == r"\operatorname{ab}_{12}^{2}{\left(x \right)}"
-    assert latex(Function('ab_1')(Symbol('x'))**2) == r"\operatorname{ab}_{1}^{2}{\left(x \right)}"
+    assert latex(Function('ab')()**2) == r"\operatorname{ab}{\left( \right)}^{2}"
+    assert latex(Function('ab1')()**2) == r"\operatorname{ab}_{1}{\left( \right)}^{2}"
+    assert latex(Function('ab12')()**2) == r"\operatorname{ab}_{12}{\left( \right)}^{2}"
+    assert latex(Function('ab_1')()**2) == r"\operatorname{ab}_{1}{\left( \right)}^{2}"
+    assert latex(Function('ab_12')()**2) == r"\operatorname{ab}_{12}{\left( \right)}^{2}"
+    assert latex(Function('ab')(Symbol('x'))**2) == r"\operatorname{ab}{\left(x \right)}^{2}"
+    assert latex(Function('ab1')(Symbol('x'))**2) == r"\operatorname{ab}_{1}{\left(x \right)}^{2}"
+    assert latex(Function('ab12')(Symbol('x'))**2) == r"\operatorname{ab}_{12}{\left(x \right)}^{2}"
+    assert latex(Function('ab_1')(Symbol('x'))**2) == r"\operatorname{ab}_{1}{\left(x \right)}^{2}"
     assert latex(Function('ab_12')(Symbol('x'))**2) == \
-        r"\operatorname{ab}_{12}^{2}{\left(x \right)}"
+        r"\operatorname{ab}_{12}{\left(x \right)}^{2}"
 
     # single letter function names
     # > simple
@@ -539,55 +539,55 @@ def test_latex_functions():
     #   does not work on functions without brackets
 
     # > with argument and power combined
-    assert latex(Function('a')()**2) == r"a^{2}{\left( \right)}"
-    assert latex(Function('a1')()**2) == r"a_{1}^{2}{\left( \right)}"
-    assert latex(Function('a12')()**2) == r"a_{12}^{2}{\left( \right)}"
-    assert latex(Function('a_1')()**2) == r"a_{1}^{2}{\left( \right)}"
-    assert latex(Function('a_12')()**2) == r"a_{12}^{2}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**2) == r"a^{2}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**2) == r"a_{1}^{2}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**2) == r"a_{12}^{2}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**2) == r"a_{1}^{2}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**2) == r"a_{12}^{2}{\left(x \right)}"
+    assert latex(Function('a')()**2) == r"a{\left( \right)}^{2}"
+    assert latex(Function('a1')()**2) == r"a_{1}{\left( \right)}^{2}"
+    assert latex(Function('a12')()**2) == r"a_{12}{\left( \right)}^{2}"
+    assert latex(Function('a_1')()**2) == r"a_{1}{\left( \right)}^{2}"
+    assert latex(Function('a_12')()**2) == r"a_{12}{\left( \right)}^{2}"
+    assert latex(Function('a')(Symbol('x'))**2) == r"a{\left(x \right)}^{2}"
+    assert latex(Function('a1')(Symbol('x'))**2) == r"a_{1}{\left(x \right)}^{2}"
+    assert latex(Function('a12')(Symbol('x'))**2) == r"a_{12}{\left(x \right)}^{2}"
+    assert latex(Function('a_1')(Symbol('x'))**2) == r"a_{1}{\left(x \right)}^{2}"
+    assert latex(Function('a_12')(Symbol('x'))**2) == r"a_{12}{\left(x \right)}^{2}"
 
-    assert latex(Function('a')()**32) == r"a^{32}{\left( \right)}"
-    assert latex(Function('a1')()**32) == r"a_{1}^{32}{\left( \right)}"
-    assert latex(Function('a12')()**32) == r"a_{12}^{32}{\left( \right)}"
-    assert latex(Function('a_1')()**32) == r"a_{1}^{32}{\left( \right)}"
-    assert latex(Function('a_12')()**32) == r"a_{12}^{32}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**32) == r"a^{32}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**32) == r"a_{1}^{32}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**32) == r"a_{12}^{32}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**32) == r"a_{1}^{32}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**32) == r"a_{12}^{32}{\left(x \right)}"
+    assert latex(Function('a')()**32) == r"a{\left( \right)}^{32}"
+    assert latex(Function('a1')()**32) == r"a_{1}{\left( \right)}^{32}"
+    assert latex(Function('a12')()**32) == r"a_{12}{\left( \right)}^{32}"
+    assert latex(Function('a_1')()**32) == r"a_{1}{\left( \right)}^{32}"
+    assert latex(Function('a_12')()**32) == r"a_{12}{\left( \right)}^{32}"
+    assert latex(Function('a')(Symbol('x'))**32) == r"a{\left(x \right)}^{32}"
+    assert latex(Function('a1')(Symbol('x'))**32) == r"a_{1}{\left(x \right)}^{32}"
+    assert latex(Function('a12')(Symbol('x'))**32) == r"a_{12}{\left(x \right)}^{32}"
+    assert latex(Function('a_1')(Symbol('x'))**32) == r"a_{1}{\left(x \right)}^{32}"
+    assert latex(Function('a_12')(Symbol('x'))**32) == r"a_{12}{\left(x \right)}^{32}"
 
-    assert latex(Function('a')()**a) == r"a^{a}{\left( \right)}"
-    assert latex(Function('a1')()**a) == r"a_{1}^{a}{\left( \right)}"
-    assert latex(Function('a12')()**a) == r"a_{12}^{a}{\left( \right)}"
-    assert latex(Function('a_1')()**a) == r"a_{1}^{a}{\left( \right)}"
-    assert latex(Function('a_12')()**a) == r"a_{12}^{a}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**a) == r"a^{a}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**a) == r"a_{1}^{a}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**a) == r"a_{12}^{a}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**a) == r"a_{1}^{a}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**a) == r"a_{12}^{a}{\left(x \right)}"
+    assert latex(Function('a')()**a) == r"a{\left( \right)}^{a}"
+    assert latex(Function('a1')()**a) == r"a_{1}{\left( \right)}^{a}"
+    assert latex(Function('a12')()**a) == r"a_{12}{\left( \right)}^{a}"
+    assert latex(Function('a_1')()**a) == r"a_{1}{\left( \right)}^{a}"
+    assert latex(Function('a_12')()**a) == r"a_{12}{\left( \right)}^{a}"
+    assert latex(Function('a')(Symbol('x'))**a) == r"a{\left(x \right)}^{a}"
+    assert latex(Function('a1')(Symbol('x'))**a) == r"a_{1}{\left(x \right)}^{a}"
+    assert latex(Function('a12')(Symbol('x'))**a) == r"a_{12}{\left(x \right)}^{a}"
+    assert latex(Function('a_1')(Symbol('x'))**a) == r"a_{1}{\left(x \right)}^{a}"
+    assert latex(Function('a_12')(Symbol('x'))**a) == r"a_{12}{\left(x \right)}^{a}"
 
     ab = Symbol('ab')
-    assert latex(Function('a')()**ab) == r"a^{ab}{\left( \right)}"
-    assert latex(Function('a1')()**ab) == r"a_{1}^{ab}{\left( \right)}"
-    assert latex(Function('a12')()**ab) == r"a_{12}^{ab}{\left( \right)}"
-    assert latex(Function('a_1')()**ab) == r"a_{1}^{ab}{\left( \right)}"
-    assert latex(Function('a_12')()**ab) == r"a_{12}^{ab}{\left( \right)}"
-    assert latex(Function('a')(Symbol('x'))**ab) == r"a^{ab}{\left(x \right)}"
-    assert latex(Function('a1')(Symbol('x'))**ab) == r"a_{1}^{ab}{\left(x \right)}"
-    assert latex(Function('a12')(Symbol('x'))**ab) == r"a_{12}^{ab}{\left(x \right)}"
-    assert latex(Function('a_1')(Symbol('x'))**ab) == r"a_{1}^{ab}{\left(x \right)}"
-    assert latex(Function('a_12')(Symbol('x'))**ab) == r"a_{12}^{ab}{\left(x \right)}"
+    assert latex(Function('a')()**ab) == r"a{\left( \right)}^{ab}"
+    assert latex(Function('a1')()**ab) == r"a_{1}{\left( \right)}^{ab}"
+    assert latex(Function('a12')()**ab) == r"a_{12}{\left( \right)}^{ab}"
+    assert latex(Function('a_1')()**ab) == r"a_{1}{\left( \right)}^{ab}"
+    assert latex(Function('a_12')()**ab) == r"a_{12}{\left( \right)}^{ab}"
+    assert latex(Function('a')(Symbol('x'))**ab) == r"a{\left(x \right)}^{ab}"
+    assert latex(Function('a1')(Symbol('x'))**ab) == r"a_{1}{\left(x \right)}^{ab}"
+    assert latex(Function('a12')(Symbol('x'))**ab) == r"a_{12}{\left(x \right)}^{ab}"
+    assert latex(Function('a_1')(Symbol('x'))**ab) == r"a_{1}{\left(x \right)}^{ab}"
+    assert latex(Function('a_12')(Symbol('x'))**ab) == r"a_{12}{\left(x \right)}^{ab}"
 
     assert latex(Function('a^12')(x)) == R"a^{12}{\left(x \right)}"
-    assert latex(Function('a^12')(x) ** ab) == R"\left(a^{12}\right)^{ab}{\left(x \right)}"
+    assert latex(Function('a^12')(x) ** ab) == R"\left(a^{12}\right){\left(x \right)}^{ab}"
     assert latex(Function('a__12')(x)) == R"a^{12}{\left(x \right)}"
-    assert latex(Function('a__12')(x) ** ab) == R"\left(a^{12}\right)^{ab}{\left(x \right)}"
+    assert latex(Function('a__12')(x) ** ab) == R"\left(a^{12}\right){\left(x \right)}^{ab}"
     assert latex(Function('a_1__1_2')(x)) == R"a^{1}_{1 2}{\left(x \right)}"
 
     # issue 5868
@@ -602,9 +602,9 @@ def test_latex_functions():
     assert latex(sin(x**2), fold_func_brackets=True) == \
         r"\sin {x^{2}}"
 
-    assert latex(asin(x)**2) == r"\operatorname{asin}^{2}{\left(x \right)}"
+    assert latex(asin(x)**2) == r"\operatorname{asin}{\left(x \right)}^{2}"
     assert latex(asin(x)**2, inv_trig_style="full") == \
-        r"\arcsin^{2}{\left(x \right)}"
+        r"\arcsin{\left(x \right)}^{2}"
     assert latex(asin(x)**2, inv_trig_style="power") == \
         r"\sin^{-1}{\left(x \right)}^{2}"
     assert latex(asin(x**2), inv_trig_style="power",
@@ -669,9 +669,9 @@ def test_latex_functions():
     assert latex(Order(x, (x, oo), (y, oo))) == \
         r"O\left(x; \left( x, \  y\right)\rightarrow \left( \infty, \  \infty\right)\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
-    assert latex(lowergamma(x, y)**2) == r'\gamma^{2}\left(x, y\right)'
+    assert latex(lowergamma(x, y)**2) == r'\gamma\left(x, y\right)^{2}'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
-    assert latex(uppergamma(x, y)**2) == r'\Gamma^{2}\left(x, y\right)'
+    assert latex(uppergamma(x, y)**2) == r'\Gamma\left(x, y\right)^{2}'
 
     assert latex(cot(x)) == r'\cot{\left(x \right)}'
     assert latex(coth(x)) == r'\coth{\left(x \right)}'
@@ -697,27 +697,27 @@ def test_latex_functions():
     assert latex(stieltjes(x, y)**2) == r"\gamma_{x}\left(y\right)^{2}"
 
     assert latex(elliptic_k(z)) == r"K\left(z\right)"
-    assert latex(elliptic_k(z)**2) == r"K^{2}\left(z\right)"
+    assert latex(elliptic_k(z)**2) == r"K\left(z\right)^{2}"
     assert latex(elliptic_f(x, y)) == r"F\left(x\middle| y\right)"
-    assert latex(elliptic_f(x, y)**2) == r"F^{2}\left(x\middle| y\right)"
+    assert latex(elliptic_f(x, y)**2) == r"F\left(x\middle| y\right)^{2}"
     assert latex(elliptic_e(x, y)) == r"E\left(x\middle| y\right)"
-    assert latex(elliptic_e(x, y)**2) == r"E^{2}\left(x\middle| y\right)"
+    assert latex(elliptic_e(x, y)**2) == r"E\left(x\middle| y\right)^{2}"
     assert latex(elliptic_e(z)) == r"E\left(z\right)"
-    assert latex(elliptic_e(z)**2) == r"E^{2}\left(z\right)"
+    assert latex(elliptic_e(z)**2) == r"E\left(z\right)^{2}"
     assert latex(elliptic_pi(x, y, z)) == r"\Pi\left(x; y\middle| z\right)"
     assert latex(elliptic_pi(x, y, z)**2) == \
-        r"\Pi^{2}\left(x; y\middle| z\right)"
+        r"\Pi\left(x; y\middle| z\right)^{2}"
     assert latex(elliptic_pi(x, y)) == r"\Pi\left(x\middle| y\right)"
-    assert latex(elliptic_pi(x, y)**2) == r"\Pi^{2}\left(x\middle| y\right)"
+    assert latex(elliptic_pi(x, y)**2) == r"\Pi\left(x\middle| y\right)^{2}"
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
-    assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'
+    assert latex(Ei(x)**2) == r'\operatorname{Ei}{\left(x \right)}^{2}'
     assert latex(expint(x, y)) == r'\operatorname{E}_{x}\left(y\right)'
-    assert latex(expint(x, y)**2) == r'\operatorname{E}_{x}^{2}\left(y\right)'
-    assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left(x \right)}'
-    assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left(x \right)}'
-    assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left(x \right)}'
-    assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}\left(x\right)'
+    assert latex(expint(x, y)**2) == r'\operatorname{E}_{x}\left(y\right)^{2}'
+    assert latex(Shi(x)**2) == r'\operatorname{Shi}{\left(x \right)}^{2}'
+    assert latex(Si(x)**2) == r'\operatorname{Si}{\left(x \right)}^{2}'
+    assert latex(Ci(x)**2) == r'\operatorname{Ci}{\left(x \right)}^{2}'
+    assert latex(Chi(x)**2) == r'\operatorname{Chi}\left(x\right)^{2}'
     assert latex(Chi(x)) == r'\operatorname{Chi}\left(x\right)'
     assert latex(jacobi(n, a, b, x)) == \
         r'P_{n}^{\left(a,b\right)}\left(x\right)'
@@ -859,8 +859,8 @@ def test_latex_fresnel():
     from sympy.abc import z
     assert latex(fresnels(z)) == r'S\left(z\right)'
     assert latex(fresnelc(z)) == r'C\left(z\right)'
-    assert latex(fresnels(z)**2) == r'S^{2}\left(z\right)'
-    assert latex(fresnelc(z)**2) == r'C^{2}\left(z\right)'
+    assert latex(fresnels(z)**2) == r'S\left(z\right)^{2}'
+    assert latex(fresnelc(z)**2) == r'C\left(z\right)^{2}'
 
 
 def test_latex_brackets():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -3322,6 +3322,3 @@ def test_issue_29690():
     assert latex(asin(x)**2, trig_pow_outside = False, inv_trig_style = "power") == \
                                                         r'\sin^{-1}{\left(x \right)}^{2}'
     assert latex(asin(x)**2, inv_trig_style = "power") ==  r'\sin^{-1}{\left(x \right)}^{2}'
-
-
-

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -3306,3 +3306,22 @@ def test_latex_disable_split_super_sub():
     assert latex(Symbol('u^a_b')) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=False) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=True) == 'u\\^a\\_b'
+
+def test_issue_29690():
+    f = Function('f')
+    assert latex(f(x)**2) == r'f{\left(x \right)}^{2}'
+    assert latex(f(x)**2, trig_pow_outside = False) == r'f{\left(x \right)}^{2}'
+    assert latex(f(x)**y) == r'f{\left(x \right)}^{y}'
+    assert latex(f(x)**y, trig_pow_outside = False) == r'f{\left(x \right)}^{y}'
+
+    assert latex(sin(x)**2) == r'\sin{\left(x \right)}^{2}'
+    assert latex(sin(x)**2, trig_pow_outside = False) == r'\sin^{2}{\left(x \right)}'
+
+    assert latex(asin(x)**2) == r'\operatorname{asin}{\left(x \right)}^{2}'
+    assert latex(asin(x)**2, trig_pow_outside = False) == r'\operatorname{asin}^{2}{\left(x \right)}'
+    assert latex(asin(x)**2, trig_pow_outside = False, inv_trig_style = "power") == \
+                                                        r'\sin^{-1}{\left(x \right)}^{2}'
+    assert latex(asin(x)**2, inv_trig_style = "power") ==  r'\sin^{-1}{\left(x \right)}^{2}'
+
+
+

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -606,7 +606,7 @@ def test_latex_functions():
     assert latex(asin(x)**2, inv_trig_style="full") == \
         r"\arcsin^{2}{\left(x \right)}"
     assert latex(asin(x)**2, inv_trig_style="power") == \
-        r"\sin^{-1}{\left(x \right)}^{2}"
+        r"\left(\sin^{-1}{\left(x \right)}\right)^{2}"
     assert latex(asin(x**2), inv_trig_style="power",
                  fold_func_brackets=True) == \
         r"\sin^{-1} {x^{2}}"
@@ -627,8 +627,8 @@ def test_latex_functions():
     assert latex(asin(x)**2) == r'\operatorname{asin}^{2}{\left(x \right)}'
     assert latex(asin(x)**2, trig_pow_outside = True) == r'\operatorname{asin}{\left(x \right)}^{2}'
     assert latex(asin(x)**2, trig_pow_outside = True, inv_trig_style = "power") == \
-                                                        r'\sin^{-1}{\left(x \right)}^{2}'
-    assert latex(asin(x)**2, inv_trig_style = "power") ==  r'\sin^{-1}{\left(x \right)}^{2}'
+                                                        r'\left(\sin^{-1}{\left(x \right)}\right)^{2}'
+    assert latex(asin(x)**2, inv_trig_style = "power") ==  r'\left(\sin^{-1}{\left(x \right)}\right)^{2}'
 
     assert latex(factorial(k)) == r"k!"
     assert latex(factorial(-k)) == r"\left(- k\right)!"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -234,9 +234,9 @@ def test_latex_basic():
     assert latex(1/sin(x)) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**Rational(3, 2)) == \
-        r"\sin{\left(x \right)}^{\frac{3}{2}}"
+        r"\sin^{\frac{3}{2}}{\left(x \right)}"
     assert latex(sin(x)**Rational(3, 2), fold_frac_powers=True) == \
-        r"\sin{\left(x \right)}^{3/2}"
+        r"\sin^{3/2}{\left(x \right)}"
 
     assert latex(~x) == r"\neg x"
     assert latex(x & y) == r"x \wedge y"
@@ -602,9 +602,9 @@ def test_latex_functions():
     assert latex(sin(x**2), fold_func_brackets=True) == \
         r"\sin {x^{2}}"
 
-    assert latex(asin(x)**2) == r"\operatorname{asin}{\left(x \right)}^{2}"
+    assert latex(asin(x)**2) == r"\operatorname{asin}^{2}{\left(x \right)}"
     assert latex(asin(x)**2, inv_trig_style="full") == \
-        r"\arcsin{\left(x \right)}^{2}"
+        r"\arcsin^{2}{\left(x \right)}"
     assert latex(asin(x)**2, inv_trig_style="power") == \
         r"\sin^{-1}{\left(x \right)}^{2}"
     assert latex(asin(x**2), inv_trig_style="power",
@@ -614,6 +614,21 @@ def test_latex_functions():
         r"\operatorname{arccsc}{\left(x \right)}"
     assert latex(asinh(x), inv_trig_style="full") == \
         r"\operatorname{arsinh}{\left(x \right)}"
+
+    f = Function('f')
+    assert latex(f(x)**2) == r'f{\left(x \right)}^{2}'
+    assert latex(f(x)**2, trig_pow_outside = True) == r'f{\left(x \right)}^{2}'
+    assert latex(f(x)**y) == r'f{\left(x \right)}^{y}'
+    assert latex(f(x)**y, trig_pow_outside = True) == r'f{\left(x \right)}^{y}'
+
+    assert latex(sin(x)**2) == r'\sin^{2}{\left(x \right)}'
+    assert latex(sin(x)**2, trig_pow_outside = True) == r'\sin{\left(x \right)}^{2}'
+
+    assert latex(asin(x)**2) == r'\operatorname{asin}^{2}{\left(x \right)}'
+    assert latex(asin(x)**2, trig_pow_outside = True) == r'\operatorname{asin}{\left(x \right)}^{2}'
+    assert latex(asin(x)**2, trig_pow_outside = True, inv_trig_style = "power") == \
+                                                        r'\sin^{-1}{\left(x \right)}^{2}'
+    assert latex(asin(x)**2, inv_trig_style = "power") ==  r'\sin^{-1}{\left(x \right)}^{2}'
 
     assert latex(factorial(k)) == r"k!"
     assert latex(factorial(-k)) == r"\left(- k\right)!"
@@ -3306,19 +3321,3 @@ def test_latex_disable_split_super_sub():
     assert latex(Symbol('u^a_b')) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=False) == 'u^{a}_{b}'
     assert latex(Symbol('u^a_b'), disable_split_super_sub=True) == 'u\\^a\\_b'
-
-def test_issue_29690():
-    f = Function('f')
-    assert latex(f(x)**2) == r'f{\left(x \right)}^{2}'
-    assert latex(f(x)**2, trig_pow_outside = False) == r'f{\left(x \right)}^{2}'
-    assert latex(f(x)**y) == r'f{\left(x \right)}^{y}'
-    assert latex(f(x)**y, trig_pow_outside = False) == r'f{\left(x \right)}^{y}'
-
-    assert latex(sin(x)**2) == r'\sin{\left(x \right)}^{2}'
-    assert latex(sin(x)**2, trig_pow_outside = False) == r'\sin^{2}{\left(x \right)}'
-
-    assert latex(asin(x)**2) == r'\operatorname{asin}{\left(x \right)}^{2}'
-    assert latex(asin(x)**2, trig_pow_outside = False) == r'\operatorname{asin}^{2}{\left(x \right)}'
-    assert latex(asin(x)**2, trig_pow_outside = False, inv_trig_style = "power") == \
-                                                        r'\sin^{-1}{\left(x \right)}^{2}'
-    assert latex(asin(x)**2, inv_trig_style = "power") ==  r'\sin^{-1}{\left(x \right)}^{2}'


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes https://github.com/sympy/sympy/issues/29680
#### Brief description of what is fixed or changed
Whenever `somefunction**exp` is called, the power should print outside the braces now.
I also added a new configuration variable to change how trigonometric powers are printed i.e `sin(x)^2` or `sin^2(x)`

#### Other comments
There were other specifically written printer methods for functions, I assumed they were also not following the convention and was not intentional

If the trig inverse style is as `^{-1}`, the power will also print outside the `()` regardless of the config value

```Python
assert latex(Function('a^12')(x)) == R"a^{12}{\left(x \right)}"
```
I am not sure about this, I believe `a^12` was used as intended here and not as a power.
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Changed the default power latex printing style of functions to be outside. I.e `latex(f(x)**2)` defaults to `f(x)^2` now.
<!-- END RELEASE NOTES -->
