### PR TITLE
refactor(lra_theory): Vastly improve `assert_lit` logic and add type hints

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -695,3 +695,7 @@ class Level:
         self.decision = decision
         self.var_settings = set()
         self.flipped = flipped
+
+    def __repr__(self):
+        return "<Level decision=%s, flipped=%s, var_settings=%s>" % (
+            self.decision, self.flipped, self.var_settings)

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -435,6 +435,9 @@ class SATSolver:
         (0, {1}, False)
 
         """
+        if len(self.levels) == 1:
+            raise IndexError("Cannot pop base decision level 0.")
+
         # Undo the variable settings
         for lit in self._current_level.var_settings:
             self.var_settings.remove(lit)

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -240,8 +240,16 @@ class SATSolver:
                     else:
                         self._simple_add_learned_clause(res[1])
 
-                        # backtrack until we unassign one of the literals causing the conflict
-                        while not any(-lit in res[1] for lit in self._current_level.var_settings):
+                        # Backtrack until reaching a level with one of the conflict causing literals.
+                        inconsistent_literals = [-lit for lit in res[1]]
+                        while True:
+                            if len(self.levels) == 1:
+                                # If theory-inconsistent literals were set right off the bat
+                                # at level 0, the formula is unsat.
+                                return
+
+                            if any(inconsistent_lit in self._current_level.var_settings for inconsistent_lit in inconsistent_literals):
+                                break
                             self._undo()
 
                     while self._current_level.flipped:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -175,11 +175,6 @@ class LRASolver():
             assert A[:, n-m:] == -eye(m)
 
         self.atom_id_to_boundary = atom_id_to_boundary  # mapping of int to lists of Boundary objects
-        self.boundary_to_atom_id = {}
-        for aid, bs in atom_id_to_boundary.items():
-            for b in bs:
-                # assert b not in self.boundary_to_atom_id
-                self.boundary_to_atom_id[b] = aid
         self.A = A
         self.slack = slack_variables
         self.nonslack = nonslack_variables
@@ -359,11 +354,9 @@ class LRASolver():
         self.result = None
         for var in self.all_var:
             var.lower = LRARational(-float("inf"), 0)
-            var.lower_source = None
-            var.lower_literal_sign = None
+            var.lower_literal = None
             var.upper = LRARational(float("inf"), 0)
-            var.upper_source = None
-            var.upper_literal_sign = None
+            var.upper_literal = None
             var.assign = LRARational(0, 0)
 
     def assert_lit(self, literal: int) -> Optional[Tuple[bool, List[int]]]:
@@ -443,13 +436,13 @@ class LRASolver():
             assert (other_bound.d * s >= 0) is True
             assert (ci.d * s <= 0) is True
             # get conflicting boundary
-            lit1, lit1_sign = xi.get_active_lower_boundary() if upper else xi.get_active_upper_boundary()
+            conflicting_lit = xi.get_active_lower_literal() if upper else xi.get_active_upper_literal()
 
-            conflict = [-lit1_sign*self.boundary_to_atom_id[lit1], -literal]
+            conflict = [-conflicting_lit, -literal]
             self.result = False, conflict
             return self.result
 
-        xi.set_bound(boundary, -1 if is_literal_negated else 1)
+        xi.set_bound(boundary, literal)
 
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
@@ -539,10 +532,10 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict = []
-                    conflict += [nb.get_active_upper_boundary() for nb in N_plus]
-                    conflict += [nb.get_active_lower_boundary() for nb in N_minus]
-                    conflict.append(xi.get_active_lower_boundary())
-                    conflict = [-literal_sign*self.boundary_to_atom_id[c] for c, literal_sign in conflict]
+                    conflict += [nb.get_active_upper_literal() for nb in N_plus]
+                    conflict += [nb.get_active_lower_literal() for nb in N_minus]
+                    conflict.append(xi.get_active_lower_literal())
+                    conflict = [-conflicting_lit for conflicting_lit in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
@@ -557,15 +550,11 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict_bounds = []
-                    conflict_bounds += [nb.get_active_upper_boundary() for nb in N_minus]
-                    conflict_bounds += [nb.get_active_lower_boundary() for nb in N_plus]
-                    conflict_bounds.append(xi.get_active_upper_boundary())
+                    conflict_bounds += [nb.get_active_upper_literal() for nb in N_minus]
+                    conflict_bounds += [nb.get_active_lower_literal() for nb in N_plus]
+                    conflict_bounds.append(xi.get_active_upper_literal())
 
-                    conflict = []
-                    for c_source, literal_sign in conflict_bounds:
-                        assert c_source is not None
-                        assert literal_sign is not None
-                        conflict.append(-literal_sign*self.boundary_to_atom_id[c_source])
+                    conflict = [-conflicting_lit for conflicting_lit in conflict_bounds]
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
@@ -810,11 +799,9 @@ class LRAVariable():
     """
     def __init__(self, var: Any) -> None:
         self.upper = LRARational(float("inf"), 0)
-        self.upper_source = None
-        self.upper_literal_sign = None
+        self.upper_literal = None
         self.lower = LRARational(-float("inf"), 0)
-        self.lower_source = None
-        self.lower_literal_sign = None
+        self.lower_literal = None
         self.assign = LRARational(0,0)
         self.var = var
         self.col_idx = None
@@ -822,7 +809,7 @@ class LRAVariable():
     def __repr__(self) -> str:
         return repr(self.var)
 
-    def set_bound(self, boundary: Boundary, literal_sign: int) -> None:
+    def set_bound(self, boundary: Boundary, literal: int) -> None:
         """
         Set the upper or lower bound and record its source.
 
@@ -833,34 +820,35 @@ class LRAVariable():
         >>> from sympy.abc import x
         >>> v = LRAVariable(x)
         >>> b = Boundary(v, 10, upper=False, strict=False)
-        >>> # Asserting a lower bound x >= 10
-        >>> v.set_bound(b, literal_sign=1)
+        >>> # Asserting a lower bound x >= 10 using literal 5
+        >>> v.set_bound(b, 5)
         >>> v.lower
         (10, 0)
-        >>> v.lower_source == b
-        True
+        >>> v.lower_literal
+        5
         """
-        ci, upper = boundary.to_rational(literal_sign == -1)
+        is_negated = literal < 0
+        ci, upper = boundary.to_rational(is_negated)
         if upper:
             self.upper = ci
-            self.upper_source = boundary
-            self.upper_literal_sign = literal_sign
+            self.upper_literal = literal
         else:
             self.lower = ci
-            self.lower_source = boundary
-            self.lower_literal_sign = literal_sign
+            self.lower_literal = literal
 
-    def get_active_upper_boundary(self) -> Tuple[Optional[Boundary], Optional[int]]:
+    def get_active_upper_literal(self) -> int:
         """
-        Return the active upper Boundary object and the sign of the literal responsible for asserting it.
+        Return the literal responsible for asserting the active upper bound.
         """
-        return self.upper_source, self.upper_literal_sign
+        assert self.upper_literal is not None
+        return self.upper_literal
 
-    def get_active_lower_boundary(self) -> Tuple[Optional[Boundary], Optional[int]]:
+    def get_active_lower_literal(self) -> int:
         """
-        Return the active lower Boundary object and the sign of the literal responsible for asserting it.
+        Return the literal responsible for asserting the active lower bound.
         """
-        return self.lower_source, self.lower_literal_sign
+        assert self.lower_literal is not None
+        return self.lower_literal
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, LRAVariable):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -400,14 +400,14 @@ class LRASolver():
             c = LRARational(c, 0)
 
         if boundary.equality:
-            res1 = self._assert_bound(sym, c, upper=False, from_equality=True, from_negated_literal=is_literal_negated)
+            res1 = self._assert_bound(sym, c, upper=False, from_equality=True, literal=literal)
             if res1 and res1[0] is False:
                 res = res1
             else:
-                res2 = self._assert_bound(sym, c, upper=True, from_equality=True, from_negated_literal=is_literal_negated)
+                res2 = self._assert_bound(sym, c, upper=True, from_equality=True, literal=literal)
                 res =  res2
         else:
-            res = self._assert_bound(sym, c, upper=upper, from_negated_literal=is_literal_negated)
+            res = self._assert_bound(sym, c, upper=upper, literal=literal)
 
         if self.is_sat and sym not in self.slack_set:
             self.is_sat = res is None
@@ -416,7 +416,7 @@ class LRASolver():
 
         return res
 
-    def _assert_bound(self, xi, ci, upper=True, from_equality=False, from_negated_literal=False):
+    def _assert_bound(self, xi, ci, upper=True, from_equality=False, literal=None):
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -441,16 +441,11 @@ class LRASolver():
             # get conflicting boundary
             lit1, lit1_sign = xi.get_active_lower_boundary() if upper else xi.get_active_upper_boundary()
 
-            lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=upper, equality=from_equality)
-            if from_negated_literal:
-                lit2 = lit2.get_negated()
-            lit2_sign = -1 if from_negated_literal else 1
-
-            conflict = [-lit1_sign*self.boundary_to_atom_id[lit1], -lit2_sign*self.boundary_to_atom_id[lit2]]
+            conflict = [-lit1_sign*self.boundary_to_atom_id[lit1], -literal]
             self.result = False, conflict
             return self.result
 
-        xi.set_bound(ci, upper, from_equality, from_negated_literal)
+        xi.set_bound(ci, upper, from_equality, literal < 0)
 
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -437,7 +437,7 @@ class LRASolver():
             assert (other_bound.d * s >= 0) is True
             assert (ci.d * s <= 0) is True
             # get conflicting boundary
-            conflicting_lit = xi.get_active_lower_literal() if upper else xi.get_active_upper_literal()
+            conflicting_lit = xi.get_lower_bound_source_literal() if upper else xi.get_upper_bound_source_literal()
 
             conflict = [-conflicting_lit, -literal]
             self.result = False, conflict
