### PR TITLE
Add internal refinement context

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, overload
 
 from sympy.core import S, Add, Expr, Basic, Mul, Pow, Rational
@@ -11,6 +12,39 @@ from sympy.assumptions import ask, Q  # type: ignore
 if TYPE_CHECKING:
     from sympy.logic.boolalg import Boolean
     from typing import Callable
+
+
+@dataclass
+class RefineContext:
+    """Internal state shared by a single refinement traversal.
+
+    The public ``refine`` API accepts assumptions as before, but internally
+    handlers receive this object so assumption queries can be centralized and
+    cached. Later refinements can add local facts, diagnostics, or alternative
+    query engines without changing every handler again.
+    """
+
+    assumptions: Boolean | bool = True
+    cache: dict[Basic, bool | None] = field(default_factory=dict)
+
+    def ask(self, proposition: Basic) -> bool | None:
+        """Return the truth value of ``proposition`` under this context.
+
+        Results are cached for the duration of one top-level ``refine`` call.
+        """
+        if proposition not in self.cache:
+            self.cache[proposition] = ask(proposition, self.assumptions)
+        return self.cache[proposition]
+
+
+def _refine_context(assumptions: Boolean | bool | RefineContext) -> RefineContext:
+    if isinstance(assumptions, RefineContext):
+        return assumptions
+    return RefineContext(assumptions)
+
+
+def _ask(proposition: Basic, ctx_or_assumptions: Boolean | bool | RefineContext) -> bool | None:
+    return _refine_context(ctx_or_assumptions).ask(proposition)
 
 
 @overload
@@ -55,28 +89,32 @@ def refine(expr: Basic, assumptions: Boolean | bool = True) -> Basic:
     sympy.simplify.simplify.simplify : Structural simplification without assumptions.
     sympy.assumptions.ask.ask : Query for boolean expressions using assumptions.
     """
+    ctx = _refine_context(assumptions)
+    return _refine(expr, ctx)
+
+
+def _refine(expr: Basic, ctx: RefineContext) -> Basic:
     if not isinstance(expr, Basic):
         return expr
 
     if not expr.is_Atom:
-        args = [refine(arg, assumptions) for arg in expr.args]
+        args = [_refine(arg, ctx) for arg in expr.args]
         # TODO: this will probably not work with Integral or Polynomial
         expr = expr.func(*args)
     if hasattr(expr, '_eval_refine'):
-        ref_expr = expr._eval_refine(assumptions)
+        ref_expr = expr._eval_refine(ctx.assumptions)
         if ref_expr is not None:
             return ref_expr
     name = expr.__class__.__name__
     handler = handlers_dict.get(name, None)
     if handler is None:
         return expr
-    new_expr = handler(expr, assumptions)
+    new_expr = handler(expr, ctx)
     if (new_expr is None) or (expr == new_expr):
         return expr
     if not isinstance(new_expr, Expr):
         return new_expr
-    return refine(new_expr, assumptions)
-
+    return _refine(new_expr, ctx)
 
 def refine_abs(expr, assumptions):
     """
