### PR TITLE
printing: Add _print_conjugate to PythonCodePrinter and NumPyPrinter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1834,6 +1834,7 @@ kangzhiq <709563092@qq.com> kangzhia <709563092@qq.com>
 kangzhiq <709563092@qq.com> kangzhiq <709563092@qq.com>
 kangzhiq <709563092@qq.com> kkkkx <709563092@qq.com>
 klaasvanaarsen <44929042+klaasvanaarsen@users.noreply.github.com>
+krokosik <krokosik@pm.me> Wiktor Krokosz <38408316+krokosik@users.noreply.github.com>
 lastcodestanding <rohang71604@gmail.com>
 latot <felipematas@yahoo.com>
 leastloris <ivedants05@gmail.com>

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -266,6 +266,9 @@ class NumPyPrinter(ArrayPrinter, PythonCodePrinter):
     def _print_re(self, expr):
         return "%s(%s)" % (self._module_format(self._module + '.real'), self._print(expr.args[0]))
 
+    def _print_conjugate(self, expr):
+        return "%s(%s)" % (self._module_format(self._module + '.conjugate'), self._print(expr.args[0]))
+
     def _print_sinc(self, expr):
         return "%s(%s)" % (self._module_format(self._module + '.sinc'), self._print(expr.args[0]/S.Pi))
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -270,6 +270,9 @@ class AbstractPythonCodePrinter(CodePrinter):
     def _print_ImaginaryUnit(self, expr):
         return '1j'
 
+    def _print_conjugate(self, expr):
+        return '({}).conjugate()'.format(self._print(expr.args[0]))
+
     def _print_KroneckerDelta(self, expr):
         a, b = expr.args
 

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -55,6 +55,11 @@ def test_numpy_logaddexp():
     assert NumPyPrinter().doprint(lae2) == 'numpy.logaddexp2(a, b)'
 
 
+def test_numpy_conjugate():
+    from sympy.functions.elementary.complexes import conjugate
+    assert NumPyPrinter().doprint(conjugate(x)) == 'numpy.conjugate(x)'
+
+
 def test_sum():
     if not np:
         skip("NumPy not installed")

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -9,7 +9,7 @@ from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.function import Derivative
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
-from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth, sec, log, sin, cos, tan, asin, atan, sinh, cosh, tanh, asinh, acosh, atanh
+from sympy.functions import acos, conjugate, KroneckerDelta, Piecewise, sign, sqrt, Min, Max, cot, acsch, asec, coth, sec, log, sin, cos, tan, asin, atan, sinh, cosh, tanh, asinh, acosh, atanh
 from sympy.functions.elementary.trigonometric import atan2
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
@@ -74,6 +74,7 @@ def test_PythonCodePrinter():
 
     assert prntr.doprint(Min(x, y)) == "min(x, y)"
     assert prntr.doprint(Max(x, y)) == "max(x, y)"
+    assert prntr.doprint(conjugate(x)) == "(x).conjugate()"
 
 def test_PythonCodePrinter_print_Indexed():
     from sympy import Symbol
@@ -174,6 +175,7 @@ def test_NumPyPrinter():
     assert p.doprint(HadamardProduct(A, B)) == "numpy.multiply(A, B)"
     assert p.doprint(KroneckerProduct(A, B)) == "numpy.kron(A, B)"
     assert p.doprint(Adjoint(A)) == "numpy.conjugate(numpy.transpose(A))"
+    assert p.doprint(conjugate(x)) == "numpy.conjugate(x)"
     assert p.doprint(DiagonalOf(A)) == "numpy.reshape(numpy.diag(A), (-1, 1))"
     assert p.doprint(DiagMatrix(C)) == "numpy.diagflat(C)"
     assert p.doprint(DiagonalMatrix(D)) == "numpy.multiply(D, numpy.eye(3, 4))"


### PR DESCRIPTION
## Summary

This PR adds support for printing `sympy.conjugate` in `PythonCodePrinter` and `NumPyPrinter` (and by inheritance `SciPyPrinter`, `CuPyPrinter`, and `JaxPrinter`).

Previously, calling `pycode(conjugate(x))` or `NumPyPrinter().doprint(conjugate(x))` raised `PrintMethodNotImplementedError`. This is a basic method that is part of the Python/NumPy Array API, and many other SymPy printers (LaTeX, Fortran, Julia, Octave, PyTorch, etc.) already support it.

## Changes

- `PythonCodePrinter._print_conjugate` emits `(<expr>).conjugate()`
- `NumPyPrinter._print_conjugate` emits `numpy.conjugate(<expr>)` for consistency with the existing `_print_Adjoint` implementation
- Tests added in `test_pycode.py` and `test_numpy.py`

## AI Disclosure

This PR was generated using OpenCode and reviewed by a human (me).

## Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added `_print_conjugate` to `PythonCodePrinter` and `NumPyPrinter` so that `sympy.conjugate` can be printed to Python/NumPy code.
<!-- END RELEASE NOTES -->