### PR TITLE
matrices: Extract scalar factors from MatMul powers

### DIFF
--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -139,6 +139,28 @@ class MatMul(MatrixExpr, Mul):
         expanded = super(MatMul, self).expand(**kwargs)
         return self._evaluate(expanded)
 
+    def _eval_power(self, exp):
+        # Match Mul._eval_power by separating only the commutative scalar
+        # coefficient and keeping the ordered matrix product intact.
+        coeff, matrices = self.as_coeff_matrices()
+        # The S.One guard avoids recursing on coefficient-free MatMul
+        # expressions such as (A*B)**2.
+        if coeff is S.One:
+            return MatPow(self, exp)
+        matrix_part = matrices[0] if len(matrices) == 1 else MatMul(*matrices)
+
+        # Unlike Mul, keep unevaluated 0*A powers intact rather than
+        # extracting scalar infinities from negative powers of the zero
+        # coefficient. Evaluated 0*A is handled by ZeroMatrix._eval_power.
+        exp_is_number = exp.is_Integer or exp.is_Rational or exp.is_Float
+        coeff_can_be_extracted = (
+            (exp.is_Integer and coeff.is_zero is not True) or
+            (not exp.is_Integer and coeff.is_positive is True)
+        )
+        if exp_is_number and coeff_can_be_extracted:
+            return coeff**exp * MatPow(matrix_part, exp).doit(deep=False)
+        return MatPow(self, exp)
+
     def _eval_transpose(self):
         """Transposition of matrix multiplication.
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -158,8 +158,10 @@ class MatMul(MatrixExpr, Mul):
             # (0*A)**-1 should raise rather than extract zoo*A**-1.
             # Maybe-zero symbolic coefficients follow SymPy's generic
             # convention of being treated as nonzero.
-            if coeff.is_zero and exp.is_negative:
-                return MatPow(self, exp)
+            if coeff.is_zero:
+                if exp.is_negative:
+                    return MatPow(self, exp)
+                return ZeroMatrix(*self.shape)
         elif not coeff.is_positive:
             # For noninteger numeric powers, only extract a positive scalar
             # coefficient to avoid branch cut issues.

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -154,8 +154,7 @@ class MatMul(MatrixExpr, Mul):
         # coefficient. Evaluated 0*A is handled by ZeroMatrix._eval_power.
         exp_is_number = exp.is_Integer or exp.is_Rational or exp.is_Float
         coeff_can_be_extracted = (
-            (exp.is_Integer and coeff.is_zero is not True) or
-            (not exp.is_Integer and coeff.is_positive is True)
+            (exp.is_Integer and coeff.is_zero is not True) or coeff.is_positive
         )
         if exp_is_number and coeff_can_be_extracted:
             return coeff**exp * MatPow(matrix_part, exp).doit(deep=False)

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -147,18 +147,28 @@ class MatMul(MatrixExpr, Mul):
         # expressions such as (A*B)**2.
         if coeff is S.One:
             return MatPow(self, exp)
-        matrix_part = matrices[0] if len(matrices) == 1 else MatMul(*matrices)
+        # Follow Mul._eval_power's design: split only concrete integer powers
+        # and exact rational/float powers. Symbolic exponents, including
+        # symbolic integers, remain unchanged.
+        if not (exp.is_Rational or exp.is_Float):
+            return MatPow(self, exp)
 
-        # Unlike Mul, keep unevaluated 0*A powers intact rather than
-        # extracting scalar infinities from negative powers of the zero
-        # coefficient. Evaluated 0*A is handled by ZeroMatrix._eval_power.
-        exp_is_number = exp.is_Integer or exp.is_Rational or exp.is_Float
-        coeff_can_be_extracted = (
-            (exp.is_Integer and coeff.is_zero is not True) or coeff.is_positive
-        )
-        if exp_is_number and coeff_can_be_extracted:
-            return coeff**exp * MatPow(matrix_part, exp).doit(deep=False)
-        return MatPow(self, exp)
+        if exp.is_Integer:
+            # Preserve matrix singularity for definite zero coefficients:
+            # (0*A)**-1 should raise rather than extract zoo*A**-1.
+            # Maybe-zero symbolic coefficients follow SymPy's generic
+            # convention of being treated as nonzero.
+            if coeff.is_zero and exp.is_negative:
+                return MatPow(self, exp)
+        elif not coeff.is_positive:
+            # For noninteger numeric powers, only extract a positive scalar
+            # coefficient to avoid branch cut issues.
+            return MatPow(self, exp)
+
+        # Only extraction cases remain: integer powers, and noninteger
+        # rational/float powers with positive scalar coefficient.
+        matrix_part = matrices[0] if len(matrices) == 1 else MatMul(*matrices)
+        return coeff**exp * MatPow(matrix_part, exp).doit(deep=False)
 
     def _eval_transpose(self):
         """Transposition of matrix multiplication.

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -90,6 +90,24 @@ def test_doit_symbol():
         assert MatPow(C, r).doit() == MatPow(C, r)
 
 
