### PR TITLE
assumptions: add refine handler for Mod

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1566,6 +1566,7 @@ Soumya Sakshi <s1december2005@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
 Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>
+Sparsh Bansal <itzzsparsh003@gmail.com>
 Srajan Garg <srajan.garg@gmail.com>
 Srinivas Vasudevan <srvasude@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Arun Yeragudipati <ysarun1999@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -576,9 +576,7 @@ def refine_Mod(expr, assumptions):
     >>> refine(Mod(5*x, 5), Q.integer(x))
     0
     """
-    from sympy.core.mod import Mod
-    args = expr.args
-    p, q = args
+    p, q = expr.args
     if ask(Q.integer(p / q), assumptions):
         return S.Zero
     return expr

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -562,6 +562,28 @@ def refine_Heaviside(expr, assumptions):
     return expr
 
 
+def refine_Mod(expr, assumptions):
+    """
+    Handler for the Mod function.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, Mod, refine
+    >>> from sympy.abc import x
+    >>> refine(Mod(x, 1), Q.integer(x))
+    0
+    >>> refine(Mod(5*x, 5), Q.integer(x))
+    0
+    """
+    from sympy.core.mod import Mod
+    args = expr.args
+    p, q = args
+    if ask(Q.integer(p / q), assumptions):
+        return S.Zero
+    return expr
+
+
 def refine_floor_ceiling(expr, assumptions):
     """
     Handler for the floor and ceiling functions
@@ -617,4 +639,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'Mod': refine_Mod,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -16,6 +16,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
+from sympy.core.mod import Mod
 
 from sympy.testing.pytest import raises
 
@@ -353,3 +354,11 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_Mod():
+    assert refine(Mod(x, 1), Q.integer(x)) == 0
+    assert refine(Mod(5*x, 5), Q.integer(x)) == 0
+    assert refine(Mod(x, 3), Q.integer(x)) == Mod(x, 3)
+    assert refine(Mod(x, y)) == Mod(x, y)
+


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes in part #27888

#### Brief description of what is fixed or changed
Added a `refine_Mod` handler that simplifies `Mod(x, q)` to `0` when `x/q` is known to be an integer under the given assumptions.

Before: `refine(Mod(x, 1), Q.integer(x))` returned `Mod(x, 1)` (not simplified).
After: `refine(Mod(x, 1), Q.integer(x))` returns `0`.

Tests added for:
- `Mod(x, 1)` with integer assumption -> 0
- `Mod(5*x, 5)` with integer assumption -> 0
- `Mod(x, 3)` with integer assumption -> unchanged (correct)
- `Mod(x, y)` without assumptions -> unchanged (correct)

#### Other comments
All existing tests pass. Doctest in refine.py passes.

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added `refine_Mod` handler, enabling `refine` to simplify `Mod` expressions using assumptions.
<!-- END RELEASE NOTES -->