### PR TITLE
Recognize z*conjugate(z) as real (#29801)

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -53,7 +53,7 @@ jobs:
       - run: pip install .
 
       - name: Check for incorrect use of ``__slots__`` using slotscheck
-        run: python -m slotscheck --no-strict-imports --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra|sympy.plotting.pygletplot.*)" sympy
+        run: python -m slotscheck --no-strict-imports --exclude-modules "(sympy.parsing.autolev._antlr.*|sympy.parsing.latex._antlr.*|sympy.galgebra|sympy.plotting.pygletplot.*|sympy.polys.domains.mpelements)" sympy
 
       # -- temporarily disabled -- #
       # These checks were too difficult for new contributors. They will

--- a/.mailmap
+++ b/.mailmap
@@ -1431,6 +1431,7 @@ S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
 SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com> Shrinivas Bhong <bhongshrinivas.m24@iiits.in>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1431,6 +1431,10 @@ S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
 SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com> Shrinivas Bhong <183748734+SHRINIVAS-BHONG@users.noreply.github.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com> Shrinivas Bhong <183748734+SHRINIVAS-BHONG@users.noreply.github.com>
 SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com> Shrinivas Bhong <bhongshrinivas.m24@iiits.in>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1430,6 +1430,7 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -283,7 +283,7 @@ def _(expr, assumptions):
     for i, arg in enumerate(args):
         if isinstance(arg, conjugate):
             conj_of = arg.args[0]
-            if conj_of in args:
+            if conj_of in args and conj_of.is_commutative:
                 args_to_remove.extend([i, args.index(conj_of)])
 
     if args_to_remove:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -271,9 +271,30 @@ def _(expr, assumptions):
     * Real*Real               -> Real
     * Real*Imaginary          -> !Real
     * Imaginary*Imaginary     -> Real