+def test_doit_MatMul_scalar_power():
+    a = symbols('a')
+    p = symbols('p')
+    pos = symbols('pos', positive=True)
+
+    assert MatPow(a*C, 2).doit() == a**2*C**2
+    assert (a*C)**2 == a**2*C**2
+    assert (a*C*D)**2 == a**2*(C*D)**2
+    assert (a*C*D)**-2 == a**-2*(C*D)**-2
+
+    assert MatPow(pos*C, S.Half).doit() == pos**S.Half*C**S.Half
+    assert (pos*C*D)**S.Half == pos**S.Half*(C*D)**S.Half
+
+    assert MatPow(a*C, S.Half).doit() == MatPow(a*C, S.Half)
+    assert (a*C)**p == MatPow(a*C, p)
+    assert (pos*C)**p == MatPow(pos*C, p)
+
+
 def test_doit_matrix():
     X = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(X, 0).doit() == ImmutableMatrix(Identity(2))

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -4,7 +4,7 @@ from sympy.testing.pytest import raises
 from sympy.core.expr import unchanged
 from sympy.core import symbols, S
 from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix, OneMatrix, Matrix
-from sympy.matrices.exceptions import NonSquareMatrixError
+from sympy.matrices.exceptions import NonInvertibleMatrixError, NonSquareMatrixError
 from sympy.matrices.expressions import MatPow, MatAdd, MatMul
 from sympy.matrices.expressions.inverse import Inverse
 from sympy.matrices.expressions.matexpr import MatrixElement
@@ -167,6 +167,7 @@ def test_zero_power():
     assert MatPow(z2, 2).doit() == z2
     assert MatPow(z2, 0).doit() == Identity(4)
     raises(ValueError, lambda:MatPow(z2, -1).doit())
+    raises(NonInvertibleMatrixError, lambda: MatMul(0, C)**-1)
 
 
 def test_OneMatrix_power():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29758.

#### Brief description of what is fixed or changed

This PR makes the behavior of `(a * B * C)**pow` with `B` and `C` `MatrixSymbol`s match the behavior of noncommutative `Symbol`s by extracting `a**pow` prefactor whenever it is safe. The behavior is not fully identical to `Mul` because sympy's handling of zero matrix inverses (`raise NonInvertibleMatrixError`) is different than that of zero inverses (`zoo`).

#### Other comments

I ran into this limitation when working on simplification of matrix expressions, reported in #29758.

#### AI Generation Disclosure

I used codex with GPT 5.5 to generate the code and the test.

I spent the amount of time and iteration roughly equivalent to implementing this by myself. I understand what is done, I significantly influenced the implementation, and I am reasonably confident that it matches the package design. Because the code is reorganized several times following my evaluation, and because it is highly sympy-specific, I am certain that there are no copyright issues here (beyond it being a sympy derivative work).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Implemented extraction of a scalar factor from MatMul powers, similar to Mul.
<!-- END RELEASE NOTES -->