@@ -97,11 +135,11 @@ def refine_abs(expr, assumptions):
     """
     from sympy.functions.elementary.complexes import Abs
     arg = expr.args[0]
-    if ask(Q.real(arg), assumptions) and \
-            fuzzy_not(ask(Q.negative(arg), assumptions)):
+    if _ask(Q.real(arg), assumptions) and \
+            fuzzy_not(_ask(Q.negative(arg), assumptions)):
         # if it's nonnegative
         return arg
-    if ask(Q.negative(arg), assumptions):
+    if _ask(Q.negative(arg), assumptions):
         return -arg
     # arg is Mul
     if isinstance(arg, Mul):
@@ -148,14 +186,14 @@ def refine_Pow(expr, assumptions):
     from sympy.functions import sign
 
     if isinstance(expr.base, Abs):
-        if ask(Q.real(expr.base.args[0]), assumptions) and \
-                ask(Q.even(expr.exp), assumptions):
+        if _ask(Q.real(expr.base.args[0]), assumptions) and \
+                _ask(Q.even(expr.exp), assumptions):
             return expr.base.args[0] ** expr.exp
-    if ask(Q.real(expr.base), assumptions):
+    if _ask(Q.real(expr.base), assumptions):
         if expr.base.is_number:
-            if ask(Q.even(expr.exp), assumptions):
+            if _ask(Q.even(expr.exp), assumptions):
                 return abs(expr.base) ** expr.exp
-            if ask(Q.odd(expr.exp), assumptions):
+            if _ask(Q.odd(expr.exp), assumptions):
                 return sign(expr.base) * abs(expr.base) ** expr.exp
         if isinstance(expr.exp, Rational):
             if isinstance(expr.base, Pow):
@@ -179,9 +217,9 @@ def refine_Pow(expr, assumptions):
                 initial_number_of_terms = len(terms)
 
                 for t in terms:
-                    if ask(Q.even(t), assumptions):
+                    if _ask(Q.even(t), assumptions):
                         even_terms.add(t)
-                    elif ask(Q.odd(t), assumptions):
+                    elif _ask(Q.odd(t), assumptions):
                         odd_terms.add(t)
 
                 terms -= even_terms
@@ -198,17 +236,17 @@ def refine_Pow(expr, assumptions):
 
                 # Handle (-1)**((-1)**n/2 + m/2)
                 e2 = 2*expr.exp
-                if ask(Q.even(e2), assumptions):
+                if _ask(Q.even(e2), assumptions):
                     if e2.could_extract_minus_sign():
                         e2 *= expr.base
                 if e2.is_Add:
                     i, p = e2.as_two_terms()
                     if p.is_Pow and p.base is S.NegativeOne:
-                        if ask(Q.integer(p.exp), assumptions):
+                        if _ask(Q.integer(p.exp), assumptions):
                             i = (i + 1)/2
-                            if ask(Q.even(i), assumptions):
+                            if _ask(Q.even(i), assumptions):
                                 return expr.base**p.exp
-                            elif ask(Q.odd(i), assumptions):
+                            elif _ask(Q.odd(i), assumptions):
                                 return expr.base**(p.exp + 1)
                             else:
                                 return expr.base**(p.exp + i)
@@ -239,7 +277,7 @@ def refine_exp(expr, assumptions):
     remaining_terms = []
     terms = coeff.args if coeff.is_Add else (coeff,)
     for term in terms:
-        if ask(Q.integer(term), assumptions):
+        if _ask(Q.integer(term), assumptions):
             integer_terms.append(term)
         else:
             remaining_terms.append(term)
@@ -280,19 +318,19 @@ def refine_atan2(expr, assumptions):
     """
     from sympy.functions.elementary.trigonometric import atan
     y, x = expr.args
-    if ask(Q.real(y) & Q.positive(x), assumptions):
+    if _ask(Q.real(y) & Q.positive(x), assumptions):
         return atan(y / x)
-    elif ask(Q.negative(y) & Q.negative(x), assumptions):
+    elif _ask(Q.negative(y) & Q.negative(x), assumptions):
         return atan(y / x) - S.Pi
-    elif ask(Q.positive(y) & Q.negative(x), assumptions):
+    elif _ask(Q.positive(y) & Q.negative(x), assumptions):
         return atan(y / x) + S.Pi
-    elif ask(Q.zero(y) & Q.negative(x), assumptions):
+    elif _ask(Q.zero(y) & Q.negative(x), assumptions):
         return S.Pi
-    elif ask(Q.positive(y) & Q.zero(x), assumptions):
+    elif _ask(Q.positive(y) & Q.zero(x), assumptions):
         return S.Pi/2
-    elif ask(Q.negative(y) & Q.zero(x), assumptions):
+    elif _ask(Q.negative(y) & Q.zero(x), assumptions):
         return -S.Pi/2
-    elif ask(Q.zero(y) & Q.zero(x), assumptions):
+    elif _ask(Q.zero(y) & Q.zero(x), assumptions):
         return S.NaN
     else:
         return expr
@@ -314,9 +352,9 @@ def refine_re(expr, assumptions):
     0
     """
     arg = expr.args[0]
-    if ask(Q.real(arg), assumptions):
+    if _ask(Q.real(arg), assumptions):
         return arg
-    if ask(Q.imaginary(arg), assumptions):
+    if _ask(Q.imaginary(arg), assumptions):
         return S.Zero
     return _refine_reim(expr, assumptions)
 
@@ -337,9 +375,9 @@ def refine_im(expr, assumptions):
     -I*x
     """
     arg = expr.args[0]
-    if ask(Q.real(arg), assumptions):
+    if _ask(Q.real(arg), assumptions):
         return S.Zero