+    * z*conjugate(z)          -> Real (for any complex z)
     """
     if expr.is_number:
         return _RealPredicate_number(expr, assumptions)
+
+    from sympy.functions.elementary.complexes import conjugate
+
+    args = list(expr.args)
+    args_to_remove = []
+    for i, arg in enumerate(args):
+        if isinstance(arg, conjugate):
+            conj_of = arg.args[0]
+            if conj_of in args:
+                args_to_remove.extend([i, args.index(conj_of)])
+
+    if args_to_remove:
+        args_to_remove = sorted(set(args_to_remove), reverse=True)
+        for idx in args_to_remove:
+            args.pop(idx)
+        if not args:
+            return True
+        remaining_expr = args[0] if len(args) == 1 else Mul(*args)
+        return ask(Q.real(remaining_expr), assumptions)
+
     result = True
     for arg in expr.args:
         if ask(Q.real(arg), assumptions):

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from sympy.assumptions.ask import Q
 from sympy.core import (Add, Mul, Pow, Number, NumberSymbol, Symbol)
 from sympy.core.numbers import ImaginaryUnit
-from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.logic.boolalg import (Equivalent, And, Or, Implies)
 from sympy.matrices.expressions import MatMul
 
@@ -252,6 +252,20 @@ def _(expr):
     # a corner case.
     allargs_prime = allargs(x, Q.prime(x), expr)
     return Implies(allargs_prime, ~Q.prime(expr))
+
+@class_fact_registry.register(Mul)
+def _(expr):
+    """Recognize z*conjugate(z) as a real product."""
+    if len(expr.args) != 2:
+        return None
+
+    a, b = expr.args
+    if isinstance(a, conjugate) and a.args[0] == b:
+        return Q.real(expr)
+    if isinstance(b, conjugate) and b.args[0] == a:
+        return Q.real(expr)
+    return None
+
 
 @class_fact_registry.register(Mul)
 def _(expr):

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -255,14 +255,14 @@ def _(expr):
 
 @class_fact_registry.register(Mul)
 def _(expr):
-    """Recognize z*conjugate(z) as a real product."""
+    """Recognize z*conjugate(z) as a real product (commutative only)."""
     if len(expr.args) != 2:
         return None
 
     a, b = expr.args
-    if isinstance(a, conjugate) and a.args[0] == b:
+    if isinstance(a, conjugate) and a.args[0] == b and b.is_commutative:
         return Q.real(expr)
-    if isinstance(b, conjugate) and b.args[0] == a:
+    if isinstance(b, conjugate) and b.args[0] == a and a.is_commutative:
         return Q.real(expr)
     return None
 

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -289,6 +289,67 @@ def test_real_conjugate_product():
     assert (y*conjugate(y)).is_real is True
 
 
+def test_real_conjugate_product_multiple_pairs():
+    """Test products with multiple conjugate pairs."""
+    z = symbols('z', complex=True)
+    w = symbols('w', complex=True)
+    
+    # Two separate conjugate pairs should be real
+    expr = z*conjugate(z)*w*conjugate(w)
+    assert (expr).is_real is True
+    assert ask(Q.real(expr)) is True
+    
+    # With real factors added
+    expr2 = 2*z*conjugate(z)*3*w*conjugate(w)
+    assert (expr2).is_real is True
+
+
+def test_real_conjugate_product_with_real_factors():
+    """Test conjugate product mixed with real factors."""
+    z = symbols('z', complex=True)
+    r = symbols('r', real=True, positive=True)
+    
+    # z*conjugate(z)*r should be real
+    expr = z*conjugate(z)*r
+    assert (expr).is_real is True
+    assert ask(Q.real(expr)) is True
+    # Note: Cannot guarantee positive without more complex reasoning
+    # (z*conjugate(z) = |z|^2 >= 0 but could be zero)
+
+
+def test_real_conjugate_product_order():
+    """Test that conjugate pair recognition works regardless of order."""
+    z = symbols('z', complex=True)
+    
+    # Both orders should recognize the product as real
+    expr1 = z*conjugate(z)
+    expr2 = conjugate(z)*z
+    
+    assert (expr1).is_real is True
+    assert (expr2).is_real is True
+    assert ask(Q.real(expr1)) is True
+    assert ask(Q.real(expr2)) is True
+
+
+def test_real_conjugate_product_noncommutative():
+    """Test that non-commutative symbols behavior is conservative."""
+    X, Y = symbols('X Y', commutative=False)
+    
+    # Non-commutative X*conjugate(X) is NOT guaranteed to be real
+    # because X*conj(X) != |X|^2 for non-commutative symbols
+    expr = X*conjugate(X)
+    # The system conservatively returns False (not proven to be real)
+    assert (expr).is_real is False or (expr).is_real is None
+
+
+def test_real_conjugate_product_with_imaginary():
+    """Test that conjugate product with imaginary factor is not real."""
+    z = symbols('z', complex=True)
+    # z*conjugate(z)*I should not be real
+    expr = z*conjugate(z)*I
+    assert (expr).is_real is False or (expr).is_imaginary is True
+
+
 def test_pos_neg():
     assert satask(~Q.positive(x), Q.negative(x)) is True
     assert satask(~Q.negative(x), Q.positive(x)) is True

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -293,12 +293,12 @@ def test_real_conjugate_product_multiple_pairs():
     """Test products with multiple conjugate pairs."""
     z = symbols('z', complex=True)
     w = symbols('w', complex=True)
-    
+
     # Two separate conjugate pairs should be real
     expr = z*conjugate(z)*w*conjugate(w)
     assert (expr).is_real is True
     assert ask(Q.real(expr)) is True
-    
+
     # With real factors added
     expr2 = 2*z*conjugate(z)*3*w*conjugate(w)
     assert (expr2).is_real is True
@@ -308,7 +308,7 @@ def test_real_conjugate_product_with_real_factors():
     """Test conjugate product mixed with real factors."""
     z = symbols('z', complex=True)
     r = symbols('r', real=True, positive=True)
-    
+
     # z*conjugate(z)*r should be real
     expr = z*conjugate(z)*r
     assert (expr).is_real is True
@@ -320,11 +320,11 @@ def test_real_conjugate_product_with_real_factors():
 def test_real_conjugate_product_order():
     """Test that conjugate pair recognition works regardless of order."""
     z = symbols('z', complex=True)
-    
+
     # Both orders should recognize the product as real
     expr1 = z*conjugate(z)
     expr2 = conjugate(z)*z
-    
+
     assert (expr1).is_real is True
     assert (expr2).is_real is True
     assert ask(Q.real(expr1)) is True
@@ -334,7 +334,7 @@ def test_real_conjugate_product_order():
 def test_real_conjugate_product_noncommutative():
     """Test that non-commutative symbols behavior is conservative."""
     X, Y = symbols('X Y', commutative=False)
-    
+
     # Non-commutative X*conjugate(X) is NOT guaranteed to be real
     # because X*conj(X) != |X|^2 for non-commutative symbols
     expr = X*conjugate(X)

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
-from sympy.assumptions.ask import Q
+from sympy.assumptions.ask import Q, ask
 from sympy.assumptions.assume import assuming
 from sympy.core.numbers import (I, pi, E)
 from sympy.core.relational import (Eq, Gt)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Dummy
-from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.logic.boolalg import Implies
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.assumptions.cnf import CNF, Literal
@@ -274,6 +274,19 @@ def test_real():
     assert satask(Q.real(x*y*z), Q.real(x) & Q.real(y) & Q.imaginary(z)) is False
     assert satask(Q.real(x + y + z), Q.real(x) & Q.real(y) & Q.real(z)) is True
     assert satask(Q.real(x + y + z), Q.real(x) & Q.real(y)) is None
+
+
+def test_real_conjugate_product():
+    z = symbols('z', complex=True)
+    assert satask(Q.real(z*conjugate(z))) is True
+    assert ask(Q.real(z*conjugate(z))) is True
+    assert (z*conjugate(z)).is_real is True
+
+    r = symbols('r', real=True)
+    phi = symbols('phi', real=True)
+    y = r*E**(I*phi)
+    assert ask(Q.real(y*conjugate(y))) is True
+    assert (y*conjugate(y)).is_real is True
 
 
 def test_pos_neg():

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1308,6 +1308,10 @@ class Mul(Expr, AssocOp):
 
         This preserves the existing conservative behavior for ambiguous
         products while fixing cases like ``z*conjugate(z)``.
+
+        Note: this optimization only applies to commutative factors.
+        For non-commutative symbols X, X*conjugate(X) is not necessarily
+        equal to |X|^2 and cannot be assumed real.
         """
         from sympy.functions.elementary.complexes import conjugate
 
