### PR TITLE
polys: fix a `NotInvertible` error when using `nonlinsolve`

### DIFF
--- a/sympy/polys/fglmtools.py
+++ b/sympy/polys/fglmtools.py
@@ -51,7 +51,7 @@ def matrix_fglm(F, ring, O_to):
                 G.append(g)
         else:
             # v is linearly independent from V
-            P = _update(s, _lambda, P)
+            P = _update(s, _lambda, P, domain)
             S.append(_incr_k(S[t[1]], t[0]))
             V.append(v)
 
@@ -85,11 +85,11 @@ def _matrix_mul(M, v):
     return [sum(row[i] * v[i] for i in range(len(v))) for row in M]
 
 
-def _update(s, _lambda, P):
+def _update(s, _lambda, P, domain):
     """
     Update ``P`` such that for the updated `P'` `P' v = e_{s}`.
     """
-    k = min(j for j in range(s, len(_lambda)) if _lambda[j] != 0)
+    k = min(j for j in range(s, len(_lambda)) if _lambda[j] != domain.zero)
 
     for r in range(len(_lambda)):
         if r != k:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2099,6 +2099,18 @@ def test_nonlinsolve_issue_25182():
         -1.0*b1*(ca - 1)*(ca + 1)/a1 - 1.0*ca*sqrt(a1**2 + b1**2*ca**2 - b1**2)/a1))
 
 
+def test_nonlinsolve_issue_29750():
+    s, c = symbols('s c')
+    eq1 = 2*s*c - 2*sqrt(3)*c**2 + sqrt(3)*s - 3*c
+    eq2 = s**2 + c**2 - 1
+    sol = nonlinsolve([eq1, eq2], [s, c])
+    expected = FiniteSet(
+        (-sqrt(3)/2, -S.Half), (sqrt(3)/2, S.Half),
+        (-S.Half, -sqrt(3)/2), (S.Half, -sqrt(3)/2),
+    )
+    assert sol == expected
+
+
 def test_issue_14642():
     x = Symbol('x')
     n1 = 0.5*x**3+x**2+0.5+I #add I in the Polynomials


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #29750


#### Brief description of what is fixed or changed

Before the fix, sympy raised a `NotInvertible: zero divisor` error for the following system. 

```python
In [1]: s, c = symbols('s c')

In [2]: str(nonlinsolve([2 * s * c - 2 * sqrt(3) * c**2 + sqrt(3) * s - 3 * c, s**2 + c**2 - 1], [s, c]))
```

Nevertheless, the system has exactly four solutions in $\mathbb{R}^2$ : 

```python
{(-1/2, -sqrt(3)/2), (1/2, -sqrt(3)/2), (-sqrt(3)/2, -1/2), (sqrt(3)/2, 1/2)}
```

The cause is in line 92 of `sympy/polys/fglmtools.py` .

https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/fglmtools.py#L88-L92

 `_lambda[j]` is an `ANP` element, but `0` is a Python `int`. Cross-type comparison `ANP != int` always returns `True` .

Therefore, I made these changes in `sympy/polys/fglmtools.py` :


```diff
# line 54
- P = _update(s, _lambda, P)
+ P = _update(s, _lambda, P, domain)

# line 88
- def _update(s, _lambda, P):
+ def _update(s, _lambda, P, domain):

# line 92
- k = min(j for j in range(s, len(_lambda)) if _lambda[j] != 0) 
+ k = min(j for j in range(s, len(_lambda)) if _lambda[j] != domain.zero) 
```
and add a regression test.

After the fix:

```python
In [1]: s, c = symbols('s c')

In [2]: str(nonlinsolve([2 * s * c - 2 * sqrt(3) * c**2 + sqrt(3) * s - 3 * c, s**2 + c**2 - 1], [s, c]))
Out[2]: '{(-1/2, -sqrt(3)/2), (1/2, -sqrt(3)/2), (-sqrt(3)/2, -1/2), (sqrt(3)/2, 1/2)}'
```

#### Other comments

The use of `domain.zero` in `_identity_matrix` inspired this fix.

https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/fglmtools.py#L75-L81


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
DeepSeek assisted in finding the cause and pointed out where to add the test. 
All code was written manually.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a `NotInvertible` error when using `nonlinsolve`.
<!-- END RELEASE NOTES -->