@@ -533,9 +533,9 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict = []
-                    conflict += [nb.get_active_upper_literal() for nb in N_plus]
-                    conflict += [nb.get_active_lower_literal() for nb in N_minus]
-                    conflict.append(xi.get_active_lower_literal())
+                    conflict += [nb.get_upper_bound_source_literal() for nb in N_plus]
+                    conflict += [nb.get_lower_bound_source_literal() for nb in N_minus]
+                    conflict.append(xi.get_lower_bound_source_literal())
                     conflict = [-conflicting_lit for conflicting_lit in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
@@ -551,9 +551,9 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict_bounds = []
-                    conflict_bounds += [nb.get_active_upper_literal() for nb in N_minus]
-                    conflict_bounds += [nb.get_active_lower_literal() for nb in N_plus]
-                    conflict_bounds.append(xi.get_active_upper_literal())
+                    conflict_bounds += [nb.get_upper_bound_source_literal() for nb in N_minus]
+                    conflict_bounds += [nb.get_lower_bound_source_literal() for nb in N_plus]
+                    conflict_bounds.append(xi.get_upper_bound_source_literal())
 
                     conflict = [-conflicting_lit for conflicting_lit in conflict_bounds]
                     return False, conflict
@@ -837,16 +837,16 @@ class LRAVariable():
             self.lower = ci
             self.lower_literal = literal
 
-    def get_active_upper_literal(self) -> int:
+    def get_upper_bound_source_literal(self) -> int:
         """
-        Return the literal responsible for asserting the active upper bound.
+        Return the literal responsible for setting the current upper bound.
         """
         assert self.upper_literal is not None
         return self.upper_literal
 
-    def get_active_lower_literal(self) -> int:
+    def get_lower_bound_source_literal(self) -> int:
         """
-        Return the literal responsible for asserting the active lower bound.
+        Return the literal responsible for setting the current lower bound.
         """
         assert self.lower_literal is not None
         return self.lower_literal

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -450,14 +450,7 @@ class LRASolver():
             self.result = False, conflict
             return self.result
 
-        if upper:
-            xi.upper = ci
-            xi.upper_from_eq = from_equality
-            xi.upper_from_neg = from_neg
-        else:
-            xi.lower = ci
-            xi.lower_from_eq = from_equality
-            xi.lower_from_neg = from_neg
+        xi.set_bound(ci, upper, from_equality, from_neg)
 
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
@@ -805,6 +798,39 @@ class LRAVariable():
 
     def __repr__(self):
         return repr(self.var)
+
+    def set_bound(self, ci, upper=True, from_equality=False, from_neg=False):
+        """
+        Set the upper or lower bound and record the sign of its origin literal.
+
+        Example
+        =======
+
+        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, LRARational
+        >>> from sympy.abc import x
+        >>> v = LRAVariable(x)
+        >>> # Asserting a lower bound x >= 10 from a direct assertion
+        >>> v.set_bound(LRARational(10, 0), upper=False, from_neg=False)
+        >>> v.lower
+        (10, 0)
+        >>> v.lower_from_neg
+        False
+
+        >>> # Asserting an upper bound x <= 5 derived from a negated atom ~(x > 5)
+        >>> v.set_bound(LRARational(5, 0), upper=True, from_neg=True)
+        >>> v.upper
+        (5, 0)
+        >>> v.upper_from_neg
+        True
+        """
+        if upper:
+            self.upper = ci
+            self.upper_from_eq = from_equality
+            self.upper_from_neg = from_neg
+        else:
+            self.lower = ci
+            self.lower_from_eq = from_equality
+            self.lower_from_neg = from_neg
 
     def __eq__(self, other):
         if not isinstance(other, LRAVariable):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -738,6 +738,18 @@ class LRARational():
     def __init__(self, rational, delta):
         self.value = (rational, delta)
 
+    @property
+    def q(self):
+        return self.value[0]
+
+    @property
+    def d(self):
+        return self.value[1]
+
+    @property
+    def is_strict(self):
+        return self.value[1] != 0
+
     def __lt__(self, other):
         return self.value < other.value
 
@@ -748,14 +760,14 @@ class LRARational():
         return self.value == other.value
 
     def __add__(self, other):
-        return LRARational(self.value[0] + other.value[0], self.value[1] + other.value[1])
+        return LRARational(self.q + other.q, self.d + other.d)
 
     def __sub__(self, other):
-        return LRARational(self.value[0] - other.value[0], self.value[1] - other.value[1])
+        return LRARational(self.q - other.q, self.d - other.d)
 
     def __mul__(self, other):
         assert not isinstance(other, LRARational)
-        return LRARational(self.value[0] * other, self.value[1] * other)
+        return LRARational(self.q * other, self.d * other)
 
     def __getitem__(self, index):
         return self.value[index]

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -438,8 +438,8 @@ class LRASolver():
         if ci * s < other_bound * s:
             assert (other_bound[1] * s >= 0) is True
             assert (ci[1] * s <= 0) is True
-            factory = Boundary.from_lower if upper else Boundary.from_upper
-            lit1, neg1 = factory(xi)
+            # get conflicting boundary
+            lit1, neg1 = xi.get_active_lower_boundary() if upper else xi.get_active_upper_boundary()
 
             lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=upper, equality=from_equality)
             if from_neg:
@@ -539,9 +539,9 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict = []
-                    conflict += [Boundary.from_upper(nb) for nb in N_plus]
-                    conflict += [Boundary.from_lower(nb) for nb in N_minus]
-                    conflict.append(Boundary.from_lower(xi))
+                    conflict += [nb.get_active_upper_boundary() for nb in N_plus]
+                    conflict += [nb.get_active_lower_boundary() for nb in N_minus]
+                    conflict.append(xi.get_active_lower_boundary())
                     conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
@@ -557,9 +557,9 @@ class LRASolver():
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
                     conflict = []
-                    conflict += [Boundary.from_upper(nb) for nb in N_minus]
-                    conflict += [Boundary.from_lower(nb) for nb in N_plus]
-                    conflict.append(Boundary.from_upper(xi))
+                    conflict += [nb.get_active_upper_boundary() for nb in N_minus]
+                    conflict += [nb.get_active_lower_boundary() for nb in N_plus]
+                    conflict.append(xi.get_active_upper_boundary())
 
                     conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
                     return False, conflict
@@ -704,22 +704,6 @@ class Boundary:
         self.strict = strict
         assert self.strict is not None
 
-    @staticmethod
-    def from_upper(var):
-        neg = -1 if var.upper_from_neg else 1
-        b = Boundary(var, var.upper[0], True, var.upper_from_eq, var.upper[1] != 0)
-        if neg < 0:
-            b = b.get_negated()
-        return b, neg
-
-    @staticmethod
-    def from_lower(var):
-        neg = -1 if var.lower_from_neg else 1
-        b = Boundary(var, var.lower[0], False, var.lower_from_eq, var.lower[1] != 0)
-        if neg < 0:
-            b = b.get_negated()
-        return b, neg
-
     def get_negated(self):
         return Boundary(self.var, self.bound, not self.upper, self.equality, not self.strict)
 
@@ -831,6 +815,39 @@ class LRAVariable():
             self.lower = ci
             self.lower_from_eq = from_equality
             self.lower_from_neg = from_neg
+
+    def _build_active_boundary(self, bound, from_eq, from_neg, is_upper):
+        neg = -1 if from_neg else 1
+        b = Boundary(self, bound[0], is_upper, from_eq, bound[1] != 0)
+        if neg < 0:
+            b = b.get_negated()
+        return b, neg
+
+    def get_active_upper_boundary(self):
+        """
+        Return the active upper Boundary object and the sign of the literal responsible for asserting it.
+
+        Example
+        =======
+
+        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, LRARational
+        >>> from sympy.abc import x
+        >>> v = LRAVariable(x)
+        >>> # Internal state representing the assertion ~(x > 5)
+        >>> v.set_bound(LRARational(5, 0), upper=True, from_neg=True)
+        >>> b, neg = v.get_active_upper_boundary()
+        >>> b
+        'Boundary(x > 5)'
+        >>> neg
+        -1
+        """
+        return self._build_active_boundary(self.upper, self.upper_from_eq, self.upper_from_neg, True)
+
+    def get_active_lower_boundary(self):
+        """
+        Return the active lower Boundary object and the sign of the literal responsible for asserting it.
+        """
+        return self._build_active_boundary(self.lower, self.lower_from_eq, self.lower_from_neg, False)
 
     def __eq__(self, other):
         if not isinstance(other, LRAVariable):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -155,7 +155,7 @@ class LRASolver():
            https://link.springer.com/chapter/10.1007/11817963_11
     """
 
-    def __init__(self, A, slack_variables, nonslack_variables, enc_to_boundary, s_subs, testing_mode):
+    def __init__(self, A, slack_variables, nonslack_variables, atom_id_to_boundary, s_subs, testing_mode):
         """
         Use the "from_encoded_cnf" method to create a new LRASolver.
         """
@@ -164,7 +164,7 @@ class LRASolver():
 
         if any(not isinstance(a, Rational) for a in A):
             raise UnhandledInput("Non-rational numbers are not handled")
-        if any(not isinstance(b.bound, Rational) for b in enc_to_boundary.values()):
+        if any(not isinstance(b.bound, Rational) for b in atom_id_to_boundary.values()):
             raise UnhandledInput("Non-rational numbers are not handled")
         m, n = len(slack_variables), len(slack_variables)+len(nonslack_variables)
         if m != 0:
@@ -172,8 +172,8 @@ class LRASolver():
         if self.run_checks:
             assert A[:, n-m:] == -eye(m)
 
-        self.enc_to_boundary = enc_to_boundary  # mapping of int to Boundary objects
-        self.boundary_to_enc = {value: key for key, value in enc_to_boundary.items()}
+        self.atom_id_to_boundary = atom_id_to_boundary  # mapping of int to Boundary objects
+        self.boundary_to_atom_id = {value: key for key, value in atom_id_to_boundary.items()}
         self.A = A
         self.slack = slack_variables
         self.nonslack = nonslack_variables
@@ -241,7 +241,7 @@ class LRASolver():
         # for an explanation of how the formula is converted into a matrix
         # and a set of single variable constraints.
 
-        encoding = {}  # maps int to boundary
+        atom_id_to_boundary = {}
         A = []
 
         basic = []
@@ -259,15 +259,15 @@ class LRASolver():
         var_to_lra_var = {}
         conflicts = []
 
-        for prop, enc in encoded_cnf_items:
+        for prop, atom_id in encoded_cnf_items:
             if isinstance(prop, Predicate):
                 prop = prop(empty_var)
             if not isinstance(prop, AppliedPredicate):
                 if prop == True:
-                    conflicts.append([enc])
+                    conflicts.append([atom_id])
                     continue
                 if prop == False:
-                    conflicts.append([-enc])
+                    conflicts.append([-atom_id])
                     continue
 
                 raise ValueError(f"Unhandled Predicate: {prop}")
@@ -283,10 +283,10 @@ class LRASolver():
             expr = prop.lhs - prop.rhs
             pred = ALLOWED_PRED[prop.function](expr, S.Zero)
             if pred == True:
-                conflicts.append([enc])
+                conflicts.append([atom_id])
                 continue
             if pred == False:
-                conflicts.append([-enc])
+                conflicts.append([-atom_id])
                 continue
             if not expr.free_symbols:
                 raise UnhandledInput(f"{prop} could not be simplified")
@@ -324,7 +324,7 @@ class LRASolver():
             upper = var_coeff > 0 if not equality else None
             strict = prop.function in [Q.gt, Q.lt]
             b = Boundary(var_to_lra_var[var], -const, upper, equality, strict)
-            encoding[enc] = b
+            atom_id_to_boundary[atom_id] = b
 
         fs = [v.free_symbols for v in nonbasic + basic]
         assert all(len(syms) > 0 for syms in fs)
@@ -338,7 +338,7 @@ class LRASolver():
         for idx, var in enumerate(nonbasic + basic):
             var.col_idx = idx
 
-        return LRASolver(A, basic, nonbasic, encoding, s_subs, testing_mode), conflicts
+        return LRASolver(A, basic, nonbasic, atom_id_to_boundary, s_subs, testing_mode), conflicts
 
     def reset_bounds(self):
         """