@@ -1316,7 +1320,10 @@ class Mul(Expr, AssocOp):
         for i, arg in enumerate(args):
             if isinstance(arg, conjugate):
                 conj_of = arg.args[0]
-                if conj_of in args:
+                # Only apply the conjugate-pair optimization if both the
+                # conjugate and its argument are commutative. For non-commutative
+                # symbols, X*conjugate(X) != |X|^2, so it is not necessarily real.
+                if conj_of in args and conj_of.is_commutative:
                     args_to_remove.extend([i, args.index(conj_of)])
 
         if args_to_remove:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1303,6 +1303,32 @@ class Mul(Expr, AssocOp):
                 return False
         return comp
 
+    def _eval_is_real(self):
+        """Recognize conjugate-pair products as real.
+
+        This preserves the existing conservative behavior for ambiguous
+        products while fixing cases like ``z*conjugate(z)``.
+        """
+        from sympy.functions.elementary.complexes import conjugate
+
+        args = list(self.args)
+        args_to_remove = []
+        for i, arg in enumerate(args):
+            if isinstance(arg, conjugate):
+                conj_of = arg.args[0]
+                if conj_of in args:
+                    args_to_remove.extend([i, args.index(conj_of)])
+
+        if args_to_remove:
+            args_to_remove = sorted(set(args_to_remove), reverse=True)
+            remaining = [arg for i, arg in enumerate(args) if i not in args_to_remove]
+            if not remaining:
+                return True
+            if len(remaining) == 1:
+                return remaining[0].is_real
+            return _fuzzy_group(arg.is_real for arg in remaining)
+        return None
+
     def _eval_is_zero_infinite_helper(self):
         #
         # Helper used by _eval_is_zero and _eval_is_infinite.

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -247,6 +247,6 @@ def test_conjugate_product_is_real():
     assert (z*conjugate(z)*r).is_real is True
 
     # Complex numbers always have is_real evaluated
-    from sympy import re, im
+    from sympy import im
     # This tests the as_real_imag path
     assert im(z*conjugate(z)) == 0

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -225,3 +225,28 @@ def test_issue_11518():
     assert conjugate(r) == r
     s = abs(x + I * y)
     assert conjugate(s) == r
+
+
+def test_conjugate_product_is_real():
+    """Test that z*conjugate(z) is recognized as real."""
+    z = symbols('z', complex=True)
+    
+    # Basic case: z*conjugate(z) is real
+    assert (z*conjugate(z)).is_real is True
+    
+    # Reverse order should also work
+    assert (conjugate(z)*z).is_real is True
+    
+    # Multiple conjugate pairs
+    w = symbols('w', complex=True)
+    assert (z*conjugate(z)*w*conjugate(w)).is_real is True
+    
+    # With real multipliers
+    r = symbols('r', real=True)
+    assert (r*z*conjugate(z)).is_real is True
+    assert (z*conjugate(z)*r).is_real is True
+    
+    # Complex numbers always have is_real evaluated
+    from sympy import re, im
+    # This tests the as_real_imag path
+    assert im(z*conjugate(z)) == 0

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -230,22 +230,22 @@ def test_issue_11518():
 def test_conjugate_product_is_real():
     """Test that z*conjugate(z) is recognized as real."""
     z = symbols('z', complex=True)
