### PR TITLE
Fix set comparison errors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -450,6 +450,7 @@ Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
 Bob Put <bobu.work@gmail.com>
+Bob Put <bobu.work@gmail.com> Bob Put <85964518+bobu-putheeckal@users.noreply.github.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -449,6 +449,7 @@ Bill Flynn <wflynny@gmail.com>
 Biswadeep Purkayastha <98874428+metabiswadeep@users.noreply.github.com>
 Björn Dahlgren <bjodah@gmail.com>
 Blair Azzopardi <blairuk@gmail.com> bsdz <bsdz@users.noreply.github.com>
+Bob Put <bobu.work@gmail.com>
 Bobby Palmer <bobbyp@umich.edu>
 Borek Saheli <boreksaheli@gmail.com>
 Boris Atamanovskiy <shaomoron@gmail.com>

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2182,27 +2182,27 @@ class FiniteSet(Set):
                 return None
         return PowerSet(biggest)
 
-    def __ge__(self, other):
+    def __ge__(self, other: Set) -> bool | None:
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            return NotImplemented
         return other.is_subset(self)
 
-    def __gt__(self, other):
+    def __gt__(self, other: Set) -> bool | None:
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            return NotImplemented
         return self.is_proper_superset(other)
 
-    def __le__(self, other):
+    def __le__(self, other: Set) -> bool | None:
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            return NotImplemented
         return self.is_subset(other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: Set) -> bool | None:
         if not isinstance(other, Set):
-            raise TypeError("Invalid comparison of set with %s" % func_name(other))
+            return NotImplemented
         return self.is_proper_subset(other)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, (set, frozenset)):
             return self._args_set == other
         return super().__eq__(other)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2202,7 +2202,7 @@ class FiniteSet(Set):
             return NotImplemented
         return self.is_proper_subset(other)
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other):
         if isinstance(other, (set, frozenset)):
             return self._args_set == other
         return super().__eq__(other)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1426,10 +1426,15 @@ def test_issue_9447():
 def test_issue_10337():
     assert (FiniteSet(2) == 3) is False
     assert (FiniteSet(2) != 3) is True
-    raises(TypeError, lambda: FiniteSet(2) < 3)
-    raises(TypeError, lambda: FiniteSet(2) <= 3)
-    raises(TypeError, lambda: FiniteSet(2) > 3)
-    raises(TypeError, lambda: FiniteSet(2) >= 3)
+    for other in (3, x):
+        raises(TypeError, lambda: FiniteSet(2) < other)
+        raises(TypeError, lambda: FiniteSet(2) <= other)
+        raises(TypeError, lambda: FiniteSet(2) > other)
+        raises(TypeError, lambda: FiniteSet(2) >= other)
+        raises(TypeError, lambda: other < FiniteSet(2))
+        raises(TypeError, lambda: other <= FiniteSet(2))
+        raises(TypeError, lambda: other > FiniteSet(2))
+        raises(TypeError, lambda: other >= FiniteSet(2))
 
 
 def test_issue_10326():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #8830

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The FiniteSet rich comparison methods now return NotImplemented when comparing with non-set objects instead of raising directly.

#### Other comments


#### AI Generation Disclosure
Used ChatGPT/Codex to help implement the comparison-method changes, add tests, and run local verification.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Invalid comparisons between FiniteSet and non-set objects now follow Python's standard unsupported-comparison behavior.
<!-- END RELEASE NOTES -->
