### PR TITLE
Adds .coeff() method to MatrixBase.

### DIFF
--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3867,6 +3867,63 @@ class MatrixBase(Printable):
         # computing the Jacobian is now easy:
         return self._new(m, n, lambda j, i: self[j].diff(X[i]))
 
+    def coeff(self, X):
+        """Extracts the coefficients of the provided expressions into a linear
+        coefficient matrix.
+
+        Parameters
+        ==========
+        self : Matrix, shape(m, 1) or Matrix, shape(1, m)
+            Vector of expressions representing functions ``f_i(x_1, ..., x_n)``
+            for ``i=1, ..., m``.
+        X : iterable of Expr
+            The ``x_i``'s in order. Matrices of shape (n, 1) or (1, n) are
+            acceptable.
+
+        Examples
+        ========
+
+        >>> from sympy import sin, cos, Matrix
+        >>> from sympy.abc import a, b, c, x, y, rho, phi
+        >>> X = Matrix([rho*cos(phi), rho*sin(phi), phi*rho**2])
+        >>> Y = Matrix([rho, phi])
+        >>> X.coeff(Y)
+        Matrix([
+        [cos(phi),      0],
+        [sin(phi),      0],
+        [       0, rho**2]])
+        >>> F = Matrix([a*x + b*y + a*c, b*x + b*c])
+        >>> F.coeff([x, y])
+        Matrix([
+        [a, b],
+        [b, 0]])
+
+        See Also
+        ========
+
+        Expr.coeff
+        Matrix.jacobian
+
+        """
+        if not isinstance(X, MatrixBase):
+            X = self._new(X)
+
+        if self.shape[0] == 1:
+            m = self.shape[1]
+        elif self.shape[1] == 1:
+            m = self.shape[0]
+        else:
+            raise TypeError("The matrix must be a row or a column matrix.")
+
+        if X.shape[0] == 1:
+            n_ = X.shape[1]
+        elif X.shape[1] == 1:
+            n_ = X.shape[0]
+        else:
+            raise TypeError("X must be a row or a column matrix")
+
+        return self._new(m, n_, lambda j, i: self[j].coeff(X[i]))
+
     def limit(self, x: Expr, xlim: Expr, dir: str = '+') -> Self:
         """Calculate the limit of each element in the matrix.
         ``args`` will be passed to the ``limit`` function.

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3901,8 +3901,8 @@ class MatrixBase(Printable):
         See Also
         ========
 
-        Expr.coeff
-        Matrix.jacobian
+        coeff
+        jacobian
 
         """
         if not isinstance(X, MatrixBase):

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -2186,6 +2186,25 @@ def test_jacobian2():
     assert X.jacobian(Y) == J
 
 
+def test_coeff():
+    rho, phi = symbols("rho, phi")
+    X = Matrix([rho*cos(phi), rho*sin(phi), phi*rho**2])
+    Y = Matrix([rho, phi])
+    J = Matrix([
+        [cos(phi), 0],
+        [sin(phi), 0],
+        [0, rho**2],
+    ])
+    assert X.coeff(Y) == J
+    Y = Matrix([rho**2, phi*rho])
+    J = Matrix([
+        [0, 0],
+        [0, 0],
+        [phi, 0],
+    ])
+    assert X.coeff(Y) == J
+
+
 def test_issue_4564():
     X = Matrix([exp(x + y + z), exp(x + y + z), exp(x + y + z)])
     Y = Matrix([x, y, z])


### PR DESCRIPTION
The MatrixBase.coeff() calls Expr.coeff() on each element of the column matrix, producing a linear coefficient matrix. It follows the same pattern as MatrixBase.jacobian(). This may be useful for extracting linear coefficients of vector functions.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Adds a `.coeff()` method to Matrices that uses `Expr.coeff()` and follows the pattern of `.jacobian()`.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

No AI used.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Added a `.coeff()` method to `Matrix` for extraction of linear coefficients in vector functions.

<!-- END RELEASE NOTES -->
