### PR TITLE
Fix/refine pow nested 29684

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1546,6 +1546,7 @@ Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>
 Siddhant Jain <siddhantashoknagar@gmail.com> Siddhant Jain <77455093+me-t1me@users.noreply.github.com>
 Siddhant Jain <siddhantashoknagar@gmail.com> me-t1me <siddhantashoknagar@gmail.com>
+Siddharth Kolichala <siddharth.kolichala@gmail.com> sidkol1 <156947180+sidkol1@users.noreply.github.com>
 Siddharth Kolichala <siddharth.kolichala@gmail.com> sidkol1 <siddharth.kolichala@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpal@users.noreply.github.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1546,7 +1546,7 @@ Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>
 Siddhant Jain <siddhantashoknagar@gmail.com> Siddhant Jain <77455093+me-t1me@users.noreply.github.com>
 Siddhant Jain <siddhantashoknagar@gmail.com> me-t1me <siddhantashoknagar@gmail.com>
-Siddharth Kolichala <siddharth.kolichala@gmail.com>
+Siddharth Kolichala <siddharth.kolichala@gmail.com> sidkol1 <siddharth.kolichala@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpal@users.noreply.github.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1546,6 +1546,7 @@ Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>
 Siddhant Jain <siddhantashoknagar@gmail.com> Siddhant Jain <77455093+me-t1me@users.noreply.github.com>
 Siddhant Jain <siddhantashoknagar@gmail.com> me-t1me <siddhantashoknagar@gmail.com>
+Siddharth Kolichala <siddharth.kolichala@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpal@users.noreply.github.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -161,7 +161,7 @@ def refine_Pow(expr, assumptions):
         # (i)   z3 is an integer            =>  z1**(z2*z3)
         # (ii)  z1 > 0 and z2 is real       =>  z1**(z2*z3)
         # (iii) z1 is real and z2 is an
