### PR TITLE
add exponential function implementation and corresponding tests

### DIFF
--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -644,6 +644,10 @@ def test_lambertw():
     n = Symbol('n', negative=True)
     assert LambertW(n).is_zero is False
 
+def test_issue_29737():
+    x = symbols('x')
+    expr = exp(LambertW(x))*LambertW(x) - x
+    assert simplify(expr).is_zero is True
 
 def test_issue_5673():
     e = LambertW(-1)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -45,6 +45,7 @@ from sympy.simplify.sqrtdenest import sqrtdenest
 from sympy.simplify.trigsimp import trigsimp, exptrigsimp
 from sympy.utilities.decorator import deprecated
 from sympy.utilities.iterables import has_variety, sift, subsets, iterable
+from sympy.functions.elementary.exponential import LambertW
 
 from sympy.external.mpmath import (
     prec_to_dps,
@@ -717,6 +718,9 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
     if expr.has(BesselBase):
         expr = besselsimp(expr)
 
+    if expr.has(LambertW):
+        expr = lambertwsimp(expr)
+
     if expr.has(TrigonometricFunction, HyperbolicFunction):
         expr = trigsimp(expr, deep=True)
 
@@ -1223,6 +1227,39 @@ def kroneckersimp(expr):
         newexpr = expr.replace(lambda e: isinstance(e, Mul), cancel_kronecker_mul)
 
     return expr
+
+def lambertwsimp(expr):
+    def f(rv):
+        if not rv.is_Mul:
+            return rv
+
+        lw_indices = {}
+        exp_lw_indices = {}
+        args = list(rv.args)
+
+        for i, a in enumerate(args):
+            if isinstance(a, LambertW):
+                lw_indices[a] = i
+            elif isinstance(a, exp) and isinstance(a.args[0], LambertW):
+                exp_lw_indices[a.args[0]] = i
+            elif a.is_Pow and a.base is S.Exp1 and isinstance(a.exp, LambertW):
+                exp_lw_indices[a.exp] = i
+
+        for lw, lw_idx in lw_indices.items():
+            if lw in exp_lw_indices:
+                exp_idx = exp_lw_indices[lw]
+                new_args = []
+                for j, a in enumerate(args):
+                    if j == lw_idx:
+                        new_args.append(lw.args[0])
+                    elif j == exp_idx:
+                        continue
+                    else:
+                        new_args.append(a)
+                return Mul(*new_args)
+        return rv
+
+    return _bottom_up(expr, f)
 
 
 def besselsimp(expr):


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29737 

#### Brief description of what is fixed or changed

This PR implements the simplification identity $e^{W(z)} = \frac{z}{W(z)}$ for the Lambert W function. 
Previously, `simplify(exp(LambertW(x)) * LambertW(x) - x)` would not evaluate to `0`. By adding an evaluation rule directly into `exp.eval()`, `exp(LambertW(x))` is now automatically simplified, solving the issue without requiring additional changes to the `simplify`.

#### Other comments

None

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * `exp(LambertW(x))` now automatically simplifies to `x / LambertW(x)`.
<!-- END RELEASE NOTES -->
