### PR TITLE
Fix SciPy sampling for DiracDelta continuous RVs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1318,6 +1318,7 @@ Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Prakhar Saxena <prakharsaxena.c
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <50932406+Psycho-Pirate@users.noreply.github.com>
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <prakharsaxena.cer18@itbhu.ac.in>
 Puneet Dixit <236133619+puneetdixit200@users.noreply.github.com>
+Puneet Dixit <236133619+puneetdixit200@users.noreply.github.com> Puneet Dixit <puneetdixit4321@gmail.com>
 Puneeth Chaganti <punchagan@gmail.com>
 Qijia Liu <liumeo@pku.edu.cn> Liumeo <liumeo@pku.edu.cn>
 Qijia Liu <liumeo@pku.edu.cn> eagleoflqj <liumeo@pku.edu.cn>

--- a/.mailmap
+++ b/.mailmap
@@ -1317,6 +1317,7 @@ Priyansh Rathi <techiepriyansh@gmail.com> techiepriyansh <techiepriyansh@gmail.c
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Prakhar Saxena <prakharsaxena.civ18@iitbhu.ac.in>
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <50932406+Psycho-Pirate@users.noreply.github.com>
 Psycho-Pirate <prakharsaxena.civ18@iitbhu.ac.in> Psycho-Pirate <prakharsaxena.cer18@itbhu.ac.in>
+Puneet Dixit <236133619+puneetdixit200@users.noreply.github.com>
 Puneeth Chaganti <punchagan@gmail.com>
 Qijia Liu <liumeo@pku.edu.cn> Liumeo <liumeo@pku.edu.cn>
 Qijia Liu <liumeo@pku.edu.cn> eagleoflqj <liumeo@pku.edu.cn>

--- a/sympy/stats/sampling/sample_scipy.py
+++ b/sympy/stats/sampling/sample_scipy.py
@@ -3,6 +3,10 @@ from functools import singledispatch
 
 from sympy.core.symbol import Dummy
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.special.delta_functions import DiracDelta
+from sympy.functions.elementary.piecewise import ExprCondPair, Piecewise
+from sympy.sets.sets import FiniteSet
+from sympy.solvers.solveset import solveset
 from sympy.utilities.lambdify import lambdify
 from sympy.external import import_module
 from sympy.stats import DiscreteDistributionHandmade
@@ -25,12 +29,37 @@ def do_sample_scipy(dist, size, seed):
 
 # CRV
 
+def _sample_dirac_delta(dist: SingleContinuousDistribution, z, size):
+    pdf = dist.pdf(z)
+    if isinstance(pdf, Piecewise):
+        nonzero_args = [
+            arg.expr for arg in pdf.args
+            if isinstance(arg, ExprCondPair) and arg.expr != 0
+        ]
+        if len(nonzero_args) != 1:
+            return None
+        pdf = nonzero_args[0]
+    if not isinstance(pdf, DiracDelta):
+        return None
+    roots = solveset(pdf.args[0], z, domain=dist.set)
+    if not isinstance(roots, FiniteSet) or len(roots) != 1:
+        return None
+    root = float(next(iter(roots)))
+    if size == ():
+        return root
+    import numpy as np
+    return np.full(size, root)
+
+
 @do_sample_scipy.register(SingleContinuousDistribution)
 def _(dist: SingleContinuousDistribution, size, seed):
     # if we don't need to make a handmade pdf, we won't
     import scipy.stats
 
     z = Dummy('z')
+    dirac_sample = _sample_dirac_delta(dist, z, size)
+    if dirac_sample is not None:
+        return dirac_sample
     handmade_pdf = lambdify(z, dist.pdf(z), ['numpy', 'scipy'])
 
     class scipy_pdf(scipy.stats.rv_continuous):

--- a/sympy/stats/sampling/tests/test_sample_continuous_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_continuous_rv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from sympy.core.numbers import oo
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.special.delta_functions import DiracDelta
 from sympy.sets.sets import Interval
 from sympy.external import import_module
 from sympy.stats import Beta, Chi, Normal, Gamma, Exponential, LogNormal, Pareto, ChiSquared, Uniform, sample, \
@@ -180,3 +181,15 @@ def test_sample_continuous():
                 assert all(s1 != s2)
         except NotImplementedError:
             continue
+
+
+def test_sample_continuous_dirac_delta():
+    scipy = import_module('scipy')
+    if not scipy:
+        skip('Scipy is not installed. Abort tests')
+    z = Symbol('z')
+    Z = ContinuousRV(z, DiracDelta(z - 3))
+
+    samps = sample(Z, size=3, library='scipy')
+
+    assert list(samps) == [3.0, 3.0, 3.0]


### PR DESCRIPTION
Fixes #29783

## Summary
- detect handmade continuous distributions whose PDF is a single `DiracDelta`
- sample those degenerate distributions directly at the delta root instead of passing `DiracDelta` to SciPy's numeric integration path
- add a regression test for SciPy sampling from `ContinuousRV(z, DiracDelta(z - 3))`

<!-- BEGIN RELEASE NOTES -->
* stats
  * Fixed SciPy sampling for continuous random variables with a single `DiracDelta` density.
<!-- END RELEASE NOTES -->

## Tests
- `.venv\Scripts\python -m pytest sympy\stats\sampling\tests -q`
- `.venv\Scripts\python -m ruff check sympy\stats\sampling\sample_scipy.py sympy\stats\sampling\tests\test_sample_continuous_rv.py`
- `git diff --check`

AI assistance was used while iterating on the patch and tests. I reviewed the change and can explain the implementation.
