### PR TITLE
Add return type annotation to residue() in series/residues.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1479,6 +1479,7 @@ Sanya Khurana <sanya@monica.in>
 Saptarshi Mandal <sapta.iitkgp@gmail.com>
 Saroj Adhikari <adh.saroj@gmail.com>
 Sartaj Singh <singhsartaj94@gmail.com>
+Sarthak Gawai <sarthak.devlog@gmail.com>
 Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -71,7 +71,7 @@ def residue(expr: Expr | complex, x: Symbol, x0: Expr | complex) -> Expr:
         args = s.args
     else:
         args = [s]
-    res: Expr = S.Zero                    
+    res: Expr = S.Zero
     for arg in args:
         c, m = arg.as_coeff_mul(x)
         m = Mul(*m)

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -2,8 +2,9 @@
 This module implements the Residue function and related tools for working
 with residues.
 """
+
 from __future__ import annotations
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
@@ -15,7 +16,8 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
     from sympy.core.symbol import Symbol
 
-@timethis('residue')
+
+@timethis("residue")
 def residue(expr: Expr | complex, x: Symbol, x0: Expr | complex) -> Expr:
     """
     Finds the residue of ``expr`` at the point x=x0.
@@ -54,12 +56,12 @@ def residue(expr: Expr | complex, x: Symbol, x0: Expr | complex) -> Expr:
     # For the definition of a resultant, see section 1.4 (and any
     # previous sections for more review).
 
-    
     from sympy.series.order import Order
     from sympy.simplify.radsimp import collect
-    _expr: Expr = cast("Expr", sympify(expr))
+
+    _expr = sympify(expr)
     if x0 != 0:
-        _expr = cast("Expr", _expr.subs(x, x + x0))
+        _expr = _expr.subs(x, x + x0)
     for n in (0, 1, 2, 4, 8, 16, 32):
         s = _expr.nseries(x, n=n)
         if not s.has(Order) or s.getn() >= 0:
@@ -74,7 +76,7 @@ def residue(expr: Expr | complex, x: Symbol, x0: Expr | complex) -> Expr:
         c, m = arg.as_coeff_mul(x)
         m = Mul(*m)
         if not (m in (S.One, x) or (isinstance(m, Pow) and m.exp.is_Integer)):
-            raise NotImplementedError('term of unexpected form: %s' % m)
-        if m == 1/x:
+            raise NotImplementedError("term of unexpected form: %s" % m)
+        if m == 1 / x:
             res += c
     return res

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -3,19 +3,20 @@ This module implements the Residue function and related tools for working
 with residues.
 """
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sympy.core.mul import Mul
+from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
 
 if TYPE_CHECKING:
     from sympy.core.expr import Expr
-
+    from sympy.core.symbol import Symbol
 
 @timethis('residue')
-def residue(expr, x, x0) -> Expr:
+def residue(expr: Expr | complex, x: Symbol, x0: Expr | complex) -> Expr:
     """
     Finds the residue of ``expr`` at the point x=x0.
 
@@ -53,13 +54,14 @@ def residue(expr, x, x0) -> Expr:
     # For the definition of a resultant, see section 1.4 (and any
     # previous sections for more review).
 
+    
     from sympy.series.order import Order
     from sympy.simplify.radsimp import collect
-    expr = sympify(expr)
+    _expr: Expr = cast("Expr", sympify(expr))
     if x0 != 0:
-        expr = expr.subs(x, x + x0)
+        _expr = cast("Expr", _expr.subs(x, x + x0))
     for n in (0, 1, 2, 4, 8, 16, 32):
-        s = expr.nseries(x, n=n)
+        s = _expr.nseries(x, n=n)
         if not s.has(Order) or s.getn() >= 0:
             break
     s = collect(s.removeO(), x)
@@ -71,7 +73,7 @@ def residue(expr, x, x0) -> Expr:
     for arg in args:
         c, m = arg.as_coeff_mul(x)
         m = Mul(*m)
-        if not (m in (S.One, x) or (m.is_Pow and m.exp.is_Integer)):  # type: ignore
+        if not (m in (S.One, x) or (isinstance(m, Pow) and m.exp.is_Integer)):
             raise NotImplementedError('term of unexpected form: %s' % m)
         if m == 1/x:
             res += c

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -13,7 +13,7 @@ from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
 
 if TYPE_CHECKING:
-    from sympy.core.expr import Expr   
+    from sympy.core.expr import Expr
     from sympy.core.symbol import Symbol
 
 

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -4,6 +4,7 @@ with residues.
 """
 from __future__ import annotations
 
+from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
@@ -11,7 +12,7 @@ from sympy.utilities.timeutils import timethis
 
 
 @timethis('residue')
-def residue(expr, x, x0):
+def residue(expr, x, x0) -> Expr:
     """
     Finds the residue of ``expr`` at the point x=x0.
 
@@ -67,7 +68,7 @@ def residue(expr, x, x0):
     for arg in args:
         c, m = arg.as_coeff_mul(x)
         m = Mul(*m)
-        if not (m in (S.One, x) or (m.is_Pow and m.exp.is_Integer)):
+        if not (m in (S.One, x) or (m.is_Pow and m.exp.is_Integer)):  # type: ignore
             raise NotImplementedError('term of unexpected form: %s' % m)
         if m == 1/x:
             res += c

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -6,6 +6,7 @@ with residues.
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
@@ -13,7 +14,6 @@ from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
 
 if TYPE_CHECKING:
-    from sympy.core.expr import Expr
     from sympy.core.symbol import Symbol
 
 
@@ -71,7 +71,7 @@ def residue(expr: Expr | complex, x: Symbol, x0: Expr | complex) -> Expr:
         args = s.args
     else:
         args = [s]
-    res = S.Zero
+    res: Expr = S.Zero                    
     for arg in args:
         c, m = arg.as_coeff_mul(x)
         m = Mul(*m)

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -3,12 +3,15 @@ This module implements the Residue function and related tools for working
 with residues.
 """
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
-from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 @timethis('residue')

--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -6,7 +6,6 @@ with residues.
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
-from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.singleton import S
@@ -14,6 +13,7 @@ from sympy.core.sympify import sympify
 from sympy.utilities.timeutils import timethis
 
 if TYPE_CHECKING:
+    from sympy.core.expr import Expr   
     from sympy.core.symbol import Symbol
 
 


### PR DESCRIPTION
Add return type annotation to residue() in series/residues.py

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #28806 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Added a -> Expr return type annotation to the residue() function in 
sympy/series/residues.py. Also added the Expr import at the top of 
the file. While doing this, mypy flagged a pre-existing issue on 
line 71 where Mul.exp is accessed, so I added a # type: ignore 
comment there to keep things clean.


#### Other comments

This is my first open source contribution! Happy to make changes 
based on any feedback.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.
DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
