### PR TITLE
[DON'T MERGE]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1744,6 +1744,7 @@ Yaser AlOsh <yaseralosh@outlook.com> Yaser <yaseralosh@outlook.com>
 Yash Reddy <write2yashreddy@gmail.com>
 Yathartha Joshi <yathartha32@gmail.com>
 Yatna Verma <yatnavermaa@gmail.com> yatna <yatnavermaa@gmail.com>
+Ycw <3833985033@qq.com>
 Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
 Yeshwanth N <yeshsurya@gmail.com> <yeshwanth.nagaraj@aptean.com>
 YiDing Jiang <yidinggjiangg@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1745,6 +1745,7 @@ Yash Reddy <write2yashreddy@gmail.com>
 Yathartha Joshi <yathartha32@gmail.com>
 Yatna Verma <yatnavermaa@gmail.com> yatna <yatnavermaa@gmail.com>
 Ycw <3833985033@qq.com>
+Ycw <3833985033@qq.com> <240279819+11350613@users.noreply.github.com>
 Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
 Yeshwanth N <yeshsurya@gmail.com> <yeshwanth.nagaraj@aptean.com>
 YiDing Jiang <yidinggjiangg@gmail.com>

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -464,6 +464,7 @@ def prde_cancel_liouvillian(b, Q, n, DE):
 
     # Why use DecrementLevel? Below line answers that:
     # Assuming that we can solve such problems over 'k' (not k[t])
+    ba = bd = None
     if DE.case == 'primitive':
         with DecrementLevel(DE):
             ba, bd = frac_in(b, DE.t, field=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None


#### Brief description of what is fixed or changed
Resolves pylint warning (possibly-used-before-assignment). No functional change.

#### Other comments
None

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
The code change was written manually.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