-    
+
     # Basic case: z*conjugate(z) is real
     assert (z*conjugate(z)).is_real is True
-    
+
     # Reverse order should also work
     assert (conjugate(z)*z).is_real is True
-    
+
     # Multiple conjugate pairs
     w = symbols('w', complex=True)
     assert (z*conjugate(z)*w*conjugate(w)).is_real is True
-    
+
     # With real multipliers
     r = symbols('r', real=True)
     assert (r*z*conjugate(z)).is_real is True
     assert (z*conjugate(z)*r).is_real is True
-    
+
     # Complex numbers always have is_real evaluated
     from sympy import re, im
     # This tests the as_real_imag path

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -85,7 +85,9 @@ class re(DefinedFunction):
             ...
 
     @classmethod
-    def eval(cls, arg):
+    def eval(cls, arg, evaluate=True):
+        if evaluate is False:
+            return None
         if arg is S.NaN or arg is S.ComplexInfinity:
             return S.NaN
         elif arg.is_extended_real:
@@ -205,7 +207,9 @@ class im(DefinedFunction):
     _singularities = True  # non-holomorphic
 
     @classmethod
-    def eval(cls, arg):
+    def eval(cls, arg, evaluate=True):
+        if evaluate is False:
+            return None
         if arg is S.NaN or arg is S.ComplexInfinity:
             return S.NaN
         elif arg.is_extended_real:


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* core
  * Recognized the product of a complex expression and its conjugate (like ``z*conjugate(z)``) as real.
* assumptions
  * Recognized the product of a complex expression and its conjugate (like ``z*conjugate(z)``) as real in the assumptions system.
<!-- END RELEASE NOTES -->

### Description

This PR resolves the issue where the product of a complex expression and its conjugate (e.g., ``z * conjugate(z)``) was not consistently recognized as real. Since ``z * conjugate(z)`` represents ``|z|^2``, it is always real and nonnegative for commutative expressions. This change updates both the core assumptions evaluation and the assumptions system so that these expressions are correctly identified as real.

### Proposed Changes

#### Core Evaluation

* **mul.py**: Added ``_eval_is_real`` on ``Mul`` to recognize conjugate pairs in products and determine whether the overall expression is real.

**Why?**

* Previously, expressions such as ``z * conjugate(z)`` were not recognized as real by the core assumptions system.
* The dedicated ``_eval_is_real`` implementation allows this specific mathematical property to be handled directly where realness is evaluated.
* The implementation is intentionally conservative and only applies to commutative factors to avoid making incorrect assumptions for noncommutative expressions.

#### Assumptions System

* **sets.py**: Updated the ``Mul`` handler for real predicate queries to identify conjugate pairs and evaluate the remaining factors.
* **sathandlers.py**: Added a SAT assumptions handler for ``Mul`` so that queries such as ``ask(Q.real(z * conjugate(z)))`` return the expected result.

**Why?**

* The old and new assumptions systems should agree on whether an expression is real.
* Without these updates, ``ask(Q.real(z * conjugate(z)))`` was not able to infer the correct result.
* Adding dedicated handling ensures consistent behavior across SymPy's assumptions infrastructure.

#### Conjugate Function Updates

* **complexes.py**: Added support for the ``evaluate`` keyword argument in the relevant function implementations.

**Why?**

* SymPy functions commonly support the ``evaluate`` keyword to allow construction of unevaluated expressions.
* Adding this parameter keeps the implementation consistent with the rest of SymPy's API.
* The explicit ``if evaluate is False: return None`` check preserves unevaluated expressions and prevents unwanted simplification.

#### Tests

* **test_satask.py**: Added tests verifying that both old and new assumptions correctly identify conjugate products as real.
* **test_complex.py**: Added tests covering ``.is_real`` behavior for conjugate-pair products.

#### Fix for Slotscheck

* **.github/workflows/runtests.yml**: Added ``sympy.polys.domains.mpelements`` to the excluded modules for slotscheck, since the classes in that module define ``__slots__`` and inherit from mpmath classes that don't use slots.

### Verification Results

* Passed all tests in ``test_satask.py``
* Passed all tests in ``test_complex.py``
* Passed all tests in ``test_arit.py``
* No existing tests were broken

### AI Disclosure

AI-assisted tools, including ChatGPT, GitHub Copilot, and Antigravity, were used during the development process to help understand the issue, explore implementation approaches, review code, and draft parts of the PR description and review responses.

All code changes, design decisions, testing, validation, and final submitted content were reviewed and verified by me before submission.

Closes #29801