@@ -355,7 +355,7 @@ class LRASolver():
             var.upper_from_negated_literal = False
             var.assign = LRARational(0, 0)
 
-    def assert_lit(self, enc_constraint):
+    def assert_lit(self, literal):
         """
         Assert a literal representing a constraint
         and update the internal state accordingly.
@@ -367,9 +367,9 @@ class LRASolver():
         Parameters
         ==========
 
-        enc_constraint : int
-            A mapping of encodings to constraints
-            can be found in `self.enc_to_boundary`.
+        literal : int
+            A mapping of IDs to constraints
+            can be found in `self.atom_id_to_boundary`.
 
         Returns
         =======
@@ -380,14 +380,14 @@ class LRASolver():
             A conflict clause that "explains" why
             the literals asserted so far are unsatisfiable.
         """
-        if abs(enc_constraint) not in self.enc_to_boundary:
+        if abs(literal) not in self.atom_id_to_boundary:
             return None
 
-        if not HANDLE_NEGATION and enc_constraint < 0:
+        if not HANDLE_NEGATION and literal < 0:
             return None
 
-        boundary = self.enc_to_boundary[abs(enc_constraint)]
-        sym, c, is_literal_negated = boundary.var, boundary.bound, enc_constraint < 0
+        boundary = self.atom_id_to_boundary[abs(literal)]
+        sym, c, is_literal_negated = boundary.var, boundary.bound, literal < 0
 
         if boundary.equality and is_literal_negated:
             return None # negated equality is not handled and should only appear in conflict clauses
@@ -446,7 +446,7 @@ class LRASolver():
                 lit2 = lit2.get_negated()
             lit2_sign = -1 if from_negated_literal else 1
 
-            conflict = [-lit1_sign*self.boundary_to_enc[lit1], -lit2_sign*self.boundary_to_enc[lit2]]
+            conflict = [-lit1_sign*self.boundary_to_atom_id[lit1], -lit2_sign*self.boundary_to_atom_id[lit2]]
             self.result = False, conflict
             return self.result
 
@@ -542,7 +542,7 @@ class LRASolver():
                     conflict += [nb.get_active_upper_boundary() for nb in N_plus]
                     conflict += [nb.get_active_lower_boundary() for nb in N_minus]
                     conflict.append(xi.get_active_lower_boundary())
