### PR TITLE
Added hyperbolic tests sinh, cosh, tanh for ANTLR LaTeX parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1598,6 +1598,7 @@ Sudeep Sidhu <sudeepmanilsidhu@gmail.com> sidhu1012 <sudeepmanilsidhu@gmail.com>
 Sudhanshu Mishra <mrsud94@gmail.com>
 Sujal Kumar <sujaljayantkumar06@gmail.com> Sujal Kumar <91939382+SujalKumar06@users.noreply.github.com>
 Suman mondal <smondal.qwerty@gmail.com>
+Sumanth Sura <surastar208@gmail.com>
 Sumit Kumar <mr.sumitkrr@gmail.com> Sumit Kumar <96618001+sumit-158@users.noreply.github.com>
 Sumith Kulal <sumith1896@gmail.com>
 Suneet Mishra <suee.suneet@gmail.com> Avedeva <suee.suneet@gmail.com>

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -17,6 +17,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.integers import (ceiling, floor)
 from sympy.functions.elementary.miscellaneous import (root, sqrt)
 from sympy.functions.elementary.trigonometric import (asin, cos, csc, sec, sin, tan)
+from sympy.functions.elementary.hyperbolic import (sinh, cosh, tanh)
 from sympy.integrals.integrals import Integral
 from sympy.series.limits import Limit
 
@@ -276,7 +277,10 @@ GOOD_PAIRS = [
     (r"\log_2 x", _log(x, 2)),
     (r"\log_a x", _log(x, a)),
     (r"5^0 - 4^0", _Add(_Pow(5, 0), _Mul(-1, _Pow(4, 0)))),
-    (r"3x - 1", _Add(_Mul(3, x), -1))
+    (r"3x - 1", _Add(_Mul(3, x), -1)),
+    (r"\sinh x", sinh(x)),
+    (r"\cosh x", cosh(x)),
+    (r"\tanh x", tanh(x))
 ]
 
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

See #25366 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Added tests for the standard hyperbolic functions $\sinh(x) := \frac{e^x - e^{-x}}2, \cosh(x) := \frac{e^x + e^{-x}}2, \tanh(x) := \frac{\sinh(x)}{\cosh(x)}$ to `GOOD_PAIRS` in `sympy/parsing/tests/test_latex.py`.

The tests were kept to ANTLR and excluded from the Lark parser tests for consistency (there probably wouldn't be any issues with doing so, though, given these functions don't use underscores).

#### Other comments

Some of the other hyperbolic functions were excluded (but for this situation would be probably redundant):

$\coth(x) := \frac1{\tanh(x)}, \textnormal{sech}(x) := \frac1{\cosh(x)}, \textnormal{csch}(x) := \frac1{\sinh(x)}$, as well as the inverse functions $\textnormal{arsinh, arcosh, artanh, arcoth, arsech, arcsch}$.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
