### PR TITLE
fix: prevent infinite recursion in FracField.from_expr with EXRAW domain

### DIFF
--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -297,10 +297,10 @@ class FracField(DefaultPrinting, Generic[Er]):
                 return 1/mapping.get(1/expr)
 
             try:
-                return domain.convert(expr)
+                return self.ground_new(domain.convert(expr))
             except CoercionFailed:
                 if not domain.is_Field and domain.has_assoc_Field:
-                    return domain.get_field().convert(expr)
+                    return self.ground_new(domain.get_field().convert(expr))
                 else:
                     raise
 

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -351,4 +351,25 @@ def test_FracField_index():
 
     raises(ValueError, lambda: F.index(1))
     raises(ValueError, lambda: F.index(a))
-    pass
+
+
+def test_FracField_from_expr_EXRAW():
+    """from_expr should not recurse infinitely when domain is EXRAW (#29761)."""
+    from sympy.polys.domains import EXRAW
+    from sympy.core.singleton import S
+
+    s = symbols('s')
+    ff = EXRAW.frac_field(s)
+
+    # Building a FracElement from a plain integer should work
+    # without triggering RecursionError.
+    elem = ff.field.from_expr(S.One)
+    assert elem == ff.field.one
+
+    # Also test via FractionField.from_sympy
+    elem2 = ff.from_sympy(S(1))
+    assert elem2 == ff.one
+
+    # Non-trivial expression should also work
+    elem3 = ff.field.from_expr(s + 1)
+    assert elem3.as_expr() == s + 1


### PR DESCRIPTION
ran into this while working with the EXRAW domain in polys. calling `field.from_sympy()` with a plain integer causes infinite recursion because:

1. `_rebuild_expr` calls `domain.convert(expr)` which returns an Expr for EXRAW domains (since EXRAW.dtype is Expr)
2. `from_expr` then passes this Expr to `field_new`, which sees an Expr and calls `from_expr` again
3. infinite loop

the fix checks if the result from `_rebuild_expr` is an Expr that isn't already a FracElement or PolyElement, and wraps it through `ground_new` instead. for nested fraction fields (e.g. `ZZ(a,b).frac_field(x)`), FracElements from the inner field still go through `field_new` for proper conversion.

fixes #29761

<!-- BEGIN RELEASE NOTES -->
polys
- Fixed infinite recursion in `FracField.from_expr()` when using EXRAW domains with plain integer arguments.
<!-- END RELEASE NOTES -->