### PR TITLE
typing(mypy): annotate 5 globals to fix mypy 2.x var-annotated CI failures

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1432,7 +1432,7 @@ def orthogonal_poly_rule(integral):
 
 
 _special_function_patterns: list[tuple[type, Expr, Callable | None, tuple]] = []
-_wilds = []
+_wilds: list[Wild] = []
 _symbol = Dummy('x')
 
 

--- a/sympy/polys/polyconfig.py
+++ b/sympy/polys/polyconfig.py
@@ -25,7 +25,7 @@ _default_config = {
     'GROEBNER':                   'buchberger',
 }
 
-_current_config = {}
+_current_config: dict[str, bool | int | str] = {}
 
 @contextmanager
 def using(**kwargs):

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -13,6 +13,7 @@ This module requires llvmlite (https://github.com/numba/llvmlite).
 from __future__ import annotations
 
 import ctypes
+from typing import Any
 
 from sympy.external import import_module
 from sympy.printing.printer import Printer
@@ -150,10 +151,10 @@ class LLVMJitCallbackPrinter(LLVMJitPrinter):
 
 # ensure lifetime of the execution engine persists (else call to compiled
 #   function will seg fault)
-exe_engines = []
+exe_engines: list[Any] = []
 
 # ensure names for generated functions are unique
-link_names = set()
+link_names: set[str] = set()
 current_link_suffix = 0
 
 

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         Only imports between relevant modules will be checked."""
         return in_module(module, 'sympy')
 
-    sorted_messages = []
+    sorted_messages: list[str] = []
 
     def msg(msg, *args):
         if options.by_process:


### PR DESCRIPTION
## References to other Issues or PRs

No existing issue tracks this — searched `var-annotated`, `mypy CI`,
`mypy llvmjitcode`, `mypy manualintegrate` with no matches. Related:
#28717 (closed, python-flint-specific). Companion to #29777 (also-stale
`Bleeding edge dependencies` job).

## Brief description of what is fixed or changed

`mypy` is unpinned in `requirements-dev.txt`, so CI installs the latest
release on every run. `mypy` 2.0.0 (2026-05-06) and 2.1.0 (2026-05-11)
tightened type inference for module-level empty container initializers
(`= {}`, `= []`, `= set()`), and now flag five existing globals with
`[var-annotated]`. Both the **Mypy** and **Mypy With python-flint** jobs
have therefore been red on every PR since 2026-05-08 (e.g. #29754,
#29760, #29763, #29769), obscuring real mypy regressions.

This PR adds the minimal type annotations needed to silence those
errors. Each annotation reflects the actual runtime contents of the
global; no behaviour changes.

<details>
<summary>Exact errors and annotations</summary>

```
sympy/polys/polyconfig.py:28: error: Need type annotation for "_current_config" ...
sympy/testing/tests/diagnose_imports.py:123: error: Need type annotation for "sorted_messages" ...
sympy/integrals/manualintegrate.py:1435: error: Need type annotation for "_wilds" ...
sympy/printing/llvmjitcode.py:153: error: Need type annotation for "exe_engines" ...
sympy/printing/llvmjitcode.py:156: error: Need type annotation for "link_names" ...
Found 5 errors in 4 files (checked 1534 source files)
```

| File:line | Annotation | Why |
| --- | --- | --- |
| `polyconfig.py:28` | `dict[str, bool \| int \| str]` | Matches `_default_config` and `setup()` semantics. |
| `diagnose_imports.py:123` | `list[str]` | Stores `msg % args` results. |
| `manualintegrate.py:1435` | `list[Wild]` | Filled by `make_wilds()`-style producers. |
| `llvmjitcode.py:153` | `list[Any]` | `llvmlite` is runtime-optional (loaded via `import_module`), so `ExecutionEngine` isn't available at module scope. |
| `llvmjitcode.py:156` | `set[str]` | Stores `default_link_name + str(...)`. |

</details>

<details>
<summary>Local verification</summary>

With `mypy` 2.1.0 (`pip install mypy==2.1.0`):

Before:
```
Found 5 errors in 4 files (checked 1534 source files)
```

After:
```
Success: no issues found in 1534 source files
```

The `Mypy With python-flint` job is failing on the exact same 5 errors
(no extras), so the same patch unblocks both jobs.

</details>

## Other comments

A follow-up worth considering separately: pin `mypy` in
`requirements-dev.txt` (e.g. `mypy>=2.0,<3.0`) so future minor releases
cannot silently break CI overnight. Out of scope for this PR.

<details>
<summary>AI Generation Disclosure</summary>

This patch was developed with Claude (Anthropic) as a coding assistant.
The investigation (mypy release-date triangulation, identifying the
exact failing job/error set across recent PRs), the type annotations
themselves, and this PR description were authored with AI assistance.
All annotations were checked against the actual runtime usages
(`grep` / read) and verified locally by installing `mypy==2.1.0` and
running `mypy sympy` against the modified tree.

</details>

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
