### PR TITLE
core/mod: Fix `Mul` in mod evaluating incorrectly in certain expressions.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -896,6 +896,7 @@ Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
+Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <157145635+JosephMehdiyev@users.noreply.github.com>
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -161,8 +161,8 @@ class Mod(DefinedFunction):
                 prod_mod = Mul(*mod)
                 prod_non_mod = Mul(*non_mod)
                 prod_mod1 = Mul(*[i.args[0] for i in mod_l])
-                net = prod_mod1*prod_mod
-                return prod_non_mod*cls(net, q)
+                net = prod_mod1*prod_mod*prod_non_mod
+                return cls(net, q)
 
             if q.is_Integer and q is not S.One:
                 if all(t.is_integer for t in p.args):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2022,6 +2022,11 @@ def test_Mod():
     expr_int = 8*Mod(floor(x1_int/64), 4).xreplace({x1_int: x1})
     assert expr == expr_int
 
+    # from issue 29757: Mod(n * Mod(x, q), q) should simplify to Mod(n*x, q)
+    x1_int = Symbol('x1_int', integer=True)
+
+    assert Mod(3 * Mod(x1_int, 7), 7) == Mod(3 * x1_int, 7)
+    assert Mod(5 * Mod(x1_int, 3), 3) == Mod(2 * x1_int, 3)
 
 def test_Mod_Pow():
     # modular exponentiation


### PR DESCRIPTION

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes an issue pointed at #29757 (not the issue itself)
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The type of equation 
```math
(n \cdot (x \mod q)) \mod q,  \ \ \ n \in \mathbb{Z}, \ \ x, q \in \mathbb{R}, q \neq 0
```
simplifies to 
```math
 (n \cdot x) \mod q
```
In the end everything should be inside modulo, as the value may be bigger than q in the end.
#### Other comments
~I also changed parts of code for it to be more readable. I can revert these changes if asked.~
#### AI Generation Disclosure
Claude used to review the code.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug on modulo of multiplications. Sometimes the result could be bigger than the modulus.
<!-- END RELEASE NOTES -->
