### PR TITLE
fix(core/relational): don't trust diff cancellation in is_ge for extended reals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -809,6 +809,7 @@ Jaime R <38530589+Jaime02@users.noreply.github.com>
 Jaime Resano <gemailpersonal02@gmail.com>
 Jainul Vaghasia <jainulvaghasia@gmail.com> <jainulvaghasia@D-10-157-53-226.dhcp4.washington.edu>
 Jakub Wilk <jwilk@jwilk.net>
+Jam Balaya <jambalaya.pyoncafe@outlook.jp>
 James A. Preiss <jamesalanpreiss@gmail.com> jpreiss <jamesalanpreiss@gmail.com>
 James Abbatiello <abbeyj@gmail.com>
 James Aspnes <aspnes@cs.yale.edu>

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -7,7 +7,7 @@ from sympy.core import symbols, Symbol
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.core.numbers import I
 
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises, XFAIL, slow
 x, y, z = symbols("x y z", real=True)
 
 def test_lra_satask():
@@ -122,6 +122,21 @@ def test_number_line_properties():
     # If a <= b, then a + c <= b + c and a - c <= b - c.
     assert ask(a + c <= b + c, a <= b) is True
     assert ask(a - c <= b - c, a <= b) is True
+
+
+@slow
+def test_extended_real_infinite_cancellation():
+    a = Symbol('a', extended_real=True)
+    assert ask(a + 1 > a, Q.extended_real(a)) is None
+    assert ask(a + 1 >= a, Q.extended_real(a)) is True
+    assert ask(a >= a + 1, Q.extended_real(a)) is None
+    assert ask(a + 1 <= a, Q.extended_real(a)) is None
+    assert ask(a < a + 1, Q.extended_real(a)) is None
+
+    b = Symbol('b', real=True)
+    assert ask(b + 1 > b, Q.real(b)) is True
+    assert ask(b + 1 >= b, Q.real(b)) is True
+    assert ask(b >= b + 1, Q.real(b)) is False
 
 
 @XFAIL

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -126,14 +126,14 @@ def test_number_line_properties():
 
 @slow
 def test_extended_real_infinite_cancellation():
-    a = Symbol('a', extended_real=True)
+    a = Symbol('a')
     assert ask(a + 1 > a, Q.extended_real(a)) is None
     assert ask(a + 1 >= a, Q.extended_real(a)) is True
     assert ask(a >= a + 1, Q.extended_real(a)) is None
     assert ask(a + 1 <= a, Q.extended_real(a)) is None
     assert ask(a < a + 1, Q.extended_real(a)) is None
 
-    b = Symbol('b', real=True)
+    b = Symbol('b')
     assert ask(b + 1 > b, Q.real(b)) is True
     assert ask(b + 1 >= b, Q.real(b)) is True
     assert ask(b >= b + 1, Q.real(b)) is False

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1430,8 +1430,15 @@ def is_ge(lhs, rhs, assumptions=None):
             diff = lhs - rhs
             if diff is not S.NaN:
                 rv = is_extended_nonnegative(diff, assumptions)
-                if rv is not None:
-                    return rv
+                if rv is True:
+                    return True
+                if rv is False:
+                    _diff = AssumptionsWrapper(diff, assumptions)
+                    if (_diff.is_finite is True
+                            and _lhs.is_finite is not True
+                            and _rhs.is_finite is not True):
+                        return None
+                    return False
 
 
 def is_neq(lhs, rhs, assumptions=None):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from sympy.core.logic import fuzzy_and
 from sympy.core.sympify import _sympify
 from sympy.multipledispatch import dispatch
-from sympy.testing.pytest import XFAIL, raises
+from sympy.testing.pytest import XFAIL, raises, slow
 from sympy.assumptions.ask import Q
 from sympy.core.add import Add
 from sympy.core.basic import Basic
@@ -1234,6 +1234,19 @@ def test_is_ge_le():
     assert is_gt(PowTest(3, 9), PowTest(3,2))
     assert is_le(PowTest(3, 2), PowTest(3,9))
     assert is_lt(PowTest(3, 2), PowTest(3,9))
+
+
+@slow
+def test_is_ge_extended_real_infinite_cancellation():
+    a = Symbol('a')
+    assert is_ge(a + 1, a, Q.extended_real(a)) is True
+    assert is_ge(a, a + 1, Q.extended_real(a)) is None
+    assert is_gt(a + 1, a, Q.extended_real(a)) is None
+    assert is_lt(a, a + 1, Q.extended_real(a)) is None
+    assert is_le(a + 1, a, Q.extended_real(a)) is None
+    b = Symbol('b')
+    assert is_gt(b + 1, b, Q.real(b)) is True
+    assert is_ge(b + 1, b, Q.real(b)) is True
 
 
 def test_weak_strict():


