### PR TITLE
Use `itertools.pairwise`

### DIFF
--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from itertools import pairwise
 from sympy.core import S, Basic, Dict, Symbol, Tuple, sympify
 from sympy.core.symbol import Str
 from sympy.sets import Set, FiniteSet, EmptySet
@@ -301,7 +302,7 @@ class CompositeMorphism(Morphism):
 
         normalised_components = Tuple()
 
-        for current, following in zip(components, components[1:]):
+        for current, following in pairwise(components):
             if not isinstance(current, Morphism) or \
                     not isinstance(following, Morphism):
                 raise TypeError("All components must be morphisms.")

--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from itertools import pairwise
 from sympy.ntheory.primetest import isprime
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.printing.defaults import DefaultPrinting
@@ -128,10 +129,7 @@ class Collector(DefaultPrinting):
             if re[index[s1]] and (e1 < 0 or e1 > re[index[s1]]-1):
                 return ((s1, e1), )
 
-        for i in range(len(array)-1):
-            s1, e1 = array[i]
-            s2, e2 = array[i+1]
-
+        for (s1, e1), (s2, e2) in pairwise(array):
             if index[s1] > index[s2]:
                 e = 1 if e2 > 0 else -1
                 return ((s1, e1), (s2, e))

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any
 
 from functools import reduce