-                    conflict = [-literal_sign*self.boundary_to_enc[c] for c, literal_sign in conflict]
+                    conflict = [-literal_sign*self.boundary_to_atom_id[c] for c, literal_sign in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
@@ -561,7 +561,7 @@ class LRASolver():
                     conflict += [nb.get_active_lower_boundary() for nb in N_plus]
                     conflict.append(xi.get_active_upper_boundary())
 
-                    conflict = [-literal_sign*self.boundary_to_enc[c] for c, literal_sign in conflict]
+                    conflict = [-literal_sign*self.boundary_to_atom_id[c] for c, literal_sign in conflict]
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -164,7 +164,7 @@ class LRASolver():
 
         if any(not isinstance(a, Rational) for a in A):
             raise UnhandledInput("Non-rational numbers are not handled")
-        if any(not isinstance(b.bound, Rational) for b in atom_id_to_boundary.values()):
+        if any(not isinstance(b.bound, Rational) for bs in atom_id_to_boundary.values() for b in bs):
             raise UnhandledInput("Non-rational numbers are not handled")
         m, n = len(slack_variables), len(slack_variables)+len(nonslack_variables)
         if m != 0:
@@ -172,8 +172,12 @@ class LRASolver():
         if self.run_checks:
             assert A[:, n-m:] == -eye(m)
 
-        self.atom_id_to_boundary = atom_id_to_boundary  # mapping of int to Boundary objects
-        self.boundary_to_atom_id = {value: key for key, value in atom_id_to_boundary.items()}
+        self.atom_id_to_boundary = atom_id_to_boundary  # mapping of int to lists of Boundary objects
+        self.boundary_to_atom_id = {}
+        for aid, bs in atom_id_to_boundary.items():
+            for b in bs:
+                # assert b not in self.boundary_to_atom_id
+                self.boundary_to_atom_id[b] = aid
         self.A = A
         self.slack = slack_variables
         self.nonslack = nonslack_variables
@@ -321,10 +325,15 @@ class LRASolver():
             assert var_coeff != 0
 
             equality = prop.function == Q.eq
-            upper = var_coeff > 0 if not equality else None
             strict = prop.function in [Q.gt, Q.lt]
-            b = Boundary(var_to_lra_var[var], -const, upper, equality, strict)
-            atom_id_to_boundary[atom_id] = b
+            if equality:
+                b1 = Boundary(var_to_lra_var[var], -const, True, False)  # x <= c
+                b2 = Boundary(var_to_lra_var[var], -const, False, False) # x >= c
+                atom_id_to_boundary[atom_id] = [b1, b2]
+            else:
+                upper = var_coeff > 0
+                b = Boundary(var_to_lra_var[var], -const, upper, strict)
+                atom_id_to_boundary[atom_id] = [b]
 
         fs = [v.free_symbols for v in nonbasic + basic]
         assert all(len(syms) > 0 for syms in fs)
@@ -348,10 +357,8 @@ class LRASolver():
         self.result = None
         for var in self.all_var:
             var.lower = LRARational(-float("inf"), 0)
-            var.lower_from_eq = False
             var.lower_from_negated_literal = False
             var.upper = LRARational(float("inf"), 0)
-            var.upper_from_eq = False
             var.upper_from_negated_literal = False
             var.assign = LRARational(0, 0)
 
@@ -386,37 +393,34 @@ class LRASolver():
         if not HANDLE_NEGATION and literal < 0:
             return None
 
-        boundary = self.atom_id_to_boundary[abs(literal)]
-        sym, c, is_literal_negated = boundary.var, boundary.bound, literal < 0
+        boundaries = self.atom_id_to_boundary[abs(literal)]
+        is_literal_negated = literal < 0
 
-        if boundary.equality and is_literal_negated:
+        if len(boundaries) > 1 and is_literal_negated:
             return None # negated equality is not handled and should only appear in conflict clauses
 
-        upper = boundary.upper != is_literal_negated
-        if boundary.strict != is_literal_negated:
-            delta = -1 if upper else 1
-            c = LRARational(c, delta)
-        else:
-            c = LRARational(c, 0)
-
-        if boundary.equality:
-            res1 = self._assert_bound(sym, c, upper=False, from_equality=True, literal=literal)
-            if res1 and res1[0] is False:
-                res = res1
+        res = None
+        for boundary in boundaries:
+            sym, c = boundary.var, boundary.bound
+            upper = boundary.upper != is_literal_negated
+            if boundary.strict != is_literal_negated:
+                delta = -1 if upper else 1
+                c = LRARational(c, delta)
             else:
-                res2 = self._assert_bound(sym, c, upper=True, from_equality=True, literal=literal)
-                res =  res2
-        else:
-            res = self._assert_bound(sym, c, upper=upper, literal=literal)
+                c = LRARational(c, 0)
 
-        if self.is_sat and sym not in self.slack_set:
+            res = self._assert_bound(sym, c, upper=upper, literal=literal)
+            if res and res[0] is False:
+                break
+
+        if self.is_sat and all(b.var not in self.slack_set for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False
 
         return res
 
-    def _assert_bound(self, xi, ci, upper=True, from_equality=False, literal=None):
+    def _assert_bound(self, xi, ci, upper=True, literal=None):
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -445,7 +449,7 @@ class LRASolver():
             self.result = False, conflict
             return self.result
 
-        xi.set_bound(ci, upper, from_equality, literal < 0)
+        xi.set_bound(ci, upper, from_negated_literal=literal < 0)
 
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
@@ -675,15 +679,26 @@ def _sep_const_terms(expr):
 
 
 class Boundary:
-    """
-    Represents an upper or lower bound or an equality between a symbol
+    r"""
+    Represents an upper or lower bound between a symbol
     and some constant.
+
+    Example
+    =======
+
+    >>> from sympy.logic.algorithms.lra_theory import Boundary, LRAVariable
+    >>> from sympy.abc import x
+    >>> var = LRAVariable(x)
+    >>> # x <= 5
+    >>> b1 = Boundary(var, 5, upper=True, strict=False)
+    >>> b1.get_inequality()
+    x <= 5
+    >>> # x > 10 (represented as a lower bound with strict=True)
+    >>> b2 = Boundary(var, 10, upper=False, strict=True)
+    >>> b2.get_inequality()
+    x > 10
     """
-    def __init__(self, var, const, upper, equality, strict=None):
-        if not equality in [True, False]:
-            assert equality in [True, False]
-
-
+    def __init__(self, var, const, upper, strict=None):
         self.var = var
         if isinstance(const, tuple):
             s = const[1] != 0
@@ -694,18 +709,15 @@ class Boundary:
         else:
             self.bound = const
             self.strict = strict
-        self.upper = upper if not equality else None
-        self.equality = equality
+        self.upper = upper
         self.strict = strict
         assert self.strict is not None
 
     def get_negated(self):
-        return Boundary(self.var, self.bound, not self.upper, self.equality, not self.strict)
+        return Boundary(self.var, self.bound, not self.upper, not self.strict)
 
     def get_inequality(self):
-        if self.equality:
-            return Eq(self.var.var, self.bound)
-        elif self.upper and self.strict:
+        if self.upper and self.strict:
             return self.var.var < self.bound
         elif not self.upper and self.strict:
             return self.var.var > self.bound
@@ -718,11 +730,11 @@ class Boundary:
         return repr("Boundary(" + repr(self.get_inequality()) + ")")
 
     def __eq__(self, other):
-        other = (other.var, other.bound, other.strict, other.upper, other.equality)
-        return (self.var, self.bound, self.strict, self.upper, self.equality) == other
+        other = (other.var, other.bound, other.strict, other.upper)
+        return (self.var, self.bound, self.strict, self.upper) == other
 
     def __hash__(self):
-        return hash((self.var, self.bound, self.strict, self.upper, self.equality))
+        return hash((self.var, self.bound, self.strict, self.upper))
 
 
 class LRARational():
@@ -778,10 +790,8 @@ class LRAVariable():
     """
     def __init__(self, var):
         self.upper = LRARational(float("inf"), 0)
-        self.upper_from_eq = False
         self.upper_from_negated_literal = False
         self.lower = LRARational(-float("inf"), 0)
-        self.lower_from_eq = False
         self.lower_from_negated_literal = False
         self.assign = LRARational(0,0)
         self.var = var
@@ -790,7 +800,7 @@ class LRAVariable():
     def __repr__(self):
         return repr(self.var)
 
-    def set_bound(self, ci, upper=True, from_equality=False, from_negated_literal=False):
+    def set_bound(self, ci, upper=True, from_negated_literal=False):
         """
         Set the upper or lower bound and record the sign of its origin literal.
 
@@ -816,16 +826,14 @@ class LRAVariable():
         """
         if upper:
             self.upper = ci
-            self.upper_from_eq = from_equality
             self.upper_from_negated_literal = from_negated_literal
         else:
             self.lower = ci
-            self.lower_from_eq = from_equality
             self.lower_from_negated_literal = from_negated_literal
 
-    def _build_active_boundary(self, bound, from_eq, from_negated_literal, is_upper):
+    def _build_active_boundary(self, bound, from_negated_literal, is_upper):
         literal_sign = -1 if from_negated_literal else 1
-        b = Boundary(self, bound.q, is_upper, from_eq, bound.d != 0)
+        b = Boundary(self, bound.q, is_upper, bound.d != 0)
         if literal_sign < 0:
             b = b.get_negated()
         return b, literal_sign
@@ -848,13 +856,13 @@ class LRAVariable():
         >>> literal_sign
         -1
         """
-        return self._build_active_boundary(self.upper, self.upper_from_eq, self.upper_from_negated_literal, True)
+        return self._build_active_boundary(self.upper, self.upper_from_negated_literal, True)
 
     def get_active_lower_boundary(self):
         """
         Return the active lower Boundary object and the sign of the literal responsible for asserting it.
         """
-        return self._build_active_boundary(self.lower, self.lower_from_eq, self.lower_from_negated_literal, False)
+        return self._build_active_boundary(self.lower, self.lower_from_negated_literal, False)
 
     def __eq__(self, other):
         if not isinstance(other, LRAVariable):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -114,6 +114,7 @@ References
        https://link.springer.com/chapter/10.1007/11817963_11
 """
 from __future__ import annotations
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from sympy.solvers.solveset import linear_eq_to_matrix
 from sympy.matrices.dense import eye
 from sympy.assumptions import Predicate
@@ -155,7 +156,8 @@ class LRASolver():
            https://link.springer.com/chapter/10.1007/11817963_11
     """
 
-    def __init__(self, A, slack_variables, nonslack_variables, atom_id_to_boundary, s_subs, testing_mode):
+    def __init__(self, A: Matrix, slack_variables: List[LRAVariable], nonslack_variables: List[LRAVariable],
+        atom_id_to_boundary: Dict[int, List[Boundary]], s_subs: Dict[Any, LRAVariable], testing_mode: bool) -> None:
         """
         Use the "from_encoded_cnf" method to create a new LRASolver.
         """
@@ -189,7 +191,7 @@ class LRASolver():
         self.result = None  # always one of: (True, assignment), (False, conflict clause), None
 
     @staticmethod
-    def from_encoded_cnf(encoded_cnf, testing_mode=False):
+    def from_encoded_cnf(encoded_cnf: EncodedCNF, testing_mode: bool=False) -> Tuple[LRASolver, List[List[int]]]:
         """
         Creates an LRASolver from an EncodedCNF object
         and a list of conflict clauses for propositions
@@ -349,7 +351,7 @@ class LRASolver():
 
         return LRASolver(A, basic, nonbasic, atom_id_to_boundary, s_subs, testing_mode), conflicts
 
-    def reset_bounds(self):
+    def reset_bounds(self) -> None:
         """
         Resets the state of the LRASolver to before
         anything was asserted.
@@ -364,7 +366,7 @@ class LRASolver():
             var.upper_literal_sign = None
             var.assign = LRARational(0, 0)
 
-    def assert_lit(self, literal):
+    def assert_lit(self, literal: int) -> Optional[Tuple[bool, List[int]]]:
         """
         Assert a literal representing a constraint
         and update the internal state accordingly.
@@ -414,7 +416,7 @@ class LRASolver():
 
         return res
 
-    def _assert_bound(self, boundary, literal):
+    def _assert_bound(self, boundary: Boundary, literal: int) -> Optional[Tuple[bool, List[int]]]:
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -460,18 +462,19 @@ class LRASolver():
 
         return None
 
-    def _update(self, xi, v):
+    def _update(self, xi: LRAVariable, v: LRARational) -> None:
         """
         Updates all slack variables that have equations that contain
         variable xi so that they stay satisfied given xi is equal to v.
         """
         i = xi.col_idx
+        assert i is not None
         for j, b in enumerate(self.slack):
             aji = self.A[j, i]
             b.assign = b.assign + (v - xi.assign)*aji
         xi.assign = v
 
-    def check(self):
+    def check(self) -> Union[Tuple[bool, Dict[LRAVariable, LRARational]], Tuple[bool, List[int]]]:
         """
         Searches for an assignment that satisfies all constraints
         or determines that no such assignment exists and gives
@@ -553,23 +556,29 @@ class LRASolver():
                     N_plus = [nb for nb in nonbasic if M[i, nb.col_idx] > 0]
                     N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
 
-                    conflict = []
-                    conflict += [nb.get_active_upper_boundary() for nb in N_minus]
-                    conflict += [nb.get_active_lower_boundary() for nb in N_plus]
-                    conflict.append(xi.get_active_upper_boundary())
+                    conflict_bounds = []
+                    conflict_bounds += [nb.get_active_upper_boundary() for nb in N_minus]
+                    conflict_bounds += [nb.get_active_lower_boundary() for nb in N_plus]
+                    conflict_bounds.append(xi.get_active_upper_boundary())
 
-                    conflict = [-literal_sign*self.boundary_to_atom_id[c] for c, literal_sign in conflict]
+                    conflict = []
+                    for c_source, literal_sign in conflict_bounds:
+                        assert c_source is not None
+                        assert literal_sign is not None
+                        conflict.append(-literal_sign*self.boundary_to_atom_id[c_source])
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
 
-    def _pivot_and_update(self, M, basic, nonbasic, xi, xj, v):
+    def _pivot_and_update(self, M: Matrix, basic: Dict[LRAVariable, int], nonbasic: Set[LRAVariable],
+        xi: LRAVariable, xj: LRAVariable, v: LRARational) -> Matrix:
         """
         Pivots basic variable xi with nonbasic variable xj,
         and sets value of xi to v and adjusts the values of all basic variables
         to keep equations satisfied.
         """
         i, j = basic[xi], xj.col_idx
+        assert j is not None
         assert M[i, j] != 0
         theta = (v - xi.assign)*(1/M[i, j])
         xi.assign = v
@@ -587,7 +596,7 @@ class LRASolver():
         return self._pivot(M, i, j)
 
     @staticmethod
-    def _pivot(M, i, j):
+    def _pivot(M: Matrix, i: int, j: int) -> Matrix:
         """
         Performs a pivot operation about entry i, j of M by performing
         a series of row operations on a copy of M and returning the result.
@@ -640,7 +649,7 @@ class LRASolver():
         return A
 
 
-def _sep_const_coeff(expr):
+def _sep_const_coeff(expr: Any) -> Tuple[Any, Any]:
     """
     Example
     =======
@@ -660,7 +669,7 @@ def _sep_const_coeff(expr):
     return Mul(*var), Mul(*const)
 
 
-def _sep_const_terms(expr):
+def _sep_const_terms(expr: Any) -> Tuple[Any, Any]:
     """
     Example
     =======
@@ -696,7 +705,7 @@ class Boundary:
     >>> b2.get_inequality()
     x > 10
     """
-    def __init__(self, var, const, upper, strict=None):
+    def __init__(self, var: LRAVariable, const: Union[Rational, Tuple[Rational, int]], upper: bool, strict: Optional[bool]=None) -> None:
         self.var = var
         if isinstance(const, tuple):
             s = const[1] != 0
@@ -710,7 +719,7 @@ class Boundary:
         self.upper = upper
         assert self.strict is not None
 
-    def to_rational(self, is_negated):
+    def to_rational(self, is_negated: bool) -> Tuple[LRARational, bool]:
         """
         Return the LRARational bound and effective direction (upper=True)
         considering whether the boundary is negated.
@@ -721,10 +730,10 @@ class Boundary:
             delta = -1 if upper else 1
         return LRARational(self.bound, delta), upper
 
-    def get_negated(self):
+    def get_negated(self) -> Boundary:
         return Boundary(self.var, self.bound, not self.upper, not self.strict)
 
-    def get_inequality(self):
+    def get_inequality(self) -> Any:
         if self.upper and self.strict:
             return self.var.var < self.bound
         elif not self.upper and self.strict:
@@ -734,14 +743,15 @@ class Boundary:
         else:
             return self.var.var >= self.bound
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr("Boundary(" + repr(self.get_inequality()) + ")")
 
-    def __eq__(self, other):
-        other = (other.var, other.bound, other.strict, other.upper)
-        return (self.var, self.bound, self.strict, self.upper) == other
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Boundary):
+            return NotImplemented
+        return (self.var, self.bound, self.strict, self.upper) == (other.var, other.bound, other.strict, other.upper)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.var, self.bound, self.strict, self.upper))
 
 
@@ -750,44 +760,46 @@ class LRARational():
     Represents a rational plus or minus some amount
     of arbitrary small deltas.
     """
-    def __init__(self, rational, delta):
+    def __init__(self, rational: Union[Rational, float], delta: int) -> None:
         self.value = (rational, delta)
 
     @property
-    def q(self):
+    def q(self) -> Union[Rational, float]:
         return self.value[0]
 
     @property
-    def d(self):
+    def d(self) -> int:
         return self.value[1]
 
     @property
-    def is_strict(self):
+    def is_strict(self) -> bool:
         return self.value[1] != 0
 
-    def __lt__(self, other):
+    def __lt__(self, other: LRARational) -> bool:
         return self.value < other.value
 
-    def __le__(self, other):
+    def __le__(self, other: LRARational) -> bool:
         return self.value <= other.value
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LRARational):
+            return NotImplemented
         return self.value == other.value
 
-    def __add__(self, other):
+    def __add__(self, other: LRARational) -> LRARational:
         return LRARational(self.q + other.q, self.d + other.d)
 
-    def __sub__(self, other):
+    def __sub__(self, other: LRARational) -> LRARational:
         return LRARational(self.q - other.q, self.d - other.d)
 
-    def __mul__(self, other):
+    def __mul__(self, other: Union[Rational, int]) -> LRARational:
         assert not isinstance(other, LRARational)
         return LRARational(self.q * other, self.d * other)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Union[Rational, float, int]:
         return self.value[index]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.value)
 
 
@@ -796,7 +808,7 @@ class LRAVariable():
     Object to keep track of upper and lower bounds
     on `self.var`.
     """