### PR DESCRIPTION
## References to other Issues or PRs

A partial fix for #29413. Repro: https://aletheia-works.github.io/vivarium/repro/sympy/29413/

<details>
<summary>Why a new PR (prior attempts)</summary>

- #29414 — closed inactive: tests in wrong location, `is_le` not covered,
  unrelated `besselsimp` changes mixed in.
- #29586 — closed by author: broader rewrite broke ~22 existing tests by
  also rejecting `x < oo` patterns in the suite.

This PR keeps the change surgical (only the negative branch of the
extended-real fallback in `is_ge`), so neither set of issues recurs.
</details>

## Brief description of what is fixed or changed

`is_ge(lhs, rhs)` falls back to the sign of `lhs - rhs` when both sides
are extended-real. The symbolic subtraction can silently cancel terms
that are only equal for finite values: for `a = Symbol('a', extended_real=True)`,
`(a + 1) - a` simplifies to `1`, even though the true value is
`oo - oo = nan` when `a` is infinite. As a result `is_ge(a, a + 1)`
returned `False`, propagating to `is_gt(a + 1, a) = True` and to
`ask(a + 1 > a, Q.extended_real(a)) = True`, while the concrete
`(oo + 1) > oo` correctly evaluates to `False`.

When `is_extended_nonnegative(diff)` is `False`, this PR trusts the
answer only if the cancellation cannot be `oo - oo` — i.e. the diff is
infinite, or at least one operand is known finite. Otherwise it returns
`None`. The `True` branch is untouched, so `is_gt(b + 1, b)` with
`b = Symbol('b', real=True)` keeps returning `True`. `is_gt`, `is_lt`,
`is_le` inherit the fix through `is_ge`.

<details>
<summary>Repro &amp; tests</summary>

```python
>>> from sympy import ask, Q, Symbol, oo
>>> a = Symbol('a', extended_real=True)
>>> ask(a + 1 > a, Q.extended_real(a))   # was True, now None
>>> (oo + 1) > oo                         # False (already correct)
```

Regression test added in `sympy/core/tests/test_relational.py`:

```python
def test_is_ge_extended_real_infinite_cancellation():
    a = Symbol('a')
    assert is_ge(a + 1, a, Q.extended_real(a)) is True
    assert is_ge(a, a + 1, Q.extended_real(a)) is None
    assert is_gt(a + 1, a, Q.extended_real(a)) is None
    assert is_lt(a, a + 1, Q.extended_real(a)) is None
    assert is_le(a + 1, a, Q.extended_real(a)) is None
    b = Symbol('b')
    assert is_gt(b + 1, b, Q.real(b)) is True
    assert is_ge(b + 1, b, Q.real(b)) is True
```
</details>

<details>
<summary>Local verification (no regressions)</summary>

Rebased onto current master (which includes #29898):

- `sympy/core/tests/test_relational.py` + `sympy/assumptions/tests/test_rel_queries.py` — 73 passed, 4 xfailed
- `sympy/simplify/tests/test_simplify.py::test_besselsimp` — passed
- `sympy/solvers/ode/tests/test_single.py::test_2nd_linear_bessel_equation` (slow) — passed (~17s)
</details>

## Other comments

An earlier version of this PR also patched `simplify.py` so that
`besselsimp`'s recurrence sort stayed comparable under the stricter `is_ge`
(the sort compared `re(a)-1 < re(a)` for a generic `a`, the same `oo - oo`
case this PR guards against). That sort has since been rewritten to be
assumption-free in #29898 (merged), so this PR no longer touches
`simplify.py` — it now contains only the `is_ge` fix and its regression
tests.

#### AI Generation Disclosure

This patch was developed with Claude (Anthropic) as a coding assistant.
The `is_ge` change in `sympy/core/relational.py` and the regression tests in
`sympy/core/tests/test_relational.py` and
`sympy/assumptions/tests/test_rel_queries.py` were authored with AI
assistance. All hunks were reviewed by the author, traced against the
failing-CI logs and existing `is_ge` callers, and validated locally before
being committed.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fix `ask(a + 1 > a, Q.extended_real(a))` and `is_ge(a, a + 1)` for
    extended-real symbols where the symbolic difference would mask an
    `oo - oo` cancellation.
<!-- END RELEASE NOTES -->