-    if ask(Q.imaginary(arg), assumptions):
+    if _ask(Q.imaginary(arg), assumptions):
         return - S.ImaginaryUnit * arg
     return _refine_reim(expr, assumptions)
 
@@ -359,9 +397,9 @@ def refine_arg(expr, assumptions):
     pi
     """
     rg = expr.args[0]
-    if ask(Q.positive(rg), assumptions):
+    if _ask(Q.positive(rg), assumptions):
         return S.Zero
-    if ask(Q.negative(rg), assumptions):
+    if _ask(Q.negative(rg), assumptions):
         return S.Pi
     return None
 
@@ -402,18 +440,18 @@ def refine_sign(expr, assumptions):
     -I
     """
     arg = expr.args[0]
-    if ask(Q.zero(arg), assumptions):
+    if _ask(Q.zero(arg), assumptions):
         return S.Zero
-    if ask(Q.real(arg)):
-        if ask(Q.positive(arg), assumptions):
+    if _ask(Q.real(arg), assumptions):
+        if _ask(Q.positive(arg), assumptions):
             return S.One
-        if ask(Q.negative(arg), assumptions):
+        if _ask(Q.negative(arg), assumptions):
             return S.NegativeOne
-    if ask(Q.imaginary(arg)):
+    if _ask(Q.imaginary(arg), assumptions):
         arg_re, arg_im = arg.as_real_imag()
-        if ask(Q.positive(arg_im), assumptions):
+        if _ask(Q.positive(arg_im), assumptions):
             return S.ImaginaryUnit
-        if ask(Q.negative(arg_im), assumptions):
+        if _ask(Q.negative(arg_im), assumptions):
             return -S.ImaginaryUnit
     return expr
 
@@ -435,7 +473,7 @@ def refine_matrixelement(expr, assumptions):
     """
     from sympy.matrices.expressions.matexpr import MatrixElement
     matrix, i, j = expr.args
-    if ask(Q.symmetric(matrix), assumptions):
+    if _ask(Q.symmetric(matrix), assumptions):
         if (i - j).could_extract_minus_sign():
             return expr
         return MatrixElement(matrix, j, i)
@@ -472,11 +510,11 @@ def refine_sin_cos(expr, assumptions):
     arg = expr.args[0]
     expr_is_sin = isinstance(expr, sin)
 
-    if (ask(Q.infinite(arg), assumptions) and
-         ask(Q.extended_real(arg), assumptions)):
+    if (_ask(Q.infinite(arg), assumptions) and
+         _ask(Q.extended_real(arg), assumptions)):
         return AccumBounds(-1, 1)
 
-    if ask(Q.zero(arg), assumptions):
+    if _ask(Q.zero(arg), assumptions):
         return 0 if expr_is_sin else 1
 
     integer_coeffs_of_pi_half = []
@@ -485,7 +523,7 @@ def refine_sin_cos(expr, assumptions):
     terms = arg.args if arg.is_Add else (arg,)
     for term in terms:
         coeff_of_pi = term.coeff(S.Pi)
-        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
+        if coeff_of_pi and _ask(Q.integer(2 * coeff_of_pi), assumptions):
             coeff_of_pi_half = 2 * coeff_of_pi
             integer_coeffs_of_pi_half.append(coeff_of_pi_half)
         else:
@@ -498,7 +536,7 @@ def refine_sin_cos(expr, assumptions):
     sum_of_parity_unknown_coeffs = 0
     sum_of_parity_known_coeffs_is_even = True
     for coeff in integer_coeffs_of_pi_half:
-        coeff_is_even = ask(Q.even(coeff), assumptions)
+        coeff_is_even = _ask(Q.even(coeff), assumptions)
         if coeff_is_even is None:
             sum_of_parity_unknown_coeffs += coeff
         else:
@@ -553,11 +591,11 @@ def refine_Heaviside(expr, assumptions):
 
     """
     arg, H0 = expr.args
-    if ask(Q.positive(arg), assumptions):
+    if _ask(Q.positive(arg), assumptions):
         return S.One
-    if ask(Q.negative(arg), assumptions):
+    if _ask(Q.negative(arg), assumptions):
         return S.Zero
-    if ask(Q.zero(arg), assumptions):
+    if _ask(Q.zero(arg), assumptions):
         return H0
     return expr
 
