### PR TITLE
Minor fixes for `lra_theory`

### DIFF
--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -361,11 +361,7 @@ class LRASolver():
         """
         self.result = None
         for var in self.all_var:
-            var.lower = LRARational(-float("inf"), 0)
-            var.lower_literal = None
-            var.upper = LRARational(float("inf"), 0)
-            var.upper_literal = None
-            var.assign = LRARational(0, 0)
+            var.initialize()
 
     def assert_lit(self, literal):
         """
@@ -640,7 +636,7 @@ class LRASolver():
         0 = -x + (-e/d)*y + (-f/d)*z
         0 = 0 + (h - e*g/d)*y + (i - f*g/d)*z
         """
-        _, _, Mij = M[i, :], M[:, j], M[i, j]
+        Mij = M[i, j]
         if Mij == 0:
             raise ZeroDivisionError("Tried to pivot about zero-valued entry.")
         A = M.copy()
@@ -806,13 +802,16 @@ class LRAVariable():
     on `self.var`.
     """
     def __init__(self, var):
+        self.initialize()
+        self.var = var
+        self.col_idx = None
+
+    def initialize(self):
         self.upper = LRARational(float("inf"), 0)
         self.upper_literal = None
         self.lower = LRARational(-float("inf"), 0)
         self.lower_literal = None
         self.assign = LRARational(0,0)
-        self.var = var
-        self.col_idx = None
 
     def __repr__(self):
         return repr(self.var)


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
#29542
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This adds the `LRAVariable.initialize` method and removes unnecessary variables.

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