-        #       even integer                =>  Abs(z1)**(z2*z3)
+        #       even integer                =>  In this case, z1**z2 = |z1|**z2, and so this reduces to case (ii).
         inner_base, inner_exp = expr.base.base, expr.base.exp
         outer_exp = expr.exp
         if ask(Q.integer(outer_exp), assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, overload
 
-from sympy.core import S, Add, Expr, Basic, Mul, Pow, Rational
+from sympy.core import S, Add, Expr, Basic, Mul, Pow
 from sympy.core.logic import fuzzy_not
 
 from sympy.assumptions import ask, Q  # type: ignore

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -151,15 +151,34 @@ def refine_Pow(expr, assumptions):
         if ask(Q.real(expr.base.args[0]), assumptions) and \
                 ask(Q.even(expr.exp), assumptions):
             return expr.base.args[0] ** expr.exp
+
+    if isinstance(expr.base, Pow):
+        # (z1**z2)**z3 admits a few sound simplifications. In each case the
+        # remaining variables (those not constrained) may be any complex
+        # number; outside these cases the rewrite is unsound due to branch
+        # cuts (e.g. ((-2)**3)**(1/2) = 2*sqrt(2)*I != Abs(-2)**(3/2)).
+        #
+        # (i)   z3 is an integer            =>  z1**(z2*z3)
+        # (ii)  z1 > 0 and z2 is real       =>  z1**(z2*z3)
+        # (iii) z1 is real and z2 is an
+        #       even integer                =>  Abs(z1)**(z2*z3)
+        inner_base, inner_exp = expr.base.base, expr.base.exp
+        outer_exp = expr.exp
+        if ask(Q.integer(outer_exp), assumptions):
+            return inner_base ** (inner_exp * outer_exp)
+        if ask(Q.positive(inner_base), assumptions) and \
+                ask(Q.real(inner_exp), assumptions):
+            return inner_base ** (inner_exp * outer_exp)
+        if ask(Q.real(inner_base), assumptions) and \
+                ask(Q.even(inner_exp), assumptions):
+            return Abs(inner_base) ** (inner_exp * outer_exp)
+
     if ask(Q.real(expr.base), assumptions):
         if expr.base.is_number:
             if ask(Q.even(expr.exp), assumptions):
                 return abs(expr.base) ** expr.exp
             if ask(Q.odd(expr.exp), assumptions):
                 return sign(expr.base) * abs(expr.base) ** expr.exp
-        if isinstance(expr.exp, Rational):
-            if isinstance(expr.base, Pow):
-                return abs(expr.base.base) ** (expr.base.exp * expr.exp)
 
         if expr.base is S.NegativeOne:
             if expr.exp.is_Add:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -153,15 +153,12 @@ def refine_Pow(expr, assumptions):
             return expr.base.args[0] ** expr.exp
 
     if isinstance(expr.base, Pow):
-        # (z1**z2)**z3 admits a few sound simplifications. In each case the
-        # remaining variables (those not constrained) may be any complex
-        # number; outside these cases the rewrite is unsound due to branch
-        # cuts (e.g. ((-2)**3)**(1/2) = 2*sqrt(2)*I != Abs(-2)**(3/2)).
-        #
+        #we simplify (z1**z2)**z3 depending on the assumptions on z1, z2, and z3.
         # (i)   z3 is an integer            =>  z1**(z2*z3)
         # (ii)  z1 > 0 and z2 is real       =>  z1**(z2*z3)
         # (iii) z1 is real and z2 is an
-        #       even integer                =>  In this case, z1**z2 = |z1|**z2, and so this reduces to case (ii).
+        #       even integer                =>  In this case, z1**z2 = |z1|**z2.
+        #So then (z1**z2)**z3 = (|z1|**z2)**z3 = |z1|**(z2*z3), where the last equality follows from case (ii).
         inner_base, inner_exp = expr.base.base, expr.base.exp
         outer_exp = expr.exp
         if ask(Q.integer(outer_exp), assumptions):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -48,6 +48,29 @@ def test_pow1():
     assert refine(sqrt(1/x), Q.real(x)) != 1/sqrt(x)
     assert refine(sqrt(1/x), Q.positive(x)) == 1/sqrt(x)
 
+    # issue 29684: (x**a)**b must not be rewritten to Abs(x)**(a*b)
+    # under Q.real(x) alone -- e.g. at x=-2 the two sides disagree.
+    assert refine((x**3)**Rational(1, 2), Q.real(x)) != Abs(x)**Rational(3, 2)
+    assert refine((x**3)**Rational(1, 3), Q.real(x)) != Abs(x)
+    # The rewrite is still applied when conditions actually hold.
+    assert refine((x**3)**Rational(1, 2), Q.positive(x)) == x**Rational(3, 2)
+    assert refine(sqrt(x**4), Q.real(x)) == x**2
+
+    # (z_1**z_2)**z_3 casework.
+    # Case (i): integer outer exponent -> z_1**(z_2*z_3) unconditionally.
+    n = Symbol('n', integer=True)
+    assert refine((x**y)**n) == x**(n*y)
+    assert refine((x**y)**z, Q.integer(z)) == x**(y*z)
+    # Case (ii): positive base, real inner exp -> z_1**(z_2*z_3) for any z_3.
+    assert refine((x**y)**z, Q.positive(x) & Q.real(y)) == x**(y*z)
+    assert refine((x**Rational(1, 2))**y, Q.positive(x)) == x**(y/2)
+    # Case (iii): real base, even integer inner exp -> Abs(z_1)**(z_2*z_3).
+    assert refine((x**y)**z, Q.real(x) & Q.even(y)) == Abs(x)**(y*z)
+    # Counterexamples: none of the three cases hold, so no rewrite.
+    assert refine((x**y)**z) == (x**y)**z
+    assert refine((x**y)**z, Q.real(x) & Q.real(y)) == (x**y)**z
+    assert refine((x**y)**z, Q.real(x) & Q.odd(y)) == (x**y)**z
+
     # powers of (-1)
     assert refine((-1)**(x + y), Q.even(x)) == (-1)**y
     assert refine((-1)**(x + y + z), Q.odd(x) & Q.odd(z)) == (-1)**y


### PR DESCRIPTION
Fixes #29684. Previously, the expression $(z_1^{z_2})^{z_3}$ would be refined to $|z_1|^{z_{2}z_{3}}$ if $z_3 \in \mathbb{Q}$. This simplification is not valid in general, and was causing test cases to fail. I replaced this incorrect logic with a few cases that do allow for a similar simplification. 

I told my Cursor agent exactly how to handle the casework. Only a few lines of code were needed, which I read and verified. I left testing to Cursor. 

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `refine_Pow` returning incorrect results for nested powers `(x**a)**b` under `Q.real(x)` (issue #29684). The handler now simplifies only when one of three conditions holds:
    * integer outer exponent; 
    * positive base with real inner exponent;
    * real base with even integer inner exponent.

<!-- END RELEASE NOTES -->


