### PR TITLE
Add tests for LaTeX trig parsing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1754,6 +1754,7 @@ Yerniyaz <yerniyaz.nurgabylov@nu.edu.kz>
 Yeshwanth N <yeshsurya@gmail.com> <yeshwanth.nagaraj@aptean.com>
 YiDing Jiang <yidinggjiangg@gmail.com>
 Yicong Guo <guoyicong100@gmail.com>
+Yiming Shao <yimings2@andrew.cmu.edu>
 Yogesh Mishra <ymishra013@gmail.com> yogesh1997 <ymishra013@gmail.com>
 Your Name <your.email@example.com>
 Yu Kobayashi <yukoba@accelart.jp>

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -16,7 +16,8 @@ from sympy.functions.elementary.complexes import (Abs, conjugate)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.integers import (ceiling, floor)
 from sympy.functions.elementary.miscellaneous import (root, sqrt)
-from sympy.functions.elementary.trigonometric import (asin, cos, csc, sec, sin, tan)
+from sympy.functions.elementary.trigonometric import (
+    acos, asin, atan, cos, csc, sec, sin, tan)
 from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 
@@ -129,7 +130,13 @@ GOOD_PAIRS = [
     (r"| x \rangle", Ket('x')),
     (r"\sin \theta", sin(theta)),
     (r"\sin(\theta)", sin(theta)),
+    (r"\sin^{2}(x)", sin(x)**2),
+    (r"\cos^{2}(x)", cos(x)**2),
+    (r"\tan^{2}(x)", tan(x)**2),
     (r"\sin^{-1} a", asin(a)),
+    (r"\arcsin(x)", asin(x)),
+    (r"\arccos(x)", acos(x)),
+    (r"\arctan(x)", atan(x)),
     (r"\sin a \cos b", _Mul(sin(a), cos(b))),
     (r"\sin \cos \theta", sin(cos(theta))),
     (r"\sin(\cos \theta)", sin(cos(theta))),


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #25366

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR adds ANTLR LaTeX parser coverage for common trigonometric forms that were missing from GOOD_PAIRS. The new cases check squared sin, cos, and tan expressions, plus the explicit inverse trig commands.

This is limited to test coverage only and does not change parser behavior.

#### Other comments
None
#### AI Generation Disclosure
Used Codex (GPT-5) to help format test entries and run verification. 

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