@@ -587,14 +625,14 @@ def refine_floor_ceiling(expr, assumptions):
     """
     from sympy.functions.elementary.integers import floor, ceiling
     arg = expr.args[0]
-    if ask(Q.integer(arg), assumptions) or ask(Q.infinite(arg), assumptions):
+    if _ask(Q.integer(arg), assumptions) or _ask(Q.infinite(arg), assumptions):
         return arg
 
     if isinstance(arg, Add):
         gaussian_integer_terms = []
         nongausian_intergers_terms = []
         for term in arg.args:
-            if ask(Q.integer(term), assumptions) or isinstance(term, (floor, ceiling)):
+            if _ask(Q.integer(term), assumptions) or isinstance(term, (floor, ceiling)):
                 gaussian_integer_terms.append(term)
             else:
                 nongausian_intergers_terms.append(term)
@@ -602,7 +640,7 @@ def refine_floor_ceiling(expr, assumptions):
     return expr
 
 
-handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
+handlers_dict: dict[str, Callable[[Basic, Boolean | bool | RefineContext], Expr]] = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
     'atan2': refine_atan2,

--- a/sympy/assumptions/tests/test_refine_context.py
+++ b/sympy/assumptions/tests/test_refine_context.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from sympy import Q, Abs, Max, Min, sign, sqrt
+from sympy.abc import x, y
+from sympy.assumptions.refine import RefineContext, refine, refine_abs, refine_sign
+from sympy.functions.elementary.integers import ceiling, floor
+from sympy.testing.pytest import XFAIL
+
+
+def test_refine_context_caches_ask_results():
+    ctx = RefineContext(Q.positive(x))
+
+    assert ctx.ask(Q.positive(x)) is True
+    assert Q.positive(x) in ctx.cache
+    assert ctx.ask(Q.positive(x)) is True
+
+
+def test_refine_handlers_still_accept_plain_assumptions():
+    assert refine_abs(Abs(x), Q.positive(x)) == x
+    assert refine_sign(sign(x), Q.positive(x)) == 1
+
+
+def test_refine_preserves_existing_recursive_behavior():
+    assert refine(1 + Abs(x), Q.positive(x)) == 1 + x
+    assert refine(sqrt(x**2), Q.real(x)) == Abs(x)
+    assert refine(sqrt(x**2), Q.positive(x)) == x
+
+
+def test_refine_preserves_existing_integer_floor_ceiling_behavior():
+    assert refine(floor(x), Q.integer(x)) == x
+    assert refine(ceiling(x), Q.integer(x)) == x
+    assert refine(floor(x + y), Q.integer(x)) == x + floor(y)
+    assert refine(ceiling(x + y), Q.integer(x)) == x + ceiling(y)
+
+
+def test_refine_should_derive_positive_sum_from_positive_terms():
+    assert refine(sqrt((x + y)**2), Q.positive(x) & Q.positive(y)) == x + y
+
+
+@XFAIL
+def test_refine_should_use_relative_assumptions_for_abs():
+    assert refine(Abs(x), Q.gt(x, 1)) == x
+
+
+@XFAIL
+def test_refine_should_use_relative_assumptions_for_shifted_abs():
+    assert refine(Abs(x - 2), Q.gt(x, 3)) == x - 2
+
+
+@XFAIL
+def test_refine_should_use_relative_assumptions_for_sign():
+    assert refine(sign(x), Q.gt(x, 0)) == 1
+
+
+@XFAIL
+def test_refine_should_use_ordering_assumptions_for_max_min():
+    assert refine(Max(x, y), Q.gt(x, y)) == x
+    assert refine(Min(x, y), Q.gt(x, y)) == y


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Adds internal RefineContext for cached assumption queries during `refine` traversal, routes existing handlers through the shared context, preserves the public `refine` API, and adds some additional regression/xfail tests for future `refine` improvements. 

This is intended as a low-risk foundation for future improvements to `refine`, including better propagation of derived assumptions, order-aware refinement, and tighter integration with `ask()`.

#### Other comments


#### AI Generation Disclosure
I did use ChatGPT to produce the tests but not for the code, which is simple enough.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Add internal `RefineContext`
  * Route recursive `refine` traversal through a shared context
  * Route existing handler assumption queries through the context
  * Preserve direct handler compatibility
  * Add regression tests for current behavior
  * Add xfail tests documenting future desired behavior
<!-- END RELEASE NOTES -->
