### PR TITLE
Wrap TableForm LaTeX output in text{} for math-mode compatibility

### DIFF
--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -364,4 +364,4 @@ class TableForm:
                 d = [self._headings[0][i]] + d
             s += " & ".join(d) + r" \\" + "\n"
         s += r"\end{tabular}"
-        return s
+        return r"\text{" + s + "}"

--- a/sympy/printing/tests/test_tableform.py
+++ b/sympy/printing/tests/test_tableform.py
@@ -104,7 +104,7 @@ def test_TableForm():
 def test_TableForm_latex():
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic")))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
@@ -112,10 +112,10 @@ def test_TableForm_latex():
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
         '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic"), alignments='l'))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
@@ -123,10 +123,10 @@ def test_TableForm_latex():
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
         '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"
     s = latex(TableForm([[0, x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             wipe_zeros=True, headings=("automatic", "automatic"), alignments='l'*3))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{l l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
@@ -134,10 +134,10 @@ def test_TableForm_latex():
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
         '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             headings=("automatic", "automatic")))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
@@ -145,10 +145,10 @@ def test_TableForm_latex():
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
         '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]],
             formats=['(%s)', None], headings=("automatic", "automatic")))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
@@ -156,7 +156,7 @@ def test_TableForm_latex():
         '2 & (c) & $\\frac{1}{4}$ \\\\\n'
         '3 & (sqrt(x)) & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"
 
     def neg_in_paren(x, i, j):
         if i % 2:
@@ -165,19 +165,19 @@ def test_TableForm_latex():
             pass  # use default print
     s = latex(TableForm([[-1, 2], [-3, 4]],
             formats=[neg_in_paren]*2, headings=("automatic", "automatic")))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{r l l}\n'
         ' & 1 & 2 \\\\\n'
         '\\hline\n'
         '1 & -1 & 2 \\\\\n'
         '2 & (-3) & 4 \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"
     s = latex(TableForm([["a", x**3], ["c", S.One/4], [sqrt(x), sin(x**2)]]))
-    assert s == (
+    assert s == r"\text{" + (
         '\\begin{tabular}{l l}\n'
         '$a$ & $x^{3}$ \\\\\n'
         '$c$ & $\\frac{1}{4}$ \\\\\n'
         '$\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
-    )
+    ) + "}"


### PR DESCRIPTION
## Summary

The _latex method on TableForm returns a tabular environment which is text-mode LaTeX. When used inside math mode (e.g., latex([t])), this produces invalid output where backslash left and backslash right are math-mode only but the tabular content is in text mode.

## Fix

Wrap the tabular output in backslash text{...} so it renders correctly within math-mode contexts. This is the standard approach for embedding text-mode content inside math mode in LaTeX (requires amsmath, which is already assumed by SymPy's latex printer).

**Changes:** 1 line in tableform.py, test assertions updated accordingly.

Fixes #20063