### PR TITLE
ci(bleeding-edge): fall back to PyPI when nightly wheels are missing

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -247,7 +247,7 @@ jobs:
       - run: |
           python -m pip install \
               --pre \
-              --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+              --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
               --upgrade --only-binary=:all: \
                           python-flint      \
                           numpy             \


### PR DESCRIPTION
## References to other Issues or PRs

No existing issue tracks this — searched `bleeding edge`, `bleeding-edge`,
`scientific-python-nightly-wheels`, `python-flint nightly` in `sympy/sympy`
with no relevant matches. Companion to #29776 (the equally-stale
`Mypy` / `Mypy With python-flint` jobs).

## Brief description of what is fixed or changed

The `Bleeding edge dependencies` job has been red on every PR since
2026-05-08 because `pip install --index-url <scientific-python nightly>
python-flint ...` errors with `No matching distribution found for
python-flint` — the channel has been empty for `python-flint` since
upstream's nightly upload stopped (last run 2026-04-05).

Switching `--index-url` to `--extra-index-url` lets pip also see PyPI
and pick the highest version that satisfies the constraints. With
`--pre`, the new behaviour is a strict superset of the current one:
nightly dev wheels still win when present, and PyPI release wheels are
used as a fallback when nightly is empty.

<details>
<summary>Behaviour matrix</summary>

| Scenario | Before (`--index-url`) | After (`--extra-index-url`) |
| --- | --- | --- |
| Nightly has `python-flint 0.9.0.dev` | Installs `0.9.0.dev` | Installs `0.9.0.dev` (unchanged) |
| Nightly empty for `python-flint` | **Job fails** | Installs PyPI release `0.8.0` |
| Nightly has `numpy 2.6.0.dev`, PyPI has `2.5.0` | Installs `2.6.0.dev` | Installs `2.6.0.dev` (unchanged) |
| Nightly empty for `numpy` / `scipy` | Job fails | Installs PyPI release |

</details>

<details>
<summary>Local verification (Python 3.14)</summary>

Reproduce the current failure:

```console
$ python3.14 -m pip install --dry-run --pre \
    --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
    --upgrade --only-binary=:all: python-flint
ERROR: Could not find a version that satisfies the requirement python-flint (from versions: none)
ERROR: No matching distribution found for python-flint
```

Verify the fix:

```console
$ python3.14 -m pip install --dry-run --pre \
    --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
    --upgrade --only-binary=:all: python-flint numpy scipy
...
Would install numpy-2.5.0.dev0 python-flint-0.8.0 scipy-1.18.0.dev0
```

`numpy` and `scipy` still come from the nightly channel (dev versions);
`python-flint` gracefully falls back to the PyPI `0.8.0` release.

</details>

## Other comments

<details>
<summary>Alternatives considered</summary>

* `|| pip install python-flint` (try/catch): splits one logical install
  into two and would also swallow non-empty-channel failures
  (e.g. transient network errors).
* `continue-on-error: true` on the install step: turns the job
  permanently yellow instead of fixing it; the job's value is verifying
  SymPy works against bleeding-edge wheels, which we'd lose.

When the upstream `python-flint` nightly pipeline resumes, no further
sympy-side change is required — `--pre` + `--extra-index-url` will
automatically prefer the nightly version once it reappears.

</details>

<details>
<summary>AI Generation Disclosure</summary>

This patch was developed with Claude (Anthropic) as a coding assistant.
The investigation (timing the channel emptying, locating the upstream
last-upload date, verifying the empty channel listing via `curl`), the
one-line workflow edit, and this PR description were authored with AI
assistance. The fix was verified locally on Python 3.14 by running both
the failing and the patched `pip install --dry-run` commands shown
above.

</details>

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
