### PR TITLE
Fix matrixexpr ellipsis indexing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -752,6 +752,7 @@ Harsh Kasat <hkasat@waymore.io>
 Harsh Menon <harsh.menon@amd.com> harsh-nod <menonharsh@gmail.com>
 Harshil Goel <harshil158@gmail.com>
 Harshil Goel <harshil158@gmail.com> <darkcoderrises@users.noreply.github.com>
+Harshil Kain <githarshil@gmail.com>
 Harshil Meena <harshil.7535@gmail.com>
 Harshit Gupta <harshithigh2001@gmail.com>
 Harshit Yadav <harshityadav2k@gmail.com> Harshit Yadav <45384915+hyadav2k@users.noreply.github.com>

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -295,6 +295,10 @@ class MatrixExpr(Expr):
                 (j >= -self.cols) != False and (j < self.cols) != False)
 
     def __getitem__(self, key):
+        if key is Ellipsis:
+            key = (slice(None), slice(None))
+        if isinstance(key, tuple) and len(key) == 2:
+            key = tuple(slice(None) if v is Ellipsis else v for v in key)
         if not isinstance(key, tuple) and isinstance(key, slice):
             from sympy.matrices.expressions.slice import MatrixSlice
             return MatrixSlice(self, key, (0, None, 1))

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -182,9 +182,6 @@ def test_slicing():
 
 
 def test_ellipsis_indexing():
-    # https://github.com/sympy/sympy/issues/XXXXX
-    # Ellipsis should be treated as slice(None) (select all), not raise
-    # IndexError or SympifyError
     X_all = X[...]
     assert isinstance(X_all, MatrixSlice)
     assert X_all.shape == X.shape

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -11,6 +11,7 @@ from sympy.matrices.expressions.matexpr import (MatrixSymbol,
 from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.expressions.special import (ZeroMatrix, Identity,
     OneMatrix)
+from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.trace import Trace, trace
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct
@@ -178,6 +179,28 @@ def test_block_index_symbolic_fail():
 
 def test_slicing():
     A.as_explicit()[0, :]  # does not raise an error
+
+
+def test_ellipsis_indexing():
+    # https://github.com/sympy/sympy/issues/XXXXX
+    # Ellipsis should be treated as slice(None) (select all), not raise
+    # IndexError or SympifyError
+    X_all = X[...]
+    assert isinstance(X_all, MatrixSlice)
+    assert X_all.shape == X.shape
+    X_row = X[1, ...]
+    assert isinstance(X_row, MatrixSlice)
+    assert X_row.shape == (1, m)
+    X_col = X[..., 1]
+    assert isinstance(X_col, MatrixSlice)
+    assert X_col.shape == (l, 1)
+    X_sym = MatrixSymbol('X', n, m)
+    X_sym_row = X_sym[k, ...]
+    assert isinstance(X_sym_row, MatrixSlice)
+    X_mixed = X[..., 0:2]
+    assert isinstance(X_mixed, MatrixSlice)
+    X_mixed2 = X[0:2, ...]
+    assert isinstance(X_mixed2, MatrixSlice)
 
 
 def test_errors():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #11345 

#### Brief description of what is fixed or changed

`MatrixExpr.__getitem__` now handles Python's Ellipsis (`...`) by normalizing it to `slice(None)` before processing.
Previously, Ellipsis indexing on `MatrixSymbol` raised errors:

```python
>>> X = MatrixSymbol('X', n, m)
>>> X[...]        # IndexError: Invalid index, wanted X[i,j]
>>> X[2, ...]     # SympifyError: Ellipsis
>>> X[..., 2]     # SympifyError: Ellipsis

#### Other comments

None

#### AI Generation Disclosure

AI tools (Gemini) were used to assist with writing the implementation in matexpr.py (lines 298-301).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * `MatrixExpr` now supports Ellipsis (`...`) indexing. `X[...]`, `X[i, ...]`, and `X[..., j]` now work correctly instead of raising `IndexError` or `SympifyError`.

<!-- END RELEASE NOTES -->