### PR TITLE
Sets: Fix bug where `OrdinalZero` could take args

### DIFF
--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -259,7 +259,8 @@ class OrdinalZero(Ordinal):
 
     OrdinalZero can be imported as ``ord0``.
     """
-    pass
+    def __new__(cls):
+        return Ordinal.__new__(cls)
 
 
 class OrdinalOmega(Ordinal):

--- a/sympy/sets/tests/test_ordinals.py
+++ b/sympy/sets/tests/test_ordinals.py
@@ -66,3 +66,7 @@ def test_comapre_not_instance():
 def test_is_successort():
     w = Ordinal(OmegaPower(5, 1))
     assert not w.is_successor_ordinal
+
+def test_atomic_classes():
+    raises(TypeError, lambda: type(ord0)(1))
+    raises(TypeError, lambda: type(omega)(1))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29753

#### Brief description of what is fixed or changed
Fixed a bug where `OrdinalZero` could take args. Previously, `OrdinalZero` inherited the `__new__` method from `Ordinal`, and so could be created with `args`. I added a new `__new__` method on `OrdinalZero` that ensures that args cannot be passed to `OrdinalZero`.

#### Other comments
Added relevant tests as well to check that calling `OrdinalZero(*args)` for non-empty args raises an error.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * fixed bug where `OrdinalZero` could be incorrectly supplied with args
<!-- END RELEASE NOTES -->
