### PR TITLE
assumptions: add refine handler for frac

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1566,6 +1566,7 @@ Soumya Sakshi <s1december2005@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
 Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>
+Sparsh Bansal <itzzsparsh003@gmail.com>
 Srajan Garg <srajan.garg@gmail.com>
 Srinivas Vasudevan <srvasude@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Arun Yeragudipati <ysarun1999@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -602,6 +602,34 @@ def refine_floor_ceiling(expr, assumptions):
     return expr
 
 
+def refine_frac(expr, assumptions):
+    """
+    Handler for the fractional part function.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, frac, refine
+    >>> from sympy.abc import x
+    >>> refine(frac(x), Q.integer(x))
+    0
+    """
+    arg = expr.args[0]
+    if ask(Q.integer(arg), assumptions):
+        return S.Zero
+    if isinstance(arg, Add):
+        integer_terms = []
+        remaining_terms = []
+        for term in arg.args:
+            if ask(Q.integer(term), assumptions):
+                integer_terms.append(term)
+            else:
+                remaining_terms.append(term)
+        if integer_terms:
+            return expr.func(Add(*remaining_terms))
+    return expr
+
+
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
@@ -617,4 +645,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'frac': refine_frac,
 }

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -614,6 +614,7 @@ def refine_frac(expr, assumptions):
     >>> refine(frac(x), Q.integer(x))
     0
     """
+    from sympy.functions.elementary.integers import floor, ceiling
     arg = expr.args[0]
     if ask(Q.integer(arg), assumptions):
         return S.Zero
@@ -621,7 +622,7 @@ def refine_frac(expr, assumptions):
         integer_terms = []
         remaining_terms = []
         for term in arg.args:
-            if ask(Q.integer(term), assumptions):
+            if ask(Q.integer(term), assumptions) or isinstance(term, (floor, ceiling)):
                 integer_terms.append(term)
             else:
                 remaining_terms.append(term)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -359,5 +359,7 @@ def test_frac():
     assert refine(frac(x), Q.integer(x)) == 0
     assert refine(frac(x + y), Q.integer(x)) == frac(y)
     assert refine(frac(x + y + z), Q.integer(x) & Q.integer(z)) == frac(y)
+    assert refine(frac(floor(x) + y)) == frac(y)
+    assert refine(frac(ceiling(x) + y)) == frac(y)
     assert refine(frac(x), Q.real(x)) == frac(x)
     assert refine(frac(x + S.Half), Q.integer(x)) == S.Half

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -14,7 +14,7 @@ from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
-from sympy.functions.elementary.integers import floor, ceiling
+from sympy.functions.elementary.integers import floor, ceiling, frac
 from sympy.functions.special.delta_functions import Heaviside
 
 from sympy.testing.pytest import raises
@@ -353,3 +353,11 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_frac():
+    assert refine(frac(x), Q.integer(x)) == 0
+    assert refine(frac(x + y), Q.integer(x)) == frac(y)
+    assert refine(frac(x + y + z), Q.integer(x) & Q.integer(z)) == frac(y)
+    assert refine(frac(x), Q.real(x)) == frac(x)
+    assert refine(frac(x + S.Half), Q.integer(x)) == S.Half


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes in part #27888

#### Brief description of what is fixed or changed
Added a `refine_frac` handler that:
1. Simplifies `frac(x)` to `0` when `x` is known to be an integer.
2. Extracts integer terms from `Add` expressions: `frac(n + y)` becomes `frac(y)` when `n` is integer.

Before: `refine(frac(x), Q.integer(x))` returned `frac(x)` (not simplified).
After: `refine(frac(x), Q.integer(x))` returns `0`.

Tests added covering integer simplification, Add extraction with multiple integer terms, no-op for real-only assumptions, and constant extraction.

#### Other comments
All existing tests pass. Doctest in refine.py passes.

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added `refine_frac` handler, enabling `refine` to simplify `frac` expressions using assumptions.
<!-- END RELEASE NOTES -->