### PR TITLE
integrals: fix branch-cut error in definite Beta-type integrals on [0,1]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1531,6 +1531,8 @@ Shivani Kohli <shivanikohli.09@gmail.com>
 Shiyao Guo <mivikq@gmail.com> Mivik <54128043+Mivik@users.noreply.github.com>
 Shiyao Guo <mivikq@gmail.com> Mivik <mivikq@gmail.com>
 Shravas K Rao <shravas@gmail.com>
+Shresth Samyak <shresthsamyak@gmail.com> Shresth Samyak <81299919+ShresthSamyak@users.noreply.github.com>
+Shresth Samyak <shresthsamyak@gmail.com> ShresthSamyak <shresthsamyak@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
 Shruti Mangipudi <shruti2395@gmail.com>
 Shuai Zhou <shuaivzhou@berkeley.edu>

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -629,14 +629,19 @@ class Integral(AddWithLimits):
                         if ret is not None:
                             function = ret
                             continue
-                    # If the antiderivative contains exp_polar it was built
-                    # with branch-tracking that may not cancel when limits are
-                    # substituted, producing a wrong definite result.  Try
-                    # meijerint_definite, which handles branch cuts correctly.
+                    # If the antiderivative introduced exp_polar (a branch-
+                    # tracking marker injected by the meijerint machinery),
+                    # that branch information may not cancel when limits are
+                    # substituted, producing a wrong definite result.  Fall
+                    # back to meijerint_definite, which handles branch cuts
+                    # correctly at the Meijer G level.  Only trigger when
+                    # exp_polar was absent from the original integrand so we
+                    # don't interfere with user-supplied exp_polar expressions.
                     if (antideriv is not None and
                             meijerg is not False and
                             len(xab) == 3 and
-                            not (xab[1].has(oo, -oo) or xab[2].has(oo, -oo))):
+                            not (xab[1].has(oo, -oo) or xab[2].has(oo, -oo)) and
+                            not function.has(exp_polar)):
                         if antideriv.has(exp_polar):
                             ret = try_meijerg(function, xab)
                             if ret is not None:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -16,7 +16,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, Wild)
 from sympy.core.sympify import sympify
 from sympy.functions import Piecewise, sqrt, piecewise_fold, tan, cot, atan
-from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.exponential import exp_polar, log
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.complexes import Abs, sign
 from sympy.functions.elementary.miscellaneous import Min, Max
@@ -629,6 +629,19 @@ class Integral(AddWithLimits):
                         if ret is not None:
                             function = ret
                             continue
+                    # If the antiderivative contains exp_polar it was built
+                    # with branch-tracking that may not cancel when limits are
+                    # substituted, producing a wrong definite result.  Try
+                    # meijerint_definite, which handles branch cuts correctly.
+                    if (antideriv is not None and
+                            meijerg is not False and
+                            len(xab) == 3 and
+                            not (xab[1].has(oo, -oo) or xab[2].has(oo, -oo))):
+                        if antideriv.has(exp_polar):
+                            ret = try_meijerg(function, xab)
+                            if ret is not None:
+                                function = ret
+                                continue
 
             final = hints.get('final', True)
             # dotit may be iterated but floor terms making atan and acot

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -10,7 +10,7 @@ from sympy.core.exprtools import factor_terms
 from sympy.core.function import diff
 from sympy.core.logic import fuzzy_bool
 from sympy.core.mul import Mul
-from sympy.core.numbers import oo, pi
+from sympy.core.numbers import I, oo, pi
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, Wild)
@@ -629,20 +629,23 @@ class Integral(AddWithLimits):
                         if ret is not None:
                             function = ret
                             continue
-                    # If the antiderivative introduced exp_polar (a branch-
-                    # tracking marker injected by the meijerint machinery),
-                    # that branch information may not cancel when limits are
-                    # substituted, producing a wrong definite result.  Fall
-                    # back to meijerint_definite, which handles branch cuts
-                    # correctly at the Meijer G level.  Only trigger when
-                    # exp_polar was absent from the original integrand so we
-                    # don't interfere with user-supplied exp_polar expressions.
+                    # If the antiderivative contains exp_polar(I*pi), the
+                    # meijerint machinery chose a branch that does not cancel
+                    # correctly when limits are substituted on a finite real
+                    # interval, yielding a wrong sign.  Fall back to
+                    # meijerint_definite, which handles the branch cut at the
+                    # Meijer G level.  Only trigger when: the bounds are finite
+                    # and extended-real (meijerint_definite requires a real
+                    # interval), and exp_polar(I*pi) was absent from the
+                    # original integrand (so user-supplied exp_polar is left
+                    # alone).
                     if (antideriv is not None and
                             meijerg is not False and
                             len(xab) == 3 and
+                            xab[1].is_extended_real and xab[2].is_extended_real and
                             not (xab[1].has(oo, -oo) or xab[2].has(oo, -oo)) and
                             not function.has(exp_polar)):
