### PR TITLE
sets: fix imageset hanging on periodic functions like tan, cot

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1895,3 +1895,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Akshara Bhardwaj <aksharabhardwaj766@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -252,6 +252,7 @@ Akhil Rajput <akh1lrjput@gmail.com> Akhil Rajput <43316490+akhil-dh1@users.norep
 Akira Kyle <ak@akirakyle.com>
 Akshansh Bhatt <akshansh@tuta.io>
 Akshansh Bhatt <akshansh@tuta.io> <53227127+akshanshbhatt@users.noreply.github.com>
+Akshara Bhardwaj <aksharabhardwaj766@gmail.com>
 Akshat Jain <akshat.jain@students.iiit.ac.in>
 Akshat Maheshwari <akshat14714@gmail.com>
 Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
@@ -1895,4 +1896,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Akshara Bhardwaj <aksharabhardwaj766@gmail.com>

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -15,6 +15,7 @@ from sympy.sets import (imageset, Interval, FiniteSet, Union, ImageSet,
 from sympy.sets.sets import EmptySet, is_function_invertible_in_set
 from sympy.sets.fancysets import Integers, Naturals, Reals
 from sympy.functions.elementary.exponential import match_real_imag
+from sympy.calculus.util import periodicity, function_range
 
 
 _x, _y = symbols("x y")
@@ -68,6 +69,21 @@ def _(f, x):
             if domain_set is S.EmptySet:
                 break
         return result
+
+    period = periodicity(expr, var)
+    if period is not None and (x.is_infinite or (isinstance(x, Interval) and x.measure >= period)):
+        # case 1 - function has singularities in one period
+        period_interval = Interval(0, period, right_open=True)
+        sing_ = singularities(expr, var, period_interval)
+        if sing_ != S.EmptySet:
+            return S.Reals
+        # case 2 - if no singularities compute actual range over one period
+        try:
+            one_period_image = function_range(expr, var, period_interval)
+            if one_period_image != S.EmptySet:
+                return one_period_image.closure
+        except NotImplementedError:
+            pass # fall through to existing logic if range cannot be determined
 
     if not x.start.is_comparable or not x.end.is_comparable:
         return

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -11,7 +11,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.functions.elementary.trigonometric import (cos, sin)
+from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.logic.boolalg import (false, true)
 from sympy.matrices.kind import MatrixKind
 from sympy.matrices.dense import Matrix
@@ -1801,3 +1801,13 @@ def test_issue_24726():
     expected_case_6 = Union(ImageSet(Lambda(n, 2*n*pi + 4*pi), Range(0, oo, 1)),
                             ImageSet(Lambda(n, 2*n*pi + 5*pi), Range(0, oo, 1)))
     assert sin_zeros.intersect(Interval(10, oo)).dummy_eq(expected_case_6)
+
+def test_imageset_periodic():
+    # issue #29675 - imageset on periodic functions with infinite singularities
+    # should return the correct image over one period instead of hanging
+    x = Symbol('x', real=True)
+    assert imageset(x, tan(x), S.Reals) == S.Reals
+    assert imageset(x, cot(x), S.Reals) == S.Reals
+    assert imageset(x, tan(x), Interval(-100, 100)) == S.Reals
+    assert imageset(x, sin(x), S.Reals) == Interval(-1, 1)
+    assert imageset(x, cos(x), S.Reals) == Interval(-1, 1)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed ``imageset`` hanging indefinitely on periodic functions like ``tan`` and ``cot``
<!-- END RELEASE NOTES -->

Fixes #29675

Brief Description of what is fixed or changed -
For periodic functions imageset now returns S.reals - if singularities exist. Else it returns function range over that period, this prevents infinite loop for functions like tan(x) and cot(x) and returns correct value for intervals of sin(x) and cos(x).

Other Comments - 
Handles periodic functions with singularities - tan(x) and cot(x) - returns S.Reals
Bounded periodic functions like - sin(x) and cos(x) - returns function range
Also handles finite intervals containing at least one full period.

AI Generation Disclosure - 
Partially