-    def __init__(self, var):
+    def __init__(self, var: Any) -> None:
         self.upper = LRARational(float("inf"), 0)
         self.upper_source = None
         self.upper_literal_sign = None
@@ -807,10 +819,10 @@ class LRAVariable():
         self.var = var
         self.col_idx = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.var)
 
-    def set_bound(self, boundary, literal_sign):
+    def set_bound(self, boundary: Boundary, literal_sign: int) -> None:
         """
         Set the upper or lower bound and record its source.
 
@@ -838,22 +850,22 @@ class LRAVariable():
             self.lower_source = boundary
             self.lower_literal_sign = literal_sign
 
-    def get_active_upper_boundary(self):
+    def get_active_upper_boundary(self) -> Tuple[Optional[Boundary], Optional[int]]:
         """
         Return the active upper Boundary object and the sign of the literal responsible for asserting it.
         """
         return self.upper_source, self.upper_literal_sign
 
-    def get_active_lower_boundary(self):
+    def get_active_lower_boundary(self) -> Tuple[Optional[Boundary], Optional[int]]:
         """
         Return the active lower Boundary object and the sign of the literal responsible for asserting it.
         """
         return self.lower_source, self.lower_literal_sign
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, LRAVariable):
             return False
         return other.var == self.var
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.var)

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -357,9 +357,11 @@ class LRASolver():
         self.result = None
         for var in self.all_var:
             var.lower = LRARational(-float("inf"), 0)
-            var.lower_from_negated_literal = False
+            var.lower_source = None
+            var.lower_literal_sign = None
             var.upper = LRARational(float("inf"), 0)
-            var.upper_from_negated_literal = False
+            var.upper_source = None
+            var.upper_literal_sign = None
             var.assign = LRARational(0, 0)
 
     def assert_lit(self, literal):
@@ -401,15 +403,7 @@ class LRASolver():
 
         res = None
         for boundary in boundaries:
-            sym, c = boundary.var, boundary.bound
-            upper = boundary.upper != is_literal_negated
-            if boundary.strict != is_literal_negated:
-                delta = -1 if upper else 1
-                c = LRARational(c, delta)
-            else:
-                c = LRARational(c, 0)
-
-            res = self._assert_bound(sym, c, upper=upper, literal=literal)
+            res = self._assert_bound(boundary, literal)
             if res and res[0] is False:
                 break
 
@@ -420,7 +414,7 @@ class LRASolver():
 
         return res
 
-    def _assert_bound(self, xi, ci, upper=True, literal=None):
+    def _assert_bound(self, boundary, literal):
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -432,6 +426,10 @@ class LRASolver():
         if self.result:
             assert self.result[0] != False
         self.result = None
+
+        xi = boundary.var
+        is_literal_negated = literal < 0
+        ci, upper = boundary.to_rational(is_literal_negated)
 
         s = 1 if upper else -1
         current_bound = xi.upper if upper else xi.lower
@@ -449,7 +447,7 @@ class LRASolver():
             self.result = False, conflict
             return self.result
 
-        xi.set_bound(ci, upper, from_negated_literal=literal < 0)
+        xi.set_bound(boundary, -1 if is_literal_negated else 1)
 
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
@@ -702,7 +700,7 @@ class Boundary:
         self.var = var
         if isinstance(const, tuple):
             s = const[1] != 0
-            if strict:
+            if strict is not None:
                 assert s == strict
             self.bound = const[0]
             self.strict = s
@@ -710,8 +708,18 @@ class Boundary:
             self.bound = const
             self.strict = strict
         self.upper = upper
-        self.strict = strict
         assert self.strict is not None
+
+    def to_rational(self, is_negated):
+        """
+        Return the LRARational bound and effective direction (upper=True)
+        considering whether the boundary is negated.
+        """
+        upper = self.upper != is_negated
+        delta = 0
+        if self.strict != is_negated:
+            delta = -1 if upper else 1
+        return LRARational(self.bound, delta), upper
 
     def get_negated(self):
         return Boundary(self.var, self.bound, not self.upper, not self.strict)
@@ -790,9 +798,11 @@ class LRAVariable():
     """
     def __init__(self, var):
         self.upper = LRARational(float("inf"), 0)
-        self.upper_from_negated_literal = False
+        self.upper_source = None
+        self.upper_literal_sign = None
         self.lower = LRARational(-float("inf"), 0)
-        self.lower_from_negated_literal = False
+        self.lower_source = None
+        self.lower_literal_sign = None
         self.assign = LRARational(0,0)
         self.var = var
         self.col_idx = None
@@ -800,69 +810,45 @@ class LRAVariable():
     def __repr__(self):
         return repr(self.var)
 
-    def set_bound(self, ci, upper=True, from_negated_literal=False):
+    def set_bound(self, boundary, literal_sign):
         """
-        Set the upper or lower bound and record the sign of its origin literal.
+        Set the upper or lower bound and record its source.
 
         Example
         =======
 
-        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, LRARational
+        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, LRARational, Boundary
         >>> from sympy.abc import x
         >>> v = LRAVariable(x)
-        >>> # Asserting a lower bound x >= 10 from a direct assertion
-        >>> v.set_bound(LRARational(10, 0), upper=False, from_negated_literal=False)
+        >>> b = Boundary(v, 10, upper=False, strict=False)
+        >>> # Asserting a lower bound x >= 10
+        >>> v.set_bound(b, literal_sign=1)
         >>> v.lower
         (10, 0)
-        >>> v.lower_from_negated_literal
-        False
-
-        >>> # Asserting an upper bound x <= 5 derived from a negated atom ~(x > 5)
-        >>> v.set_bound(LRARational(5, 0), upper=True, from_negated_literal=True)
-        >>> v.upper
-        (5, 0)
-        >>> v.upper_from_negated_literal
+        >>> v.lower_source == b
         True
         """
+        ci, upper = boundary.to_rational(literal_sign == -1)
         if upper:
             self.upper = ci
-            self.upper_from_negated_literal = from_negated_literal
+            self.upper_source = boundary
+            self.upper_literal_sign = literal_sign
         else:
             self.lower = ci
