### PR TITLE
parsing: Fix implicit multiplication after superscript in Lark parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -942,6 +942,7 @@ Kenneth Emeka Odoh <kenneth.odoh@gmail.com>
 Kenneth Lyons <ixjlyons@gmail.com>
 Keno Goertz <keno@goertz-berlin.com>
 Keval Shah <kevalshah_96@yahoo.co.in>
+Kevin Dai <89949771+K1ngHungry@users.noreply.github.com>
 Kevin Goodsell <kevin-opensource@omegacrash.net>
 Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -215,13 +215,14 @@ add: _expression ADD _expression_mul
     | ADD _expression_mul
 sub: _expression SUB _expression_mul
     | SUB _expression_mul
-mul: _expression_mul MUL_SYMBOL _expression_power
-div: _expression_mul DIV_SYMBOL _expression_power
+mul: _expression_mul MUL_SYMBOL (_expression_power | adjacent_expressions)
+div: _expression_mul DIV_SYMBOL (_expression_power | adjacent_expressions)
 
 adjacent_expressions: (_one_letter_symbol | number) _expression_mul
     | (group_round_parentheses | group_square_brackets | group_curly_literal_parentheses) (group_round_parentheses | group_square_brackets | group_curly_parentheses | group_curly_literal_parentheses | _one_letter_symbol)
     | _function _function
     | fraction _expression_mul
+    | superscript _expression_mul
 
 _expression_func: _expression_core
     | group_round_parentheses

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -273,6 +273,14 @@ EVALUATED_POWER_EXPRESSION_PAIRS = [
     (r"180^\circ", pi)
 ]
 
+SUPERSCRIPT_IMPLICIT_MUL_PAIRS = [
+    (r"a^{2}bc",    _Mul(_Pow(a, 2), _Mul(b, c))),
+    (r"a^{2}*bc",   _Mul(_Pow(a, 2), _Mul(b, c))),
+    (r"a^{2}*b*c",  _Mul(_Mul(_Pow(a, 2), b), c)),
+    (r"a^{2}b^{3}", _Mul(_Pow(a, 2), _Pow(b, 3))),
+    (r"2^{3}bc",    _Mul(_Pow(2, 3), _Mul(b, c))),
+]
+
 UNEVALUATED_INTEGRAL_EXPRESSION_PAIRS = [
     (r"\int x dx", Integral(_Mul(1, x), x)),
     (r"\int x \, dx", Integral(_Mul(1, x), x)),
@@ -779,6 +787,12 @@ def test_power_expressions():
         if i in expected_failures:
             continue
         assert parse_latex_lark(latex_str) == sympy_expr, latex_str
+
+
+def test_superscript_implicit_multiplication():
+    for latex_str, sympy_expr in SUPERSCRIPT_IMPLICIT_MUL_PAIRS:
+        with evaluate(False):
+            assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
 
 def test_integral_expressions():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29663


#### Brief description of what is fixed or changed

Fixed two bugs in the Lark parser where implicit multiplication after a superscript expression raised an UnexpectedCharacters error.

For example, 
- a^{2}bc failed because adjacent_expressions had no alternative for superscript as the left operand.
- a^{2}*bc failed because mul and div required _expression_power on the right-hand side, which excludes valid adjacent_expressions.
The fix adds superscript _expression_mul as an additional case in adjacent_expressions, and allows the right-hand side of mul and div to also accept adjacent_expressions.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used AI to help me understand the lark parser syntax. The fix and test cases were written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Fixed a bug in the lark LaTeX parser where implicit multiplication
    after a superscript expression raised an UnexpectedCharacters error.

<!-- END RELEASE NOTES -->
