### PR TITLE
holonomic, functions: fix typos in comments and docstrings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1566,6 +1566,7 @@ Soumya Sakshi <s1december2005@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
 Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>
+Sparsh Bansal <itzzsparsh003@gmail.com>
 Srajan Garg <srajan.garg@gmail.com>
 Srinivas Vasudevan <srvasude@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Arun Yeragudipati <ysarun1999@gmail.com>

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1322,7 +1322,7 @@ class expint(DefinedFunction):
     >>> expint(nu, z).diff(nu)
     -z**(nu - 1)*meijerg(((), (1, 1)), ((0, 0, 1 - nu), ()), z)
 
-    At non-postive integer orders, the exponential integral reduces to the
+    At non-positive integer orders, the exponential integral reduces to the
     exponential function:
 
     >>> expint(0, z)

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1939,7 +1939,7 @@ class HolonomicFunction:
                 continue
 
             # if the coefficient u0[i] is zero, then the
-            # independent hypergeomtric series starting with
+            # independent hypergeometric series starting with
             # x**i is not a part of the answer.
             if S(u0[i]) == 0:
                 continue


### PR DESCRIPTION
#### References to other Issues or PRs
N/A — found via automated typo scanning of the codebase.

#### Brief description of what is fixed or changed
Fixed two typos in comments/docstrings:
- `sympy/holonomic/holonomic.py`: "hypergeomtric" → "hypergeometric"
- `sympy/functions/special/error_functions.py`: "non-postive" → "non-positive"

#### Other comments
First contribution. Verified no code behavior changes.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
