### PR TITLE
Fix inconsistency between __eq__ and __hash__ in sets.ordinals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1284,6 +1284,7 @@ Pierre Haessig <pierre.haessig@crans.org>
 Pieter Eendebak <pieter.eendebak@gmail.com>
 Pieter Gijsbers <p.gijsbers@tue.nl>
 Piotr Korgul <p.korgul@gmail.com>
+Piyush Bhakuni <bhakunipiyush23@gmail.com> <bhakunipiyush23@gmail.com>
 Pontus von Brömssen <pontus.vonbromssen+github@gmail.com> <118356995+Pontus-vB@users.noreply.github.com>
 Poom Chiarawongse <eight1911@gmail.com> <15707729+Eight1911@users.noreply.github.com>
 Poom Chiarawongse <eight1911@gmail.com> <Eight1911@users.noreply.github.com>

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -143,11 +143,11 @@ class Ordinal(Basic):
         return self.terms == other.terms
 
     def __hash__(self) -> int:
-        if len(self.args)==0:
+        if len(self.terms)==0:
             return hash(0)
-        if len(self.args)==1 and self.args[0].exp==ord0:
-            return hash(int(self.args[0].mult))
-        return hash(self.args)
+        if len(self.terms)==1 and self.terms[0].exp==ord0:
+            return hash(int(self.terms[0].mult))
+        return hash(self.terms)
 
     def __lt__(self, other: Ordinal | Integer | int) -> bool:
         if not isinstance(other, Ordinal):

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -47,6 +47,8 @@ class OmegaPower(Basic):
         return self.args == other.args
 
     def __hash__(self) -> int:
+        if self.exp==ord0:
+            return hash(int(self.mult))
         return Basic.__hash__(self)
 
     def __lt__(self, other: OmegaPower | Integer | int) -> bool:
@@ -141,6 +143,10 @@ class Ordinal(Basic):
         return self.terms == other.terms
 
     def __hash__(self) -> int:
+        if len(self.args)==0:
+            return hash(0)
+        if len(self.args)==1 and self.args[0].exp==ord0:
+            return hash(int(self.args[0].mult))
         return hash(self.args)
 
     def __lt__(self, other: Ordinal | Integer | int) -> bool:

--- a/sympy/sets/tests/test_ordinals.py
+++ b/sympy/sets/tests/test_ordinals.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sympy.sets.ordinals import Ordinal, OmegaPower, ord0, omega
+from sympy.sets.ordinals import Ordinal, OmegaPower, ord0, omega, OrdinalOmega
 from sympy.testing.pytest import raises
 
 def test_string_ordinals():
@@ -76,3 +76,7 @@ def test_hash_consistency():
     assert hash(b)==hash(5)
     assert ord0==0
     assert hash(ord0)==hash(0)
+    o=OrdinalOmega()
+    r=Ordinal(OmegaPower(1,1))
+    assert o==r
+    assert hash(o)==hash(r)

--- a/sympy/sets/tests/test_ordinals.py
+++ b/sympy/sets/tests/test_ordinals.py
@@ -66,3 +66,13 @@ def test_comapre_not_instance():
 def test_is_successort():
     w = Ordinal(OmegaPower(5, 1))
     assert not w.is_successor_ordinal
+
+def test_hash_consistency():
+    a=Ordinal.convert(5)
+    assert a==5
+    assert hash(a)==hash(5)
+    b=OmegaPower(0,5)
+    assert b==5
+    assert hash(b)==hash(5)
+    assert ord0==0
+    assert hash(ord0)==hash(0)


### PR DESCRIPTION
OmegaPower and Ordinal had custom __eq__ methods that allowed comparison with integers, but __hash__ was not updated to match. This violated Python's rule that a == b requires hash(a) == hash(b).

Fixes #29662

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29662 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
In sets.ordinals file there are two classes omega power and ordinal. both of these classes have their own custom equality operator __eq__method implemented that can compare a plain integer against an omega power object or oridinal object ,but the hash method was not updated accordingly  which was breaking the pythons rule  that if a==b then hash a ==hash b  for example- before a=Ordinal.convert(5)  creates an ordinal object and  when we compared a with a plain integer 5 ,a==5  then this was giving true  but when we try to match their hashes it was giving false hash(a)==hash(5) ->false and this was happening with  the omega power object as well so i fixed the hash method of both the omega power class and the ordinal class   and also there was an edge case  ord0 which  represents 0 but it was not hashing like a integer 0


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed inconsistency between __eq__ and __hash__ in OmegaPower 
    and Ordinal classes in sets.ordinals.
<!-- END RELEASE NOTES -->