-            self.lower_from_negated_literal = from_negated_literal
-
-    def _build_active_boundary(self, bound, from_negated_literal, is_upper):
-        literal_sign = -1 if from_negated_literal else 1
-        b = Boundary(self, bound.q, is_upper, bound.d != 0)
-        if literal_sign < 0:
-            b = b.get_negated()
-        return b, literal_sign
+            self.lower_source = boundary
+            self.lower_literal_sign = literal_sign
 
     def get_active_upper_boundary(self):
         """
         Return the active upper Boundary object and the sign of the literal responsible for asserting it.
-
-        Example
-        =======
-
-        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, LRARational
-        >>> from sympy.abc import x
-        >>> v = LRAVariable(x)
-        >>> # Internal state representing the assertion ~(x > 5)
-        >>> v.set_bound(LRARational(5, 0), upper=True, from_negated_literal=True)
-        >>> b, literal_sign = v.get_active_upper_boundary()
-        >>> b
-        'Boundary(x > 5)'
-        >>> literal_sign
-        -1
         """
-        return self._build_active_boundary(self.upper, self.upper_from_negated_literal, True)
+        return self.upper_source, self.upper_literal_sign
 
     def get_active_lower_boundary(self):
         """
         Return the active lower Boundary object and the sign of the literal responsible for asserting it.
         """
-        return self._build_active_boundary(self.lower, self.lower_from_negated_literal, False)
+        return self.lower_source, self.lower_literal_sign
 
     def __eq__(self, other):
         if not isinstance(other, LRAVariable):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -436,8 +436,8 @@ class LRASolver():
 
         other_bound = xi.lower if upper else xi.upper
         if ci * s < other_bound * s:
-            assert (other_bound[1] * s >= 0) is True
-            assert (ci[1] * s <= 0) is True
+            assert (other_bound.d * s >= 0) is True
+            assert (ci.d * s <= 0) is True
             # get conflicting boundary
             lit1, lit1_sign = xi.get_active_lower_boundary() if upper else xi.get_active_upper_boundary()
 
@@ -455,10 +455,10 @@ class LRASolver():
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
 
