### PR TITLE
polys: Canonicalized dmp_mul_ground(0) and added zero shape regressions

### DIFF
--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -298,6 +298,9 @@ def dmp_mul_ground(f: dmp[Er], c: Er, u: int, K: Domain[Er]) -> dmp[Er]:
     if not u:
         return _dmp(dup_mul_ground(_dup(f), c, K))
 
+    if not c:
+        return dmp_zero(u, K)
+
     v = u - 1
 
     return [ dmp_mul_ground(cf, c, v, K) for cf in f ]

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -190,6 +190,8 @@ def test_dup_mul_ground():
 
 
 def test_dmp_mul_ground():
+    assert dmp_mul_ground(f_0, ZZ(0), 2, ZZ) == [[[]]]
+
     assert dmp_mul_ground(f_0, ZZ(2), 2, ZZ) == [
         [[ZZ(2), ZZ(4), ZZ(6)], [ZZ(4)]],
         [[ZZ(6)]],

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -740,6 +740,12 @@ def test_Poly_mul_ground():
     assert Poly(x + 1).mul_ground(2) == Poly(2*x + 2)
 
 
+def test_Poly_rep_mul_zero_is_zero():
+    # issue 29715
+    p = Poly(x**4 + y, x, y)
+    assert (p.rep * 0).is_zero is True
+
+
 def test_Poly_quo_ground():
     assert Poly(2*x + 4).quo_ground(2) == Poly(x + 2)
     assert Poly(2*x + 3).quo_ground(2) == Poly(x + 1)
@@ -1662,6 +1668,10 @@ def test_Poly_diff():
 
     assert Poly(x**2*y**2 + x*y).diff(x, y) == Poly(4*x*y + 1)
     assert Poly(x**2*y**2 + x*y).diff(y, x) == Poly(4*x*y + 1)
+
+    p = Poly(x**7*y**5 + 2*x**7*y**4 + x**2, x, y, z, modulus=7)
+    assert p.diff() == Poly(2*x, x, y, z, modulus=7)
+    assert p.diff().gcd(p) == Poly(x, x, y, z, modulus=7)
 
 
 def test_issue_9585():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29715
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Multiplying a multivariate dense polynomial by ground zero in `dmp_mul_ground()` could return noncanonical nested zero lists. Those shapes are not always recognized by `dmp_zero_p()`, so they can survive `dmp_strip()` and leak into later algos.

In practice this showed up in `FF` differentiation where degree factors become `0 mod p`. The derivative could carry malformed leading coefficients and `gcd()` could then fail with `ZeroDivisionError`.

Fixed this by short circuiting `dmp_mul_ground()` to return `dmp_zero(u, K)` when `c == 0` for `u > 0`.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE 

(Subject to change since I have been using AI to write tests, a newcomer seems interested in this issue so will ask them to suggest some tests for this patch, if not provided with viable tests, I'll use AI assistance to write tests for this PR, even though the patch made here is minor.)

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed bug in `dmp_mul_ground` that caused production of noncanonical zero when 
     the multiplier is zero in a FF. 
<!-- END RELEASE NOTES -->
