### PR TITLE
Make sure pickled tensors compare as equal to the original

### DIFF
--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -951,14 +951,14 @@ def get_symmetric_group_sgs(n, antisym=False):
     ([0, 1], [(4)(0 1), (4)(1 2)])
     """
     if n == 1:
-        return [], [_af_new(list(range(3)))]
+        return [], [Permutation(list(range(3)))]
     gens = [Permutation(n - 1)(i, i + 1)._array_form for i in range(n - 1)]
     if antisym == 0:
         gens = [x + [n, n + 1] for x in gens]
     else:
         gens = [x + [n + 1, n] for x in gens]
     base = list(range(n - 1))
-    return base, [_af_new(h) for h in gens]
+    return base, [Permutation(h) for h in gens]
 
 riemann_bsgs = [0, 2], [Permutation(0, 1)(4, 5), Permutation(2, 3)(4, 5),
                         Permutation(5)(0, 2)(1, 3)]

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -211,9 +211,20 @@ def test_Singletons():
 
 #================== combinatorics ===================
 from sympy.combinatorics.free_groups import FreeGroup
+from sympy.combinatorics.permutations import Permutation
 
 def test_free_group():
     check(FreeGroup("x, y, z"), check_attr=False)
+
+def test_Permutation():
+    #fails with check_attr=True because Permutation uses attributes to cache properties (e.g. _cyclic_form)
+    check(Permutation([0,3,2,1,4]), check_attr=False, check_eq=True)
+
+    p = Permutation(S(2))(0,1)
+    check(p, check_attr=False, check_eq=True)
+
+    p2 = Permutation(p.array_form + [S(4),S(3)])
+    check(p2, check_attr=False, check_eq=True)
 
 #================== functions ===================
 from sympy.functions import (Piecewise, lowergamma, acosh, chebyshevu,

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -48,7 +48,7 @@ dont_check_attrs = {
 }
 
 
-def check(a, exclude=[], check_attr=True, deprecated=()):
+def check(a, exclude=[], check_attr=True, deprecated=(), check_eq=False):
     """ Check that pickling and copying round-trips.
     """
     # Pickling with protocols 0 and 1 is disabled for Basic instances:
@@ -77,6 +77,9 @@ def check(a, exclude=[], check_attr=True, deprecated=()):
         d1 = dir(a)
         d2 = dir(b)
         assert set(d1) == set(d2)
+
+        if check_eq:
+            assert a == b
 
         if not check_attr:
             continue

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -714,6 +714,33 @@ def test_deprecation_warning():
 def test_issue_18438():
     assert pickle.loads(pickle.dumps(S.Half)) == S.Half
 
+#================= tensor ======================
+import sympy.tensor.tensor as tens
+from sympy.combinatorics.tensor_can import get_symmetric_group_sgs
+
+def test_get_symmetric_group_sgs():
+    base, sgs = get_symmetric_group_sgs(S(3), antisym=True)
+    check(base, check_attr=False, check_eq=True)
+    check(sgs, check_attr=False, check_eq=True)
+
+def test_TensorSymmetry():
+    t = tens.TensorSymmetry.fully_symmetric(-S(3))
+    check(t, check_attr=False, check_eq=True)
+
+def test_TensorHead():
+    R3 = tens.TensorIndexType("R", dim=3)
+    check(R3.epsilon, check_attr=False, check_eq=True)
+
+def test_TensorHead_2():
+    R3 = tens.TensorIndexType("R", dim=3)
+    K = tens.TensorHead("K", [R3,R3,R3])
+    check(K, check_attr=False, check_eq=True)
+
+def test_epsilon():
+    R3 = tens.TensorIndexType("R", dim=3)
+    i, j, k = tens.tensor_indices("i j k", R3)
+
+    check(R3.epsilon(i,j,k), check_attr=False, check_eq=True)
 
 #================= old pickles =================
 def test_unpickle_from_older_versions():

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -220,13 +220,13 @@ def test_free_group():
 
 def test_Permutation():
     #fails with check_attr=True because Permutation uses attributes to cache properties (e.g. _cyclic_form)
-    check(Permutation([0,3,2,1,4]), check_attr=False, check_eq=True)
+    check(Permutation([0,3,2,1,4]), check_attr=False)
 
     p = Permutation(S(2))(0,1)
-    check(p, check_attr=False, check_eq=True)
+    check(p, check_attr=False)
 
     p2 = Permutation(p.array_form + [S(4),S(3)])
-    check(p2, check_attr=False, check_eq=True)
+    check(p2, check_attr=False)
 
 #================== functions ===================
 from sympy.functions import (Piecewise, lowergamma, acosh, chebyshevu,
@@ -736,27 +736,27 @@ from sympy.combinatorics.tensor_can import get_symmetric_group_sgs
 
 def test_get_symmetric_group_sgs():
     base, sgs = get_symmetric_group_sgs(S(3), antisym=True)
-    check(base, check_attr=False, check_eq=True)
-    check(sgs, check_attr=False, check_eq=True)
+    check(base, check_attr=False)
+    check(sgs, check_attr=False)
 
 def test_TensorSymmetry():
     t = tens.TensorSymmetry.fully_symmetric(-S(3))
-    check(t, check_attr=False, check_eq=True)
+    check(t, check_attr=False)
 
 def test_TensorHead():
     R3 = tens.TensorIndexType("R", dim=3)
-    check(R3.epsilon, check_attr=False, check_eq=True)
+    check(R3.epsilon, check_attr=False)
 
 def test_TensorHead_2():
     R3 = tens.TensorIndexType("R", dim=3)
     K = tens.TensorHead("K", [R3,R3,R3])
-    check(K, check_attr=False, check_eq=True)
+    check(K, check_attr=False)
 
 def test_epsilon():
     R3 = tens.TensorIndexType("R", dim=3)
     i, j, k = tens.tensor_indices("i j k", R3)
 
-    check(R3.epsilon(i,j,k), check_attr=False, check_eq=True)
+    check(R3.epsilon(i,j,k), check_attr=False)
 
 #================= old pickles =================
 def test_unpickle_from_older_versions():

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -111,8 +111,10 @@ def check(a, exclude=[], check_attr=True, deprecated=(), check_eq=False):
 
 
 def test_core_basic():
-    for c in (Atom, Atom(), Basic, Basic(), SingletonRegistry, S):
+    for c in (Atom, Atom(), Basic, Basic(), SingletonRegistry):
         check(c)
+
+    check(S, check_eq=False)
 
 def test_core_Str():
     check(Str('x'))
@@ -191,8 +193,8 @@ def test_core_interval():
 
 
 def test_core_multidimensional():
-    for c in (vectorize, vectorize(0)):
-        check(c)
+    check(vectorize)
+    check(vectorize(0), check_eq=False)
 
 
 def test_Singletons():
@@ -311,8 +313,8 @@ from sympy.ntheory.generate import Sieve
 
 
 def test_ntheory():
-    for c in (Sieve, Sieve()):
-        check(c)
+    check(Sieve)
+    check(Sieve(), check_eq=False)
 
 #================== physics =====================
 from sympy.physics.paulialgebra import Pauli
@@ -579,70 +581,71 @@ def test_pickling_polys_errors():
     # for c in (OperationNotSupported, OperationNotSupported(Poly(x), Poly.gcd)):
     #    check(c)
 
-    for c in (HeuristicGCDFailed, HeuristicGCDFailed()):
-        check(c)
+    check(HeuristicGCDFailed)
+    check(HeuristicGCDFailed, check_eq=False)
 
-    for c in (HomomorphismFailed, HomomorphismFailed()):
-        check(c)
+    check(HomomorphismFailed)
+    check(HomomorphismFailed(), check_eq=False)
 
-    for c in (IsomorphismFailed, IsomorphismFailed()):
-        check(c)
+    check(IsomorphismFailed)
+    check(IsomorphismFailed(), check_eq=False)
 
-    for c in (ExtraneousFactors, ExtraneousFactors()):
-        check(c)
+    check(ExtraneousFactors)
+    check(ExtraneousFactors(), check_eq=False)
 
-    for c in (EvaluationFailed, EvaluationFailed()):
-        check(c)
+    check(EvaluationFailed)
+    check(EvaluationFailed(), check_eq=False)
 
-    for c in (RefinementFailed, RefinementFailed()):
-        check(c)
+    check(RefinementFailed)
+    check(RefinementFailed(), check_eq=False)
 
-    for c in (CoercionFailed, CoercionFailed()):
-        check(c)
+    check(CoercionFailed)
+    check(CoercionFailed(), check_eq=False)
 
-    for c in (NotInvertible, NotInvertible()):
-        check(c)
+    check(NotInvertible)
+    check(NotInvertible(), check_eq=False)
 
-    for c in (NotReversible, NotReversible()):
-        check(c)
+    check(NotReversible)
+    check(NotReversible(), check_eq=False)
 
-    for c in (NotAlgebraic, NotAlgebraic()):
-        check(c)
+    check(NotAlgebraic)
+    check(NotAlgebraic(), check_eq=False)
 
-    for c in (DomainError, DomainError()):
-        check(c)
+    check(DomainError)
+    check(DomainError(), check_eq=False)
 
-    for c in (PolynomialError, PolynomialError()):
-        check(c)
+    check(PolynomialError)
+    check(PolynomialError(), check_eq=False)
 
-    for c in (UnificationFailed, UnificationFailed()):
-        check(c)
+    check(UnificationFailed)
+    check(UnificationFailed(), check_eq=False)
 
-    for c in (GeneratorsError, GeneratorsError()):
-        check(c)
+    check(GeneratorsError)
+    check(GeneratorsError(), check_eq=False)
 
-    for c in (GeneratorsNeeded, GeneratorsNeeded()):
-        check(c)
+    check(GeneratorsNeeded)
+    check(GeneratorsNeeded(), check_eq=False)
 
     # TODO: PicklingError: Can't pickle <function <lambda> at 0x38578c0>: it's not found as __main__.<lambda>
     # for c in (ComputationFailed, ComputationFailed(lambda t: t, 3, None)):
     #    check(c)
 
-    for c in (UnivariatePolynomialError, UnivariatePolynomialError()):
-        check(c)
+    check(UnivariatePolynomialError)
+    check(UnivariatePolynomialError(), check_eq=False)
 
-    for c in (MultivariatePolynomialError, MultivariatePolynomialError()):
-        check(c)
+    check(MultivariatePolynomialError)
+    check(MultivariatePolynomialError(), check_eq=False)
 
     # TODO: TypeError: __init__() takes at least 3 arguments (1 given)
     # for c in (PolificationFailed, PolificationFailed({}, x, x, False)):
     #    check(c)
 
-    for c in (OptionError, OptionError()):
-        check(c)
+    check(OptionError)
+    check(OptionError(), check_eq=False)
 
-    for c in (FlagError, FlagError()):
-        check(c)
+
+    check(FlagError)
+    check(FlagError(), check_eq=False)
 
 #def test_pickling_polys_options():
     #from sympy.polys.polyoptions import Options
@@ -677,11 +680,13 @@ from sympy.printing.python import PythonPrinter
 
 
 def test_printing():
-    for c in (LatexPrinter, LatexPrinter(), MathMLContentPrinter,
+    for c in (LatexPrinter, MathMLContentPrinter,
               MathMLPresentationPrinter, PrettyPrinter, prettyForm, stringPict,
-              stringPict("a"), Printer, Printer(), PythonPrinter,
-              PythonPrinter()):
+              stringPict("a"), Printer, PythonPrinter):
         check(c)
+
+    for c in (LatexPrinter(), Printer(), PythonPrinter()):
+        check(c, check_eq=False)
 
 
 @XFAIL
@@ -695,7 +700,7 @@ def test_printing2():
 
 
 def test_printing3():
-    check(PrettyPrinter())
+    check(PrettyPrinter(), check_eq=False)
 
 #================== series ======================
 from sympy.series.limits import Limit

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -48,7 +48,7 @@ dont_check_attrs = {
 }
 
 
-def check(a, exclude=[], check_attr=True, deprecated=(), check_eq=False):
+def check(a, exclude=[], check_attr=True, deprecated=(), check_eq=True):
     """ Check that pickling and copying round-trips.
     """
     # Pickling with protocols 0 and 1 is disabled for Basic instances:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Supersedes #29701

#### Brief description of what is fixed or changed

Certain tensors were comparing as unequal to the original after being loaded from a pickle:
```
IPython console for SymPy 1.14.0 (Python 3.14.4-64-bit) (ground types: gmpy)

These commands were executed:
>>> from sympy import *
>>> x, y, z, t = symbols('x y z t')
>>> k, m, n = symbols('k m n', integer=True)
>>> f, g, h = symbols('f g h', cls=Function)
>>> init_printing()

Documentation can be found at https://docs.sympy.org/1.14.0/


In [1]: from sympy import *

In [2]: import sympy.tensor.tensor as tens

In [3]: R3 = tens.TensorIndexType("R", dim=3)

In [4]: i, j, k = tens.tensor_indices("i, j, k", R3)

In [5]: expr = R3.epsilon(i,j,k)

In [6]: import pickle

In [7]: with open("tmp.pickle", 'wb') as f:
   ...:     pickle.dump(expr, f)
   ...: 

In [8]: with open("tmp.pickle", 'rb') as f:
   ...:     expr_2 = pickle.load(f)
   ...: 

In [9]: expr
Out[9]: 
   ijk
Eps   
      

In [10]: expr_2
Out[10]: 
   ijk
Eps   
      

In [11]: expr == expr_2
Out[11]: False
```
With the changes in this PR, the last equality above returns True. I have added this as a test.

#### Other comments

1. The root cause was that `tensor_can.py/get_symmetric_group_sgs` was internally calling the constructor `Permutation._af_new` rather than `Permutation.__new__`. Since it is `__new__` that is called during the unpickling process, this was leading to differences in the types of the elements in `Permutation._array_form` (int vs Integer), leading to `Basic.__eq__` considering the reconstructed object as unequal to the original one.

2. It does seem fishy to me that `Basic.__eq__` explicitly checks types for equality
https://github.com/sympy/sympy/blob/53a2ded8a512c9652482e603fe2ea4a73329091a/sympy/core/basic.py#L541
This was added in commit c388adb0ff3dbbb1906b510411ae6494a564407a (#22651) to handle `Expr` objects. Should it be guarded behind, say, `if isinstance(self, Expr)`?

3. In `tensor_can.py`, many other internal methods/attributes are called (`_af_new`, `_array_form`). I have not touched them for now.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