-                        if antideriv.has(exp_polar):
+                        if antideriv.has(exp_polar(I*pi)):
                             ret = try_meijerg(function, xab)
                             if ret is not None:
                                 function = ret

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1432,7 +1432,7 @@ def orthogonal_poly_rule(integral):
 
 
 _special_function_patterns: list[tuple[type, Expr, Callable | None, tuple]] = []
-_wilds = []
+_wilds: list[Wild] = []
 _symbol = Dummy('x')
 
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -776,9 +776,9 @@ def test_issue_25949():
 
 
 def test_issue_29751():
-    # Beta-type integral on [0,1]: meijerint_definite must be tried first so
-    # that branch-cut issues in the indefinite antiderivative don't produce a
-    # numerically wrong (negative) result for a non-negative integrand.
+    # Beta-type integral on [0,1]: when the antiderivative contains exp_polar
+    # (branch-tracking introduced by meijerint), substituting limits can give
+    # the wrong sign.  The fallback to meijerint_definite fixes this.
     from sympy.functions.special.beta_functions import beta
     result = integrate(x**Rational(1, 3) * (1 - x)**Rational(1, 2), (x, 0, 1))
     expected = beta(Rational(4, 3), Rational(3, 2))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -773,3 +773,13 @@ def test_issue_25949():
     from sympy.core.symbol import symbols
     y = symbols("y", nonzero=True)
     assert integrate(cosh(y*(x + 1)), (x, -1, -0.25), meijerg=True) == sinh(0.75*y)/y
+
+
+def test_issue_29751():
+    # Beta-type integral on [0,1]: meijerint_definite must be tried first so
+    # that branch-cut issues in the indefinite antiderivative don't produce a
+    # numerically wrong (negative) result for a non-negative integrand.
+    from sympy.functions.special.beta_functions import beta
+    result = integrate(x**Rational(1, 3) * (1 - x)**Rational(1, 2), (x, 0, 1))
+    expected = beta(Rational(4, 3), Rational(3, 2))
+    assert simplify(result - expected) == 0

--- a/sympy/polys/polyconfig.py
+++ b/sympy/polys/polyconfig.py
@@ -25,7 +25,7 @@ _default_config = {
     'GROEBNER':                   'buchberger',
 }
 
-_current_config = {}
+_current_config: dict[str, bool | int | str] = {}
 
 @contextmanager
 def using(**kwargs):

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -150,10 +150,10 @@ class LLVMJitCallbackPrinter(LLVMJitPrinter):
 
 # ensure lifetime of the execution engine persists (else call to compiled
 #   function will seg fault)
-exe_engines = []
+exe_engines: list[object] = []
 
 # ensure names for generated functions are unique
-link_names = set()
+link_names: set[str] = set()
 current_link_suffix = 0
 
 

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         Only imports between relevant modules will be checked."""
         return in_module(module, 'sympy')
 
-    sorted_messages = []
+    sorted_messages: list[str] = []
 
     def msg(msg, *args):
         if options.by_process:


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29751

#### Brief description of what is fixed or changed

`integrate(x**Rational(1, 3) * (1 - x)**Rational(1, 2), (x, 0, 1))` returned a numerically negative result (`-2*hyper((-1/3, 3/2), (5/2,), 1)/3`) even though the integrand is non-negative on [0, 1]. The correct value is `beta(Rational(4, 3), Rational(3, 2))`.

**Root cause:** For finite-bound definite integrals, `Integral.doit()` computed an indefinite antiderivative first and then substituted limits. When the antiderivative is built by the meijerint machinery, it may contain `exp_polar(I*pi)` — a half-turn branch-tracking marker. This branch choice does not cancel correctly when limits are substituted, producing a wrong sign.

**Fix:** After computing the antiderivative for a finite real-bound definite integral, check whether it contains `exp_polar(I*pi)`. If it does (and `exp_polar` was absent from the original integrand), fall back to `meijerint_definite`, which handles branch cuts correctly at the Meijer G level.

The trigger is precise: `exp_polar(I*pi)` only appears when the half-turn branch cut is the problem. Symbolic antiderivatives (e.g. for the Beta distribution normalisation integral) use `exp_polar(2*I*pi)` instead and are not affected.

#### Other comments

Also fixes 5 pre-existing `mypy` `var-annotated` errors in unrelated files (`polyconfig.py`, `diagnose_imports.py`, `manualintegrate.py`, `llvmjitcode.py`) that were causing the Mypy CI check to fail on all PRs.

#### AI Generation Disclosure

This pull request was written with assistance from Claude Code (Anthropic). The logic changes in `sympy/integrals/integrals.py` (lines 632–651) and the regression test in `sympy/integrals/tests/test_meijerint.py` (lines 778–787) were AI-assisted. The `.mailmap` entry and mypy type annotation fixes were also AI-assisted.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed incorrect (numerically negative) results for definite Beta-type integrals like `integrate(x**Rational(1, 3) * (1 - x)**Rational(1, 2), (x, 0, 1))` caused by branch-cut issues in the indefinite antiderivative.
<!-- END RELEASE NOTES -->