### PR TITLE
piecewise: fix hang when integrating products of non-overlapping Piecewise functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1580,6 +1580,7 @@ Stefan Behnle <84378403+behnle@users.noreply.github.com>
 Stefan Krastanov <krastanov.stefan@gmail.com>
 Stefan Petrea <stefan@garage-coding.com>
 Stefan van der Walt <stefan@sun.ac.za>
+Stefania Koulouri <t8230063@aueb.gr>
 Stefano Maggiolo <s.maggiolo@gmail.com>
 Stefen Yin <zqyin@ucdavis.edu>
 Stepan Roucka <stepan@roucka.eu>
@@ -1690,6 +1691,7 @@ Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
 Vasileios Kalos <kalosbasileios@gmail.com> Basileios Kalos <kalosbasileios@gmail.com>
 Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
+Vasiliki Zagoraiou <t8230036@aueb.gr>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1147,6 +1147,26 @@ def _clip(A, B, k):
 
     return p
 
+def _remove_subsumed_clauses(conj):
+    """Remove redundant clauses from a CNF `And` expression.
+
+    A disjunctive clause `C1` subsumes `C2` when every literal of `C1`
+    also appears in `C2`, e.g. (a | b) & (a | b | c) reduces
+    to (a | b).  Dropping these before a CNF-to-DNF conversion avoids
+    the exponential blow-up that `distribute_or_over_and` can hit on the
+    highly redundant conditions produced by `piecewise_fold`, see:
+    https://github.com/sympy/sympy/issues/29064.
+    """
+    clauses = []
+    for c in conj.args:
+        lits = frozenset(c.args) if isinstance(c, Or) else frozenset([c])
+        clauses.append((lits, c))
+    clauses.sort(key=lambda t: len(t[0]))
+    kept = []
+    for lits, c in clauses:
+        if not any(k <= lits for k, _ in kept):
+            kept.append((lits, c))
+    return And(*[c for _, c in kept])
 
 def piecewise_simplify_arguments(expr, **kwargs):
     from sympy.simplify.simplify import simplify

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -673,6 +673,8 @@ class Piecewise(DefinedFunction):
 
             cond = to_cnf(cond)
             if isinstance(cond, And):
+                cond = _remove_subsumed_clauses(cond)
+            if isinstance(cond, And):
                 cond = distribute_or_over_and(cond)
 
             if isinstance(cond, Or):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -16,7 +16,8 @@ from sympy.functions.elementary.complexes import (Abs, adjoint, arg, conjugate, 
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import (Piecewise,
-    piecewise_fold, piecewise_exclusive, Undefined, ExprCondPair)
+    piecewise_fold, piecewise_exclusive, Undefined, ExprCondPair,
+    _remove_subsumed_clauses)
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -1649,3 +1650,59 @@ def test_piecewise_integrate_29064():
     b2 = Piecewise((0, x < Rational(5, 8)), (8, x < Rational(3, 4)),
                    (-8, x < Rational(7, 8)), (0, True))
     assert integrate(b1*b2, (x, 0, 1)) == 0