-        if self.run_checks and all(v.assign[0] != float("inf") and v.assign[0] != -float("inf")
+        if self.run_checks and all(v.assign.q != float("inf") and v.assign.q != -float("inf")
                                    for v in self.all_var):
             M = self.A
-            X = Matrix([v.assign[0] for v in self.all_var])
+            X = Matrix([v.assign.q for v in self.all_var])
             assert all(abs(val) < 10 ** (-10) for val in M * X)
 
         return None
@@ -508,9 +508,9 @@ class LRASolver():
 
                 # assignments for x must always satisfy Ax = 0
                 # probably have to turn this off when dealing with strict ineq
-                if all(v.assign[0] != float("inf") and v.assign[0] != -float("inf")
+                if all(v.assign.q != float("inf") and v.assign.q != -float("inf")
                                    for v in self.all_var):
-                    X = Matrix([v.assign[0] for v in self.all_var])
+                    X = Matrix([v.assign.q for v in self.all_var])
                     assert all(abs(val) < 10**(-10) for val in M*X)
 
                 # check upper and lower match this format:
@@ -519,8 +519,8 @@ class LRASolver():
                 # this wouldn't make sense:
                 # x <= rat - delta
                 # x >= rat + delta
-                assert all(x.upper[1] <= 0 for x in self.all_var)
-                assert all(x.lower[1] >= 0 for x in self.all_var)
+                assert all(x.upper.d <= 0 for x in self.all_var)
+                assert all(x.lower.d >= 0 for x in self.all_var)
 
             cand = [b for b in basic if b.assign < b.lower or b.assign > b.upper]
 
@@ -830,7 +830,7 @@ class LRAVariable():
 
     def _build_active_boundary(self, bound, from_eq, from_negated_literal, is_upper):
         literal_sign = -1 if from_negated_literal else 1
-        b = Boundary(self, bound[0], is_upper, from_eq, bound[1] != 0)
+        b = Boundary(self, bound.q, is_upper, from_eq, bound.d != 0)
         if literal_sign < 0:
             b = b.get_negated()
         return b, literal_sign

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -120,6 +120,7 @@ from sympy.matrices.dense import eye
 from sympy.assumptions import Predicate
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.ask import Q
+from sympy.assumptions.cnf import EncodedCNF
 from sympy.core import Dummy
 from sympy.core.mul import Mul
 from sympy.core.add import Add
@@ -816,7 +817,7 @@ class LRAVariable():
         Example
         =======
 
-        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, LRARational, Boundary
+        >>> from sympy.logic.algorithms.lra_theory import LRAVariable, Boundary
         >>> from sympy.abc import x
         >>> v = LRAVariable(x)
         >>> b = Boundary(v, 10, upper=False, strict=False)

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -400,16 +400,14 @@ class LRASolver():
             c = LRARational(c, 0)
 
         if boundary.equality:
-            res1 = self._assert_lower(sym, c, from_equality=True, from_neg=negated)
-            if res1 and res1[0] == False:
+            res1 = self._assert_bound(sym, c, upper=False, from_equality=True, from_neg=negated)
+            if res1 and res1[0] is False:
                 res = res1
             else:
-                res2 = self._assert_upper(sym, c, from_equality=True, from_neg=negated)
+                res2 = self._assert_bound(sym, c, upper=True, from_equality=True, from_neg=negated)
                 res =  res2
-        elif upper:
-            res = self._assert_upper(sym, c, from_neg=negated)
         else:
-            res = self._assert_lower(sym, c, from_neg=negated)
+            res = self._assert_bound(sym, c, upper=upper, from_neg=negated)
 
         if self.is_sat and sym not in self.slack_set:
             self.is_sat = res is None
@@ -418,9 +416,9 @@ class LRASolver():
 
         return res
 
-    def _assert_upper(self, xi, ci, from_equality=False, from_neg=False):
+    def _assert_bound(self, xi, ci, upper=True, from_equality=False, from_neg=False):
         """
-        Adjusts the upper bound on variable xi if the new upper bound is
+        Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
         within the new bound if needed.
 
@@ -430,15 +428,20 @@ class LRASolver():
         if self.result:
             assert self.result[0] != False
         self.result = None
-        if ci >= xi.upper:
+
+        s = 1 if upper else -1
+        current_bound = xi.upper if upper else xi.lower
+        if ci * s >= current_bound * s:
             return None
-        if ci < xi.lower:
-            assert (xi.lower[1] >= 0) is True
-            assert (ci[1] <= 0) is True
 
-            lit1, neg1 = Boundary.from_lower(xi)
+        other_bound = xi.lower if upper else xi.upper
+        if ci * s < other_bound * s:
+            assert (other_bound[1] * s >= 0) is True
+            assert (ci[1] * s <= 0) is True
+            factory = Boundary.from_lower if upper else Boundary.from_upper
+            lit1, neg1 = factory(xi)
 
-            lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=True, equality=from_equality)
+            lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=upper, equality=from_equality)
             if from_neg:
                 lit2 = lit2.get_negated()
             neg2 = -1 if from_neg else 1
@@ -446,52 +449,17 @@ class LRASolver():
             conflict = [-neg1*self.boundary_to_enc[lit1], -neg2*self.boundary_to_enc[lit2]]
             self.result = False, conflict
             return self.result
-        xi.upper = ci
-        xi.upper_from_eq = from_equality
-        xi.upper_from_neg = from_neg
-        if xi in self.nonslack and xi.assign > ci:
-            self._update(xi, ci)
 
-        if self.run_checks and all(v.assign[0] != float("inf") and v.assign[0] != -float("inf")
-                                   for v in self.all_var):
-            M = self.A
-            X = Matrix([v.assign[0] for v in self.all_var])
-            assert all(abs(val) < 10 ** (-10) for val in M * X)
+        if upper:
+            xi.upper = ci
+            xi.upper_from_eq = from_equality
+            xi.upper_from_neg = from_neg
+        else:
+            xi.lower = ci
+            xi.lower_from_eq = from_equality
+            xi.lower_from_neg = from_neg
 
-        return None
-
-    def _assert_lower(self, xi, ci, from_equality=False, from_neg=False):
-        """
-        Adjusts the lower bound on variable xi if the new lower bound is
-        more limiting. The assignment of variable xi is adjusted to be
-        within the new bound if needed.
-
-        Also calls `self._update` to update the assignment for slack variables
-        to keep all equalities satisfied.
-        """
-        if self.result:
-            assert self.result[0] != False
-        self.result = None
-        if ci <= xi.lower:
-            return None
-        if ci > xi.upper:
-            assert (xi.upper[1] <= 0) is True
-            assert (ci[1] >= 0) is True
-
-            lit1, neg1 = Boundary.from_upper(xi)
-
-            lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=False, equality=from_equality)
-            if from_neg:
-                lit2 = lit2.get_negated()
-            neg2 = -1 if from_neg else 1
-
-            conflict = [-neg1*self.boundary_to_enc[lit1],-neg2*self.boundary_to_enc[lit2]]
-            self.result = False, conflict
-            return self.result
-        xi.lower = ci
-        xi.lower_from_eq = from_equality
-        xi.lower_from_neg = from_neg
-        if xi in self.nonslack and xi.assign < ci:
+        if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
 
         if self.run_checks and all(v.assign[0] != float("inf") and v.assign[0] != -float("inf")

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -349,10 +349,10 @@ class LRASolver():
         for var in self.all_var:
             var.lower = LRARational(-float("inf"), 0)
             var.lower_from_eq = False
-            var.lower_from_neg = False
+            var.lower_from_negated_literal = False
             var.upper = LRARational(float("inf"), 0)
             var.upper_from_eq = False
-            var.upper_from_neg = False
+            var.upper_from_negated_literal = False
             var.assign = LRARational(0, 0)
 
     def assert_lit(self, enc_constraint):
@@ -387,27 +387,27 @@ class LRASolver():
             return None
 
         boundary = self.enc_to_boundary[abs(enc_constraint)]
-        sym, c, negated = boundary.var, boundary.bound, enc_constraint < 0
+        sym, c, is_literal_negated = boundary.var, boundary.bound, enc_constraint < 0
 
-        if boundary.equality and negated:
+        if boundary.equality and is_literal_negated:
             return None # negated equality is not handled and should only appear in conflict clauses
 
-        upper = boundary.upper != negated
-        if boundary.strict != negated:
+        upper = boundary.upper != is_literal_negated
+        if boundary.strict != is_literal_negated:
             delta = -1 if upper else 1
             c = LRARational(c, delta)
         else:
             c = LRARational(c, 0)
 
         if boundary.equality:
-            res1 = self._assert_bound(sym, c, upper=False, from_equality=True, from_neg=negated)
+            res1 = self._assert_bound(sym, c, upper=False, from_equality=True, from_negated_literal=is_literal_negated)
             if res1 and res1[0] is False:
                 res = res1
             else:
-                res2 = self._assert_bound(sym, c, upper=True, from_equality=True, from_neg=negated)
+                res2 = self._assert_bound(sym, c, upper=True, from_equality=True, from_negated_literal=is_literal_negated)
                 res =  res2
         else:
-            res = self._assert_bound(sym, c, upper=upper, from_neg=negated)
+            res = self._assert_bound(sym, c, upper=upper, from_negated_literal=is_literal_negated)
 
         if self.is_sat and sym not in self.slack_set:
             self.is_sat = res is None
@@ -416,7 +416,7 @@ class LRASolver():
 
         return res
 
-    def _assert_bound(self, xi, ci, upper=True, from_equality=False, from_neg=False):
+    def _assert_bound(self, xi, ci, upper=True, from_equality=False, from_negated_literal=False):
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -439,18 +439,18 @@ class LRASolver():
             assert (other_bound[1] * s >= 0) is True
             assert (ci[1] * s <= 0) is True
             # get conflicting boundary
-            lit1, neg1 = xi.get_active_lower_boundary() if upper else xi.get_active_upper_boundary()
+            lit1, lit1_sign = xi.get_active_lower_boundary() if upper else xi.get_active_upper_boundary()
 
             lit2 = Boundary(var=xi, const=ci[0], strict=ci[1] != 0, upper=upper, equality=from_equality)
-            if from_neg:
+            if from_negated_literal:
                 lit2 = lit2.get_negated()
-            neg2 = -1 if from_neg else 1
+            lit2_sign = -1 if from_negated_literal else 1
 
-            conflict = [-neg1*self.boundary_to_enc[lit1], -neg2*self.boundary_to_enc[lit2]]
+            conflict = [-lit1_sign*self.boundary_to_enc[lit1], -lit2_sign*self.boundary_to_enc[lit2]]
             self.result = False, conflict
             return self.result
 
-        xi.set_bound(ci, upper, from_equality, from_neg)
+        xi.set_bound(ci, upper, from_equality, from_negated_literal)
 
         if xi in self.nonslack and xi.assign * s > ci * s:
             self._update(xi, ci)
@@ -542,7 +542,7 @@ class LRASolver():
                     conflict += [nb.get_active_upper_boundary() for nb in N_plus]
                     conflict += [nb.get_active_lower_boundary() for nb in N_minus]
                     conflict.append(xi.get_active_lower_boundary())
-                    conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
+                    conflict = [-literal_sign*self.boundary_to_enc[c] for c, literal_sign in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
@@ -561,7 +561,7 @@ class LRASolver():
                     conflict += [nb.get_active_lower_boundary() for nb in N_plus]
                     conflict.append(xi.get_active_upper_boundary())
 
-                    conflict = [-neg*self.boundary_to_enc[c] for c, neg in conflict]
+                    conflict = [-literal_sign*self.boundary_to_enc[c] for c, literal_sign in conflict]
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
@@ -784,10 +784,10 @@ class LRAVariable():
     def __init__(self, var):
         self.upper = LRARational(float("inf"), 0)
         self.upper_from_eq = False
-        self.upper_from_neg = False
+        self.upper_from_negated_literal = False
         self.lower = LRARational(-float("inf"), 0)
         self.lower_from_eq = False
-        self.lower_from_neg = False
+        self.lower_from_negated_literal = False
         self.assign = LRARational(0,0)
         self.var = var
         self.col_idx = None
@@ -795,7 +795,7 @@ class LRAVariable():
     def __repr__(self):
         return repr(self.var)
 
-    def set_bound(self, ci, upper=True, from_equality=False, from_neg=False):
+    def set_bound(self, ci, upper=True, from_equality=False, from_negated_literal=False):
         """
         Set the upper or lower bound and record the sign of its origin literal.
 
@@ -806,34 +806,34 @@ class LRAVariable():
         >>> from sympy.abc import x
         >>> v = LRAVariable(x)
         >>> # Asserting a lower bound x >= 10 from a direct assertion
-        >>> v.set_bound(LRARational(10, 0), upper=False, from_neg=False)
+        >>> v.set_bound(LRARational(10, 0), upper=False, from_negated_literal=False)
         >>> v.lower
         (10, 0)
-        >>> v.lower_from_neg
+        >>> v.lower_from_negated_literal
         False
 
         >>> # Asserting an upper bound x <= 5 derived from a negated atom ~(x > 5)
-        >>> v.set_bound(LRARational(5, 0), upper=True, from_neg=True)
+        >>> v.set_bound(LRARational(5, 0), upper=True, from_negated_literal=True)
         >>> v.upper
         (5, 0)
-        >>> v.upper_from_neg
+        >>> v.upper_from_negated_literal
         True
         """
         if upper:
             self.upper = ci
             self.upper_from_eq = from_equality
-            self.upper_from_neg = from_neg
+            self.upper_from_negated_literal = from_negated_literal
         else:
             self.lower = ci
             self.lower_from_eq = from_equality
-            self.lower_from_neg = from_neg
+            self.lower_from_negated_literal = from_negated_literal
 
-    def _build_active_boundary(self, bound, from_eq, from_neg, is_upper):
-        neg = -1 if from_neg else 1
+    def _build_active_boundary(self, bound, from_eq, from_negated_literal, is_upper):
+        literal_sign = -1 if from_negated_literal else 1
         b = Boundary(self, bound[0], is_upper, from_eq, bound[1] != 0)
-        if neg < 0:
+        if literal_sign < 0:
             b = b.get_negated()
-        return b, neg
+        return b, literal_sign
 
     def get_active_upper_boundary(self):
         """
@@ -846,20 +846,20 @@ class LRAVariable():
         >>> from sympy.abc import x
         >>> v = LRAVariable(x)
         >>> # Internal state representing the assertion ~(x > 5)
-        >>> v.set_bound(LRARational(5, 0), upper=True, from_neg=True)
-        >>> b, neg = v.get_active_upper_boundary()
+        >>> v.set_bound(LRARational(5, 0), upper=True, from_negated_literal=True)
+        >>> b, literal_sign = v.get_active_upper_boundary()
         >>> b
         'Boundary(x > 5)'
-        >>> neg
+        >>> literal_sign
         -1
         """
-        return self._build_active_boundary(self.upper, self.upper_from_eq, self.upper_from_neg, True)
+        return self._build_active_boundary(self.upper, self.upper_from_eq, self.upper_from_negated_literal, True)
 
     def get_active_lower_boundary(self):
         """
         Return the active lower Boundary object and the sign of the literal responsible for asserting it.
         """
-        return self._build_active_boundary(self.lower, self.lower_from_eq, self.lower_from_neg, False)
+        return self._build_active_boundary(self.lower, self.lower_from_eq, self.lower_from_negated_literal, False)
 
     def __eq__(self, other):
         if not isinstance(other, LRAVariable):

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -418,6 +418,7 @@ def test_z3_vs_lra_dpll2():
 
 
 def test_issue_27733():
+    # original regression
     x, y = symbols('x,y')
     clauses = [[1, -3, -2], [5, 7, -8, -6, -4], [-10, -9, 10, 11, -4], [-12, 13, 14], [-10, 9, -6, 11, -4],
                [16, -15, 18, -19, -17], [11, -6, 10, -9], [9, 11, -10, -9], [2, -3, -1], [-13, 12], [-15, 3, -17],
@@ -429,5 +430,14 @@ def test_issue_27733():
     encoding[Q.gt(x, 0)] = 11
     encoding[Q.lt(x, 0)] = 12
 
+    cnf = EncodedCNF(clauses, encoding)
+    assert satisfiable(cnf, use_lra_theory=True) is False
+
+
+def test_issue_27733_second_fix():
+    # regression for flawed initial fix of issue 27733
+    x0, x1 = symbols('x0 x1')
+    clauses = [[1, 2], [-3, -4]]
+    encoding = {Q.gt(x0, x1): 1, Q.lt(x1, x0): 2, Q.le(x1, x0): 3, Q.ge(x0, x1): 4}
     cnf = EncodedCNF(clauses, encoding)
     assert satisfiable(cnf, use_lra_theory=True) is False

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -100,11 +100,15 @@ def test_from_encoded_cnf():
     assert str(lra.nonslack) == '[x, y, z]'
     assert lra.A == Matrix([[ 1,  1, 0, -1,  0],
                             [-1, -2, 1,  0, -1]])
-    assert {(str(b.var), b.bound, b.upper, b.equality, b.strict) for b in lra.atom_id_to_boundary.values()} == {('_s1', 2, None, True, False),
-    ('_s1', 2, True, False, False),
-    ('_s2', -4, True, False, True),
-    ('_s2', -6, True, False, False),
-    ('x', 0, False, False, False)}
+    actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundary.values()}
+    expected = {
+        (('_s1', 2, False, False), ('_s1', 2, True, False)), # Eq(x + y, 2)
+        (('_s1', 2, True, False),),                          # x + y <= 2
+        (('_s2', -4, True, True),),                          # x + 2*y - z > 4 -> _s2 < -4
+        (('_s2', -6, True, False),),                         # x + 2*y - z >= 6 -> _s2 <= -6
+        (('x', 0, False, False),)                            # x >= 0
+    }
+    assert actual == expected
 
 
 def test_problem():
@@ -181,7 +185,7 @@ def test_random_problems():
         lits = {lit for clause in enc.data for lit in clause}
 
         bounds = [(lra.atom_id_to_boundary[l], l) for l in lits if l in lra.atom_id_to_boundary]
-        bounds = sorted(bounds, key=lambda x: (str(x[0].var), x[0].bound, str(x[0].upper))) # to remove nondeterminism
+        bounds = sorted(bounds, key=lambda x: (str(x[0][0].var), x[0][0].bound, str(x[0][0].upper))) # to remove nondeterminism
 
         for b, l in bounds:
             if lra.result and lra.result[0] == False:
@@ -209,7 +213,12 @@ def test_random_problems():
 
             conflict = feasible[1]
             assert len(conflict) >= 2
-            conflict = {lra.atom_id_to_boundary[-l].get_inequality() for l in conflict}
+            def get_expr(bs):
+                if len(bs) == 2:
+                    return Eq(bs[0].var.var, bs[0].bound)
+                return bs[0].get_inequality()
+
+            conflict = {get_expr(lra.atom_id_to_boundary[abs(l)]) for l in conflict}
             conflict = {clause.subs(s_subs_rev) for clause in conflict}
             assert check_if_satisfiable_with_z3(conflict) is False
 
@@ -434,9 +443,7 @@ def test_reset_bounds():
     state_variables = [
         ('lower', LRARational(10, 0), LRARational(-float("inf"), 0)),
         ('upper', LRARational(10, 0), LRARational(float("inf"), 0)),
-        ('lower_from_eq', True, False),
         ('lower_from_negated_literal', True, False),
-        ('upper_from_eq', True, False),
         ('upper_from_negated_literal', True, False),
         ('assign', LRARational(10, 0), LRARational(0, 0))
     ]

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -100,7 +100,7 @@ def test_from_encoded_cnf():
     assert str(lra.nonslack) == '[x, y, z]'
     assert lra.A == Matrix([[ 1,  1, 0, -1,  0],
                             [-1, -2, 1,  0, -1]])
-    assert {(str(b.var), b.bound, b.upper, b.equality, b.strict) for b in lra.enc_to_boundary.values()} == {('_s1', 2, None, True, False),
+    assert {(str(b.var), b.bound, b.upper, b.equality, b.strict) for b in lra.atom_id_to_boundary.values()} == {('_s1', 2, None, True, False),
     ('_s1', 2, True, False, False),
     ('_s2', -4, True, False, True),
     ('_s2', -6, True, False, False),
@@ -180,7 +180,7 @@ def test_random_problems():
         s_subs_rev = {value: key for key, value in s_subs.items()}
         lits = {lit for clause in enc.data for lit in clause}
 
-        bounds = [(lra.enc_to_boundary[l], l) for l in lits if l in lra.enc_to_boundary]
+        bounds = [(lra.atom_id_to_boundary[l], l) for l in lits if l in lra.atom_id_to_boundary]
         bounds = sorted(bounds, key=lambda x: (str(x[0].var), x[0].bound, str(x[0].upper))) # to remove nondeterminism
 
         for b, l in bounds:
@@ -209,7 +209,7 @@ def test_random_problems():
 
             conflict = feasible[1]
             assert len(conflict) >= 2
-            conflict = {lra.enc_to_boundary[-l].get_inequality() for l in conflict}
+            conflict = {lra.atom_id_to_boundary[-l].get_inequality() for l in conflict}
             conflict = {clause.subs(s_subs_rev) for clause in conflict}
             assert check_if_satisfiable_with_z3(conflict) is False
 
@@ -226,7 +226,7 @@ def test_pos_neg_zero():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 3
+    assert len(lra.atom_id_to_boundary) == 3
     assert lra.check()[0] == False
 
     bf = Q.positive(x) & Q.lt(x, -1)
@@ -235,7 +235,7 @@ def test_pos_neg_zero():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == False
 
     bf = Q.positive(x) & Q.zero(x)
@@ -244,7 +244,7 @@ def test_pos_neg_zero():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == False
 
     bf = Q.positive(x) & Q.zero(y)
@@ -253,7 +253,7 @@ def test_pos_neg_zero():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == True
 
 
@@ -265,7 +265,7 @@ def test_pos_neg_infinite():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 3
+    assert len(lra.atom_id_to_boundary) == 3
     assert lra.check()[0] == False
 
     bf = Q.positive_infinite(x) & Q.gt(x, 10000000) & Q.positive_infinite(y)
@@ -274,7 +274,7 @@ def test_pos_neg_infinite():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 3
+    assert len(lra.atom_id_to_boundary) == 3
     assert lra.check()[0] == True
 
     bf = Q.positive_infinite(x) & Q.negative_infinite(x)
@@ -283,7 +283,7 @@ def test_pos_neg_infinite():
     for lit in enc.encoding.values():
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == False
 
 
@@ -291,13 +291,13 @@ def test_binrel_evaluation():
     bf = Q.gt(3, 2)
     enc = boolean_formula_to_encoded_cnf(bf)
     lra, conflicts = LRASolver.from_encoded_cnf(enc, testing_mode=True)
-    assert len(lra.enc_to_boundary) == 0
+    assert len(lra.atom_id_to_boundary) == 0
     assert conflicts == [[1]]
 
     bf = Q.lt(3, 2)
     enc = boolean_formula_to_encoded_cnf(bf)
     lra, conflicts = LRASolver.from_encoded_cnf(enc, testing_mode=True)
-    assert len(lra.enc_to_boundary) == 0
+    assert len(lra.atom_id_to_boundary) == 0
     assert conflicts == [[-1]]
 
 
@@ -309,7 +309,7 @@ def test_negation():
     for clause in enc.data:
         for lit in clause:
             lra.assert_lit(lit)
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == False
     assert sorted(lra.check()[1]) in [[-1, 2], [-2, 1]]
 
@@ -319,7 +319,7 @@ def test_negation():
     for clause in enc.data:
         for lit in clause:
             lra.assert_lit(lit)
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == True
 
     bf = ~Q.gt(x, 0) & ~Q.lt(x, 1)
@@ -328,7 +328,7 @@ def test_negation():
     for clause in enc.data:
         for lit in clause:
             lra.assert_lit(lit)
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == False
 
     bf = ~Q.gt(x, 0) & ~Q.le(x, 0)
@@ -337,7 +337,7 @@ def test_negation():
     for clause in enc.data:
         for lit in clause:
             lra.assert_lit(lit)
-    assert len(lra.enc_to_boundary) == 2
+    assert len(lra.atom_id_to_boundary) == 2
     assert lra.check()[0] == False
 
     bf = ~Q.le(x+y, 2) & ~Q.ge(x-y, 2) & ~Q.ge(y, 0)
@@ -346,7 +346,7 @@ def test_negation():
     for clause in enc.data:
         for lit in clause:
             lra.assert_lit(lit)
-    assert len(lra.enc_to_boundary) == 3
+    assert len(lra.atom_id_to_boundary) == 3
     assert lra.check()[0] == False
     assert len(lra.check()[1]) == 3
     assert all(i > 0 for i in lra.check()[1])
@@ -395,7 +395,7 @@ def test_infinite_strict_inequalities():
     for lit in sorted(enc.encoding.values()):
         if lra.assert_lit(lit) is not None:
             break
-    assert len(lra.enc_to_boundary) == 3
+    assert len(lra.atom_id_to_boundary) == 3
     assert lra.check()[0] == True
 
 

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -435,9 +435,9 @@ def test_reset_bounds():
         ('lower', LRARational(10, 0), LRARational(-float("inf"), 0)),
         ('upper', LRARational(10, 0), LRARational(float("inf"), 0)),
         ('lower_from_eq', True, False),
-        ('lower_from_neg', True, False),
+        ('lower_from_negated_literal', True, False),
         ('upper_from_eq', True, False),
-        ('upper_from_neg', True, False),
+        ('upper_from_negated_literal', True, False),
         ('assign', LRARational(10, 0), LRARational(0, 0))
     ]
 

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -443,10 +443,8 @@ def test_reset_bounds():
     state_variables = [
         ('lower', LRARational(10, 0), LRARational(-float("inf"), 0)),
         ('upper', LRARational(10, 0), LRARational(float("inf"), 0)),
-        ('lower_source', "some source", None),
-        ('lower_literal_sign', 1, None),
-        ('upper_source', "some source", None),
-        ('upper_literal_sign', -1, None),
+        ('lower_literal', 5, None),
+        ('upper_literal', -5, None),
         ('assign', LRARational(10, 0), LRARational(0, 0))
     ]
 

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -443,8 +443,10 @@ def test_reset_bounds():
     state_variables = [
         ('lower', LRARational(10, 0), LRARational(-float("inf"), 0)),
         ('upper', LRARational(10, 0), LRARational(float("inf"), 0)),
-        ('lower_from_negated_literal', True, False),
-        ('upper_from_negated_literal', True, False),
+        ('lower_source', "some source", None),
+        ('lower_literal_sign', 1, None),
+        ('upper_source', "some source", None),
+        ('upper_literal_sign', -1, None),
         ('assign', LRARational(10, 0), LRARational(0, 0))
     ]
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Related to #29542



#### Brief description of what is fixed or changed

Before fixing a bug with lra_theory related to the `assert_lit` function, I wanted to improve the code to be more readable and less complicated as that was the reason why the code was buggy in the first place. To that end, I made the following improvements:

- Simplified logic and improved readability greatly of `assert_lit` and associated functions/classes.
- Added type hints throughout `lra_theory.py`.


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used an LLM cli tool very extensively. Pretty much all the code is AI written, but all of the commits for the most part are written by me.  The description of the commit "refactor(lra_theory): use .q, .d LRAVar properties" was AI written but that should be the only non-human written commit message iirc. Anyway, I was very intentional with all changes and careful when reviewing AI written code. This PR description is also only human written. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
