### PR TITLE
stats: raise NotImplementedError in conditional_space when normalize=False

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1691,6 +1691,7 @@ Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
+Vasiliki Zagoraiou <t8230036@aueb.gr>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1580,6 +1580,7 @@ Stefan Behnle <84378403+behnle@users.noreply.github.com>
 Stefan Krastanov <krastanov.stefan@gmail.com>
 Stefan Petrea <stefan@garage-coding.com>
 Stefan van der Walt <stefan@sun.ac.za>
+Stefania Koulouri <t8230063@aueb.gr>
 Stefano Maggiolo <s.maggiolo@gmail.com>
 Stefen Yin <zqyin@ucdavis.edu>
 Stepan Roucka <stepan@roucka.eu>

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -459,7 +459,8 @@ class ContinuousPSpace(PSpace):
             # XXX: Converting set to tuple. The order matters to Lambda though
             # so we shouldn't be starting with a set here...
             density = Lambda(tuple(domain.symbols), pdf)
-
+        else:
+            raise NotImplementedError("normalize=False is not implemented")
         return ContinuousPSpace(domain, density)
 
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -534,9 +534,9 @@ class IndependentProductPSpace(ProductPSpace):
             replacement  = {rv: Dummy(str(rv)) for rv in self.symbols}
             norm = domain.compute_expectation(self.pdf, **kwargs)
             pdf = self.pdf / norm.xreplace(replacement)
-            # XXX: Converting symbols from set to tuple. The order matters to
-            # Lambda though so we shouldn't be starting with a set here...
             density = Lambda(tuple(domain.symbols), pdf)
+        else:
+            raise NotImplementedError("normalize=False is not implemented")
 
         return space(domain, density)
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -534,6 +534,8 @@ class IndependentProductPSpace(ProductPSpace):
             replacement  = {rv: Dummy(str(rv)) for rv in self.symbols}
             norm = domain.compute_expectation(self.pdf, **kwargs)
             pdf = self.pdf / norm.xreplace(replacement)
+            # XXX: Converting symbols from set to tuple. The order matters to
+            # Lambda though so we shouldn't be starting with a set here...
             density = Lambda(tuple(domain.symbols), pdf)
         else:
             raise NotImplementedError("normalize=False is not implemented")

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1582,3 +1582,12 @@ def test_issue_16318():
 def test_compute_density():
     X = Normal('X', 0, Symbol("sigma")**2)
     raises(ValueError, lambda: density(X**5 + X))
+
+def test_conditional_space_normalize_false():
+    from sympy.stats import Normal
+    from sympy.stats.rv import pspace
+    X = Normal('X', 0, 1)
+    pspace(X).conditional_space(X > 0, normalize=True)
+    # normalize=False should raise NotImplementedError, not UnboundLocalError
+    raises(NotImplementedError,
+           lambda: pspace(X).conditional_space(X > 0, normalize=False))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29805
#### Brief description of what is fixed or changed
`conditional_space` in both `rv.py` and `crv.py` raises `UnboundLocalError` when called with `normalize=False`, because `density` is only assigned inside the `if normalize:` block but used unconditionally in the `return` statement.

After searching the codebase, `normalize=False` is never used anywhere , the parameter only appears in the method definitions and the `if normalize:` checks. Therefore, instead of implementing untested behavior, this PR raises a clear `NotImplementedError`.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * `conditional_space` now raises `NotImplementedError` when called with `normalize=False` instead of raising `UnboundLocalError`.
<!-- END RELEASE NOTES -->
