### PR TITLE
satisfiable: Fix theory backtracking

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -695,3 +695,7 @@ class Level:
         self.decision = decision
         self.var_settings = set()
         self.flipped = flipped
+
+    def __repr__(self):
+        return "<Level decision=%s, flipped=%s, var_settings=%s>" % (
+            self.decision, self.flipped, self.var_settings)

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -435,6 +435,9 @@ class SATSolver:
         (0, {1}, False)
 
         """
+        if len(self.levels) == 1:
+            raise IndexError("Cannot pop base decision level 0.")
+
         # Undo the variable settings
         for lit in self._current_level.var_settings:
             self.var_settings.remove(lit)

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -240,8 +240,16 @@ class SATSolver:
                     else:
                         self._simple_add_learned_clause(res[1])
 
-                        # backtrack until we unassign one of the literals causing the conflict
-                        while not any(-lit in res[1] for lit in self._current_level.var_settings):
+                        # Backtrack until reaching a level with one of the conflict causing literals.
+                        inconsistent_literals = [-lit for lit in res[1]]
+                        while True:
+                            if len(self.levels) == 1:
+                                # If theory-inconsistent literals were set right off the bat
+                                # at level 0, the formula is unsat.
+                                return
+
+                            if any(inconsistent_lit in self._current_level.var_settings for inconsistent_lit in inconsistent_literals):
+                                break
                             self._undo()
 
                     while self._current_level.flipped:

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -418,6 +418,7 @@ def test_z3_vs_lra_dpll2():
 
 
 def test_issue_27733():
+    # original regression
     x, y = symbols('x,y')
     clauses = [[1, -3, -2], [5, 7, -8, -6, -4], [-10, -9, 10, 11, -4], [-12, 13, 14], [-10, 9, -6, 11, -4],
                [16, -15, 18, -19, -17], [11, -6, 10, -9], [9, 11, -10, -9], [2, -3, -1], [-13, 12], [-15, 3, -17],
@@ -429,5 +430,14 @@ def test_issue_27733():
     encoding[Q.gt(x, 0)] = 11
     encoding[Q.lt(x, 0)] = 12
 
+    cnf = EncodedCNF(clauses, encoding)
+    assert satisfiable(cnf, use_lra_theory=True) is False
+
+
+def test_issue_27733_second_fix():
+    # regression for flawed initial fix of issue 27733
+    x0, x1 = symbols('x0 x1')
+    clauses = [[1, 2], [-3, -4]]
+    encoding = {Q.gt(x0, x1): 1, Q.lt(x1, x0): 2, Q.le(x1, x0): 3, Q.ge(x0, x1): 4}
     cnf = EncodedCNF(clauses, encoding)
     assert satisfiable(cnf, use_lra_theory=True) is False


### PR DESCRIPTION
Fix defect in backtracking logic and incorrect comment:
- Check for unsetting *conflict causing* literals rather than
  literals part of conflict clause.
- ~Halt backtracking after unsetting conflict causing literals rather than before. Previously, backtracking halted before one of the literals that needed to be unset got unset.~
- Rewrite comment which falsely claimed backtracking halted after popping a level with a conflict causing literal instead of halting at that level before popping it. Doing what the comment suggested would be incorrect because the flipped level may still need to be explored.

Also, refactor logic for clarity by breaking up two line logic into multiple more explicit steps.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes https://github.com/sympy/sympy/issues/27733

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Most of this PR entirely human written. However, I did use an llm cli tool to help identify what was wrong with this version of this fix (the version before I force pushed). Technically, these lines are AI written:
```python
if any(inconsistent_lit in self._current_level.var_settings for inconsistent_lit in inconsistent_literals):
    break
```

Oh, I forgot to mention earlier that the "satisfiable: Implement __repr__ for Level" commit is entirely AI generated - I just asked the AI to implement a __repr__ method to help with debugging. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* logic
  * Fixed `IndexError` bug with `satisfiable` when `use_lra_theory` was set to True.

<!-- END RELEASE NOTES -->