-from itertools import permutations
+from itertools import pairwise, permutations
 
 from sympy.combinatorics import Permutation
 from sympy.core import (
@@ -455,7 +455,7 @@ That is, replace {s} with Symbol({s!r}, real=True).
         path = cls._dijkstra(sys1, sys2)
 
         transforms = []
-        for s1, s2 in zip(path, path[1:]):
+        for s1, s2 in pairwise(path):
             if (s1, s2) in rel:
                 transforms.append(rel[(s1, s2)])
             else:

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from itertools import pairwise
 from sympy.core import S, sympify
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise, piecewise_fold
@@ -311,7 +312,7 @@ def interpolating_spline(d, x, X, Y):
         raise ValueError("Number of X and Y coordinates must be the same.")
     if len(X) < d + 1:
         raise ValueError("Degree must be less than the number of control points.")
-    if not all(a < b for a, b in zip(X, X[1:])):
+    if not all(a < b for a, b in pairwise(X)):
         raise ValueError("The x-coordinates must be strictly increasing.")
     X = [sympify(i) for i in X]
 

--- a/sympy/matrices/expressions/_shape.py
+++ b/sympy/matrices/expressions/_shape.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from itertools import pairwise
+
 from sympy.core.relational import Eq
 from sympy.core.numbers import Integer
 from sympy.logic.boolalg import Boolean, And
@@ -35,8 +37,8 @@ def is_matadd_valid(*args: MatrixExpr) -> Boolean:
     """
     rows, cols = zip(*(arg.shape for arg in args))
     return And(
-        *(Eq(i, j) for i, j in zip(rows[:-1], rows[1:])),
-        *(Eq(i, j) for i, j in zip(cols[:-1], cols[1:])),
+        *(Eq(i, j) for i, j in pairwise(rows)),
+        *(Eq(i, j) for i, j in pairwise(cols)),
     )
 
 
@@ -100,7 +102,7 @@ def validate_matadd_integer(*args: MatrixExpr) -> None:
 
 def validate_matmul_integer(*args: MatrixExpr) -> None:
     """Validate matrix shape for multiplication only for integer values"""
-    for A, B in zip(args[:-1], args[1:]):
+    for A, B in pairwise(args):
         i, j = A.cols, B.rows
         if isinstance(i, (int, Integer)) and isinstance(j, (int, Integer)) and i != j:
             raise ShapeError("Matrices are not aligned", i, j)

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -12,6 +12,7 @@ import builtins
 import types
 from typing import Any, Callable
 from functools import reduce
+from itertools import pairwise
 from sympy.assumptions.ask import AssumptionKeys
 from sympy.core.basic import Basic
 from sympy.core import Symbol
@@ -213,7 +214,7 @@ def _implicit_multiplication(tokens: list[TOKEN | AppliedFunction], local_dict: 
     """
     result: list[TOKEN | AppliedFunction] = []
     skip = False
-    for tok, nextTok in zip(tokens, tokens[1:]):
+    for tok, nextTok in pairwise(tokens):
         result.append(tok)
         if skip:
             skip = False
@@ -268,7 +269,7 @@ def _implicit_application(tokens: list[TOKEN | AppliedFunction], local_dict: DIC
               # capture **, ^, etc.)
     exponentSkip = False  # skipping tokens before inserting parentheses to
                           # work with function exponentiation
-    for tok, nextTok in zip(tokens, tokens[1:]):
+    for tok, nextTok in pairwise(tokens):
         result.append(tok)
         if (tok[0] == NAME and nextTok[0] not in [OP, ENDMARKER, NEWLINE]):
             if _token_callable(tok, local_dict, global_dict, nextTok):  # type: ignore
@@ -327,7 +328,7 @@ def function_exponentiation(tokens: list[TOKEN], local_dict: DICT, global_dict: 
     exponent: list[TOKEN] = []
     consuming_exponent = False
     level = 0
-    for tok, nextTok in zip(tokens, tokens[1:]):
+    for tok, nextTok in pairwise(tokens):
         if tok[0] == NAME and nextTok[0] == OP and nextTok[1] == '**':
             if _token_callable(tok, local_dict, global_dict):
                 consuming_exponent = True
@@ -538,7 +539,7 @@ def auto_symbol(tokens: list[TOKEN], local_dict: DICT, global_dict: DICT):
     prevTok = (-1, '')
 
     tokens.append((-1, ''))  # so zip traverses all tokens
-    for tok, nextTok in zip(tokens, tokens[1:]):
+    for tok, nextTok in pairwise(tokens):
         tokNum, tokVal = tok
         nextTokNum, nextTokVal = nextTok
         if tokNum == NAME:

--- a/sympy/plotting/series.py
+++ b/sympy/plotting/series.py
@@ -1,6 +1,7 @@
 ### The base class for all series
 from __future__ import annotations
 from collections.abc import Callable
+from itertools import pairwise
 from sympy.calculus.util import continuous_domain
 from sympy.concrete import Sum, Product
 from sympy.core.containers import Tuple
@@ -2307,8 +2308,8 @@ class ImplicitSeries(BaseSeries):
         xsample += jitterx
         ysample += jittery
 
-        xinter = [interval(x1, x2) for x1, x2 in zip(xsample[:-1], xsample[1:])]
-        yinter = [interval(y1, y2) for y1, y2 in zip(ysample[:-1], ysample[1:])]
+        xinter = [interval(x1, x2) for x1, x2 in pairwise(xsample)]
+        yinter = [interval(y1, y2) for y1, y2 in pairwise(ysample)]
         interval_list = [[x, y] for x in xinter for y in yinter]
         plot_list = []
 

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -1,6 +1,7 @@
 """Low-level linear systems solver. """
 from __future__ import annotations
 
+from itertools import pairwise
 
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import connected_components
@@ -336,7 +337,7 @@ def _solve_lin_sys(eqs_coeffs, eqs_rhs, ring):
     E = []
     for eq_coeffs in eqs_coeffs:
         syms = list(eq_coeffs)
-        E.extend(zip(syms[:-1], syms[1:]))
+        E.extend(pairwise(syms))
     G = V, E
 
     components = connected_components(G)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, overload
 from functools import reduce
 from collections import defaultdict
+from itertools import pairwise
 import inspect
 
 from sympy.core.kind import Kind, UndefinedKind, NumberKind
@@ -2053,7 +2054,7 @@ class FiniteSet(Set):
                 nums.sort()
                 intervals = []  # Build up a list of intervals between the elements
                 intervals += [Interval(S.NegativeInfinity, nums[0], True, True)]
-                for a, b in zip(nums[:-1], nums[1:]):
+                for a, b in pairwise(nums):
                     intervals.append(Interval(a, b, True, True))  # both open
                 intervals.append(Interval(nums[-1], S.Infinity, True, True))
                 if syms != []:


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
`itertools.pairwise` was added in Python 3.10. Using this function simplifies several `for` loops.

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