+
+def test_remove_subsumed_clauses_basic():
+    """All larger clauses are supersets of the smallest."""
+    a, b, c, d = symbols('a b c d')
+    # (a|b) AND (a|b|c) AND (a|b|d) → only (a|b) survives
+    expr = And(Or(a, b), Or(a, b, c), Or(a, b, d))
+    result = _remove_subsumed_clauses(expr)
+    assert result == Or(a, b)
+ 
+ 
+def test_remove_subsumed_clauses_no_redundant():
+    """No clause is a subset of another — all kept."""
+    a, b, c, d = symbols('a b c d')
+    # (a|b) AND (c|d) → neither is subset → keep both
+    expr = And(Or(a, b), Or(c, d))
+    result = _remove_subsumed_clauses(expr)
+    assert result == And(Or(a, b), Or(c, d))
+ 
+def test_remove_subsumed_clauses_two_kept():
+    """Two independent small clauses subsume everything else."""
+    a, b, c, d, e = symbols('a b c d e')
+    # Simulates the actual 12-clause scenario simplified
+    expr = And(
+        Or(a, b),           # size 2 — kept
+        Or(a, c),           # size 2 — kept (b not in {a,c})
+        Or(a, b, c),        # {a,b} subset → skip
+        Or(a, b, d),        # {a,b} subset → skip
+        Or(a, c, d),        # {a,c} subset → skip
+        Or(a, b, c, d, e),  # {a,b} subset → skip
+    )
+    result = _remove_subsumed_clauses(expr)
+    assert result == And(Or(a, b), Or(a, c))
+
+def test_piecewise_integrate_disjoint_simple():
+    """Completely disjoint intervals [0,1] and [2,3]."""
+    x = symbols('x', real=True)
+    p1 = Piecewise((1, (x >= 0) & (x < 1)), (0, True))
+    p2 = Piecewise((1, (x >= 2) & (x < 3)), (0, True))
+    assert integrate(p1 * p2, (x, 0, 4)) == 0
+ 
+def test_piecewise_integrate_overlapping():
+    """Overlapping intervals — must give non-zero result."""
+    x = symbols('x', real=True)
+    p1 = Piecewise((1, (x >= 0) & (x < 2)), (0, True))
+    p2 = Piecewise((1, (x >= 1) & (x < 3)), (0, True))
+    # Overlap is [1, 2), length 1
+    assert integrate(p1 * p2, (x, 0, 3)) == 1
+ 
+def test_piecewise_integrate_adjacent_triangles():
+    """Different non-overlapping triangular functions."""
+    x = symbols('x', real=True)
+    t1 = Piecewise((0, x < 0), (4*x, x < Rational(1, 4)),
+                   (2 - 4*x, x < Rational(1, 2)), (0, True))
+    t2 = Piecewise((0, x < Rational(1, 2)), (4*x - 2, x < Rational(3, 4)),
+                   (4 - 4*x, x < 1), (0, True))
+    assert integrate(t1 * t2, (x, 0, 1)) == 0

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1638,3 +1638,14 @@ def test_piecewise__eval_is_meromorphic():
     assert f.is_meromorphic(x, 2) == True
     assert f.is_meromorphic(x, Symbol('a')) is None
     assert f.is_meromorphic(x, Symbol('a', real=True)) is None
+
+def test_piecewise_integrate_29064():
+    """Product of non-overlapping Piecewise functions should integrate
+    to zero without hanging due to an exponential blow-up in the
+    condition simplification (see #29064)."""
+    x = symbols('x', real=True)
+    b1 = Piecewise((0, x < Rational(3, 8)), (8, x < Rational(1, 2)),
+                   (-8, x < Rational(5, 8)), (0, True))
+    b2 = Piecewise((0, x < Rational(5, 8)), (8, x < Rational(3, 4)),
+                   (-8, x < Rational(7, 8)), (0, True))
+    assert integrate(b1*b2, (x, 0, 1)) == 0


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29064 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
When you multiply two non-overlapping Piecewise functions and try to integrate, it hangs. The hang is in _intervals: piecewise_fold produces a CNF condition with many redundant clauses, and distribute_or_over_and then expands it to DNF, which is exponential.

In the reported case the condition has 12 clauses. Substituting symbols for the inequalities (as shown in the issue) it looks like:

    (a|b) & (b|c) & (a|b|c) & (a|b|d) &...

which is logically equivalent to just b|(a&c).
* distribute_or_over_and doesn't detect this and tries to expand all of it.

This PR adds _remove_subsumed_clauses, which runs before the DNF step and drops any clause that is a superset of another (e.g. (a|b|c) is redundant when (a|b) is present).  That reduces the 12 clauses to 2 and
distribute_or_over_and finishes immediately.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a hang when integrating products of Piecewise functions with
    many non-overlapping branches.
<!-- END RELEASE NOTES -->
