### PR TITLE
Raise ValueError for invalid CartanType names

### DIFF
--- a/sympy/liealgebras/cartan_type.py
+++ b/sympy/liealgebras/cartan_type.py
@@ -46,6 +46,7 @@ class CartanType_generator():
             if n == 2:
                 from . import type_g
                 return type_g.TypeG(n)
+        raise ValueError(f"Invalid Cartan type: {c}")
 
 CartanType = CartanType_generator()
 

--- a/sympy/liealgebras/tests/test_cartan_type.py
+++ b/sympy/liealgebras/tests/test_cartan_type.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from sympy.liealgebras.cartan_type import CartanType, Standard_Cartan
+from sympy.testing.pytest import raises
 
 def test_Standard_Cartan():
     c = CartanType("A4")
@@ -11,3 +12,14 @@ def test_Standard_Cartan():
     b = CartanType("B12")
     assert b.rank() == 12
     assert b.series == "B"
+
+
+def test_valid_cartan_type():
+    c = CartanType("F4")
+    assert c.rank() == 4
+    assert c.series == "F"
+
+
+def test_invalid_cartan_type_raises():
+    with raises(ValueError):
+        CartanType("Z6")


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #29537

#### Brief description of what is fixed or changed

Previously, calling `CartanType` with an invalid type name (e.g. `CartanType("Z6")`) 
would silently return `None` instead of raising an error. This fix adds a `ValueError` 
at the end of `CartanType_generator.__call__` so that invalid Cartan type names produce 
a clear error message.

#### Other comments


#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* liealgebras
  * `CartanType` now raises `ValueError` when given an invalid Cartan type name, instead of silently returning `None`.


<!-- END RELEASE NOTES -->
