### PR TITLE
Replacing self with pass for better clarity

### DIFF
--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -472,7 +472,7 @@ class SingleFinitePSpace(SinglePSpace, FinitePSpace):
         symbolic dimensions is currently not possible.
         """
         if self._is_symbolic:
-            self
+            pass
         domain = self.where(condition)
         prob = self.probability(condition)
         density = {key: val / prob


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

fixes [#29720](https://github.com/sympy/sympy/issues/29720)


#### Brief description of what is fixed or changed
Removes or replaces the stray self statement that evaluates to nothing and has no effect
Clarifies code intent by replacing it with either pass (if it's intentional to do nothing for symbolic distributions) 
#### Other comments
Impact:

Code cleanliness: removes dead/confusing code
Maintainability: makes the code's actual behavior explicit
No functional change: the method still works the same way since self was already a no-op

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
NO ENTRY
